### PR TITLE
fix: replace no-op writer.finish(&header) with proper BAM writer finalization

### DIFF
--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -38,7 +38,6 @@ use fgumi_raw_bam::RawRecord;
 use fgumi_lib::validation::{optional_string_to_tag, validate_file_exists};
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::io::{self, Write as IoWrite};
 use std::sync::Arc;
 
@@ -442,8 +441,8 @@ impl Command for Codec {
         timer.log_completion(consensus_count);
 
         // Close rejects writer if it was opened
-        if let Some(mut rw) = rejects_writer {
-            rw.finish(&header).context("Failed to finish rejects file")?;
+        if let Some(rw) = rejects_writer {
+            rw.into_inner().finish().context("Failed to finish rejects file")?;
             info!("Rejected reads written successfully");
         }
 
@@ -645,13 +644,13 @@ impl Codec {
         if track_rejects && !all_rejects.is_empty() {
             if let Some(rejects_path) = &self.rejects_opts.rejects {
                 let writer_threads = self.threading.num_threads();
-                let mut rejects_writer = create_optional_bam_writer(
+                let rejects_writer = create_optional_bam_writer(
                     Some(rejects_path),
                     &rejects_header,
                     writer_threads,
                     self.compression.compression_level,
                 )?;
-                if let Some(ref mut rw) = rejects_writer {
+                if let Some(mut rw) = rejects_writer {
                     for raw_record in &all_rejects {
                         let block_size = raw_record.len() as u32;
                         rw.get_mut()
@@ -661,7 +660,7 @@ impl Codec {
                             .write_all(raw_record)
                             .context("Failed to write rejected read")?;
                     }
-                    rw.finish(&rejects_header).context("Failed to finish rejects file")?;
+                    rw.into_inner().finish().context("Failed to finish rejects file")?;
                     info!("Wrote {} rejected reads", all_rejects.len());
                 }
             }
@@ -695,6 +694,7 @@ impl Codec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noodles::sam::alignment::io::Write as AlignmentWrite;
     use rstest::rstest;
     use std::path::PathBuf;
 

--- a/src/commands/correct.rs
+++ b/src/commands/correct.rs
@@ -1253,7 +1253,7 @@ impl CorrectUmis {
                     rejects_writer.get_mut().write_all(raw)?;
                 }
 
-                rejects_writer.finish(&header_for_rejects)?;
+                rejects_writer.into_inner().finish()?;
                 let total_reject_records = all_rejects.len() + all_raw_rejects.len();
                 info!("Wrote {total_reject_records} rejected records to rejects file");
             }
@@ -1451,9 +1451,9 @@ impl CorrectUmis {
         progress.log_final();
 
         // Finish writers
-        writer.finish(&header)?;
-        if let Some(ref mut rw) = reject_writer {
-            rw.finish(&header)?;
+        writer.into_inner().finish()?;
+        if let Some(rw) = reject_writer {
+            rw.into_inner().finish()?;
         }
 
         // Finalize and write metrics
@@ -1904,7 +1904,7 @@ mod tests {
             writer.write_alignment_record(&header, &record)?;
         }
 
-        writer.finish(&header)?;
+        writer.try_finish()?;
         Ok(temp_file)
     }
 

--- a/src/commands/duplex.rs
+++ b/src/commands/duplex.rs
@@ -41,7 +41,6 @@ use fgumi_lib::validation::{optional_string_to_tag, validate_file_exists};
 use fgumi_raw_bam::RawRecord;
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::io;
 use std::io::Write as IoWrite;
 use std::sync::Arc;
@@ -470,8 +469,8 @@ impl Command for Duplex {
         }
 
         // Finish the rejects writer to ensure BGZF EOF marker is written
-        if let Some(mut rw) = rejects_writer {
-            rw.finish(&header).context("Failed to finish rejects file")?;
+        if let Some(rw) = rejects_writer {
+            rw.into_inner().finish().context("Failed to finish rejects file")?;
         }
 
         progress.log_final();
@@ -721,13 +720,13 @@ impl Duplex {
         if track_rejects && !all_rejects.is_empty() {
             if let Some(rejects_path) = &self.rejects_opts.rejects {
                 let writer_threads = self.threading.num_threads();
-                let mut rejects_writer = create_optional_bam_writer(
+                let rejects_writer = create_optional_bam_writer(
                     Some(rejects_path),
                     &rejects_header,
                     writer_threads,
                     self.compression.compression_level,
                 )?;
-                if let Some(ref mut rw) = rejects_writer {
+                if let Some(mut rw) = rejects_writer {
                     for raw_record in &all_rejects {
                         let block_size = raw_record.len() as u32;
                         rw.get_mut()
@@ -737,7 +736,7 @@ impl Duplex {
                             .write_all(raw_record)
                             .context("Failed to write rejected read")?;
                     }
-                    rw.finish(&rejects_header).context("Failed to finish rejects file")?;
+                    rw.into_inner().finish().context("Failed to finish rejects file")?;
                     info!("Wrote {} rejected reads", all_rejects.len());
                 }
             }

--- a/src/commands/duplex_metrics.rs
+++ b/src/commands/duplex_metrics.rs
@@ -2314,7 +2314,7 @@ mod tests {
         let mut writer = noodles::bam::io::Writer::new(std::fs::File::create(&bam_path)?);
         writer.write_header(&header)?;
         writer.write_alignment_record(&header, &rec)?;
-        writer.finish(&header)?;
+        writer.try_finish()?;
         drop(writer);
 
         // Try to run duplex-metrics on this consensus BAM

--- a/src/commands/simplex.rs
+++ b/src/commands/simplex.rs
@@ -32,7 +32,6 @@ use fgumi_lib::validation::optional_string_to_tag;
 use fgumi_lib::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::io;
 use std::io::Write as IoWrite;
 use std::sync::Arc;
@@ -444,8 +443,8 @@ impl Command for Simplex {
         timer.log_completion(consensus_count);
 
         // Close rejects writer if it was opened
-        if let Some(mut rw) = rejects_writer {
-            rw.finish(&header).context("Failed to finish rejects file")?;
+        if let Some(rw) = rejects_writer {
+            rw.into_inner().finish().context("Failed to finish rejects file")?;
             info!("Rejected reads written successfully");
         }
 
@@ -657,13 +656,13 @@ impl Simplex {
         if track_rejects && !all_rejects.is_empty() {
             if let Some(rejects_path) = &self.rejects_opts.rejects {
                 let writer_threads = self.threading.num_threads();
-                let mut rejects_writer = create_optional_bam_writer(
+                let rejects_writer = create_optional_bam_writer(
                     Some(rejects_path),
                     &rejects_header,
                     writer_threads,
                     self.compression.compression_level,
                 )?;
-                if let Some(ref mut rw) = rejects_writer {
+                if let Some(mut rw) = rejects_writer {
                     for raw_record in &all_rejects {
                         let block_size = raw_record.len() as u32;
                         rw.get_mut()
@@ -673,7 +672,7 @@ impl Simplex {
                             .write_all(raw_record)
                             .context("Failed to write rejected read")?;
                     }
-                    rw.finish(&rejects_header).context("Failed to finish rejects file")?;
+                    rw.into_inner().finish().context("Failed to finish rejects file")?;
                     info!("Wrote {} rejected reads", all_rejects.len());
                 }
             }

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -29,7 +29,7 @@ fn write_test_bam(path: &Path, records: &[RecordBuf]) {
     for record in records {
         writer.write_alignment_record(&header, record).expect("Failed to write record");
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Write a BAM file with MI-tagged records (grouped input for consensus callers).
@@ -47,7 +47,7 @@ fn write_grouped_bam(path: &Path, families: &[(&str, &[RecordBuf])]) {
             writer.write_alignment_record(&header, &rec).expect("Failed to write record");
         }
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create paired-end duplicate reads at a given position with MC tags.
@@ -156,6 +156,49 @@ fn create_duplex_pair(
     r2.data_mut().insert(mi, Value::from(mi_tag));
 
     (r1, r2)
+}
+
+/// Create a single-template family (will be rejected by --min-reads > 1).
+fn create_rejected_family(name: &str, umi: &str, start: usize) -> Vec<RecordBuf> {
+    let cigar = "8M";
+    let r1 = RecordBuilder::new()
+        .name(name)
+        .sequence("ACGTACGT")
+        .qualities(&[30; 8])
+        .paired(true)
+        .first_segment(true)
+        .properly_paired(true)
+        .reference_sequence_id(0)
+        .alignment_start(start)
+        .mapping_quality(60)
+        .cigar(cigar)
+        .mate_reference_sequence_id(0)
+        .mate_alignment_start(start + 100)
+        .template_length(108)
+        .tag("RX", umi)
+        .tag("MC", cigar)
+        .build();
+
+    let r2 = RecordBuilder::new()
+        .name(name)
+        .sequence("ACGTACGT")
+        .qualities(&[30; 8])
+        .paired(true)
+        .first_segment(false)
+        .properly_paired(true)
+        .reverse_complement(true)
+        .reference_sequence_id(0)
+        .alignment_start(start + 100)
+        .mapping_quality(60)
+        .cigar(cigar)
+        .mate_reference_sequence_id(0)
+        .mate_alignment_start(start)
+        .template_length(-108)
+        .tag("RX", umi)
+        .tag("MC", cigar)
+        .build();
+
+    vec![r1, r2]
 }
 
 /// Create a CODEC read pair (FR orientation, same position).
@@ -593,4 +636,217 @@ fn test_piped_simplex_to_filter_has_bgzf_eof() {
     assert!(simplex_status.success(), "simplex command failed in pipe");
     assert!(filter.status.success(), "filter command failed in pipe");
     assert_has_bgzf_eof(&output_bam);
+}
+
+// ============================================================================
+// Rejects writer BGZF EOF tests
+// ============================================================================
+
+#[test]
+fn test_simplex_rejects_has_bgzf_eof() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // One family with 3 reads (kept) and one singleton family (rejected by --min-reads 2)
+    let kept = create_umi_family("ACGT", 3, "kept", "ACGTACGT", 30);
+    let rejected = create_rejected_family("reject", "TTTT", 500);
+    write_grouped_bam(&input_bam, &[("1", &kept), ("2", &rejected)]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run simplex command");
+
+    assert!(status.success(), "simplex command with rejects failed");
+    assert_has_bgzf_eof(&output_bam);
+    assert_has_bgzf_eof(&rejects_bam);
+}
+
+#[test]
+fn test_duplex_rejects_has_bgzf_eof() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // 3 /A pairs and 3 /B pairs (kept), plus a singleton /A pair (rejected by --min-reads 2)
+    let mut records = Vec::new();
+    for i in 0..3 {
+        let (r1, r2) = create_duplex_pair(&format!("a_{i}"), "1/A", "ACGTACGT", 100, false);
+        records.push(r1);
+        records.push(r2);
+    }
+    for i in 0..3 {
+        let (r1, r2) = create_duplex_pair(&format!("b_{i}"), "1/B", "ACGTACGT", 100, true);
+        records.push(r1);
+        records.push(r2);
+    }
+    // Singleton family that will be rejected
+    let (r1, r2) = create_duplex_pair("reject_a", "2/A", "ACGTACGT", 500, false);
+    records.push(r1);
+    records.push(r2);
+    write_test_bam(&input_bam, &records);
+
+    // Use single-threaded mode: duplex multi-threaded pipeline doesn't collect
+    // raw reject bytes, so rejects writing only happens in the single-threaded path.
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run duplex command");
+
+    assert!(status.success(), "duplex command with rejects failed");
+    assert_has_bgzf_eof(&output_bam);
+    assert_has_bgzf_eof(&rejects_bam);
+}
+
+#[test]
+fn test_codec_rejects_has_bgzf_eof() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // One family with 3 reads (kept) and one singleton (rejected by --min-reads 2)
+    let mut records = Vec::new();
+    for i in 0..3 {
+        let (r1, r2) = create_codec_pair(&format!("read{i}"), "1", 100);
+        records.push(r1);
+        records.push(r2);
+    }
+    let (r1, r2) = create_codec_pair("reject", "2", 500);
+    records.push(r1);
+    records.push(r2);
+    write_test_bam(&input_bam, &records);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "codec",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run codec command");
+
+    assert!(status.success(), "codec command with rejects failed");
+    assert_has_bgzf_eof(&output_bam);
+    assert_has_bgzf_eof(&rejects_bam);
+}
+
+#[test]
+fn test_correct_rejects_has_bgzf_eof() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // Reads with matching UMI (kept) and non-matching UMI (rejected)
+    let mut records = create_umi_family("ACGTACGT", 3, "kept", "AAAAGGGG", 30);
+    records.extend(create_umi_family("NNNNNNNN", 2, "reject", "AAAAGGGG", 30));
+    write_test_bam(&input_bam, &records);
+    fs::write(&whitelist, "ACGTACGT").expect("Failed to write whitelist");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "correct",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--umi-files",
+            whitelist.to_str().unwrap(),
+            "--max-mismatches",
+            "1",
+            "--min-distance",
+            "1",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run correct command");
+
+    assert!(status.success(), "correct command with rejects failed");
+    assert_has_bgzf_eof(&output_bam);
+    assert_has_bgzf_eof(&rejects_bam);
+}
+
+#[test]
+fn test_correct_single_threaded_rejects_has_bgzf_eof() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    let mut records = create_umi_family("ACGTACGT", 3, "kept", "AAAAGGGG", 30);
+    records.extend(create_umi_family("NNNNNNNN", 2, "reject", "AAAAGGGG", 30));
+    write_test_bam(&input_bam, &records);
+    fs::write(&whitelist, "ACGTACGT").expect("Failed to write whitelist");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "correct",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--umi-files",
+            whitelist.to_str().unwrap(),
+            "--max-mismatches",
+            "1",
+            "--min-distance",
+            "1",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run correct command");
+
+    assert!(status.success(), "correct single-threaded with rejects failed");
+    assert_has_bgzf_eof(&output_bam);
+    assert_has_bgzf_eof(&rejects_bam);
 }

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -27,7 +27,7 @@ fn create_paired_bam(path: &Path, pairs: Vec<(RecordBuf, RecordBuf)>) {
         writer.write_alignment_record(&header, &r1).expect("Failed to write R1");
         writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Test basic clip command with fixed-end clipping.

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -100,7 +100,7 @@ fn create_codec_test_bam(path: &PathBuf, pairs: Vec<(RecordBuf, RecordBuf)>) {
         writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Test basic CODEC consensus calling.

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -29,7 +29,7 @@ fn create_umi_bam(
             writer.write_alignment_record(&header, &record).expect("Failed to write record");
         }
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Write a UMI whitelist file.

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -29,7 +29,7 @@ fn create_sorted_bam(path: &PathBuf, records: Vec<RecordBuf>) {
     for record in records {
         writer.write_alignment_record(&header, &record).expect("Failed to write record");
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create a group of paired-end reads at the same position with the same UMI

--- a/tests/integration/test_downsample_command.rs
+++ b/tests/integration/test_downsample_command.rs
@@ -42,7 +42,7 @@ fn create_grouped_bam(path: &PathBuf, families: Vec<(&str, usize)>) {
         }
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Read records from a BAM file.

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -104,7 +104,7 @@ fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RecordBuf, RecordBuf)>>) {
             writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
         }
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create a single duplex molecule with `depth` read pairs on each strand.

--- a/tests/integration/test_fastq_command.rs
+++ b/tests/integration/test_fastq_command.rs
@@ -52,7 +52,7 @@ fn create_paired_bam(path: &PathBuf, read_pairs: Vec<(&str, &str, &str, &str, &s
         writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Parse FASTQ records from a file.
@@ -268,7 +268,7 @@ fn create_bam_with_flags(path: &PathBuf) {
         .build();
     writer.write_alignment_record(&header, &supplementary).expect("Failed to write supplementary");
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Test flag filtering with -F option.

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -26,7 +26,7 @@ fn create_consensus_bam(path: &Path, records: Vec<RecordBuf>) {
     for record in records {
         writer.write_alignment_record(&header, &record).expect("Failed to write record");
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Test basic filter command with passing reads.

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -133,7 +133,7 @@ fn create_test_input_bam(path: &PathBuf) {
         writer.write_alignment_record(&header, record).expect("Failed to write record");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Helper function to create a BAM file with UMIs containing N bases.
@@ -153,5 +153,5 @@ fn create_test_bam_with_n_umis(path: &PathBuf) {
         writer.write_alignment_record(&header, record).expect("Failed to write record");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -32,7 +32,7 @@ fn create_grouped_bam(path: &Path, families: Vec<(&str, Vec<RecordBuf>)>) {
             writer.write_alignment_record(&header, &record).expect("Failed to write record");
         }
     }
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Test basic simplex consensus calling.

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -253,7 +253,7 @@ fn create_test_input_bam(path: &PathBuf) {
         writer.write_alignment_record(&header, record).expect("Failed to write record");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create a test BAM with already-grouped reads (MI tag set).
@@ -291,5 +291,5 @@ fn create_grouped_test_bam(path: &PathBuf) {
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
-    writer.finish(&header).expect("Failed to finish BAM");
+    writer.try_finish().expect("Failed to finish BAM");
 }


### PR DESCRIPTION
## Summary

- Replace all `writer.finish(&header)` calls (a **no-op** in noodles `bam::io::Writer`) with proper finalization methods
- For `BamWriter` (wrapping `BgzfWriterEnum`): use `writer.into_inner().finish()` which flushes and writes the BGZF EOF block — critical for multi-threaded writers that don't write EOF on Drop
- For `bam::io::Writer<bgzf::io::Writer<File>>` (test helpers, `build_from_path` writers): use `writer.try_finish()` which delegates to bgzf's flush + EOF write
- Fixes rejects writers in simplex, duplex, codec, and correct commands that were silently producing BAM files missing BGZF EOF when using multi-threaded writers

**Stacked on #126** — review that PR first.

## Test plan

- [x] `cargo ci-test` — all 1809 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Verified zero remaining `writer.finish(&header)` calls in src/ and tests/

Relates to #125