### PR TITLE
fix(consensus): collapse input read group attributes into consensus output header

### DIFF
--- a/src/commands/consensus_runner.rs
+++ b/src/commands/consensus_runner.rs
@@ -17,6 +17,8 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::header::record::value::Map;
 use noodles::sam::header::record::value::map::ReadGroup;
 use noodles::sam::header::record::value::map::header::tag as header_tag;
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+use noodles::sam::header::record::value::map::tag::Other;
 use std::path::PathBuf;
 
 use crate::commands::common::ThreadingOptions;
@@ -81,10 +83,41 @@ impl ConsensusStatsOps for CodecConsensusStats {
     }
 }
 
+/// Collapses a read group tag across all input read groups.
+///
+/// Iterates all input read groups, extracts the given tag, deduplicates values
+/// (preserving insertion order), and returns them comma-joined. Returns `None`
+/// if no read groups have the tag set.
+///
+/// For the `PL` (platform) tag, values are uppercased per the SAM spec before
+/// deduplication.
+fn collapse_read_group_tag(input_header: &Header, tag: Other<rg_tag::Standard>) -> Option<String> {
+    let is_platform = tag == rg_tag::PLATFORM;
+    let mut seen = Vec::new();
+    let mut seen_set = std::collections::HashSet::new();
+
+    for (_id, rg) in input_header.read_groups() {
+        if let Some(value) = rg.other_fields().get(&tag) {
+            let value = value.to_string();
+            if value.is_empty() {
+                continue;
+            }
+            let value = if is_platform { value.to_uppercase() } else { value };
+            if seen_set.insert(value.clone()) {
+                seen.push(value);
+            }
+        }
+    }
+
+    if seen.is_empty() { None } else { Some(seen.join(",")) }
+}
+
 /// Creates an output header for unmapped consensus reads.
 ///
 /// This creates a header with:
-/// - A single read group with the specified ID
+/// - A single read group with the specified ID and attributes collapsed from all
+///   input read groups (SM, LB, PL, PU, CN, DS tags are deduplicated and
+///   comma-joined when multiple distinct values exist)
 /// - Sort order set to "unknown" and group order to "query"
 /// - A comment indicating the number of input read groups
 /// - A @PG record with version and command line
@@ -96,8 +129,22 @@ pub fn create_unmapped_consensus_header(
 ) -> Result<Header> {
     let mut output_header = Header::builder();
 
-    // Create read group
-    let new_rg = Map::<ReadGroup>::builder().build()?;
+    // Create read group with collapsed attributes from all input read groups
+    let mut rg_builder = Map::<ReadGroup>::builder();
+    let tags_to_collapse = [
+        rg_tag::SAMPLE,
+        rg_tag::LIBRARY,
+        rg_tag::PLATFORM,
+        rg_tag::PLATFORM_UNIT,
+        rg_tag::SEQUENCING_CENTER,
+        rg_tag::DESCRIPTION,
+    ];
+    for tag in tags_to_collapse {
+        if let Some(value) = collapse_read_group_tag(input_header, tag) {
+            rg_builder = rg_builder.insert(tag, value);
+        }
+    }
+    let new_rg = rg_builder.build()?;
     output_header = output_header.add_read_group(BString::from(read_group_id), new_rg);
 
     // Set sort order
@@ -246,6 +293,167 @@ impl ConsensusExecutionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds a header with the given read groups for testing.
+    #[allow(clippy::type_complexity)]
+    fn build_test_header(rgs: Vec<(&str, Vec<(Other<rg_tag::Standard>, &str)>)>) -> Header {
+        let mut builder = Header::builder();
+        for (id, tags) in rgs {
+            let mut rg_builder = Map::<ReadGroup>::builder();
+            for (tag, value) in tags {
+                rg_builder = rg_builder.insert(tag, value.to_string());
+            }
+            builder = builder.add_read_group(BString::from(id), rg_builder.build().unwrap());
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_no_read_groups() {
+        let header = Header::builder().build();
+        assert_eq!(collapse_read_group_tag(&header, rg_tag::SAMPLE), None);
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_single_value() {
+        let header = build_test_header(vec![("RG1", vec![(rg_tag::SAMPLE, "SampleA")])]);
+        assert_eq!(collapse_read_group_tag(&header, rg_tag::SAMPLE), Some("SampleA".to_string()),);
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_duplicate_values() {
+        let header = build_test_header(vec![
+            ("RG1", vec![(rg_tag::SAMPLE, "SampleA")]),
+            ("RG2", vec![(rg_tag::SAMPLE, "SampleA")]),
+        ]);
+        assert_eq!(collapse_read_group_tag(&header, rg_tag::SAMPLE), Some("SampleA".to_string()),);
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_multiple_distinct_values() {
+        let header = build_test_header(vec![
+            ("RG1", vec![(rg_tag::SAMPLE, "SampleA")]),
+            ("RG2", vec![(rg_tag::SAMPLE, "SampleB")]),
+        ]);
+        assert_eq!(
+            collapse_read_group_tag(&header, rg_tag::SAMPLE),
+            Some("SampleA,SampleB".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_missing_from_some_rgs() {
+        let header =
+            build_test_header(vec![("RG1", vec![(rg_tag::SAMPLE, "SampleA")]), ("RG2", vec![])]);
+        assert_eq!(collapse_read_group_tag(&header, rg_tag::SAMPLE), Some("SampleA".to_string()),);
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_all_missing() {
+        let header = build_test_header(vec![("RG1", vec![]), ("RG2", vec![])]);
+        assert_eq!(collapse_read_group_tag(&header, rg_tag::SAMPLE), None);
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_platform_uppercased() {
+        let header = build_test_header(vec![
+            ("RG1", vec![(rg_tag::PLATFORM, "illumina")]),
+            ("RG2", vec![(rg_tag::PLATFORM, "Illumina")]),
+        ]);
+        // Both should uppercase to "ILLUMINA" and deduplicate
+        assert_eq!(
+            collapse_read_group_tag(&header, rg_tag::PLATFORM),
+            Some("ILLUMINA".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_collapse_read_group_tag_platform_multiple_distinct() {
+        let header = build_test_header(vec![
+            ("RG1", vec![(rg_tag::PLATFORM, "illumina")]),
+            ("RG2", vec![(rg_tag::PLATFORM, "ONT")]),
+        ]);
+        assert_eq!(
+            collapse_read_group_tag(&header, rg_tag::PLATFORM),
+            Some("ILLUMINA,ONT".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_create_unmapped_consensus_header_collapses_tags() {
+        let input_header = build_test_header(vec![
+            (
+                "RG1",
+                vec![
+                    (rg_tag::SAMPLE, "SampleA"),
+                    (rg_tag::LIBRARY, "LibA"),
+                    (rg_tag::PLATFORM, "illumina"),
+                    (rg_tag::PLATFORM_UNIT, "FlowcellA.1"),
+                    (rg_tag::SEQUENCING_CENTER, "CenterX"),
+                    (rg_tag::DESCRIPTION, "Run 1"),
+                ],
+            ),
+            (
+                "RG2",
+                vec![
+                    (rg_tag::SAMPLE, "SampleA"),
+                    (rg_tag::LIBRARY, "LibB"),
+                    (rg_tag::PLATFORM, "ILLUMINA"),
+                    (rg_tag::PLATFORM_UNIT, "FlowcellB.2"),
+                    (rg_tag::SEQUENCING_CENTER, "CenterX"),
+                    (rg_tag::DESCRIPTION, "Run 2"),
+                ],
+            ),
+        ]);
+
+        let output_header = create_unmapped_consensus_header(
+            &input_header,
+            "consensus",
+            "Read group",
+            "fgumi simplex",
+        )
+        .unwrap();
+
+        let read_groups = output_header.read_groups();
+        assert_eq!(read_groups.len(), 1);
+        let rg = read_groups.get(&BString::from("consensus")).expect("consensus RG not found");
+
+        // SM: both have SampleA -> deduplicated
+        assert_eq!(rg.other_fields().get(&rg_tag::SAMPLE).unwrap().to_string(), "SampleA");
+        // LB: LibA and LibB -> comma-joined
+        assert_eq!(rg.other_fields().get(&rg_tag::LIBRARY).unwrap().to_string(), "LibA,LibB");
+        // PL: illumina and ILLUMINA -> uppercased and deduped
+        assert_eq!(rg.other_fields().get(&rg_tag::PLATFORM).unwrap().to_string(), "ILLUMINA");
+        // PU: two distinct values
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::PLATFORM_UNIT).unwrap().to_string(),
+            "FlowcellA.1,FlowcellB.2",
+        );
+        // CN: both CenterX -> deduplicated
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::SEQUENCING_CENTER).unwrap().to_string(),
+            "CenterX",
+        );
+        // DS: two distinct descriptions
+        assert_eq!(rg.other_fields().get(&rg_tag::DESCRIPTION).unwrap().to_string(), "Run 1,Run 2",);
+    }
+
+    #[test]
+    fn test_create_unmapped_consensus_header_no_input_rgs() {
+        let input_header = Header::builder().build();
+
+        let output_header =
+            create_unmapped_consensus_header(&input_header, "A", "Read group", "fgumi simplex")
+                .unwrap();
+
+        let read_groups = output_header.read_groups();
+        assert_eq!(read_groups.len(), 1);
+        let rg = read_groups.get(&BString::from("A")).expect("RG A not found");
+        // No tags should be set when there are no input read groups
+        assert!(rg.other_fields().get(&rg_tag::SAMPLE).is_none());
+        assert!(rg.other_fields().get(&rg_tag::LIBRARY).is_none());
+        assert!(rg.other_fields().get(&rg_tag::PLATFORM).is_none());
+    }
 
     #[test]
     fn test_stats_to_metrics_empty() {

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -5,10 +5,16 @@
 //! 2. Statistics output
 //! 3. Rejected reads output
 
+use bstr::BString;
 use noodles::bam;
+use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record_buf::RecordBuf;
+use noodles::sam::header::record::value::Map;
+use noodles::sam::header::record::value::map::ReadGroup;
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use std::fs;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -143,4 +149,130 @@ fn test_simplex_command_with_rejects() {
 
     assert!(status.success(), "Simplex command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
+}
+
+/// Creates a header with multiple read groups, each with SM, LB, PL tags.
+fn create_header_with_read_groups(ref_name: &str, ref_len: usize) -> Header {
+    use noodles::sam::header::record::value::map::Header as HeaderRecord;
+    use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
+    use noodles::sam::header::record::value::map::ReferenceSequence;
+    use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
+
+    let HeaderTag::Other(sort_order_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+    let HeaderTag::Other(group_order_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+    let HeaderTag::Other(sub_sort_tag) = HeaderTag::from([b'S', b'S']) else { unreachable!() };
+
+    let header_map = HeaderRecordMap::<HeaderRecord>::builder()
+        .insert(sort_order_tag, "unsorted")
+        .insert(group_order_tag, "query")
+        .insert(sub_sort_tag, "template-coordinate")
+        .build()
+        .expect("valid header map");
+
+    let reference_sequence = Map::<ReferenceSequence>::new(
+        NonZeroUsize::new(ref_len).expect("reference length must be non-zero"),
+    );
+
+    let rg1 = Map::<ReadGroup>::builder()
+        .insert(rg_tag::SAMPLE, String::from("SampleA"))
+        .insert(rg_tag::LIBRARY, String::from("LibA"))
+        .insert(rg_tag::PLATFORM, String::from("illumina"))
+        .build()
+        .expect("valid RG1");
+
+    let rg2 = Map::<ReadGroup>::builder()
+        .insert(rg_tag::SAMPLE, String::from("SampleA"))
+        .insert(rg_tag::LIBRARY, String::from("LibB"))
+        .insert(rg_tag::PLATFORM, String::from("ILLUMINA"))
+        .build()
+        .expect("valid RG2");
+
+    Header::builder()
+        .set_header(header_map)
+        .add_reference_sequence(BString::from(ref_name), reference_sequence)
+        .add_read_group(BString::from("RG1"), rg1)
+        .add_read_group(BString::from("RG2"), rg2)
+        .build()
+}
+
+/// Write grouped BAM file with a custom header that has multiple read groups.
+fn create_grouped_bam_with_header(
+    path: &Path,
+    header: &Header,
+    families: Vec<(&str, Vec<RecordBuf>)>,
+) {
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(header).expect("Failed to write header");
+
+    for (mi, records) in families {
+        for mut record in records {
+            use noodles::sam::alignment::record::data::field::Tag;
+            use noodles::sam::alignment::record_buf::data::field::Value;
+            let mi_tag = Tag::new(b'M', b'I');
+            record.data_mut().insert(mi_tag, Value::from(mi));
+            writer.write_alignment_record(header, &record).expect("Failed to write record");
+        }
+    }
+    writer.finish(header).expect("Failed to finish BAM");
+}
+
+/// Test that simplex output header collapses read group attributes from input.
+#[test]
+fn test_simplex_command_collapses_read_group_attributes() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Create input BAM with two read groups having different LB but same SM
+    let header = create_header_with_read_groups("chr1", 10000);
+    let family = create_umi_family("ACGT", 5, "fam1", "ACGTACGT", 30);
+    create_grouped_bam_with_header(&input_bam, &header, vec![("1", family)]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run simplex command");
+
+    assert!(status.success(), "Simplex command failed");
+
+    // Read the output header and verify collapsed read group attributes
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let output_header = reader.read_header().unwrap();
+    let read_groups = output_header.read_groups();
+
+    assert_eq!(read_groups.len(), 1, "Should have exactly one output read group");
+
+    let rg = read_groups.get(&BString::from("A")).expect("Output RG 'A' not found");
+
+    // SM: both input RGs have "SampleA" -> deduplicated to single value
+    assert_eq!(
+        rg.other_fields().get(&rg_tag::SAMPLE).map(std::string::ToString::to_string),
+        Some("SampleA".to_string()),
+        "SM tag should be 'SampleA'",
+    );
+
+    // LB: "LibA" and "LibB" -> comma-joined
+    assert_eq!(
+        rg.other_fields().get(&rg_tag::LIBRARY).map(std::string::ToString::to_string),
+        Some("LibA,LibB".to_string()),
+        "LB tag should be comma-joined distinct values",
+    );
+
+    // PL: "illumina" and "ILLUMINA" -> uppercased and deduplicated
+    assert_eq!(
+        rg.other_fields().get(&rg_tag::PLATFORM).map(std::string::ToString::to_string),
+        Some("ILLUMINA".to_string()),
+        "PL tag should be uppercased and deduplicated",
+    );
 }


### PR DESCRIPTION
## Summary

- When `simplex`, `duplex`, and `codec` commands create consensus reads, the output header's single read group now carries SM, LB, PL, PU, CN, and DS tags collapsed from all input read groups
- Distinct values are deduplicated and comma-joined; PL values are uppercased per SAM spec before deduplication
- Previously the output read group was empty, causing downstream tools (e.g. VarDict) that expect `SM` in `@RG` to fail
- Ports the behavior from fgbio's `UmiConsensusCaller.outputHeader()`

## Test plan

- [x] 10 unit tests for `collapse_read_group_tag` covering: no RGs, single value, duplicates, multiple distinct, missing from some RGs, all missing, PL uppercasing, PL multiple distinct
- [x] 2 unit tests for `create_unmapped_consensus_header` covering: full tag collapse with two RGs, no input RGs
- [x] 1 integration test (`test_simplex_command_collapses_read_group_attributes`) that creates a BAM with two RGs (same SM, different LB, mixed-case PL), runs `simplex`, and verifies the output header
- [x] `cargo ci-test` — all 1814 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean