### PR TITLE
feat(duplex): add inline metrics collection to duplex command

### DIFF
--- a/src/commands/duplex.rs
+++ b/src/commands/duplex.rs
@@ -26,6 +26,9 @@ use fgumi_lib::consensus_caller::{
 };
 use fgumi_lib::duplex_consensus_caller::DuplexConsensusCaller;
 use fgumi_lib::logging::{OperationTimer, log_consensus_summary};
+use fgumi_lib::metrics::duplex::{
+    DuplexMetricsCollector, DuplexMetricsWriter, DuplexYieldMetric, calculate_ideal_duplex_fraction,
+};
 use fgumi_lib::mi_group::{MiGroup, MiGroupBatch, MiGroupIteratorWithTransform, MiGrouper};
 use fgumi_lib::overlapping_consensus::{
     AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
@@ -193,6 +196,18 @@ pub struct Duplex {
     /// Scheduler and pipeline stats options
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
+
+    /// Output prefix for duplex metrics files. When specified, collects family size
+    /// distributions, yield metrics, and UMI statistics during consensus calling.
+    /// Generates: `PREFIX.family_sizes.txt`, `PREFIX.duplex_family_sizes.txt`,
+    /// `PREFIX.duplex_yield_metrics.txt`, `PREFIX.umi_counts.txt`, and `PREFIX.duplex_qc.pdf`
+    #[arg(long = "metrics-output")]
+    pub metrics_output: Option<std::path::PathBuf>,
+
+    /// Sample description for metric plots (used in PDF titles).
+    /// Defaults to the output BAM filename if not specified.
+    #[arg(long = "description")]
+    pub description: Option<String>,
 }
 
 impl Command for Duplex {
@@ -254,6 +269,8 @@ impl Command for Duplex {
     ///     max_reads_per_strand: None,
     ///     cell_tag: None,
     ///     scheduler_opts: SchedulerOptions::default(),
+    ///     metrics_output: None,
+    ///     description: None,
     /// };
     ///
     /// duplex.execute("test")?;
@@ -325,7 +342,19 @@ impl Command for Duplex {
         // ============================================================
         // IMPORTANT: Check this BEFORE creating any output file handles to avoid
         // file handle conflicts that can corrupt the output.
-        if let Some(threads) = self.threading.threads {
+
+        // If metrics output is requested but threading is not enabled,
+        // automatically enable threading (default to 4 threads) since
+        // metrics collection requires position-based grouping
+        let effective_threads = if self.metrics_output.is_some() && self.threading.threads.is_none()
+        {
+            info!("Metrics collection requires threading; using 4 threads");
+            Some(4)
+        } else {
+            self.threading.threads
+        };
+
+        if let Some(threads) = effective_threads {
             let result = self.execute_threads_mode(
                 threads,
                 reader,
@@ -504,6 +533,18 @@ impl Duplex {
         track_rejects: bool,
         command_line: &str,
     ) -> Result<()> {
+        // If metrics output is requested, use the metrics-enabled pipeline path
+        if self.metrics_output.is_some() {
+            return self.execute_threads_mode_with_metrics(
+                num_threads,
+                reader,
+                input_header,
+                read_name_prefix,
+                track_rejects,
+                command_line,
+            );
+        }
+
         info!("Using 7-step unified pipeline with {num_threads} threads");
 
         // Create output header (for duplex, output is unmapped like simplex)
@@ -741,6 +782,467 @@ impl Duplex {
 
         Ok(())
     }
+
+    /// Execute using 7-step unified pipeline with metrics collection.
+    ///
+    /// This method is called when `--metrics-output` is specified.
+    /// It uses `MiGrouper` with CS tracking enabled, which computes CS family sizes
+    /// in the single-threaded Group step by tracking consecutive coordinates.
+    #[allow(clippy::too_many_lines)]
+    fn execute_threads_mode_with_metrics(
+        &self,
+        num_threads: usize,
+        reader: Box<dyn std::io::Read + Send>,
+        input_header: Header,
+        read_name_prefix: String,
+        track_rejects: bool,
+        command_line: &str,
+    ) -> Result<()> {
+        info!("Using 7-step unified pipeline with {num_threads} threads (with metrics collection)");
+
+        // Create output header (for duplex, output is unmapped like simplex)
+        let output_header = create_unmapped_consensus_header(
+            &input_header,
+            &self.read_group.read_group_id,
+            "Read group",
+            crate::version::VERSION.as_str(),
+            command_line,
+        )?;
+
+        // Configure pipeline
+        let mut pipeline_config =
+            BamPipelineConfig::auto_tuned(num_threads, self.compression.compression_level);
+        pipeline_config.pipeline.scheduler_strategy = self.scheduler_opts.strategy();
+        if self.scheduler_opts.collect_stats() {
+            pipeline_config.pipeline = pipeline_config.pipeline.with_stats(true);
+        }
+        pipeline_config.pipeline.deadlock_timeout_secs =
+            self.scheduler_opts.deadlock_timeout_secs();
+        pipeline_config.pipeline.deadlock_recover_enabled =
+            self.scheduler_opts.deadlock_recover_enabled();
+
+        // Lock-free metrics collection
+        let collected_metrics: Arc<SegQueue<CollectedDuplexMetrics>> = Arc::new(SegQueue::new());
+        let collected_metrics_for_serialize = Arc::clone(&collected_metrics);
+
+        // Lock-free family metrics collection (collector + read_pairs + CS family sizes)
+        let collected_family_metrics: Arc<SegQueue<(DuplexMetricsCollector, usize, Vec<usize>)>> =
+            Arc::new(SegQueue::new());
+        let collected_family_metrics_for_serialize = Arc::clone(&collected_family_metrics);
+
+        // Capture configuration for closures
+        let min_reads = self.min_reads.clone();
+        let min_input_base_quality = self.consensus.min_input_base_quality;
+        let output_per_base_tags = self.consensus.output_per_base_tags;
+        let trim = self.consensus.trim;
+        let max_reads_per_strand = self.max_reads_per_strand;
+        let error_rate_pre_umi = self.consensus.error_rate_pre_umi;
+        let error_rate_post_umi = self.consensus.error_rate_post_umi;
+        let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
+        let read_group_id = self.read_group.read_group_id.clone();
+        let cell_tag = optional_string_to_tag(self.cell_tag.as_deref(), "cell-tag")?;
+        let batch_size = 100; // MI groups per batch
+
+        // Clone input_header before pipeline (needed for rejects writing)
+        let rejects_header = input_header.clone();
+
+        // MI tag for extracting strand info
+        let mi_tag = noodles::sam::alignment::record::data::field::Tag::from([b'M', b'I']);
+        // RX tag for raw UMI sequences
+        let rx_tag = noodles::sam::alignment::record::data::field::Tag::from([b'R', b'X']);
+
+        // Record filter for duplex: skip secondary/supplementary, keep mapped or mate-mapped
+        let record_filter = |record: &RecordBuf| -> bool {
+            let flags = record.flags();
+            if flags.is_secondary() || flags.is_supplementary() {
+                return false;
+            }
+            let is_mapped = !flags.is_unmapped();
+            let has_mapped_mate = flags.is_segmented() && !flags.is_mate_unmapped();
+            is_mapped || has_mapped_mate
+        };
+
+        // MI transform: strip /A and /B suffixes for duplex grouping
+        let mi_transform = |mi: &str| extract_mi_base(mi).to_string();
+
+        // Run the 7-step pipeline with fast MiGrouper
+        let groups_processed = run_bam_pipeline_from_reader(
+            pipeline_config,
+            reader,
+            input_header,
+            &self.io.output,
+            Some(output_header.clone()),
+            // ========== grouper_fn: Create MiGrouper with CS tracking ==========
+            move |_header: &Header| {
+                Box::new(
+                    MiGrouper::with_filter_and_transform(
+                        "MI",
+                        batch_size,
+                        record_filter,
+                        mi_transform,
+                    )
+                    .with_cs_tracking(),
+                ) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+            },
+            // ========== process_fn: Duplex consensus calling with metrics ==========
+            move |batch: MiGroupBatch| -> io::Result<DuplexProcessedBatchWithMetrics> {
+                // Create per-thread duplex consensus caller
+                let mut caller = DuplexConsensusCaller::new(
+                    read_name_prefix.clone(),
+                    read_group_id.clone(),
+                    min_reads.clone(),
+                    min_input_base_quality,
+                    output_per_base_tags,
+                    trim,
+                    max_reads_per_strand,
+                    cell_tag,
+                    track_rejects,
+                    error_rate_pre_umi,
+                    error_rate_post_umi,
+                )
+                .map_err(|e| {
+                    io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}"))
+                })?;
+
+                // Create overlapping caller if enabled
+                let mut overlapping_caller = if overlapping_enabled {
+                    Some(OverlappingBasesConsensusCaller::new(
+                        AgreementStrategy::Consensus,
+                        DisagreementStrategy::Consensus,
+                    ))
+                } else {
+                    None
+                };
+
+                let mut all_consensus = Vec::new();
+                let mut all_rejects = Vec::new();
+                let mut batch_stats = ConsensusCallingStats::new();
+                let mut batch_overlapping = CorrectionStats::new();
+                let mut family_metrics = DuplexMetricsCollector::new(1, 1, false);
+                let groups_count = batch.groups.len() as u64;
+                let mut batch_read_pairs = 0usize;
+
+                // CS family sizes are computed in the Group step (single-threaded, consecutive coordinates)
+                let batch_cs_family_sizes = batch.cs_family_sizes;
+
+                for MiGroup { mi: base_mi, records: group_records } in batch.groups {
+                    caller.clear();
+
+                    // Track strand counts by counting R1 primaries (no qname hashing needed)
+                    let mut a_count = 0usize;
+                    let mut b_count = 0usize;
+                    // Collect (is_a_strand, rx_bytes) for UMI metrics - no string allocation
+                    let mut strand_rx_pairs: Vec<(bool, Vec<u8>)> = Vec::new();
+
+                    for record in &group_records {
+                        use noodles::sam::alignment::record_buf::data::field::Value;
+
+                        let flags = record.flags();
+
+                        // Check if this is R1 primary (for strand counting and UMI metrics)
+                        let is_r1_primary = flags.is_first_segment()
+                            && !flags.is_secondary()
+                            && !flags.is_supplementary();
+
+                        // Get MI tag for strand counting (only for R1 primary)
+                        if is_r1_primary {
+                            if let Some(Value::String(mi_bytes)) = record.data().get(&mi_tag) {
+                                let mi_raw: &[u8] = mi_bytes.as_ref();
+
+                                // Count templates per strand (no allocation - check raw bytes)
+                                let is_a_strand = mi_raw.ends_with(b"/A");
+                                if is_a_strand {
+                                    a_count += 1;
+                                } else if mi_raw.ends_with(b"/B") {
+                                    b_count += 1;
+                                }
+
+                                // Collect strand + RX for UMI metrics (minimal allocation)
+                                if let Some(Value::String(rx_bytes)) = record.data().get(&rx_tag) {
+                                    let rx_raw: &[u8] = rx_bytes.as_ref();
+                                    strand_rx_pairs.push((is_a_strand, rx_raw.to_vec()));
+                                }
+                            }
+                        }
+                    }
+                    let ds_size = a_count + b_count;
+
+                    // Record DS family size
+                    if ds_size > 0 {
+                        family_metrics.record_ds_family(ds_size);
+                    }
+
+                    // Record SS family sizes
+                    if a_count > 0 {
+                        family_metrics.record_ss_family(a_count);
+                    }
+                    if b_count > 0 {
+                        family_metrics.record_ss_family(b_count);
+                    }
+
+                    // Record duplex family sizes (AB x BA)
+                    family_metrics.record_duplex_family(a_count, b_count);
+
+                    // Track read pairs
+                    batch_read_pairs += a_count + b_count;
+
+                    // Apply overlapping consensus if enabled
+                    let mut group_reads = group_records;
+                    if let Some(ref mut oc) = overlapping_caller {
+                        if DuplexConsensusCaller::has_both_strands(&group_reads) {
+                            oc.reset_stats();
+                            if apply_overlapping_consensus(&mut group_reads, oc).is_err() {
+                                continue;
+                            }
+                            batch_overlapping.merge(oc.stats());
+                        }
+                    }
+
+                    // Call duplex consensus
+                    match caller.consensus_reads_from_sam_records(group_reads) {
+                        Ok(consensus_reads) => {
+                            // Update UMI metrics using consensus UMI from output reads
+                            // The consensus reads have the RX tag with the consensus UMI already computed
+                            if !consensus_reads.is_empty() && !strand_rx_pairs.is_empty() {
+                                // Get consensus UMI from first consensus read's RX tag
+                                if let Some(
+                                    noodles::sam::alignment::record_buf::data::field::Value::String(
+                                        consensus_rx,
+                                    ),
+                                ) = consensus_reads[0].data().get(&rx_tag)
+                                {
+                                    let consensus_rx_bytes: &[u8] = consensus_rx.as_ref();
+                                    family_metrics.update_umi_metrics_from_consensus(
+                                        consensus_rx_bytes,
+                                        &strand_rx_pairs,
+                                    );
+                                }
+                            }
+
+                            all_consensus.extend(consensus_reads);
+                            batch_stats.merge(&caller.statistics());
+                            if track_rejects {
+                                all_rejects.extend(caller.take_rejected_reads());
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!("Duplex consensus error for MI {base_mi}: {e}");
+                        }
+                    }
+                }
+
+                Ok(DuplexProcessedBatchWithMetrics {
+                    consensus_reads: all_consensus,
+                    rejects: all_rejects,
+                    groups_count,
+                    stats: batch_stats,
+                    overlapping_stats: if overlapping_enabled {
+                        Some(batch_overlapping)
+                    } else {
+                        None
+                    },
+                    family_metrics,
+                    read_pairs: batch_read_pairs,
+                    cs_family_sizes: batch_cs_family_sizes,
+                })
+            },
+            // ========== serialize_fn: Serialize + collect metrics ==========
+            move |processed: DuplexProcessedBatchWithMetrics,
+                  header: &Header,
+                  output: &mut Vec<u8>|
+                  -> io::Result<u64> {
+                // Collect consensus metrics (lock-free)
+                collected_metrics_for_serialize.push(CollectedDuplexMetrics {
+                    stats: processed.stats,
+                    overlapping_stats: processed.overlapping_stats,
+                    groups_processed: processed.groups_count,
+                    rejects: processed.rejects,
+                });
+
+                // Collect family metrics + CS family sizes (lock-free)
+                collected_family_metrics_for_serialize.push((
+                    processed.family_metrics,
+                    processed.read_pairs,
+                    processed.cs_family_sizes,
+                ));
+
+                // Serialize consensus reads
+                serialize_bam_records_into(&processed.consensus_reads, header, output)
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?;
+
+        // ========== Post-pipeline: Aggregate metrics ==========
+        let mut total_groups = 0u64;
+        let mut merged_stats = ConsensusCallingStats::new();
+        let mut merged_overlapping_stats = CorrectionStats::new();
+        let mut all_rejects: Vec<RecordBuf> = Vec::new();
+
+        while let Some(metrics) = collected_metrics.pop() {
+            total_groups += metrics.groups_processed;
+            merged_stats.merge(&metrics.stats);
+            if let Some(ref ocs) = metrics.overlapping_stats {
+                merged_overlapping_stats.merge(ocs);
+            }
+            if track_rejects {
+                all_rejects.extend(metrics.rejects);
+            }
+        }
+
+        // Aggregate family metrics and CS family sizes
+        let mut merged_family_metrics = DuplexMetricsCollector::new(1, 1, false);
+        let mut total_read_pairs = 0usize;
+
+        while let Some((family_metrics, read_pairs, cs_family_sizes)) =
+            collected_family_metrics.pop()
+        {
+            merged_family_metrics.merge(&family_metrics);
+            total_read_pairs += read_pairs;
+            // Record CS families directly (sizes computed in Group step)
+            for size in cs_family_sizes {
+                merged_family_metrics.record_cs_family(size);
+            }
+        }
+
+        // Write deferred rejects
+        if track_rejects && !all_rejects.is_empty() {
+            if let Some(rejects_path) = &self.rejects_opts.rejects {
+                let writer_threads = self.threading.num_threads();
+                let mut rejects_writer = create_optional_bam_writer(
+                    Some(rejects_path),
+                    &rejects_header,
+                    writer_threads,
+                    self.compression.compression_level,
+                )?;
+                if let Some(ref mut rw) = rejects_writer {
+                    for record in &all_rejects {
+                        rw.write_alignment_record(&rejects_header, record)
+                            .context("Failed to write rejected read")?;
+                    }
+                    rw.finish(&rejects_header).context("Failed to finish rejects file")?;
+                    info!("Wrote {} rejected reads", all_rejects.len());
+                }
+            }
+        }
+
+        // Log overlapping consensus statistics if enabled
+        if self.overlapping.consensus_call_overlapping_bases {
+            log_overlapping_stats(&merged_overlapping_stats);
+        }
+
+        // Log statistics
+        info!("Duplex consensus calling complete");
+        info!("Total MI groups processed: {total_groups}");
+        info!("Total groups processed by pipeline: {groups_processed}");
+
+        let metrics = merged_stats.to_metrics();
+        let consensus_count = metrics.consensus_reads;
+        log_consensus_summary(&metrics);
+
+        // Write statistics file if requested
+        if let Some(stats_path) = &self.stats_opts.stats {
+            let kv_metrics = metrics.to_kv_metrics();
+            DelimFile::default()
+                .write_tsv(stats_path, kv_metrics)
+                .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
+            info!("Wrote statistics to: {}", stats_path.display());
+        }
+
+        // Write family metrics files
+        if let Some(ref metrics_prefix) = self.metrics_output {
+            self.write_family_metrics(metrics_prefix, &merged_family_metrics, total_read_pairs)?;
+        }
+
+        info!("Wrote {consensus_count} duplex consensus reads");
+
+        Ok(())
+    }
+
+    /// Write family metrics files using the shared writer.
+    fn write_family_metrics(
+        &self,
+        prefix: &std::path::Path,
+        metrics: &DuplexMetricsCollector,
+        read_pairs: usize,
+    ) -> Result<()> {
+        // Generate yield metrics for 100% fraction
+        let family_size_metrics = metrics.family_size_metrics();
+        let duplex_family_size_metrics = metrics.duplex_family_size_metrics();
+
+        let total_cs: usize = family_size_metrics.iter().map(|m| m.cs_count).sum();
+        let total_ss: usize = family_size_metrics.iter().map(|m| m.ss_count).sum();
+        let total_ds: usize = family_size_metrics.iter().map(|m| m.ds_count).sum();
+        let total_duplexes: usize = duplex_family_size_metrics
+            .iter()
+            .filter(|m| m.ab_size >= 1 && m.ba_size >= 1)
+            .map(|m| m.count)
+            .sum();
+
+        // Calculate ideal duplex fraction using binomial model
+        let ds_family_sizes: Vec<usize> =
+            family_size_metrics.iter().flat_map(|m| vec![m.family_size; m.ds_count]).collect();
+        let ideal_fraction = calculate_ideal_duplex_fraction(&ds_family_sizes, 1, 1);
+
+        // Log summary
+        info!("Family metrics summary:");
+        info!("  CS families: {total_cs}");
+        info!("  SS families: {total_ss}");
+        info!("  DS families: {total_ds}");
+        info!("  Duplex families: {total_duplexes}");
+        info!("  Read pairs: {read_pairs}");
+
+        // Create yield metric for 100% fraction
+        let yield_metric = DuplexYieldMetric {
+            fraction: 1.0,
+            read_pairs,
+            cs_families: total_cs,
+            ss_families: total_ss,
+            ds_families: total_ds,
+            ds_duplexes: total_duplexes,
+            ds_fraction_duplexes: if total_ds > 0 {
+                total_duplexes as f64 / total_ds as f64
+            } else {
+                0.0
+            },
+            ds_fraction_duplexes_ideal: ideal_fraction,
+        };
+
+        // Write all metrics files
+        let writer = DuplexMetricsWriter::new(prefix).with_description(self.description.as_deref());
+        writer.write_all(metrics, &[yield_metric])?;
+
+        Ok(())
+    }
+}
+
+/// Result from processing a batch of MI groups with metrics.
+struct DuplexProcessedBatchWithMetrics {
+    /// Consensus reads to write to output BAM
+    consensus_reads: Vec<RecordBuf>,
+    /// Rejected reads (written to rejects file if enabled)
+    rejects: Vec<RecordBuf>,
+    /// Number of MI groups in this batch
+    groups_count: u64,
+    /// Consensus calling statistics for this batch
+    stats: ConsensusCallingStats,
+    /// Overlapping correction stats for this batch (if enabled)
+    overlapping_stats: Option<CorrectionStats>,
+    /// Family metrics collected from this batch (SS/DS/duplex families)
+    family_metrics: DuplexMetricsCollector,
+    /// Number of read pairs in this batch
+    read_pairs: usize,
+    /// CS family sizes from the grouper (computed in Group step)
+    cs_family_sizes: Vec<usize>,
+}
+
+impl MemoryEstimate for DuplexProcessedBatchWithMetrics {
+    fn estimate_heap_size(&self) -> usize {
+        self.consensus_reads
+            .iter()
+            .chain(self.rejects.iter())
+            .map(MemoryEstimate::estimate_heap_size)
+            .sum()
+    }
 }
 
 #[cfg(test)]
@@ -801,6 +1303,8 @@ mod tests {
             max_reads_per_strand: None,
             cell_tag: None,
             scheduler_opts: SchedulerOptions::default(),
+            metrics_output: None,
+            description: None,
         }
     }
 

--- a/src/commands/duplex_metrics.rs
+++ b/src/commands/duplex_metrics.rs
@@ -11,22 +11,23 @@ use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_lib::bam_io::create_bam_reader;
 use fgumi_lib::logging::OperationTimer;
-use fgumi_lib::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric};
+use fgumi_lib::metrics::duplex::{
+    DuplexMetricsCollector, DuplexYieldMetric, calculate_ideal_duplex_fraction,
+};
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::simple_umi_consensus::SimpleUmiConsensusCaller;
 use fgumi_lib::template::TemplateIterator;
-use fgumi_lib::umi::extract_mi_base;
 use fgumi_lib::validation::validate_file_exists;
 use log::info;
 use murmur3::murmur3_32;
 use noodles::sam::alignment::record::Cigar;
 use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record_buf::RecordBuf;
-use statrs::distribution::{Binomial, DiscreteCDF};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use super::command::Command;
+use super::common::ThreadingOptions;
 
 /// Embedded R script for PDF plot generation (bundled with binary)
 const R_SCRIPT: &str = include_str!("../../resources/CollectDuplexSeqMetrics.R");
@@ -211,6 +212,10 @@ pub struct DuplexMetrics {
     /// Optional SAM tag for cell barcode (for single-cell data)
     #[arg(long = "cell-tag")]
     pub cell_tag: Option<String>,
+
+    /// Threading options for parallel BAM decompression
+    #[command(flatten)]
+    pub threading: ThreadingOptions,
 }
 
 impl Command for DuplexMetrics {
@@ -221,6 +226,7 @@ impl Command for DuplexMetrics {
         info!("  Min AB reads: {}", self.min_ab_reads);
         info!("  Min BA reads: {}", self.min_ba_reads);
         info!("  Collect duplex UMI counts: {}", self.duplex_umi_counts);
+        info!("  Threads: {}", self.threading.num_threads());
 
         let timer = OperationTimer::new("Computing duplex metrics");
 
@@ -400,7 +406,7 @@ impl DuplexMetrics {
     fn validate_not_consensus_bam(&self) -> Result<()> {
         use fgumi_lib::consensus_tags::is_consensus;
 
-        let (mut reader, header) = create_bam_reader(&self.input, 1)?;
+        let (mut reader, header) = create_bam_reader(&self.input, self.threading.num_threads())?;
 
         // Look at the first valid R1 record
         for result in reader.record_bufs(&header) {
@@ -564,7 +570,7 @@ impl DuplexMetrics {
         collectors: &mut [DuplexMetricsCollector],
         umi_consensus_caller: &mut SimpleUmiConsensusCaller,
     ) -> Result<(usize, Vec<usize>)> {
-        let (mut reader, header) = create_bam_reader(&self.input, 1)?;
+        let (mut reader, header) = create_bam_reader(&self.input, self.threading.num_threads())?;
 
         let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
         let template_iter = TemplateIterator::new(record_iter);
@@ -770,7 +776,7 @@ impl DuplexMetrics {
         collectors: &mut [DuplexMetricsCollector],
         umi_consensus_caller: &mut SimpleUmiConsensusCaller,
         fraction_template_counts: &mut [usize],
-        metrics: &DuplexMetrics,
+        _metrics: &DuplexMetrics,
     ) {
         use std::collections::HashMap;
 
@@ -856,13 +862,10 @@ impl DuplexMetrics {
                         .map(|(mi, rx)| ((*mi).to_string(), (*rx).to_string()))
                         .collect();
 
-                    metrics.update_umi_metrics(
-                        &mut collectors[idx],
+                    collectors[idx].update_umi_metrics_for_family(
                         umi_consensus_caller,
                         &owned_pairs,
                         base_umi,
-                        *a_count,
-                        *b_count,
                     );
                 }
             }
@@ -931,11 +934,8 @@ impl DuplexMetrics {
         let ds_family_sizes: Vec<usize> =
             family_size_metrics.iter().flat_map(|m| vec![m.family_size; m.ds_count]).collect();
 
-        let ideal_fraction = Self::calculate_ideal_duplex_fraction(
-            &ds_family_sizes,
-            self.min_ab_reads,
-            self.min_ba_reads,
-        );
+        let ideal_fraction =
+            calculate_ideal_duplex_fraction(&ds_family_sizes, self.min_ab_reads, self.min_ba_reads);
 
         let cs_families: usize = family_size_metrics.iter().map(|m| m.cs_count).sum();
         let ss_families: usize = duplex_family_size_metrics
@@ -965,159 +965,6 @@ impl DuplexMetrics {
                 0.0
             },
             ds_fraction_duplexes_ideal: ideal_fraction,
-        }
-    }
-
-    /// Calculates the ideal duplex fraction using binomial model.
-    ///
-    /// For each family of size N, calculates the probability that both strands
-    /// have sufficient reads (A >= `min_ab` AND B >= `min_ba` where A + B = N).
-    /// Assumes each read has 0.5 probability of being on each strand.
-    fn calculate_ideal_duplex_fraction(
-        family_sizes: &[usize],
-        min_ab: usize,
-        min_ba: usize,
-    ) -> f64 {
-        if family_sizes.is_empty() {
-            return 0.0;
-        }
-
-        let mut ideal_duplexes = 0.0;
-        let total_families = family_sizes.len() as f64;
-
-        for &size in family_sizes {
-            if size < min_ab + min_ba {
-                // Impossible to form a duplex with this family size
-                continue;
-            }
-
-            // Calculate P(A >= min_ab AND B >= min_ba) where A ~ Binomial(n=size, p=0.5)
-            // and B = size - A
-            //
-            // This is equivalent to: P(min_ba <= A <= size - min_ab)
-            // = P(A <= size - min_ab) - P(A < min_ba)
-            // = CDF(size - min_ab) - CDF(min_ba - 1)
-
-            let binomial = match Binomial::new(0.5, size as u64) {
-                Ok(b) => b,
-                Err(_) => continue, // Skip if binomial creation fails
-            };
-
-            let upper_bound = size - min_ba;
-            let lower_bound = min_ab;
-
-            // P(A >= lower_bound AND A <= upper_bound)
-            let prob = if upper_bound >= lower_bound {
-                let p_upper = binomial.cdf(upper_bound as u64);
-                let p_lower =
-                    if lower_bound > 0 { binomial.cdf((lower_bound - 1) as u64) } else { 0.0 };
-                p_upper - p_lower
-            } else {
-                0.0
-            };
-
-            ideal_duplexes += prob;
-        }
-
-        ideal_duplexes / total_families
-    }
-
-    /// Updates UMI metrics for a duplex family
-    ///
-    /// This method:
-    /// 1. Uses RX tags (raw UMI sequences) to extract individual UMI observations
-    /// 2. Separates by strand (/A and /B suffixes in MI tags), swapping UMI parts for B strand
-    /// 3. Calls consensus for each UMI position
-    /// 4. Records raw observations, errors, and unique observations for each individual UMI
-    /// 5. Records duplex UMI metrics if enabled
-    ///
-    /// This matches the Scala implementation in CollectDuplexSeqMetrics.scala:407-431
-    fn update_umi_metrics(
-        &self,
-        collector: &mut DuplexMetricsCollector,
-        umi_consensus_caller: &mut SimpleUmiConsensusCaller,
-        group_pairs: &[(String, String)],
-        base_umi: &str,
-        _a_count: usize,
-        _b_count: usize,
-    ) {
-        // Collect individual UMI parts from each strand's RX tag
-        // For /A strand: split RX "AAA-TTT" → umi1s += "AAA", umi2s += "TTT"
-        // For /B strand: split RX "TTT-AAA" → umi1s += "AAA", umi2s += "TTT" (swapped)
-        let mut umi1s = Vec::new();
-        let mut umi2s = Vec::new();
-
-        for (mi, rx) in group_pairs {
-            // Check if this MI tag belongs to the current base_umi family
-            let mi_base = extract_mi_base(mi);
-
-            if mi_base != base_umi {
-                continue;
-            }
-
-            // Split the RX tag to get individual UMI parts
-            let parts: Vec<&str> = rx.split('-').collect();
-            if parts.len() != 2 {
-                // Not a valid duplex UMI, skip
-                continue;
-            }
-
-            // Check that both components are non-empty
-            if parts[0].is_empty() || parts[1].is_empty() {
-                // Empty component, skip
-                continue;
-            }
-
-            // Add UMI parts based on strand
-            if mi.ends_with("/A") {
-                // For /A strand: u1 goes to umi1s, u2 goes to umi2s
-                umi1s.push(parts[0].to_string());
-                umi2s.push(parts[1].to_string());
-            } else if mi.ends_with("/B") {
-                // For /B strand: u2 goes to umi1s, u1 goes to umi2s (swapped)
-                umi1s.push(parts[1].to_string());
-                umi2s.push(parts[0].to_string());
-            }
-        }
-
-        // Call consensus for each UMI position and record metrics
-        let mut consensus_umis = Vec::new();
-
-        if !umi1s.is_empty() {
-            let (consensus, _had_errors) = umi_consensus_caller.consensus(&umi1s);
-            let raw_count = umi1s.len();
-            let error_count = umi1s.iter().filter(|u| **u != consensus).count();
-            collector.record_umi(&consensus, raw_count, error_count, true);
-            consensus_umis.push(consensus);
-        }
-
-        if !umi2s.is_empty() {
-            let (consensus, _had_errors) = umi_consensus_caller.consensus(&umi2s);
-            let raw_count = umi2s.len();
-            let error_count = umi2s.iter().filter(|u| **u != consensus).count();
-            collector.record_umi(&consensus, raw_count, error_count, true);
-            consensus_umis.push(consensus);
-        }
-
-        // Record duplex UMI metrics if enabled
-        if self.duplex_umi_counts && consensus_umis.len() == 2 {
-            let duplex_umi = format!("{}-{}", consensus_umis[0], consensus_umis[1]);
-            // Each read pair contributes one observation to the duplex UMI
-            // (not two, even though we track each component separately)
-            let total_raw = umi1s.len();
-
-            // Count how many raw RX tags had errors (don't match either duplex orientation)
-            let expected_duplex1 = format!("{}-{}", consensus_umis[0], consensus_umis[1]);
-            let expected_duplex2 = format!("{}-{}", consensus_umis[1], consensus_umis[0]);
-            let error_count = group_pairs
-                .iter()
-                .filter(|(mi, rx)| {
-                    let mi_base = extract_mi_base(mi);
-                    mi_base == base_umi && *rx != expected_duplex1 && *rx != expected_duplex2
-                })
-                .count();
-
-            collector.record_duplex_umi(&duplex_umi, total_raw, error_count, true);
         }
     }
 
@@ -1313,6 +1160,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -1379,6 +1227,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -1468,6 +1317,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -1595,6 +1445,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -1750,6 +1601,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -1876,6 +1728,7 @@ mod tests {
                 umi_tag: "RX".to_string(),
                 mi_tag: "MI".to_string(),
                 cell_tag: None,
+                threading: ThreadingOptions::none(),
             };
 
             cmd.execute("test")?;
@@ -1906,6 +1759,7 @@ mod tests {
                 umi_tag: "RX".to_string(),
                 mi_tag: "MI".to_string(),
                 cell_tag: None,
+                threading: ThreadingOptions::none(),
             };
 
             cmd.execute("test")?;
@@ -1936,6 +1790,7 @@ mod tests {
                 umi_tag: "RX".to_string(),
                 mi_tag: "MI".to_string(),
                 cell_tag: None,
+                threading: ThreadingOptions::none(),
             };
 
             cmd.execute("test")?;
@@ -2073,6 +1928,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -2137,6 +1993,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         cmd.execute("test")?;
@@ -2342,6 +2199,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         // This should fail with an error about consensus BAM
@@ -2369,6 +2227,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         assert_eq!(metrics.min_ab_reads, 1);
@@ -2391,6 +2250,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         assert_eq!(metrics.min_ab_reads, 3);
@@ -2412,6 +2272,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         // The validation happens in execute(), check during command construction would be ideal
@@ -2553,6 +2414,7 @@ mod tests {
             umi_tag: "RX".to_string(),
             mi_tag: "MI".to_string(),
             cell_tag: None,
+            threading: ThreadingOptions::none(),
         };
 
         // Should complete without panicking or errors

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -563,6 +563,514 @@ impl Grouper for PositionGrouper {
 }
 
 // ============================================================================
+// PositionMiGrouper - Groups by position then by MI for duplex metrics
+// ============================================================================
+
+use crate::umi::extract_mi_base;
+use noodles::sam::alignment::record::Cigar;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::collections::HashMap;
+
+/// Coordinate grouping key matching fgbio's `ReadInfo` structure.
+/// Uses unclipped 5' positions of both R1 and R2, normalized so lower position comes first.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ReadInfoKey {
+    /// Reference index for position 1 (lower).
+    pub ref_index1: Option<usize>,
+    /// Unclipped 5' position for position 1.
+    pub start1: i32,
+    /// Strand for position 1 (true = reverse).
+    pub strand1: bool,
+    /// Reference index for position 2 (higher).
+    pub ref_index2: Option<usize>,
+    /// Unclipped 5' position for position 2.
+    pub start2: i32,
+    /// Strand for position 2 (true = reverse).
+    pub strand2: bool,
+}
+
+impl ReadInfoKey {
+    /// Create an "unknown" key for unpaired/unmapped reads (excluded from metrics).
+    #[must_use]
+    pub fn unknown() -> Self {
+        Self {
+            ref_index1: None,
+            start1: 0,
+            strand1: false,
+            ref_index2: None,
+            start2: 0,
+            strand2: false,
+        }
+    }
+
+    /// Returns true if this key represents a valid paired read.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.ref_index1.is_some() && self.ref_index2.is_some()
+    }
+
+    /// Compute `ReadInfoKey` from template records (R1 + R2).
+    ///
+    /// Uses same filtering criteria as duplex-metrics:
+    /// - R1: segmented, mapped, mate mapped, first segment, primary
+    /// - R2: segmented, mapped, mate mapped, last segment, primary
+    ///
+    /// Returns `ReadInfoKey::unknown()` if R1/R2 cannot be identified or are on different references.
+    #[must_use]
+    pub fn from_template_records(records: &[RecordBuf]) -> Self {
+        Self::compute_from_iter(records.iter())
+    }
+
+    /// Compute `ReadInfoKey` from template record references (R1 + R2).
+    ///
+    /// Same as `from_template_records` but takes references to avoid cloning.
+    #[must_use]
+    pub fn from_template_refs(records: &[&RecordBuf]) -> Self {
+        Self::compute_from_iter(records.iter().copied())
+    }
+
+    /// Compute `ReadInfoKey` directly from R1 and R2 records.
+    ///
+    /// This is the most efficient method when R1 and R2 are already identified.
+    /// Returns `ReadInfoKey::unknown()` if records are on different references.
+    #[must_use]
+    pub fn from_r1_r2(r1: &RecordBuf, r2: &RecordBuf) -> Self {
+        let r1_ref = r1.reference_sequence_id();
+        let r2_ref = r2.reference_sequence_id();
+
+        // Only process if same reference
+        if r1_ref != r2_ref || r1_ref.is_none() {
+            return Self::unknown();
+        }
+
+        let r1_5prime = unclipped_five_prime_position(r1);
+        let r2_5prime = unclipped_five_prime_position(r2);
+        let r1_strand = r1.flags().is_reverse_complemented();
+        let r2_strand = r2.flags().is_reverse_complemented();
+
+        match (r1_5prime, r2_5prime) {
+            (Some(s1), Some(s2)) => {
+                // Normalize: lower position comes first (matching fgbio)
+                if (r1_ref, s1) <= (r2_ref, s2) {
+                    Self {
+                        ref_index1: r1_ref,
+                        start1: s1,
+                        strand1: r1_strand,
+                        ref_index2: r2_ref,
+                        start2: s2,
+                        strand2: r2_strand,
+                    }
+                } else {
+                    Self {
+                        ref_index1: r2_ref,
+                        start1: s2,
+                        strand1: r2_strand,
+                        ref_index2: r1_ref,
+                        start2: s1,
+                        strand2: r1_strand,
+                    }
+                }
+            }
+            _ => Self::unknown(),
+        }
+    }
+
+    /// Internal helper to compute `ReadInfoKey` from an iterator of record references.
+    fn compute_from_iter<'a>(records: impl Iterator<Item = &'a RecordBuf>) -> Self {
+        let records: Vec<&RecordBuf> = records.collect();
+
+        // Find R1: segmented, mapped, mate mapped, first segment, primary
+        let r1 = records.iter().find(|r| {
+            let f = r.flags();
+            f.is_segmented()
+                && !f.is_unmapped()
+                && !f.is_mate_unmapped()
+                && f.is_first_segment()
+                && !f.is_secondary()
+                && !f.is_supplementary()
+        });
+
+        // Find R2: segmented, mapped, mate mapped, last segment, primary
+        let r2 = records.iter().find(|r| {
+            let f = r.flags();
+            f.is_segmented()
+                && !f.is_unmapped()
+                && !f.is_mate_unmapped()
+                && f.is_last_segment()
+                && !f.is_secondary()
+                && !f.is_supplementary()
+        });
+
+        match (r1, r2) {
+            (Some(r1), Some(r2)) => {
+                let r1_ref = r1.reference_sequence_id();
+                let r2_ref = r2.reference_sequence_id();
+
+                // Only process if same reference
+                if r1_ref != r2_ref || r1_ref.is_none() {
+                    return Self::unknown();
+                }
+
+                let r1_5prime = unclipped_five_prime_position(r1);
+                let r2_5prime = unclipped_five_prime_position(r2);
+                let r1_strand = r1.flags().is_reverse_complemented();
+                let r2_strand = r2.flags().is_reverse_complemented();
+
+                match (r1_5prime, r2_5prime) {
+                    (Some(s1), Some(s2)) => {
+                        // Normalize: lower position comes first (matching fgbio)
+                        if (r1_ref, s1) <= (r2_ref, s2) {
+                            Self {
+                                ref_index1: r1_ref,
+                                start1: s1,
+                                strand1: r1_strand,
+                                ref_index2: r2_ref,
+                                start2: s2,
+                                strand2: r2_strand,
+                            }
+                        } else {
+                            Self {
+                                ref_index1: r2_ref,
+                                start1: s2,
+                                strand1: r2_strand,
+                                ref_index2: r1_ref,
+                                start2: s1,
+                                strand2: r1_strand,
+                            }
+                        }
+                    }
+                    _ => Self::unknown(),
+                }
+            }
+            _ => Self::unknown(),
+        }
+    }
+}
+
+/// Computes the unclipped 5' position for a read, matching fgbio's `positionOf`.
+///
+/// For forward strand reads: `unclipped_start = alignment_start - leading_soft_clips`
+/// For reverse strand reads: `unclipped_end = alignment_end + trailing_soft_clips`
+fn unclipped_five_prime_position(record: &RecordBuf) -> Option<i32> {
+    let is_reverse = record.flags().is_reverse_complemented();
+    let cigar = record.cigar();
+
+    if is_reverse {
+        // For reverse strand, 5' is at the end
+        // unclippedEnd = alignmentEnd + trailing soft clips
+        let alignment_end = record.alignment_end().map(|p| usize::from(p) as i32)?;
+
+        // Count trailing soft clips (last element if it's S)
+        let trailing_clips: i32 = cigar
+            .iter()
+            .filter_map(std::result::Result::ok)
+            .last()
+            .filter(|op| op.kind() == Kind::SoftClip)
+            .map_or(0, |op| op.len() as i32);
+
+        Some(alignment_end + trailing_clips)
+    } else {
+        // For forward strand, 5' is at the start
+        // unclippedStart = alignmentStart - leading soft clips
+        let alignment_start = record.alignment_start().map(|p| usize::from(p) as i32)?;
+
+        // Count leading soft clips (first element if it's S)
+        let leading_clips: i32 = cigar
+            .iter()
+            .find_map(std::result::Result::ok)
+            .filter(|op| op.kind() == Kind::SoftClip)
+            .map_or(0, |op| op.len() as i32);
+
+        Some(alignment_start - leading_clips)
+    }
+}
+
+/// A position-MI group containing records at the same position, organized by MI.
+///
+/// This structure is used for collecting duplex metrics during consensus calling.
+/// It groups records first by genomic position (using `ReadInfoKey`), then by
+/// molecular identifier (MI).
+///
+/// Family size definitions:
+/// - **CS** (Coordinate & Strand): Total templates at this position (`total_templates`)
+/// - **SS** (Single Strand): Templates with same position AND full MI tag (including /A or /B)
+/// - **DS** (Double Strand): Templates with same position AND base MI (without /A, /B)
+#[derive(Debug)]
+pub struct PositionMiGroup {
+    /// The coordinate key for this group (computed from R1+R2 unclipped 5' positions).
+    pub read_info_key: ReadInfoKey,
+    /// Records organized by base MI (without /A, /B suffix).
+    /// Each entry maps `base_mi` -> records with that MI.
+    pub mi_groups: HashMap<String, Vec<RecordBuf>>,
+    /// Total number of templates at this position (CS family size).
+    pub total_templates: usize,
+    /// Total number of records at this position.
+    pub total_records: usize,
+}
+
+impl BatchWeight for PositionMiGroup {
+    /// Returns the number of templates in this group.
+    fn batch_weight(&self) -> usize {
+        self.total_templates
+    }
+}
+
+impl MemoryEstimate for PositionMiGroup {
+    fn estimate_heap_size(&self) -> usize {
+        // read_info_key: ReadInfoKey has minimal heap allocation
+        // mi_groups: HashMap<String, Vec<RecordBuf>>
+        let mi_groups_size: usize = self
+            .mi_groups
+            .iter()
+            .map(|(k, v)| {
+                let key_size = k.capacity();
+                let vec_size: usize = v.iter().map(MemoryEstimate::estimate_heap_size).sum();
+                let vec_overhead = v.capacity() * std::mem::size_of::<RecordBuf>();
+                key_size + vec_size + vec_overhead
+            })
+            .sum();
+        let hashmap_overhead = self.mi_groups.capacity() * 48; // rough estimate
+        mi_groups_size + hashmap_overhead
+    }
+}
+
+/// A batch of position-MI groups for parallel processing.
+#[derive(Default)]
+pub struct PositionMiGroupBatch {
+    /// The position-MI groups in this batch.
+    pub groups: Vec<PositionMiGroup>,
+}
+
+impl PositionMiGroupBatch {
+    /// Creates a new empty batch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { groups: Vec::new() }
+    }
+
+    /// Returns the number of groups in the batch.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Returns true if the batch is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+}
+
+impl BatchWeight for PositionMiGroupBatch {
+    fn batch_weight(&self) -> usize {
+        self.groups.iter().map(|g| g.total_templates).sum()
+    }
+}
+
+impl MemoryEstimate for PositionMiGroupBatch {
+    fn estimate_heap_size(&self) -> usize {
+        let groups_size: usize = self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum();
+        let groups_vec_overhead = self.groups.capacity() * std::mem::size_of::<PositionMiGroup>();
+        groups_size + groups_vec_overhead
+    }
+}
+
+/// A grouper that groups records by position, then by MI.
+///
+/// Used by the `duplex` command with `--metrics-output` to collect duplex metrics
+/// during consensus calling. Groups records first by genomic position using
+/// `ReadInfoKey` (matching duplex-metrics exactly), then organizes them by base MI.
+///
+/// Expects input sorted by template-coordinate with MI tags already assigned
+/// (output from `group` command).
+pub struct PositionMiGrouper {
+    /// MI tag name (e.g., "MI").
+    mi_tag: Tag,
+    /// Number of position groups per batch.
+    batch_size: usize,
+
+    // Template accumulation (group records by QNAME first)
+    /// Current template name hash being accumulated.
+    current_name_hash: Option<u64>,
+    /// Records for the current template.
+    current_template_records: Vec<RecordBuf>,
+
+    // Position group (using ReadInfoKey computed from template)
+    /// Current `ReadInfoKey` for the position group.
+    current_read_info_key: Option<ReadInfoKey>,
+    /// Records at current position, organized by base MI.
+    current_mi_groups: HashMap<String, Vec<RecordBuf>>,
+    /// Number of templates at current position (for CS family count).
+    current_template_count: usize,
+    /// Total records at current position.
+    current_record_count: usize,
+
+    /// Completed groups waiting to be batched.
+    pending_groups: VecDeque<PositionMiGroup>,
+    /// Whether `finish()` has been called.
+    finished: bool,
+}
+
+impl PositionMiGrouper {
+    /// Create a new `PositionMiGrouper`.
+    ///
+    /// # Arguments
+    /// * `mi_tag_name` - The MI tag name (e.g., "MI")
+    /// * `batch_size` - Number of position groups per batch
+    ///
+    /// # Panics
+    /// Panics if `mi_tag_name` is not exactly 2 characters.
+    #[must_use]
+    pub fn new(mi_tag_name: &str, batch_size: usize) -> Self {
+        assert!(mi_tag_name.len() == 2, "Tag name must be exactly 2 characters");
+        let tag_bytes = mi_tag_name.as_bytes();
+        let mi_tag = Tag::from([tag_bytes[0], tag_bytes[1]]);
+
+        Self {
+            mi_tag,
+            batch_size: batch_size.max(1),
+            current_name_hash: None,
+            current_template_records: Vec::new(),
+            current_read_info_key: None,
+            current_mi_groups: HashMap::new(),
+            current_template_count: 0,
+            current_record_count: 0,
+            pending_groups: VecDeque::new(),
+            finished: false,
+        }
+    }
+
+    /// Extract the MI tag value from a record.
+    fn get_record_mi(&self, record: &RecordBuf) -> Option<String> {
+        if let Some(val) = record.data().get(&self.mi_tag) {
+            use noodles::sam::alignment::record_buf::data::field::Value;
+            if let Value::String(s) = val {
+                return Some(s.to_string());
+            }
+        }
+        None
+    }
+
+    /// Process accumulated template: compute `ReadInfoKey` and add to position group.
+    fn flush_template(&mut self) {
+        if self.current_template_records.is_empty() {
+            return;
+        }
+
+        let records = std::mem::take(&mut self.current_template_records);
+        let read_info_key = ReadInfoKey::from_template_records(&records);
+        self.current_name_hash = None;
+
+        // Skip templates with invalid ReadInfoKey (unpaired, unmapped, etc.)
+        if !read_info_key.is_valid() {
+            return;
+        }
+
+        // Check if position changed
+        if self.current_read_info_key.as_ref() != Some(&read_info_key) {
+            self.flush_current_position_group();
+            self.current_read_info_key = Some(read_info_key);
+        }
+
+        // Extract MI from first record with MI tag
+        let full_mi = records.iter().find_map(|r| self.get_record_mi(r)).unwrap_or_default();
+        let base_mi = extract_mi_base(&full_mi).to_string();
+
+        // Add records to MI group
+        let record_count = records.len();
+        self.current_mi_groups.entry(base_mi).or_default().extend(records);
+        self.current_template_count += 1;
+        self.current_record_count += record_count;
+    }
+
+    /// Flush current position group to pending queue.
+    fn flush_current_position_group(&mut self) {
+        if let Some(key) = self.current_read_info_key.take() {
+            if !self.current_mi_groups.is_empty() || self.current_record_count > 0 {
+                let mi_groups = std::mem::take(&mut self.current_mi_groups);
+                let total_templates = self.current_template_count;
+                let total_records = self.current_record_count;
+                self.current_template_count = 0;
+                self.current_record_count = 0;
+
+                self.pending_groups.push_back(PositionMiGroup {
+                    read_info_key: key,
+                    mi_groups,
+                    total_templates,
+                    total_records,
+                });
+            }
+        }
+    }
+
+    /// Try to form complete batches from pending groups.
+    fn drain_batches(&mut self) -> Vec<PositionMiGroupBatch> {
+        let mut batches = Vec::new();
+        while self.pending_groups.len() >= self.batch_size {
+            let groups: Vec<PositionMiGroup> =
+                self.pending_groups.drain(..self.batch_size).collect();
+            batches.push(PositionMiGroupBatch { groups });
+        }
+        batches
+    }
+}
+
+impl Grouper for PositionMiGrouper {
+    type Group = PositionMiGroupBatch;
+
+    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
+        for decoded in records {
+            let record = decoded.record;
+            let key = decoded.key;
+
+            // Skip secondary and supplementary reads
+            let flags = record.flags();
+            if flags.is_secondary() || flags.is_supplementary() {
+                continue;
+            }
+
+            // Check if same template (by name hash)
+            if self.current_name_hash != Some(key.name_hash) {
+                // New template - flush previous
+                self.flush_template();
+                self.current_name_hash = Some(key.name_hash);
+            }
+
+            self.current_template_records.push(record);
+        }
+
+        Ok(self.drain_batches())
+    }
+
+    fn finish(&mut self) -> io::Result<Option<Self::Group>> {
+        if self.finished {
+            return Ok(None);
+        }
+        self.finished = true;
+
+        // Flush any remaining template
+        self.flush_template();
+
+        // Flush any remaining position group
+        self.flush_current_position_group();
+
+        // Return remaining groups as final batch
+        if self.pending_groups.is_empty() {
+            Ok(None)
+        } else {
+            let groups: Vec<PositionMiGroup> = self.pending_groups.drain(..).collect();
+            Ok(Some(PositionMiGroupBatch { groups }))
+        }
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.current_template_records.is_empty()
+            || !self.current_mi_groups.is_empty()
+            || !self.pending_groups.is_empty()
+    }
+}
+
+// ============================================================================
 // FASTQ Record Parsing Utilities
 // ============================================================================
 

--- a/src/lib/metrics/duplex.rs
+++ b/src/lib/metrics/duplex.rs
@@ -1,9 +1,13 @@
-//! Metrics for the `duplex_metrics` command.
+//! Metrics for duplex sequencing QC.
 //!
 //! This module provides comprehensive QC metrics for duplex sequencing experiments,
 //! including family size distributions, UMI frequencies, and duplex yield at multiple
 //! sampling levels.
+//!
+//! Used by both `duplex` and `duplex-metrics` commands.
 
+use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
+use crate::umi::extract_mi_base;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -361,6 +365,42 @@ impl DuplexMetricsCollector {
         }
     }
 
+    /// Merge another collector's metrics into this one.
+    ///
+    /// Used for aggregating metrics from parallel batch processing.
+    pub fn merge(&mut self, other: &Self) {
+        for (size, count) in &other.cs_family_sizes {
+            *self.cs_family_sizes.entry(*size).or_insert(0) += count;
+        }
+        for (size, count) in &other.ss_family_sizes {
+            *self.ss_family_sizes.entry(*size).or_insert(0) += count;
+        }
+        for (size, count) in &other.ds_family_sizes {
+            *self.ds_family_sizes.entry(*size).or_insert(0) += count;
+        }
+        for (sizes, count) in &other.duplex_family_sizes {
+            *self.duplex_family_sizes.entry(*sizes).or_insert(0) += count;
+        }
+        for (umi, count) in &other.umi_raw_counts {
+            *self.umi_raw_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+        for (umi, count) in &other.umi_raw_error_counts {
+            *self.umi_raw_error_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+        for (umi, count) in &other.umi_unique_counts {
+            *self.umi_unique_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+        for (umi, count) in &other.duplex_umi_raw_counts {
+            *self.duplex_umi_raw_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+        for (umi, count) in &other.duplex_umi_raw_error_counts {
+            *self.duplex_umi_raw_error_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+        for (umi, count) in &other.duplex_umi_unique_counts {
+            *self.duplex_umi_unique_counts.entry(umi.clone()).or_insert(0) += count;
+        }
+    }
+
     /// Records a duplex UMI observation
     ///
     /// # Arguments
@@ -382,6 +422,194 @@ impl DuplexMetricsCollector {
         *self.duplex_umi_raw_error_counts.entry(umi.to_string()).or_insert(0) += error_count;
         if is_unique {
             *self.duplex_umi_unique_counts.entry(umi.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    /// Updates UMI metrics for a duplex family.
+    ///
+    /// This method:
+    /// 1. Uses RX tags (raw UMI sequences) to extract individual UMI observations
+    /// 2. Separates by strand (/A and /B suffixes in MI tags), swapping UMI parts for B strand
+    /// 3. Calls consensus for each UMI position
+    /// 4. Records raw observations, errors, and unique observations for each individual UMI
+    /// 5. Records duplex UMI metrics if enabled
+    ///
+    /// # Arguments
+    /// * `umi_consensus_caller` - Caller for computing UMI consensus sequences
+    /// * `mi_rx_pairs` - Pairs of (MI tag value, RX tag value) for each read in the family
+    /// * `base_mi` - The base MI (without /A or /B suffix) for this family
+    pub fn update_umi_metrics_for_family(
+        &mut self,
+        umi_consensus_caller: &mut SimpleUmiConsensusCaller,
+        mi_rx_pairs: &[(String, String)],
+        base_mi: &str,
+    ) {
+        // Collect individual UMI parts from each strand's RX tag
+        // For /A strand: split RX "AAA-TTT" → umi1s += "AAA", umi2s += "TTT"
+        // For /B strand: split RX "TTT-AAA" → umi1s += "AAA", umi2s += "TTT" (swapped)
+        let mut umi1s = Vec::new();
+        let mut umi2s = Vec::new();
+
+        for (mi, rx) in mi_rx_pairs {
+            // Check if this MI tag belongs to the current base_mi family
+            let mi_base = extract_mi_base(mi);
+
+            if mi_base != base_mi {
+                continue;
+            }
+
+            // Split the RX tag to get individual UMI parts
+            let parts: Vec<&str> = rx.split('-').collect();
+            if parts.len() != 2 {
+                // Not a valid duplex UMI, skip
+                continue;
+            }
+
+            // Check that both components are non-empty
+            if parts[0].is_empty() || parts[1].is_empty() {
+                // Empty component, skip
+                continue;
+            }
+
+            // Add UMI parts based on strand
+            if mi.ends_with("/A") {
+                // For /A strand: u1 goes to umi1s, u2 goes to umi2s
+                umi1s.push(parts[0].to_string());
+                umi2s.push(parts[1].to_string());
+            } else if mi.ends_with("/B") {
+                // For /B strand: u2 goes to umi1s, u1 goes to umi2s (swapped)
+                umi1s.push(parts[1].to_string());
+                umi2s.push(parts[0].to_string());
+            }
+        }
+
+        // Call consensus for each UMI position and record metrics
+        let mut consensus_umis = Vec::new();
+
+        if !umi1s.is_empty() {
+            let (consensus, _had_errors) = umi_consensus_caller.consensus(&umi1s);
+            let raw_count = umi1s.len();
+            let error_count = umi1s.iter().filter(|u| **u != consensus).count();
+            self.record_umi(&consensus, raw_count, error_count, true);
+            consensus_umis.push(consensus);
+        }
+
+        if !umi2s.is_empty() {
+            let (consensus, _had_errors) = umi_consensus_caller.consensus(&umi2s);
+            let raw_count = umi2s.len();
+            let error_count = umi2s.iter().filter(|u| **u != consensus).count();
+            self.record_umi(&consensus, raw_count, error_count, true);
+            consensus_umis.push(consensus);
+        }
+
+        // Record duplex UMI metrics if enabled
+        if self.collect_duplex_umi_counts && consensus_umis.len() == 2 {
+            let duplex_umi = format!("{}-{}", consensus_umis[0], consensus_umis[1]);
+            // Each read pair contributes one observation to the duplex UMI
+            let total_raw = umi1s.len();
+
+            // Count how many raw RX tags had errors (don't match either duplex orientation)
+            let expected_duplex1 = format!("{}-{}", consensus_umis[0], consensus_umis[1]);
+            let expected_duplex2 = format!("{}-{}", consensus_umis[1], consensus_umis[0]);
+            let error_count = mi_rx_pairs
+                .iter()
+                .filter(|(mi, rx)| {
+                    let mi_base = extract_mi_base(mi);
+                    mi_base == base_mi && *rx != expected_duplex1 && *rx != expected_duplex2
+                })
+                .count();
+
+            self.record_duplex_umi(&duplex_umi, total_raw, error_count, true);
+        }
+    }
+
+    /// Updates UMI metrics using the consensus UMI from the main caller's output.
+    ///
+    /// This method takes the consensus UMI that was already computed by `DuplexConsensusCaller`
+    /// and compares it against the raw UMI observations to count errors.
+    ///
+    /// # Arguments
+    /// * `consensus_rx` - The consensus UMI from the output read's RX tag (e.g., "AAT-CCG")
+    /// * `strand_rx_pairs` - Raw UMI observations: (`is_a_strand`, `rx_bytes`) for each read
+    pub fn update_umi_metrics_from_consensus(
+        &mut self,
+        consensus_rx: &[u8],
+        strand_rx_pairs: &[(bool, Vec<u8>)],
+    ) {
+        // Parse consensus UMI into two parts
+        let Some(consensus_sep) = consensus_rx.iter().position(|&b| b == b'-') else {
+            return;
+        };
+        let consensus_umi1 = &consensus_rx[..consensus_sep];
+        let consensus_umi2 = &consensus_rx[consensus_sep + 1..];
+
+        if consensus_umi1.is_empty() || consensus_umi2.is_empty() {
+            return;
+        }
+
+        // Count raw observations and errors for each UMI position
+        let mut umi1_count = 0usize;
+        let mut umi1_errors = 0usize;
+        let mut umi2_count = 0usize;
+        let mut umi2_errors = 0usize;
+
+        for (is_a_strand, rx) in strand_rx_pairs {
+            // Split raw RX tag
+            let Some(sep_pos) = rx.iter().position(|&b| b == b'-') else {
+                continue;
+            };
+            let part1 = &rx[..sep_pos];
+            let part2 = &rx[sep_pos + 1..];
+
+            if part1.is_empty() || part2.is_empty() {
+                continue;
+            }
+
+            // Normalize by strand (B strand is swapped)
+            let (raw_umi1, raw_umi2) = if *is_a_strand { (part1, part2) } else { (part2, part1) };
+
+            // Count UMI1
+            umi1_count += 1;
+            if raw_umi1 != consensus_umi1 {
+                umi1_errors += 1;
+            }
+
+            // Count UMI2
+            umi2_count += 1;
+            if raw_umi2 != consensus_umi2 {
+                umi2_errors += 1;
+            }
+        }
+
+        // Record metrics for each UMI position
+        if umi1_count > 0 {
+            let umi1_str = String::from_utf8_lossy(consensus_umi1);
+            self.record_umi(&umi1_str, umi1_count, umi1_errors, true);
+        }
+        if umi2_count > 0 {
+            let umi2_str = String::from_utf8_lossy(consensus_umi2);
+            self.record_umi(&umi2_str, umi2_count, umi2_errors, true);
+        }
+
+        // Record duplex UMI metrics if enabled
+        if self.collect_duplex_umi_counts && umi1_count > 0 && umi2_count > 0 {
+            let duplex_umi = String::from_utf8_lossy(consensus_rx);
+            // Count errors: raw RX doesn't match consensus in either orientation
+            let reversed_consensus: Vec<u8> = consensus_umi2
+                .iter()
+                .chain(std::iter::once(&b'-'))
+                .chain(consensus_umi1.iter())
+                .copied()
+                .collect();
+
+            let duplex_errors = strand_rx_pairs
+                .iter()
+                .filter(|(_, rx)| {
+                    rx.as_slice() != consensus_rx && rx.as_slice() != reversed_consensus.as_slice()
+                })
+                .count();
+
+            self.record_duplex_umi(&duplex_umi, umi1_count, duplex_errors, true);
         }
     }
 
@@ -568,6 +796,259 @@ impl DuplexMetricsCollector {
     #[must_use]
     pub fn yield_metrics(&self) -> &[DuplexYieldMetric] {
         &self.yield_metrics
+    }
+}
+
+// ============================================================================
+// Ideal Duplex Fraction Calculation - Shared binomial model
+// ============================================================================
+
+use statrs::distribution::{Binomial, DiscreteCDF};
+
+/// Calculates the ideal duplex fraction using binomial model.
+///
+/// For each family of size N, calculates the probability that both strands
+/// have sufficient reads (A >= `min_ab` AND B >= `min_ba` where A + B = N).
+/// Assumes each read has 0.5 probability of being on each strand.
+///
+/// # Arguments
+///
+/// * `family_sizes` - Slice of DS family sizes
+/// * `min_ab` - Minimum reads required on AB strand
+/// * `min_ba` - Minimum reads required on BA strand
+///
+/// # Returns
+///
+/// Expected fraction of DS families that should be duplexes under ideal model.
+#[must_use]
+pub fn calculate_ideal_duplex_fraction(
+    family_sizes: &[usize],
+    min_ab: usize,
+    min_ba: usize,
+) -> f64 {
+    if family_sizes.is_empty() {
+        return 0.0;
+    }
+
+    let mut ideal_duplexes = 0.0;
+    let total_families = family_sizes.len() as f64;
+
+    for &size in family_sizes {
+        if size < min_ab + min_ba {
+            // Impossible to form a duplex with this family size
+            continue;
+        }
+
+        // Calculate P(A >= min_ab AND B >= min_ba) where A ~ Binomial(n=size, p=0.5)
+        // and B = size - A
+        //
+        // This is equivalent to: P(min_ba <= A <= size - min_ab)
+        // = P(A <= size - min_ab) - P(A < min_ba)
+        // = CDF(size - min_ab) - CDF(min_ba - 1)
+
+        let Ok(binomial) = Binomial::new(0.5, size as u64) else { continue };
+
+        let upper_bound = size - min_ba;
+        let lower_bound = min_ab;
+
+        // P(A >= lower_bound AND A <= upper_bound)
+        let prob = if upper_bound >= lower_bound {
+            let p_upper = binomial.cdf(upper_bound as u64);
+            let p_lower =
+                if lower_bound > 0 { binomial.cdf((lower_bound - 1) as u64) } else { 0.0 };
+            p_upper - p_lower
+        } else {
+            0.0
+        };
+
+        ideal_duplexes += prob;
+    }
+
+    ideal_duplexes / total_families
+}
+
+// ============================================================================
+// Metrics Writer - Shared logic for writing duplex metrics files
+// ============================================================================
+
+use std::sync::OnceLock;
+
+/// Embedded R script for PDF plot generation (bundled with binary)
+const R_SCRIPT: &str = include_str!("../../../resources/CollectDuplexSeqMetrics.R");
+
+/// Cached R availability check (computed once per process)
+static R_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+/// Writer for duplex metrics files.
+///
+/// This struct provides shared logic for writing metrics files from both
+/// the `duplex` and `duplex-metrics` commands.
+pub struct DuplexMetricsWriter<'a> {
+    /// Output prefix for metrics files
+    prefix: &'a std::path::Path,
+    /// Optional description for PDF plots
+    description: Option<&'a str>,
+}
+
+impl<'a> DuplexMetricsWriter<'a> {
+    /// Create a new metrics writer with the given output prefix.
+    #[must_use]
+    pub fn new(prefix: &'a std::path::Path) -> Self {
+        Self { prefix, description: None }
+    }
+
+    /// Set the description for PDF plot titles.
+    #[must_use]
+    pub fn with_description(mut self, description: Option<&'a str>) -> Self {
+        self.description = description;
+        self
+    }
+
+    /// Write all metrics files from a collector.
+    ///
+    /// Writes:
+    /// - `PREFIX.family_sizes.txt`
+    /// - `PREFIX.duplex_family_sizes.txt`
+    /// - `PREFIX.duplex_yield_metrics.txt`
+    /// - `PREFIX.umi_counts.txt`
+    /// - `PREFIX.duplex_qc.pdf` (if R is available)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any file cannot be written.
+    pub fn write_all(
+        &self,
+        collector: &DuplexMetricsCollector,
+        yield_metrics: &[DuplexYieldMetric],
+    ) -> anyhow::Result<()> {
+        use anyhow::Context;
+        use fgoxide::io::DelimFile;
+        use log::info;
+
+        // Write family_sizes.txt
+        let family_size_metrics = collector.family_size_metrics();
+        let family_size_path = format!("{}.family_sizes.txt", self.prefix.display());
+        DelimFile::default()
+            .write_tsv(&family_size_path, family_size_metrics)
+            .with_context(|| format!("Failed to write family size metrics: {family_size_path}"))?;
+        info!("Wrote family size metrics to {family_size_path}");
+
+        // Write duplex_family_sizes.txt
+        let duplex_family_size_metrics = collector.duplex_family_size_metrics();
+        let duplex_family_size_path = format!("{}.duplex_family_sizes.txt", self.prefix.display());
+        DelimFile::default()
+            .write_tsv(&duplex_family_size_path, duplex_family_size_metrics)
+            .with_context(|| {
+                format!("Failed to write duplex family size metrics: {duplex_family_size_path}")
+            })?;
+        info!("Wrote duplex family size metrics to {duplex_family_size_path}");
+
+        // Write umi_counts.txt
+        let umi_metrics = collector.umi_metrics();
+        let umi_path = format!("{}.umi_counts.txt", self.prefix.display());
+        DelimFile::default()
+            .write_tsv(&umi_path, umi_metrics.clone())
+            .with_context(|| format!("Failed to write UMI metrics: {umi_path}"))?;
+        info!("Wrote UMI metrics to {umi_path}");
+
+        // Write duplex_yield_metrics.txt
+        let yield_path = format!("{}.duplex_yield_metrics.txt", self.prefix.display());
+        DelimFile::default()
+            .write_tsv(&yield_path, yield_metrics.to_vec())
+            .with_context(|| format!("Failed to write yield metrics: {yield_path}"))?;
+        info!("Wrote yield metrics to {yield_path}");
+
+        // Generate PDF plots using R script (optional)
+        let pdf_path = format!("{}.duplex_qc.pdf", self.prefix.display());
+        if Self::is_r_available() {
+            let description = self.description.unwrap_or("Sample");
+            match Self::execute_r_script(
+                &family_size_path,
+                &duplex_family_size_path,
+                &yield_path,
+                &umi_path,
+                &pdf_path,
+                description,
+            ) {
+                Ok(()) => info!("Generated PDF plots: {pdf_path}"),
+                Err(e) => {
+                    log::warn!("Failed to generate PDF plots: {e}. Continuing without plots.");
+                    log::warn!(
+                        "To enable PDF generation, ensure R is installed with ggplot2 and scales packages:"
+                    );
+                    log::warn!("  install.packages(c(\"ggplot2\", \"scales\"))");
+                }
+            }
+        } else {
+            log::warn!(
+                "R or required packages (ggplot2, scales) not available. Skipping PDF generation."
+            );
+            log::warn!("To enable PDF generation, install R and required packages:");
+            log::warn!("  install.packages(c(\"ggplot2\", \"scales\"))");
+        }
+
+        Ok(())
+    }
+
+    /// Checks if R and required packages (ggplot2, scales) are available.
+    /// Result is cached for the lifetime of the process.
+    fn is_r_available() -> bool {
+        use std::process::Command;
+
+        *R_AVAILABLE.get_or_init(|| {
+            Command::new("Rscript")
+                .args(["-e", "stopifnot(require(ggplot2)); stopifnot(require(scales))"])
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        })
+    }
+
+    /// Executes the R script to generate PDF plots.
+    fn execute_r_script(
+        family_size_path: &str,
+        duplex_family_size_path: &str,
+        yield_path: &str,
+        umi_path: &str,
+        pdf_path: &str,
+        description: &str,
+    ) -> anyhow::Result<()> {
+        use anyhow::Context;
+        use log::info;
+        use std::process::Command;
+
+        // Write embedded R script to temp file
+        let temp_dir = std::env::temp_dir();
+        let r_script_path = temp_dir.join("fgumi_CollectDuplexSeqMetrics.R");
+        std::fs::write(&r_script_path, R_SCRIPT)
+            .context("Failed to write embedded R script to temp file")?;
+
+        info!("Executing R script to generate PDF plots...");
+
+        let output = Command::new("Rscript")
+            .arg(&r_script_path)
+            .arg(family_size_path)
+            .arg(duplex_family_size_path)
+            .arg(yield_path)
+            .arg(umi_path)
+            .arg(pdf_path)
+            .arg(description)
+            .output()
+            .context("Failed to execute Rscript command")?;
+
+        // Clean up temp file (ignore errors)
+        let _ = std::fs::remove_file(&r_script_path);
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "R script execution failed with exit code {:?}. Error: {}",
+                output.status.code(),
+                stderr
+            )
+        }
     }
 }
 

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -418,19 +418,21 @@ impl MemoryEstimate for MiGroupBatch {
 pub struct MiGroupBatch {
     /// The MI groups in this batch
     pub groups: Vec<MiGroup>,
+    /// CS family sizes collected during grouping (only populated if CS tracking is enabled)
+    pub cs_family_sizes: Vec<usize>,
 }
 
 impl MiGroupBatch {
     /// Creates a new empty MI group batch.
     #[must_use]
     pub fn new() -> Self {
-        Self { groups: Vec::new() }
+        Self { groups: Vec::new(), cs_family_sizes: Vec::new() }
     }
 
     /// Creates a new MI group batch with pre-allocated capacity.
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self { groups: Vec::with_capacity(capacity) }
+        Self { groups: Vec::with_capacity(capacity), cs_family_sizes: Vec::new() }
     }
 
     /// Returns the number of groups in the batch.
@@ -500,6 +502,9 @@ type MiTransformFn = Box<dyn Fn(&str) -> String + Send + Sync>;
 ///     |mi| extract_mi_base(mi).to_string(),   // transform function
 /// );
 /// ```
+/// Coordinate key type for CS family tracking (ref1, pos1, strand1, ref2, pos2, strand2)
+pub type CoordinateKey = (i32, i32, u8, i32, i32, u8);
+
 pub struct MiGrouper {
     /// The MI tag to group by (e.g., "MI")
     tag: Tag,
@@ -517,6 +522,14 @@ pub struct MiGrouper {
     record_filter: Option<RecordFilterFn>,
     /// Optional MI tag transformation function
     mi_transform: Option<MiTransformFn>,
+    /// Whether to track CS (Coordinate & Strand) families
+    track_cs_families: bool,
+    /// Current coordinate being tracked for CS families
+    current_coordinate: Option<CoordinateKey>,
+    /// Count of templates at current coordinate
+    current_cs_count: usize,
+    /// CS family sizes collected during grouping
+    pending_cs_sizes: Vec<usize>,
 }
 
 impl MiGrouper {
@@ -544,7 +557,21 @@ impl MiGrouper {
             finished: false,
             record_filter: None,
             mi_transform: None,
+            track_cs_families: false,
+            current_coordinate: None,
+            current_cs_count: 0,
+            pending_cs_sizes: Vec::new(),
         }
+    }
+
+    /// Enable CS (Coordinate & Strand) family tracking.
+    ///
+    /// When enabled, the grouper will track consecutive coordinates and
+    /// count CS families. The counts are returned in `MiGroupBatch::cs_family_sizes`.
+    #[must_use]
+    pub fn with_cs_tracking(mut self) -> Self {
+        self.track_cs_families = true;
+        self
     }
 
     /// Create a `MiGrouper` with record filtering and MI tag transformation.
@@ -585,6 +612,10 @@ impl MiGrouper {
             finished: false,
             record_filter: Some(Box::new(record_filter)),
             mi_transform: Some(Box::new(mi_transform)),
+            track_cs_families: false,
+            current_coordinate: None,
+            current_cs_count: 0,
+            pending_cs_sizes: Vec::new(),
         }
     }
 
@@ -627,7 +658,9 @@ impl MiGrouper {
         let mut batches = Vec::new();
         while self.pending_groups.len() >= self.batch_size {
             let groups: Vec<MiGroup> = self.pending_groups.drain(..self.batch_size).collect();
-            batches.push(MiGroupBatch { groups });
+            // Move CS sizes to batch (they correspond to coordinates seen while building these groups)
+            let cs_family_sizes = std::mem::take(&mut self.pending_cs_sizes);
+            batches.push(MiGroupBatch { groups, cs_family_sizes });
         }
         batches
     }
@@ -639,9 +672,41 @@ impl Grouper for MiGrouper {
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
         for decoded in records {
             let record = decoded.record;
+            let key = decoded.key;
+
             // Apply record filter if configured - skip records that don't pass
             if !self.should_keep(&record) {
                 continue;
+            }
+
+            // Track CS families if enabled (for R1 primaries with valid coordinates)
+            if self.track_cs_families {
+                let flags = record.flags();
+                let is_r1_primary =
+                    flags.is_first_segment() && !flags.is_secondary() && !flags.is_supplementary();
+
+                if is_r1_primary && key.is_valid_paired() {
+                    let coord = key.coordinate_key();
+                    match &self.current_coordinate {
+                        Some(current) if *current == coord => {
+                            // Same coordinate, increment count
+                            self.current_cs_count += 1;
+                        }
+                        Some(_) => {
+                            // Different coordinate, record current and start new
+                            if self.current_cs_count > 0 {
+                                self.pending_cs_sizes.push(self.current_cs_count);
+                            }
+                            self.current_coordinate = Some(coord);
+                            self.current_cs_count = 1;
+                        }
+                        None => {
+                            // First coordinate
+                            self.current_coordinate = Some(coord);
+                            self.current_cs_count = 1;
+                        }
+                    }
+                }
             }
 
             // Get MI tag from record (with optional transformation)
@@ -680,12 +745,20 @@ impl Grouper for MiGrouper {
         // Flush any remaining current group
         self.flush_current_group();
 
+        // Flush final CS count if tracking
+        if self.track_cs_families && self.current_cs_count > 0 {
+            self.pending_cs_sizes.push(self.current_cs_count);
+            self.current_cs_count = 0;
+            self.current_coordinate = None;
+        }
+
         // Return any remaining groups as final batch
-        if self.pending_groups.is_empty() {
+        if self.pending_groups.is_empty() && self.pending_cs_sizes.is_empty() {
             Ok(None)
         } else {
             let groups: Vec<MiGroup> = self.pending_groups.drain(..).collect();
-            Ok(Some(MiGroupBatch { groups }))
+            let cs_family_sizes = std::mem::take(&mut self.pending_cs_sizes);
+            Ok(Some(MiGroupBatch { groups, cs_family_sizes }))
         }
     }
 

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -927,6 +927,21 @@ impl GroupKey {
             self.cell_hash,
         )
     }
+
+    /// Returns the coordinate-only key for CS family counting.
+    ///
+    /// This groups by genomic position only (R1 + R2 unclipped 5' positions and strands),
+    /// ignoring library, cell, and name. Used for Coordinate & Strand (CS) family metrics.
+    #[must_use]
+    pub fn coordinate_key(&self) -> (i32, i32, u8, i32, i32, u8) {
+        (self.ref_id1, self.pos1, self.strand1, self.ref_id2, self.pos2, self.strand2)
+    }
+
+    /// Returns true if this represents a valid paired-end coordinate.
+    #[must_use]
+    pub fn is_valid_paired(&self) -> bool {
+        self.ref_id1 != Self::UNKNOWN_REF && self.ref_id2 != Self::UNKNOWN_REF
+    }
 }
 
 impl PartialOrd for GroupKey {


### PR DESCRIPTION
## Summary

- Add `--metrics-output <PREFIX>` flag to collect family size metrics during consensus calling
- Eliminates the need to run `duplex-metrics` separately for basic family size distributions
- Add `PositionMiGrouper` for position-based grouping with MI sub-groups
- Auto-enables 4 threads when metrics requested without explicit `--threads` flag

## Performance

Benchmarked on 5GB BAM file (~27M read pairs):

| Scenario | Time | Overhead |
|----------|------|----------|
| Baseline (8 threads) | 46.8s | - |
| With metrics (8 threads) | 48.6s | +1.8s (~4%) |

**No regression when `--metrics-output` is not specified.**

## Output Files

- `{prefix}.family_sizes.txt` - CS, SS, DS family size distributions
- `{prefix}.duplex_family_sizes.txt` - AB x BA duplex family size matrix

## Test plan

- [x] Verify no performance regression without `--metrics-output`
- [x] Verify metrics files are generated correctly
- [x] Verify BAM output is identical with and without metrics
- [x] All existing tests pass
- [ ] Add unit tests for `PositionMiGrouper`