### PR TITLE
feat(pipeline): add memory profiling and debug infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "bgzf"
@@ -584,6 +608,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +746,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "csv",
+ "dhat",
  "enum_dispatch",
  "env_logger",
  "fgoxide",
@@ -708,6 +755,7 @@ dependencies = [
  "isal-rs",
  "itertools 0.14.0",
  "libdeflater",
+ "libmimalloc-sys",
  "log",
  "lru",
  "memchr",
@@ -848,6 +896,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
@@ -1298,6 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "cty",
  "libc",
 ]
 
@@ -1440,6 +1495,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "murmur3"
@@ -1696,6 +1757,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2113,6 +2183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2557,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ noodles = { version = "0.102.0", features = ["bam", "fasta", "sam", "bgzf", "cor
 noodles-bgzf = { version = "0.45.0", features = ["libdeflate"] }
 noodles-util = { version = "0.71.0", features = ["alignment"] }
 mimalloc = { version = "0.1.48", default-features = false }
+libmimalloc-sys = { version = "0.1.44", features = ["extended"], optional = true }
 env_logger = "0.11.8"
 enum_dispatch = "0.3.13"
 anyhow = "1.0.100"
@@ -59,9 +60,13 @@ bgzf = "0.3.0"
 wide = "0.7"
 rand_distr = "0.5"
 flate2 = "1.1"
+dhat = { version = "0.3", optional = true }
 
 [features]
 default = []
+dhat-heap = ["dep:dhat"]
+# Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
+memory-debug = ["dep:libmimalloc-sys"]
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
 # Enable simulate commands for generating synthetic test data

--- a/src/lib/unified_pipeline/queue.rs
+++ b/src/lib/unified_pipeline/queue.rs
@@ -14,6 +14,14 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
+/// Memory statistics for a queue
+#[derive(Debug, Clone)]
+pub struct QueueMemoryStats {
+    pub current_bytes: u64,
+    pub peak_bytes: u64,
+    pub limit_bytes: u64,
+}
+
 /// Statistics collected per queue for rebalancing decisions.
 #[derive(Debug, Clone, Default)]
 pub struct QueueStats {
@@ -132,6 +140,15 @@ impl<T> MemoryBoundedQueue<T> {
     /// Current memory usage in bytes.
     pub fn current_bytes(&self) -> u64 {
         self.current_bytes.load(Ordering::Acquire)
+    }
+
+    /// Get queue memory statistics for reporting.
+    pub fn memory_stats(&self) -> QueueMemoryStats {
+        QueueMemoryStats {
+            current_bytes: self.current_bytes(),
+            peak_bytes: self.peak_bytes.load(Ordering::Relaxed),
+            limit_bytes: self.limit_bytes.load(Ordering::Relaxed),
+        }
     }
 
     /// Check if queue is at or over memory limit.

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ const FEATURE_GATED_COMMANDS: &[(&str, &str)] = &[
     ("simulate", "simulate"),
 ];
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static GLOBAL: dhat::Alloc = dhat::Alloc;
+
+#[cfg(not(feature = "dhat-heap"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
@@ -121,6 +126,9 @@ enum Subcommand {
 }
 
 fn main() -> Result<()> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     // Capture full command line BEFORE clap parsing for @PG records


### PR DESCRIPTION
## Summary of changes

Adds comprehensive memory profiling and debug infrastructure to the unified pipeline, gated behind the `memory-debug` feature flag. Includes runtime memory tracking via per-queue atomic counters, system RSS monitoring, mimalloc stats integration, and a periodic monitor thread that logs memory breakdowns. Refactors the group command to use shared pipeline infrastructure for serialization, reducing code duplication. Adds `--debug-memory` flag for detailed pipeline diagnostics.

**Stacked on #62**

### Issue(s) addressed by this PR

Provides tooling to understand and debug pipeline memory usage, which is critical for tuning queue memory limits introduced in #62.

### Reviewer guidance

- All memory tracking is gated behind `#[cfg(feature = "memory-debug")]` — zero overhead in release builds
- `PipelineStats` memory fields are consolidated into a `MemoryDebugStats` nested struct
- The `FGUMI_SHORT_CIRCUIT` env var allows truncating the pipeline at a specific stage for memory profiling
- Template heap size estimation uses sampling (first 5 of large batches) via a shared helper function

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### :heavy_check_mark: Checklist

- [x] I have checked there are not other open [Pull Requests](../../../pulls) for the same update/change
- [x] I added test case(s) whose failure behavior is different before vs after the change
- [x] All non-obvious additions to the code are thoroughly commented
- [x] All CI checks pass (compile, test, format, lints)
- [ ] I added/updated all relevant documentation (e.g., `README.md` and `docs/*`)
- [ ] All relevant logs, outputs, screenshots, etc. are attached
- [x] I have followed all the other contributing guidelines not covered by the above items