### PR TITLE
feat(group,dedup): add --no-umi mode for position-only grouping

### DIFF
--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -207,6 +207,8 @@ struct DedupFilterConfig {
     include_non_pf: bool,
     /// Minimum UMI length.
     min_umi_length: Option<usize>,
+    /// Skip UMI validation (position-only grouping).
+    no_umi: bool,
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -327,6 +329,7 @@ fn filter_template_raw(
         let flg = bam_fields::flags(raw);
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
+        let check_umi = !config.no_umi;
 
         let mut found_mq: Option<i64> = None;
         let mut found_umi: Option<&[u8]> = None;
@@ -335,7 +338,7 @@ fn filter_template_raw(
             let t = [aux[p], aux[p + 1]];
             let val_type = aux[p + 2];
 
-            if t == config.umi_tag && val_type == b'Z' {
+            if check_umi && t == config.umi_tag && val_type == b'Z' {
                 let start = p + 3;
                 if let Some(end) = aux[start..].iter().position(|&b| b == 0) {
                     found_umi = Some(&aux[start..start + end]);
@@ -380,7 +383,7 @@ fn filter_template_raw(
             } else {
                 break;
             }
-            if found_umi.is_some() && (!check_mq || found_mq.is_some()) {
+            if (!check_umi || found_umi.is_some()) && (!check_mq || found_mq.is_some()) {
                 break;
             }
         }
@@ -393,6 +396,11 @@ fn filter_template_raw(
                     return false;
                 }
             }
+        }
+
+        // Skip UMI validation in no-umi mode
+        if config.no_umi {
+            continue;
         }
 
         if let Some(umi_bytes) = found_umi {
@@ -482,6 +490,11 @@ fn filter_template(
                     }
                 }
             }
+        }
+
+        // Skip UMI validation in no-umi mode
+        if config.no_umi {
+            continue;
         }
 
         // Check UMI for Ns and minimum length using common validation
@@ -621,6 +634,7 @@ fn assign_umi_groups_for_indices(
     assigner: &dyn UmiAssigner,
     raw_tag: [u8; 2],
     min_umi_length: Option<usize>,
+    no_umi: bool,
 ) -> Result<()> {
     if indices.is_empty() {
         return Ok(());
@@ -632,56 +646,63 @@ fn assign_umi_groups_for_indices(
     for &idx in indices {
         let template = &templates[idx];
 
-        let (umi_str_ref, is_r1_earlier) = if raw_mode {
-            let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
-                let aux = bam_fields::aux_data_slice(r1_raw);
-                bam_fields::find_string_tag(aux, &raw_tag)
-            } else if let Some(r2_raw) = template.raw_r2() {
-                let aux = bam_fields::aux_data_slice(r2_raw);
-                bam_fields::find_string_tag(aux, &raw_tag)
-            } else {
-                None
-            };
-            let umi_bytes = umi_bytes.ok_or_else(|| anyhow::anyhow!("No UMI tag found"))?;
-            let umi_str = std::str::from_utf8(umi_bytes)
-                .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
-            let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
-                is_r1_genomically_earlier_raw(r1, r2)
-            } else {
-                true
-            };
-            (umi_str, earlier)
+        // In no-umi mode, use empty string for all templates
+        let processed_umi = if no_umi {
+            String::new()
         } else {
-            let umi_bytes = if let Some(r1) = template.r1() {
-                if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
-                    bytes
+            let (umi_str_ref, is_r1_earlier) = if raw_mode {
+                let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
+                    let aux = bam_fields::aux_data_slice(r1_raw);
+                    bam_fields::find_string_tag(aux, &raw_tag)
+                } else if let Some(r2_raw) = template.raw_r2() {
+                    let aux = bam_fields::aux_data_slice(r2_raw);
+                    bam_fields::find_string_tag(aux, &raw_tag)
                 } else {
-                    bail!("UMI tag is not a string");
-                }
-            } else if let Some(r2) = template.r2() {
-                if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
-                    bytes
+                    None
+                };
+                let umi_bytes = umi_bytes.ok_or_else(|| anyhow::anyhow!("No UMI tag found"))?;
+                let umi_str = std::str::from_utf8(umi_bytes)
+                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
+                let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
+                    is_r1_genomically_earlier_raw(r1, r2)
                 } else {
-                    bail!("UMI tag is not a string");
-                }
+                    true
+                };
+                (umi_str, earlier)
             } else {
-                bail!("Template has no reads");
+                let umi_bytes = if let Some(r1) = template.r1() {
+                    if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
+                        bytes
+                    } else {
+                        bail!("UMI tag is not a string");
+                    }
+                } else if let Some(r2) = template.r2() {
+                    if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
+                        bytes
+                    } else {
+                        bail!("UMI tag is not a string");
+                    }
+                } else {
+                    bail!("Template has no reads");
+                };
+                let umi_str = std::str::from_utf8(umi_bytes)
+                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
+                let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
+                    is_r1_genomically_earlier(r1, r2)?
+                } else {
+                    true
+                };
+                (umi_str, earlier)
             };
-            let umi_str = std::str::from_utf8(umi_bytes)
-                .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
-            let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
-                is_r1_genomically_earlier(r1, r2)?
-            } else {
-                true
-            };
-            (umi_str, earlier)
+
+            umi_for_read(umi_str_ref, is_r1_earlier, assigner)?
         };
 
-        let processed_umi = umi_for_read(umi_str_ref, is_r1_earlier, assigner)?;
         umis.push(processed_umi);
     }
 
-    let truncated_umis = truncate_umis(umis, min_umi_length)?;
+    // Truncate UMIs if needed (skip in no-umi mode)
+    let truncated_umis = if no_umi { umis } else { truncate_umis(umis, min_umi_length)? };
     let assignments = assigner.assign(&truncated_umis);
 
     for (i, &idx) in indices.iter().enumerate() {
@@ -697,6 +718,7 @@ fn assign_umi_groups(
     assigner: &dyn UmiAssigner,
     raw_tag: [u8; 2],
     min_umi_length: Option<usize>,
+    no_umi: bool,
 ) -> Result<()> {
     if assigner.split_templates_by_pair_orientation() {
         let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
@@ -706,11 +728,25 @@ fn assign_umi_groups(
         }
 
         for indices in subgroups.values() {
-            assign_umi_groups_for_indices(templates, indices, assigner, raw_tag, min_umi_length)?;
+            assign_umi_groups_for_indices(
+                templates,
+                indices,
+                assigner,
+                raw_tag,
+                min_umi_length,
+                no_umi,
+            )?;
         }
     } else {
         let all_indices: Vec<usize> = (0..templates.len()).collect();
-        assign_umi_groups_for_indices(templates, &all_indices, assigner, raw_tag, min_umi_length)?;
+        assign_umi_groups_for_indices(
+            templates,
+            &all_indices,
+            assigner,
+            raw_tag,
+            min_umi_length,
+            no_umi,
+        )?;
     }
 
     Ok(())
@@ -815,6 +851,7 @@ fn process_position_group(
     assigner: &dyn UmiAssigner,
     raw_tag: [u8; 2],
     min_umi_length: Option<usize>,
+    no_umi: bool,
 ) -> io::Result<ProcessedDedupGroup> {
     let mut dedup_metrics = DedupMetrics::default();
     let input_record_count = group.records.len() as u64;
@@ -866,7 +903,7 @@ fn process_position_group(
             t
         })
         .collect();
-    if let Err(e) = assign_umi_groups(&mut templates, assigner, raw_tag, min_umi_length) {
+    if let Err(e) = assign_umi_groups(&mut templates, assigner, raw_tag, min_umi_length, no_umi) {
         return Err(io::Error::new(io::ErrorKind::InvalidData, e));
     }
 
@@ -1075,6 +1112,11 @@ pub struct MarkDuplicates {
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 
+    /// Skip UMI-based grouping; group by position only. Forces identity strategy
+    /// and ignores any existing UMI tags.
+    #[arg(long = "no-umi")]
+    pub no_umi: bool,
+
     /// Scheduler and pipeline options
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
@@ -1091,6 +1133,21 @@ impl Command for MarkDuplicates {
             bail!("Paired strategy cannot be used with --min-umi-length");
         }
 
+        // Validate --no-umi is not used with paired strategy
+        if self.no_umi && matches!(self.strategy, Strategy::Paired) {
+            bail!("--no-umi cannot be used with --strategy paired");
+        }
+
+        // Handle --no-umi mode: force identity strategy
+        let (effective_strategy, no_umi_edits_override) = if self.no_umi {
+            if !matches!(self.strategy, Strategy::Identity) {
+                info!("--no-umi mode: overriding strategy to identity");
+            }
+            (Strategy::Identity, true)
+        } else {
+            (self.strategy, false)
+        };
+
         // Validate input file exists
         if !is_stdin_path(&self.io.input) {
             validate_file_exists(&self.io.input, "input BAM file")?;
@@ -1098,15 +1155,27 @@ impl Command for MarkDuplicates {
 
         let min_mapq: u8 = self.min_map_q.unwrap_or(0);
 
+        // Identity strategy requires edits=0, others use the configured value
+        // Also force edits=0 in no-umi mode
+        let effective_edits =
+            if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
+                0
+            } else {
+                self.edits
+            };
+
         let timer = OperationTimer::new("Marking duplicates");
 
         info!("Starting dedup");
         info!("Input: {}", self.io.input.display());
         info!("Output: {}", self.io.output.display());
-        info!("Strategy: {:?}", self.strategy);
-        info!("Edits: {}", self.edits);
+        info!("Strategy: {effective_strategy:?}");
+        info!("Edits: {effective_edits}");
         info!("Remove duplicates: {}", self.remove_duplicates);
-        if matches!(self.strategy, Strategy::Adjacency | Strategy::Paired) {
+        if self.no_umi {
+            info!("No-UMI mode: deduplicating by position only");
+        }
+        if matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired) {
             info!("Index threshold: {}", self.index_threshold);
         }
         info!("{}", self.threading.log_message());
@@ -1140,23 +1209,22 @@ impl Command for MarkDuplicates {
 
         let assign_tag_bytes: [u8; 2] = validate_tag(&self.assign_tag, "assign-tag")?;
 
-        let effective_edits =
-            if matches!(self.strategy, Strategy::Identity) { 0 } else { self.edits };
-
         let filter_config = DedupFilterConfig {
             umi_tag: raw_tag,
             min_mapq,
             include_non_pf: self.include_non_pf_reads,
             min_umi_length: self.min_umi_length,
+            no_umi: self.no_umi,
         };
 
         // Shared state for collecting metrics
         let collected_metrics: Arc<SegQueue<CollectedDedupMetrics>> = Arc::new(SegQueue::new());
 
         // Clone values needed by closures
-        let strategy = self.strategy;
+        let strategy = effective_strategy;
         let index_threshold = self.index_threshold;
         let min_umi_length = self.min_umi_length;
+        let no_umi = self.no_umi;
         let remove_duplicates = self.remove_duplicates;
         let collected_metrics_clone = Arc::clone(&collected_metrics);
 
@@ -1199,6 +1267,7 @@ impl Command for MarkDuplicates {
                     assigner.as_ref(),
                     raw_tag,
                     min_umi_length,
+                    no_umi,
                 )
             },
             // Serialize function (serial, ordered)
@@ -1757,6 +1826,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         }
     }
 
@@ -2441,6 +2511,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
 
@@ -2483,6 +2554,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
 
@@ -2657,6 +2729,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(filter_template_raw(&template, &config, &mut metrics));
@@ -2681,6 +2754,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -2706,6 +2780,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -2730,6 +2805,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -2754,6 +2830,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: Some(6),
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -2777,6 +2854,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -2827,5 +2905,187 @@ mod tests {
             estimate >= vec_overhead,
             "estimate {estimate} should include Vec<Template> overhead {vec_overhead}"
         );
+    }
+
+    // ========================================================================
+    // no_umi mode tests
+    // ========================================================================
+
+    #[test]
+    fn test_filter_template_accepts_missing_umi_when_no_umi_mode() {
+        let mut config = default_filter_config();
+        config.no_umi = true;
+        let mut metrics = FilterMetrics::new();
+
+        // Create template without RX tag
+        let record = RecordBuilder::new()
+            .name("q1")
+            .sequence("ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .cigar("4M")
+            .mapping_quality(30)
+            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
+            .build();
+        let template = Template::from_records(vec![record]).unwrap();
+
+        // In no_umi mode, templates without UMI tags should be accepted
+        assert!(filter_template(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    #[test]
+    fn test_filter_template_accepts_umi_with_n_when_no_umi_mode() {
+        let mut config = default_filter_config();
+        config.no_umi = true;
+        let mut metrics = FilterMetrics::new();
+        let template = create_mapped_template_with_umi("q1", "ACNTACGT", 30);
+
+        // In no_umi mode, UMIs with N should be accepted (UMI validation is skipped)
+        assert!(filter_template(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    #[test]
+    fn test_filter_template_accepts_short_umi_when_no_umi_mode() {
+        let mut config = default_filter_config();
+        config.min_umi_length = Some(8);
+        config.no_umi = true;
+        let mut metrics = FilterMetrics::new();
+        let template = create_mapped_template_with_umi("q1", "ACGT", 30);
+
+        // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
+        assert!(filter_template(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    // ========================================================================
+    // no_umi mode tests (raw path)
+    // ========================================================================
+
+    /// Creates a raw BAM record without any auxiliary tags (no UMI tag).
+    fn make_raw_bam_for_dedup_no_tags(
+        name: &[u8],
+        flag: u16,
+        mapq: u8,
+        seq_len: usize,
+        qualities: &[u8],
+    ) -> Vec<u8> {
+        use fgumi_lib::sort::bam_fields;
+
+        let l_read_name = (name.len() + 1) as u8;
+        let cigar_ops: &[u32] =
+            if (flag & bam_fields::flags::UNMAPPED) == 0 { &[(seq_len as u32) << 4] } else { &[] };
+        let n_cigar_op = cigar_ops.len() as u16;
+        let seq_bytes = seq_len.div_ceil(2);
+        let total = 32 + l_read_name as usize + cigar_ops.len() * 4 + seq_bytes + seq_len;
+        let mut buf = vec![0u8; total];
+
+        buf[0..4].copy_from_slice(&0i32.to_le_bytes());
+        buf[4..8].copy_from_slice(&100i32.to_le_bytes());
+        buf[8] = l_read_name;
+        buf[9] = mapq;
+        buf[12..14].copy_from_slice(&n_cigar_op.to_le_bytes());
+        buf[14..16].copy_from_slice(&flag.to_le_bytes());
+        buf[16..20].copy_from_slice(&(seq_len as u32).to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        let cigar_start = name_start + l_read_name as usize;
+        for (i, &op) in cigar_ops.iter().enumerate() {
+            let off = cigar_start + i * 4;
+            buf[off..off + 4].copy_from_slice(&op.to_le_bytes());
+        }
+
+        let qo = bam_fields::qual_offset(&buf);
+        let copy_len = std::cmp::min(qualities.len(), seq_len);
+        buf[qo..qo + copy_len].copy_from_slice(&qualities[..copy_len]);
+
+        buf
+    }
+
+    #[test]
+    fn test_filter_template_raw_accepts_missing_umi_when_no_umi_mode() {
+        let raw = make_raw_bam_for_dedup_no_tags(
+            b"rea",
+            fgumi_lib::sort::bam_fields::flags::PAIRED
+                | fgumi_lib::sort::bam_fields::flags::FIRST_SEGMENT
+                | fgumi_lib::sort::bam_fields::flags::MATE_UNMAPPED,
+            30,
+            4,
+            &[20, 20, 20, 20],
+        );
+        let template = Template::from_raw_records(vec![raw]).unwrap();
+        let config = DedupFilterConfig {
+            umi_tag: [b'R', b'X'],
+            min_mapq: 20,
+            include_non_pf: false,
+            min_umi_length: None,
+            no_umi: true,
+        };
+        let mut metrics = FilterMetrics::new();
+
+        // In no_umi mode, templates without UMI tags should be accepted
+        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    #[test]
+    fn test_filter_template_raw_accepts_umi_with_n_when_no_umi_mode() {
+        let raw = make_raw_bam_for_dedup(
+            b"rea",
+            fgumi_lib::sort::bam_fields::flags::PAIRED
+                | fgumi_lib::sort::bam_fields::flags::FIRST_SEGMENT
+                | fgumi_lib::sort::bam_fields::flags::MATE_UNMAPPED,
+            30,
+            4,
+            &[20, 20, 20, 20],
+            b"ANGT",
+        );
+        let template = Template::from_raw_records(vec![raw]).unwrap();
+        let config = DedupFilterConfig {
+            umi_tag: [b'R', b'X'],
+            min_mapq: 0,
+            include_non_pf: false,
+            min_umi_length: None,
+            no_umi: true,
+        };
+        let mut metrics = FilterMetrics::new();
+
+        // In no_umi mode, UMIs with N should be accepted (UMI validation is skipped)
+        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    #[test]
+    fn test_filter_template_raw_accepts_short_umi_when_no_umi_mode() {
+        let raw = make_raw_bam_for_dedup(
+            b"rea",
+            fgumi_lib::sort::bam_fields::flags::PAIRED
+                | fgumi_lib::sort::bam_fields::flags::FIRST_SEGMENT
+                | fgumi_lib::sort::bam_fields::flags::MATE_UNMAPPED,
+            30,
+            4,
+            &[20, 20, 20, 20],
+            b"AC",
+        );
+        let template = Template::from_raw_records(vec![raw]).unwrap();
+        let config = DedupFilterConfig {
+            umi_tag: [b'R', b'X'],
+            min_mapq: 0,
+            include_non_pf: false,
+            min_umi_length: Some(6),
+            no_umi: true,
+        };
+        let mut metrics = FilterMetrics::new();
+
+        // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
+        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert_eq!(metrics.accepted_templates, 1);
     }
 }

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -91,6 +91,8 @@ struct GroupFilterConfig {
     include_non_pf: bool,
     /// Minimum UMI length (None to disable).
     min_umi_length: Option<usize>,
+    /// Skip UMI validation (position-only grouping).
+    no_umi: bool,
 }
 
 /// Filter a template based on filtering criteria.
@@ -163,6 +165,11 @@ fn filter_template(
                     }
                 }
             }
+        }
+
+        // Skip UMI validation in no-umi mode
+        if config.no_umi {
+            continue;
         }
 
         // Check UMI for Ns and minimum length using common validation
@@ -252,6 +259,7 @@ fn filter_template_raw(
         let flg = bam_fields::flags(raw);
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
+        let check_umi = !config.no_umi;
 
         // Single pass over aux data to find both MQ and UMI tags
         let mut found_mq: Option<i64> = None;
@@ -261,7 +269,7 @@ fn filter_template_raw(
             let t = [aux[p], aux[p + 1]];
             let val_type = aux[p + 2];
 
-            if t == config.umi_tag && val_type == b'Z' {
+            if check_umi && t == config.umi_tag && val_type == b'Z' {
                 let start = p + 3;
                 if let Some(end) = aux[start..].iter().position(|&b| b == 0) {
                     found_umi = Some(&aux[start..start + end]);
@@ -307,7 +315,7 @@ fn filter_template_raw(
             } else {
                 break;
             }
-            if found_umi.is_some() && (!check_mq || found_mq.is_some()) {
+            if (!check_umi || found_umi.is_some()) && (!check_mq || found_mq.is_some()) {
                 break;
             }
         }
@@ -320,6 +328,11 @@ fn filter_template_raw(
                     return false;
                 }
             }
+        }
+
+        // Skip UMI validation in no-umi mode
+        if config.no_umi {
+            continue;
         }
 
         // Check UMI for Ns and minimum length
@@ -470,6 +483,7 @@ fn assign_umi_groups_impl(
     raw_tag: [u8; 2],
     assign_tag_bytes: [u8; 2],
     min_umi_length: Option<usize>,
+    no_umi: bool,
 ) -> Result<()> {
     // Determine orientation getter based on mode
     let raw_mode = templates.first().is_some_and(Template::is_raw_byte_mode);
@@ -499,6 +513,7 @@ fn assign_umi_groups_impl(
                 raw_tag,
                 assign_tag_bytes,
                 min_umi_length,
+                no_umi,
             )?;
         }
     } else {
@@ -511,6 +526,7 @@ fn assign_umi_groups_impl(
             raw_tag,
             assign_tag_bytes,
             min_umi_length,
+            no_umi,
         )?;
     }
 
@@ -528,6 +544,7 @@ fn assign_umi_groups_for_indices_impl(
     raw_tag: [u8; 2],
     _assign_tag_bytes: [u8; 2], // No longer used here - tags set during serialization
     min_umi_length: Option<usize>,
+    no_umi: bool,
 ) -> Result<()> {
     if indices.is_empty() {
         return Ok(());
@@ -540,67 +557,73 @@ fn assign_umi_groups_for_indices_impl(
     for &idx in indices {
         let template = &templates[idx];
 
-        let (umi_str_ref, is_r1_earlier) = if raw_mode {
-            // Raw-byte mode: extract UMI from raw bytes
-            use fgumi_lib::sort::bam_fields;
-
-            let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
-                let aux = bam_fields::aux_data_slice(r1_raw);
-                bam_fields::find_string_tag(aux, &raw_tag)
-                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
-            } else if let Some(r2_raw) = template.raw_r2() {
-                let aux = bam_fields::aux_data_slice(r2_raw);
-                bam_fields::find_string_tag(aux, &raw_tag)
-                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
-            } else {
-                bail!("Template has no reads");
-            };
-
-            let umi_s = std::str::from_utf8(umi_bytes)
-                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
-
-            let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
-                is_r1_genomically_earlier_raw(r1, r2)
-            } else {
-                true
-            };
-
-            (umi_s, earlier)
+        // In no-umi mode, use empty string for all templates
+        let processed_umi = if no_umi {
+            String::new()
         } else {
-            // Noodles mode
-            let umi_bytes = if let Some(r1) = template.r1() {
-                if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
-                    bytes
-                } else {
-                    bail!("UMI tag is not a string");
-                }
-            } else if let Some(r2) = template.r2() {
-                if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
-                    bytes
-                } else {
-                    bail!("UMI tag is not a string");
-                }
-            } else {
-                bail!("Template has no reads");
-            };
-            let umi_s = std::str::from_utf8(umi_bytes)
-                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
+            let (umi_str_ref, is_r1_earlier) = if raw_mode {
+                // Raw-byte mode: extract UMI from raw bytes
+                use fgumi_lib::sort::bam_fields;
 
-            let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
-                is_r1_genomically_earlier_impl(r1, r2)?
+                let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
+                    let aux = bam_fields::aux_data_slice(r1_raw);
+                    bam_fields::find_string_tag(aux, &raw_tag)
+                        .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
+                } else if let Some(r2_raw) = template.raw_r2() {
+                    let aux = bam_fields::aux_data_slice(r2_raw);
+                    bam_fields::find_string_tag(aux, &raw_tag)
+                        .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
+                } else {
+                    bail!("Template has no reads");
+                };
+
+                let umi_s = std::str::from_utf8(umi_bytes)
+                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
+
+                let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
+                    is_r1_genomically_earlier_raw(r1, r2)
+                } else {
+                    true
+                };
+
+                (umi_s, earlier)
             } else {
-                true
+                // Noodles mode
+                let umi_bytes = if let Some(r1) = template.r1() {
+                    if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
+                        bytes
+                    } else {
+                        bail!("UMI tag is not a string");
+                    }
+                } else if let Some(r2) = template.r2() {
+                    if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
+                        bytes
+                    } else {
+                        bail!("UMI tag is not a string");
+                    }
+                } else {
+                    bail!("Template has no reads");
+                };
+                let umi_s = std::str::from_utf8(umi_bytes)
+                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
+
+                let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
+                    is_r1_genomically_earlier_impl(r1, r2)?
+                } else {
+                    true
+                };
+
+                (umi_s, earlier)
             };
 
-            (umi_s, earlier)
+            umi_for_read_impl(umi_str_ref, is_r1_earlier, assigner)?
         };
 
-        let processed_umi = umi_for_read_impl(umi_str_ref, is_r1_earlier, assigner)?;
         umis.push(processed_umi);
     }
 
-    // Truncate UMIs if needed
-    let truncated_umis = truncate_umis_impl(umis, min_umi_length)?;
+    // Truncate UMIs if needed (skip in no-umi mode)
+    let truncated_umis = if no_umi { umis } else { truncate_umis_impl(umis, min_umi_length)? };
 
     // Assign UMI groups - returns Vec<MoleculeId> indexed by input position
     let assignments = assigner.assign(&truncated_umis);
@@ -759,6 +782,11 @@ pub struct GroupReadsByUmi {
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 
+    /// Skip UMI-based grouping; group by position only. Forces identity strategy
+    /// and ignores any existing UMI tags.
+    #[arg(long = "no-umi")]
+    pub no_umi: bool,
+
     /// Scheduler and pipeline statistics options.
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
@@ -838,6 +866,21 @@ impl Command for GroupReadsByUmi {
             bail!("Paired strategy cannot be used with --min-umi-length");
         }
 
+        // Validate --no-umi is not used with paired strategy
+        if self.no_umi && matches!(self.strategy, Strategy::Paired) {
+            bail!("--no-umi cannot be used with --strategy paired");
+        }
+
+        // Handle --no-umi mode: force identity strategy
+        let (effective_strategy, no_umi_edits_override) = if self.no_umi {
+            if !matches!(self.strategy, Strategy::Identity) {
+                info!("--no-umi mode: overriding strategy to identity");
+            }
+            (Strategy::Identity, true)
+        } else {
+            (self.strategy, false)
+        };
+
         // Validate input file exists (skip for stdin)
         if !is_stdin_path(&self.io.input) {
             validate_file_exists(&self.io.input, "input BAM file")?;
@@ -846,15 +889,27 @@ impl Command for GroupReadsByUmi {
         // Set minimum mapping quality
         let min_mapq: u8 = self.min_map_q.unwrap_or(1);
 
+        // Identity strategy requires edits=0, others use the configured value
+        // Also force edits=0 in no-umi mode
+        let effective_edits =
+            if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
+                0
+            } else {
+                self.edits
+            };
+
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
 
         info!("Starting group");
         info!("Input: {}", self.io.input.display());
         info!("Output: {}", self.io.output.display());
-        info!("Strategy: {:?}", self.strategy);
-        info!("Edits: {}", self.edits);
-        if matches!(self.strategy, Strategy::Adjacency | Strategy::Paired) {
+        info!("Strategy: {effective_strategy:?}");
+        info!("Edits: {effective_edits}");
+        if self.no_umi {
+            info!("No-UMI mode: grouping by position only");
+        }
+        if matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired) {
             info!("Index threshold: {}", self.index_threshold);
         }
 
@@ -895,16 +950,13 @@ impl Command for GroupReadsByUmi {
             [bytes[0], bytes[1]]
         };
 
-        // Identity strategy requires edits=0, others use the configured value
-        let effective_edits =
-            if matches!(self.strategy, Strategy::Identity) { 0 } else { self.edits };
-
         // Create filter configuration
         let filter_config = GroupFilterConfig {
             umi_tag: raw_tag,
             min_mapq,
             include_non_pf: self.include_non_pf_reads,
             min_umi_length: self.min_umi_length,
+            no_umi: self.no_umi,
         };
 
         // ============================================================
@@ -915,6 +967,7 @@ impl Command for GroupReadsByUmi {
             return self.execute_single_threaded(
                 reader,
                 &header,
+                effective_strategy,
                 effective_edits,
                 raw_tag,
                 assign_tag_bytes,
@@ -932,8 +985,9 @@ impl Command for GroupReadsByUmi {
         let collected_metrics: Arc<SegQueue<CollectedMetrics>> = Arc::new(SegQueue::new());
 
         // Clone values needed by closures
-        let strategy = self.strategy;
+        let strategy = effective_strategy;
         let index_threshold = self.index_threshold;
+        let no_umi = self.no_umi;
         let collected_metrics_clone = Arc::clone(&collected_metrics);
 
         // Setup comprehensive memory monitoring first if debug mode is enabled
@@ -1143,6 +1197,7 @@ impl Command for GroupReadsByUmi {
                     raw_tag,
                     assign_tag_bytes,
                     filter_config.min_umi_length,
+                    no_umi,
                 ) {
                     log::warn!("UMI assignment failed, returning empty group: {e}");
                     #[cfg(feature = "memory-debug")]
@@ -1411,6 +1466,7 @@ impl GroupReadsByUmi {
         &self,
         reader: Box<dyn std::io::Read + Send>,
         header: &Header,
+        effective_strategy: Strategy,
         effective_edits: u32,
         raw_tag: [u8; 2],
         assign_tag_bytes: [u8; 2],
@@ -1463,7 +1519,7 @@ impl GroupReadsByUmi {
                 Self::process_and_write_position_group(
                     group,
                     filter_config,
-                    self.strategy,
+                    effective_strategy,
                     effective_edits,
                     self.index_threshold,
                     raw_tag,
@@ -1484,7 +1540,7 @@ impl GroupReadsByUmi {
             Self::process_and_write_position_group(
                 final_group,
                 filter_config,
-                self.strategy,
+                effective_strategy,
                 effective_edits,
                 self.index_threshold,
                 raw_tag,
@@ -1578,6 +1634,7 @@ impl GroupReadsByUmi {
             raw_tag,
             assign_tag_bytes,
             filter_config.min_umi_length,
+            filter_config.no_umi,
         ) {
             // Log error but continue processing
             log::warn!("Failed to assign UMI groups: {e}");
@@ -1729,6 +1786,7 @@ mod tests {
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             index_threshold: 100,
+            no_umi: false,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions {
                 queue_memory: "768".to_string(),
@@ -2592,6 +2650,126 @@ mod tests {
         assert_eq!(output_records.len(), 0, "Should have no output records");
 
         Ok(())
+    }
+
+    // ========================================================================
+    // no_umi mode tests
+    // ========================================================================
+
+    #[test]
+    fn test_no_umi_mode_accepts_missing_umi_tag() -> Result<()> {
+        // Test that templates without UMI tags are accepted when --no-umi is used
+        let mut records = Vec::new();
+
+        // Create a pair WITHOUT the RX tag
+        let (mut r1, mut r2) = build_test_pair("a01", 0, 100, 300, 60, 60, "dummy");
+
+        // Remove the RX tag
+        use noodles::sam::alignment::record::data::field::Tag;
+        let rx_tag = Tag::from([b'R', b'X']);
+        r1.data_mut().remove(&rx_tag);
+        r2.data_mut().remove(&rx_tag);
+
+        records.push(r1);
+        records.push(r2);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let mut cmd = test_group_cmd(Strategy::Identity, 0);
+        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.no_umi = true;
+
+        cmd.execute("test")?;
+
+        // With no_umi mode, templates without UMI tags should be accepted
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 2, "Should have 2 output records");
+
+        // All records should have an MI tag assigned
+        let unique_groups = count_unique_mi_tags(&output_records);
+        assert_eq!(unique_groups, 1, "All records at same position should be in 1 group");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_umi_mode_groups_by_position_only() -> Result<()> {
+        // Test that templates with different UMIs at the same position get the same MI
+        let mut records = Vec::new();
+
+        // Create pairs at the same position with DIFFERENT UMIs
+        let (r1a, r2a) = build_test_pair("a01", 0, 100, 300, 60, 60, "AAAAAAAA");
+        let (r1b, r2b) = build_test_pair("a02", 0, 100, 300, 60, 60, "TTTTTTTT");
+        let (r1c, r2c) = build_test_pair("a03", 0, 100, 300, 60, 60, "CCCCCCCC");
+
+        records.push(r1a);
+        records.push(r2a);
+        records.push(r1b);
+        records.push(r2b);
+        records.push(r1c);
+        records.push(r2c);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let mut cmd = test_group_cmd(Strategy::Adjacency, 1);
+        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.no_umi = true; // Will be overridden to identity
+
+        cmd.execute("test")?;
+
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 6, "Should have 6 output records (3 pairs)");
+
+        // All records at the same position should have the same MI (ignoring UMI differences)
+        let unique_groups = count_unique_mi_tags(&output_records);
+        assert_eq!(
+            unique_groups, 1,
+            "All records at same position should be in 1 group (UMI ignored)"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_umi_mode_accepts_umi_with_n() -> Result<()> {
+        // Test that UMIs with N are accepted in no-umi mode
+        let mut records = Vec::new();
+
+        let (r1, r2) = build_test_pair("a01", 0, 100, 300, 60, 60, "ACNTNACGT");
+        records.push(r1);
+        records.push(r2);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let mut cmd = test_group_cmd(Strategy::Identity, 0);
+        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.no_umi = true;
+
+        cmd.execute("test")?;
+
+        // With no_umi mode, UMIs with N should be accepted
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 2, "Should have 2 output records");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_umi_mode_rejects_paired_strategy() {
+        // Test that --no-umi with --strategy paired returns an error
+        let mut cmd = test_group_cmd(Strategy::Paired, 1);
+        cmd.no_umi = true;
+
+        let result = cmd.execute("test");
+        assert!(result.is_err(), "Should fail when --no-umi is used with --strategy paired");
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("--no-umi cannot be used with --strategy paired"),
+            "Error message should mention the conflict"
+        );
     }
 
     #[test]
@@ -4279,6 +4457,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(filter_template_raw(&template, &config, &mut metrics));
@@ -4301,6 +4480,7 @@ mod tests {
             min_mapq: 20,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -4324,6 +4504,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -4346,6 +4527,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -4368,6 +4550,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: Some(6),
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -4389,6 +4572,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
@@ -4435,6 +4619,7 @@ mod tests {
             min_mapq: 0,
             include_non_pf: false,
             min_umi_length: None,
+            no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
         // Supplementary-only template has no primary R1/R2 → raw_r1() returns None


### PR DESCRIPTION
## Summary

- Add `--no-umi` flag to both `group` and `dedup` commands to enable position-only grouping/deduplication without UMI tags
- Similar to Picard's MarkDuplicates behavior when UMIs are not available

## Changes

When `--no-umi` is specified:
- Strategy is forced to identity (with info log if overriding another strategy)
- UMI validation is skipped (templates without UMI tags are accepted)
- Empty strings are used for UMI grouping (all templates at same position get same MI)
- UMI truncation is skipped
- Error is thrown if combined with `--strategy paired`

## Test plan

- [x] Added unit tests for `filter_template` with `no_umi: true` in dedup.rs
- [x] Added integration tests for full workflow in group.rs
- [x] Verified error case when `--no-umi` used with `--strategy paired`
- [x] All 2329 tests pass
- [x] Formatting and linting pass

## Usage

```bash
# Group reads by position only (ignore UMIs)
fgumi group --no-umi -i input.bam -o output.bam

# Mark duplicates by position only (like Picard MarkDuplicates)
fgumi dedup --no-umi -i input.bam -o output.bam
```