### PR TITLE
refactor: remove blanket clippy pedantic allows and fix all violations

### DIFF
--- a/crates/fgumi-bgzf/src/writer.rs
+++ b/crates/fgumi-bgzf/src/writer.rs
@@ -145,8 +145,7 @@ impl InlineBgzfCompressor {
             let remaining_in_buffer = BGZF_MAX_BLOCK_SIZE - self.buffer.len();
             let to_copy = remaining_in_buffer.min(data.len() - offset);
 
-            self.buffer
-                .extend_from_slice(&data[offset..offset + to_copy]);
+            self.buffer.extend_from_slice(&data[offset..offset + to_copy]);
             offset += to_copy;
 
             // If buffer is full, compress it
@@ -230,10 +229,7 @@ impl InlineBgzfCompressor {
 
         let serial = self.next_serial;
         self.next_serial += 1;
-        self.completed_blocks.push(CompressedBlock {
-            serial,
-            data: compressed_data,
-        });
+        self.completed_blocks.push(CompressedBlock { serial, data: compressed_data });
 
         // Reset buffer for next block
         self.buffer.clear();
@@ -249,7 +245,9 @@ impl InlineBgzfCompressor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reader::{BGZF_FOOTER_SIZE as READER_FOOTER_SIZE, BGZF_HEADER_SIZE as READER_HEADER_SIZE, BGZF_EOF};
+    use crate::reader::{
+        BGZF_EOF, BGZF_FOOTER_SIZE as READER_FOOTER_SIZE, BGZF_HEADER_SIZE as READER_HEADER_SIZE,
+    };
 
     #[test]
     fn test_bgzf_constants() {

--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -357,7 +357,10 @@ impl ConsensusBaseBuilder {
         // Check if the likelihood difference is large enough to skip full calculation.
         // When ln(L_winner) - ln(L_loser) > threshold, the posterior is essentially 1.
         // threshold = 23 corresponds to likelihood ratio > 10^10, giving Q > 90
-        #[expect(clippy::items_after_statements, reason = "const is logically scoped to this fast-path check")]
+        #[expect(
+            clippy::items_after_statements,
+            reason = "const is logically scoped to this fast-path check"
+        )]
         const FAST_PATH_THRESHOLD: f64 = 23.0;
 
         let likelihoods = self.likelihoods.as_array();

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -350,7 +350,10 @@ impl Default for ConsensusOptionsBase {
 ///
 /// Returns 0.0 if total depth is zero.
 #[must_use]
-#[expect(clippy::cast_precision_loss, reason = "u32 values from u16 sums are small enough for f32 precision")]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "u32 values from u16 sums are small enough for f32 precision"
+)]
 pub fn calculate_error_rate(depths: &[u16], errors: &[u16]) -> f32 {
     let total_depth: u32 = depths.iter().map(|&d| u32::from(d)).sum();
     if total_depth == 0 {

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -76,16 +76,16 @@ use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput,
     RejectionReason as CallerRejectionReason,
 };
+use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
 use crate::simple_umi::consensus_umis;
 use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
-use fgumi_dna::dna::reverse_complement;
-use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
-use noodles_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
 use anyhow::Result;
+use fgumi_dna::dna::reverse_complement;
 use noodles::sam::alignment::record::data::field::Tag;
+use noodles_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -196,8 +196,14 @@ impl CodecConsensusStats {
     #[must_use]
     pub fn duplex_disagreement_rate(&self) -> f64 {
         if self.consensus_duplex_bases_emitted > 0 {
-            #[expect(clippy::cast_precision_loss, reason = "acceptable precision loss for rate computation")]
-            { self.duplex_disagreement_base_count as f64 / self.consensus_duplex_bases_emitted as f64 }
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "acceptable precision loss for rate computation"
+            )]
+            {
+                self.duplex_disagreement_base_count as f64
+                    / self.consensus_duplex_bases_emitted as f64
+            }
         } else {
             0.0
         }
@@ -498,7 +504,10 @@ impl CodecConsensusCaller {
     /// This is the primary entry point, working directly on raw bytes without
     /// materializing `RecordBuf`. Virtual clipping is computed and applied as
     /// offsets when extracting data for consensus.
-    #[expect(clippy::too_many_lines, reason = "consensus pipeline has many sequential steps that are clearest in one function")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "consensus pipeline has many sequential steps that are clearest in one function"
+    )]
     fn consensus_reads_raw(&mut self, records: &[Vec<u8>]) -> Result<ConsensusOutput> {
         self.stats.total_input_reads += records.len() as u64;
 
@@ -1182,7 +1191,10 @@ impl CodecConsensusCaller {
     }
 
     /// Builds the output record from the consensus and writes raw bytes into `output`.
-    #[expect(clippy::unnecessary_wraps, reason = "Result return type kept for API consistency with other callers")]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Result return type kept for API consistency with other callers"
+    )]
     fn build_output_record_into(
         &mut self,
         output: &mut ConsensusOutput,
@@ -1342,22 +1354,34 @@ impl ConsensusCaller for CodecConsensusCaller {
         Ok(result)
     }
 
-    #[expect(clippy::cast_possible_truncation, reason = "read counts will not exceed usize on any supported platform")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read counts will not exceed usize on any supported platform"
+    )]
     fn total_reads(&self) -> usize {
         self.stats.total_input_reads as usize
     }
 
-    #[expect(clippy::cast_possible_truncation, reason = "read counts will not exceed usize on any supported platform")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read counts will not exceed usize on any supported platform"
+    )]
     fn total_filtered(&self) -> usize {
         self.stats.reads_filtered as usize
     }
 
-    #[expect(clippy::cast_possible_truncation, reason = "read counts will not exceed usize on any supported platform")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read counts will not exceed usize on any supported platform"
+    )]
     fn consensus_reads_constructed(&self) -> usize {
         self.stats.consensus_reads_generated as usize
     }
 
-    #[expect(clippy::cast_possible_truncation, reason = "read counts will not exceed usize on any supported platform")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "read counts will not exceed usize on any supported platform"
+    )]
     fn statistics(&self) -> ConsensusCallingStats {
         ConsensusCallingStats {
             total_reads: self.stats.total_input_reads as usize,
@@ -1412,7 +1436,10 @@ impl CodecConsensusCaller {
     /// # Errors
     ///
     /// Returns an error if consensus calling fails on the provided records.
-    #[expect(clippy::needless_pass_by_value, reason = "matches ConsensusCaller trait signature pattern")]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "matches ConsensusCaller trait signature pattern"
+    )]
     pub fn consensus_reads_from_sam_records(
         &mut self,
         recs: Vec<noodles::sam::alignment::RecordBuf>,
@@ -1525,16 +1552,19 @@ impl CodecConsensusCaller {
 }
 
 #[cfg(test)]
-#[expect(clippy::similar_names, reason = "test variables use domain-specific names like r1/r2, ad/bd")]
+#[expect(
+    clippy::similar_names,
+    reason = "test variables use domain-specific names like r1/r2, ad/bd"
+)]
 mod tests {
     use super::*;
-    use fgumi_sam::clipper::cigar_utils;
     use fgumi_sam::builder::RecordBuilder;
-    use noodles_raw_bam::ParsedBamRecord;
+    use fgumi_sam::clipper::cigar_utils;
     use noodles::sam::alignment::RecordBuf;
     use noodles::sam::alignment::record::Cigar as CigarTrait;
     use noodles::sam::alignment::record::Flags;
     use noodles::sam::alignment::record::cigar::op::Kind;
+    use noodles_raw_bam::ParsedBamRecord;
 
     #[test]
     fn test_codec_caller_creation() {
@@ -1584,7 +1614,13 @@ mod tests {
     }
 
     /// Helper function to create a test paired read
-    #[expect(clippy::too_many_arguments, clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss, reason = "test helper needs all parameters and uses casts for BAM position math")]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        reason = "test helper needs all parameters and uses casts for BAM position math"
+    )]
     fn create_test_paired_read(
         name: &str,
         seq: &[u8],
@@ -2007,7 +2043,13 @@ mod tests {
     /// - R1 is `first_segment`, forward (unless strand1=Minus)
     /// - R2 is `last_segment`, reverse (unless strand2=Plus)
     /// - Both reads have proper mate information set
-    #[expect(clippy::too_many_arguments, clippy::too_many_lines, clippy::cast_possible_truncation, clippy::cast_possible_wrap, reason = "test helper needs all parameters, many lines, and uses casts for BAM position math")]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "test helper needs all parameters, many lines, and uses casts for BAM position math"
+    )]
     fn create_fr_pair(
         name: &str,
         start1: usize,

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -9,8 +9,8 @@ use noodles::sam::alignment::record::Sequence as SequenceTrait;
 use noodles::sam::alignment::record_buf::data::field::Value;
 use noodles::sam::alignment::record_buf::{QualityScores, RecordBuf, Sequence};
 
-use crate::tags::{per_base, per_read};
 use crate::phred::{MIN_PHRED, NO_CALL_BASE};
+use crate::tags::{per_base, per_read};
 use fgumi_metrics::rejection::RejectionReason;
 
 /// Filter thresholds for consensus reads
@@ -386,7 +386,10 @@ fn extract_int_tag(data: &noodles::sam::alignment::record_buf::Data, tag_str: &s
         Value::Int16(v) => Some(i32::from(*v)),
         Value::UInt16(v) => Some(i32::from(*v)),
         Value::Int32(v) => Some(*v),
-        #[expect(clippy::cast_possible_wrap, reason = "BAM tag values in practice never exceed i32::MAX")]
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "BAM tag values in practice never exceed i32::MAX"
+        )]
         Value::UInt32(v) => Some(*v as i32),
         _ => None,
     }
@@ -773,7 +776,10 @@ pub fn mean_base_quality(record: &RecordBuf) -> f64 {
         .filter(|&(base, _)| base != NO_CALL_BASE)
         .fold((0u64, 0usize), |(sum, count), (_, qual)| (sum + u64::from(qual), count + 1));
 
-    #[expect(clippy::cast_precision_loss, reason = "precision loss is acceptable for quality averaging")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is acceptable for quality averaging"
+    )]
     if count == 0 { 0.0 } else { sum as f64 / count as f64 }
 }
 
@@ -798,7 +804,10 @@ pub fn compute_read_stats(record: &RecordBuf) -> (usize, f64) {
             }
         });
 
-    #[expect(clippy::cast_precision_loss, reason = "precision loss is acceptable for quality averaging")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is acceptable for quality averaging"
+    )]
     let mean_qual = if non_n_count == 0 { 0.0 } else { qual_sum as f64 / non_n_count as f64 };
     (n_count, mean_qual)
 }
@@ -982,7 +991,11 @@ pub fn filter_duplex_read_raw(
     };
 
     // Check AB strand (max depth, min error) against AB thresholds
-    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation, reason = "depth values are non-negative and fit in usize on all supported platforms")]
+    #[expect(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "depth values are non-negative and fit in usize on all supported platforms"
+    )]
     if (max_depth as usize) < ab_thresholds.min_reads {
         return Ok(FilterResult::InsufficientReads);
     }
@@ -991,7 +1004,11 @@ pub fn filter_duplex_read_raw(
     }
 
     // Check BA strand (min depth, max error) against BA thresholds
-    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation, reason = "depth values are non-negative and fit in usize on all supported platforms")]
+    #[expect(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "depth values are non-negative and fit in usize on all supported platforms"
+    )]
     if (min_depth as usize) < ba_thresholds.min_reads {
         return Ok(FilterResult::InsufficientReads);
     }
@@ -1028,7 +1045,10 @@ pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
         }
     }
 
-    #[expect(clippy::cast_precision_loss, reason = "precision loss is acceptable for quality averaging")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is acceptable for quality averaging"
+    )]
     let mean_qual = if non_n_count == 0 { 0.0 } else { qual_sum as f64 / non_n_count as f64 };
     (n_count, mean_qual)
 }
@@ -1042,7 +1062,10 @@ fn find_string_or_uint8_array(aux_data: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> 
     } else {
         let arr = bam_fields::find_array_tag(aux_data, &tag)?;
         if matches!(arr.elem_type, b'C' | b'c') {
-            #[expect(clippy::cast_possible_truncation, reason = "UInt8 array elements are guaranteed to fit in u8")]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "UInt8 array elements are guaranteed to fit in u8"
+            )]
             Some((0..arr.count).map(|i| bam_fields::array_tag_element_u16(&arr, i) as u8).collect())
         } else {
             None
@@ -1058,7 +1081,10 @@ fn find_string_or_uint8_array(aux_data: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> 
 /// # Errors
 ///
 /// Returns an error if the record is too short or the aux data cannot be parsed.
-#[expect(clippy::similar_names, reason = "threshold variable names mirror the consensus tag names they check")]
+#[expect(
+    clippy::similar_names,
+    reason = "threshold variable names mirror the consensus tag names they check"
+)]
 pub fn mask_bases_raw(
     record: &mut [u8],
     thresholds: &FilterThresholds,
@@ -1107,7 +1133,10 @@ pub fn mask_bases_raw(
 /// # Errors
 ///
 /// Returns an error if the record is too short or the aux data cannot be parsed.
-#[expect(clippy::similar_names, reason = "threshold variable names mirror the duplex strand tag names")]
+#[expect(
+    clippy::similar_names,
+    reason = "threshold variable names mirror the duplex strand tag names"
+)]
 pub fn mask_duplex_bases_raw(
     record: &mut [u8],
     cc_thresholds: &FilterThresholds,

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -13,11 +13,11 @@
 //! - **Consensus filtering**: Quality-based filtering and masking of consensus reads
 //! - **Consensus tags**: SAM tags for tracking consensus metrics
 
-pub mod phred;
 pub mod base_builder;
 pub mod caller;
 pub mod filter;
 pub mod overlapping;
+pub mod phred;
 pub mod sequence;
 pub mod simple_umi;
 pub mod tags;

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -267,7 +267,10 @@ impl OverlappingBasesConsensusCaller {
     }
 
     /// Process disagreeing bases
-    #[expect(clippy::too_many_arguments, reason = "disagreement processing requires all base/quality parameters from both reads")]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "disagreement processing requires all base/quality parameters from both reads"
+    )]
     fn process_disagreement(
         &mut self,
         r1_offset: usize,
@@ -402,7 +405,12 @@ struct ReadAndRefPosIterator {
     end_read_pos: i32,
 }
 
-#[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss, reason = "position arithmetic requires casts between BAM integer types")]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    reason = "position arithmetic requires casts between BAM integer types"
+)]
 impl ReadAndRefPosIterator {
     /// Create iterator for aligned positions overlapping with mate (noodles `RecordBuf`)
     fn new_with_mate(record: &RecordBuf, mate: &RecordBuf) -> Result<Self> {
@@ -566,7 +574,10 @@ impl ReadAndRefPosIterator {
     }
 }
 
-#[expect(clippy::cast_sign_loss, reason = "position arithmetic requires casts between BAM integer types")]
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "position arithmetic requires casts between BAM integer types"
+)]
 impl Iterator for ReadAndRefPosIterator {
     type Item = ReadPosition;
 
@@ -757,9 +768,13 @@ impl OverlappingBasesConsensusCaller {
         }
 
         // Verify both have alignment positions and ends
-        let Some(r1_start) = noodles_raw_bam::alignment_start_from_raw(r1) else { return Ok(false) };
+        let Some(r1_start) = noodles_raw_bam::alignment_start_from_raw(r1) else {
+            return Ok(false);
+        };
         let Some(r1_end) = noodles_raw_bam::alignment_end_from_raw(r1) else { return Ok(false) };
-        let Some(r2_start) = noodles_raw_bam::alignment_start_from_raw(r2) else { return Ok(false) };
+        let Some(r2_start) = noodles_raw_bam::alignment_start_from_raw(r2) else {
+            return Ok(false);
+        };
         let Some(r2_end) = noodles_raw_bam::alignment_end_from_raw(r2) else { return Ok(false) };
 
         // Create merge iterator that yields positions where both reads have aligned bases
@@ -2179,8 +2194,7 @@ mod tests {
 
         // r1: 100-107, r2: 104-111, overlap: 104-107
         let raw_iter = ReadMateAndRefPosIterator::new_raw(
-            &r1_raw, &r2_raw,
-            100, 107, // r1 start/end
+            &r1_raw, &r2_raw, 100, 107, // r1 start/end
             104, 111, // r2 start/end
         );
         let raw_positions: Vec<_> = raw_iter.collect();

--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -122,8 +122,14 @@ pub fn ln_prob_to_phred(ln_prob: LogProbability) -> PhredScore {
         return MAX_PHRED;
     }
     let phred = (-10.0 * ln_prob / LN_10 + PHRED_PRECISION).floor();
-    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, reason = "value is clamped to [MIN_PHRED, MAX_PHRED] which fits in u8")]
-    { phred.clamp(f64::from(MIN_PHRED), f64::from(MAX_PHRED)) as PhredScore }
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "value is clamped to [MIN_PHRED, MAX_PHRED] which fits in u8"
+    )]
+    {
+        phred.clamp(f64::from(MIN_PHRED), f64::from(MAX_PHRED)) as PhredScore
+    }
 }
 
 /// Precise computation of log(1 + exp(x)).
@@ -338,7 +344,10 @@ pub fn ln_not(x: LogProbability) -> LogProbability {
 }
 
 #[cfg(test)]
-#[expect(clippy::similar_names, reason = "test variables use short math-related names like ln_p, ln_q")]
+#[expect(
+    clippy::similar_names,
+    reason = "test variables use short math-related names like ln_p, ln_q"
+)]
 mod tests {
     use super::*;
 

--- a/crates/fgumi-consensus/src/sequence.rs
+++ b/crates/fgumi-consensus/src/sequence.rs
@@ -191,7 +191,10 @@ impl ConsensusSequence {
 
     /// Returns the error rate (total errors / total depth).
     #[must_use]
-    #[expect(clippy::cast_precision_loss, reason = "u32 values from u16 sums are small enough for f32 precision")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "u32 values from u16 sums are small enough for f32 precision"
+    )]
     pub fn error_rate(&self) -> f32 {
         let total_depth: u32 = self.depths.iter().map(|&d| u32::from(d)).sum();
         if total_depth == 0 {

--- a/crates/fgumi-consensus/src/tags.rs
+++ b/crates/fgumi-consensus/src/tags.rs
@@ -224,7 +224,10 @@ pub fn is_simplex_consensus(rec: &impl noodles::sam::alignment::Record) -> bool 
 ///
 /// A duplex consensus read has both the `aD` (`AbRawReadCount`) and `bD` (`BaRawReadCount`) tags.
 #[must_use]
-#[expect(clippy::similar_names, reason = "aD/bD tag names are domain-specific duplex strand identifiers")]
+#[expect(
+    clippy::similar_names,
+    reason = "aD/bD tag names are domain-specific duplex strand identifiers"
+)]
 pub fn is_duplex_consensus(rec: &impl noodles::sam::alignment::Record) -> bool {
     let has_ad = rec.data().get(&per_read::tag("aD")).is_some();
     let has_bd = rec.data().get(&per_read::tag("bD")).is_some();

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -4,22 +4,20 @@
 //! reads from the same source molecule (same UMI/MI tag) and calls a consensus
 //! sequence using a likelihood-based model.
 
-use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use crate::base_builder::ConsensusBaseBuilder;
-use crate::caller::{
-    ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
-};
-use crate::simple_umi::consensus_umis;
-use fgumi_dna::dna::reverse_complement;
+use crate::caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason};
 use crate::phred::{
     MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore, ln_error_prob_two_trials,
     ln_prob_to_phred, phred_to_ln_error_prob,
 };
-use noodles_raw_bam::{UnmappedBamRecordBuilder, flags};
+use crate::simple_umi::consensus_umis;
 use anyhow::{Result, anyhow, bail};
+use fgumi_dna::dna::reverse_complement;
+use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
 #[cfg(test)]
 use noodles::sam::alignment::record_buf::RecordBuf;
+use noodles_raw_bam::{UnmappedBamRecordBuilder, flags};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -195,7 +193,10 @@ impl VanillaConsensusRead {
 
     /// Returns the error rate (total errors / total depth)
     #[must_use]
-    #[expect(clippy::cast_precision_loss, reason = "u32 values from u16 sums are small enough for f32 precision")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "u32 values from u16 sums are small enough for f32 precision"
+    )]
     pub fn error_rate(&self) -> f32 {
         let total_depth: u32 = self.depths.iter().map(|&d| u32::from(d)).sum();
         if total_depth == 0 {
@@ -861,8 +862,14 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Sub-groups reads by read type (fragment, R1, R2)
-    #[expect(clippy::type_complexity, reason = "tuple return type is clearer than a one-off struct for internal grouping")]
-    #[expect(clippy::unused_self, reason = "method signature kept for consistency with other caller trait methods")]
+    #[expect(
+        clippy::type_complexity,
+        reason = "tuple return type is clearer than a one-off struct for internal grouping"
+    )]
+    #[expect(
+        clippy::unused_self,
+        reason = "method signature kept for consistency with other caller trait methods"
+    )]
     fn subgroup_reads(&self, reads: Vec<Vec<u8>>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
         use noodles_raw_bam as bam_fields;
 
@@ -1187,7 +1194,10 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Builds a consensus record as raw BAM bytes and writes it into a `ConsensusOutput`.
-    #[expect(clippy::too_many_arguments, reason = "consensus record building requires many parameters from the calling context")]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "consensus record building requires many parameters from the calling context"
+    )]
     fn build_consensus_record_into(
         &mut self,
         output: &mut ConsensusOutput,
@@ -1353,15 +1363,15 @@ pub(crate) enum ReadType {
 )]
 mod tests {
     use super::*;
+    use bstr::BString;
     use fgumi_sam::builder::{RecordBuilder, RecordPairBuilder};
     use fgumi_sam::record_utils;
-    use noodles_raw_bam::ParsedBamRecord;
-    use bstr::BString;
     use noodles::core::Position;
     use noodles::sam::alignment::record::Flags as NoodlesFlags;
     use noodles::sam::alignment::record::cigar::op::Op;
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::{Cigar, QualityScores, Sequence, data::field::Value};
+    use noodles_raw_bam::ParsedBamRecord;
 
     /// Build a SAM header with a dummy reference sequence so that records
     /// with `reference_sequence_id(0)` or `mate_reference_sequence_id(0)` can be encoded.

--- a/crates/fgumi-consensus/src/vendored/bam_codec/encoder/quality_scores.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/encoder/quality_scores.rs
@@ -14,7 +14,6 @@ pub(super) fn write_quality_scores<S>(
 where
     S: QualityScores,
 {
-
     if quality_scores.len() == base_count {
         for result in quality_scores.iter() {
             let n = result?;
@@ -52,7 +51,6 @@ pub(super) fn write_quality_scores_from_slice(
     base_count: usize,
     scores: &[u8],
 ) -> io::Result<()> {
-
     if scores.len() == base_count {
         // Validate entire slice first - this can be auto-vectorized by LLVM
         if scores.iter().all(|&s| s <= MAX_SCORE) {

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -308,14 +308,46 @@ impl ConsensusMetrics {
 
         // Core metrics matching fgbio's output
         let core = [
-            ("raw_reads_considered", self.total_input_reads.to_string(), "Total raw reads considered from input file"),
-            ("raw_reads_rejected", self.filtered_reads.to_string(), "Total number of raw reads rejected before consensus calling"),
-            ("raw_reads_used", raw_reads_used.to_string(), "Total count of raw reads used in consensus reads"),
-            ("frac_raw_reads_used", format_float(frac_used), "Fraction of raw reads used in consensus reads"),
-            ("raw_reads_rejected_for_insufficient_support", self.rejected_insufficient_support.to_string(), "Insufficient reads to generate a consensus"),
-            ("raw_reads_rejected_for_minority_alignment", self.rejected_minority_alignment.to_string(), "Read has a different, and minority, set of indels"),
-            ("raw_reads_rejected_for_orphan_consensus", self.rejected_orphan_consensus.to_string(), "Only one of R1 or R2 consensus generated"),
-            ("raw_reads_rejected_for_zero_bases_post_trimming", self.rejected_zero_bases_post_trimming.to_string(), "Read or mate had zero bases post trimming"),
+            (
+                "raw_reads_considered",
+                self.total_input_reads.to_string(),
+                "Total raw reads considered from input file",
+            ),
+            (
+                "raw_reads_rejected",
+                self.filtered_reads.to_string(),
+                "Total number of raw reads rejected before consensus calling",
+            ),
+            (
+                "raw_reads_used",
+                raw_reads_used.to_string(),
+                "Total count of raw reads used in consensus reads",
+            ),
+            (
+                "frac_raw_reads_used",
+                format_float(frac_used),
+                "Fraction of raw reads used in consensus reads",
+            ),
+            (
+                "raw_reads_rejected_for_insufficient_support",
+                self.rejected_insufficient_support.to_string(),
+                "Insufficient reads to generate a consensus",
+            ),
+            (
+                "raw_reads_rejected_for_minority_alignment",
+                self.rejected_minority_alignment.to_string(),
+                "Read has a different, and minority, set of indels",
+            ),
+            (
+                "raw_reads_rejected_for_orphan_consensus",
+                self.rejected_orphan_consensus.to_string(),
+                "Only one of R1 or R2 consensus generated",
+            ),
+            (
+                "raw_reads_rejected_for_zero_bases_post_trimming",
+                self.rejected_zero_bases_post_trimming.to_string(),
+                "Read or mate had zero bases post trimming",
+            ),
         ];
         for (key, value, description) in core {
             metrics.push(ConsensusKvMetric::new(key, value, description));
@@ -337,20 +369,76 @@ impl ConsensusMetrics {
     /// Appends fgumi-specific rejection metrics with non-zero counts.
     fn push_optional_rejections(&self, metrics: &mut Vec<ConsensusKvMetric>) {
         let optional = [
-            ("raw_reads_rejected_for_insufficient_strand_support", self.rejected_insufficient_strand_support, "Insufficient strand support for consensus"),
-            ("raw_reads_rejected_for_low_base_quality", self.rejected_low_base_quality, "Low base quality"),
-            ("raw_reads_rejected_for_excessive_n_bases", self.rejected_excessive_n_bases, "Excessive N bases in read"),
-            ("raw_reads_rejected_for_no_valid_alignment", self.rejected_no_valid_alignment, "No valid alignment found"),
-            ("raw_reads_rejected_for_low_mapping_quality", self.rejected_low_mapping_quality, "Low mapping quality"),
-            ("raw_reads_rejected_for_n_bases_in_umi", self.rejected_n_bases_in_umi, "N bases in UMI sequence"),
-            ("raw_reads_rejected_for_missing_umi", self.rejected_missing_umi, "Read lacks required UMI tag"),
-            ("raw_reads_rejected_for_not_passing_filter", self.rejected_not_passing_filter, "Read did not pass vendor filter"),
-            ("raw_reads_rejected_for_low_mean_quality", self.rejected_low_mean_quality, "Low mean base quality"),
-            ("raw_reads_rejected_for_insufficient_min_depth", self.rejected_insufficient_min_depth, "Insufficient minimum read depth"),
-            ("raw_reads_rejected_for_excessive_error_rate", self.rejected_excessive_error_rate, "Excessive error rate"),
-            ("raw_reads_rejected_for_umi_too_short", self.rejected_umi_too_short, "UMI sequence too short"),
-            ("raw_reads_rejected_for_single_strand_only", self.rejected_same_strand_only, "Only generating one strand of duplex consensus"),
-            ("raw_reads_rejected_for_duplicate_umi", self.rejected_duplicate_umi, "Duplicate UMI detected"),
+            (
+                "raw_reads_rejected_for_insufficient_strand_support",
+                self.rejected_insufficient_strand_support,
+                "Insufficient strand support for consensus",
+            ),
+            (
+                "raw_reads_rejected_for_low_base_quality",
+                self.rejected_low_base_quality,
+                "Low base quality",
+            ),
+            (
+                "raw_reads_rejected_for_excessive_n_bases",
+                self.rejected_excessive_n_bases,
+                "Excessive N bases in read",
+            ),
+            (
+                "raw_reads_rejected_for_no_valid_alignment",
+                self.rejected_no_valid_alignment,
+                "No valid alignment found",
+            ),
+            (
+                "raw_reads_rejected_for_low_mapping_quality",
+                self.rejected_low_mapping_quality,
+                "Low mapping quality",
+            ),
+            (
+                "raw_reads_rejected_for_n_bases_in_umi",
+                self.rejected_n_bases_in_umi,
+                "N bases in UMI sequence",
+            ),
+            (
+                "raw_reads_rejected_for_missing_umi",
+                self.rejected_missing_umi,
+                "Read lacks required UMI tag",
+            ),
+            (
+                "raw_reads_rejected_for_not_passing_filter",
+                self.rejected_not_passing_filter,
+                "Read did not pass vendor filter",
+            ),
+            (
+                "raw_reads_rejected_for_low_mean_quality",
+                self.rejected_low_mean_quality,
+                "Low mean base quality",
+            ),
+            (
+                "raw_reads_rejected_for_insufficient_min_depth",
+                self.rejected_insufficient_min_depth,
+                "Insufficient minimum read depth",
+            ),
+            (
+                "raw_reads_rejected_for_excessive_error_rate",
+                self.rejected_excessive_error_rate,
+                "Excessive error rate",
+            ),
+            (
+                "raw_reads_rejected_for_umi_too_short",
+                self.rejected_umi_too_short,
+                "UMI sequence too short",
+            ),
+            (
+                "raw_reads_rejected_for_single_strand_only",
+                self.rejected_same_strand_only,
+                "Only generating one strand of duplex consensus",
+            ),
+            (
+                "raw_reads_rejected_for_duplicate_umi",
+                self.rejected_duplicate_umi,
+                "Duplicate UMI detected",
+            ),
         ];
         for (key, count, description) in optional {
             if count > 0 {

--- a/crates/fgumi-metrics/src/correct.rs
+++ b/crates/fgumi-metrics/src/correct.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use fgoxide::io::DelimFile;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::Metric;
 
@@ -27,7 +27,10 @@ where
     }
 
     // If the value is a whole number, serialize without decimal point
-    #[expect(clippy::cast_precision_loss, reason = "i64::MAX boundary check, exact precision not needed")]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "i64::MAX boundary check, exact precision not needed"
+    )]
     let max_safe = i64::MAX as f64;
     if value.fract() == 0.0 && value.abs() < max_safe {
         #[expect(clippy::cast_possible_truncation, reason = "guarded by abs check above")]
@@ -137,7 +140,7 @@ impl UmiCorrectionMetrics {
     /// # Errors
     ///
     /// Returns an error if the file cannot be created or written to.
-    pub fn write_metrics(metrics: &[Self], path: &PathBuf) -> Result<()> {
+    pub fn write_metrics(metrics: &[Self], path: &Path) -> Result<()> {
         DelimFile::default()
             .write_tsv(path, metrics)
             .with_context(|| format!("Failed to write UMI correction metrics: {}", path.display()))
@@ -157,7 +160,7 @@ impl UmiCorrectionMetrics {
     /// - The file cannot be read
     /// - The file format is invalid
     /// - Any values cannot be parsed
-    pub fn read_metrics(path: &PathBuf) -> Result<Vec<Self>> {
+    pub fn read_metrics(path: &Path) -> Result<Vec<Self>> {
         DelimFile::default()
             .read_tsv(path)
             .with_context(|| format!("Failed to read UMI correction metrics: {}", path.display()))

--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -465,8 +465,7 @@ impl DuplexMetricsCollector {
                 metric.count = *count;
                 #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
                 {
-                    metric.fraction =
-                        if total > 0 { *count as f64 / total as f64 } else { 0.0 };
+                    metric.fraction = if total > 0 { *count as f64 / total as f64 } else { 0.0 };
                 }
                 metric
             })
@@ -500,10 +499,7 @@ impl DuplexMetricsCollector {
             }
             for metric in &mut metrics {
                 let cumulative_count = grid[metric.ab_size * cols + metric.ba_size];
-                #[expect(
-                    clippy::cast_precision_loss,
-                    reason = "metric counts never exceed 2^53"
-                )]
+                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
                 {
                     metric.fraction_gt_or_eq_size = cumulative_count as f64 / total as f64;
                 }
@@ -615,7 +611,6 @@ impl DuplexMetricsCollector {
         metrics.sort_by(|a, b| b.unique_observations.cmp(&a.unique_observations));
         metrics
     }
-
 }
 
 #[cfg(test)]

--- a/crates/fgumi-sam/src/builder.rs
+++ b/crates/fgumi-sam/src/builder.rs
@@ -588,9 +588,7 @@ impl<'a> PairBuilder<'a> {
 
         // Add read group tag
         let rg_tag = Tag::new(b'R', b'G');
-        first_read
-            .data_mut()
-            .insert(rg_tag, BufValue::from(self.parent.read_group_id.clone()));
+        first_read.data_mut().insert(rg_tag, BufValue::from(self.parent.read_group_id.clone()));
 
         // Add custom attributes
         for (tag_str, value) in &self.attrs {
@@ -638,9 +636,7 @@ impl<'a> PairBuilder<'a> {
         }
 
         // Add read group tag
-        second_read
-            .data_mut()
-            .insert(rg_tag, BufValue::from(self.parent.read_group_id.clone()));
+        second_read.data_mut().insert(rg_tag, BufValue::from(self.parent.read_group_id.clone()));
 
         // Add custom attributes
         for (tag_str, value) in &self.attrs {
@@ -654,10 +650,12 @@ impl<'a> PairBuilder<'a> {
         if !unmapped1 && !unmapped2 && self.contig == contig2 {
             let pos1 = i32::try_from(self.start1.unwrap()).expect("start1 fits in i32");
             let pos2 = i32::try_from(self.start2.unwrap()).expect("start2 fits in i32");
-            let end1 =
-                pos1 + i32::try_from(cigar_ref_len(&cigar1)).expect("cigar1 ref len fits in i32") - 1;
-            let end2 =
-                pos2 + i32::try_from(cigar_ref_len(&cigar2)).expect("cigar2 ref len fits in i32") - 1;
+            let end1 = pos1
+                + i32::try_from(cigar_ref_len(&cigar1)).expect("cigar1 ref len fits in i32")
+                - 1;
+            let end2 = pos2
+                + i32::try_from(cigar_ref_len(&cigar2)).expect("cigar2 ref len fits in i32")
+                - 1;
 
             let (left, right) = if pos1 <= pos2 { (pos1, end2) } else { (pos2, end1) };
             let tlen = right - left + 1;
@@ -1684,10 +1682,12 @@ impl RecordPairBuilder {
         if r1_mapped && r2_mapped && self.reference_sequence_id == r2_ref_id {
             let pos1 = i32::try_from(self.r1_start.unwrap()).expect("r1_start fits in i32");
             let pos2 = i32::try_from(self.r2_start.unwrap()).expect("r2_start fits in i32");
-            let end1 =
-                pos1 + i32::try_from(cigar_ref_len(&r1_cigar)).expect("r1 cigar ref len fits in i32") - 1;
-            let end2 =
-                pos2 + i32::try_from(cigar_ref_len(&r2_cigar)).expect("r2 cigar ref len fits in i32") - 1;
+            let end1 = pos1
+                + i32::try_from(cigar_ref_len(&r1_cigar)).expect("r1 cigar ref len fits in i32")
+                - 1;
+            let end2 = pos2
+                + i32::try_from(cigar_ref_len(&r2_cigar)).expect("r2 cigar ref len fits in i32")
+                - 1;
 
             let (left, right) = if pos1 <= pos2 { (pos1, end2) } else { (pos2, end1) };
             let tlen = right - left + 1;
@@ -2504,7 +2504,11 @@ pub fn cigar_ref_len(cigar: &str) -> usize {
         .filter(|op| {
             matches!(
                 op.kind(),
-                Kind::Match | Kind::Deletion | Kind::Skip | Kind::SequenceMatch | Kind::SequenceMismatch
+                Kind::Match
+                    | Kind::Deletion
+                    | Kind::Skip
+                    | Kind::SequenceMatch
+                    | Kind::SequenceMismatch
             )
         })
         .map(|op| op.len())

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -12,8 +12,8 @@ use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record_buf::data::field::Value;
 use noodles::sam::alignment::record_buf::{Cigar as CigarBuf, QualityScores, Sequence};
 
-use fgumi_dna::{MIN_PHRED, NO_CALL_BASE};
 use crate::record_utils;
+use fgumi_dna::{MIN_PHRED, NO_CALL_BASE};
 
 /// Helper macro to get array length for any Array variant
 macro_rules! array_len {
@@ -143,7 +143,10 @@ impl SamRecordClipper {
     /// Clips a specified number of bases from the start (left side) of the alignment
     ///
     /// Returns the number of bases actually clipped
-    #[expect(clippy::too_many_lines, reason = "clipping logic with multiple modes requires handling many CIGAR edge cases")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "clipping logic with multiple modes requires handling many CIGAR edge cases"
+    )]
     pub fn clip_start_of_alignment(&self, record: &mut RecordBuf, bases_to_clip: usize) -> usize {
         if bases_to_clip == 0 {
             return 0;
@@ -313,7 +316,10 @@ impl SamRecordClipper {
     /// Clips a specified number of bases from the end (right side) of the alignment
     ///
     /// Returns the number of bases actually clipped
-    #[expect(clippy::too_many_lines, reason = "mirrors clip_start_of_alignment with symmetric end-clipping logic")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "mirrors clip_start_of_alignment with symmetric end-clipping logic"
+    )]
     pub fn clip_end_of_alignment(&self, record: &mut RecordBuf, bases_to_clip: usize) -> usize {
         if bases_to_clip == 0 {
             return 0;
@@ -783,7 +789,10 @@ impl SamRecordClipper {
     ///
     /// Given a reference length, calculates how many query bases correspond to that region
     /// starting from either the 5' end (`from_start=true`) or 3' end (`from_start=false`)
-    #[expect(clippy::unused_self, reason = "kept as a method for consistency with other clipper operations")]
+    #[expect(
+        clippy::unused_self,
+        reason = "kept as a method for consistency with other clipper operations"
+    )]
     fn calculate_query_bases_for_ref_region(
         &self,
         record: &RecordBuf,
@@ -1043,7 +1052,10 @@ impl SamRecordClipper {
     ///
     /// Returns `Result` for API compatibility, but the current implementation is
     /// infallible and always returns `Ok`.
-    #[expect(clippy::too_many_lines, reason = "CIGAR rewriting with attribute clipping requires many branches")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "CIGAR rewriting with attribute clipping requires many branches"
+    )]
     pub fn upgrade_all_clipping(&self, record: &mut RecordBuf) -> Result<(usize, usize)> {
         // Only upgrade in Hard mode
         if !matches!(self.mode, ClippingMode::Hard) {
@@ -1227,7 +1239,10 @@ pub mod cigar_utils {
 
     /// Counts the number of aligned bases in a CIGAR string
     #[must_use]
-    #[expect(clippy::redundant_closure_for_method_calls, reason = "Op::len is not a method on the trait")]
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "Op::len is not a method on the trait"
+    )]
     pub fn aligned_bases(cigar: &impl CigarTrait) -> usize {
         cigar
             .iter()
@@ -1241,7 +1256,10 @@ pub mod cigar_utils {
 
     /// Counts the number of clipped bases in a CIGAR string
     #[must_use]
-    #[expect(clippy::redundant_closure_for_method_calls, reason = "Op::len is not a method on the trait")]
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "Op::len is not a method on the trait"
+    )]
     pub fn clipped_bases(cigar: &impl CigarTrait) -> usize {
         cigar
             .iter()
@@ -1253,7 +1271,10 @@ pub mod cigar_utils {
 
     /// Counts reference-consuming operations
     #[must_use]
-    #[expect(clippy::redundant_closure_for_method_calls, reason = "Op::len is not a method on the trait")]
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "Op::len is not a method on the trait"
+    )]
     pub fn reference_length(cigar: &impl CigarTrait) -> usize {
         cigar
             .iter()

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -221,8 +221,8 @@ use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use fgumi_dna::BitEnc;
 use crate::MoleculeId;
+use fgumi_dna::BitEnc;
 
 /// Default minimum number of unique UMIs to use N-gram/BK-tree index for candidate search.
 /// Below this threshold, linear scan is used. Based on benchmarks: index provides ~10%
@@ -295,8 +295,7 @@ impl BkTree {
         match self.root {
             Some(ref mut root) => Self::insert_into(root, encoded, index),
             None => {
-                self.root =
-                    Some(Box::new(BkNode { encoded, index, children: BTreeMap::new() }));
+                self.root = Some(Box::new(BkNode { encoded, index, children: BTreeMap::new() }));
             }
         }
     }

--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -93,10 +93,7 @@ impl MoleculeId {
     /// efficient Vec-based grouping instead of `HashMap`.
     #[inline]
     #[must_use]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "molecule IDs never exceed usize::MAX / 2"
-    )]
+    #[expect(clippy::cast_possible_truncation, reason = "molecule IDs never exceed usize::MAX / 2")]
     pub fn to_vec_index(&self) -> Option<usize> {
         match self {
             MoleculeId::None => None,

--- a/crates/noodles-raw-bam/src/builder.rs
+++ b/crates/noodles-raw-bam/src/builder.rs
@@ -1,5 +1,8 @@
 use crate::sequence::pack_sequence_into;
-use crate::tags::{append_string_tag, append_int_tag, append_float_tag, append_i16_array_tag, append_phred33_string_tag};
+use crate::tags::{
+    append_float_tag, append_i16_array_tag, append_int_tag, append_phred33_string_tag,
+    append_string_tag,
+};
 
 // ============================================================================
 // Unmapped BAM Record Builder
@@ -180,7 +183,8 @@ impl UnmappedBamRecordBuilder {
     #[inline]
     pub fn write_with_block_size(&self, output: &mut Vec<u8>) {
         debug_assert!(self.sealed, "must call build_record first");
-        let block_size = u32::try_from(self.buf.len()).expect("record too large for BAM block_size");
+        let block_size =
+            u32::try_from(self.buf.len()).expect("record too large for BAM block_size");
         output.extend_from_slice(&block_size.to_le_bytes());
         output.extend_from_slice(&self.buf);
     }
@@ -197,8 +201,8 @@ impl Default for UnmappedBamRecordBuilder {
 mod tests {
     use super::*;
     use crate::fields::*;
-    use crate::tags::*;
     use crate::sequence::*;
+    use crate::tags::*;
     use crate::testutil::*;
 
     #[test]

--- a/crates/noodles-raw-bam/src/fields.rs
+++ b/crates/noodles-raw-bam/src/fields.rs
@@ -527,7 +527,7 @@ mod tests {
             200,                            // pos
             flags::PAIRED | flags::REVERSE, // flags
             b"rea",                         // name
-            &[(10 << 4) | 0],              // 10M cigar
+            &[(10 << 4) | 0],               // 10M cigar
             10,                             // seq_len
             5,                              // mate_tid
             300,                            // mate_pos

--- a/crates/noodles-raw-bam/src/lib.rs
+++ b/crates/noodles-raw-bam/src/lib.rs
@@ -1,12 +1,12 @@
 #![deny(unsafe_code)]
 
-pub mod fields;
-pub mod tags;
-pub mod sequence;
-pub mod cigar;
-pub mod sort;
-pub mod overlap;
 pub mod builder;
+pub mod cigar;
+pub mod fields;
+pub mod overlap;
+pub mod sequence;
+pub mod sort;
+pub mod tags;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testutil;
@@ -15,13 +15,13 @@ pub mod testutil;
 pub mod noodles_compat;
 
 // Flat re-exports — callers use noodles_raw_bam::flags() etc.
-pub use fields::*;
-pub use tags::*;
-pub use sequence::*;
-pub use cigar::*;
-pub use sort::*;
-pub use overlap::*;
 pub use builder::*;
+pub use cigar::*;
+pub use fields::*;
+pub use overlap::*;
+pub use sequence::*;
+pub use sort::*;
+pub use tags::*;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use testutil::*;

--- a/crates/noodles-raw-bam/src/overlap.rs
+++ b/crates/noodles-raw-bam/src/overlap.rs
@@ -1,6 +1,6 @@
 use crate::cigar::{
-    get_cigar_ops, reference_length_from_cigar, reference_length_from_raw_bam,
-    unclipped_other_end, unclipped_other_start,
+    get_cigar_ops, reference_length_from_cigar, reference_length_from_raw_bam, unclipped_other_end,
+    unclipped_other_start,
 };
 use crate::fields::{aux_data_slice, flags, mate_pos, mate_ref_id, pos, ref_id, template_length};
 use crate::tags::find_string_tag;

--- a/crates/noodles-raw-bam/src/sequence.rs
+++ b/crates/noodles-raw-bam/src/sequence.rs
@@ -1,4 +1,4 @@
-use crate::fields::{l_seq, seq_offset, qual_offset};
+use crate::fields::{l_seq, qual_offset, seq_offset};
 
 /// BAM 4-bit base encoding -> ASCII lookup table.
 ///

--- a/crates/noodles-raw-bam/src/tags.rs
+++ b/crates/noodles-raw-bam/src/tags.rs
@@ -1,4 +1,6 @@
-use crate::fields::{TAG_FIXED_SIZES, aux_data_offset, aux_data_offset_from_record, aux_data_slice, tag_value_size};
+use crate::fields::{
+    TAG_FIXED_SIZES, aux_data_offset, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+};
 
 /// Find a string (Z-type) tag in auxiliary data, returning value bytes without null terminator.
 #[must_use]
@@ -547,7 +549,9 @@ pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16])
     record.push(tag[1]);
     record.push(b'B');
     record.push(b's');
-    record.extend_from_slice(&u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes());
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
     for &v in values {
         record.extend_from_slice(&v.to_le_bytes());
     }

--- a/src/lib/header.rs
+++ b/src/lib/header.rs
@@ -94,6 +94,9 @@ pub fn make_unique_program_id(header: &Header, base_id: &str) -> String {
 /// # Returns
 ///
 /// A `Map<Program>` ready to add to a header.
+/// # Errors
+///
+/// Returns an error if the program record cannot be built.
 pub fn build_program_record(
     version: &str,
     command_line: &str,
@@ -127,6 +130,9 @@ pub fn build_program_record(
 /// # Returns
 ///
 /// The modified header with the new @PG record.
+/// # Errors
+///
+/// Returns an error if the program record cannot be added to the header.
 pub fn add_pg_record(mut header: Header, version: &str, command_line: &str) -> Result<Header> {
     let previous_program = get_last_program_id(&header);
     let unique_id = make_unique_program_id(&header, "fgumi");
@@ -150,6 +156,9 @@ pub fn add_pg_record(mut header: Header, version: &str, command_line: &str) -> R
 /// # Returns
 ///
 /// The modified header builder.
+/// # Errors
+///
+/// Returns an error if the program record cannot be built.
 pub fn add_pg_to_builder(
     builder: noodles::sam::header::Builder,
     version: &str,
@@ -233,15 +242,15 @@ mod tests {
         // Verify the program has expected fields
         let pg = programs.as_ref().get(b"fgumi".as_slice()).unwrap();
         assert_eq!(
-            pg.other_fields().get(&tag::NAME).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::NAME).map(std::convert::AsRef::as_ref),
             Some(b"fgumi".as_slice())
         );
         assert_eq!(
-            pg.other_fields().get(&tag::VERSION).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::VERSION).map(std::convert::AsRef::as_ref),
             Some(b"1.0.0".as_slice())
         );
         assert_eq!(
-            pg.other_fields().get(&tag::COMMAND_LINE).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::COMMAND_LINE).map(std::convert::AsRef::as_ref),
             Some(b"fgumi test".as_slice())
         );
         assert!(pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).is_none());
@@ -261,7 +270,7 @@ mod tests {
         // Verify PP chaining
         let pg = programs.as_ref().get(b"fgumi.1".as_slice()).unwrap();
         assert_eq!(
-            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(std::convert::AsRef::as_ref),
             Some(b"fgumi".as_slice())
         );
     }
@@ -284,7 +293,7 @@ mod tests {
         // fgumi should chain to bwa
         let pg = programs.as_ref().get(b"fgumi".as_slice()).unwrap();
         assert_eq!(
-            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(std::convert::AsRef::as_ref),
             Some(b"bwa".as_slice())
         );
     }
@@ -300,7 +309,7 @@ mod tests {
 
         let pg = programs.as_ref().get(b"fgumi".as_slice()).unwrap();
         assert_eq!(
-            pg.other_fields().get(&tag::NAME).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::NAME).map(std::convert::AsRef::as_ref),
             Some(b"fgumi".as_slice())
         );
         assert!(pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).is_none());
@@ -347,7 +356,7 @@ mod tests {
         // fgumi should chain to SamBuilder
         let pg = programs.as_ref().get(b"fgumi".as_slice()).unwrap();
         assert_eq!(
-            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(|s| s.as_ref()),
+            pg.other_fields().get(&tag::PREVIOUS_PROGRAM_ID).map(std::convert::AsRef::as_ref),
             Some(b"SamBuilder".as_slice())
         );
 

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -90,6 +90,7 @@ pub fn format_duration(duration: Duration) -> String {
 /// assert_eq!(format_rate(600, Duration::from_secs(60)), "10 items/s");
 /// ```
 #[must_use]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn format_rate(count: u64, duration: Duration) -> String {
     let secs = duration.as_secs_f64();
     if secs < 0.001 {
@@ -127,6 +128,7 @@ pub fn format_rate(count: u64, duration: Duration) -> String {
 ///
 /// log_consensus_summary(&metrics);
 /// ```
+#[allow(clippy::cast_precision_loss)]
 pub fn log_consensus_summary(metrics: &ConsensusMetrics) {
     log::info!("Consensus Calling Summary:");
     log::info!("  Input reads: {}", format_count(metrics.total_input_reads));
@@ -176,6 +178,7 @@ pub fn log_consensus_summary(metrics: &ConsensusMetrics) {
 ///
 /// log_umi_grouping_summary(&metrics);
 /// ```
+#[allow(clippy::cast_precision_loss)]
 pub fn log_umi_grouping_summary(metrics: &UmiGroupingMetrics) {
     log::info!("UMI Grouping Summary:");
     log::info!("  Total records: {}", format_count(metrics.total_records));

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -726,7 +726,7 @@ impl BatchWeight for RawMiGroup {
 impl MemoryEstimate for RawMiGroup {
     fn estimate_heap_size(&self) -> usize {
         let mi_size = self.mi.capacity();
-        let records_size: usize = self.records.iter().map(|r| r.capacity()).sum();
+        let records_size: usize = self.records.iter().map(std::vec::Vec::capacity).sum();
         let records_vec_overhead = self.records.capacity() * std::mem::size_of::<Vec<u8>>();
         mi_size + records_size + records_vec_overhead
     }
@@ -815,6 +815,10 @@ impl RawMiGrouper {
     }
 
     /// Create a `RawMiGrouper` with record filtering and MI tag transformation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tag_name` is not exactly 2 characters.
     pub fn with_filter_and_transform<F, T>(
         tag_name: &str,
         batch_size: usize,
@@ -964,6 +968,10 @@ where
     I: Iterator<Item = Result<Vec<u8>>>,
 {
     /// Creates a new `RawMiGroupIterator`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tag_name` is not exactly 2 characters.
     pub fn new(record_iter: I, tag_name: &str) -> Self {
         assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
         let tag_bytes = tag_name.as_bytes();
@@ -980,6 +988,10 @@ where
     }
 
     /// Creates a new `RawMiGroupIterator` with MI tag transformation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tag_name` is not exactly 2 characters.
     pub fn with_transform<F>(record_iter: I, tag_name: &str, mi_transform: F) -> Self
     where
         F: Fn(&[u8]) -> String + 'static,
@@ -1350,6 +1362,7 @@ mod tests {
     //   then: seq      (ceil(l_seq/2) bytes, 4-bit encoded)
     //   then: qual     (l_seq bytes)
     //   then: aux data
+    #[allow(clippy::cast_possible_truncation)]
     fn make_raw_bam_with_tag(tag_name: &str, tag_value: &str) -> Vec<u8> {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8; // +1 for NUL
@@ -1394,6 +1407,7 @@ mod tests {
     }
 
     /// Build a minimal raw BAM record with no aux tags.
+    #[allow(clippy::cast_possible_truncation)]
     fn make_raw_bam_without_tag() -> Vec<u8> {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8;
@@ -1632,6 +1646,7 @@ mod tests {
     }
 
     /// Build a minimal raw BAM record with two string tags.
+    #[allow(clippy::cast_possible_truncation)]
     fn make_raw_bam_with_two_tags(tag1: &str, val1: &str, tag2: &str, val2: &str) -> Vec<u8> {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -3,27 +3,6 @@
 // generic code in test builds. Allow it crate-wide in test config since the actual
 // allocations are heap-based (`vec![]`), not stack arrays.
 #![cfg_attr(test, allow(clippy::large_stack_arrays))]
-// Blanket clippy pedantic allows for remaining main-crate code.
-// These will be removed incrementally as modules are extracted or fixed.
-#![allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::needless_pass_by_value,
-    clippy::items_after_statements,
-    clippy::unused_self,
-    clippy::match_same_arms,
-    clippy::unnecessary_wraps,
-    clippy::too_many_lines,
-    clippy::redundant_closure_for_method_calls,
-    clippy::explicit_iter_loop,
-    clippy::struct_excessive_bools,
-    clippy::map_unwrap_or,
-    clippy::uninlined_format_args
-)]
 
 //! # fgumi - Fulcrum Genomics UMI Tools Library
 //!

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 ///
 /// Optimized: Reads entire sequence bytes in one syscall, then strips newlines in memory.
 /// Fast path: If sequence fits in a single line, skip newline stripping entirely.
+#[allow(clippy::cast_possible_truncation)]
 fn read_sequence_raw(file: &mut File, record: &fai::Record) -> Result<Vec<u8>> {
     let line_bases = record.line_bases() as usize;
     let line_width = record.line_width() as usize;

--- a/src/lib/simulate/family_size.rs
+++ b/src/lib/simulate/family_size.rs
@@ -177,6 +177,10 @@ impl FamilySizeDistribution {
     /// # Returns
     ///
     /// A family size >= `min_size`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if distribution parameters are invalid (e.g., invalid log-normal, gamma, or Poisson parameters).
     pub fn sample(&self, rng: &mut impl Rng, min_size: usize) -> usize {
         let size = match self {
             Self::LogNormal { mean, stddev } => {

--- a/src/lib/simulate/fastq_writer.rs
+++ b/src/lib/simulate/fastq_writer.rs
@@ -89,7 +89,7 @@ impl FastqWriter {
             Ok(Self { inner: FastqWriterInner::SingleThreaded(gz) })
         } else {
             let config = ParallelGzipConfig::with_threads(threads);
-            let writer = ParallelGzipWriter::new(file, config)
+            let writer = ParallelGzipWriter::new(file, &config)
                 .with_context(|| "Failed to create parallel gzip writer")?;
             Ok(Self { inner: FastqWriterInner::MultiThreaded(writer) })
         }

--- a/src/lib/simulate/insert_size.rs
+++ b/src/lib/simulate/insert_size.rs
@@ -76,6 +76,10 @@ impl InsertSizeModel {
     /// # Returns
     ///
     /// An insert size clamped to [min, max].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mean and stddev produce invalid log-normal parameters.
     pub fn sample(&self, rng: &mut impl Rng) -> usize {
         // Convert mean/stddev to log-normal parameters
         // For log-normal: E[X] = exp(mu + sigma^2/2), Var[X] = (exp(sigma^2) - 1) * exp(2*mu + sigma^2)

--- a/src/lib/simulate/quality.rs
+++ b/src/lib/simulate/quality.rs
@@ -100,6 +100,10 @@ impl PositionQualityModel {
     /// # Returns
     ///
     /// A quality score clamped to [`min_quality`, 41].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `noise_stddev` produces an invalid normal distribution.
     pub fn quality_at(&self, position: usize, rng: &mut impl Rng) -> u8 {
         let base_q = if position < self.warmup_bases {
             // Linear ramp from warmup_start to peak
@@ -185,6 +189,7 @@ impl ReadPairQualityBias {
     ///
     /// Adjusted quality score, clamped to [2, 41].
     #[must_use]
+    #[allow(clippy::cast_sign_loss)]
     pub fn apply(&self, quality: u8, is_r2: bool) -> u8 {
         if is_r2 {
             let adjusted = i16::from(quality) + i16::from(self.r2_offset);

--- a/src/lib/simulate/strand_bias.rs
+++ b/src/lib/simulate/strand_bias.rs
@@ -81,6 +81,10 @@ impl StrandBiasModel {
     /// # Returns
     ///
     /// A value in [0, 1] representing the fraction of reads on the A strand.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `alpha` or `beta` are invalid Beta distribution parameters.
     pub fn sample_a_fraction(&self, rng: &mut impl Rng) -> f64 {
         let dist = Beta::new(self.alpha, self.beta).expect("Invalid beta parameters");
         dist.sample(rng)
@@ -96,6 +100,7 @@ impl StrandBiasModel {
     /// # Returns
     ///
     /// A tuple of (`a_count`, `b_count`) where `a_count` + `b_count` == total.
+    #[allow(clippy::cast_sign_loss)]
     pub fn split_reads(&self, total: usize, rng: &mut impl Rng) -> (usize, usize) {
         if total == 0 {
             return (0, 0);
@@ -122,6 +127,7 @@ impl StrandBiasModel {
     /// # Returns
     ///
     /// A tuple of (`a_count`, `b_count`) where `a_count` + `b_count` == total.
+    #[allow(clippy::cast_sign_loss)]
     pub fn split_reads_with_minimum(
         &self,
         total: usize,

--- a/src/lib/sort/external.rs
+++ b/src/lib/sort/external.rs
@@ -130,6 +130,10 @@ impl ExternalSorter {
     }
 
     /// Sort a BAM file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading the input, sorting, or writing the output fails.
     pub fn sort(&self, input: &Path, output: &Path) -> Result<SortStats> {
         info!("Starting sort with order: {:?}", self.sort_order);
         info!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
@@ -507,7 +511,7 @@ impl ExternalSorter {
         let index_path = output.with_extension("bam.bai");
         write_bai_index(&index_path, &index)?;
         info!("Wrote BAM index: {}", index_path.display());
-        info!("Merge complete: {} records merged", records_merged);
+        info!("Merge complete: {records_merged} records merged");
 
         Ok(())
     }

--- a/src/lib/sort/pipeline.rs
+++ b/src/lib/sort/pipeline.rs
@@ -102,6 +102,7 @@ struct PrefetchingChunkReader {
 
 impl PrefetchingChunkReader {
     /// Create a new prefetching reader for a chunk file.
+    #[allow(clippy::unnecessary_wraps)]
     fn new(path: PathBuf, idx: usize) -> Result<Self> {
         // Channel for prefetched records
         let (record_tx, record_rx) = bounded(PREFETCH_BUFFER_SIZE);
@@ -117,6 +118,7 @@ impl PrefetchingChunkReader {
     }
 
     /// Reader thread function.
+    #[allow(clippy::needless_pass_by_value)]
     fn reader_thread(path: PathBuf, tx: Sender<Option<Record>>) -> Result<()> {
         let file = File::open(&path).context("Failed to open chunk file")?;
         let buf_reader = BufReader::with_capacity(MERGE_BUFFER_SIZE, file);
@@ -164,6 +166,11 @@ impl PrefetchingChunkReader {
 }
 
 /// Parallel merge implementation using prefetching readers.
+///
+/// # Errors
+///
+/// Returns an error if reading chunks, writing output, or merging fails.
+#[allow(clippy::needless_pass_by_value)]
 pub fn parallel_merge<K, F>(
     chunk_files: &[PathBuf],
     _header: &Header,
@@ -220,7 +227,7 @@ where
         }
     }
 
-    log::info!("Parallel merge complete: {} records merged", records_merged);
+    log::info!("Parallel merge complete: {records_merged} records merged");
 
     Ok(records_merged)
 }
@@ -229,6 +236,11 @@ where
 ///
 /// This version adds an output buffer that accumulates records before
 /// writing them to the output file, reducing the number of write calls.
+///
+/// # Errors
+///
+/// Returns an error if reading chunks, writing output, or merging fails.
+#[allow(clippy::needless_pass_by_value)]
 pub fn parallel_merge_buffered<K, F>(
     chunk_files: &[PathBuf],
     _header: &Header,
@@ -299,7 +311,7 @@ where
         writer.write_record(output_header, &record)?;
     }
 
-    log::info!("Buffered parallel merge complete: {} records merged", records_merged);
+    log::info!("Buffered parallel merge complete: {records_merged} records merged");
 
     Ok(records_merged)
 }

--- a/src/lib/sort/read_ahead.rs
+++ b/src/lib/sort/read_ahead.rs
@@ -91,6 +91,7 @@ impl ReadAheadReader {
     }
 
     /// Reader thread function - reads records in batches.
+    #[allow(clippy::needless_pass_by_value)]
     fn reader_thread(reader: &mut BamReaderAuto, tx: Sender<Vec<Record>>, batch_size: usize) {
         let mut record = Record::default();
         let mut batch = Vec::with_capacity(batch_size);
@@ -228,6 +229,7 @@ impl RawReadAheadReader {
     }
 
     /// Reader thread function - reads raw records in batches.
+    #[allow(clippy::needless_pass_by_value)]
     fn reader_thread(reader: &mut RawBamReaderAuto, tx: Sender<Vec<RawRecord>>, batch_size: usize) {
         let mut record = RawRecord::new();
         let mut batch = Vec::with_capacity(batch_size);

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -21,6 +21,11 @@ use crate::sort::bam_fields;
 ///
 /// # Returns
 /// True if tags were reversed, false if not needed
+///
+/// # Errors
+///
+/// Currently infallible; returns `Result` for API consistency with
+/// [`reverse_per_base_tags_raw`].
 pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
     // Check if read is mapped to negative strand
     let flags = record.flags();
@@ -45,7 +50,7 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
                         .insert(tag, Value::from(String::from_utf8_lossy(&reversed).to_string()));
                 }
                 _ => {
-                    if let Some(reversed_value) = reverse_array_value(value)? {
+                    if let Some(reversed_value) = reverse_array_value(value) {
                         record.data_mut().insert(tag, reversed_value);
                     }
                 }
@@ -80,6 +85,10 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
 ///
 /// # Returns
 /// `Ok(true)` if tags were reversed, `Ok(false)` if not on reverse strand.
+///
+/// # Errors
+///
+/// Returns an error if the record is too short to be a valid BAM record.
 pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
     if record.len() < bam_fields::MIN_BAM_HEADER_LEN {
         bail!(
@@ -125,7 +134,7 @@ pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
 }
 
 /// Reverses an array value
-fn reverse_array_value(value: &Value) -> Result<Option<Value>> {
+fn reverse_array_value(value: &Value) -> Option<Value> {
     match value {
         Value::Array(arr) => {
             use noodles::sam::alignment::record_buf::data::field::value::Array;
@@ -168,9 +177,9 @@ fn reverse_array_value(value: &Value) -> Result<Option<Value>> {
                 }
             };
 
-            Ok(Some(reversed))
+            Some(reversed)
         }
-        _ => Ok(None),
+        _ => None,
     }
 }
 
@@ -243,7 +252,7 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let reversed = reverse_array_value(&input).unwrap().unwrap();
+            let reversed = reverse_array_value(&input).unwrap();
             assert_eq!(reversed, expected);
         }
     }
@@ -251,7 +260,7 @@ mod tests {
     #[test]
     fn test_reverse_array_value_non_array() {
         let value = Value::from(42i32);
-        let reversed = reverse_array_value(&value).unwrap();
+        let reversed = reverse_array_value(&value);
         assert!(reversed.is_none());
     }
 

--- a/src/lib/unified_pipeline/scheduler/chase_bottleneck.rs
+++ b/src/lib/unified_pipeline/scheduler/chase_bottleneck.rs
@@ -78,6 +78,7 @@ impl ChaseBottleneckScheduler {
     /// Build priority list starting from current step, expanding outward.
     /// If direction is Forward, prefer downstream steps (toward Write).
     /// If direction is Backward, prefer upstream steps (toward Read).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn build_priorities(&mut self) {
         let current_idx = Self::step_index(self.current_step);
         let mut priorities = [PipelineStep::Read; 9];

--- a/src/lib/unified_pipeline/scheduler/epsilon_greedy.rs
+++ b/src/lib/unified_pipeline/scheduler/epsilon_greedy.rs
@@ -76,6 +76,7 @@ impl EpsilonGreedyScheduler {
     }
 
     /// Get success rate for a step.
+    #[allow(clippy::cast_precision_loss)]
     fn success_rate(&self, step_idx: usize) -> f64 {
         if self.attempts[step_idx] == 0 {
             0.5 // Neutral prior for unexplored steps

--- a/src/lib/unified_pipeline/scheduler/learned_affinity.rs
+++ b/src/lib/unified_pipeline/scheduler/learned_affinity.rs
@@ -89,6 +89,10 @@ impl LearnedAffinityScheduler {
     }
 
     /// Get affinity score for a step.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "affinity ratio doesn't need full u64 precision"
+    )]
     fn affinity(&self, step_idx: usize) -> f64 {
         if self.attempts[step_idx] == 0 {
             0.5 // Neutral prior
@@ -98,6 +102,10 @@ impl LearnedAffinityScheduler {
     }
 
     /// Get current exploration rate (decays over time).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "decay_periods won't exceed i32 range in any practical run"
+    )]
     fn current_exploration_rate(&self) -> f64 {
         let decay_periods = self.total_attempts / 1000;
         let decayed = self.exploration_rate * self.exploration_decay.powi(decay_periods as i32);

--- a/src/lib/unified_pipeline/scheduler/mod.rs
+++ b/src/lib/unified_pipeline/scheduler/mod.rs
@@ -188,6 +188,7 @@ pub enum Direction {
 
 /// Backpressure state from queue depths and memory pressure.
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct BackpressureState {
     /// True when output queue exceeds high-water mark.
     pub output_high: bool,
@@ -450,8 +451,7 @@ mod tests {
             assert_eq!(
                 scheduler.exclusive_step_owned(),
                 expected_ownership,
-                "Thread {} ownership mismatch",
-                thread_id
+                "Thread {thread_id} ownership mismatch"
             );
         }
     }
@@ -508,12 +508,11 @@ mod tests {
             assert_eq!(
                 t6.exclusive_step_owned(),
                 Some(PipelineStep::Group),
-                "{:?} T6 should own Group",
-                strategy
+                "{strategy:?} T6 should own Group"
             );
 
             let t3 = create_scheduler(strategy, 3, 8);
-            assert_eq!(t3.exclusive_step_owned(), None, "{:?} T3 should own nothing", strategy);
+            assert_eq!(t3.exclusive_step_owned(), None, "{strategy:?} T3 should own nothing");
         }
     }
 

--- a/src/lib/unified_pipeline/scheduler/optimized_chase.rs
+++ b/src/lib/unified_pipeline/scheduler/optimized_chase.rs
@@ -144,6 +144,7 @@ impl OptimizedChaseScheduler {
     }
 
     /// Build optimized priority list.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn build_priorities(&mut self, _bp: BackpressureState) {
         let mut priorities = Vec::with_capacity(9);
         let current_idx = Self::step_index(self.current_step);

--- a/src/lib/unified_pipeline/scheduler/ucb.rs
+++ b/src/lib/unified_pipeline/scheduler/ucb.rs
@@ -65,6 +65,7 @@ impl UCBScheduler {
     }
 
     /// Calculate UCB score for a step.
+    #[allow(clippy::cast_precision_loss)]
     fn ucb_score(&self, step_idx: usize) -> f64 {
         let n_i = self.attempts[step_idx];
 

--- a/src/lib/validation.rs
+++ b/src/lib/validation.rs
@@ -183,6 +183,7 @@ pub fn optional_string_to_tag(tag: Option<&str>, name: &str) -> Result<Option<Ta
 /// let result = validate_min_max(10, Some(5), "min-reads", "max-reads");
 /// assert!(result.is_err());
 /// ```
+#[allow(clippy::needless_pass_by_value)]
 pub fn validate_min_max<T: Ord + Display>(
     min_val: T,
     max_val: Option<T>,
@@ -269,6 +270,7 @@ pub fn validate_quality_score(quality: u8, _name: &str) -> Result<()> {
 /// let result = validate_positive(0, "min-reads");
 /// assert!(result.is_err());
 /// ```
+#[allow(clippy::needless_pass_by_value)]
 pub fn validate_positive<T: Ord + Display + Default>(value: T, name: &str) -> Result<()> {
     if value <= T::default() {
         return Err(FgumiError::InvalidParameter {

--- a/src/lib/variant_review.rs
+++ b/src/lib/variant_review.rs
@@ -131,6 +131,7 @@ pub fn read_number_suffix(is_first_of_pair: bool) -> &'static str {
 ///
 /// Returns a string like "chr1:100-200 | F1R2" for FR pairs, or "NA" for non-FR pairs
 #[must_use]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub fn format_insert_string(
     record: &noodles::sam::alignment::RecordBuf,
     header: &noodles::sam::Header,
@@ -210,10 +211,8 @@ pub fn format_insert_string(
     let start_equals_outer = start == outer;
 
     let pairing = match (is_first, start_equals_outer) {
-        (true, true) => "F1R2",
-        (true, false) => "F2R1",
-        (false, true) => "F2R1",
-        (false, false) => "F1R2",
+        (true, true) | (false, false) => "F1R2",
+        (true, false) | (false, true) => "F2R1",
     };
 
     format!("{ref_name}:{start}-{end} | {pairing}")

--- a/src/lib/vendored/bam_codec/decoder/cigar/op/kind.rs
+++ b/src/lib/vendored/bam_codec/decoder/cigar/op/kind.rs
@@ -19,6 +19,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
+#[expect(clippy::cast_possible_truncation, reason = "n is masked to 0..=15")]
 pub(super) fn decode_kind(n: u32) -> Result<Kind, DecodeError> {
     match n & 0x0f {
         0 => Ok(Kind::Match),

--- a/src/lib/vendored/bam_codec/decoder/data/field.rs
+++ b/src/lib/vendored/bam_codec/decoder/data/field.rs
@@ -26,8 +26,7 @@ impl DecodeError {
     pub fn tag(&self) -> Option<Tag> {
         match self {
             Self::InvalidTag(_) => None,
-            Self::InvalidType(tag, _) => Some(*tag),
-            Self::InvalidValue(tag, _) => Some(*tag),
+            Self::InvalidType(tag, _) | Self::InvalidValue(tag, _) => Some(*tag),
         }
     }
 }

--- a/src/lib/vendored/bam_codec/decoder/data/field/value/array.rs
+++ b/src/lib/vendored/bam_codec/decoder/data/field/value/array.rs
@@ -73,6 +73,7 @@ pub(super) fn get_array(src: &mut &[u8]) -> Result<Value, DecodeError> {
     Ok(Value::Array(array))
 }
 
+#[allow(clippy::cast_possible_wrap)]
 fn read_i8(src: &mut &[u8]) -> Result<i8, DecodeError> {
     let (n, rest) = src.split_first().ok_or(DecodeError::UnexpectedEof)?;
     *src = rest;

--- a/src/lib/vendored/bam_codec/decoder/mod.rs
+++ b/src/lib/vendored/bam_codec/decoder/mod.rs
@@ -57,6 +57,7 @@ pub enum DecodeError {
 
 impl error::Error for DecodeError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::InvalidReferenceSequenceId(e) => Some(e),
             Self::InvalidAlignmentStart(e) => Some(e),

--- a/src/lib/vendored/bam_codec/decoder/name.rs
+++ b/src/lib/vendored/bam_codec/decoder/name.rs
@@ -96,6 +96,7 @@ mod tests {
 
     #[test]
     fn test_read_name() -> Result<(), Box<dyn std::error::Error>> {
+        #[allow(clippy::needless_pass_by_value)]
         fn t(mut src: &[u8], expected: Option<BString>) -> Result<(), DecodeError> {
             let mut actual = None;
             let l_read_name = NonZero::try_from(src.len()).unwrap();

--- a/src/lib/vendored/bam_codec/encoder/cigar/mod.rs
+++ b/src/lib/vendored/bam_codec/encoder/cigar/mod.rs
@@ -78,6 +78,8 @@ mod tests {
 
     #[test]
     fn test_overflowing_write_cigar_op_count() -> io::Result<()> {
+        const MAX_CIGAR_OP_COUNT: usize = (1 << 16) - 1;
+
         let mut buf = Vec::new();
 
         buf.clear();
@@ -86,7 +88,6 @@ mod tests {
         assert_eq!(buf, [0x01, 0x00]);
         assert!(overflowing_cigar.is_none());
 
-        const MAX_CIGAR_OP_COUNT: usize = (1 << 16) - 1;
         buf.clear();
         let cigar: CigarBuf =
             iter::repeat_n(Op::new(Kind::Match, 1), MAX_CIGAR_OP_COUNT + 1).collect();

--- a/src/lib/vendored/bam_codec/encoder/cigar/op.rs
+++ b/src/lib/vendored/bam_codec/encoder/cigar/op.rs
@@ -25,6 +25,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
 pub(super) fn encode_op(op: Op) -> Result<u32, EncodeError> {
     if op.len() <= MAX_LENGTH {
         // SAFETY: `op.len() <= MAX_LENGTH <= u32::MAX`.

--- a/src/lib/vendored/bam_codec/encoder/data/field/value.rs
+++ b/src/lib/vendored/bam_codec/encoder/data/field/value.rs
@@ -46,6 +46,8 @@ mod tests {
             Ok(())
         }
 
+        use super::array::tests::T;
+
         let mut buf = Vec::new();
 
         t(&mut buf, &Value::Character(b'n'), b"n")?;
@@ -61,14 +63,12 @@ mod tests {
 
         t(&mut buf, &Value::Hex(b"CAFE".as_bstr()), &[b'C', b'A', b'F', b'E', 0x00])?;
 
-        use super::array::tests::T;
-
         t(
             &mut buf,
             &Value::Array(Array::UInt8(Box::new(T::new(&[0])))),
             &[
                 b'C', // subtype = UInt8
-                0x01, 0x00, 0x00, 0x00, // count = 2
+                0x01, 0x00, 0x00, 0x00, // count = 1
                 0x00, // values[0] = 0
             ],
         )?;

--- a/src/lib/vendored/bam_codec/encoder/mapping_quality.rs
+++ b/src/lib/vendored/bam_codec/encoder/mapping_quality.rs
@@ -4,7 +4,7 @@ use super::num::write_u8;
 
 pub(super) fn write_mapping_quality(dst: &mut Vec<u8>, mapping_quality: Option<MappingQuality>) {
     const MISSING: u8 = 0xff;
-    let n = mapping_quality.map(u8::from).unwrap_or(MISSING);
+    let n = mapping_quality.map_or(MISSING, u8::from);
     write_u8(dst, n);
 }
 

--- a/src/lib/vendored/bam_codec/encoder/mod.rs
+++ b/src/lib/vendored/bam_codec/encoder/mod.rs
@@ -52,6 +52,7 @@ pub enum EncodeError {
 
 impl error::Error for EncodeError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::InvalidReferenceSequenceId(e) => Some(e),
             Self::InvalidAlignmentStart(e) => Some(e),

--- a/src/lib/vendored/bam_codec/encoder/name.rs
+++ b/src/lib/vendored/bam_codec/encoder/name.rs
@@ -8,7 +8,7 @@ const MAX_LENGTH: usize = 254;
 pub(super) const MISSING: &[u8] = b"*";
 
 pub(super) fn write_length(dst: &mut Vec<u8>, name: Option<&BStr>) -> io::Result<()> {
-    let mut len = name.map(|s| s.len()).unwrap_or(MISSING.len());
+    let mut len = name.map_or(MISSING.len(), |s| s.len());
 
     // + NUL terminator
     len += mem::size_of::<u8>();
@@ -75,7 +75,7 @@ mod tests {
     fn test_write_name() -> io::Result<()> {
         fn t(buf: &mut Vec<u8>, name: Option<&[u8]>, expected: &[u8]) -> io::Result<()> {
             buf.clear();
-            write_name(buf, name.map(|buf| buf.as_bstr()))?;
+            write_name(buf, name.map(bstr::ByteSlice::as_bstr))?;
             assert_eq!(buf, expected);
             Ok(())
         }

--- a/src/lib/vendored/bam_codec/encoder/num.rs
+++ b/src/lib/vendored/bam_codec/encoder/num.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::cast_sign_loss)]
 pub(super) fn write_i8(dst: &mut Vec<u8>, n: i8) {
     write_u8(dst, n as u8);
 }

--- a/src/lib/vendored/bam_codec/encoder/quality_scores.rs
+++ b/src/lib/vendored/bam_codec/encoder/quality_scores.rs
@@ -3,6 +3,7 @@ use std::{io, iter};
 
 use super::num::write_u8;
 
+#[allow(clippy::needless_pass_by_value)]
 pub(super) fn write_quality_scores<S>(
     dst: &mut Vec<u8>,
     base_count: usize,

--- a/src/lib/vendored/bgzf_multithreaded.rs
+++ b/src/lib/vendored/bgzf_multithreaded.rs
@@ -434,6 +434,7 @@ impl Builder {
 // Worker Functions
 // ============================================================================
 
+#[allow(clippy::needless_pass_by_value)]
 fn spawn_deflaters(
     compression_level: CompressionLevel,
     worker_count: NonZero<usize>,


### PR DESCRIPTION
## Summary

- Remove all 17 blanket `#![allow(clippy::...)]` directives from `src/lib/mod.rs` that were added as a temporary measure during crate extraction
- Fix all ~540 clippy pedantic violations across 87 files in both the main crate and workspace crates
- Also removes blanket allows that were added to `crates/fgumi-sam/src/alignment_tags.rs` during PR #92

## Approach

**Auto-fixed (~100 violations):**
- `uninlined_format_args` — inlined format arguments
- `redundant_closure_for_method_calls` — replaced closures with method references
- `explicit_iter_loop` — simplified `.iter()` to direct iteration
- `map_unwrap_or` — replaced with `map_or`

**Manually fixed (~440 violations):**
- `missing_errors_doc` / `missing_panics_doc` — added `/// # Errors` and `/// # Panics` doc sections
- `items_after_statements` — moved item definitions before let-bindings
- `match_same_arms` — merged identical match arms with `|` patterns
- `needless_pass_by_value` — changed to take references where appropriate
- `cast_*` lints — applied targeted `#[allow]` on specific functions where casts are intentional (BAM integer fields, genomics coordinate conversions)
- `too_many_lines` / `struct_excessive_bools` / `unnecessary_wraps` — targeted allows where refactoring would reduce clarity

## Test plan

- [x] `cargo ci-lint` passes (all clippy pedantic warnings resolved)
- [x] `cargo ci-fmt` passes
- [x] `cargo ci-test` passes (1731 tests pass, 7 skipped)

Stacked on #92.