### PR TITLE
perf: remove filter single-threaded fallback, fix MemoryEstimate accuracy, and add ordered reject output

### DIFF
--- a/src/commands/duplex.rs
+++ b/src/commands/duplex.rs
@@ -68,7 +68,9 @@ struct DuplexProcessedBatch {
 
 impl MemoryEstimate for DuplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
-        self.consensus_output.data.len() + self.rejects.iter().map(Vec::len).sum::<usize>()
+        self.consensus_output.data.capacity()
+            + self.rejects.iter().map(Vec::capacity).sum::<usize>()
+            + self.rejects.capacity() * std::mem::size_of::<Vec<u8>>()
     }
 }
 
@@ -1620,5 +1622,25 @@ mod tests {
         assert!(&paths.output.exists());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_duplex_processed_batch_memory_estimate() {
+        let mut data = Vec::with_capacity(1024);
+        data.extend_from_slice(&[0u8; 100]);
+        let mut reject = Vec::with_capacity(512);
+        reject.extend_from_slice(&[0u8; 50]);
+
+        let batch = DuplexProcessedBatch {
+            consensus_output: ConsensusOutput { data, count: 1 },
+            rejects: vec![reject],
+            groups_count: 1,
+            stats: ConsensusCallingStats::default(),
+            overlapping_stats: None,
+        };
+
+        let estimate = batch.estimate_heap_size();
+        assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
+        assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
     }
 }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -1573,6 +1573,8 @@ impl MemoryEstimate for TemplateBatch {
 #[must_use]
 pub fn estimate_record_buf_heap_size(record: &RecordBuf) -> usize {
     // Name: Option<BString> which is a Vec<u8>
+    // NB: noodles API returns &BStr, so we can only measure len(), not capacity().
+    // Same constraint applies to sequence and quality_scores below.
     let name_size = record.name().map_or(0, |n| n.len());
 
     // Sequence: noodles stores bases as unpacked ASCII (1 byte per base in Vec<u8>)


### PR DESCRIPTION
## Summary

- **Remove filter single-threaded fallback** (~200 lines): The `execute_single_threaded()` path decoded records into `RecordBuf` via noodles then re-encoded to raw bytes. The unified pipeline with `threads=1` is strictly faster and already validated equivalent by `test_threading_modes`.
- **Fix MemoryEstimate accuracy** across 9 types: Multiple implementations used `.len()` instead of `.capacity()` and missed `Vec` element overhead, causing backpressure to activate late and risking memory spikes. Fixed types: `SimplexProcessedBatch`, `DuplexProcessedBatch`, `CodecProcessedBatch`, `Vec<RecordBuf>`, `ClipProcessedBatch`, `ProcessedDedupGroup`, `FastqDecompressedBatch`, `FastqBoundaryBatch`, `FastqParsedBatch`.
- **Add ordered reject output** for the filter command's `--rejects` option. Previously rejected records were written via a `Mutex` in arbitrary thread completion order. Now rejects are routed through the pipeline's secondary output infrastructure (`secondary_data` on `SerializedBatch`/`CompressedBlockBatch`, `secondary_serialize_fn` on `PipelineFunctions`) so both kept and rejected BAM files maintain input order.
- **Remove unused `--sort-order` CLI arg** from filter (was parsed but never applied).
- **Extract `FilterProcessCaptures`** to reduce duplication between single-read and template pipeline modes.
- **Additional correctness fixes**: preserve primary error when secondary finalization fails, pre-allocate secondary buffer capacity, reset `secondary_data` in batch `clear()` methods, use aggregated `failed_reads` consistently.

## Test plan

- [x] All 1778 tests pass (`cargo ci-test`)
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `test_threading_modes` validates `None`, `Some(1)`, `Some(2)` equivalence
- [x] New unit tests for all 9 fixed `MemoryEstimate` implementations
- [x] Manual verification: filter with `--rejects` and `--threads 4` on 8.6M records, reject BAM maintains input order, `fgumi compare bams` confirms identical kept output vs baseline