### PR TITLE
feat: add raw-byte BAM pipeline for filter command

### DIFF
--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -3,12 +3,13 @@
 //! When consensus reads are mapped to negative strand, their per-base tags need to be
 //! reversed to match the orientation of the sequence in the BAM file.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::alignment::record_buf::data::field::Value;
 
 use crate::consensus_tags::per_base;
 use crate::dna::reverse_complement;
+use crate::sort::bam_fields;
 
 /// Reverses per-base tags for a negative-strand read
 ///
@@ -34,8 +35,20 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
         let tag = per_base::tag(tag_str);
 
         if let Some(value) = record.data().get(&tag) {
-            if let Some(reversed_value) = reverse_array_value(value)? {
-                record.data_mut().insert(tag, reversed_value);
+            match value {
+                Value::String(s) => {
+                    // Z-type string tags (e.g. aq, bq quality strings) — reverse bytes
+                    let mut reversed: Vec<u8> = s.iter().copied().collect();
+                    reversed.reverse();
+                    record
+                        .data_mut()
+                        .insert(tag, Value::from(String::from_utf8_lossy(&reversed).to_string()));
+                }
+                _ => {
+                    if let Some(reversed_value) = reverse_array_value(value)? {
+                        record.data_mut().insert(tag, reversed_value);
+                    }
+                }
             }
         }
     }
@@ -54,6 +67,58 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
                 .data_mut()
                 .insert(tag, Value::from(String::from_utf8_lossy(&revcomp).to_string()));
         }
+    }
+
+    Ok(true)
+}
+
+/// Reverses per-base tags for a negative-strand read using raw BAM bytes.
+///
+/// Operates directly on the binary record without parsing into `RecordBuf`.
+/// Array tags (cd, ce, ad, ae, bd, be, aq, bq) are reversed in-place.
+/// String tags (ac, bc) are reverse-complemented in-place.
+///
+/// # Returns
+/// `Ok(true)` if tags were reversed, `Ok(false)` if not on reverse strand.
+pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
+    if record.len() < bam_fields::MIN_BAM_HEADER_LEN {
+        bail!(
+            "BAM record too short ({} bytes, minimum {})",
+            record.len(),
+            bam_fields::MIN_BAM_HEADER_LEN
+        );
+    }
+    let flg = bam_fields::flags(record);
+    if (flg & bam_fields::flags::REVERSE) == 0 {
+        return Ok(false);
+    }
+
+    let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
+    if aux_off >= record.len() {
+        return Ok(true);
+    }
+
+    // Tags to reverse: cd, ce, ad, ae, bd, be, aq, bq
+    // These may be B-type arrays or Z-type strings (aq, bq are Phred+33 strings)
+    for tag_str in per_base::tags_to_reverse() {
+        let tag_bytes: [u8; 2] = [tag_str.as_bytes()[0], tag_str.as_bytes()[1]];
+        // Check tag type to determine reversal method
+        let tag_type = bam_fields::find_tag_type(&record[aux_off..], &tag_bytes);
+        match tag_type {
+            Some(b'B') => {
+                bam_fields::reverse_array_tag_in_place(record, aux_off, &tag_bytes);
+            }
+            Some(b'Z') => {
+                bam_fields::reverse_string_tag_in_place(record, aux_off, &tag_bytes);
+            }
+            _ => {} // Tag not found or unsupported type — skip
+        }
+    }
+
+    // Tags to reverse-complement: ac, bc
+    for tag_str in per_base::tags_to_reverse_complement() {
+        let tag_bytes: [u8; 2] = [tag_str.as_bytes()[0], tag_str.as_bytes()[1]];
+        bam_fields::reverse_complement_string_tag_in_place(record, aux_off, &tag_bytes);
     }
 
     Ok(true)
@@ -188,5 +253,102 @@ mod tests {
         let value = Value::from(42i32);
         let reversed = reverse_array_value(&value).unwrap();
         assert!(reversed.is_none());
+    }
+
+    #[test]
+    fn test_reverse_string_tag_aq() {
+        // aq is a Z-type quality string — should be reversed on negative strand
+        let mut record = RecordBuilder::new()
+            .sequence("ACGT")
+            .reverse_complement(true)
+            .tag("aq", "IIHG")
+            .build();
+
+        let reversed = reverse_per_base_tags(&mut record).unwrap();
+        assert!(reversed);
+
+        let tag = Tag::from([b'a', b'q']);
+        if let Some(Value::String(s)) = record.data().get(&tag) {
+            let bytes: Vec<u8> = s.iter().copied().collect();
+            assert_eq!(bytes, b"GHII");
+        } else {
+            panic!("Expected aq tag to be present as String");
+        }
+    }
+
+    #[test]
+    fn test_reverse_per_base_tags_raw_string_tag_aq() {
+        // Verify aq Z-type tag is reversed via the raw path too
+        use crate::sort::bam_fields;
+        use crate::vendored::bam_codec::encoder::encode_record_buf;
+        use noodles::sam::Header;
+
+        let record_buf = RecordBuilder::new()
+            .sequence("ACGT")
+            .reverse_complement(true)
+            .tag("aq", "IIHG")
+            .build();
+
+        let header = Header::default();
+        let mut raw = Vec::new();
+        encode_record_buf(&mut raw, &header, &record_buf).unwrap();
+
+        let result = reverse_per_base_tags_raw(&mut raw).unwrap();
+        assert!(result);
+
+        let aux = bam_fields::aux_data_slice(&raw);
+        let s = bam_fields::find_string_tag(aux, b"aq").expect("aq tag should exist");
+        assert_eq!(s, b"GHII");
+    }
+
+    #[test]
+    fn test_reverse_per_base_tags_raw_short_record() {
+        // A record shorter than MIN_BAM_HEADER_LEN (32 bytes) should return an error
+        let mut short_record = vec![0u8; 16];
+        let result = reverse_per_base_tags_raw(&mut short_record);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too short"));
+    }
+
+    #[test]
+    fn test_reverse_per_base_tags_raw_positive_strand() {
+        // Build a valid raw record on positive strand — should return Ok(false)
+        use crate::vendored::bam_codec::encoder::encode_record_buf;
+        use noodles::sam::Header;
+
+        let record_buf = RecordBuilder::new().sequence("ACGT").build();
+        let header = Header::default();
+        let mut raw = Vec::new();
+        encode_record_buf(&mut raw, &header, &record_buf).unwrap();
+
+        let result = reverse_per_base_tags_raw(&mut raw);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // positive strand => false
+    }
+
+    #[test]
+    fn test_reverse_per_base_tags_raw_negative_strand() {
+        // Build a valid raw record on negative strand with a cd tag — should reverse it
+        use crate::sort::bam_fields;
+        use crate::vendored::bam_codec::encoder::encode_record_buf;
+        use noodles::sam::Header;
+
+        let mut record_buf = RecordBuilder::new().sequence("ACGT").reverse_complement(true).build();
+        let tag = Tag::from([b'c', b'd']);
+        record_buf.data_mut().insert(tag, Value::from(vec![1u16, 2, 3, 4]));
+
+        let header = Header::default();
+        let mut raw = Vec::new();
+        encode_record_buf(&mut raw, &header, &record_buf).unwrap();
+
+        let result = reverse_per_base_tags_raw(&mut raw);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // negative strand => true
+
+        // Verify the cd tag was reversed: find it in the raw record's aux data
+        let aux = bam_fields::aux_data_slice(&raw);
+        let arr = bam_fields::find_array_tag(aux, b"cd").expect("cd tag should exist");
+        let values = bam_fields::array_tag_to_vec_u16(&arr);
+        assert_eq!(values, vec![4, 3, 2, 1]);
     }
 }

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1388,6 +1388,12 @@ impl MemoryEstimate for Vec<RecordBuf> {
     }
 }
 
+impl MemoryEstimate for Vec<u8> {
+    fn estimate_heap_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
 // ============================================================================
 // GroupKeyConfig - Configuration for computing `GroupKey` during Decode
 // ============================================================================


### PR DESCRIPTION
## Summary

- Convert the filter command from `RecordBuf`-based processing to raw BAM bytes, following the same pattern used for group, dedup, correct, simplex, duplex, and codec commands
- Add raw-byte utilities to `bam_fields.rs` (`ArrayTagRef`, `find_array_tag`, typed tag finders, in-place tag mutation/reversal, `BAM_BASE_TO_ASCII`)
- Add raw-byte filter/mask functions (`mask_bases_raw`, `mask_duplex_bases_raw`, `filter_read_raw`, `filter_duplex_read_raw`, `template_passes_raw`, etc.)
- Add `regenerate_alignment_tags_raw` and `reverse_per_base_tags_raw` for in-place operation
- Convert all three filter execution paths (single-threaded, pipeline single-read, pipeline template) to raw bytes

## Benchmark

10M duplex consensus reads (2.3GB), `--threads 8`, 3 runs each on synthetic-pipeline-xlarge:

| | Run 1 | Run 2 | Run 3 | Mean |
|---|---|---|---|---|
| **Baseline** (RecordBuf) | 16.18s | 15.67s | 15.77s | 15.87s |
| **Raw bytes** | 15.49s | 15.29s | 15.60s | 15.46s |

~2.6% wall-clock improvement. Filter's per-record work is lightweight (tag reads + comparisons), so the pipeline is I/O-bound at 8 threads. The main value is consistency with the raw-byte pattern used across all other commands.

## Test plan

- [x] `cargo ci-test` — 2761 tests pass, 0 failures
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] All 173 filter-specific tests pass
- [x] Benchmark shows no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)