### PR TITLE
refactor(metrics): improve code reuse, quality, and efficiency in fgumi-metrics

### DIFF
--- a/crates/fgumi-metrics/src/clip.rs
+++ b/crates/fgumi-metrics/src/clip.rs
@@ -9,6 +9,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::Metric;
 
+/// Bundled counts for a single clipping operation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ClipCounts {
+    /// Number of bases clipped before `clip`
+    pub prior: usize,
+    /// Number of bases clipped from 5' end
+    pub five_prime: usize,
+    /// Number of bases clipped from 3' end
+    pub three_prime: usize,
+    /// Number of bases clipped due to overlap
+    pub overlapping: usize,
+    /// Number of bases clipped due to extending past mate
+    pub extending: usize,
+}
+
 /// Type of read for metrics tracking
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReadType {
@@ -99,20 +114,8 @@ impl ClippingMetrics {
     ///
     /// # Arguments
     /// * `record` - The record that was clipped
-    /// * `prior_bases_clipped` - Number of bases clipped before `clip`
-    /// * `num_five_prime` - Number of bases clipped from 5' end
-    /// * `num_three_prime` - Number of bases clipped from 3' end
-    /// * `num_overlapping` - Number of bases clipped due to overlap
-    /// * `num_extending` - Number of bases clipped due to extending past mate
-    pub fn update(
-        &mut self,
-        record: &RecordBuf,
-        prior_bases_clipped: usize,
-        num_five_prime: usize,
-        num_three_prime: usize,
-        num_overlapping: usize,
-        num_extending: usize,
-    ) {
+    /// * `counts` - The clip counts for this operation
+    pub fn update(&mut self, record: &RecordBuf, counts: ClipCounts) {
         self.reads += 1;
 
         // Count aligned bases
@@ -131,38 +134,39 @@ impl ClippingMetrics {
         self.bases += aligned_bases;
 
         // Track pre-clipping
-        if prior_bases_clipped > 0 {
+        if counts.prior > 0 {
             self.reads_clipped_pre += 1;
-            self.bases_clipped_pre += prior_bases_clipped;
+            self.bases_clipped_pre += counts.prior;
         }
 
         // Track 5' clipping
-        if num_five_prime > 0 {
+        if counts.five_prime > 0 {
             self.reads_clipped_five_prime += 1;
-            self.bases_clipped_five_prime += num_five_prime;
+            self.bases_clipped_five_prime += counts.five_prime;
         }
 
         // Track 3' clipping
-        if num_three_prime > 0 {
+        if counts.three_prime > 0 {
             self.reads_clipped_three_prime += 1;
-            self.bases_clipped_three_prime += num_three_prime;
+            self.bases_clipped_three_prime += counts.three_prime;
         }
 
         // Track overlapping clipping
-        if num_overlapping > 0 {
+        if counts.overlapping > 0 {
             self.reads_clipped_overlapping += 1;
-            self.bases_clipped_overlapping += num_overlapping;
+            self.bases_clipped_overlapping += counts.overlapping;
         }
 
         // Track extending clipping
-        if num_extending > 0 {
+        if counts.extending > 0 {
             self.reads_clipped_extending += 1;
-            self.bases_clipped_extending += num_extending;
+            self.bases_clipped_extending += counts.extending;
         }
 
         // Total clipping after ClipBam
-        let additional_clipped = num_five_prime + num_three_prime + num_overlapping + num_extending;
-        let total_clipped = additional_clipped + prior_bases_clipped;
+        let additional_clipped =
+            counts.five_prime + counts.three_prime + counts.overlapping + counts.extending;
+        let total_clipped = additional_clipped + counts.prior;
 
         if total_clipped > 0 {
             self.reads_clipped_post += 1;
@@ -177,6 +181,12 @@ impl ClippingMetrics {
 
     /// Adds metrics from another `ClippingMetrics` instance
     pub fn add(&mut self, other: &ClippingMetrics) {
+        *self += other;
+    }
+}
+
+impl std::ops::AddAssign<&ClippingMetrics> for ClippingMetrics {
+    fn add_assign(&mut self, other: &ClippingMetrics) {
         self.reads += other.reads;
         self.reads_unmapped += other.reads_unmapped;
         self.reads_clipped_pre += other.reads_clipped_pre;
@@ -242,8 +252,8 @@ impl ClippingMetricsCollection {
 
     /// Returns all metrics in order
     #[must_use]
-    pub fn all_metrics(&self) -> Vec<&ClippingMetrics> {
-        vec![&self.fragment, &self.read_one, &self.read_two, &self.pair, &self.all]
+    pub fn all_metrics(&self) -> [&ClippingMetrics; 5] {
+        [&self.fragment, &self.read_one, &self.read_two, &self.pair, &self.all]
     }
 }
 
@@ -281,11 +291,21 @@ mod tests {
     }
 
     #[test]
+    fn test_clip_counts_default() {
+        let counts = ClipCounts::default();
+        assert_eq!(counts.prior, 0);
+        assert_eq!(counts.five_prime, 0);
+        assert_eq!(counts.three_prime, 0);
+        assert_eq!(counts.overlapping, 0);
+        assert_eq!(counts.extending, 0);
+    }
+
+    #[test]
     fn test_clipping_metrics_update_no_clipping() {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("100M", false);
 
-        metrics.update(&record, 0, 0, 0, 0, 0);
+        metrics.update(&record, ClipCounts::default());
 
         assert_eq!(metrics.reads, 1);
         assert_eq!(metrics.bases, 100);
@@ -298,7 +318,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("90M", false);
 
-        metrics.update(&record, 10, 0, 0, 0, 0);
+        metrics.update(&record, ClipCounts { prior: 10, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads, 1);
         assert_eq!(metrics.reads_clipped_pre, 1);
@@ -312,7 +332,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("95M", false);
 
-        metrics.update(&record, 0, 5, 0, 0, 0);
+        metrics.update(&record, ClipCounts { five_prime: 5, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_clipped_five_prime, 1);
         assert_eq!(metrics.bases_clipped_five_prime, 5);
@@ -325,7 +345,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("97M", false);
 
-        metrics.update(&record, 0, 0, 3, 0, 0);
+        metrics.update(&record, ClipCounts { three_prime: 3, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_clipped_three_prime, 1);
         assert_eq!(metrics.bases_clipped_three_prime, 3);
@@ -338,7 +358,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("80M", false);
 
-        metrics.update(&record, 0, 0, 0, 20, 0);
+        metrics.update(&record, ClipCounts { overlapping: 20, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_clipped_overlapping, 1);
         assert_eq!(metrics.bases_clipped_overlapping, 20);
@@ -351,7 +371,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("85M", false);
 
-        metrics.update(&record, 0, 0, 0, 0, 15);
+        metrics.update(&record, ClipCounts { extending: 15, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_clipped_extending, 1);
         assert_eq!(metrics.bases_clipped_extending, 15);
@@ -364,7 +384,10 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("50M", false);
 
-        metrics.update(&record, 10, 5, 3, 20, 12);
+        metrics.update(
+            &record,
+            ClipCounts { prior: 10, five_prime: 5, three_prime: 3, overlapping: 20, extending: 12 },
+        );
 
         assert_eq!(metrics.reads, 1);
         assert_eq!(metrics.bases_clipped_pre, 10);
@@ -380,7 +403,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("", true);
 
-        metrics.update(&record, 0, 100, 0, 0, 0);
+        metrics.update(&record, ClipCounts { five_prime: 100, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_unmapped, 1);
     }
@@ -391,7 +414,7 @@ mod tests {
 
         for _ in 0..5 {
             let record = create_test_record("90M", false);
-            metrics.update(&record, 0, 10, 0, 0, 0);
+            metrics.update(&record, ClipCounts { five_prime: 10, ..ClipCounts::default() });
         }
 
         assert_eq!(metrics.reads, 5);
@@ -404,11 +427,11 @@ mod tests {
     fn test_clipping_metrics_add() {
         let mut metrics1 = ClippingMetrics::new(ReadType::ReadOne);
         let record1 = create_test_record("90M", false);
-        metrics1.update(&record1, 0, 10, 0, 0, 0);
+        metrics1.update(&record1, ClipCounts { five_prime: 10, ..ClipCounts::default() });
 
         let mut metrics2 = ClippingMetrics::new(ReadType::ReadOne);
         let record2 = create_test_record("85M", false);
-        metrics2.update(&record2, 0, 0, 15, 0, 0);
+        metrics2.update(&record2, ClipCounts { three_prime: 15, ..ClipCounts::default() });
 
         metrics1.add(&metrics2);
 
@@ -442,9 +465,15 @@ mod tests {
         let mut collection = ClippingMetricsCollection::new();
 
         let record = create_test_record("90M", false);
-        collection.read_one.update(&record, 0, 10, 0, 0, 0);
-        collection.read_two.update(&record, 0, 0, 10, 0, 0);
-        collection.fragment.update(&record, 0, 5, 0, 0, 0);
+        collection
+            .read_one
+            .update(&record, ClipCounts { five_prime: 10, ..ClipCounts::default() });
+        collection
+            .read_two
+            .update(&record, ClipCounts { three_prime: 10, ..ClipCounts::default() });
+        collection
+            .fragment
+            .update(&record, ClipCounts { five_prime: 5, ..ClipCounts::default() });
 
         collection.finalize();
 
@@ -476,7 +505,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("40M10D40M", false);
 
-        metrics.update(&record, 0, 0, 0, 0, 0);
+        metrics.update(&record, ClipCounts::default());
 
         // Only matches count as aligned bases
         assert_eq!(metrics.bases, 80);
@@ -487,7 +516,7 @@ mod tests {
         let mut metrics = ClippingMetrics::new(ReadType::ReadOne);
         let record = create_test_record("45M5I45M", false);
 
-        metrics.update(&record, 0, 0, 0, 0, 0);
+        metrics.update(&record, ClipCounts::default());
 
         // Only matches count as aligned bases
         assert_eq!(metrics.bases, 90);
@@ -499,7 +528,7 @@ mod tests {
         let record = create_test_record("", true);
 
         // No additional clipping, so shouldn't count as unmapped
-        metrics.update(&record, 10, 0, 0, 0, 0);
+        metrics.update(&record, ClipCounts { prior: 10, ..ClipCounts::default() });
 
         assert_eq!(metrics.reads_unmapped, 0);
     }
@@ -517,12 +546,30 @@ mod tests {
         let metrics2 = ClippingMetrics::new(ReadType::ReadOne);
 
         let record = create_test_record("90M", false);
-        metrics1.update(&record, 0, 10, 0, 0, 0);
+        metrics1.update(&record, ClipCounts { five_prime: 10, ..ClipCounts::default() });
 
         metrics1.add(&metrics2);
 
         // Should still have just the one record's data
         assert_eq!(metrics1.reads, 1);
+    }
+
+    #[test]
+    fn test_clipping_metrics_add_assign() {
+        let mut metrics1 = ClippingMetrics::new(ReadType::ReadOne);
+        let record1 = create_test_record("90M", false);
+        metrics1.update(&record1, ClipCounts { five_prime: 10, ..ClipCounts::default() });
+
+        let mut metrics2 = ClippingMetrics::new(ReadType::ReadOne);
+        let record2 = create_test_record("85M", false);
+        metrics2.update(&record2, ClipCounts { three_prime: 15, ..ClipCounts::default() });
+
+        metrics1 += &metrics2;
+
+        assert_eq!(metrics1.reads, 2);
+        assert_eq!(metrics1.bases, 175);
+        assert_eq!(metrics1.reads_clipped_five_prime, 1);
+        assert_eq!(metrics1.reads_clipped_three_prime, 1);
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use crate::rejection::RejectionReason;
 
-use crate::{Metric, format_float};
+use crate::{Metric, format_float, frac_u64};
 
 /// A key-value-description metric row matching fgbio's `ConsensusKvMetric` format.
 ///
@@ -123,6 +123,54 @@ pub struct ConsensusMetrics {
     pub rejected_zero_bases_post_trimming: u64,
 }
 
+/// Core rejection reasons always included in KV metrics output.
+const CORE_REJECTIONS: [RejectionReason; 4] = [
+    RejectionReason::InsufficientSupport,
+    RejectionReason::MinorityAlignment,
+    RejectionReason::OrphanConsensus,
+    RejectionReason::ZeroBasesPostTrimming,
+];
+
+/// Optional rejection reasons included in KV metrics output only when non-zero.
+const OPTIONAL_REJECTIONS: [RejectionReason; 14] = [
+    RejectionReason::InsufficientStrandSupport,
+    RejectionReason::LowBaseQuality,
+    RejectionReason::ExcessiveNBases,
+    RejectionReason::NoValidAlignment,
+    RejectionReason::LowMappingQuality,
+    RejectionReason::NBasesInUmi,
+    RejectionReason::MissingUmi,
+    RejectionReason::NotPassingFilter,
+    RejectionReason::LowMeanQuality,
+    RejectionReason::InsufficientMinDepth,
+    RejectionReason::ExcessiveErrorRate,
+    RejectionReason::UmiTooShort,
+    RejectionReason::SameStrandOnly,
+    RejectionReason::DuplicateUmi,
+];
+
+/// All rejection reasons, combining core and optional.
+const ALL_REJECTIONS: [RejectionReason; 18] = [
+    RejectionReason::InsufficientSupport,
+    RejectionReason::MinorityAlignment,
+    RejectionReason::InsufficientStrandSupport,
+    RejectionReason::LowBaseQuality,
+    RejectionReason::ExcessiveNBases,
+    RejectionReason::NoValidAlignment,
+    RejectionReason::LowMappingQuality,
+    RejectionReason::NBasesInUmi,
+    RejectionReason::MissingUmi,
+    RejectionReason::NotPassingFilter,
+    RejectionReason::LowMeanQuality,
+    RejectionReason::InsufficientMinDepth,
+    RejectionReason::ExcessiveErrorRate,
+    RejectionReason::UmiTooShort,
+    RejectionReason::SameStrandOnly,
+    RejectionReason::DuplicateUmi,
+    RejectionReason::OrphanConsensus,
+    RejectionReason::ZeroBasesPostTrimming,
+];
+
 impl ConsensusMetrics {
     /// Creates a new consensus metrics struct with all counts initialized to zero.
     #[must_use]
@@ -159,6 +207,33 @@ impl ConsensusMetrics {
         }
     }
 
+    /// Returns the rejection count for a specific reason.
+    #[must_use]
+    fn rejection_count(&self, reason: RejectionReason) -> u64 {
+        match reason {
+            RejectionReason::InsufficientSupport => self.rejected_insufficient_support,
+            RejectionReason::MinorityAlignment => self.rejected_minority_alignment,
+            RejectionReason::InsufficientStrandSupport => {
+                self.rejected_insufficient_strand_support
+            }
+            RejectionReason::LowBaseQuality => self.rejected_low_base_quality,
+            RejectionReason::ExcessiveNBases => self.rejected_excessive_n_bases,
+            RejectionReason::NoValidAlignment => self.rejected_no_valid_alignment,
+            RejectionReason::LowMappingQuality => self.rejected_low_mapping_quality,
+            RejectionReason::NBasesInUmi => self.rejected_n_bases_in_umi,
+            RejectionReason::MissingUmi => self.rejected_missing_umi,
+            RejectionReason::NotPassingFilter => self.rejected_not_passing_filter,
+            RejectionReason::LowMeanQuality => self.rejected_low_mean_quality,
+            RejectionReason::InsufficientMinDepth => self.rejected_insufficient_min_depth,
+            RejectionReason::ExcessiveErrorRate => self.rejected_excessive_error_rate,
+            RejectionReason::UmiTooShort => self.rejected_umi_too_short,
+            RejectionReason::SameStrandOnly => self.rejected_same_strand_only,
+            RejectionReason::DuplicateUmi => self.rejected_duplicate_umi,
+            RejectionReason::OrphanConsensus => self.rejected_orphan_consensus,
+            RejectionReason::ZeroBasesPostTrimming => self.rejected_zero_bases_post_trimming,
+        }
+    }
+
     /// Adds a rejection count for a specific reason.
     ///
     /// This is used to populate rejection statistics from caller stats.
@@ -192,24 +267,7 @@ impl ConsensusMetrics {
     /// Returns the total number of rejections across all reasons.
     #[must_use]
     pub fn total_rejections(&self) -> u64 {
-        self.rejected_insufficient_support
-            + self.rejected_minority_alignment
-            + self.rejected_insufficient_strand_support
-            + self.rejected_low_base_quality
-            + self.rejected_excessive_n_bases
-            + self.rejected_no_valid_alignment
-            + self.rejected_low_mapping_quality
-            + self.rejected_n_bases_in_umi
-            + self.rejected_missing_umi
-            + self.rejected_not_passing_filter
-            + self.rejected_low_mean_quality
-            + self.rejected_insufficient_min_depth
-            + self.rejected_excessive_error_rate
-            + self.rejected_umi_too_short
-            + self.rejected_same_strand_only
-            + self.rejected_duplicate_umi
-            + self.rejected_orphan_consensus
-            + self.rejected_zero_bases_post_trimming
+        ALL_REJECTIONS.iter().map(|r| self.rejection_count(*r)).sum()
     }
 
     /// Returns a map of rejection reasons to their counts.
@@ -217,74 +275,13 @@ impl ConsensusMetrics {
     /// Only includes rejection reasons with non-zero counts.
     #[must_use]
     pub fn rejection_summary(&self) -> HashMap<RejectionReason, u64> {
-        let mut summary = HashMap::new();
-
-        if self.rejected_insufficient_support > 0 {
-            summary
-                .insert(RejectionReason::InsufficientSupport, self.rejected_insufficient_support);
-        }
-        if self.rejected_minority_alignment > 0 {
-            summary.insert(RejectionReason::MinorityAlignment, self.rejected_minority_alignment);
-        }
-        if self.rejected_insufficient_strand_support > 0 {
-            summary.insert(
-                RejectionReason::InsufficientStrandSupport,
-                self.rejected_insufficient_strand_support,
-            );
-        }
-        if self.rejected_low_base_quality > 0 {
-            summary.insert(RejectionReason::LowBaseQuality, self.rejected_low_base_quality);
-        }
-        if self.rejected_excessive_n_bases > 0 {
-            summary.insert(RejectionReason::ExcessiveNBases, self.rejected_excessive_n_bases);
-        }
-        if self.rejected_no_valid_alignment > 0 {
-            summary.insert(RejectionReason::NoValidAlignment, self.rejected_no_valid_alignment);
-        }
-        if self.rejected_low_mapping_quality > 0 {
-            summary.insert(RejectionReason::LowMappingQuality, self.rejected_low_mapping_quality);
-        }
-        if self.rejected_n_bases_in_umi > 0 {
-            summary.insert(RejectionReason::NBasesInUmi, self.rejected_n_bases_in_umi);
-        }
-        if self.rejected_missing_umi > 0 {
-            summary.insert(RejectionReason::MissingUmi, self.rejected_missing_umi);
-        }
-        if self.rejected_not_passing_filter > 0 {
-            summary.insert(RejectionReason::NotPassingFilter, self.rejected_not_passing_filter);
-        }
-        if self.rejected_low_mean_quality > 0 {
-            summary.insert(RejectionReason::LowMeanQuality, self.rejected_low_mean_quality);
-        }
-        if self.rejected_insufficient_min_depth > 0 {
-            summary.insert(
-                RejectionReason::InsufficientMinDepth,
-                self.rejected_insufficient_min_depth,
-            );
-        }
-        if self.rejected_excessive_error_rate > 0 {
-            summary.insert(RejectionReason::ExcessiveErrorRate, self.rejected_excessive_error_rate);
-        }
-        if self.rejected_umi_too_short > 0 {
-            summary.insert(RejectionReason::UmiTooShort, self.rejected_umi_too_short);
-        }
-        if self.rejected_same_strand_only > 0 {
-            summary.insert(RejectionReason::SameStrandOnly, self.rejected_same_strand_only);
-        }
-        if self.rejected_duplicate_umi > 0 {
-            summary.insert(RejectionReason::DuplicateUmi, self.rejected_duplicate_umi);
-        }
-        if self.rejected_orphan_consensus > 0 {
-            summary.insert(RejectionReason::OrphanConsensus, self.rejected_orphan_consensus);
-        }
-        if self.rejected_zero_bases_post_trimming > 0 {
-            summary.insert(
-                RejectionReason::ZeroBasesPostTrimming,
-                self.rejected_zero_bases_post_trimming,
-            );
-        }
-
-        summary
+        ALL_REJECTIONS
+            .iter()
+            .filter_map(|&reason| {
+                let count = self.rejection_count(reason);
+                if count > 0 { Some((reason, count)) } else { None }
+            })
+            .collect()
     }
 
     /// Converts metrics to fgbio-compatible key-value-description format.
@@ -296,61 +293,37 @@ impl ConsensusMetrics {
         let mut metrics = Vec::new();
 
         let raw_reads_used = self.total_input_reads.saturating_sub(self.filtered_reads);
-        let frac_used = if self.total_input_reads == 0 {
-            0.0
-        } else {
-            #[expect(clippy::cast_precision_loss, reason = "read counts never exceed 2^53")]
-            let numerator = raw_reads_used as f64;
-            #[expect(clippy::cast_precision_loss, reason = "read counts never exceed 2^53")]
-            let denominator = self.total_input_reads as f64;
-            numerator / denominator
-        };
+        let frac_used = frac_u64(raw_reads_used, self.total_input_reads);
 
-        // Core metrics matching fgbio's output
-        let core = [
-            (
-                "raw_reads_considered",
-                self.total_input_reads.to_string(),
-                "Total raw reads considered from input file",
-            ),
-            (
-                "raw_reads_rejected",
-                self.filtered_reads.to_string(),
-                "Total number of raw reads rejected before consensus calling",
-            ),
-            (
-                "raw_reads_used",
-                raw_reads_used.to_string(),
-                "Total count of raw reads used in consensus reads",
-            ),
-            (
-                "frac_raw_reads_used",
-                format_float(frac_used),
-                "Fraction of raw reads used in consensus reads",
-            ),
-            (
-                "raw_reads_rejected_for_insufficient_support",
-                self.rejected_insufficient_support.to_string(),
-                "Insufficient reads to generate a consensus",
-            ),
-            (
-                "raw_reads_rejected_for_minority_alignment",
-                self.rejected_minority_alignment.to_string(),
-                "Read has a different, and minority, set of indels",
-            ),
-            (
-                "raw_reads_rejected_for_orphan_consensus",
-                self.rejected_orphan_consensus.to_string(),
-                "Only one of R1 or R2 consensus generated",
-            ),
-            (
-                "raw_reads_rejected_for_zero_bases_post_trimming",
-                self.rejected_zero_bases_post_trimming.to_string(),
-                "Read or mate had zero bases post trimming",
-            ),
-        ];
-        for (key, value, description) in core {
-            metrics.push(ConsensusKvMetric::new(key, value, description));
+        // Core pipeline metrics
+        metrics.push(ConsensusKvMetric::new(
+            "raw_reads_considered",
+            self.total_input_reads.to_string(),
+            "Total raw reads considered from input file",
+        ));
+        metrics.push(ConsensusKvMetric::new(
+            "raw_reads_rejected",
+            self.filtered_reads.to_string(),
+            "Total number of raw reads rejected before consensus calling",
+        ));
+        metrics.push(ConsensusKvMetric::new(
+            "raw_reads_used",
+            raw_reads_used.to_string(),
+            "Total count of raw reads used in consensus reads",
+        ));
+        metrics.push(ConsensusKvMetric::new(
+            "frac_raw_reads_used",
+            format_float(frac_used),
+            "Fraction of raw reads used in consensus reads",
+        ));
+
+        // Core rejection reasons (always included)
+        for reason in &CORE_REJECTIONS {
+            metrics.push(ConsensusKvMetric::new(
+                reason.tsv_key(),
+                self.rejection_count(*reason).to_string(),
+                reason.kv_description(),
+            ));
         }
 
         // Optional rejection reasons (only included when non-zero)
@@ -368,81 +341,14 @@ impl ConsensusMetrics {
 
     /// Appends fgumi-specific rejection metrics with non-zero counts.
     fn push_optional_rejections(&self, metrics: &mut Vec<ConsensusKvMetric>) {
-        let optional = [
-            (
-                "raw_reads_rejected_for_insufficient_strand_support",
-                self.rejected_insufficient_strand_support,
-                "Insufficient strand support for consensus",
-            ),
-            (
-                "raw_reads_rejected_for_low_base_quality",
-                self.rejected_low_base_quality,
-                "Low base quality",
-            ),
-            (
-                "raw_reads_rejected_for_excessive_n_bases",
-                self.rejected_excessive_n_bases,
-                "Excessive N bases in read",
-            ),
-            (
-                "raw_reads_rejected_for_no_valid_alignment",
-                self.rejected_no_valid_alignment,
-                "No valid alignment found",
-            ),
-            (
-                "raw_reads_rejected_for_low_mapping_quality",
-                self.rejected_low_mapping_quality,
-                "Low mapping quality",
-            ),
-            (
-                "raw_reads_rejected_for_n_bases_in_umi",
-                self.rejected_n_bases_in_umi,
-                "N bases in UMI sequence",
-            ),
-            (
-                "raw_reads_rejected_for_missing_umi",
-                self.rejected_missing_umi,
-                "Read lacks required UMI tag",
-            ),
-            (
-                "raw_reads_rejected_for_not_passing_filter",
-                self.rejected_not_passing_filter,
-                "Read did not pass vendor filter",
-            ),
-            (
-                "raw_reads_rejected_for_low_mean_quality",
-                self.rejected_low_mean_quality,
-                "Low mean base quality",
-            ),
-            (
-                "raw_reads_rejected_for_insufficient_min_depth",
-                self.rejected_insufficient_min_depth,
-                "Insufficient minimum read depth",
-            ),
-            (
-                "raw_reads_rejected_for_excessive_error_rate",
-                self.rejected_excessive_error_rate,
-                "Excessive error rate",
-            ),
-            (
-                "raw_reads_rejected_for_umi_too_short",
-                self.rejected_umi_too_short,
-                "UMI sequence too short",
-            ),
-            (
-                "raw_reads_rejected_for_single_strand_only",
-                self.rejected_same_strand_only,
-                "Only generating one strand of duplex consensus",
-            ),
-            (
-                "raw_reads_rejected_for_duplicate_umi",
-                self.rejected_duplicate_umi,
-                "Duplicate UMI detected",
-            ),
-        ];
-        for (key, count, description) in optional {
+        for reason in &OPTIONAL_REJECTIONS {
+            let count = self.rejection_count(*reason);
             if count > 0 {
-                metrics.push(ConsensusKvMetric::new(key, count.to_string(), description));
+                metrics.push(ConsensusKvMetric::new(
+                    reason.tsv_key(),
+                    count.to_string(),
+                    reason.kv_description(),
+                ));
             }
         }
     }

--- a/crates/fgumi-metrics/src/correct.rs
+++ b/crates/fgumi-metrics/src/correct.rs
@@ -2,8 +2,7 @@
 //!
 //! This module provides metrics for tracking UMI correction operations.
 
-use anyhow::{Context, Result};
-use fgoxide::io::DelimFile;
+use anyhow::Result;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::Path;
 
@@ -141,9 +140,7 @@ impl UmiCorrectionMetrics {
     ///
     /// Returns an error if the file cannot be created or written to.
     pub fn write_metrics(metrics: &[Self], path: &Path) -> Result<()> {
-        DelimFile::default()
-            .write_tsv(path, metrics)
-            .with_context(|| format!("Failed to write UMI correction metrics: {}", path.display()))
+        crate::writer::write_metrics_auto(path, metrics)
     }
 
     /// Reads metrics from a TSV file.
@@ -161,9 +158,7 @@ impl UmiCorrectionMetrics {
     /// - The file format is invalid
     /// - Any values cannot be parsed
     pub fn read_metrics(path: &Path) -> Result<Vec<Self>> {
-        DelimFile::default()
-            .read_tsv(path)
-            .with_context(|| format!("Failed to read UMI correction metrics: {}", path.display()))
+        crate::writer::read_metrics_auto(path)
     }
 }
 

--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::Metric;
+use crate::{Metric, frac};
 
 /// Metrics quantifying the distribution of different kinds of read family sizes.
 ///
@@ -272,6 +272,54 @@ impl Metric for DuplexUmiMetric {
     }
 }
 
+/// Tracks raw, error, and unique UMI observation counts.
+#[allow(clippy::struct_field_names)]
+struct UmiCountTracker {
+    raw_counts: HashMap<String, usize>,
+    error_counts: HashMap<String, usize>,
+    unique_counts: HashMap<String, usize>,
+}
+
+impl UmiCountTracker {
+    /// Creates an empty tracker.
+    fn new() -> Self {
+        Self {
+            raw_counts: HashMap::new(),
+            error_counts: HashMap::new(),
+            unique_counts: HashMap::new(),
+        }
+    }
+
+    /// Records an observation for a UMI.
+    fn record(&mut self, umi: &str, raw_count: usize, error_count: usize, is_unique: bool) {
+        let key = umi.to_string();
+        *self.raw_counts.entry(key.clone()).or_insert(0) += raw_count;
+        *self.error_counts.entry(key.clone()).or_insert(0) += error_count;
+        if is_unique {
+            *self.unique_counts.entry(key).or_insert(0) += 1;
+        }
+    }
+
+    /// Total raw observations across all UMIs.
+    fn total_raw(&self) -> usize {
+        self.raw_counts.values().sum()
+    }
+
+    /// Total unique observations across all UMIs.
+    fn total_unique(&self) -> usize {
+        self.unique_counts.values().sum()
+    }
+
+    /// Iterates over all tracked UMIs, yielding `(umi, raw_count, error_count, unique_count)`.
+    fn iter(&self) -> impl Iterator<Item = (&str, usize, usize, usize)> {
+        self.raw_counts.iter().map(|(umi, &raw)| {
+            let errors = self.error_counts.get(umi).copied().unwrap_or(0);
+            let unique = self.unique_counts.get(umi).copied().unwrap_or(0);
+            (umi.as_str(), raw, errors, unique)
+        })
+    }
+}
+
 /// Collector for duplex sequencing metrics.
 ///
 /// Tracks family sizes, UMI frequencies, and yields at multiple sampling levels.
@@ -286,12 +334,8 @@ pub struct DuplexMetricsCollector {
     duplex_family_sizes: HashMap<(usize, usize), usize>,
 
     // UMI tracking
-    umi_raw_counts: HashMap<String, usize>,
-    umi_raw_error_counts: HashMap<String, usize>,
-    umi_unique_counts: HashMap<String, usize>,
-    duplex_umi_raw_counts: HashMap<String, usize>,
-    duplex_umi_raw_error_counts: HashMap<String, usize>,
-    duplex_umi_unique_counts: HashMap<String, usize>,
+    umi_counts: UmiCountTracker,
+    duplex_umi_counts: UmiCountTracker,
 }
 
 impl DuplexMetricsCollector {
@@ -304,12 +348,8 @@ impl DuplexMetricsCollector {
             ss_family_sizes: HashMap::new(),
             ds_family_sizes: HashMap::new(),
             duplex_family_sizes: HashMap::new(),
-            umi_raw_counts: HashMap::new(),
-            umi_raw_error_counts: HashMap::new(),
-            umi_unique_counts: HashMap::new(),
-            duplex_umi_raw_counts: HashMap::new(),
-            duplex_umi_raw_error_counts: HashMap::new(),
-            duplex_umi_unique_counts: HashMap::new(),
+            umi_counts: UmiCountTracker::new(),
+            duplex_umi_counts: UmiCountTracker::new(),
         }
     }
 
@@ -343,12 +383,7 @@ impl DuplexMetricsCollector {
     /// * `error_count` - Number of raw observations that had errors (differed from consensus)
     /// * `is_unique` - Whether this is a unique family observation
     pub fn record_umi(&mut self, umi: &str, raw_count: usize, error_count: usize, is_unique: bool) {
-        let key = umi.to_string();
-        *self.umi_raw_counts.entry(key.clone()).or_insert(0) += raw_count;
-        *self.umi_raw_error_counts.entry(key.clone()).or_insert(0) += error_count;
-        if is_unique {
-            *self.umi_unique_counts.entry(key).or_insert(0) += 1;
-        }
+        self.umi_counts.record(umi, raw_count, error_count, is_unique);
     }
 
     /// Records a duplex UMI observation
@@ -368,12 +403,7 @@ impl DuplexMetricsCollector {
         if !self.collect_duplex_umi_counts {
             return;
         }
-        let key = umi.to_string();
-        *self.duplex_umi_raw_counts.entry(key.clone()).or_insert(0) += raw_count;
-        *self.duplex_umi_raw_error_counts.entry(key.clone()).or_insert(0) += error_count;
-        if is_unique {
-            *self.duplex_umi_unique_counts.entry(key).or_insert(0) += 1;
-        }
+        self.duplex_umi_counts.record(umi, raw_count, error_count, is_unique);
     }
 
     /// Generates family size metrics
@@ -403,34 +433,13 @@ impl DuplexMetricsCollector {
             let mut metric = FamilySizeMetric::new(size);
 
             metric.cs_count = *self.cs_family_sizes.get(&size).unwrap_or(&0);
-            #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-            {
-                metric.cs_fraction = if coord_strand_total > 0 {
-                    metric.cs_count as f64 / coord_strand_total as f64
-                } else {
-                    0.0
-                };
-            }
+            metric.cs_fraction = frac(metric.cs_count, coord_strand_total);
 
             metric.ss_count = *self.ss_family_sizes.get(&size).unwrap_or(&0);
-            #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-            {
-                metric.ss_fraction = if single_strand_total > 0 {
-                    metric.ss_count as f64 / single_strand_total as f64
-                } else {
-                    0.0
-                };
-            }
+            metric.ss_fraction = frac(metric.ss_count, single_strand_total);
 
             metric.ds_count = *self.ds_family_sizes.get(&size).unwrap_or(&0);
-            #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-            {
-                metric.ds_fraction = if double_strand_total > 0 {
-                    metric.ds_count as f64 / double_strand_total as f64
-                } else {
-                    0.0
-                };
-            }
+            metric.ds_fraction = frac(metric.ds_count, double_strand_total);
 
             metrics.push(metric);
         }
@@ -463,10 +472,7 @@ impl DuplexMetricsCollector {
             .map(|((ab, ba), count)| {
                 let mut metric = DuplexFamilySizeMetric::new(*ab, *ba);
                 metric.count = *count;
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction = if total > 0 { *count as f64 / total as f64 } else { 0.0 };
-                }
+                metric.fraction = frac(*count, total);
                 metric
             })
             .collect();
@@ -499,10 +505,7 @@ impl DuplexMetricsCollector {
             }
             for metric in &mut metrics {
                 let cumulative_count = grid[metric.ab_size * cols + metric.ba_size];
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction_gt_or_eq_size = cumulative_count as f64 / total as f64;
-                }
+                metric.fraction_gt_or_eq_size = frac(cumulative_count, total);
             }
         }
 
@@ -512,34 +515,19 @@ impl DuplexMetricsCollector {
     /// Generates UMI metrics
     #[must_use]
     pub fn umi_metrics(&self) -> Vec<UmiMetric> {
-        let total_raw: usize = self.umi_raw_counts.values().sum();
-        let total_unique: usize = self.umi_unique_counts.values().sum();
+        let total_raw = self.umi_counts.total_raw();
+        let total_unique = self.umi_counts.total_unique();
 
         let mut metrics: Vec<_> = self
-            .umi_raw_counts
-            .keys()
-            .map(|umi| {
-                let mut metric = UmiMetric::new(umi.clone());
-                metric.raw_observations = *self.umi_raw_counts.get(umi).unwrap_or(&0);
-                metric.raw_observations_with_errors =
-                    *self.umi_raw_error_counts.get(umi).unwrap_or(&0);
-                metric.unique_observations = *self.umi_unique_counts.get(umi).unwrap_or(&0);
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction_raw_observations = if total_raw > 0 {
-                        metric.raw_observations as f64 / total_raw as f64
-                    } else {
-                        0.0
-                    };
-                }
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction_unique_observations = if total_unique > 0 {
-                        metric.unique_observations as f64 / total_unique as f64
-                    } else {
-                        0.0
-                    };
-                }
+            .umi_counts
+            .iter()
+            .map(|(umi, raw, errors, unique)| {
+                let mut metric = UmiMetric::new(umi.to_string());
+                metric.raw_observations = raw;
+                metric.raw_observations_with_errors = errors;
+                metric.unique_observations = unique;
+                metric.fraction_raw_observations = frac(raw, total_raw);
+                metric.fraction_unique_observations = frac(unique, total_unique);
                 metric
             })
             .collect();
@@ -563,34 +551,19 @@ impl DuplexMetricsCollector {
         let single_umi_fractions: HashMap<&str, f64> =
             umi_metrics.iter().map(|m| (m.umi.as_str(), m.fraction_unique_observations)).collect();
 
-        let total_raw: usize = self.duplex_umi_raw_counts.values().sum();
-        let total_unique: usize = self.duplex_umi_unique_counts.values().sum();
+        let total_raw = self.duplex_umi_counts.total_raw();
+        let total_unique = self.duplex_umi_counts.total_unique();
 
         let mut metrics: Vec<_> = self
-            .duplex_umi_raw_counts
-            .keys()
-            .map(|umi| {
-                let mut metric = DuplexUmiMetric::new(umi.clone());
-                metric.raw_observations = *self.duplex_umi_raw_counts.get(umi).unwrap_or(&0);
-                metric.raw_observations_with_errors =
-                    *self.duplex_umi_raw_error_counts.get(umi).unwrap_or(&0);
-                metric.unique_observations = *self.duplex_umi_unique_counts.get(umi).unwrap_or(&0);
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction_raw_observations = if total_raw > 0 {
-                        metric.raw_observations as f64 / total_raw as f64
-                    } else {
-                        0.0
-                    };
-                }
-                #[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
-                {
-                    metric.fraction_unique_observations = if total_unique > 0 {
-                        metric.unique_observations as f64 / total_unique as f64
-                    } else {
-                        0.0
-                    };
-                }
+            .duplex_umi_counts
+            .iter()
+            .map(|(umi, raw, errors, unique)| {
+                let mut metric = DuplexUmiMetric::new(umi.to_string());
+                metric.raw_observations = raw;
+                metric.raw_observations_with_errors = errors;
+                metric.unique_observations = unique;
+                metric.fraction_raw_observations = frac(raw, total_raw);
+                metric.fraction_unique_observations = frac(unique, total_unique);
 
                 // Calculate expected fraction based on individual UMI frequencies
                 // Expected frequency = freq(umi1) * freq(umi2) assuming independence
@@ -616,6 +589,35 @@ impl DuplexMetricsCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // UmiCountTracker tests
+    // =========================================================================
+
+    #[test]
+    fn test_umi_count_tracker_empty() {
+        let tracker = UmiCountTracker::new();
+        assert_eq!(tracker.total_raw(), 0);
+        assert_eq!(tracker.total_unique(), 0);
+        assert_eq!(tracker.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_umi_count_tracker_record_and_iter() {
+        let mut tracker = UmiCountTracker::new();
+        tracker.record("AAAA", 10, 2, true);
+        tracker.record("AAAA", 5, 1, false);
+        tracker.record("CCCC", 8, 0, true);
+
+        assert_eq!(tracker.total_raw(), 23); // 15 + 8
+        assert_eq!(tracker.total_unique(), 2); // 1 + 1
+
+        let mut items: Vec<_> = tracker.iter().collect();
+        items.sort_by(|a, b| a.0.cmp(b.0));
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], ("AAAA", 15, 3, 1));
+        assert_eq!(items[1], ("CCCC", 8, 0, 1));
+    }
 
     // =========================================================================
     // FamilySizeMetric tests

--- a/crates/fgumi-metrics/src/group.rs
+++ b/crates/fgumi-metrics/src/group.rs
@@ -11,7 +11,7 @@ use crate::Metric;
 ///
 /// These metrics track how reads are grouped by UMI and provide insight into
 /// data quality and molecule representation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UmiGroupingMetrics {
     /// Total SAM records processed
     pub total_records: u64,
@@ -54,26 +54,7 @@ impl UmiGroupingMetrics {
     /// Creates a new UMI grouping metrics struct with all counts initialized to zero.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            total_records: 0,
-            accepted_records: 0,
-            discarded_non_pf: 0,
-            discarded_poor_alignment: 0,
-            discarded_ns_in_umi: 0,
-            discarded_umi_too_short: 0,
-            unique_molecule_ids: 0,
-            total_families: 0,
-            avg_reads_per_molecule: 0.0,
-            median_reads_per_molecule: 0,
-            min_reads_per_molecule: 0,
-            max_reads_per_molecule: 0,
-        }
-    }
-}
-
-impl Default for UmiGroupingMetrics {
-    fn default() -> Self {
-        Self::new()
+        Self::default()
     }
 }
 

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -38,6 +38,20 @@ pub fn format_float(value: f64) -> String {
     format!("{value:.FLOAT_PRECISION$}")
 }
 
+/// Computes `numerator / denominator`, returning 0.0 if the denominator is zero.
+#[must_use]
+#[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
+pub fn frac(numerator: usize, denominator: usize) -> f64 {
+    if denominator > 0 { numerator as f64 / denominator as f64 } else { 0.0 }
+}
+
+/// Computes `numerator / denominator` for `u64` values, returning 0.0 if denominator is zero.
+#[must_use]
+#[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
+pub fn frac_u64(numerator: u64, denominator: u64) -> f64 {
+    if denominator > 0 { numerator as f64 / denominator as f64 } else { 0.0 }
+}
+
 /// A metric type that can be serialized to TSV files.
 ///
 /// All metric types in fgumi implement this trait, providing a consistent
@@ -65,19 +79,13 @@ pub trait ProcessingMetrics {
 
     /// Processing efficiency as a percentage (output / input * 100).
     fn efficiency(&self) -> f64 {
-        if self.total_input() == 0 {
-            0.0
-        } else {
-            #[expect(clippy::cast_precision_loss, reason = "read counts never exceed 2^53")]
-            let result = self.total_output() as f64 / self.total_input() as f64 * 100.0;
-            result
-        }
+        frac_u64(self.total_output(), self.total_input()) * 100.0
     }
 }
 
 // Re-export commonly used types
 #[cfg(feature = "clip")]
-pub use clip::{ClippingMetrics, ClippingMetricsCollection, ReadType};
+pub use clip::{ClipCounts, ClippingMetrics, ClippingMetricsCollection, ReadType};
 pub use consensus::{ConsensusKvMetric, ConsensusMetrics};
 pub use correct::UmiCorrectionMetrics;
 pub use duplex::{
@@ -86,11 +94,41 @@ pub use duplex::{
 };
 pub use group::{FamilySizeMetrics, UmiGroupingMetrics};
 pub use rejection::{RejectionReason, format_count};
-pub use writer::write_metrics;
+pub use writer::{read_metrics, read_metrics_auto, write_metrics};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_frac_normal() {
+        assert!((frac(3, 4) - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_frac_zero_denominator() {
+        assert!((frac(5, 0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_frac_zero_numerator() {
+        assert!((frac(0, 10)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_frac_u64_normal() {
+        assert!((frac_u64(3, 4) - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_frac_u64_zero_denominator() {
+        assert!((frac_u64(5, 0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_frac_u64_zero_numerator() {
+        assert!((frac_u64(0, 10)).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn test_processing_metrics_consensus() {

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -75,6 +75,58 @@ impl RejectionReason {
             Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
         }
     }
+
+    /// Returns the TSV metric key for this rejection reason.
+    #[must_use]
+    pub fn tsv_key(&self) -> &'static str {
+        match self {
+            Self::InsufficientSupport => "raw_reads_rejected_for_insufficient_support",
+            Self::MinorityAlignment => "raw_reads_rejected_for_minority_alignment",
+            Self::InsufficientStrandSupport => {
+                "raw_reads_rejected_for_insufficient_strand_support"
+            }
+            Self::LowBaseQuality => "raw_reads_rejected_for_low_base_quality",
+            Self::ExcessiveNBases => "raw_reads_rejected_for_excessive_n_bases",
+            Self::NoValidAlignment => "raw_reads_rejected_for_no_valid_alignment",
+            Self::LowMappingQuality => "raw_reads_rejected_for_low_mapping_quality",
+            Self::NBasesInUmi => "raw_reads_rejected_for_n_bases_in_umi",
+            Self::MissingUmi => "raw_reads_rejected_for_missing_umi",
+            Self::NotPassingFilter => "raw_reads_rejected_for_not_passing_filter",
+            Self::LowMeanQuality => "raw_reads_rejected_for_low_mean_quality",
+            Self::InsufficientMinDepth => "raw_reads_rejected_for_insufficient_min_depth",
+            Self::ExcessiveErrorRate => "raw_reads_rejected_for_excessive_error_rate",
+            Self::UmiTooShort => "raw_reads_rejected_for_umi_too_short",
+            Self::SameStrandOnly => "raw_reads_rejected_for_single_strand_only",
+            Self::DuplicateUmi => "raw_reads_rejected_for_duplicate_umi",
+            Self::OrphanConsensus => "raw_reads_rejected_for_orphan_consensus",
+            Self::ZeroBasesPostTrimming => "raw_reads_rejected_for_zero_bases_post_trimming",
+        }
+    }
+
+    /// Returns a short description for key-value metrics output.
+    #[must_use]
+    pub fn kv_description(&self) -> &'static str {
+        match self {
+            Self::InsufficientSupport => "Insufficient reads to generate a consensus",
+            Self::MinorityAlignment => "Read has a different, and minority, set of indels",
+            Self::InsufficientStrandSupport => "Insufficient strand support for consensus",
+            Self::LowBaseQuality => "Low base quality",
+            Self::ExcessiveNBases => "Excessive N bases in read",
+            Self::NoValidAlignment => "No valid alignment found",
+            Self::LowMappingQuality => "Low mapping quality",
+            Self::NBasesInUmi => "N bases in UMI sequence",
+            Self::MissingUmi => "Read lacks required UMI tag",
+            Self::NotPassingFilter => "Read did not pass vendor filter",
+            Self::LowMeanQuality => "Low mean base quality",
+            Self::InsufficientMinDepth => "Insufficient minimum read depth",
+            Self::ExcessiveErrorRate => "Excessive error rate",
+            Self::UmiTooShort => "UMI sequence too short",
+            Self::SameStrandOnly => "Only generating one strand of duplex consensus",
+            Self::DuplicateUmi => "Duplicate UMI detected",
+            Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
+            Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
+        }
+    }
 }
 
 impl fmt::Display for RejectionReason {
@@ -84,10 +136,6 @@ impl fmt::Display for RejectionReason {
 }
 
 /// Formats a count with thousands separators.
-///
-/// # Panics
-///
-/// Cannot panic: input is always valid UTF-8 since it comes from `u64::to_string()`.
 ///
 /// # Examples
 ///
@@ -101,13 +149,16 @@ impl fmt::Display for RejectionReason {
 pub fn format_count(n: u64) -> String {
     let s = n.to_string();
     let bytes = s.as_bytes();
-
-    bytes
-        .rchunks(3)
-        .rev()
-        .map(|chunk| std::str::from_utf8(chunk).unwrap())
-        .collect::<Vec<_>>()
-        .join(",")
+    let len = bytes.len();
+    let num_commas = if len > 3 { (len - 1) / 3 } else { 0 };
+    let mut result = String::with_capacity(len + num_commas);
+    for (i, &byte) in bytes.iter().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            result.push(',');
+        }
+        result.push(byte as char);
+    }
+    result
 }
 
 #[cfg(test)]
@@ -122,6 +173,65 @@ mod tests {
             RejectionReason::MinorityAlignment.to_string(),
             "Read has a different, and minority, set of indels"
         );
+    }
+
+    #[test]
+    fn test_tsv_key_prefix() {
+        let all_reasons = [
+            RejectionReason::InsufficientSupport,
+            RejectionReason::MinorityAlignment,
+            RejectionReason::InsufficientStrandSupport,
+            RejectionReason::LowBaseQuality,
+            RejectionReason::ExcessiveNBases,
+            RejectionReason::NoValidAlignment,
+            RejectionReason::LowMappingQuality,
+            RejectionReason::NBasesInUmi,
+            RejectionReason::MissingUmi,
+            RejectionReason::NotPassingFilter,
+            RejectionReason::LowMeanQuality,
+            RejectionReason::InsufficientMinDepth,
+            RejectionReason::ExcessiveErrorRate,
+            RejectionReason::UmiTooShort,
+            RejectionReason::SameStrandOnly,
+            RejectionReason::DuplicateUmi,
+            RejectionReason::OrphanConsensus,
+            RejectionReason::ZeroBasesPostTrimming,
+        ];
+        for reason in &all_reasons {
+            assert!(
+                reason.tsv_key().starts_with("raw_reads_rejected_for_"),
+                "tsv_key for {:?} does not have expected prefix: {}",
+                reason,
+                reason.tsv_key()
+            );
+        }
+    }
+
+    #[test]
+    fn test_kv_description_non_empty() {
+        let all_reasons = [
+            RejectionReason::InsufficientSupport,
+            RejectionReason::MinorityAlignment,
+            RejectionReason::InsufficientStrandSupport,
+            RejectionReason::LowBaseQuality,
+            RejectionReason::ExcessiveNBases,
+            RejectionReason::NoValidAlignment,
+            RejectionReason::LowMappingQuality,
+            RejectionReason::NBasesInUmi,
+            RejectionReason::MissingUmi,
+            RejectionReason::NotPassingFilter,
+            RejectionReason::LowMeanQuality,
+            RejectionReason::InsufficientMinDepth,
+            RejectionReason::ExcessiveErrorRate,
+            RejectionReason::UmiTooShort,
+            RejectionReason::SameStrandOnly,
+            RejectionReason::DuplicateUmi,
+            RejectionReason::OrphanConsensus,
+            RejectionReason::ZeroBasesPostTrimming,
+        ];
+        for reason in &all_reasons {
+            assert!(!reason.kv_description().is_empty(), "kv_description for {:?} is empty", reason);
+        }
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/writer.rs
+++ b/crates/fgumi-metrics/src/writer.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use fgoxide::io::DelimFile;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::Metric;
@@ -76,6 +76,37 @@ pub fn write_metrics<P: AsRef<Path>, T: Serialize>(
 /// ```
 pub fn write_metrics_auto<P: AsRef<Path>, T: Metric>(path: P, metrics: &[T]) -> Result<()> {
     write_metrics(path, metrics, T::metric_name())
+}
+
+/// Read metrics from a TSV file with consistent error handling.
+///
+/// # Arguments
+/// * `path` - Path to the TSV file
+/// * `description` - Human-readable description for error messages
+///
+/// # Errors
+/// Returns an error if the file cannot be read or parsed
+pub fn read_metrics<P: AsRef<Path>, T: for<'de> Deserialize<'de>>(
+    path: P,
+    description: &str,
+) -> Result<Vec<T>> {
+    let path_ref = path.as_ref();
+    DelimFile::default()
+        .read_tsv(path_ref)
+        .with_context(|| format!("Failed to read {} metrics: {}", description, path_ref.display()))
+}
+
+/// Read metrics implementing the Metric trait from a TSV file.
+///
+/// Uses the metric's own name for error messages.
+///
+/// # Arguments
+/// * `path` - Path to the TSV file
+///
+/// # Errors
+/// Returns an error if the file cannot be read or parsed
+pub fn read_metrics_auto<P: AsRef<Path>, T: Metric>(path: P) -> Result<Vec<T>> {
+    read_metrics(path, T::metric_name())
 }
 
 #[cfg(test)]
@@ -177,6 +208,44 @@ mod tests {
         let content = fs::read_to_string(temp_file.path())?;
         assert!(content.contains("auto"));
         assert!(content.contains("42"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_metrics_roundtrip() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let original = vec![
+            TestMetrics { name: "a".to_string(), count: 1, value: 1.1 },
+            TestMetrics { name: "b".to_string(), count: 2, value: 2.2 },
+        ];
+
+        write_metrics(temp_file.path(), &original, "test")?;
+        let read_back: Vec<TestMetrics> = read_metrics(temp_file.path(), "test")?;
+
+        assert_eq!(original, read_back);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_metrics_invalid_path() {
+        let result: Result<Vec<TestMetrics>> =
+            read_metrics("/nonexistent/path/file.tsv", "test");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Failed to read test metrics"));
+    }
+
+    #[test]
+    fn test_read_metrics_auto_roundtrip() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let original = vec![TestMetrics { name: "auto".to_string(), count: 42, value: 3.14 }];
+
+        write_metrics_auto(temp_file.path(), &original)?;
+        let read_back: Vec<TestMetrics> = read_metrics_auto(temp_file.path())?;
+
+        assert_eq!(original, read_back);
 
         Ok(())
     }

--- a/src/commands/clip.rs
+++ b/src/commands/clip.rs
@@ -14,7 +14,7 @@ use fgumi_lib::bam_io::{
 use fgumi_lib::clipper::{ClippingMode, SamRecordClipper};
 use fgumi_lib::grouper::TemplateGrouper;
 use fgumi_lib::logging::OperationTimer;
-use fgumi_lib::metrics::clip::ClippingMetricsCollection;
+use fgumi_lib::metrics::clip::{ClipCounts, ClippingMetricsCollection};
 use fgumi_lib::metrics::writer::write_metrics as write_metrics_tsv;
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::reference::ReferenceReader;
@@ -472,11 +472,12 @@ impl Clip {
         if let Some(metrics) = metrics {
             metrics.fragment.update(
                 record,
-                prior_bases_clipped,
-                num_five_prime,
-                num_three_prime,
-                0, // no overlapping
-                0, // no extending
+                ClipCounts {
+                    prior: prior_bases_clipped,
+                    five_prime: num_five_prime,
+                    three_prime: num_three_prime,
+                    ..ClipCounts::default()
+                },
             );
         }
 
@@ -580,45 +581,32 @@ impl Clip {
 
         // Update metrics
         if let Some(metrics) = metrics {
+            let r1_counts = ClipCounts {
+                prior: prior_bases_clipped_r1,
+                five_prime: num_r1_five_prime,
+                three_prime: num_r1_three_prime,
+                overlapping: num_overlapping_r1,
+                extending: num_extending_r1,
+            };
+            let r2_counts = ClipCounts {
+                prior: prior_bases_clipped_r2,
+                five_prime: num_r2_five_prime,
+                three_prime: num_r2_three_prime,
+                overlapping: num_overlapping_r2,
+                extending: num_extending_r2,
+            };
+
             // Determine which metric to update based on read flags
             if is_r1_first {
-                metrics.read_one.update(
-                    r1,
-                    prior_bases_clipped_r1,
-                    num_r1_five_prime,
-                    num_r1_three_prime,
-                    num_overlapping_r1,
-                    num_extending_r1,
-                );
+                metrics.read_one.update(r1, r1_counts);
             } else {
-                metrics.read_two.update(
-                    r1,
-                    prior_bases_clipped_r1,
-                    num_r1_five_prime,
-                    num_r1_three_prime,
-                    num_overlapping_r1,
-                    num_extending_r1,
-                );
+                metrics.read_two.update(r1, r1_counts);
             }
 
             if is_r2_last {
-                metrics.read_two.update(
-                    r2,
-                    prior_bases_clipped_r2,
-                    num_r2_five_prime,
-                    num_r2_three_prime,
-                    num_overlapping_r2,
-                    num_extending_r2,
-                );
+                metrics.read_two.update(r2, r2_counts);
             } else {
-                metrics.read_one.update(
-                    r2,
-                    prior_bases_clipped_r2,
-                    num_r2_five_prime,
-                    num_r2_three_prime,
-                    num_overlapping_r2,
-                    num_extending_r2,
-                );
+                metrics.read_one.update(r2, r2_counts);
             }
         }
 
@@ -2487,5 +2475,221 @@ mod tests {
             estimate >= vec_overhead,
             "estimate {estimate} should include Vec<RecordBuf> overhead {vec_overhead}"
         );
+    }
+
+    /// Helper to create a `Clip` struct with specified clipping parameters and
+    /// all other fields set to sensible defaults.
+    fn make_clip(
+        read_one_five_prime: usize,
+        read_one_three_prime: usize,
+        read_two_five_prime: usize,
+        read_two_three_prime: usize,
+    ) -> Clip {
+        Clip {
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+            },
+            reference: PathBuf::from("reference.fa"),
+            clipping_mode: "soft".to_string(),
+            clip_overlapping_reads: false,
+            clip_extending_past_mate: false,
+            regenerate_tags: true,
+            read_one_five_prime,
+            read_one_three_prime,
+            read_two_five_prime,
+            read_two_three_prime,
+            upgrade_clipping: false,
+            auto_clip_attributes: false,
+            metrics: None,
+            sort_order: None,
+            threading: ThreadingOptions::none(),
+            compression: CompressionOptions { compression_level: 1 },
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+        }
+    }
+
+    #[test]
+    fn test_clip_fragment_with_metrics() {
+        use fgumi_lib::clipper::{ClippingMode, SamRecordClipper};
+        use fgumi_lib::metrics::clip::ClippingMetricsCollection;
+        use fgumi_lib::sam::builder::RecordBuilder;
+
+        let clip = make_clip(3, 2, 0, 0);
+        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let mut metrics = ClippingMetricsCollection::new();
+
+        // Build a mapped fragment record with 20M CIGAR
+        let mut record = RecordBuilder::new()
+            .sequence("ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar("20M")
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+
+        clip.clip_fragment(&clipper, &mut record, Some(&mut metrics)).unwrap();
+
+        // Fragment metrics should be updated
+        assert_eq!(metrics.fragment.reads, 1);
+        assert_eq!(metrics.fragment.bases_clipped_five_prime, 3);
+        assert_eq!(metrics.fragment.bases_clipped_three_prime, 2);
+        // Remaining aligned bases: 20 - 3 - 2 = 15
+        assert_eq!(metrics.fragment.bases, 15);
+    }
+
+    #[test]
+    fn test_clip_fragment_no_clipping_with_metrics() {
+        use fgumi_lib::clipper::{ClippingMode, SamRecordClipper};
+        use fgumi_lib::metrics::clip::ClippingMetricsCollection;
+        use fgumi_lib::sam::builder::RecordBuilder;
+
+        let clip = make_clip(0, 0, 0, 0);
+        // Need at least one clipping option active for the Clip struct to be valid,
+        // but clip_fragment only uses read_one_*; we just test the method directly.
+        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let mut metrics = ClippingMetricsCollection::new();
+
+        let mut record = RecordBuilder::new()
+            .sequence("ACGTACGTACGT")
+            .qualities(&[30; 12])
+            .cigar("12M")
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+
+        clip.clip_fragment(&clipper, &mut record, Some(&mut metrics)).unwrap();
+
+        assert_eq!(metrics.fragment.reads, 1);
+        assert_eq!(metrics.fragment.bases, 12);
+        assert_eq!(metrics.fragment.bases_clipped_five_prime, 0);
+        assert_eq!(metrics.fragment.bases_clipped_three_prime, 0);
+    }
+
+    #[test]
+    fn test_clip_pair_with_metrics() {
+        use fgumi_lib::clipper::{ClippingMode, SamRecordClipper};
+        use fgumi_lib::metrics::clip::ClippingMetricsCollection;
+        use fgumi_lib::sam::builder::RecordBuilder;
+
+        let clip = make_clip(2, 1, 1, 2);
+        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let mut metrics = ClippingMetricsCollection::new();
+
+        // R1: first segment, forward strand, 20M
+        let mut r1 = RecordBuilder::new()
+            .name("pair1")
+            .sequence("ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar("20M")
+            .paired(true)
+            .first_segment(true)
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .mate_reference_sequence_id(0)
+            .mate_alignment_start(200)
+            .template_length(120)
+            .build();
+
+        // R2: last segment, reverse strand, 20M (non-overlapping)
+        let mut r2 = RecordBuilder::new()
+            .name("pair1")
+            .sequence("ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar("20M")
+            .paired(true)
+            .first_segment(false)
+            .reverse_complement(true)
+            .reference_sequence_id(0)
+            .alignment_start(200)
+            .mapping_quality(60)
+            .mate_reference_sequence_id(0)
+            .mate_alignment_start(100)
+            .template_length(-120)
+            .build();
+
+        let (overlap, extend) =
+            clip.clip_pair(&clipper, &mut r1, &mut r2, Some(&mut metrics)).unwrap();
+
+        assert!(!overlap, "no overlapping clipping expected");
+        assert!(!extend, "no extending clipping expected");
+
+        // R1 is first segment -> gets read_one clipping: 5'=2, 3'=1
+        assert_eq!(metrics.read_one.reads, 1);
+        assert_eq!(metrics.read_one.bases_clipped_five_prime, 2);
+        assert_eq!(metrics.read_one.bases_clipped_three_prime, 1);
+
+        // R2 is last segment -> gets read_two clipping: 5'=1, 3'=2
+        assert_eq!(metrics.read_two.reads, 1);
+        assert_eq!(metrics.read_two.bases_clipped_five_prime, 1);
+        assert_eq!(metrics.read_two.bases_clipped_three_prime, 2);
+    }
+
+    #[test]
+    fn test_clip_pair_with_metrics_swapped_flags() {
+        use fgumi_lib::clipper::{ClippingMode, SamRecordClipper};
+        use fgumi_lib::metrics::clip::ClippingMetricsCollection;
+        use fgumi_lib::sam::builder::RecordBuilder;
+
+        // Test the !is_r1_first and !is_r2_last branches:
+        // r1 is NOT first_segment, r2 is NOT last_segment
+        let clip = make_clip(2, 1, 1, 2);
+        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let mut metrics = ClippingMetricsCollection::new();
+
+        // r1: last segment (not first)
+        let mut r1 = RecordBuilder::new()
+            .name("pair1")
+            .sequence("ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar("20M")
+            .paired(true)
+            .first_segment(false)
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .mate_reference_sequence_id(0)
+            .mate_alignment_start(200)
+            .template_length(120)
+            .build();
+
+        // r2: first segment (not last)
+        let mut r2 = RecordBuilder::new()
+            .name("pair1")
+            .sequence("ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar("20M")
+            .paired(true)
+            .first_segment(true)
+            .reverse_complement(true)
+            .reference_sequence_id(0)
+            .alignment_start(200)
+            .mapping_quality(60)
+            .mate_reference_sequence_id(0)
+            .mate_alignment_start(100)
+            .template_length(-120)
+            .build();
+
+        let (overlap, extend) =
+            clip.clip_pair(&clipper, &mut r1, &mut r2, Some(&mut metrics)).unwrap();
+
+        assert!(!overlap);
+        assert!(!extend);
+
+        // r1 is not first_segment -> goes to read_two metrics
+        // r1 gets read_two clipping: 5'=1, 3'=2
+        assert_eq!(metrics.read_two.reads, 1);
+        assert_eq!(metrics.read_two.bases_clipped_five_prime, 1);
+        assert_eq!(metrics.read_two.bases_clipped_three_prime, 2);
+
+        // r2 is not last_segment -> goes to read_one metrics
+        // r2 gets read_one clipping: 5'=2, 3'=1
+        assert_eq!(metrics.read_one.reads, 1);
+        assert_eq!(metrics.read_one.bases_clipped_five_prime, 2);
+        assert_eq!(metrics.read_one.bases_clipped_three_prime, 1);
     }
 }

--- a/src/lib/metrics/mod.rs
+++ b/src/lib/metrics/mod.rs
@@ -33,4 +33,4 @@ pub use duplex::{
     FamilySizeMetric, UmiMetric,
 };
 pub use group::{FamilySizeMetrics, UmiGroupingMetrics};
-pub use writer::write_metrics;
+pub use writer::{read_metrics, write_metrics};


### PR DESCRIPTION
## Summary

- Add `frac()`/`frac_u64()` safe division utilities to centralize the repeated zero-denominator-check pattern (9+ call sites)
- Extract `UmiCountTracker` struct to replace 6 parallel `HashMap` fields in `DuplexMetricsCollector`, eliminating redundant `.keys()` + `.get()` lookups
- Introduce `ClipCounts` struct to bundle 5 clipping parameters into a single argument
- Add `tsv_key()`/`kv_description()` methods to `RejectionReason` with constant arrays and `rejection_count()` helper, simplifying `total_rejections()`, `rejection_summary()`, `push_optional_rejections()`, and `to_kv_metrics()`
- Add generic `read_metrics()`/`read_metrics_auto()` to `writer` module, delegate from `UmiCorrectionMetrics`
- Derive `Default` for `UmiGroupingMetrics`, implement `AddAssign` for `ClippingMetrics`, return `[&ClippingMetrics; 5]` from `all_metrics()`, optimize `format_count()` with direct string building

## Test plan

- [x] All 1834 existing tests pass unchanged (`cargo ci-test`)
- [x] Formatting passes (`cargo ci-fmt`)
- [x] Linting passes (`cargo ci-lint`)
- [x] New unit tests for `frac()`/`frac_u64()` edge cases
- [x] New unit tests for `UmiCountTracker` record/iter/empty
- [x] New unit tests for `ClipCounts` default
- [x] New unit test for `AddAssign` on `ClippingMetrics`
- [x] New unit tests for `RejectionReason::tsv_key()` and `kv_description()`
- [x] New unit tests for `read_metrics()`/`read_metrics_auto()` roundtrip and error handling