### PR TITLE
fix(extract): preserve input order in parallel synchronized mode

### DIFF
--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -2518,10 +2518,10 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
                 }
 
                 let count = templates.len();
-                // Use atomic serial assignment (no lock needed!)
-                // Note: Serial order may differ from input order due to parallel completion,
-                // but this is acceptable for unmapped BAM output where record order is irrelevant.
-                let template_serial = state.next_template_serial.fetch_add(1, Ordering::Relaxed);
+                // Use the original batch serial to preserve input order.
+                // The downstream reorder buffer will ensure batches are written in order
+                // even if they complete out-of-order due to parallel processing.
+                let template_serial = serial;
 
                 // Push templates directly to Q3 with spin-wait
                 let mut templates_to_push = templates;


### PR DESCRIPTION
## Summary
- Fix output ordering bug in `fgumi extract` when running with multiple threads
- The parallel parse step was using an atomic counter to assign template serials, which caused batches to be ordered by completion time rather than input order
- This resulted in output BAM files with reads out of order compared to the input FASTQs (~1.4% of reads affected in large datasets)

## Root Cause
In synchronized mode (used by extract), the parse step processes batches in parallel without a mutex. When multiple threads complete parsing simultaneously, the `next_template_serial.fetch_add()` atomic counter assigns serials in completion order, not input order.

For example, if thread A is processing batch 5 and thread B is processing batch 6, whichever thread reaches the atomic counter first gets serial 0, regardless of which batch they have.

## Fix
Use the original batch serial from the boundary finding step instead of the atomic counter. This serial was assigned sequentially during the read step and preserved through the boundary finding reorder buffer, so it correctly reflects input order.

The downstream write reorder buffer will ensure batches are written in the correct order even if they complete out-of-order due to parallel processing.

## Test plan
- [x] Existing unit test `test_multithreaded_extraction_preserves_order` passes
- [ ] Run AWS Batch benchmark to verify fgumi extract output matches fgbio FastqToBam