### PR TITLE
refactor: consolidate code duplication across commands and library

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1024,10 +1024,10 @@ pub fn filter_duplex_read_raw(
 /// Returns (`no_call_count`, `mean_base_quality`).
 ///
 /// # Panics
-/// Panics if the record is shorter than `MIN_BAM_HEADER_LEN` (36 bytes).
+/// Panics if the record is shorter than `MIN_BAM_RECORD_LEN` (36 bytes).
 #[must_use]
 pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
-    assert!(bam.len() >= bam_fields::MIN_BAM_HEADER_LEN, "BAM record too short");
+    assert!(bam.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(bam);
     let qual_off = bam_fields::qual_offset(bam);
     let len = bam_fields::l_seq(bam) as usize;
@@ -1090,7 +1090,7 @@ pub fn mask_bases_raw(
     thresholds: &FilterThresholds,
     min_base_quality: Option<u8>,
 ) -> Result<usize> {
-    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_HEADER_LEN, "BAM record too short");
+    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
     let len = bam_fields::l_seq(record) as usize;
@@ -1145,7 +1145,7 @@ pub fn mask_duplex_bases_raw(
     min_base_quality: Option<u8>,
     require_ss_agreement: bool,
 ) -> Result<usize> {
-    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_HEADER_LEN, "BAM record too short");
+    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
     let len = bam_fields::l_seq(record) as usize;

--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -253,11 +253,11 @@ pub fn regenerate_alignment_tags_raw(
     header: &Header,
     reference: &impl ReferenceProvider,
 ) -> Result<bool> {
-    if record.len() < noodles_raw_bam::MIN_BAM_HEADER_LEN {
+    if record.len() < noodles_raw_bam::MIN_BAM_RECORD_LEN {
         anyhow::bail!(
             "BAM record too short ({} bytes, minimum {})",
             record.len(),
-            noodles_raw_bam::MIN_BAM_HEADER_LEN
+            noodles_raw_bam::MIN_BAM_RECORD_LEN
         );
     }
     let flg = noodles_raw_bam::flags(record);
@@ -934,7 +934,7 @@ mod tests {
         let (_fasta, reference) = create_test_reference()?;
         let header = create_test_header();
 
-        // Record shorter than MIN_BAM_HEADER_LEN (36 bytes)
+        // Record shorter than MIN_BAM_RECORD_LEN (36 bytes)
         let mut too_short = vec![0u8; 10];
         let result = regenerate_alignment_tags_raw(&mut too_short, &header, &reference);
         assert!(result.is_err());

--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -20,17 +20,18 @@ use fgumi_lib::bam_io::{
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, QueueMemoryOptions,
     ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions, ThreadingOptions,
+    build_pipeline_config,
 };
 use fgumi_lib::consensus::codec_caller::{
     CodecConsensusCaller, CodecConsensusOptions, CodecConsensusStats,
 };
-use fgumi_lib::consensus_caller::{ConsensusCaller, ConsensusOutput, make_prefix_from_header};
+use fgumi_lib::consensus_caller::{ConsensusCaller, ConsensusOutput};
 use fgumi_lib::logging::{OperationTimer, log_consensus_summary};
 use fgumi_lib::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::read_info::LibraryIndex;
 use fgumi_lib::unified_pipeline::{
-    BamPipelineConfig, GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
 };
 use fgumi_lib::vendored::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
@@ -278,11 +279,7 @@ impl Command for Codec {
         )?;
 
         // Use library name from header if no prefix is specified (like fgbio)
-        let read_name_prefix = self
-            .read_group
-            .read_name_prefix
-            .clone()
-            .unwrap_or_else(|| make_prefix_from_header(&header));
+        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
 
         // Parse cell tag
         let cell_tag = optional_string_to_tag(self.cell_tag.as_deref(), "cell-tag")?;
@@ -501,21 +498,12 @@ impl Codec {
         track_rejects: bool,
     ) -> Result<()> {
         // Configure pipeline
-        let mut pipeline_config =
-            BamPipelineConfig::auto_tuned(num_threads, self.compression.compression_level);
-        pipeline_config.pipeline.scheduler_strategy = self.scheduler_opts.strategy();
-        if self.scheduler_opts.collect_stats() {
-            pipeline_config.pipeline = pipeline_config.pipeline.with_stats(true);
-        }
-        pipeline_config.pipeline.deadlock_timeout_secs =
-            self.scheduler_opts.deadlock_timeout_secs();
-        pipeline_config.pipeline.deadlock_recover_enabled =
-            self.scheduler_opts.deadlock_recover_enabled();
-
-        // Calculate and apply queue memory limit
-        let queue_memory_limit_bytes = self.queue_memory.calculate_memory_limit(num_threads)?;
-        pipeline_config.pipeline.queue_memory_limit = queue_memory_limit_bytes;
-        self.queue_memory.log_memory_config(num_threads, queue_memory_limit_bytes);
+        let mut pipeline_config = build_pipeline_config(
+            &self.scheduler_opts,
+            &self.compression,
+            &self.queue_memory,
+            num_threads,
+        )?;
 
         // Lock-free metrics collection
         let collected_metrics: Arc<SegQueue<CollectedCodecMetrics>> = Arc::new(SegQueue::new());

--- a/src/commands/simplex.rs
+++ b/src/commands/simplex.rs
@@ -13,7 +13,6 @@ use fgumi_lib::bam_io::{
 };
 use fgumi_lib::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
-    make_prefix_from_header,
 };
 use fgumi_lib::logging::{OperationTimer, log_consensus_summary};
 use fgumi_lib::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
@@ -24,7 +23,7 @@ use fgumi_lib::overlapping_consensus::{
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::read_info::LibraryIndex;
 use fgumi_lib::unified_pipeline::{
-    BamPipelineConfig, GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
 };
 use fgumi_lib::vendored::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
@@ -42,7 +41,7 @@ use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
     QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions,
+    ThreadingOptions, build_pipeline_config,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -262,11 +261,7 @@ impl Command for Simplex {
         )?;
 
         // Use library name from header if no prefix is specified (like fgbio)
-        let read_name_prefix = self
-            .read_group
-            .read_name_prefix
-            .clone()
-            .unwrap_or_else(|| make_prefix_from_header(&header));
+        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
 
         // Parse cell tag if provided
         let cell_tag = optional_string_to_tag(self.cell_tag.as_deref(), "cell-tag")?;
@@ -470,21 +465,12 @@ impl Simplex {
         track_rejects: bool,
     ) -> Result<()> {
         // Configure pipeline
-        let mut pipeline_config =
-            BamPipelineConfig::auto_tuned(num_threads, self.compression.compression_level);
-        pipeline_config.pipeline.scheduler_strategy = self.scheduler_opts.strategy();
-        if self.scheduler_opts.collect_stats() {
-            pipeline_config.pipeline = pipeline_config.pipeline.with_stats(true);
-        }
-        pipeline_config.pipeline.deadlock_timeout_secs =
-            self.scheduler_opts.deadlock_timeout_secs();
-        pipeline_config.pipeline.deadlock_recover_enabled =
-            self.scheduler_opts.deadlock_recover_enabled();
-
-        // Calculate and apply queue memory limit
-        let queue_memory_limit_bytes = self.queue_memory.calculate_memory_limit(num_threads)?;
-        pipeline_config.pipeline.queue_memory_limit = queue_memory_limit_bytes;
-        self.queue_memory.log_memory_config(num_threads, queue_memory_limit_bytes);
+        let mut pipeline_config = build_pipeline_config(
+            &self.scheduler_opts,
+            &self.compression,
+            &self.queue_memory,
+            num_threads,
+        )?;
 
         // Lock-free metrics collection
         let collected_metrics: Arc<SegQueue<CollectedSimplexMetrics>> = Arc::new(SegQueue::new());

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -1964,9 +1964,9 @@ mod tests {
             "MI",
             10,
             |bam: &[u8]| {
-                // Check flag field at offset 14..16
-                let flag = u16::from_le_bytes([bam[14], bam[15]]);
-                flag & 0x100 == 0 // keep if NOT secondary
+                // Check flag field
+                let flag = noodles_raw_bam::flags(bam);
+                flag & noodles_raw_bam::flags::SECONDARY == 0 // keep if NOT secondary
             },
             |raw: &[u8]| {
                 let s = String::from_utf8_lossy(raw);

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -1742,7 +1742,8 @@ impl RawExternalSorter {
 /// heap allocations for the read name by using a hash instead.
 #[must_use]
 pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup) -> TemplateKey {
-    use crate::sort::bam_fields::{
+    use crate::sort::bam_fields;
+    use bam_fields::{
         find_mc_tag_in_record, find_mi_tag_in_record, flags, get_cigar_ops, mate_unclipped_5prime,
         unclipped_5prime,
     };
@@ -1754,12 +1755,12 @@ pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup)
     let library = lib_lookup.get_ordinal(bam_bytes);
 
     // Extract fields from raw bytes
-    let tid = i32::from_le_bytes([bam_bytes[0], bam_bytes[1], bam_bytes[2], bam_bytes[3]]);
-    let pos = i32::from_le_bytes([bam_bytes[4], bam_bytes[5], bam_bytes[6], bam_bytes[7]]);
-    let l_read_name = bam_bytes[8] as usize;
-    let flag = u16::from_le_bytes([bam_bytes[14], bam_bytes[15]]);
-    let mate_tid = i32::from_le_bytes([bam_bytes[20], bam_bytes[21], bam_bytes[22], bam_bytes[23]]);
-    let mate_pos = i32::from_le_bytes([bam_bytes[24], bam_bytes[25], bam_bytes[26], bam_bytes[27]]);
+    let tid = bam_fields::ref_id(bam_bytes);
+    let pos = bam_fields::pos(bam_bytes);
+    let l_read_name = bam_fields::l_read_name(bam_bytes) as usize;
+    let flag = bam_fields::flags(bam_bytes);
+    let mate_tid = bam_fields::mate_ref_id(bam_bytes);
+    let mate_pos = bam_fields::mate_pos(bam_bytes);
 
     // Extract flags
     let is_unmapped = (flag & flags::UNMAPPED) != 0;

--- a/src/lib/sort/raw_bam_reader.rs
+++ b/src/lib/sort/raw_bam_reader.rs
@@ -32,8 +32,7 @@ use std::io::{self, BufReader, Read};
 /// Number of BGZF blocks to read per batch.
 const BLOCKS_PER_BATCH: usize = 64;
 
-/// BAM magic bytes (appears in decompressed data, not raw file).
-const BAM_MAGIC: &[u8; 4] = b"BAM\x01";
+use noodles_raw_bam::BAM_MAGIC;
 
 /// A raw BAM record reader that reads directly from BGZF blocks.
 ///
@@ -380,7 +379,7 @@ mod tests {
         let mut raw_bam = Vec::new();
 
         // Magic
-        raw_bam.extend_from_slice(b"BAM\x01");
+        raw_bam.extend_from_slice(BAM_MAGIC);
 
         // Header text
         let text_bytes = header_text.as_bytes();

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -90,11 +90,11 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
 ///
 /// Returns an error if the record is too short to be a valid BAM record.
 pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
-    if record.len() < bam_fields::MIN_BAM_HEADER_LEN {
+    if record.len() < bam_fields::MIN_BAM_RECORD_LEN {
         bail!(
             "BAM record too short ({} bytes, minimum {})",
             record.len(),
-            bam_fields::MIN_BAM_HEADER_LEN
+            bam_fields::MIN_BAM_RECORD_LEN
         );
     }
     let flg = bam_fields::flags(record);
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_reverse_per_base_tags_raw_short_record() {
-        // A record shorter than MIN_BAM_HEADER_LEN (32 bytes) should return an error
+        // A record shorter than MIN_BAM_RECORD_LEN (32 bytes) should return an error
         let mut short_record = vec![0u8; 16];
         let result = reverse_per_base_tags_raw(&mut short_record);
         assert!(result.is_err());

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -659,11 +659,11 @@ impl Template {
 
         // Guard against truncated records
         for (i, r) in raw_records.iter().enumerate() {
-            if r.len() < bam_fields::MIN_BAM_HEADER_LEN {
+            if r.len() < bam_fields::MIN_BAM_RECORD_LEN {
                 bail!(
                     "Raw BAM record {i} too short to parse ({} < {})",
                     r.len(),
-                    bam_fields::MIN_BAM_HEADER_LEN
+                    bam_fields::MIN_BAM_RECORD_LEN
                 );
             }
             let l_rn = r[8] as usize;

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -111,7 +111,7 @@ impl BoundaryState {
         }
 
         // Check magic
-        if &data[0..4] != b"BAM\x01" {
+        if &data[0..4] != bam_fields::BAM_MAGIC {
             // Not a valid BAM file, but let's not error here
             // Just return 0 so records start immediately
             return Some(0);


### PR DESCRIPTION
## Summary
- Extract shared helpers to eliminate code duplication identified in `plans/code-duplication-consolidation.md`
- Net reduction of ~116 lines (262 insertions, 378 deletions) across 18 files
- All 1498 tests pass, CI format and lint checks clean

## Changes

**P0 — Pipeline config setup:** `build_pipeline_config()` helper in `common.rs`, replacing ~15 lines of boilerplate across 9 commands (clip, codec, correct, dedup, duplex, filter x2, group, simplex).

**P0 — Template grouping:** `group_by_name_and_build()` generic helper in `grouper.rs`, eliminating parallel raw/parsed implementations.

**P1 — BAM header serialization:** `write_bam_header()` free function in `bam_io.rs`, shared by `RawBamWriter` and `IndexingBamWriter`.

**P1 — Raw BAM field extraction:** Replace inline `i32::from_le_bytes` calls with `noodles_raw_bam` accessor functions (`ref_id`, `pos`, `flags`, etc.) across `bam_io.rs`, `sort/keys.rs`, `sort/inline_buffer.rs`, `sort/raw.rs`, and `mi_group.rs`.

**P2 — BGZF reader/writer init:** `make_bgzf_reader()` and `make_bgzf_writer()` helpers in `bam_io.rs`, replacing duplicated threading dispatch across 4 factory functions.

**P3 — BAM magic constant:** `BAM_MAGIC` constant in `noodles-raw-bam`, replacing literal `b"BAM\x01"` across 4 files.

**P3 — Consensus read name prefix:** `prefix_or_from_header()` method on `ReadGroupOptions`, replacing repeated `unwrap_or_else` pattern in simplex, duplex, and codec commands.

### Intentionally skipped items
- **Threading dispatch (2b):** Command-specific args make a generic helper impractical
- **R1/R2 categorization (1d):** 4-line if/else on different types; helper would need 7+ params
- **Sort validation (3b):** Intentionally different error messages per command
- **Cell tag parsing (3c), rejects writer (3d):** Already one-liner calls to shared functions
- **Progress tracker (2e), memory estimates (3f):** Already minimal

## Test plan
- [x] `cargo nextest run` — 1498 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean