### PR TITLE
refactor: crate review fixes and coderabbitai feedback

### DIFF
--- a/crates/fgumi-bgzf/src/writer.rs
+++ b/crates/fgumi-bgzf/src/writer.rs
@@ -75,7 +75,8 @@ impl InlineBgzfCompressor {
     /// Panics if compression level 6 is rejected by the bgzf library (should never happen).
     #[must_use]
     pub fn new(compression_level: u32) -> Self {
-        let level = u8::try_from(compression_level.clamp(1, 12)).unwrap_or(6);
+        let level = u8::try_from(compression_level.clamp(1, 12))
+            .expect("value in [1, 12] always fits in u8");
         let compression_level_obj =
             CompressionLevel::new(level).unwrap_or_else(|_| CompressionLevel::new(6).unwrap());
         let compressor = BgzfCompressor::new(compression_level_obj);

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -515,7 +515,7 @@ impl RejectionReason {
             Self::MinorityAlignment => CentralReason::MinorityAlignment,
             Self::QualityTooLow | Self::QualityTrimmed => CentralReason::LowBaseQuality,
             Self::FailedQC => CentralReason::NotPassingFilter,
-            Self::MissingUmi => CentralReason::NBasesInUmi, // Closest match
+            Self::MissingUmi => CentralReason::MissingUmi,
             // For reasons that don't have a direct centralized equivalent,
             // we use the closest semantic match
             Self::FragmentRead => CentralReason::SameStrandOnly,

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -308,12 +308,12 @@ pub struct DuplexConsensusCaller {
     track_rejects: bool,
 }
 
-#[allow(
+#[expect(
     clippy::similar_names,
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    reason = "consensus calling uses numeric casts for quality/position math and has domain-specific variable names"
 )]
 impl DuplexConsensusCaller {
     /// Creates a new duplex consensus caller
@@ -342,7 +342,7 @@ impl DuplexConsensusCaller {
     /// # Panics
     ///
     /// Panics if `min_reads` is empty (though this is checked and returns an error first).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, reason = "constructor needs all configuration parameters from CLI options")]
     #[expect(clippy::needless_pass_by_value, reason = "changing to &[usize] would require updating many call sites across the codebase")]
     pub fn new(
         read_name_prefix: String,
@@ -450,6 +450,7 @@ impl DuplexConsensusCaller {
 
     /// Test helper: accepts `Vec<RecordBuf>`, encodes to raw bytes, and delegates to `consensus_reads`.
     #[cfg(test)]
+    #[expect(clippy::needless_pass_by_value, reason = "test helper takes ownership for convenience")]
     pub(crate) fn consensus_reads_from_sam_records(
         &mut self,
         records: Vec<noodles::sam::alignment::RecordBuf>,
@@ -579,7 +580,7 @@ impl DuplexConsensusCaller {
     ///
     /// IMPORTANT: This function requires that all reads have MI tags with /A or /B suffixes.
     /// The duplex command MUST be used with reads grouped using the "paired" strategy.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity, reason = "tuple return type is clearer than a one-off struct for strand partitioning")]
     fn partition_records_by_strand(
         records: Vec<Vec<u8>>,
     ) -> Result<(Option<String>, Vec<Vec<u8>>, Vec<Vec<u8>>)> {
@@ -643,7 +644,7 @@ impl DuplexConsensusCaller {
     /// NOTE: This function is used only in tests. Production code uses
     /// [`partition_reads_by_strand_simple`] which is more efficient.
     #[cfg(test)]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity, reason = "tuple return type is clearer than a one-off struct for test grouping")]
     fn group_by_mi_and_strand(
         reads: Vec<RecordBuf>,
     ) -> Result<AHashMap<String, (Vec<RecordBuf>, Vec<RecordBuf>)>> {
@@ -971,7 +972,7 @@ impl DuplexConsensusCaller {
     /// * `first_of_pair` - Whether this is first of pair (for RX orientation)
     /// * `cell_tag` - Optional cell barcode tag (e.g., CB)
     /// * `cell_barcode` - Optional cell barcode value to add to record
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, reason = "duplex record construction requires many parameters from the calling context")]
     #[expect(clippy::too_many_lines, reason = "BAM record construction has many sequential tag-writing steps")]
     #[expect(clippy::unnecessary_wraps, reason = "Result return type kept for API consistency with other consensus record builders")]
     pub(crate) fn duplex_read_into(
@@ -1173,6 +1174,13 @@ impl DuplexConsensusCaller {
 
     /// Calls duplex consensus from paired single-strand consensuses
     #[cfg(test)]
+    #[expect(
+        clippy::too_many_lines,
+        clippy::needless_pass_by_value,
+        clippy::items_after_statements,
+        clippy::cast_possible_wrap,
+        reason = "test-only duplex calling helper with complex setup"
+    )]
     fn call_duplex_from_ss_pair(
         ss_a: RecordBuf,
         ss_b: RecordBuf,
@@ -1556,7 +1564,7 @@ impl DuplexConsensusCaller {
     }
 
     /// Processes a single UMI group to generate duplex consensus
-    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, reason = "group processing requires many parameters")]
     #[expect(clippy::too_many_lines, reason = "duplex group processing has many sequential steps including strand separation, SS calling, duplex calling, and output")]
     #[expect(clippy::needless_pass_by_value, reason = "owned values consumed by downstream consensus pipeline")]
     fn process_group(
@@ -2077,7 +2085,12 @@ impl ConsensusCaller for DuplexConsensusCaller {
 }
 
 #[cfg(test)]
-#[allow(clippy::similar_names)]
+#[expect(
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::items_after_statements,
+    reason = "test code uses domain-specific names and has long integration tests"
+)]
 mod tests {
     use super::*;
     use fgumi_sam::builder::RecordBuilder;

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1058,7 +1058,7 @@ fn find_string_or_uint8_array(aux_data: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> 
 /// # Errors
 ///
 /// Returns an error if the record is too short or the aux data cannot be parsed.
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names, reason = "threshold variable names mirror the consensus tag names they check")]
 pub fn mask_bases_raw(
     record: &mut [u8],
     thresholds: &FilterThresholds,
@@ -1107,7 +1107,7 @@ pub fn mask_bases_raw(
 /// # Errors
 ///
 /// Returns an error if the record is too short or the aux data cannot be parsed.
-#[allow(clippy::too_many_arguments, clippy::similar_names)]
+#[expect(clippy::similar_names, reason = "threshold variable names mirror the duplex strand tag names")]
 pub fn mask_duplex_bases_raw(
     record: &mut [u8],
     cc_thresholds: &FilterThresholds,
@@ -1206,7 +1206,6 @@ pub fn mask_duplex_bases_raw(
 }
 
 #[cfg(test)]
-#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
     use fgumi_sam::builder::RecordBuilder;

--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -338,7 +338,7 @@ pub fn ln_not(x: LogProbability) -> LogProbability {
 }
 
 #[cfg(test)]
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names, reason = "test variables use short math-related names like ln_p, ln_q")]
 mod tests {
     use super::*;
 

--- a/crates/fgumi-consensus/src/tags.rs
+++ b/crates/fgumi-consensus/src/tags.rs
@@ -224,7 +224,7 @@ pub fn is_simplex_consensus(rec: &impl noodles::sam::alignment::Record) -> bool 
 ///
 /// A duplex consensus read has both the `aD` (`AbRawReadCount`) and `bD` (`BaRawReadCount`) tags.
 #[must_use]
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names, reason = "aD/bD tag names are domain-specific duplex strand identifiers")]
 pub fn is_duplex_consensus(rec: &impl noodles::sam::alignment::Record) -> bool {
     let has_ad = rec.data().get(&per_read::tag("aD")).is_some();
     let has_bd = rec.data().get(&per_read::tag("bD")).is_some();

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -371,12 +371,11 @@ pub struct VanillaUmiConsensusCaller {
     bam_builder: UnmappedBamRecordBuilder,
 }
 
-#[allow(
-    clippy::similar_names,
+#[expect(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
-    clippy::cast_sign_loss
+    reason = "consensus calling uses numeric casts for quality/position math"
 )]
 impl VanillaUmiConsensusCaller {
     /// Creates a new vanilla consensus caller
@@ -862,7 +861,7 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Sub-groups reads by read type (fragment, R1, R2)
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity, reason = "tuple return type is clearer than a one-off struct for internal grouping")]
     #[expect(clippy::unused_self, reason = "method signature kept for consistency with other caller trait methods")]
     fn subgroup_reads(&self, reads: Vec<Vec<u8>>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
         use noodles_raw_bam as bam_fields;
@@ -1188,7 +1187,7 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Builds a consensus record as raw BAM bytes and writes it into a `ConsensusOutput`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, reason = "consensus record building requires many parameters from the calling context")]
     fn build_consensus_record_into(
         &mut self,
         output: &mut ConsensusOutput,
@@ -1345,7 +1344,13 @@ pub(crate) enum ReadType {
 }
 
 #[cfg(test)]
-#[allow(clippy::similar_names)]
+#[expect(
+    clippy::needless_pass_by_value,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    reason = "test helpers use owned values and numeric casts for quality score math"
+)]
 mod tests {
     use super::*;
     use fgumi_sam::builder::{RecordBuilder, RecordPairBuilder};

--- a/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/field/value.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/field/value.rs
@@ -68,7 +68,7 @@ mod tests {
             &Value::Array(Array::UInt8(Box::new(T::new(&[0])))),
             &[
                 b'C', // subtype = UInt8
-                0x01, 0x00, 0x00, 0x00, // count = 2
+                0x01, 0x00, 0x00, 0x00, // count = 1
                 0x00, // values[0] = 0
             ],
         )?;

--- a/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/field/value/array.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/field/value/array.rs
@@ -184,8 +184,8 @@ pub(super) mod tests {
             &[
                 b'I', // subtype = UInt32
                 0x02, 0x00, 0x00, 0x00, // count = 2
-                0x90, 0x00, 0x00, 0x00, // values[0] = 55
-                0xdf, 0x00, 0x00, 0x00, // values[1] = -89
+                0x90, 0x00, 0x00, 0x00, // values[0] = 144
+                0xdf, 0x00, 0x00, 0x00, // values[1] = 223
             ],
         )?;
 

--- a/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/mod.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/encoder/data/mod.rs
@@ -134,6 +134,7 @@ fn try_write_common_tag(dst: &mut Vec<u8>, tag: Tag, value: &RecordBufValue) -> 
             {
                 // Write header: tag + 'B' + 's' + count
                 dst.extend([tag_bytes[0], tag_bytes[1], b'B', b's']);
+                debug_assert!(values.len() <= u32::MAX as usize, "array length exceeds u32::MAX");
                 write_u32_le(dst, values.len() as u32);
 
                 // Write each i16 value in little-endian format

--- a/crates/fgumi-consensus/src/vendored/bam_codec/encoder/name.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/encoder/name.rs
@@ -22,8 +22,11 @@ pub(super) fn write_length(dst: &mut Vec<u8>, name: Option<&BStr>) -> io::Result
 pub(super) fn write_name(dst: &mut Vec<u8>, name: Option<&BStr>) -> io::Result<()> {
     const NUL: u8 = 0x00;
 
+    let orig_len = dst.len();
+
     if let Some(name) = name {
         if !is_valid(name) {
+            dst.truncate(orig_len);
             return Err(io::Error::from(io::ErrorKind::InvalidInput));
         }
 

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -92,6 +92,9 @@ pub struct ConsensusMetrics {
     /// Reads rejected due to N bases in UMI
     pub rejected_n_bases_in_umi: u64,
 
+    /// Reads rejected due to missing UMI tag
+    pub rejected_missing_umi: u64,
+
     /// Reads rejected due to not passing filter
     pub rejected_not_passing_filter: u64,
 
@@ -143,6 +146,7 @@ impl ConsensusMetrics {
             rejected_no_valid_alignment: 0,
             rejected_low_mapping_quality: 0,
             rejected_n_bases_in_umi: 0,
+            rejected_missing_umi: 0,
             rejected_not_passing_filter: 0,
             rejected_low_mean_quality: 0,
             rejected_insufficient_min_depth: 0,
@@ -170,6 +174,7 @@ impl ConsensusMetrics {
             RejectionReason::NoValidAlignment => self.rejected_no_valid_alignment += count,
             RejectionReason::LowMappingQuality => self.rejected_low_mapping_quality += count,
             RejectionReason::NBasesInUmi => self.rejected_n_bases_in_umi += count,
+            RejectionReason::MissingUmi => self.rejected_missing_umi += count,
             RejectionReason::NotPassingFilter => self.rejected_not_passing_filter += count,
             RejectionReason::LowMeanQuality => self.rejected_low_mean_quality += count,
             RejectionReason::InsufficientMinDepth => self.rejected_insufficient_min_depth += count,
@@ -195,6 +200,7 @@ impl ConsensusMetrics {
             + self.rejected_no_valid_alignment
             + self.rejected_low_mapping_quality
             + self.rejected_n_bases_in_umi
+            + self.rejected_missing_umi
             + self.rejected_not_passing_filter
             + self.rejected_low_mean_quality
             + self.rejected_insufficient_min_depth
@@ -240,6 +246,9 @@ impl ConsensusMetrics {
         }
         if self.rejected_n_bases_in_umi > 0 {
             summary.insert(RejectionReason::NBasesInUmi, self.rejected_n_bases_in_umi);
+        }
+        if self.rejected_missing_umi > 0 {
+            summary.insert(RejectionReason::MissingUmi, self.rejected_missing_umi);
         }
         if self.rejected_not_passing_filter > 0 {
             summary.insert(RejectionReason::NotPassingFilter, self.rejected_not_passing_filter);
@@ -304,7 +313,7 @@ impl ConsensusMetrics {
             ("raw_reads_used", raw_reads_used.to_string(), "Total count of raw reads used in consensus reads"),
             ("frac_raw_reads_used", format_float(frac_used), "Fraction of raw reads used in consensus reads"),
             ("raw_reads_rejected_for_insufficient_support", self.rejected_insufficient_support.to_string(), "Insufficient reads to generate a consensus"),
-            ("raw_reads_rejected_for_minority_alignment", self.rejected_minority_alignment.to_string(), "Reads has a different, and minority, set of indels"),
+            ("raw_reads_rejected_for_minority_alignment", self.rejected_minority_alignment.to_string(), "Read has a different, and minority, set of indels"),
             ("raw_reads_rejected_for_orphan_consensus", self.rejected_orphan_consensus.to_string(), "Only one of R1 or R2 consensus generated"),
             ("raw_reads_rejected_for_zero_bases_post_trimming", self.rejected_zero_bases_post_trimming.to_string(), "Read or mate had zero bases post trimming"),
         ];
@@ -334,6 +343,7 @@ impl ConsensusMetrics {
             ("raw_reads_rejected_for_no_valid_alignment", self.rejected_no_valid_alignment, "No valid alignment found"),
             ("raw_reads_rejected_for_low_mapping_quality", self.rejected_low_mapping_quality, "Low mapping quality"),
             ("raw_reads_rejected_for_n_bases_in_umi", self.rejected_n_bases_in_umi, "N bases in UMI sequence"),
+            ("raw_reads_rejected_for_missing_umi", self.rejected_missing_umi, "Read lacks required UMI tag"),
             ("raw_reads_rejected_for_not_passing_filter", self.rejected_not_passing_filter, "Read did not pass vendor filter"),
             ("raw_reads_rejected_for_low_mean_quality", self.rejected_low_mean_quality, "Low mean base quality"),
             ("raw_reads_rejected_for_insufficient_min_depth", self.rejected_insufficient_min_depth, "Insufficient minimum read depth"),

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -28,6 +28,8 @@ pub enum RejectionReason {
     LowMappingQuality,
     /// UMI contained N bases
     NBasesInUmi,
+    /// Read lacks required UMI tag
+    MissingUmi,
     /// Reads were marked as not passing filter (PF flag)
     NotPassingFilter,
     /// Consensus read had too low mean quality
@@ -61,6 +63,7 @@ impl RejectionReason {
             Self::NoValidAlignment => "Template had no valid alignments",
             Self::LowMappingQuality => "Reads failed mapping quality threshold",
             Self::NBasesInUmi => "UMI contained N bases",
+            Self::MissingUmi => "Read lacks required UMI tag",
             Self::NotPassingFilter => "Reads were marked as not passing filter",
             Self::LowMeanQuality => "Consensus read had too low mean quality",
             Self::InsufficientMinDepth => "Consensus read had insufficient minimum depth",

--- a/crates/fgumi-sam/src/builder.rs
+++ b/crates/fgumi-sam/src/builder.rs
@@ -1848,6 +1848,20 @@ impl ConsensusTagsBuilder {
     /// Builds the tags as a vector of (Tag, Value) pairs.
     #[must_use]
     pub fn build(self) -> Vec<(Tag, BufValue)> {
+        // Guard against conflicting tag sources
+        debug_assert!(
+            !(self.depth_max.is_some() && self.per_base_depths.is_some()),
+            "depth_max and per_base_depths both set cD tag; use one or the other"
+        );
+        debug_assert!(
+            !(self.error_rate.is_some() && self.per_base_errors.is_some()),
+            "error_rate and per_base_errors both set cE tag; use one or the other"
+        );
+        debug_assert!(
+            !(self.error_count.is_some() && self.per_base_errors.is_some()),
+            "error_count and per_base_errors both set cE tag; use one or the other"
+        );
+
         let mut tags = Vec::new();
 
         // Standard consensus tags
@@ -1901,6 +1915,7 @@ impl ConsensusTagsBuilder {
 }
 
 #[cfg(test)]
+#[expect(clippy::similar_names, reason = "test code uses domain-specific tag names like cd/cm/ce")]
 mod tests {
     use super::*;
     use noodles::sam::alignment::record::Cigar;

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -1343,6 +1343,7 @@ pub mod cigar_utils {
 }
 
 #[cfg(test)]
+#[expect(clippy::similar_names, reason = "test code uses clipper/clipped naming pattern")]
 mod tests {
     use super::*;
     use crate::builder::RecordBuilder;

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -277,7 +277,7 @@ pub fn reverse_buf_value(value: &BufValue) -> BufValue {
 /// in per-base tags. It reverses the order of bases and complements each base:
 /// - A <-> T
 /// - C <-> G
-/// - Preserves case (a <-> t, c <-> g)
+/// - Normalizes to uppercase (a -> T, t -> A, c -> G, g -> C)
 /// - Other characters are left unchanged
 ///
 /// This is essential for per-base sequence tags (like consensus bases) when reads


### PR DESCRIPTION
## Summary

- Convert all `#[allow(clippy::...)]` to `#[expect(clippy::..., reason = "...")]` across 7 files in fgumi-consensus (30+ instances)
- Add test module `#[expect]` attributes for fgumi-sam and fgumi-consensus test code (clippy pedantic with `--all-targets`)
- Fix u8 overflow in overlapping quality summation: `(r1_qual + r2_qual)` → `(u16::from(r1_qual) + u16::from(r2_qual))` 
- Fix doc mismatch in `revcomp_buf_value` (lowercase bases normalize to uppercase, not preserved)
- Fix typo "Reads has" → "Read has" in minority alignment metric description
- Add `MissingUmi` variant to centralized `RejectionReason` enum (was incorrectly mapped to `NBasesInUmi`)
- Remove dead commented-out test in `codec_caller.rs`
- Replace unreachable `unwrap_or(6)` with `expect()` in bgzf writer

## Test plan

- [x] `cargo nextest run` — 1517 tests pass
- [x] `cargo ci-lint` — passes
- [x] `cargo ci-fmt` — passes
- [x] `cargo clippy --package fgumi-consensus --all-targets` — clean
- [x] `cargo clippy --package fgumi-sam --all-targets` — clean
- [x] `cargo clippy --package fgumi-bgzf --all-targets` — clean
- [x] `cargo clippy --package fgumi-metrics --all-targets` — clean