### PR TITLE
feat(pipeline): unified queue memory limits with human-readable parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +692,7 @@ dependencies = [
  "built",
  "bytemuck",
  "bytes",
+ "bytesize",
  "clap",
  "crc32fast",
  "criterion",
@@ -721,6 +728,7 @@ dependencies = [
  "seq_io",
  "serde",
  "statrs",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.17",
  "wide",
@@ -921,7 +929,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1630,6 +1638,15 @@ dependencies = [
  "noodles-csi",
  "noodles-tabix",
  "percent-encoding",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2400,6 +2417,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2698,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,16 +2723,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2694,6 +2779,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2716,6 +2812,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ csv = "1.1"
 memchr = "2"
 murmur3 = "0.5"
 statrs = "0.18"
+bytesize = "1.3"
+sysinfo = { version = "0.31", default-features = false, features = ["system"] }
 rayon = "1.10"
 approx = "0.5.1"
 ahash = "0.8"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The diagram shows the workflow from FASTQ files to filtered consensus reads:
 
 * [Documentation](https://docs.rs/fgumi)
 * [Best Practice Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/best-practice-consensus-pipeline.md): Recommended workflow from FASTQ to consensus
+* [Performance Tuning Guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/performance-tuning.md): Threading, memory, and compression optimization
 * [Snakemake Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/FastqToConsensus-RnD.smk): Reference implementation
 * [Metrics](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/metrics.md): Output metrics documentation
 * [Developing](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/DEVELOPING.md): Developer guide
@@ -206,21 +207,15 @@ fgumi filter \
   --reference ref.fa
 ```
 
-## Threading Options
+## Performance Options
 
-fgumi supports multi-threading for parallel processing:
+fgumi supports multi-threading and memory management for optimal performance:
 
-- `--threads 0` or `--threads 1` or omitted → single-threaded
-- `--threads N` where N > 1 → multi-threaded with N threads
+- **Threading**: `--threads N` for parallel processing
+- **Memory**: `--queue-memory 768` (plain numbers are MB; supports human-readable formats like `2GB`)
+- **Compression**: `--compression-level 1-9` for speed vs size trade-offs
 
-Thread distribution is optimized per-command based on workload profiling.
-
-| Scenario | Recommendation |
-|----------|----------------|
-| SLURM job with 8 CPUs allocated | `--threads 8` |
-| Dedicated 16-core workstation | `--threads 16` |
-| Shared login node | `--threads 2` (or avoid heavy jobs) |
-| Snakemake/Nextflow with resource limits | `--threads {threads}` |
+For detailed performance tuning guidance, see the [Performance Tuning Guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/performance-tuning.md).
 
 ## Performance
 

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,0 +1,214 @@
+# Performance Tuning Guide
+
+fgumi provides three key options to optimize performance for your system: threading, memory management, and compression. This guide explains how to configure these options for different scenarios.
+
+## Threading Options
+
+### Single-threaded Mode
+- **Usage**: `--threads 1` or omit the parameter
+- **Behavior**: Uses optimized fast path with minimal overhead
+- **Best for**: Small files, memory-constrained systems, debugging
+
+### Multi-threaded Mode
+- **Usage**: `--threads N` where N > 1
+- **Behavior**: Uses unified 7-step pipeline with work-stealing scheduler
+- **Best for**: Large files, high-performance systems, production workloads
+
+## Memory Management
+
+fgumi's unified memory management controls pipeline queue memory to prevent out-of-memory conditions while maintaining throughput.
+
+### Queue Memory Options
+
+```bash
+# Basic usage (768MB per thread - default)
+fgumi filter --queue-memory 768 --queue-memory-per-thread true
+
+# Human-readable formats
+fgumi filter --queue-memory 2GB
+fgumi filter --queue-memory 1024MiB
+
+# Fixed total memory (no per-thread scaling)
+fgumi filter --queue-memory 4096 --queue-memory-per-thread false
+```
+
+### Memory Scaling Behavior
+
+| Threads | Per-thread Mode | Fixed Mode |
+|---------|----------------|------------|
+| 1       | 768MB          | 768MB      |
+| 4       | 3GB            | 768MB      |
+| 8       | 6GB            | 768MB      |
+| 16      | 12GB           | 768MB      |
+
+### Memory Validation
+
+- **System check**: Warns if requesting >90% of available system memory
+- **Overflow protection**: Prevents integer overflow with checked arithmetic
+- **Decimal support**: Accepts formats like `1.5GB` in addition to integers
+
+## Compression Options
+
+### Compression Level
+- **Range**: 1 (fastest) to 9 (best compression)
+- **Default**: 1 (fastest)
+- **Usage**: `--compression-level N`
+
+### Compression Threading
+- **Default**: Matches `--threads` setting
+- **Override**: `--compression-threads N`
+- **Best practice**: Usually leave at default
+
+## Scenario-Based Configurations
+
+### High-Throughput Server
+**Goal**: Maximum processing speed for large datasets
+
+```bash
+fgumi filter \
+  --threads 16 \
+  --queue-memory 1GB \
+  --compression-level 3 \
+  --input large_dataset.bam \
+  --output filtered.bam
+```
+
+**Rationale**:
+- High thread count for parallel processing
+- Generous memory for pipeline buffers
+- Lower compression for speed
+
+### Memory-Constrained Node
+**Goal**: Minimize memory usage while maintaining reasonable performance
+
+```bash
+fgumi filter \
+  --threads 8 \
+  --queue-memory 512 \
+  --queue-memory-per-thread false \
+  --compression-level 6 \
+  --input dataset.bam \
+  --output filtered.bam
+```
+
+**Rationale**:
+- Moderate thread count
+- Fixed memory limit (512MB total)
+- Default compression for balance
+
+### Fast Local SSD
+**Goal**: Optimize for fast I/O with minimal compression overhead
+
+```bash
+fgumi filter \
+  --threads 8 \
+  --queue-memory 2GB \
+  --compression-level 1 \
+  --input dataset.bam \
+  --output filtered.bam
+```
+
+**Rationale**:
+- High memory for large pipeline buffers
+- Minimal compression (I/O not bottleneck)
+
+### Network Storage
+**Goal**: Minimize network I/O with maximum compression
+
+```bash
+fgumi filter \
+  --threads 4 \
+  --queue-memory 512 \
+  --compression-level 9 \
+  --input dataset.bam \
+  --output filtered.bam
+```
+
+**Rationale**:
+- Moderate threading to avoid overwhelming network
+- Conservative memory usage
+- Maximum compression to reduce network transfer
+
+### Development/Testing
+**Goal**: Fast iteration with minimal resource usage
+
+```bash
+fgumi filter \
+  --queue-memory 256 \
+  --compression-level 1 \
+  --input small_test.bam \
+  --output test_output.bam
+```
+
+**Rationale**:
+- Single-threaded for simplicity
+- Minimal memory footprint
+- Fast compression for quick turnaround
+
+## Performance Monitoring
+
+### Memory Usage
+- Monitor system memory usage during execution
+- Watch for "exceeds available memory" warnings
+- Adjust `--queue-memory` if seeing swap activity
+
+### Thread Utilization
+- Use `htop` or similar to monitor CPU usage
+- All threads should show activity during processing
+- Consider reducing threads if not fully utilized
+
+### I/O Patterns
+- Monitor disk I/O with `iotop`
+- Network storage may benefit from lower thread counts
+- SSD storage can handle higher thread counts
+
+## Troubleshooting
+
+### Out of Memory Errors
+1. Reduce `--queue-memory`
+2. Set `--queue-memory-per-thread false` for fixed limits
+3. Reduce `--threads`
+
+### Poor Performance
+1. Increase `--threads` if CPU usage is low
+2. Increase `--queue-memory` if I/O bound
+3. Reduce `--compression-level` if CPU bound
+
+### System Memory Warnings
+```text
+Requested memory 16GB exceeds 90% of system memory (14.4GB)
+```
+- Reduce memory allocation or add more RAM
+- Consider using `--queue-memory-per-thread false`
+
+## Command-Specific Considerations
+
+### Extract
+- Benefits from high memory (large FASTQ processing)
+- Compression level affects output size significantly
+
+### Group/Dedup
+- Memory usage scales with UMI diversity
+- Higher thread counts improve UMI processing
+
+### Consensus (Simplex/Duplex/CODEC)
+- Memory proportional to family sizes
+- Benefits from balanced threading and memory
+
+### Filter
+- Streaming operation benefits from pipeline memory
+- Compression affects final output size
+
+## Migration from Legacy Parameters
+
+If using deprecated `--queue-memory-limit-mb`:
+
+```bash
+# Old (deprecated)
+fgumi group --queue-memory-limit-mb 4096
+
+# New (recommended)
+fgumi group --queue-memory 4096 --queue-memory-per-thread false
+```
+
+The new parameters provide better control and human-readable formats while maintaining backward compatibility.


### PR DESCRIPTION
## Summary of changes

Standardizes memory management across all 9 pipeline commands with consistent `--queue-memory` and `--queue-memory-per-thread` CLI parameters. Adds human-readable memory parsing ("2GB", "1024MiB") alongside plain numbers (interpreted as MB). Includes comprehensive memory validation: overflow protection, system memory checks, and per-thread limits. Deprecates `--queue-memory-limit-mb` in group/dedup with migration warnings.

### Commands updated

- **Replaced parameters**: group, dedup (`--queue-memory-limit-mb` → unified parameters)
- **Added memory controls**: extract, filter, duplex, simplex, codec, correct, clip

### Issue(s) addressed by this PR

Memory configuration was inconsistent across commands — only group and dedup had `--queue-memory-limit-mb`, while other pipeline commands had no memory controls at all.

### Reviewer guidance

- The `parse_memory_size` function handles both human-readable strings and plain numbers
- Legacy `--queue-memory-limit-mb` is preserved with deprecation warnings and migration guidance
- System memory validation warns (but does not error) when requesting >90% of available memory

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

The deprecated `--queue-memory-limit-mb` parameter continues to work with a warning.

### :heavy_check_mark: Checklist

- [x] I have checked there are not other open [Pull Requests](../../../pulls) for the same update/change
- [x] I added test case(s) whose failure behavior is different before vs after the change
- [x] All non-obvious additions to the code are thoroughly commented
- [x] All CI checks pass (compile, test, format, lints)
- [ ] I added/updated all relevant documentation (e.g., `README.md` and `docs/*`)
- [ ] All relevant logs, outputs, screenshots, etc. are attached
- [x] I have followed all the other contributing guidelines not covered by the above items