### PR TITLE
ci: group dependabot PRs and switch to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,18 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      all-cargo-deps:
+        patterns: ["*"]
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

- Switches dependabot from **daily** to **weekly** schedule for both cargo and GitHub Actions
- Groups all cargo dependency updates into a **single PR** instead of one per dependency
- Groups all GitHub Actions updates into a single PR as well
- Reduces `open-pull-requests-limit` from 10 to 5

This reduces PR noise significantly — instead of up to 10 individual PRs per day for patch/minor bumps, we get at most one combined cargo PR and one combined actions PR per week.

## Test plan

- [ ] Verify dependabot creates grouped PRs on next weekly run