### PR TITLE
feat: convert all consensus callers to raw-byte BAM pipeline

### DIFF
--- a/src/lib/consensus/overlapping.rs
+++ b/src/lib/consensus/overlapping.rs
@@ -10,6 +10,7 @@ use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER};
+use crate::sort::bam_fields;
 
 /// Check if a base is a no-call (N, n, or .)
 /// Matches htsjdk's SequenceUtil.isNoCall behavior
@@ -703,6 +704,380 @@ pub fn apply_overlapping_consensus(
     Ok(())
 }
 
+// ============================================================================
+// Raw-byte overlapping consensus
+// ============================================================================
+
+impl OverlappingBasesConsensusCaller {
+    /// Process overlapping bases in a read pair using raw BAM bytes.
+    ///
+    /// Same logic as `call()` but extracts fields from raw bytes directly.
+    /// Modifies the raw byte records in-place.
+    ///
+    /// # Returns
+    /// * `true` if overlapping bases were processed, `false` if reads don't overlap
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss
+    )]
+    pub fn call_raw(&mut self, r1: &mut [u8], r2: &mut [u8]) -> Result<bool> {
+        // Only process paired reads where both are mapped
+        if bam_fields::flags(r1) & bam_fields::flags::UNMAPPED != 0
+            || bam_fields::flags(r2) & bam_fields::flags::UNMAPPED != 0
+        {
+            return Ok(false);
+        }
+
+        // Must be on the same reference sequence
+        if bam_fields::ref_id(r1) != bam_fields::ref_id(r2) {
+            return Ok(false);
+        }
+
+        // Verify both have alignment positions and ends
+        let Some(r1_start) = bam_fields::alignment_start_from_raw(r1) else { return Ok(false) };
+        let Some(r1_end) = bam_fields::alignment_end_from_raw(r1) else { return Ok(false) };
+        let Some(r2_start) = bam_fields::alignment_start_from_raw(r2) else { return Ok(false) };
+        let Some(r2_end) = bam_fields::alignment_end_from_raw(r2) else { return Ok(false) };
+
+        // Create merge iterator that yields positions where both reads have aligned bases
+        let Ok(overlap_iter) =
+            RawReadMateAndRefPosIterator::new(r1, r2, r1_start, r1_end, r2_start, r2_end)
+        else {
+            return Ok(false);
+        };
+
+        let overlapping_positions: Vec<_> = overlap_iter.collect();
+
+        if overlapping_positions.is_empty() {
+            return Ok(false);
+        }
+
+        // Extract sequences and qualities for modification
+        let mut r1_seq = bam_fields::extract_sequence(r1);
+        let mut r2_seq = bam_fields::extract_sequence(r2);
+        let mut r1_quals: Vec<u8> = bam_fields::quality_scores_slice(r1).to_vec();
+        let mut r2_quals: Vec<u8> = bam_fields::quality_scores_slice(r2).to_vec();
+        let mut modified = false;
+
+        for pos in overlapping_positions {
+            let r1_base = r1_seq[pos.read_offset];
+            let r2_base = r2_seq[pos.mate_offset];
+
+            if is_no_call(r1_base) || is_no_call(r2_base) {
+                continue;
+            }
+
+            self.stats.overlapping_bases += 1;
+
+            let r1_qual = r1_quals[pos.read_offset];
+            let r2_qual = r2_quals[pos.mate_offset];
+
+            if r1_base == r2_base {
+                self.stats.bases_agreeing += 1;
+                if self.process_agreement(
+                    pos.read_offset,
+                    pos.mate_offset,
+                    r1_qual,
+                    r2_qual,
+                    &mut r1_quals,
+                    &mut r2_quals,
+                ) {
+                    modified = true;
+                }
+            } else {
+                self.stats.bases_disagreeing += 1;
+                self.process_disagreement(
+                    pos.read_offset,
+                    pos.mate_offset,
+                    r1_base,
+                    r2_base,
+                    r1_qual,
+                    r2_qual,
+                    &mut r1_seq,
+                    &mut r2_seq,
+                    &mut r1_quals,
+                    &mut r2_quals,
+                );
+                modified = true;
+            }
+        }
+
+        // Write back modified sequences and qualities into the raw BAM records
+        if modified {
+            let r1_seq_off = bam_fields::seq_offset(r1);
+            let r2_seq_off = bam_fields::seq_offset(r2);
+            for (i, &base) in r1_seq.iter().enumerate() {
+                bam_fields::set_base(r1, r1_seq_off, i, base);
+            }
+            for (i, &base) in r2_seq.iter().enumerate() {
+                bam_fields::set_base(r2, r2_seq_off, i, base);
+            }
+            let r1_qual_off = bam_fields::qual_offset(r1);
+            let r2_qual_off = bam_fields::qual_offset(r2);
+            r1[r1_qual_off..r1_qual_off + r1_quals.len()].copy_from_slice(&r1_quals);
+            r2[r2_qual_off..r2_qual_off + r2_quals.len()].copy_from_slice(&r2_quals);
+        }
+
+        Ok(true)
+    }
+}
+
+/// Raw-byte version of `ReadAndRefPosIterator`.
+///
+/// Walks through aligned (M/X/=) positions in a raw BAM record's CIGAR.
+struct RawReadAndRefPosIterator {
+    cur_read_pos: i32,
+    cur_ref_pos: i32,
+    cigar_ops: Vec<(u8, usize)>, // (op_type, op_len)
+    element_index: usize,
+    in_elem_offset: usize,
+    start_ref_pos: i32,
+    end_ref_pos: i32,
+    start_read_pos: i32,
+    end_read_pos: i32,
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+impl RawReadAndRefPosIterator {
+    /// Create iterator for aligned positions overlapping with mate.
+    fn new_with_mate(
+        bam: &[u8],
+        rec_start: usize,
+        rec_end: usize,
+        mate_start: usize,
+        mate_end: usize,
+    ) -> Result<Self> {
+        let rec_start_i32 = rec_start as i32;
+        let rec_end_i32 = rec_end as i32;
+        let rec_len = bam_fields::l_seq(bam) as i32;
+
+        let min_ref_pos = rec_start_i32.max(mate_start as i32);
+        let max_ref_pos = rec_end_i32.min(mate_end as i32);
+
+        // Extract CIGAR ops from raw BAM
+        let raw_ops = bam_fields::get_cigar_ops(bam);
+        let cigar_ops: Vec<(u8, usize)> =
+            raw_ops.iter().map(|&op| ((op & 0xF) as u8, (op >> 4) as usize)).collect();
+
+        let start_read_pos = 1i32;
+        let end_read_pos = rec_len;
+        let start_ref_pos = rec_start_i32.max(min_ref_pos);
+        let end_ref_pos = rec_end_i32.min(max_ref_pos);
+
+        let mut iter = Self {
+            cur_read_pos: 1,
+            cur_ref_pos: rec_start_i32,
+            cigar_ops,
+            element_index: 0,
+            in_elem_offset: 0,
+            start_ref_pos,
+            end_ref_pos,
+            start_read_pos,
+            end_read_pos,
+        };
+
+        iter.skip_to_start();
+        Ok(iter)
+    }
+
+    fn cur_elem_length_on_target(&self) -> usize {
+        if self.element_index >= self.cigar_ops.len() {
+            return 0;
+        }
+        let (op_type, len) = self.cigar_ops[self.element_index];
+        // M(0), D(2), N(3), =(7), X(8) consume reference
+        if matches!(op_type, 0 | 2 | 3 | 7 | 8) { len } else { 0 }
+    }
+
+    fn cur_elem_length_on_query(&self) -> usize {
+        if self.element_index >= self.cigar_ops.len() {
+            return 0;
+        }
+        let (op_type, len) = self.cigar_ops[self.element_index];
+        // M(0), I(1), S(4), =(7), X(8) consume query
+        if matches!(op_type, 0 | 1 | 4 | 7 | 8) { len } else { 0 }
+    }
+
+    fn cur_elem_is_alignment(&self) -> bool {
+        if self.element_index >= self.cigar_ops.len() {
+            return false;
+        }
+        let (op_type, _) = self.cigar_ops[self.element_index];
+        // M(0), =(7), X(8) are alignment operations
+        matches!(op_type, 0 | 7 | 8)
+    }
+
+    fn skip_to_start(&mut self) {
+        while self.element_index < self.cigar_ops.len() {
+            let cur_ref_end = self.cur_ref_pos + self.cur_elem_length_on_target() as i32 - 1;
+            let cur_read_end = self.cur_read_pos + self.cur_elem_length_on_query() as i32 - 1;
+
+            if cur_ref_end >= self.start_ref_pos && cur_read_end >= self.start_read_pos {
+                break;
+            }
+
+            self.cur_ref_pos += self.cur_elem_length_on_target() as i32;
+            self.cur_read_pos += self.cur_elem_length_on_query() as i32;
+            self.element_index += 1;
+        }
+
+        self.skip_non_aligned_and_adjust_offset();
+    }
+
+    fn skip_non_aligned_and_adjust_offset(&mut self) {
+        self.in_elem_offset = 0;
+
+        while self.element_index < self.cigar_ops.len() && !self.cur_elem_is_alignment() {
+            self.cur_ref_pos += self.cur_elem_length_on_target() as i32;
+            self.cur_read_pos += self.cur_elem_length_on_query() as i32;
+            self.element_index += 1;
+        }
+
+        if self.element_index < self.cigar_ops.len()
+            && (self.cur_ref_pos < self.start_ref_pos || self.cur_read_pos < self.start_read_pos)
+        {
+            let offset = (self.start_ref_pos - self.cur_ref_pos)
+                .max(self.start_read_pos - self.cur_read_pos);
+            self.in_elem_offset = offset as usize;
+            self.cur_ref_pos += offset;
+            self.cur_read_pos += offset;
+        }
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+impl Iterator for RawReadAndRefPosIterator {
+    type Item = ReadPosition;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.element_index < self.cigar_ops.len() {
+            let (_, len) = self.cigar_ops[self.element_index];
+            if self.in_elem_offset >= len {
+                self.element_index += 1;
+                self.skip_non_aligned_and_adjust_offset();
+            }
+        }
+
+        if self.element_index >= self.cigar_ops.len()
+            || self.cur_read_pos > self.end_read_pos
+            || self.cur_ref_pos > self.end_ref_pos
+        {
+            return None;
+        }
+
+        let pos = ReadPosition {
+            read_offset: (self.cur_read_pos - 1) as usize,
+            ref_pos: self.cur_ref_pos,
+        };
+
+        self.cur_read_pos += 1;
+        self.cur_ref_pos += 1;
+        self.in_elem_offset += 1;
+
+        Some(pos)
+    }
+}
+
+/// Raw-byte version of `ReadMateAndRefPosIterator`.
+struct RawReadMateAndRefPosIterator {
+    rec_iter: std::iter::Peekable<RawReadAndRefPosIterator>,
+    mate_iter: std::iter::Peekable<RawReadAndRefPosIterator>,
+}
+
+impl RawReadMateAndRefPosIterator {
+    fn new(
+        r1: &[u8],
+        r2: &[u8],
+        r1_start: usize,
+        r1_end: usize,
+        r2_start: usize,
+        r2_end: usize,
+    ) -> Result<Self> {
+        let rec_iter =
+            RawReadAndRefPosIterator::new_with_mate(r1, r1_start, r1_end, r2_start, r2_end)?
+                .peekable();
+        let mate_iter =
+            RawReadAndRefPosIterator::new_with_mate(r2, r2_start, r2_end, r1_start, r1_end)?
+                .peekable();
+
+        Ok(Self { rec_iter, mate_iter })
+    }
+}
+
+impl Iterator for RawReadMateAndRefPosIterator {
+    type Item = ReadMateAndRefPos;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use std::cmp::Ordering;
+
+        loop {
+            let rec_pos = self.rec_iter.peek()?;
+            let mate_pos = self.mate_iter.peek()?;
+
+            match rec_pos.ref_pos.cmp(&mate_pos.ref_pos) {
+                Ordering::Less => {
+                    self.rec_iter.next();
+                }
+                Ordering::Greater => {
+                    self.mate_iter.next();
+                }
+                Ordering::Equal => {
+                    let rec = self.rec_iter.next().expect("peeked Some");
+                    let mate = self.mate_iter.next().expect("peeked Some");
+
+                    return Some(ReadMateAndRefPos {
+                        read_offset: rec.read_offset,
+                        mate_offset: mate.read_offset,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Applies overlapping consensus calling to pairs of raw-byte reads within a group.
+///
+/// This is the raw-byte equivalent of `apply_overlapping_consensus`.
+pub fn apply_overlapping_consensus_raw(
+    records: &mut [Vec<u8>],
+    caller: &mut OverlappingBasesConsensusCaller,
+) -> Result<()> {
+    use ahash::AHashMap;
+
+    // Group reads by name for pairing
+    let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> = AHashMap::new();
+
+    for (idx, record) in records.iter().enumerate() {
+        let name = bam_fields::read_name(record).to_vec();
+        let flg = bam_fields::flags(record);
+
+        if flg & bam_fields::flags::FIRST_SEGMENT != 0 {
+            read_pairs.entry(name).or_insert((None, None)).0 = Some(idx);
+        } else if flg & bam_fields::flags::LAST_SEGMENT != 0 {
+            read_pairs.entry(name).or_insert((None, None)).1 = Some(idx);
+        }
+    }
+
+    // Process pairs
+    for (r1_idx, r2_idx) in read_pairs.values() {
+        if let (Some(idx1), Some(idx2)) = (r1_idx, r2_idx) {
+            let (r1, r2) = if idx1 < idx2 {
+                let (left, right) = records.split_at_mut(*idx2);
+                (&mut left[*idx1], &mut right[0])
+            } else {
+                let (left, right) = records.split_at_mut(*idx1);
+                (&mut right[0], &mut left[*idx2])
+            };
+
+            caller.call_raw(r1, r2).context("Failed to call overlapping consensus on raw bytes")?;
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 mod tests {
@@ -1197,5 +1572,766 @@ mod tests {
         // Quality difference is 1, but should be at least 2
         assert_eq!(r1.quality_scores().as_ref()[0], 2);
         assert_eq!(r2.quality_scores().as_ref()[0], 2);
+    }
+
+    // ========================================================================
+    // Raw-byte tests
+    // ========================================================================
+
+    /// SAM spec 4-bit encoding for A=1, C=2, G=4, T=8, N=15.
+    fn base_to_4bit(b: u8) -> u8 {
+        match b {
+            b'A' | b'a' => 1,
+            b'C' | b'c' => 2,
+            b'G' | b'g' => 4,
+            b'T' | b't' => 8,
+            b'N' | b'n' => 15,
+            _ => 15,
+        }
+    }
+
+    /// Pack ASCII bases into BAM 4-bit-per-base format.
+    fn pack_seq(bases: &[u8]) -> Vec<u8> {
+        let mut packed = Vec::with_capacity(bases.len().div_ceil(2));
+        for pair in bases.chunks(2) {
+            let hi = base_to_4bit(pair[0]);
+            let lo = if pair.len() > 1 { base_to_4bit(pair[1]) } else { 0 };
+            packed.push((hi << 4) | lo);
+        }
+        packed
+    }
+
+    /// Build a raw BAM record with populated sequence and quality data.
+    ///
+    /// `pos_0based` is the 0-based leftmost position (BAM pos field).
+    /// `cigar_ops` are pre-encoded BAM CIGAR u32 values.
+    /// `flag` is the BAM flag field.
+    /// `name` should have length+1 divisible by 4 for alignment.
+    fn make_raw_bam(
+        name: &[u8],
+        flag: u16,
+        tid: i32,
+        pos_0based: i32,
+        cigar_ops: &[u32],
+        seq: &[u8],
+        qual: &[u8],
+    ) -> Vec<u8> {
+        let l_read_name = (name.len() + 1) as u8; // +1 for null terminator
+        let n_cigar_op = cigar_ops.len() as u16;
+        let seq_len = seq.len();
+        let packed_seq = pack_seq(seq);
+        let total = 32 + l_read_name as usize + cigar_ops.len() * 4 + packed_seq.len() + seq_len;
+        let mut buf = vec![0u8; total];
+
+        // Fixed header
+        buf[0..4].copy_from_slice(&tid.to_le_bytes());
+        buf[4..8].copy_from_slice(&pos_0based.to_le_bytes());
+        buf[8] = l_read_name;
+        buf[9] = 60; // mapq
+        buf[10..12].copy_from_slice(&0u16.to_le_bytes()); // bin
+        buf[12..14].copy_from_slice(&n_cigar_op.to_le_bytes());
+        buf[14..16].copy_from_slice(&flag.to_le_bytes());
+        buf[16..20].copy_from_slice(&(seq_len as u32).to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes()); // mate tid
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes()); // mate pos
+        buf[28..32].copy_from_slice(&0i32.to_le_bytes()); // tlen
+
+        // Read name + null terminator
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        // CIGAR
+        let cigar_start = name_start + l_read_name as usize;
+        for (i, &op) in cigar_ops.iter().enumerate() {
+            let off = cigar_start + i * 4;
+            buf[off..off + 4].copy_from_slice(&op.to_le_bytes());
+        }
+
+        // Sequence (4-bit packed)
+        let seq_start = cigar_start + cigar_ops.len() * 4;
+        buf[seq_start..seq_start + packed_seq.len()].copy_from_slice(&packed_seq);
+
+        // Quality scores (raw Phred)
+        let qual_start = seq_start + packed_seq.len();
+        buf[qual_start..qual_start + qual.len()].copy_from_slice(qual);
+
+        buf
+    }
+
+    /// Encode a single CIGAR op as BAM u32: `(len << 4) | op_type`.
+    /// `op_type`: M=0, I=1, D=2, N=3, S=4, H=5, P=6, =7, X=8.
+    fn cigar_op(len: usize, op_type: u8) -> u32 {
+        ((len as u32) << 4) | u32::from(op_type)
+    }
+
+    /// Create a raw BAM record mirroring `create_test_record`.
+    ///
+    /// `start_1based` is a 1-based alignment start (matching the `RecordBuf` tests).
+    fn create_raw_test_record(
+        seq: &[u8],
+        qual: &[u8],
+        start_1based: usize,
+        cigar: &[u32],
+    ) -> Vec<u8> {
+        let pos_0based = (start_1based as i32) - 1;
+        // Use name "rea" (3 chars + 1 NUL = 4, divisible by 4)
+        make_raw_bam(b"rea", 0, 0, pos_0based, cigar, seq, qual)
+    }
+
+    #[test]
+    fn test_raw_agreement_strategy_consensus() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Check that qualities were summed (30 + 20 = 50)
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 50);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 50);
+    }
+
+    #[test]
+    fn test_raw_agreement_strategy_max_qual() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::MaxQual,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Max quality used (max(30, 20) = 30)
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 30);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 30);
+    }
+
+    #[test]
+    fn test_raw_agreement_strategy_pass_through() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Qualities unchanged
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 30);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 20);
+    }
+
+    #[test]
+    fn test_raw_disagreement_strategy_consensus() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Higher quality base (A from r1) chosen, qual = 30 - 20 = 10
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'A');
+        assert_eq!(r2_seq[0], b'A');
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 10);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 10);
+    }
+
+    #[test]
+    fn test_raw_disagreement_strategy_mask_both() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskBoth,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Both bases masked to N with quality 2
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'N');
+        assert_eq!(r2_seq[0], b'N');
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 2);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 2);
+    }
+
+    #[test]
+    fn test_raw_disagreement_strategy_mask_lower_qual() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskLowerQual,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Only lower quality base (r2) masked
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'A'); // Unchanged
+        assert_eq!(r2_seq[0], b'N'); // Masked
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 30); // Unchanged
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 2); // Masked
+    }
+
+    #[test]
+    fn test_raw_disagreement_mask_lower_qual_r1_lower() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskLowerQual,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Only lower quality base (r1) masked
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'N'); // Masked
+        assert_eq!(r2_seq[0], b'G'); // Unchanged
+    }
+
+    #[test]
+    fn test_raw_disagreement_mask_lower_qual_equal_quality() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskLowerQual,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Both masked when qualities are equal
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'N');
+        assert_eq!(r2_seq[0], b'N');
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 2);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 2);
+    }
+
+    #[test]
+    fn test_raw_disagreement_consensus_equal_quality() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Both masked when qualities are equal
+        let r1_seq = bam_fields::extract_sequence(&r1);
+        let r2_seq = bam_fields::extract_sequence(&r2);
+        assert_eq!(r1_seq[0], b'N');
+        assert_eq!(r2_seq[0], b'N');
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 2);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 2);
+    }
+
+    #[test]
+    fn test_raw_no_overlap() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // Reads don't overlap: r1 at 100-103, r2 at 200-203
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 200, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_raw_unmapped_reads() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // r1 is unmapped (flag=0x4)
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = make_raw_bam(
+            b"rea",
+            bam_fields::flags::UNMAPPED,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        );
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_raw_different_references() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // r1 on tid=0, r2 on tid=1
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = make_raw_bam(b"rea", 0, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let mut r2 = make_raw_bam(b"rea", 0, 1, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_raw_quality_capping_at_93() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[50, 50, 50, 50], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[50, 50, 50, 50], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Quality capped at 93
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 93);
+    }
+
+    #[test]
+    fn test_raw_stats_tracking() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        assert!(caller.stats().overlapping_bases > 0);
+        assert_eq!(caller.stats().bases_agreeing, caller.stats().overlapping_bases);
+        assert_eq!(caller.stats().bases_disagreeing, 0);
+        assert_eq!(caller.stats().bases_corrected, caller.stats().overlapping_bases);
+    }
+
+    #[test]
+    fn test_raw_stats_tracking_with_disagreements() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"TGCA", &[20, 20, 20, 20], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        assert!(caller.stats().overlapping_bases > 0);
+        assert_eq!(caller.stats().bases_agreeing, 0);
+        assert_eq!(caller.stats().bases_disagreeing, caller.stats().overlapping_bases);
+    }
+
+    #[test]
+    fn test_raw_overlap_different_start_positions() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // R1: positions 100-103 (ACGT), R2: positions 102-105 (GTAC)
+        // Overlap: positions 102-103 (GT matches GT)
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GTAC", &[20, 20, 20, 20], 102, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+        assert_eq!(caller.stats().overlapping_bases, 2);
+        assert_eq!(caller.stats().bases_agreeing, 2); // GT == GT
+
+        // Check quality sums at overlapping positions
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[2], 50); // 30 + 20
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[3], 50);
+    }
+
+    #[test]
+    fn test_raw_cigar_with_soft_clips() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // R1: 2S4M (6 bases, first 2 soft-clipped, aligned at ref 100-103)
+        let r1_cigar = [cigar_op(2, 4), cigar_op(4, 0)]; // 2S4M
+        let r2_cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"NNACGT", &[2, 2, 30, 30, 30, 30], 100, &r1_cigar);
+        let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &r2_cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+        assert_eq!(caller.stats().overlapping_bases, 4);
+        assert_eq!(caller.stats().bases_agreeing, 4); // ACGT == ACGT
+
+        // Check quality sums at overlapping positions
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[2], 50); // 30 + 20
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[3], 50);
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[4], 50);
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[5], 50);
+    }
+
+    #[test]
+    fn test_raw_cigar_with_insertions() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // R1: 2M2I2M (6 bases), R2: 4M
+        let r1_cigar = [cigar_op(2, 0), cigar_op(2, 1), cigar_op(2, 0)]; // 2M2I2M
+        let r2_cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACTTGG", &[30, 30, 30, 30, 30, 30], 100, &r1_cigar);
+        let mut r2 = create_raw_test_record(b"ACGG", &[20, 20, 20, 20], 100, &r2_cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_raw_cigar_with_deletions() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // R1: 2M2D2M (4 bases, spans 6 ref positions), R2: 6M
+        let r1_cigar = [cigar_op(2, 0), cigar_op(2, 2), cigar_op(2, 0)]; // 2M2D2M
+        let r2_cigar = [cigar_op(6, 0)]; // 6M
+        let mut r1 = create_raw_test_record(b"ACGG", &[30, 30, 30, 30], 100, &r1_cigar);
+        let mut r2 = create_raw_test_record(b"ACTTGG", &[20, 20, 20, 20, 20, 20], 100, &r2_cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_raw_disagreement_consensus_min_quality() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut r2 = create_raw_test_record(b"GCTA", &[29, 29, 29, 29], 100, &cigar);
+
+        let result = caller.call_raw(&mut r1, &mut r2).unwrap();
+        assert!(result);
+
+        // Quality difference is 1, but minimum is 2
+        assert_eq!(bam_fields::quality_scores_slice(&r1)[0], 2);
+        assert_eq!(bam_fields::quality_scores_slice(&r2)[0], 2);
+    }
+
+    /// Verify that `call_raw` produces the same results as `call` for agreement.
+    #[test]
+    fn test_raw_matches_recordbuf_agreement() {
+        let mut caller_buf = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+        let mut caller_raw = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // RecordBuf path
+        let mut rb_r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
+        let mut rb_r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
+        caller_buf.call(&mut rb_r1, &mut rb_r2).unwrap();
+
+        // Raw path
+        let cigar = [cigar_op(4, 0)];
+        let mut raw_r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut raw_r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
+        caller_raw.call_raw(&mut raw_r1, &mut raw_r2).unwrap();
+
+        // Compare results
+        assert_eq!(rb_r1.quality_scores().as_ref(), bam_fields::quality_scores_slice(&raw_r1));
+        assert_eq!(rb_r2.quality_scores().as_ref(), bam_fields::quality_scores_slice(&raw_r2));
+        assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
+        assert_eq!(caller_buf.stats().bases_agreeing, caller_raw.stats().bases_agreeing);
+        assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
+    }
+
+    /// Verify that `call_raw` produces the same results as `call` for disagreement.
+    #[test]
+    fn test_raw_matches_recordbuf_disagreement() {
+        let mut caller_buf = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskBoth,
+        );
+        let mut caller_raw = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::PassThrough,
+            DisagreementStrategy::MaskBoth,
+        );
+
+        // RecordBuf path
+        let mut rb_r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
+        let mut rb_r2 = create_test_record(b"GCTA", &[20, 20, 20, 20], 100, "4M");
+        caller_buf.call(&mut rb_r1, &mut rb_r2).unwrap();
+
+        // Raw path
+        let cigar = [cigar_op(4, 0)];
+        let mut raw_r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
+        let mut raw_r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
+        caller_raw.call_raw(&mut raw_r1, &mut raw_r2).unwrap();
+
+        // Compare sequences
+        let buf_r1_seq: Vec<u8> = rb_r1.sequence().as_ref().to_vec();
+        let buf_r2_seq: Vec<u8> = rb_r2.sequence().as_ref().to_vec();
+        let raw_r1_seq = bam_fields::extract_sequence(&raw_r1);
+        let raw_r2_seq = bam_fields::extract_sequence(&raw_r2);
+        assert_eq!(buf_r1_seq, raw_r1_seq);
+        assert_eq!(buf_r2_seq, raw_r2_seq);
+
+        // Compare qualities
+        assert_eq!(rb_r1.quality_scores().as_ref(), bam_fields::quality_scores_slice(&raw_r1));
+        assert_eq!(rb_r2.quality_scores().as_ref(), bam_fields::quality_scores_slice(&raw_r2));
+
+        // Compare stats
+        assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
+        assert_eq!(caller_buf.stats().bases_disagreeing, caller_raw.stats().bases_disagreeing);
+        assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
+    }
+
+    // ========================================================================
+    // apply_overlapping_consensus_raw tests
+    // ========================================================================
+
+    #[test]
+    fn test_apply_overlapping_consensus_raw_pair() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // R1 (first segment): flag = PAIRED | FIRST_SEGMENT
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let r1_flag = bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT;
+        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        // R2 (last segment): flag = PAIRED | LAST_SEGMENT
+        let r2_flag = bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT;
+        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+
+        let mut records = vec![r1, r2];
+        apply_overlapping_consensus_raw(&mut records, &mut caller).unwrap();
+
+        // Check that qualities were summed (30 + 20 = 50)
+        assert_eq!(bam_fields::quality_scores_slice(&records[0])[0], 50);
+        assert_eq!(bam_fields::quality_scores_slice(&records[1])[0], 50);
+        assert!(caller.stats().overlapping_bases > 0);
+    }
+
+    #[test]
+    fn test_apply_overlapping_consensus_raw_no_pair() {
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        // Only FIRST_SEGMENT, no matching LAST_SEGMENT for this name
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let r1_flag = bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT;
+        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        // Different name so no pairing occurs
+        let r2_flag = bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT;
+        let r2 = make_raw_bam(b"reb", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+
+        let mut records = vec![r1, r2];
+        apply_overlapping_consensus_raw(&mut records, &mut caller).unwrap();
+
+        // Qualities unchanged because no matching pair
+        assert_eq!(bam_fields::quality_scores_slice(&records[0])[0], 30);
+        assert_eq!(bam_fields::quality_scores_slice(&records[1])[0], 20);
+        assert_eq!(caller.stats().overlapping_bases, 0);
+    }
+
+    #[test]
+    fn test_apply_overlapping_consensus_raw_reversed_indices() {
+        // Test when R2 appears before R1 in the slice (exercises the idx1 > idx2 branch)
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+        let r2_flag = bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT;
+        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r1_flag = bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT;
+        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+
+        // R2 at index 0, R1 at index 1
+        let mut records = vec![r2, r1];
+        apply_overlapping_consensus_raw(&mut records, &mut caller).unwrap();
+
+        // Both should have been consensus-called
+        assert!(caller.stats().overlapping_bases > 0);
+        assert_eq!(
+            bam_fields::quality_scores_slice(&records[0])[0],
+            bam_fields::quality_scores_slice(&records[1])[0]
+        );
+    }
+
+    // ========================================================================
+    // CorrectionStats::merge tests
+    // ========================================================================
+
+    #[test]
+    fn test_correction_stats_merge() {
+        let mut stats_a = CorrectionStats {
+            overlapping_bases: 10,
+            bases_agreeing: 8,
+            bases_disagreeing: 2,
+            bases_corrected: 3,
+        };
+
+        let stats_b = CorrectionStats {
+            overlapping_bases: 5,
+            bases_agreeing: 4,
+            bases_disagreeing: 1,
+            bases_corrected: 2,
+        };
+
+        stats_a.merge(&stats_b);
+
+        assert_eq!(stats_a.overlapping_bases, 15);
+        assert_eq!(stats_a.bases_agreeing, 12);
+        assert_eq!(stats_a.bases_disagreeing, 3);
+        assert_eq!(stats_a.bases_corrected, 5);
+    }
+
+    #[test]
+    fn test_correction_stats_merge_with_empty() {
+        let mut stats = CorrectionStats {
+            overlapping_bases: 10,
+            bases_agreeing: 8,
+            bases_disagreeing: 2,
+            bases_corrected: 3,
+        };
+
+        let empty = CorrectionStats::new();
+        stats.merge(&empty);
+
+        // Values unchanged after merging with empty
+        assert_eq!(stats.overlapping_bases, 10);
+        assert_eq!(stats.bases_agreeing, 8);
+        assert_eq!(stats.bases_disagreeing, 2);
+        assert_eq!(stats.bases_corrected, 3);
+    }
+
+    #[test]
+    fn test_correction_stats_merge_into_empty() {
+        let mut empty = CorrectionStats::new();
+
+        let stats = CorrectionStats {
+            overlapping_bases: 7,
+            bases_agreeing: 5,
+            bases_disagreeing: 2,
+            bases_corrected: 4,
+        };
+
+        empty.merge(&stats);
+
+        assert_eq!(empty.overlapping_bases, 7);
+        assert_eq!(empty.bases_agreeing, 5);
+        assert_eq!(empty.bases_disagreeing, 2);
+        assert_eq!(empty.bases_corrected, 4);
+    }
+
+    #[test]
+    fn test_correction_stats_merge_multiple() {
+        let mut total = CorrectionStats::new();
+
+        let a = CorrectionStats {
+            overlapping_bases: 3,
+            bases_agreeing: 2,
+            bases_disagreeing: 1,
+            bases_corrected: 1,
+        };
+        let b = CorrectionStats {
+            overlapping_bases: 5,
+            bases_agreeing: 5,
+            bases_disagreeing: 0,
+            bases_corrected: 5,
+        };
+        let c = CorrectionStats {
+            overlapping_bases: 2,
+            bases_agreeing: 0,
+            bases_disagreeing: 2,
+            bases_corrected: 4,
+        };
+
+        total.merge(&a);
+        total.merge(&b);
+        total.merge(&c);
+
+        assert_eq!(total.overlapping_bases, 10);
+        assert_eq!(total.bases_agreeing, 7);
+        assert_eq!(total.bases_disagreeing, 3);
+        assert_eq!(total.bases_corrected, 10);
     }
 }

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -696,6 +696,401 @@ impl Grouper for MiGrouper {
     }
 }
 
+// ============================================================================
+// Raw-byte MI grouping for consensus callers
+// ============================================================================
+
+/// A single MI group holding raw-byte BAM records.
+#[derive(Debug, Clone)]
+pub struct RawMiGroup {
+    /// The MI tag value (e.g., "0", "1/A", "1/B")
+    pub mi: String,
+    /// Raw BAM records sharing this MI value
+    pub records: Vec<Vec<u8>>,
+}
+
+impl RawMiGroup {
+    /// Creates a new raw MI group.
+    #[must_use]
+    pub fn new(mi: String, records: Vec<Vec<u8>>) -> Self {
+        Self { mi, records }
+    }
+}
+
+impl BatchWeight for RawMiGroup {
+    fn batch_weight(&self) -> usize {
+        self.records.len()
+    }
+}
+
+impl MemoryEstimate for RawMiGroup {
+    fn estimate_heap_size(&self) -> usize {
+        let mi_size = self.mi.capacity();
+        let records_size: usize = self.records.iter().map(|r| r.capacity()).sum();
+        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<Vec<u8>>();
+        mi_size + records_size + records_vec_overhead
+    }
+}
+
+/// A batch of raw MI groups for parallel processing.
+#[derive(Default)]
+pub struct RawMiGroupBatch {
+    /// The raw MI groups in this batch
+    pub groups: Vec<RawMiGroup>,
+}
+
+impl RawMiGroupBatch {
+    /// Creates a new empty raw MI group batch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { groups: Vec::new() }
+    }
+}
+
+impl BatchWeight for RawMiGroupBatch {
+    fn batch_weight(&self) -> usize {
+        self.groups.iter().map(|g| g.records.len()).sum()
+    }
+}
+
+impl MemoryEstimate for RawMiGroupBatch {
+    fn estimate_heap_size(&self) -> usize {
+        let groups_size: usize = self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum();
+        let groups_vec_overhead = self.groups.capacity() * std::mem::size_of::<RawMiGroup>();
+        groups_size + groups_vec_overhead
+    }
+}
+
+/// Type alias for raw-byte MI tag transformation function.
+type RawMiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
+
+/// Type alias for raw-byte record filter function.
+type RawRecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
+
+/// A Grouper that groups raw-byte BAM records by MI tag.
+///
+/// This is the raw-byte equivalent of `MiGrouper`. Instead of parsing records
+/// into `RecordBuf`, it extracts MI tags directly from raw BAM bytes using
+/// `bam_fields::find_string_tag_in_record()`.
+pub struct RawMiGrouper {
+    /// The MI tag bytes to search for
+    tag: [u8; 2],
+    /// Number of MI groups per batch
+    batch_size: usize,
+    /// Current MI value being accumulated
+    current_mi: Option<String>,
+    /// Records in current MI group (raw bytes)
+    current_records: Vec<Vec<u8>>,
+    /// Completed groups waiting to be batched
+    pending_groups: VecDeque<RawMiGroup>,
+    /// Whether `finish()` has been called
+    finished: bool,
+    /// Optional MI tag transformation function
+    mi_transform: Option<RawMiTransformFn>,
+    /// Optional record filter
+    record_filter: Option<RawRecordFilterFn>,
+}
+
+impl RawMiGrouper {
+    /// Create a new `RawMiGrouper`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tag_name` is not exactly 2 characters.
+    #[must_use]
+    pub fn new(tag_name: &str, batch_size: usize) -> Self {
+        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
+        let tag_bytes = tag_name.as_bytes();
+
+        Self {
+            tag: [tag_bytes[0], tag_bytes[1]],
+            batch_size: batch_size.max(1),
+            current_mi: None,
+            current_records: Vec::new(),
+            pending_groups: VecDeque::new(),
+            finished: false,
+            mi_transform: None,
+            record_filter: None,
+        }
+    }
+
+    /// Create a `RawMiGrouper` with record filtering and MI tag transformation.
+    pub fn with_filter_and_transform<F, T>(
+        tag_name: &str,
+        batch_size: usize,
+        record_filter: F,
+        mi_transform: T,
+    ) -> Self
+    where
+        F: Fn(&[u8]) -> bool + Send + Sync + 'static,
+        T: Fn(&[u8]) -> String + Send + Sync + 'static,
+    {
+        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
+        let tag_bytes = tag_name.as_bytes();
+
+        Self {
+            tag: [tag_bytes[0], tag_bytes[1]],
+            batch_size: batch_size.max(1),
+            current_mi: None,
+            current_records: Vec::new(),
+            pending_groups: VecDeque::new(),
+            finished: false,
+            mi_transform: Some(Box::new(mi_transform)),
+            record_filter: Some(Box::new(record_filter)),
+        }
+    }
+
+    /// Get MI tag from raw BAM bytes, optionally applying transformation.
+    fn get_mi_tag(&self, bam: &[u8]) -> Option<String> {
+        use crate::sort::bam_fields;
+        let value = bam_fields::find_string_tag_in_record(bam, &self.tag)?;
+        if let Some(ref transform) = self.mi_transform {
+            Some(transform(value))
+        } else {
+            Some(String::from_utf8_lossy(value).into_owned())
+        }
+    }
+
+    /// Check if a raw record passes the filter.
+    fn should_keep(&self, bam: &[u8]) -> bool {
+        match &self.record_filter {
+            Some(filter) => filter(bam),
+            None => true,
+        }
+    }
+
+    /// Flush current MI group to pending.
+    fn flush_current_group(&mut self) {
+        if let Some(mi) = self.current_mi.take() {
+            if !self.current_records.is_empty() {
+                let records = std::mem::take(&mut self.current_records);
+                self.pending_groups.push_back(RawMiGroup::new(mi, records));
+            }
+        }
+    }
+
+    /// Try to form complete batches from pending groups.
+    fn drain_batches(&mut self) -> Vec<RawMiGroupBatch> {
+        let mut batches = Vec::new();
+        while self.pending_groups.len() >= self.batch_size {
+            let groups: Vec<RawMiGroup> = self.pending_groups.drain(..self.batch_size).collect();
+            batches.push(RawMiGroupBatch { groups });
+        }
+        batches
+    }
+}
+
+impl Grouper for RawMiGrouper {
+    type Group = RawMiGroupBatch;
+
+    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
+        for decoded in records {
+            let raw = decoded.into_raw_bytes().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "RawMiGrouper requires raw byte records")
+            })?;
+
+            // Apply record filter if configured
+            if !self.should_keep(&raw) {
+                continue;
+            }
+
+            // Get MI tag from raw bytes (use empty string if absent, matching MiGrouper behavior)
+            let mi = self.get_mi_tag(&raw).unwrap_or_default();
+
+            // Check if this starts a new MI group
+            match &self.current_mi {
+                Some(current) if current == &mi => {
+                    self.current_records.push(raw);
+                }
+                Some(_) => {
+                    self.flush_current_group();
+                    self.current_mi = Some(mi);
+                    self.current_records.push(raw);
+                }
+                None => {
+                    self.current_mi = Some(mi);
+                    self.current_records.push(raw);
+                }
+            }
+        }
+
+        Ok(self.drain_batches())
+    }
+
+    fn finish(&mut self) -> io::Result<Option<Self::Group>> {
+        if self.finished {
+            return Ok(None);
+        }
+        self.finished = true;
+
+        self.flush_current_group();
+
+        if self.pending_groups.is_empty() {
+            Ok(None)
+        } else {
+            let groups: Vec<RawMiGroup> = self.pending_groups.drain(..).collect();
+            Ok(Some(RawMiGroupBatch { groups }))
+        }
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending_groups.is_empty() || self.current_mi.is_some()
+    }
+}
+
+/// An iterator that groups consecutive raw BAM records by their MI tag.
+///
+/// This is the raw-byte equivalent of `MiGroupIterator` for the single-threaded path.
+#[allow(clippy::type_complexity)]
+pub struct RawMiGroupIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    record_iter: I,
+    tag: [u8; 2],
+    /// Optional cell barcode tag for composite grouping (MI + cell barcode)
+    cell_tag: Option<[u8; 2]>,
+    current_mi: Option<String>,
+    current_group: Vec<Vec<u8>>,
+    done: bool,
+    /// Pending error to return after flushing a group
+    pending_error: Option<anyhow::Error>,
+    /// Optional MI tag transformation function
+    mi_transform: Option<Box<dyn Fn(&[u8]) -> String>>,
+}
+
+impl<I> RawMiGroupIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    /// Creates a new `RawMiGroupIterator`.
+    pub fn new(record_iter: I, tag_name: &str) -> Self {
+        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
+        let tag_bytes = tag_name.as_bytes();
+        Self {
+            record_iter,
+            tag: [tag_bytes[0], tag_bytes[1]],
+            cell_tag: None,
+            current_mi: None,
+            current_group: Vec::new(),
+            done: false,
+            pending_error: None,
+            mi_transform: None,
+        }
+    }
+
+    /// Creates a new `RawMiGroupIterator` with MI tag transformation.
+    pub fn with_transform<F>(record_iter: I, tag_name: &str, mi_transform: F) -> Self
+    where
+        F: Fn(&[u8]) -> String + 'static,
+    {
+        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
+        let tag_bytes = tag_name.as_bytes();
+        Self {
+            record_iter,
+            tag: [tag_bytes[0], tag_bytes[1]],
+            cell_tag: None,
+            current_mi: None,
+            current_group: Vec::new(),
+            done: false,
+            pending_error: None,
+            mi_transform: Some(Box::new(mi_transform)),
+        }
+    }
+
+    /// Sets an optional cell barcode tag for composite grouping.
+    ///
+    /// When set, the group key becomes `"MI_VALUE\tCELL_VALUE"` so that reads from
+    /// different cells with the same MI tag are placed in separate groups.
+    #[must_use]
+    pub fn with_cell_tag(mut self, cell_tag: Option<[u8; 2]>) -> Self {
+        self.cell_tag = cell_tag;
+        self
+    }
+
+    /// Extracts the group key from raw BAM bytes.
+    ///
+    /// When `cell_tag` is set, returns a composite key of `"MI\tCELL"`.
+    /// Otherwise returns just the MI tag value.
+    fn get_mi(&self, bam: &[u8]) -> Option<String> {
+        use crate::sort::bam_fields;
+        let value = bam_fields::find_string_tag_in_record(bam, &self.tag)?;
+        let mut key = if let Some(ref transform) = self.mi_transform {
+            transform(value)
+        } else {
+            String::from_utf8_lossy(value).into_owned()
+        };
+        if let Some(ct) = &self.cell_tag {
+            key.push('\t');
+            if let Some(cell_value) = bam_fields::find_string_tag_in_record(bam, ct) {
+                key.push_str(&String::from_utf8_lossy(cell_value));
+            }
+        }
+        Some(key)
+    }
+}
+
+impl<I> Iterator for RawMiGroupIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    type Item = Result<(String, Vec<Vec<u8>>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // Check for pending error (return after we've flushed any pending group)
+        if let Some(e) = self.pending_error.take() {
+            self.done = true;
+            return Some(Err(e));
+        }
+
+        loop {
+            match self.record_iter.next() {
+                None => {
+                    self.done = true;
+                    if self.current_group.is_empty() {
+                        return None;
+                    }
+                    let mi = self.current_mi.take().unwrap_or_default();
+                    let group = std::mem::take(&mut self.current_group);
+                    return Some(Ok((mi, group)));
+                }
+                Some(Err(e)) => {
+                    if !self.current_group.is_empty() {
+                        self.pending_error = Some(e);
+                        let mi = self.current_mi.take().unwrap_or_default();
+                        let group = std::mem::take(&mut self.current_group);
+                        return Some(Ok((mi, group)));
+                    }
+                    self.done = true;
+                    return Some(Err(e));
+                }
+                Some(Ok(raw)) => {
+                    let Some(mi) = self.get_mi(&raw) else {
+                        continue;
+                    };
+
+                    if self.current_group.is_empty() {
+                        self.current_mi = Some(mi);
+                        self.current_group.push(raw);
+                    } else if self.current_mi.as_ref() == Some(&mi) {
+                        self.current_group.push(raw);
+                    } else {
+                        let old_mi = self.current_mi.take().unwrap_or_default();
+                        let group = std::mem::take(&mut self.current_group);
+                        self.current_mi = Some(mi);
+                        self.current_group.push(raw);
+                        return Some(Ok((old_mi, group)));
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::similar_names)]
 mod tests {
@@ -930,5 +1325,1011 @@ mod tests {
         assert_eq!(result.1.len(), 3);
 
         assert!(iter.next().is_none());
+    }
+
+    // ========================================================================
+    // Helpers for raw BAM byte construction
+    // ========================================================================
+
+    // Build a minimal raw BAM record with the given string tag.
+    //
+    // The BAM binary format (after the 4-byte block_size prefix, which we omit):
+    //   bytes 0..4   : refID  (i32 LE)
+    //   bytes 4..8   : pos    (i32 LE)
+    //   byte  8      : l_read_name (u8, includes NUL)
+    //   byte  9      : mapq
+    //   bytes 10..12 : bin    (u16 LE)
+    //   bytes 12..14 : n_cigar_op (u16 LE)
+    //   bytes 14..16 : flag   (u16 LE)
+    //   bytes 16..20 : l_seq  (u32 LE)
+    //   bytes 20..24 : next_refID (i32 LE)
+    //   bytes 24..28 : next_pos   (i32 LE)
+    //   bytes 28..32 : tlen       (i32 LE)
+    //   then: read_name (l_read_name bytes, NUL-terminated)
+    //   then: cigar    (n_cigar_op * 4 bytes)
+    //   then: seq      (ceil(l_seq/2) bytes, 4-bit encoded)
+    //   then: qual     (l_seq bytes)
+    //   then: aux data
+    fn make_raw_bam_with_tag(tag_name: &str, tag_value: &str) -> Vec<u8> {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8; // +1 for NUL
+        let seq_len: u32 = 4; // 4 bases (ACGT)
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        // Aux data: tag[0] tag[1] 'Z' value NUL
+        let tag_bytes = tag_name.as_bytes();
+        let aux: Vec<u8> =
+            [&[tag_bytes[0], tag_bytes[1], b'Z'], tag_value.as_bytes(), &[0u8]].concat();
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
+        let mut buf = vec![0u8; total];
+
+        // refID = -1 (unmapped)
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        // pos = -1 (unmapped)
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        // l_read_name
+        buf[8] = l_read_name;
+        // n_cigar_op = 0
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        // l_seq
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        // next_refID = -1
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        // next_pos = -1
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+
+        // read_name + NUL
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        // seq and qual are left as zeros
+
+        // aux data
+        let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
+
+        buf
+    }
+
+    /// Build a minimal raw BAM record with no aux tags.
+    fn make_raw_bam_without_tag() -> Vec<u8> {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        let mut buf = vec![0u8; total];
+
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[8] = l_read_name;
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        buf
+    }
+
+    // ========================================================================
+    // RawMiGroupIterator tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_empty_iterator() {
+        let records: Vec<Result<Vec<u8>>> = vec![];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_single_group() {
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_with_tag("MI", "0")),
+        ];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 3);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_multiple_groups() {
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+            Ok(make_raw_bam_with_tag("MI", "2")),
+        ];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 2);
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1");
+        assert_eq!(result.1.len(), 3);
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "2");
+        assert_eq!(result.1.len(), 1);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_skips_records_without_mi_tag() {
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_without_tag()),
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Ok(make_raw_bam_without_tag()),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+        ];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 2); // Skipped records without MI
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1");
+        assert_eq!(result.1.len(), 1);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_error_propagation() {
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0")),
+            Err(anyhow::anyhow!("test error")),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+        ];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+
+        // First group before error
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 1);
+
+        // Error should be returned after flushing the pending group
+        let err = iter.next().unwrap();
+        assert!(err.is_err());
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_error_with_no_pending_group() {
+        let records: Vec<Result<Vec<u8>>> =
+            vec![Err(anyhow::anyhow!("immediate error")), Ok(make_raw_bam_with_tag("MI", "0"))];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+
+        // Error should be returned directly
+        let result = iter.next().unwrap();
+        assert!(result.is_err());
+
+        // Iterator should be done after error
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_custom_tag() {
+        let records: Vec<Result<Vec<u8>>> =
+            vec![Ok(make_raw_bam_with_tag("RX", "ACGT")), Ok(make_raw_bam_with_tag("RX", "ACGT"))];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "RX");
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "ACGT");
+        assert_eq!(result.1.len(), 2);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Tag name must be exactly 2 characters")]
+    fn test_raw_invalid_tag_length() {
+        let records: Vec<Result<Vec<u8>>> = vec![];
+        let _ = RawMiGroupIterator::new(records.into_iter(), "M");
+    }
+
+    #[test]
+    fn test_raw_with_transform() {
+        // Simulate duplex reads: 1/A, 1/B should group under "1"
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "1/A")),
+            Ok(make_raw_bam_with_tag("MI", "1/A")),
+            Ok(make_raw_bam_with_tag("MI", "1/B")),
+            Ok(make_raw_bam_with_tag("MI", "1/B")),
+            Ok(make_raw_bam_with_tag("MI", "2/A")),
+            Ok(make_raw_bam_with_tag("MI", "2/B")),
+        ];
+        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            let s = String::from_utf8_lossy(raw);
+            extract_mi_base(&s).to_string()
+        });
+
+        // First group: base MI "1" with 4 reads
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1");
+        assert_eq!(result.1.len(), 4);
+
+        // Second group: base MI "2" with 2 reads
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "2");
+        assert_eq!(result.1.len(), 2);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_with_transform_empty() {
+        let records: Vec<Result<Vec<u8>>> = vec![];
+        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            String::from_utf8_lossy(raw).to_uppercase()
+        });
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Tag name must be exactly 2 characters")]
+    fn test_raw_with_transform_invalid_tag_length() {
+        let records: Vec<Result<Vec<u8>>> = vec![];
+        let _ = RawMiGroupIterator::with_transform(records.into_iter(), "ABC", |raw| {
+            String::from_utf8_lossy(raw).into_owned()
+        });
+    }
+
+    #[test]
+    fn test_raw_get_mi_without_transform() {
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let bam = make_raw_bam_with_tag("MI", "42");
+        assert_eq!(iter.get_mi(&bam), Some("42".to_string()));
+    }
+
+    #[test]
+    fn test_raw_get_mi_with_transform() {
+        let iter = RawMiGroupIterator::with_transform(
+            std::iter::empty::<Result<Vec<u8>>>(),
+            "MI",
+            |raw| {
+                let s = String::from_utf8_lossy(raw);
+                s.to_uppercase()
+            },
+        );
+        let bam = make_raw_bam_with_tag("MI", "abc");
+        assert_eq!(iter.get_mi(&bam), Some("ABC".to_string()));
+    }
+
+    #[test]
+    fn test_raw_get_mi_missing_tag() {
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let bam = make_raw_bam_without_tag();
+        assert_eq!(iter.get_mi(&bam), None);
+    }
+
+    #[test]
+    fn test_raw_get_mi_wrong_tag() {
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let bam = make_raw_bam_with_tag("RX", "ACGT");
+        assert_eq!(iter.get_mi(&bam), None);
+    }
+
+    /// Build a minimal raw BAM record with two string tags.
+    fn make_raw_bam_with_two_tags(tag1: &str, val1: &str, tag2: &str, val2: &str) -> Vec<u8> {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        let t1 = tag1.as_bytes();
+        let t2 = tag2.as_bytes();
+        let aux: Vec<u8> = [
+            &[t1[0], t1[1], b'Z'],
+            val1.as_bytes(),
+            &[0u8],
+            &[t2[0], t2[1], b'Z'],
+            val2.as_bytes(),
+            &[0u8],
+        ]
+        .concat();
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
+        let mut buf = vec![0u8; total];
+
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[8] = l_read_name;
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
+
+        buf
+    }
+
+    #[test]
+    fn test_raw_cell_tag_composite_grouping() {
+        // Same MI but different cell barcodes should form separate groups
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
+        ];
+        let mut iter =
+            RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some([b'C', b'B']));
+
+        // First group: MI=1, CB=ACGT
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\tACGT");
+        assert_eq!(result.1.len(), 2);
+
+        // Second group: MI=1, CB=TGCA
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\tTGCA");
+        assert_eq!(result.1.len(), 2);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_cell_tag_none_groups_by_mi_only() {
+        // Without cell_tag, same MI records group together regardless of other tags
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
+        ];
+        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(None);
+
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1");
+        assert_eq!(result.1.len(), 2); // Both records in same group
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_cell_tag_missing_cell_value() {
+        // Records with MI but no cell tag get grouped under "MI\t" (empty cell)
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "1")),
+            Ok(make_raw_bam_with_tag("MI", "1")),
+            Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
+        ];
+        let mut iter =
+            RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some([b'C', b'B']));
+
+        // First group: MI=1, no CB (key = "1\t")
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\t");
+        assert_eq!(result.1.len(), 2);
+
+        // Second group: MI=1, CB=ACGT (key = "1\tACGT")
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\tACGT");
+        assert_eq!(result.1.len(), 1);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_raw_cell_tag_with_transform() {
+        // Cell tag should work with MI transform (duplex-style /A /B stripping)
+        let records: Vec<Result<Vec<u8>>> = vec![
+            Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "ACGT")),
+            Ok(make_raw_bam_with_two_tags("MI", "1/B", "CB", "ACGT")),
+            Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "TGCA")),
+        ];
+        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            let s = String::from_utf8_lossy(raw);
+            extract_mi_base(&s).to_string()
+        })
+        .with_cell_tag(Some([b'C', b'B']));
+
+        // All three have base MI "1", but different cells
+        // First group: base MI=1, CB=ACGT (2 records: 1/A and 1/B)
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\tACGT");
+        assert_eq!(result.1.len(), 2);
+
+        // Second group: base MI=1, CB=TGCA
+        let result = iter.next().unwrap().unwrap();
+        assert_eq!(result.0, "1\tTGCA");
+        assert_eq!(result.1.len(), 1);
+
+        assert!(iter.next().is_none());
+    }
+
+    // ========================================================================
+    // RawMiGrouper tests (Grouper trait impl)
+    // ========================================================================
+
+    /// Helper: create a `DecodedRecord` from raw bytes with a dummy group key.
+    fn make_raw_decoded_record(tag_name: &str, tag_value: &str) -> DecodedRecord {
+        let raw = make_raw_bam_with_tag(tag_name, tag_value);
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        DecodedRecord::from_raw_bytes(raw, key)
+    }
+
+    /// Helper: create a `DecodedRecord` from raw bytes with no tags.
+    fn make_raw_decoded_record_no_tag() -> DecodedRecord {
+        let raw = make_raw_bam_without_tag();
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        DecodedRecord::from_raw_bytes(raw, key)
+    }
+
+    /// Helper: create a parsed `DecodedRecord` (for testing error paths).
+    fn make_parsed_decoded_record(mi: &str) -> DecodedRecord {
+        let record = create_record_with_mi(mi);
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        DecodedRecord::new(record, key)
+    }
+
+    #[test]
+    fn test_raw_grouper_single_mi_group() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        let records = vec![
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record("MI", "0"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        // Only 1 MI group so far, batch_size=10, no complete batch yet
+        assert!(batches.is_empty());
+        assert!(grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "0");
+        assert_eq!(final_batch.groups[0].records.len(), 3);
+    }
+
+    #[test]
+    fn test_raw_grouper_multiple_mi_groups() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        let records = vec![
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record("MI", "1"),
+            make_raw_decoded_record("MI", "1"),
+            make_raw_decoded_record("MI", "1"),
+            make_raw_decoded_record("MI", "2"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty()); // 3 groups < batch_size 10
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 3);
+        assert_eq!(final_batch.groups[0].mi, "0");
+        assert_eq!(final_batch.groups[0].records.len(), 2);
+        assert_eq!(final_batch.groups[1].mi, "1");
+        assert_eq!(final_batch.groups[1].records.len(), 3);
+        assert_eq!(final_batch.groups[2].mi, "2");
+        assert_eq!(final_batch.groups[2].records.len(), 1);
+    }
+
+    #[test]
+    fn test_raw_grouper_batch_size_triggers() {
+        let mut grouper = RawMiGrouper::new("MI", 2);
+
+        let records = vec![
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record("MI", "1"),
+            make_raw_decoded_record("MI", "2"),
+            make_raw_decoded_record("MI", "3"),
+            make_raw_decoded_record("MI", "4"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        // 5 MI values => 4 completed groups (0,1,2,3) while "4" is still current
+        // batch_size=2 => 2 batches of 2 groups each
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].groups.len(), 2);
+        assert_eq!(batches[0].groups[0].mi, "0");
+        assert_eq!(batches[0].groups[1].mi, "1");
+        assert_eq!(batches[1].groups.len(), 2);
+        assert_eq!(batches[1].groups[0].mi, "2");
+        assert_eq!(batches[1].groups[1].mi, "3");
+
+        // "4" is still pending
+        assert!(grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "4");
+    }
+
+    #[test]
+    fn test_raw_grouper_groups_records_without_mi_under_empty_key() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        let records = vec![
+            make_raw_decoded_record("MI", "0"),
+            make_raw_decoded_record_no_tag(),
+            make_raw_decoded_record("MI", "0"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+
+        // Records without MI are now grouped under "" (matching MiGrouper behavior)
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 3);
+        assert_eq!(final_batch.groups[0].mi, "0");
+        assert_eq!(final_batch.groups[0].records.len(), 1);
+        assert_eq!(final_batch.groups[1].mi, "");
+        assert_eq!(final_batch.groups[1].records.len(), 1);
+        assert_eq!(final_batch.groups[2].mi, "0");
+        assert_eq!(final_batch.groups[2].records.len(), 1);
+    }
+
+    #[test]
+    fn test_raw_grouper_rejects_parsed_records() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        let records = vec![make_parsed_decoded_record("0")];
+        let result = grouper.add_records(records);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_grouper_finish_empty() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+        assert!(!grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap();
+        assert!(final_batch.is_none());
+    }
+
+    #[test]
+    fn test_raw_grouper_finish_idempotent() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        let records = vec![make_raw_decoded_record("MI", "0")];
+        grouper.add_records(records).unwrap();
+
+        let batch1 = grouper.finish().unwrap();
+        assert!(batch1.is_some());
+
+        let batch2 = grouper.finish().unwrap();
+        assert!(batch2.is_none());
+    }
+
+    #[test]
+    fn test_raw_grouper_has_pending_states() {
+        let mut grouper = RawMiGrouper::new("MI", 10);
+
+        // Initially nothing pending
+        assert!(!grouper.has_pending());
+
+        // After adding records, current_mi is set
+        let records = vec![make_raw_decoded_record("MI", "0")];
+        grouper.add_records(records).unwrap();
+        assert!(grouper.has_pending());
+
+        // After adding a different MI, first group moves to pending_groups
+        let records = vec![make_raw_decoded_record("MI", "1")];
+        grouper.add_records(records).unwrap();
+        assert!(grouper.has_pending());
+    }
+
+    #[test]
+    fn test_raw_grouper_with_filter_and_transform() {
+        // Build records with flag field set: use byte 14..16 for flag.
+        // We create a filter that checks the flag field for secondary alignment (0x100).
+        let mut grouper = RawMiGrouper::with_filter_and_transform(
+            "MI",
+            10,
+            |bam: &[u8]| {
+                // Check flag field at offset 14..16
+                let flag = u16::from_le_bytes([bam[14], bam[15]]);
+                flag & 0x100 == 0 // keep if NOT secondary
+            },
+            |raw: &[u8]| {
+                let s = String::from_utf8_lossy(raw);
+                extract_mi_base(&s).to_string()
+            },
+        );
+
+        // Create records: 1/A (primary), 1/A (secondary flag), 1/B (primary)
+        let rec_primary = make_raw_bam_with_tag("MI", "1/A");
+        // rec_primary flag is 0 (primary) - default
+
+        let mut rec_secondary = make_raw_bam_with_tag("MI", "1/A");
+        // Set secondary flag (0x100) at bytes 14..16
+        rec_secondary[14..16].copy_from_slice(&0x100u16.to_le_bytes());
+
+        let rec_b = make_raw_bam_with_tag("MI", "1/B");
+
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        let records = vec![
+            DecodedRecord::from_raw_bytes(rec_primary, key),
+            DecodedRecord::from_raw_bytes(rec_secondary, key),
+            DecodedRecord::from_raw_bytes(rec_b, key),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        // Secondary was filtered out, and 1/A and 1/B transform to "1"
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "1");
+        assert_eq!(final_batch.groups[0].records.len(), 2); // primary 1/A + 1/B
+    }
+
+    // ========================================================================
+    // MiGrouper tests (Grouper trait impl)
+    // ========================================================================
+
+    // Helper: create a parsed `DecodedRecord` for `MiGrouper` tests.
+    fn make_decoded_record_for_mi_grouper(mi: &str) -> DecodedRecord {
+        let record = create_record_with_mi(mi);
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        DecodedRecord::new(record, key)
+    }
+
+    #[test]
+    fn test_mi_grouper_single_group() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        let records = vec![
+            make_decoded_record_for_mi_grouper("0"),
+            make_decoded_record_for_mi_grouper("0"),
+            make_decoded_record_for_mi_grouper("0"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+        assert!(grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "0");
+        assert_eq!(final_batch.groups[0].records.len(), 3);
+    }
+
+    #[test]
+    fn test_mi_grouper_multiple_groups() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        let records = vec![
+            make_decoded_record_for_mi_grouper("0"),
+            make_decoded_record_for_mi_grouper("0"),
+            make_decoded_record_for_mi_grouper("1"),
+            make_decoded_record_for_mi_grouper("1"),
+            make_decoded_record_for_mi_grouper("1"),
+            make_decoded_record_for_mi_grouper("2"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 3);
+        assert_eq!(final_batch.groups[0].mi, "0");
+        assert_eq!(final_batch.groups[0].records.len(), 2);
+        assert_eq!(final_batch.groups[1].mi, "1");
+        assert_eq!(final_batch.groups[1].records.len(), 3);
+        assert_eq!(final_batch.groups[2].mi, "2");
+        assert_eq!(final_batch.groups[2].records.len(), 1);
+    }
+
+    #[test]
+    fn test_mi_grouper_batch_size_triggers() {
+        let mut grouper = MiGrouper::new("MI", 2);
+
+        let records = vec![
+            make_decoded_record_for_mi_grouper("0"),
+            make_decoded_record_for_mi_grouper("1"),
+            make_decoded_record_for_mi_grouper("2"),
+            make_decoded_record_for_mi_grouper("3"),
+            make_decoded_record_for_mi_grouper("4"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].groups.len(), 2);
+        assert_eq!(batches[0].groups[0].mi, "0");
+        assert_eq!(batches[0].groups[1].mi, "1");
+        assert_eq!(batches[1].groups.len(), 2);
+        assert_eq!(batches[1].groups[0].mi, "2");
+        assert_eq!(batches[1].groups[1].mi, "3");
+
+        assert!(grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "4");
+    }
+
+    #[test]
+    fn test_mi_grouper_rejects_raw_records() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        let records = vec![make_raw_decoded_record("MI", "0")];
+        let result = grouper.add_records(records);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mi_grouper_finish_empty() {
+        let mut grouper = MiGrouper::new("MI", 10);
+        assert!(!grouper.has_pending());
+
+        let final_batch = grouper.finish().unwrap();
+        assert!(final_batch.is_none());
+    }
+
+    #[test]
+    fn test_mi_grouper_finish_idempotent() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        let records = vec![make_decoded_record_for_mi_grouper("0")];
+        grouper.add_records(records).unwrap();
+
+        let batch1 = grouper.finish().unwrap();
+        assert!(batch1.is_some());
+
+        let batch2 = grouper.finish().unwrap();
+        assert!(batch2.is_none());
+    }
+
+    #[test]
+    fn test_mi_grouper_with_filter_and_transform() {
+        let mut grouper = MiGrouper::with_filter_and_transform(
+            "MI",
+            10,
+            |_r| true, // keep all records
+            |mi| extract_mi_base(mi).to_string(),
+        );
+
+        let records = vec![
+            make_decoded_record_for_mi_grouper("1/A"),
+            make_decoded_record_for_mi_grouper("1/B"),
+            make_decoded_record_for_mi_grouper("2/A"),
+        ];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 2);
+        assert_eq!(final_batch.groups[0].mi, "1");
+        assert_eq!(final_batch.groups[0].records.len(), 2);
+        assert_eq!(final_batch.groups[1].mi, "2");
+        assert_eq!(final_batch.groups[1].records.len(), 1);
+    }
+
+    #[test]
+    fn test_mi_grouper_has_pending_states() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        assert!(!grouper.has_pending());
+
+        let records = vec![make_decoded_record_for_mi_grouper("0")];
+        grouper.add_records(records).unwrap();
+        assert!(grouper.has_pending());
+
+        let records = vec![make_decoded_record_for_mi_grouper("1")];
+        grouper.add_records(records).unwrap();
+        assert!(grouper.has_pending());
+    }
+
+    #[test]
+    fn test_mi_grouper_record_without_mi_gets_empty_string() {
+        let mut grouper = MiGrouper::new("MI", 10);
+
+        let record = create_record_without_mi();
+        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        let records = vec![DecodedRecord::new(record, key)];
+
+        let batches = grouper.add_records(records).unwrap();
+        assert!(batches.is_empty());
+
+        // Record without MI tag gets default empty string as MI value
+        let final_batch = grouper.finish().unwrap().unwrap();
+        assert_eq!(final_batch.groups.len(), 1);
+        assert_eq!(final_batch.groups[0].mi, "");
+        assert_eq!(final_batch.groups[0].records.len(), 1);
+    }
+
+    // ========================================================================
+    // Batch type tests
+    // ========================================================================
+
+    #[test]
+    fn test_mi_group_batch_new() {
+        let batch = MiGroupBatch::new();
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_mi_group_batch_with_capacity() {
+        let batch = MiGroupBatch::with_capacity(16);
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_mi_group_batch_len_and_is_empty() {
+        let mut batch = MiGroupBatch::new();
+        assert!(batch.is_empty());
+
+        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
+        assert!(!batch.is_empty());
+        assert_eq!(batch.len(), 1);
+
+        batch.groups.push(MiGroup::new(
+            "1".to_string(),
+            vec![create_record_with_mi("1"), create_record_with_mi("1")],
+        ));
+        assert_eq!(batch.len(), 2);
+    }
+
+    #[test]
+    fn test_mi_group_batch_clear() {
+        let mut batch = MiGroupBatch::new();
+        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
+        assert!(!batch.is_empty());
+
+        batch.clear();
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_mi_group_batch_weight() {
+        let mut batch = MiGroupBatch::new();
+        assert_eq!(batch.batch_weight(), 0);
+
+        batch.groups.push(MiGroup::new(
+            "0".to_string(),
+            vec![create_record_with_mi("0"), create_record_with_mi("0")],
+        ));
+        assert_eq!(batch.batch_weight(), 2);
+
+        batch.groups.push(MiGroup::new("1".to_string(), vec![create_record_with_mi("1")]));
+        assert_eq!(batch.batch_weight(), 3);
+    }
+
+    #[test]
+    fn test_mi_group_batch_default() {
+        let batch = MiGroupBatch::default();
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn test_mi_group_batch_memory_estimate() {
+        let batch = MiGroupBatch::new();
+        // Empty batch should have minimal heap size (just vec overhead)
+        let _ = batch.estimate_heap_size(); // Should not panic
+
+        let mut batch = MiGroupBatch::new();
+        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
+        let size = batch.estimate_heap_size();
+        assert!(size > 0);
+    }
+
+    #[test]
+    fn test_mi_group_new() {
+        let group = MiGroup::new("42".to_string(), vec![create_record_with_mi("42")]);
+        assert_eq!(group.mi, "42");
+        assert_eq!(group.records.len(), 1);
+    }
+
+    #[test]
+    fn test_mi_group_batch_weight_single() {
+        let group = MiGroup::new(
+            "0".to_string(),
+            vec![
+                create_record_with_mi("0"),
+                create_record_with_mi("0"),
+                create_record_with_mi("0"),
+            ],
+        );
+        assert_eq!(group.batch_weight(), 3);
+    }
+
+    #[test]
+    fn test_mi_group_memory_estimate() {
+        let group = MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]);
+        let size = group.estimate_heap_size();
+        assert!(size > 0);
+    }
+
+    // ========================================================================
+    // Raw batch type tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_mi_group_new() {
+        let raw = make_raw_bam_with_tag("MI", "42");
+        let group = RawMiGroup::new("42".to_string(), vec![raw]);
+        assert_eq!(group.mi, "42");
+        assert_eq!(group.records.len(), 1);
+    }
+
+    #[test]
+    fn test_raw_mi_group_batch_weight() {
+        let group = RawMiGroup::new(
+            "0".to_string(),
+            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
+        );
+        assert_eq!(group.batch_weight(), 2);
+    }
+
+    #[test]
+    fn test_raw_mi_group_memory_estimate() {
+        let group = RawMiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]);
+        let size = group.estimate_heap_size();
+        assert!(size > 0);
+    }
+
+    #[test]
+    fn test_raw_mi_group_batch_new() {
+        let batch = RawMiGroupBatch::new();
+        assert!(batch.groups.is_empty());
+    }
+
+    #[test]
+    fn test_raw_mi_group_batch_default() {
+        let batch = RawMiGroupBatch::default();
+        assert!(batch.groups.is_empty());
+    }
+
+    #[test]
+    fn test_raw_mi_group_batch_weight_method() {
+        let mut batch = RawMiGroupBatch::new();
+        assert_eq!(batch.batch_weight(), 0);
+
+        batch.groups.push(RawMiGroup::new(
+            "0".to_string(),
+            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
+        ));
+        assert_eq!(batch.batch_weight(), 2);
+
+        batch.groups.push(RawMiGroup::new("1".to_string(), vec![make_raw_bam_with_tag("MI", "1")]));
+        assert_eq!(batch.batch_weight(), 3);
+    }
+
+    #[test]
+    fn test_raw_mi_group_batch_memory_estimate() {
+        let batch = RawMiGroupBatch::new();
+        let _ = batch.estimate_heap_size(); // Should not panic
+
+        let mut batch = RawMiGroupBatch::new();
+        batch.groups.push(RawMiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]));
+        let size = batch.estimate_heap_size();
+        assert!(size > 0);
     }
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+// Clippy can misattribute large_stack_arrays to byte_offset 0 when monomorphizing
+// generic code in test builds. Allow it crate-wide in test config since the actual
+// allocations are heap-based (`vec![]`), not stack arrays.
+#![cfg_attr(test, allow(clippy::large_stack_arrays))]
 // Clippy lint configuration for CI
 // These lints are allowed because:
 // - cast_*: Scientific/bioinformatics code intentionally casts between numeric types


### PR DESCRIPTION
## Summary

Convert simplex, duplex, and codec consensus callers from noodles RecordBuf to raw BAM bytes, eliminating expensive parsing/serialization overhead. This completes the raw-byte pipeline across all consensus calling commands (~28% faster for codec, ~22-29% for simplex, ~12% for duplex).

### Raw-byte infrastructure (`bam_fields.rs`, +6000 lines)
- `UnmappedBamRecordBuilder` for direct BAM record construction without noodles overhead
- CIGAR clipping functions (`clip_cigar_ops_raw`, `upgrade_clipping_raw`) matching Clipper's `clip_start_of_read`/`clip_end_of_read` semantics
- Position/overlap utilities (`read_pos_at_ref_pos_raw`, `num_bases_extending_past_mate_raw`, `is_fr_pair_raw`)
- Tag manipulation (append/remove/find tags directly on raw bytes)
- Phred+33 encoding with overflow guard

### Consensus callers
- **Codec**: Full rewrite with `ClippedRecordInfo` for virtual CIGAR clipping, eliminating RecordBuf entirely
- **Simplex**: Raw-byte `consensus_reads` and reject writing
- **Duplex**: Raw-byte strand partitioning (zero-clone via ownership transfer)
- **Vanilla**: Raw-byte subgrouping and output building
- Raw-byte overlapping consensus (`call_raw`, `apply_overlapping_consensus_raw`)

### Commands (`simplex`, `duplex`, `codec`)
- Wire raw-byte consensus output directly to BAM writers
- Write rejected reads as raw bytes (no re-serialization)
- Track stats for min_reads-skipped groups in threaded path

### MI grouping (`mi_group.rs`)
- `RawMiGroupIterator` and `RawMiGrouper` for raw-byte grouped iteration
- Proper `pending_error` handling to avoid silently dropping errors

### Testing (+239 new tests)
- 105 tests in `bam_fields.rs` (clipping, FR pair detection, position mapping, builder)
- 53 tests in `overlapping.rs` (raw consensus, stats merge)
- 67 tests in `mi_group.rs` (raw iterator, raw grouper, batch types)
- Fix subgroup_reads destructuring order in vanilla_caller test

## Test plan
- [x] All 2969 tests pass (`cargo ci-test`)
- [x] `cargo ci-fmt` and `cargo ci-lint` clean
- [x] Codec output byte-identical to baseline via `fgumi compare bams --mode content` (107,893 records)
- [x] ~28% wall-clock improvement (8-thread), ~29% (1-thread), ~42% fewer instructions

Generated with [Claude Code](https://claude.com/claude-code)