### PR TITLE
refactor: move alignment_tags into fgumi-sam and clip into fgumi-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,6 +772,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fgoxide",
+ "fgumi-sam",
+ "noodles",
  "serde",
  "tempfile",
 ]
@@ -785,6 +787,7 @@ dependencies = [
  "fgumi-dna",
  "log",
  "noodles",
+ "noodles-raw-bam",
  "tempfile",
 ]
 

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -10,9 +10,15 @@ license = "MIT"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 fgoxide = "0.6.0"
+noodles = { version = "0.104.0", features = ["sam"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
+fgumi-sam = { path = "../fgumi-sam" }
+
+[features]
+default = ["clip"]
+clip = ["dep:noodles"]
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-metrics/src/clip.rs
+++ b/crates/fgumi-metrics/src/clip.rs
@@ -7,7 +7,7 @@ use noodles::sam::alignment::record::Cigar;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use serde::{Deserialize, Serialize};
 
-use super::Metric;
+use crate::Metric;
 
 /// Type of read for metrics tracking
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -256,7 +256,7 @@ impl Default for ClippingMetricsCollection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_sam::builder::RecordBuilder;
 
     /// Creates a test record with the given CIGAR string.
     /// Sequence and qualities are auto-generated from CIGAR length.

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -8,6 +8,8 @@
 //! - [`rejection`] module for rejection reason tracking
 //! - [`writer`] module for TSV file output
 
+#[cfg(feature = "clip")]
+pub mod clip;
 pub mod consensus;
 pub mod correct;
 pub mod duplex;
@@ -74,6 +76,8 @@ pub trait ProcessingMetrics {
 }
 
 // Re-export commonly used types
+#[cfg(feature = "clip")]
+pub use clip::{ClippingMetrics, ClippingMetricsCollection, ReadType};
 pub use consensus::{ConsensusKvMetric, ConsensusMetrics};
 pub use correct::UmiCorrectionMetrics;
 pub use duplex::{

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -8,11 +8,15 @@ license = "MIT"
 
 [dependencies]
 noodles = { version = "0.104.0", features = ["bam", "sam", "core"] }
+noodles-raw-bam = { path = "../noodles-raw-bam", features = ["noodles"] }
 bstr = "1.12.1"
 log = "0"
 anyhow = "1.0"
 fgumi-dna = { path = "../fgumi-dna" }
 tempfile = "3.3.0"
+
+[dev-dependencies]
+noodles-raw-bam = { path = "../noodles-raw-bam", features = ["test-utils"] }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/src/lib/metrics/mod.rs
+++ b/src/lib/metrics/mod.rs
@@ -17,14 +17,12 @@
 pub use fgumi_metrics::{FLOAT_PRECISION, Metric, ProcessingMetrics, format_float};
 
 // Re-export submodules for path compatibility (e.g. fgumi_lib::metrics::consensus::ConsensusMetrics)
+pub use fgumi_metrics::clip;
 pub use fgumi_metrics::consensus;
 pub use fgumi_metrics::correct;
 pub use fgumi_metrics::duplex;
 pub use fgumi_metrics::group;
 pub use fgumi_metrics::writer;
-
-// Clip module stays in main crate (depends on noodles RecordBuf)
-pub mod clip;
 
 // Re-export commonly used types
 pub use clip::{ClippingMetrics, ClippingMetricsCollection, ReadType};

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -360,6 +360,17 @@ impl ReferenceReader {
     }
 }
 
+impl fgumi_sam::ReferenceProvider for ReferenceReader {
+    fn fetch(
+        &self,
+        chrom: &str,
+        start: noodles::core::Position,
+        end: noodles::core::Position,
+    ) -> anyhow::Result<Vec<u8>> {
+        self.fetch(chrom, start, end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib/sam/mod.rs
+++ b/src/lib/sam/mod.rs
@@ -1,9 +1,10 @@
 //! SAM/BAM file utilities and header manipulation.
 //!
-//! This module re-exports functionality from the `fgumi-sam` crate and provides
+//! This module re-exports functionality from the `fgumi-sam` crate, including
 //! alignment tag regeneration via the `alignment_tags` submodule.
 
-pub mod alignment_tags;
+// Re-export alignment_tags from fgumi-sam
+pub use fgumi_sam::alignment_tags;
 
 // Re-export modules from fgumi-sam
 pub use fgumi_sam::{builder, record_utils};


### PR DESCRIPTION
## Summary

- Move `alignment_tags.rs` into `fgumi-sam` crate with a `ReferenceProvider` trait to decouple from the concrete `ReferenceReader` type. A blanket `Deref` impl allows `Arc<ReferenceReader>` to work transparently.
- Move `clip.rs` into `fgumi-metrics` crate behind a default-enabled `clip` feature that gates the noodles dependency.
- Both `src/lib/sam/mod.rs` and `src/lib/metrics/mod.rs` are now pure re-export wrappers, completing the workspace crate extraction started in #83.

## Test plan

- [x] `cargo check` — compiles
- [x] `cargo check --tests` — test compilation passes
- [x] `cargo ci-test` — all 1731 tests pass
- [x] `cargo ci-fmt` — formatting clean
- [x] `cargo ci-lint` — no clippy warnings
- [x] `cargo check -p fgumi-metrics --no-default-features` — builds without clip/noodles
- [x] `cargo check -p fgumi-sam` — builds independently