### PR TITLE
fix: use find_tag_type for pa-tag validation in dedup raw-byte path

### DIFF
--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -930,9 +930,7 @@ fn process_position_group(
                 }
                 if is_secondary || is_supplementary {
                     let aux = bam_fields::aux_data_slice(raw);
-                    if bam_fields::find_string_tag(aux, &pa_tag_bytes).is_none()
-                        && bam_fields::find_int_tag(aux, &pa_tag_bytes).is_none()
-                    {
+                    if bam_fields::find_tag_type(aux, &pa_tag_bytes).is_none() {
                         dedup_metrics.missing_pa_tag += 1;
                     }
                 }


### PR DESCRIPTION
## Summary

- The dedup pa-tag validation used `find_string_tag` (Z-type only) and `find_int_tag` (scalar int only) to check for the `pa` tag on secondary/supplementary reads. The `pa` tag is a `B:i` (int32 array), which neither function can find, causing dedup to falsely report all supplementary reads as missing the `pa` tag and error out.
- Replace with `find_tag_type` which handles all BAM aux tag types in a single pass (also faster than the previous two-pass approach).
- Add exhaustive unit tests covering all 17 SAM/BAM tag type variants across `find_string_tag`, `find_int_tag`, and `find_tag_type`.

## Test plan

- [x] `cargo ci-fmt` passes
- [x] `cargo ci-lint` passes
- [x] `cargo nextest run` — 2502 tests pass
- [x] Verified fix against real CODEC BAM that reproduced the failure