### PR TITLE
ci: remove temporary publish=false overrides from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,19 +11,3 @@ git_release_enable = true
 semver_check = false
 # increase timeout to allow crates.io index propagation between dependent crates
 publish_timeout = "10m"
-
-# TODO: remove after first publish completes for all crates.
-# release-plz publishes alphabetically, not topologically. These crates have
-# dev-dependencies on not-yet-published crates, so skip them until their
-# dependencies are on crates.io.
-[[package]]
-name = "fgumi-metrics"
-publish = false
-
-[[package]]
-name = "fgumi-consensus"
-publish = false
-
-[[package]]
-name = "fgumi"
-publish = false


### PR DESCRIPTION
## Summary
- Remove the temporary `publish = false` overrides for `fgumi-metrics`, `fgumi-consensus`, and `fgumi`
- All dependency crates are now published to crates.io (`fgumi-bgzf`, `fgumi-dna`, `fgumi-raw-bam`, `fgumi-sam`, `fgumi-umi`), so the remaining 3 crates can be published normally

## Context
release-plz publishes alphabetically, not topologically. These overrides were added in #115 to prevent publish failures for crates whose dev-dependencies weren't yet on crates.io.