### PR TITLE
build: update bgzf dependency to version 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,8 +124,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bgzf"
-version = "0.1.0"
-source = "git+https://github.com/fulcrumgenomics/bgzf.git?branch=main#36b7e44af94b0ea23f14ee7d1791cb9d8a83108b"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb34b265c76cea4adf8478fc193bc159c4df33ceca9044f8576f709df87b4bf"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ approx = "0.5.1"
 ahash = "0.8"
 bytemuck = { version = "1.14", features = ["derive"] }
 noodles-csi = "0.52.0"
-bgzf = { git = "https://github.com/fulcrumgenomics/bgzf.git", branch = "main" }
+bgzf = "0.3.0"
 wide = "0.7"
 rand_distr = "0.5"
 flate2 = "1.1"


### PR DESCRIPTION
## Summary
- Update bgzf dependency from git reference to published crates.io version 0.3.0
- All tests pass locally

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo ci-test` passes (2329 tests)