### PR TITLE
refactor: improve workspace crates after extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,10 +69,13 @@ fgumi-bgzf = { path = "crates/fgumi-bgzf" }
 fgumi-metrics = { path = "crates/fgumi-metrics" }
 fgumi-sam = { path = "crates/fgumi-sam" }
 fgumi-umi = { path = "crates/fgumi-umi" }
-fgumi-consensus = { path = "crates/fgumi-consensus" }
+fgumi-consensus = { path = "crates/fgumi-consensus", default-features = false }
 
 [features]
-default = []
+default = ["simplex", "duplex", "codec"]
+simplex = ["fgumi-consensus/simplex"]
+duplex = ["fgumi-consensus/duplex"]
+codec = ["fgumi-consensus/codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
 memory-debug = ["dep:libmimalloc-sys", "dep:sysinfo"]

--- a/crates/fgumi-umi/Cargo.toml
+++ b/crates/fgumi-umi/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 ahash = "0.8"
 anyhow = "1.0"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"], optional = true }
 rayon = "1.10"
 fgumi-dna = { path = "../fgumi-dna" }
 
@@ -18,6 +18,8 @@ rstest = "0.25"
 proptest = "1"
 
 [features]
+default = ["cli"]
+cli = ["dep:clap"]
 profile-adjacency = []
 
 [lints.clippy]

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -215,7 +215,6 @@
 
 use ahash::AHashMap;
 use anyhow::Result;
-use clap::ValueEnum;
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
 use std::any::Any;
@@ -511,7 +510,8 @@ pub const BOTTOM_STRAND_DUPLEX: &str = "/B";
 ///
 /// Determines how reads are grouped based on their UMI sequences. Each strategy makes
 /// different tradeoffs between speed, error tolerance, and grouping behavior.
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum Strategy {
     /// Only reads with identical UMI sequences are grouped together
     ///

--- a/src/lib/consensus/mod.rs
+++ b/src/lib/consensus/mod.rs
@@ -4,16 +4,30 @@
 
 pub use fgumi_consensus::{base_builder, caller, filter, overlapping, sequence, simple_umi, tags};
 
-pub use fgumi_consensus::{codec_caller, duplex_caller, vanilla_caller};
+#[cfg(feature = "codec")]
+pub use fgumi_consensus::codec_caller;
+#[cfg(feature = "duplex")]
+pub use fgumi_consensus::duplex_caller;
+#[cfg(feature = "simplex")]
+pub use fgumi_consensus::vanilla_caller;
 
 // Re-export commonly used items
 pub use fgumi_consensus::{
-    AgreementStrategy, CodecConsensusCaller, CodecConsensusOptions, CodecConsensusStats,
-    ConsensusBaseBuilder, ConsensusCaller, ConsensusOptionsBase, ConsensusSequence, ConsensusType,
-    CorrectionStats, DisagreementStrategy, DuplexConsensusCaller, DuplexConsensusRead,
-    FilterConfig, FilterResult, FilterThresholds, OverlappingBasesConsensusCaller,
-    RejectionTracker, VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
+    AgreementStrategy, ConsensusBaseBuilder, ConsensusCaller, ConsensusOptionsBase,
+    ConsensusSequence, ConsensusType, CorrectionStats, DisagreementStrategy, FilterConfig,
+    FilterResult, FilterThresholds, OverlappingBasesConsensusCaller, RejectionTracker,
     apply_overlapping_consensus, calculate_error_rate, compute_read_stats, count_no_calls,
     filter_duplex_read, filter_read, is_duplex_consensus, log_consensus_statistics, mask_bases,
     mask_duplex_bases, mean_base_quality, template_passes,
 };
+
+#[cfg(feature = "simplex")]
+pub use fgumi_consensus::{
+    VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
+};
+
+#[cfg(feature = "duplex")]
+pub use fgumi_consensus::{DuplexConsensusCaller, DuplexConsensusRead};
+
+#[cfg(feature = "codec")]
+pub use fgumi_consensus::{CodecConsensusCaller, CodecConsensusOptions, CodecConsensusStats};


### PR DESCRIPTION
## Summary

- **Unify overlapping CIGAR iterators**: Merged `ReadAndRefPosIterator` and `RawReadAndRefPosIterator` into a single iterator that stores CIGAR ops as BAM integer codes internally, eliminating ~200 lines of duplicated logic
- **Fix template length computation**: Use CIGAR reference span instead of sequence length in `SamBuilder` and `RecordPairBuilder`, so reads with insertions/deletions get correct template lengths
- **Track block serial numbers**: `InlineBgzfCompressor` now assigns incrementing serial numbers to compressed blocks for ordering
- **Make clap optional in fgumi-umi**: Clap is now behind a default-enabled `cli` feature, so downstream library consumers can depend on fgumi-umi without pulling in clap
- **Feature-gate consensus caller re-exports**: Simplex, duplex, and codec caller modules are gated behind forwarding features from the root crate to fgumi-consensus

## Test plan

- [x] All 1776 existing tests pass (`cargo ci-test`)
- [x] New tests for unified iterator agreement between noodles and raw paths
- [x] New tests for template length with insertions and deletions
- [x] New tests for `cigar_ref_len` and `kind_to_bam_op`
- [x] New test for BGZF block serial number tracking
- [x] `cargo ci-fmt` and `cargo ci-lint` pass
- [x] `fgumi-umi` builds with `--no-default-features` (without clap)