### PR TITLE
refactor: convert extract command to raw byte BAM I/O

### DIFF
--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -1130,8 +1130,7 @@ impl<R: BufRead + Send> MultiRecordCountReader<R> {
 
 /// Read exactly `n` complete FASTQ records from a buffered reader.
 ///
-/// Uses `BufRead::read_until` (which delegates to `memchr` internally) for
-/// SIMD-accelerated newline scanning. Each FASTQ record
+/// Uses `BufRead::read_until` for line-by-line reading. Each FASTQ record
 /// consists of exactly 4 lines (name, sequence, plus, quality).
 ///
 /// Returns `(data, offsets, at_eof)` where:


### PR DESCRIPTION
## Summary

- Replaces noodles `RecordBuf`-based I/O with `UnmappedBamRecordBuilder` and `RawBamWriter` in the extract command, completing the raw byte BAM conversion across all commands (following PRs #96-#99)
- Introduces `ExtractedBatch` struct as the pipeline output type, writing pre-serialized BAM bytes directly instead of allocating `RecordBuf` objects
- Removes the `add_tag` helper and all noodles `RecordBuf`/`Flags`/`Tag`/`Value` imports from production code

## Details

Key changes to `src/commands/extract.rs`:
- `make_sam_records` → `make_raw_records`: uses builder to write records directly via `RawBamWriter`
- `make_sam_records_static` → `make_raw_records_static`: returns `ExtractedBatch` with pre-serialized bytes
- `process_singlethreaded`: takes `RawBamWriter` instead of `BamWriter`, no longer needs header ref
- `process_with_pipeline`: serialize closure is trivial (`extend_from_slice`)
- `execute`: uses `create_raw_bam_writer` instead of `create_bam_writer`

Output is byte-identical to the `RecordBuf` version (verified on 15.8M vendor FASTQ records). Single-threaded performance improved ~17% (248K → 291K items/s).

## Test plan

- [x] All 1777 tests pass (`cargo test --features simulate,compare`)
- [x] Clippy clean (`cargo clippy --features simulate,compare -- -D warnings`)
- [x] Format clean (`cargo fmt -- --check`)
- [x] Output equivalence verified: SAM text identical on vendor FASTQs (15.8M records)
- [ ] Multi-threaded benchmark comparison (8 threads)