### PR TITLE
docs: add Zenodo DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation at docs.rs](https://img.shields.io/docsrs/fgumi)](https://docs.rs/fgumi)
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgumi/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgumi)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgumi/blob/main/LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18702474.svg)](https://doi.org/10.5281/zenodo.18702474)
 
 # fgumi
 


### PR DESCRIPTION
## Summary
- Adds a Zenodo DOI badge (10.5281/zenodo.18702474) to the README badge row for citation tracking.

## Test plan
- [ ] Verify badge renders correctly in the README on GitHub