### PR TITLE
docs: fix inaccurate memchr/SIMD claim in read_n_fastq_records docstring

### DIFF
--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -1130,8 +1130,7 @@ impl<R: BufRead + Send> MultiRecordCountReader<R> {
 
 /// Read exactly `n` complete FASTQ records from a buffered reader.
 ///
-/// Uses `BufRead::read_until` (which delegates to `memchr` internally) for
-/// SIMD-accelerated newline scanning. Each FASTQ record
+/// Uses `BufRead::read_until` for line-by-line reading. Each FASTQ record
 /// consists of exactly 4 lines (name, sequence, plus, quality).
 ///
 /// Returns `(data, offsets, at_eof)` where:


### PR DESCRIPTION
## Summary
- Fix docstring for `read_n_fastq_records` that incorrectly claimed SIMD-accelerated newline scanning via `memchr` when the implementation uses `BufRead::read_until`

## Test plan
- [x] `cargo ci-fmt` passes
- [x] `cargo ci-lint` passes