### PR TITLE
fix(group): handle empty umi_counts in AdjacencyUmiAssigner

### DIFF
--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -196,30 +196,27 @@ pub fn log_umi_grouping_summary(metrics: &UmiGroupingMetrics) {
         log::info!("  Max reads/molecule: {}", metrics.max_reads_per_molecule);
     }
 
-    // Log discard reasons if any
-    let total_discarded = metrics.discarded_non_pf
-        + metrics.discarded_poor_alignment
-        + metrics.discarded_ns_in_umi
-        + metrics.discarded_umi_too_short
-        + metrics.discarded_duplicate_umi;
-
-    if total_discarded > 0 {
-        log::info!("  Discard reasons:");
-        if metrics.discarded_non_pf > 0 {
-            log::info!("    Non-PF: {}", format_count(metrics.discarded_non_pf));
-        }
-        if metrics.discarded_poor_alignment > 0 {
-            log::info!("    Poor alignment: {}", format_count(metrics.discarded_poor_alignment));
-        }
-        if metrics.discarded_ns_in_umi > 0 {
-            log::info!("    Ns in UMI: {}", format_count(metrics.discarded_ns_in_umi));
-        }
-        if metrics.discarded_umi_too_short > 0 {
-            log::info!("    UMI too short: {}", format_count(metrics.discarded_umi_too_short));
-        }
-        if metrics.discarded_duplicate_umi > 0 {
-            log::info!("    Duplicate UMI: {}", format_count(metrics.discarded_duplicate_umi));
-        }
+    // Log filter counts (matching fgbio's logging style)
+    // Non-PF only logged if > 0
+    if metrics.discarded_non_pf > 0 {
+        log::info!("Filtered out {} non-PF records.", format_count(metrics.discarded_non_pf));
+    }
+    // Poor alignment always logged (like fgbio)
+    log::info!(
+        "Filtered out {} records due to mapping issues.",
+        format_count(metrics.discarded_poor_alignment)
+    );
+    // Ns in UMI always logged (like fgbio)
+    log::info!(
+        "Filtered out {} records that contained one or more Ns in their UMIs.",
+        format_count(metrics.discarded_ns_in_umi)
+    );
+    // UMI too short only logged if > 0
+    if metrics.discarded_umi_too_short > 0 {
+        log::info!(
+            "Filtered out {} records that contained UMIs that were too short.",
+            format_count(metrics.discarded_umi_too_short)
+        );
     }
 }
 

--- a/src/lib/metrics/group.rs
+++ b/src/lib/metrics/group.rs
@@ -31,9 +31,6 @@ pub struct UmiGroupingMetrics {
     /// Records discarded (UMI too short)
     pub discarded_umi_too_short: u64,
 
-    /// Records discarded (duplicate UMI at same position)
-    pub discarded_duplicate_umi: u64,
-
     /// Number of unique molecule IDs assigned
     pub unique_molecule_ids: u64,
 
@@ -64,7 +61,6 @@ impl UmiGroupingMetrics {
             discarded_poor_alignment: 0,
             discarded_ns_in_umi: 0,
             discarded_umi_too_short: 0,
-            discarded_duplicate_umi: 0,
             unique_molecule_ids: 0,
             total_families: 0,
             avg_reads_per_molecule: 0.0,
@@ -101,7 +97,6 @@ impl super::ProcessingMetrics for UmiGroupingMetrics {
             + self.discarded_poor_alignment
             + self.discarded_ns_in_umi
             + self.discarded_umi_too_short
-            + self.discarded_duplicate_umi
     }
 }
 

--- a/src/lib/umi/assigner.rs
+++ b/src/lib/umi/assigner.rs
@@ -1532,6 +1532,11 @@ impl UmiAssigner for AdjacencyUmiAssigner {
             counts.into_iter().map(|(enc, (count, idx))| (enc, count, idx)).collect()
         };
 
+        // Handle case where all UMIs had invalid characters
+        if umi_counts.is_empty() {
+            return vec![MoleculeId::None; raw_umis.len()];
+        }
+
         #[cfg(feature = "profile-adjacency")]
         let t_after_count = std::time::Instant::now();
 


### PR DESCRIPTION
## Summary

- Fix panic in `AdjacencyUmiAssigner::assign()` when all UMIs in a position group contain invalid characters
- Align UMI validation behavior with fgbio's `GroupReadsByUmi`
- Match fgbio's logging style for filter counts
- Refactor UMI validation into shared code used by both `group` and `dedup` commands

## Bug Fix

When all UMIs in a group contain characters that `BitEnc::from_umi_str()` cannot encode (e.g., 'N' for ambiguous bases), they are silently skipped during encoding. This leaves `umi_counts` empty, causing an "index out of bounds" panic when the code later accesses `umi_counts[0]`.

**Solution:** Add an early return when `umi_counts` is empty, returning `MoleculeId::None` for all inputs.

## fgbio Compatibility

Aligned UMI validation with fgbio's exact behavior:

| Character | fgbio | fgumi (before) | fgumi (after) |
|-----------|-------|----------------|---------------|
| `A/C/G/T` | ✅ counted | ✅ counted | ✅ counted |
| `a/c/g/t` | ✅ counted | ❌ skipped | ✅ counted |
| `N` | ❌ rejected | ❌ rejected | ❌ rejected |
| `n` | ✅ skipped | ✅ skipped | ✅ skipped |
| `-` | ✅ skipped | ✅ skipped | ✅ skipped |

Aligned logging with fgbio's style:
- Always log "Filtered out X records due to mapping issues."
- Always log "Filtered out X records that contained one or more Ns in their UMIs."
- Only log non-PF and UMI-too-short if count > 0

fgbio reference: `GroupReadsByUmi.scala` lines 663-775

## Changes

- `src/lib/umi/assigner.rs`: Add early return for empty `umi_counts`
- `src/lib/umi/mod.rs`: Add `validate_umi()` function with comprehensive tests
- `src/commands/group.rs`: Use shared `validate_umi()` 
- `src/commands/dedup.rs`: Use shared `validate_umi()`
- `src/lib/metrics/group.rs`: Remove unused `discarded_duplicate_umi` field
- `src/lib/logging.rs`: Match fgbio's logging style for filter counts

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo ci-test` passes (2230 tests)
- [x] New unit tests for `validate_umi()` cover all edge cases
- [x] Tested on sample BAM that triggered original panic