### PR TITLE
docs: fix CLI examples and improve fgbio compatibility for first release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Build with features: `cargo build --release --features compare,simulate`
 
 **Core UMI Processing:**
 - `umi/` - UMI assignment strategies: identity, edit-distance, adjacency, paired
-- `consensus/` - Consensus callers: simplex, duplex, codec, vanilla
+- `consensus/` - Consensus callers: simplex, duplex, codec
 - `grouper.rs` - Read grouping by UMI
 
 **I/O:**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,19 +108,22 @@ codegen-units = 1
 inherits = "release"
 debug = "line-tables-only"
 
-# Config for 'cargo dist'
+# Config for 'dist'
 [workspace.metadata.dist]
-cargo-dist-version = "0.4.3"
-ci = ["github"]
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.30.3"
+# CI backends to support
+ci = "github"
+# The installers to generate for each app
 installers = ["shell", "powershell"]
-targets = [
-    "x86_64-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    
-]
-# Necessary to be able to modify the release workflow
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+# Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
+# Whether to install an updater program
+install-updater = false
 
 
 # The profile that 'cargo dist' will build with

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fgumi provides comprehensive functionality for:
 - **UMI extraction** from FASTQ files
 - **Read grouping** by UMI with multiple assignment strategies
 - **UMI-aware deduplication** for marking/removing PCR duplicates
-- **Consensus calling** (simplex, duplex, and vanilla)
+- **Consensus calling** (simplex, duplex, and CODEC)
 - **Quality filtering** of consensus reads
 - **Read clipping** for overlapping pairs
 - **Metrics collection** for QC and analysis
@@ -109,7 +109,7 @@ Enable with: `cargo build --release --features <feature>`
 | `correct` | Correct UMIs based on sequence similarity | `fgbio CorrectUmis` |
 | `zipper` | Restore original FASTQ from unaligned BAM | `fgbio ZipperBams`, `picard MergeBamAlignment` |
 | `fastq` | Convert BAM to FASTQ format | `samtools fastq` |
-| `sort` | Sort BAM by coordinate/queryname/template | `samtools sort` |
+| `sort` | Sort BAM by coordinate/queryname/template | — |
 | `group` | Group reads by UMI | `fgbio GroupReadsByUmi` |
 | `dedup` | Mark/remove UMI-aware duplicates | `gatk UmiAwareMarkDuplicatesWithMateCigar`, `umi-tools dedup` |
 | `simplex` | Call single-strand consensus reads | `fgbio CallMolecularConsensusReads` |
@@ -137,7 +137,9 @@ fgumi <command> --help
 fgumi extract \
   --inputs R1.fastq.gz R2.fastq.gz \
   --read-structures +T +M \
-  --output unaligned.bam
+  --output unaligned.bam \
+  --sample MySample \
+  --library MyLibrary
 ```
 
 2. **(Optional) Correct UMIs** for fixed UMI sets:
@@ -145,7 +147,8 @@ fgumi extract \
 fgumi correct \
   --input unaligned.bam \
   --output corrected.bam \
-  --includelist umis.txt
+  --umi-files umis.txt \
+  --min-distance 1
 ```
 
 3. **Align and sort** reads using fgumi fastq + zipper + sort pipeline:
@@ -186,8 +189,8 @@ fgumi codec \
 6. **(Optional) Collect duplex metrics**:
 ```bash
 fgumi duplex-metrics \
-  --input duplex.bam \
-  --output metrics.txt
+  --input grouped.bam \
+  --output metrics
 ```
 
 7. **Filter** consensus reads:
@@ -195,7 +198,8 @@ fgumi duplex-metrics \
 fgumi filter \
   --input consensus.bam \
   --output filtered.bam \
-  --ref ref.fa
+  --ref ref.fa \
+  --min-reads 1,1,1
 ```
 
 ## Performance Options

--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "BGZF block reading, decompression, and compression utilities"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "Consensus calling algorithms for fgumi: simplex, duplex, and CODEC"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "DNA sequence utilities: complement, reverse-complement, 2-bit encoding"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "Structured metric types and TSV writer for fgumi operations"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "SAM/BAM record utilities, CIGAR parsing, and read-pair clipping for fgumi"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/crates/fgumi-umi/Cargo.toml
+++ b/crates/fgumi-umi/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "UMI assignment strategies and utilities for fgumi"
+repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [dependencies]

--- a/docs/best-practice-consensus-pipeline.md
+++ b/docs/best-practice-consensus-pipeline.md
@@ -121,7 +121,8 @@ For fixed/known UMI sets, correct sequencing errors before alignment:
 fgumi correct \
   --input unmapped.bam \
   --output corrected.bam \
-  --includelist known_umis.txt
+  --umi-files known_umis.txt \
+  --min-distance 1
 ```
 
 ### Step 1.2: Alignment
@@ -339,6 +340,8 @@ C-->D["fgumi dedup"];
 fgumi extract \
   --inputs r1.fq.gz r2.fq.gz \
   --read-structures 8M+T 8M+T \
+  --sample "sample_name" \
+  --library "library_name" \
   --output unmapped.bam
 
 # Step 2: Align reads (fgumi zipper adds required `pa` tag)

--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -218,8 +218,8 @@ pub struct Codec {
     #[arg(short = 'X', long = "max-duplex-disagreements")]
     pub max_duplex_disagreements: Option<usize>,
 
-    /// Cell barcode tag name (e.g., "CB"). Optional - only specify if filtering by cell.
-    #[arg(short = 'c', long = "cell-tag")]
+    /// SAM tag containing the cell barcode
+    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: Option<String>,
 
     /// Output sort order (Unsorted, Queryname, Coordinate, Unknown)
@@ -274,7 +274,6 @@ impl Command for Codec {
             &header,
             &self.read_group.read_group_id,
             "Read group",
-            crate::version::VERSION.as_str(),
             command_line,
         )?;
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -11,6 +11,24 @@ use clap::Args;
 use fgumi_lib::bam_io::is_stdin_path;
 use fgumi_lib::unified_pipeline::SchedulerStrategy;
 use fgumi_lib::validation::validate_file_exists;
+use noodles::sam::Header;
+
+/// Add a @PG record to an existing header, using the current fgumi version.
+///
+/// Wraps [`fgumi_lib::header::add_pg_record`] with the binary's version string.
+pub fn add_pg_record(header: Header, command_line: &str) -> anyhow::Result<Header> {
+    fgumi_lib::header::add_pg_record(header, crate::version::VERSION.as_str(), command_line)
+}
+
+/// Add a @PG record to a header builder, using the current fgumi version.
+///
+/// Wraps [`fgumi_lib::header::add_pg_to_builder`] with the binary's version string.
+pub fn add_pg_to_builder(
+    builder: noodles::sam::header::Builder,
+    command_line: &str,
+) -> anyhow::Result<noodles::sam::header::Builder> {
+    fgumi_lib::header::add_pg_to_builder(builder, crate::version::VERSION.as_str(), command_line)
+}
 
 /// Common input/output options for commands that read a BAM and write a BAM.
 #[derive(Debug, Clone, Args)]

--- a/src/commands/compare/bams.rs
+++ b/src/commands/compare/bams.rs
@@ -88,7 +88,7 @@ MODES:
 
   grouping:
     For comparing grouped BAM files where MI assignment order may differ.
-    Both files MUST be in the same order (e.g., query-name sorted with `samtools sort -n`).
+    Both files MUST be in the same order (e.g., query-name sorted with `fgumi sort --order queryname`).
     Validates that:
     1. Read names and R1/R2 flags match between files
     2. Reads with the same MI in file 1 have the same MI in file 2 (and vice versa)

--- a/src/commands/consensus_runner.rs
+++ b/src/commands/consensus_runner.rs
@@ -92,7 +92,6 @@ pub fn create_unmapped_consensus_header(
     input_header: &Header,
     read_group_id: &str,
     comment_prefix: &str,
-    version: &str,
     command_line: &str,
 ) -> Result<Header> {
     let mut output_header = Header::builder();
@@ -115,7 +114,7 @@ pub fn create_unmapped_consensus_header(
     ));
 
     // Add @PG record
-    output_header = fgumi_lib::header::add_pg_to_builder(output_header, version, command_line)?;
+    output_header = crate::commands::common::add_pg_to_builder(output_header, command_line)?;
 
     Ok(output_header.build())
 }
@@ -199,7 +198,6 @@ impl ConsensusExecutionContext {
         config: ConsensusConfig,
         read_group_id: &str,
         comment_prefix: &str,
-        version: &str,
         command_line: &str,
         read_name_prefix_override: Option<String>,
     ) -> Result<Self> {
@@ -209,13 +207,8 @@ impl ConsensusExecutionContext {
         let (_reader, header) = create_bam_reader(&config.input, 1)?;
 
         // Create output header for unmapped consensus reads
-        let output_header = create_unmapped_consensus_header(
-            &header,
-            read_group_id,
-            comment_prefix,
-            version,
-            command_line,
-        )?;
+        let output_header =
+            create_unmapped_consensus_header(&header, read_group_id, comment_prefix, command_line)?;
 
         // Determine read name prefix
         let read_name_prefix =

--- a/src/commands/correct.rs
+++ b/src/commands/correct.rs
@@ -208,7 +208,7 @@ pub struct CorrectUmis {
     pub rejects_opts: RejectsOptions,
 
     /// Optional output path for metrics TSV file.
-    #[arg(short = 'm', long)]
+    #[arg(short = 'M', long)]
     pub metrics: Option<PathBuf>,
 
     /// Maximum number of mismatches allowed.
@@ -431,11 +431,7 @@ impl Command for CorrectUmis {
         let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
 
         // Add @PG record with PP chaining to input's last program
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Dispatch based on thread count:
         // - Some(threads) -> 7-step pipeline

--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -1037,7 +1037,7 @@ pub struct MarkDuplicates {
     #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
     pub assign_tag: String,
 
-    /// The tag containing the cell barcode (for single-cell data)
+    /// SAM tag containing the cell barcode
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: String,
 
@@ -1115,18 +1115,15 @@ impl Command for MarkDuplicates {
         if !is_template_coordinate_sorted(&header) {
             bail!(
                 "Input BAM must be template-coordinate sorted.\n\n\
-                To sort your BAM file, run:\n  \
-                samtools sort --template-coordinate input.bam -o sorted.bam"
+                To prepare your BAM file, run:\n  \
+                fgumi zipper -u unmapped.bam -r reference.fa -o merged.bam\n  \
+                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
             );
         }
         info!("Template-coordinate sorted");
 
         // Add @PG record
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Prepare tags
         if self.raw_tag.len() != 2 {

--- a/src/commands/downsample.rs
+++ b/src/commands/downsample.rs
@@ -138,11 +138,7 @@ impl Command for Downsample {
         info!("Header validation passed (template-coordinate order confirmed)");
 
         // Add @PG record with PP chaining to input's last program
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Create output BAM writer (single-threaded, downsample doesn't have threads parameter)
         let mut writer =

--- a/src/commands/duplex.rs
+++ b/src/commands/duplex.rs
@@ -185,7 +185,7 @@ pub struct Duplex {
     #[arg(long = "max-reads-per-strand")]
     pub max_reads_per_strand: Option<usize>,
 
-    /// Cellular barcode tag for filtering (e.g., CB for 10X)
+    /// SAM tag containing the cell barcode
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: Option<String>,
 
@@ -294,11 +294,7 @@ impl Command for Duplex {
         let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
 
         // Add @PG record with PP chaining to input's last program
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Use library name from header if no prefix is specified (like fgbio)
         let read_name_prefix = self
@@ -533,7 +529,6 @@ impl Duplex {
             &input_header,
             &self.read_group.read_group_id,
             "Read group",
-            crate::version::VERSION.as_str(),
             command_line,
         )?;
 

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -397,8 +397,8 @@ pub(crate) struct Extract {
     #[arg(long, short = 'q')]
     umi_qual_tag: Option<String>,
 
-    /// Tag in which to store the cellular barcodes
-    #[arg(long, short = 'c', default_value = "CB")]
+    /// SAM tag containing the cell barcode
+    #[arg(long = "cell-tag", short = 'c', default_value = "CB")]
     cell_tag: String,
 
     /// Tag in which to store the cellular barcode qualities
@@ -626,11 +626,7 @@ impl Extract {
         header = header.add_read_group(self.read_group_id.clone(), rg.build()?);
 
         // Add @PG record
-        header = fgumi_lib::header::add_pg_to_builder(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        header = crate::commands::common::add_pg_to_builder(header, command_line)?;
 
         Ok(header.build())
     }

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -674,7 +674,7 @@ Accepts reads in any order (including unsorted) and outputs reads sorted by:
    4. Read Name
 
 It is recommended to sort the reads into template-coordinate order prior to running
-this tool to avoid re-sorting the input. Use `samtools sort --template-coordinate` for
+this tool to avoid re-sorting the input. Use `fgumi sort --order template-coordinate` for
 the pre-sorting. The output will always be written in template-coordinate order.
 
 During grouping, reads and templates are filtered out as follows:
@@ -744,7 +744,7 @@ pub struct GroupReadsByUmi {
     #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
     pub assign_tag: String,
 
-    /// The tag containing the cell barcode
+    /// SAM tag containing the cell barcode
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: String,
 
@@ -840,22 +840,13 @@ impl Command for GroupReadsByUmi {
             bail!(
                 "Input BAM must be template-coordinate sorted.\n\n\
                 To sort your BAM file, run:\n  \
-                samtools sort -n -t CO input.bam | samtools sort -t CO -O bam -o sorted.bam\n\n\
-                Or if you have samtools 1.18+:\n  \
-                samtools sort --template-coordinate input.bam -o sorted.bam\n\n\
-                Note: Pre-sorting is required because fgumi does not include an internal sorter.\n\
-                This design choice keeps the tool lightweight and allows users to leverage\n\
-                samtools' highly optimized sorting routines."
+                fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
             );
         }
         info!("template coordinate sorted");
 
         // Add @PG record with PP chaining to input's last program
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Prepare raw tag as byte array
         if self.raw_tag.len() != 2 {

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -597,11 +597,7 @@ impl Review {
         let header = reader.read_header()?;
 
         // Add @PG record with PP chaining
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         // Create output BAM
         let consensus_out_path = self.output.with_extension("consensus.bam");
@@ -672,11 +668,7 @@ impl Review {
         let header = reader.read_header()?;
 
         // Add @PG record with PP chaining
-        let header = fgumi_lib::header::add_pg_record(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         let grouped_out_path = self.output.with_extension("grouped.bam");
         let mut writer = bam::io::writer::Builder.build_from_path(&grouped_out_path)?;

--- a/src/commands/simplex.rs
+++ b/src/commands/simplex.rs
@@ -206,7 +206,7 @@ pub struct Simplex {
     #[arg(short = 'S', long = "sort-order")]
     pub sort_order: Option<String>,
 
-    /// Tag containing cellular barcodes
+    /// SAM tag containing the cell barcode
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: Option<String>,
 
@@ -258,7 +258,6 @@ impl Command for Simplex {
             &header,
             &self.read_group.read_group_id,
             "Read group",
-            crate::version::VERSION.as_str(),
             command_line,
         )?;
 

--- a/src/commands/simulate/consensus_reads.rs
+++ b/src/commands/simulate/consensus_reads.rs
@@ -140,11 +140,7 @@ impl Command for ConsensusReads {
         let mut header_builder = Header::builder();
 
         // Add @PG record
-        header_builder = fgumi_lib::header::add_pg_to_builder(
-            header_builder,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        header_builder = crate::commands::common::add_pg_to_builder(header_builder, command_line)?;
 
         let header = header_builder.build();
 

--- a/src/commands/simulate/correct_reads.rs
+++ b/src/commands/simulate/correct_reads.rs
@@ -184,11 +184,7 @@ impl Command for CorrectReads {
         let mut header_builder = Header::builder();
 
         // Add @PG record
-        header_builder = fgumi_lib::header::add_pg_to_builder(
-            header_builder,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        header_builder = crate::commands::common::add_pg_to_builder(header_builder, command_line)?;
 
         let header = header_builder.build();
 

--- a/src/commands/simulate/grouped_reads.rs
+++ b/src/commands/simulate/grouped_reads.rs
@@ -189,11 +189,7 @@ impl Command for GroupedReads {
         header = header.add_reference_sequence(BString::from(&*ref_name), ref_seq);
 
         // Add @PG record
-        header = fgumi_lib::header::add_pg_to_builder(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        header = crate::commands::common::add_pg_to_builder(header, command_line)?;
 
         let header = header.build();
 

--- a/src/commands/simulate/mapped_reads.rs
+++ b/src/commands/simulate/mapped_reads.rs
@@ -165,11 +165,7 @@ impl Command for MappedReads {
         header = header.add_reference_sequence(BString::from(&*ref_name), ref_seq);
 
         // Add @PG record
-        header = fgumi_lib::header::add_pg_to_builder(
-            header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        header = crate::commands::common::add_pg_to_builder(header, command_line)?;
 
         let header = header.build();
 

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -75,8 +75,7 @@ SORT ORDERS:
                       Use for `fgumi zipper`, template-level operations.
 
   template-coordinate Template-level position sort for UMI grouping.
-                      Use for `fgumi group` input. Equivalent to:
-                        samtools sort --template-coordinate
+                      Use for `fgumi group`, `fgumi dedup`, and `fgumi downsample` input.
 
 PERFORMANCE:
 

--- a/src/commands/zipper.rs
+++ b/src/commands/zipper.rs
@@ -109,7 +109,7 @@ Named tag sets like "Consensus" are automatically expanded to their constituent 
 By default, input is read from stdin and output is written to stdout, allowing for streaming
 workflows like:
 
-  fgumi zipper -u unmapped.bam -r reference.fa | samtools sort -@ $(nproc) -o output.bam
+  bwa mem -t 8 -p -K 150000000 -Y ref.fa reads.fq | fgumi zipper -u unmapped.bam -r ref.fa | fgumi sort -i /dev/stdin -o output.bam --order template-coordinate
 "#
 )]
 #[command(verbatim_doc_comment)]
@@ -802,11 +802,7 @@ impl Command for Zipper {
         let output_header = build_output_header(&unmapped_header, &mapped_header, &dict_path)?;
 
         // Add @PG record with PP chaining
-        let output_header = fgumi_lib::header::add_pg_record(
-            output_header,
-            crate::version::VERSION.as_str(),
-            command_line,
-        )?;
+        let output_header = crate::commands::common::add_pg_record(output_header, command_line)?;
 
         let tag_info = TagInfo::new(
             self.tags_to_remove.clone(),


### PR DESCRIPTION
## Summary

Pre-release review of CLI, documentation, and fgbio compatibility:

- Fix incorrect `--includelist` flag in README and pipeline docs (should be `--umi-files`)
- Add missing required args to README examples (`--sample`, `--library`, `--min-distance`, `--min-reads`)
- Fix `duplex-metrics` example to use grouped BAM input and output prefix
- Change "vanilla" to "CODEC" in overview/CLAUDE.md (vanilla is internal to simplex)
- Add `repository` field to all 6 publishable workspace crate Cargo.toml files
- Update `filter --max-no-call-fraction` help text to document dual-mode behavior (fraction < 1.0, count >= 1.0)
- Rename `clip --clip-extending-past-mate` to `--clip-bases-past-mate` to match fgbio (old name kept as hidden alias)
- Add `--ref` as alias for `clip --reference` to match fgbio
- Change `duplex-metrics --intervals` short flag from `-L` to `-l` to match fgbio
- Add Picard interval list format support to `duplex-metrics` (auto-detected alongside BED)
- Change `correct --metrics` short flag from `-m` to `-M` to match fgbio
- Update cargo-dist from 0.4.3 to 0.30.3

## Test plan

- [x] All 261 relevant command tests pass (duplex_metrics, correct, filter, clip)
- [x] 3 new tests added for interval list parsing (unit tests for BED and interval list format, integration test with interval list)
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (ci-fmt, ci-lint)