### PR TITLE
fix: match samtools coordinate sort (no name tie-breaking)

### DIFF
--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -587,7 +587,7 @@ impl RawExternalSorter {
                     self.threads,
                 )?;
                 for r in buffer.refs() {
-                    let key = RawCoordinateKey { sort_key: r.sort_key, name_hash: r.name_hash };
+                    let key = RawCoordinateKey { sort_key: r.sort_key };
                     let record_bytes = buffer.get_record(r);
                     writer.write_record(&key, record_bytes)?;
                 }
@@ -639,7 +639,7 @@ impl RawExternalSorter {
                     .refs()
                     .iter()
                     .map(|r| {
-                        let key = RawCoordinateKey { sort_key: r.sort_key, name_hash: r.name_hash };
+                        let key = RawCoordinateKey { sort_key: r.sort_key };
                         let record_bytes = buffer.get_record(r).to_vec();
                         (key, record_bytes)
                     })
@@ -712,7 +712,7 @@ impl RawExternalSorter {
                     self.threads,
                 )?;
                 for r in buffer.refs() {
-                    let key = RawCoordinateKey { sort_key: r.sort_key, name_hash: r.name_hash };
+                    let key = RawCoordinateKey { sort_key: r.sort_key };
                     let record_bytes = buffer.get_record(r);
                     writer.write_record(&key, record_bytes)?;
                 }
@@ -771,7 +771,7 @@ impl RawExternalSorter {
                     .refs()
                     .iter()
                     .map(|r| {
-                        let key = RawCoordinateKey { sort_key: r.sort_key, name_hash: r.name_hash };
+                        let key = RawCoordinateKey { sort_key: r.sort_key };
                         let record_bytes = buffer.get_record(r).to_vec();
                         (key, record_bytes)
                     })


### PR DESCRIPTION
## Summary

Remove read name/hash tie-breaking from coordinate sort to match samtools behavior. Samtools relies on stable sort to maintain input order for records with equal keys (tid, pos, reverse).

## Changes

- `CoordinateKey`: Remove `name` field
- `RawCoordinateKey`: Remove `name_hash` field (now 8 bytes instead of 16)
- `RecordRef`: Remove `name_hash` field  
- `InlineHeader`: Remove `name_hash` field (now 16 bytes instead of 24)
- Use stable sort (`sort()` instead of `sort_unstable()`)
- Remove `extract_coordinate_key_inline` name hashing

## Details

Samtools' `bam1_cmp_core()` for coordinate sort compares only:
1. tid (reference ID)
2. pos+1 (position)
3. bam_is_rev (reverse strand flag)

If all three are equal, samtools returns 0 (equal) and relies on stable sort to maintain input order. Previously, fgumi used a name hash for tie-breaking which caused unmapped reads (all with equal keys) to be reordered differently than samtools.

## Test plan
- [x] All 81 sort module tests pass
- [x] Verified fgumi coordinate sort output matches samtools (200 records, 0 differences)