### PR TITLE
fix: Use cargo-audit directly to avoid PR annotation permission errors

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,8 +16,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Set up compilation cache (sccache)
-        uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run security audit
+        run: cargo audit


### PR DESCRIPTION
## Summary

The `rustsec/audit-check` action tries to create GitHub check annotations, which requires write permissions that dependabot PRs don't have. This causes the audit to fail with:

```
Resource not accessible by integration
```

This PR switches to running `cargo audit` directly, which:
- Still fails the build on security vulnerabilities
- Works with dependabot's limited permissions
- Removes the unnecessary sccache step (cargo-audit doesn't benefit from it)

## Test plan

- [ ] CI passes on this PR
- [ ] Dependabot PRs should now pass the security audit check