### PR TITLE
fix(reference): support both naming conventions for .dict files

### DIFF
--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::progress::ProgressTracker;
+use fgumi_lib::reference::find_dict_path;
 use fgumi_lib::umi::extract_mi_base;
 use fgumi_lib::validation::validate_file_exists;
 use fgumi_lib::variant_review::{
@@ -219,13 +220,17 @@ impl Review {
         }
 
         // Check for sequence dictionary (.dict)
-        let dict_path = self.reference.with_extension("dict");
-        if !dict_path.exists() {
+        // Supports both fgbio/HTSJDK convention (ref.dict) and GATK convention (ref.fa.dict)
+        if find_dict_path(&self.reference).is_none() {
             bail!(
-                "The reference file has no sequence dictionary. Please run:\n  \
-                samtools dict {} -o {}",
+                "The reference file has no sequence dictionary. Tried:\n  \
+                - {}\n  \
+                - {}.dict\n\
+                Please run: samtools dict {} -o {}",
+                self.reference.with_extension("dict").display(),
                 self.reference.display(),
-                dict_path.display()
+                self.reference.display(),
+                self.reference.with_extension("dict").display()
             );
         }
 


### PR DESCRIPTION
## Summary

- Add `find_dict_path()` function that tries both naming conventions for sequence dictionary files
- Support fgbio/HTSJDK/Picard convention: `ref.fa` → `ref.dict` (replacing extension)
- Support GATK convention: `ref.fa` → `ref.fa.dict` (appending `.dict`)
- Updated `zipper` and `review` commands to use the new fallback logic
- Improved error messages showing both paths that were tried

## Context

A user reported that fgumi couldn't find their reference dictionary because it was named `ref.fa.dict` instead of `ref.dict`. They had to create symlinks as a workaround:
https://github.com/Sequure-Dx/guide-seq-nf/blob/9e34824e0cc62d8ff642a8745096163b0401ca6f/modules/DEDUPLICATE-ALIGN-FGUMI.nf#L64

This change adds fallback logic similar to what already exists for `.fai` files, trying both conventions before failing.

## Test plan

- [x] Added unit tests for `find_dict_path()` covering:
  - Replacing convention (`ref.dict`)
  - Appending convention (`ref.fa.dict`)
  - Preference for replacing convention when both exist
  - Not found case
  - Both `.fa` and `.fasta` extensions
- [x] All existing tests pass (`cargo ci-test`)
- [x] Lint checks pass (`cargo ci-lint`)
- [x] Format checks pass (`cargo ci-fmt`)

🤖 Generated with [Claude Code](https://claude.ai/code)