### PR TITLE
fix: replace TLEN with MC-tag-based computation in is_fr_pair

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1690,6 +1690,7 @@ mod tests {
             .mate_alignment_start(mate_start)
             .template_length(tlen)
             .tag("MI", "UMI123")
+            .tag("MC", &cigar_str)
             .build()
     }
 

--- a/crates/noodles-raw-bam/src/cigar.rs
+++ b/crates/noodles-raw-bam/src/cigar.rs
@@ -259,6 +259,18 @@ pub fn mate_unclipped_5prime_1based(
     }
 }
 
+/// Calculate mate's alignment end (1-based inclusive) from MC tag CIGAR string.
+///
+/// Returns `mate_pos + ref_len - 1` where `ref_len` is computed from MC tag.
+/// This gives the rightmost aligned position of the mate, which is the negative
+/// strand 5' position for FR pair detection.
+#[inline]
+#[must_use]
+pub fn mate_alignment_end(mate_pos: i32, mc_cigar: &str) -> i32 {
+    let (ref_len, _trailing_clips) = parse_ref_len_and_trailing_clips(mc_cigar);
+    mate_pos + ref_len - 1
+}
+
 /// Calculate mate's unclipped start from MC tag CIGAR string.
 ///
 /// For forward strand mates, this is the 5' position.

--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -829,6 +829,8 @@ mod tests {
 
         let insert_size: i32 = (start2 + read_len) as i32 - start1 as i32;
 
+        let cigar_str = format!("{read_len}M");
+
         // R1: Forward strand, first segment
         let r1 = RecordBuilder::new()
             .name(&format!("read_{mi_value}"))
@@ -842,12 +844,13 @@ mod tests {
             )
             .reference_sequence_id(0)
             .alignment_start(start1)
-            .cigar(&format!("{read_len}M"))
+            .cigar(&cigar_str)
             .mate_reference_sequence_id(0)
             .mate_alignment_start(start2)
             .template_length(insert_size)
             .tag("MI", mi_value)
             .tag("RG", "A")
+            .tag("MC", cigar_str.as_str())
             .build();
 
         // R2: Reverse strand, last segment (stored as revcomp in BAM)
@@ -863,12 +866,13 @@ mod tests {
             )
             .reference_sequence_id(0)
             .alignment_start(start2)
-            .cigar(&format!("{read_len}M"))
+            .cigar(&cigar_str)
             .mate_reference_sequence_id(0)
             .mate_alignment_start(start1)
             .template_length(-insert_size)
             .tag("MI", mi_value)
             .tag("RG", "A")
+            .tag("MC", cigar_str.as_str())
             .build();
 
         (r1, r2)

--- a/tests/integration/test_codec_pipeline.rs
+++ b/tests/integration/test_codec_pipeline.rs
@@ -32,6 +32,7 @@ fn create_codec_read(
     mate_start: usize,
     cigar_ops: &[(Kind, usize)],
     umi: &str,
+    mc_cigar: &str,
 ) -> RecordBuf {
     // Build CIGAR and calculate reference length
     let mut cigar = Cigar::default();
@@ -70,6 +71,7 @@ fn create_codec_read(
         .mate_reference_sequence_id(0)
         .mate_alignment_start(mate_start)
         .tag("MI", umi)
+        .tag("MC", mc_cigar)
         .build();
 
     // Set CIGAR (built from ops) and template length
@@ -91,6 +93,10 @@ fn create_codec_read_pair(
     r2_start: usize,
     umi: &str,
 ) -> (RecordBuf, RecordBuf) {
+    // MC tags: each read gets the mate's CIGAR string
+    let r1_mc = format!("{}M", r2_seq.len());
+    let r2_mc = format!("{}M", r1_seq.len());
+
     let r1 = create_codec_read(
         name,
         r1_seq,
@@ -102,6 +108,7 @@ fn create_codec_read_pair(
         r2_start, // mate_start
         &[(Kind::Match, r1_seq.len())],
         umi,
+        &r1_mc,
     );
 
     let r2 = create_codec_read(
@@ -115,6 +122,7 @@ fn create_codec_read_pair(
         r1_start, // mate_start
         &[(Kind::Match, r2_seq.len())],
         umi,
+        &r2_mc,
     );
 
     (r1, r2)


### PR DESCRIPTION
## Summary

- Replace unreliable TLEN-based mate position computation with MC (mate CIGAR) tag in `is_fr_pair_raw` and `is_fr_pair_from_tags` for the forward-strand case
- Add `mate_alignment_end` helper to `noodles-raw-bam` cigar module that computes `mate_pos + ref_len - 1` from an MC tag CIGAR string
- Fall back to `false` when MC tag is missing, matching fgbio's requirement that MC must be present

## Motivation

TLEN is aligner-provided and can be incorrect — stale after post-processing, inconsistent across aligners, or simply wrong. When TLEN is wrong, `is_fr_pair` returns the wrong answer, causing `num_bases_extending_past_mate` to either skip clipping (false negative) or clip incorrectly (false positive). fgbio avoids this by computing mate coordinates from the MC tag and mate position instead.

## Changes

- `crates/noodles-raw-bam/src/cigar.rs` — add `mate_alignment_end` function
- `crates/noodles-raw-bam/src/overlap.rs` — fix `is_fr_pair_raw`, add tests
- `crates/fgumi-sam/src/record_utils.rs` — fix `is_fr_pair_from_tags`, add tests
- `crates/fgumi-consensus/src/codec_caller.rs` — add MC tag to test helper
- `src/commands/codec.rs` — add MC tag to test helper
- `tests/integration/test_codec_pipeline.rs` — add MC tag to test helpers

## Test plan

- [x] `cargo ci-test` — all 1731 tests pass
- [x] `cargo ci-fmt` — formatting clean
- [x] `cargo ci-lint` — no clippy warnings
- [x] New tests demonstrate incorrect TLEN is ignored when MC tag is present
- [x] New tests verify `false` is returned when MC tag is missing
- [x] Existing tests updated with MC tags continue to pass