### PR TITLE
Fix UMI correction metrics to count per-read instead of per-template

### DIFF
--- a/src/commands/correct.rs
+++ b/src/commands/correct.rs
@@ -872,20 +872,23 @@ impl CorrectUmis {
                                 &mut cache_ref,
                             );
 
+                            // Count records for per-read metrics (matches fgbio behavior)
+                            let num_records = records.len() as u64;
+
                             if correction.matched {
-                                // Update metrics for matched UMIs
+                                // Update metrics for matched UMIs (count per-read, not per-template)
                                 for m in &correction.matches {
                                     if m.matched {
                                         let entry =
                                             umi_matches_map.entry(m.umi.clone()).or_insert_with(
                                                 || UmiCorrectionMetrics::new(m.umi.clone()),
                                             );
-                                        entry.total_matches += 1;
+                                        entry.total_matches += num_records;
                                         match m.mismatches {
-                                            0 => entry.perfect_matches += 1,
-                                            1 => entry.one_mismatch_matches += 1,
-                                            2 => entry.two_mismatch_matches += 1,
-                                            _ => entry.other_matches += 1,
+                                            0 => entry.perfect_matches += num_records,
+                                            1 => entry.one_mismatch_matches += num_records,
+                                            2 => entry.two_mismatch_matches += num_records,
+                                            _ => entry.other_matches += num_records,
                                         }
                                     }
                                 }
@@ -902,7 +905,6 @@ impl CorrectUmis {
                                 }
                             } else {
                                 // Rejection - update counters based on reason
-                                let num_records = records.len() as u64;
                                 match correction.rejection_reason {
                                     RejectionReason::WrongLength => wrong_length += num_records,
                                     RejectionReason::Mismatched => mismatched += num_records,
@@ -1169,16 +1171,16 @@ impl CorrectUmis {
                     );
 
                     if correction.matched {
-                        // Update metrics for matched UMIs
+                        // Update metrics for matched UMIs (count per-read, not per-template)
                         for m in &correction.matches {
                             if m.matched {
                                 let entry = umi_metrics.get_mut(&m.umi).unwrap();
-                                entry.total_matches += 1;
+                                entry.total_matches += num_records;
                                 match m.mismatches {
-                                    0 => entry.perfect_matches += 1,
-                                    1 => entry.one_mismatch_matches += 1,
-                                    2 => entry.two_mismatch_matches += 1,
-                                    _ => entry.other_matches += 1,
+                                    0 => entry.perfect_matches += num_records,
+                                    1 => entry.one_mismatch_matches += num_records,
+                                    2 => entry.two_mismatch_matches += num_records,
+                                    _ => entry.other_matches += num_records,
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Fixed systematic 2x difference between fgumi and fgbio UMI correction metrics
- Changed metrics counting from per-template to per-read to match fgbio behavior
- Updated both multi-threaded and single-threaded code paths in `correct.rs`

## Problem
The `correct` command metrics were incrementing by 1 for each matched template, while fgbio counts per individual read. For paired-end data (2 reads per template), this caused all count columns in fgbio to be exactly 2x the fgumi values.

## Solution
Changed metrics counters (`total_matches`, `perfect_matches`, `one_mismatch_matches`, `two_mismatch_matches`, `other_matches`) to increment by `num_records` (the number of reads in the template) rather than by 1.

## Test plan
- [x] All existing tests pass (77 tests)
- [ ] Verify metrics now match fgbio output on benchmark data