### PR TITLE
refactor: add RecordPositionGrouper to defer Template building to parallel step

### DIFF
--- a/src/lib/read_info.rs
+++ b/src/lib/read_info.rs
@@ -39,8 +39,7 @@ use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 ///
 /// Both `LibraryLookup` and [`LibraryIndex`] exist for different use cases:
 /// - `LibraryLookup`: String-based lookup returning library names. Used by
-///   [`ReadInfo::from`] and [`PositionGrouperConfig`](crate::grouper::PositionGrouperConfig)
-///   where the actual library name string is needed.
+///   [`ReadInfo::from`] where the actual library name string is needed.
 /// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
 ///   [`compute_group_key`] in the hot path where only equality comparison matters,
 ///   avoiding string allocations.
@@ -227,8 +226,8 @@ pub fn compute_group_key(
     // Extract name hash
     let name_hash = LibraryIndex::hash_name(record.name().map(AsRef::as_ref));
 
-    // Skip secondary and supplementary alignments - they get a default key
-    // (they'll be filtered out by PositionGrouper anyway)
+    // Skip secondary and supplementary alignments - they get a default key with UNKNOWN_REF.
+    // RecordPositionGrouper either skips them or coalesces them by name_hash.
     let flags = record.flags();
     if flags.is_secondary() || flags.is_supplementary() {
         return GroupKey { name_hash, ..GroupKey::default() };

--- a/src/lib/sam/builder.rs
+++ b/src/lib/sam/builder.rs
@@ -1632,6 +1632,12 @@ impl RecordPairBuilder {
             r2_builder = r2_builder.tag(tag, value.clone());
         }
 
+        // Add MC (mate CIGAR) tags when both reads are mapped
+        if r1_mapped && r2_mapped {
+            r1_builder = r1_builder.tag("MC", r2_cigar.as_str());
+            r2_builder = r2_builder.tag("MC", r1_cigar.as_str());
+        }
+
         // Calculate template length if both mapped to same reference
         let mut r1 = r1_builder.build();
         let mut r2 = r2_builder.build();

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -3405,7 +3405,7 @@ impl BamPipelineConfig {
 ///
 /// # Type Parameters
 ///
-/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `PositionGroup`, `MiGroup`)
+/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `RawPositionGroup`, `MiGroup`)
 /// - `P`: Processed type produced by the process function (e.g., `Vec<RecordBuf>`)
 ///
 /// # Arguments
@@ -3530,7 +3530,7 @@ where
 ///
 /// # Type Parameters
 ///
-/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `PositionGroup`, `MiGroup`)
+/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `RawPositionGroup`, `MiGroup`)
 /// - `P`: Processed type produced by the process function (e.g., `Vec<RecordBuf>`)
 ///
 /// # Arguments
@@ -3658,7 +3658,7 @@ where
 ///
 /// # Type Parameters
 ///
-/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `PositionGroup`, `MiGroup`)
+/// - `G`: Group type produced by the grouper (e.g., `RecordBuf`, `RawPositionGroup`, `MiGroup`)
 /// - `P`: Processed type produced by the process function (e.g., `Vec<RecordBuf>`)
 /// - `R`: Reader type that implements `Read + Send`
 ///

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -100,7 +100,7 @@ pub struct MemoryDebugStats {
     pub template_processing_bytes: AtomicU64,
     /// Memory held in reorder buffers
     pub reorder_buffer_bytes: AtomicU64,
-    /// Memory held by PositionGrouper state
+    /// Memory held by grouper state
     pub grouper_memory_bytes: AtomicU64,
     /// Memory held by worker-local allocations
     pub worker_local_memory_bytes: AtomicU64,
@@ -1232,7 +1232,7 @@ impl GroupKey {
 
     /// Returns the position-only key for grouping by genomic position.
     ///
-    /// This is used by `PositionGrouper` to determine if records belong to
+    /// This is used by `RecordPositionGrouper` to determine if records belong to
     /// the same position group (ignoring name).
     #[must_use]
     pub fn position_key(&self) -> (i32, i32, u8, i32, i32, u8, u16, u64) {
@@ -2228,7 +2228,7 @@ pub struct PipelineConfig {
     /// create tiny blocks instead of optimal 64KB blocks.
     ///
     /// - **`batch_size=1`**: For commands with naturally large work units
-    ///   (e.g., `group` with `PositionGroups` containing many records).
+    ///   (e.g., `group` with `RawPositionGroups` containing many records).
     /// - **`batch_size>1`**: For commands with small work units
     ///   (e.g., `filter` with single records). Use ~400 for ~60KB batches.
     pub batch_size: usize,


### PR DESCRIPTION
## Summary

Replaces `PositionGrouper` with `RecordPositionGrouper` in both the group and dedup commands, moving Template construction from the serial Group step to the parallel Process step. Removes ~400 lines of dead code.

### Changes

- Add `RecordPositionGrouper` that emits raw `DecodedRecord`s grouped by position, with name-hash coalescing for unmapped mates
- Add `build_templates_from_records()` for parallel Template construction in the Process step
- Wire `RecordPositionGrouper` into group (pipeline + single-threaded) and dedup commands
- Pass user's `--cell-tag` into dedup pipeline's `GroupKeyConfig` (was previously validated but unused)
- Add MC tags to SAM output for mapped paired-end reads
- Add `debug_assert` in `finish()` to catch invariant violations
- Remove `PositionGrouper`, `PositionGrouperConfig`, `PositionGroup`, `combine_keys`, and associated tests (~400 lines)
- Fix test helper `build_test_pair_with_orientation` missing MC tag
- Fix misleading `div_ceil` comments in `batch_weight` tests

## Correctness

Validated all 4 strategies on agilent-hs2 (8 threads) — exact match with baseline:

| Strategy | Accepted | Unique Molecules | Baseline | New |
|----------|----------|-----------------|----------|-----|
| identity | 53,139,936 | 10,292,162 | 27.45s | 28.86s |
| edit | 53,139,936 | 10,220,308 | 25.19s | 23.36s |
| adjacency | 53,139,936 | 10,220,628 | 23.47s | 23.36s |
| paired | 53,139,936 | 10,220,662 | 24.89s | 26.51s |

Performance within run-to-run noise. No regression.

## Test plan

- [x] `cargo ci-test` — all tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Verified exact record/molecule counts on agilent-hs2 across all 4 strategies
- [x] Benchmarked wall time against baseline — no regression