### PR TITLE
Lockstep workspace versions and fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  release-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,8 +24,118 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
+      - name: Create or update release PR
         uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Verify lockstep workspace versions
+        run: |
+          set -euo pipefail
+          WORKSPACE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r \
+            '.packages[] | select(.name == "fgumi") | .version')
+          MISMATCHES=$(cargo metadata --no-deps --format-version 1 | jq -r \
+            --arg ver "$WORKSPACE_VERSION" \
+            '.packages[] | select(.name | startswith("fgumi-")) | select(.version != $ver) | "\(.name) \(.version)"')
+          if [ -n "$MISMATCHES" ]; then
+            echo "ERROR: workspace version drift detected (expected $WORKSPACE_VERSION):"
+            echo "$MISMATCHES"
+            exit 1
+          fi
+          echo "All workspace crates at v$WORKSPACE_VERSION"
+      - name: Publish workspace crates in dependency order
+        id: publish
+        env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # All workspace crates share a single version (lockstep).
+          # Check the root crate to decide if publishing is needed.
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r \
+            '.packages[] | select(.name == "fgumi") | .version')
+
+          PUBLISHED_VERSION=$(curl -sSf \
+            -H "User-Agent: fgumi-ci (https://github.com/fulcrumgenomics/fgumi)" \
+            "https://crates.io/api/v1/crates/fgumi" | jq -r \
+            '.crate.max_version // "0.0.0"')
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "All crates already at v$VERSION -- nothing to publish"
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Publishing all workspace crates (v$VERSION)..."
+
+          # Workspace crates in topological (dependency) order.
+          # Leaf crates first, root crate last.  Update this list when
+          # adding new workspace crates or changing inter-crate dependencies.
+          CRATES=(
+            fgumi-dna
+            fgumi-bgzf
+            fgumi-raw-bam
+            fgumi-umi
+            fgumi-sam
+            fgumi-metrics
+            fgumi-consensus
+            fgumi
+          )
+
+          for crate in "${CRATES[@]}"; do
+            CRATE_MAX_VERSION=$(curl -sS \
+              -H "User-Agent: fgumi-ci (https://github.com/fulcrumgenomics/fgumi)" \
+              "https://crates.io/api/v1/crates/${crate}" | jq -r \
+              '.crate.max_version // "0.0.0"')
+
+            if [ "$CRATE_MAX_VERSION" = "$VERSION" ]; then
+              echo "$crate v$VERSION already exists on crates.io -- skipping"
+              continue
+            fi
+
+            echo "Publishing $crate v$VERSION..."
+            cargo publish -p "$crate"
+            echo "✓ Published $crate v$VERSION"
+          done
+
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.publish.outputs.version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.publish.outputs.version }}"
+          TAG="v${VERSION}"
+
+          # Idempotent: skip if tag/release already exist (e.g. from a
+          # previous partial run that published crates but failed here).
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+          fi
+          if ! git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            git push origin "$TAG"
+          fi
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --latest
+          else
+            echo "Release $TAG already exists -- skipping"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "fgumi-bgzf"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bgzf",
  "crc32fast",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "fgumi-dna"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "fgumi-metrics"
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "fgumi-umi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,20 +2,36 @@
 members = [".", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-umi", "crates/fgumi-consensus"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.1"
+edition = "2024"
+rust-version = "1.87.0"
+repository = "https://github.com/fulcrumgenomics/fgumi"
+license = "MIT"
+
+[workspace.dependencies]
+fgumi-bgzf = { version = "0.1.1", path = "crates/fgumi-bgzf" }
+fgumi-consensus = { version = "0.1.1", path = "crates/fgumi-consensus", default-features = false }
+fgumi-dna = { version = "0.1.1", path = "crates/fgumi-dna" }
+fgumi-metrics = { version = "0.1.1", path = "crates/fgumi-metrics" }
+fgumi-raw-bam = { version = "0.1.1", path = "crates/fgumi-raw-bam" }
+fgumi-sam = { version = "0.1.1", path = "crates/fgumi-sam" }
+fgumi-umi = { version = "0.1.1", path = "crates/fgumi-umi" }
+
 [package]
 name = "fgumi"
-version = "0.1.1"
+version.workspace = true
 authors = ["Nils Homer <nils@fulcrumgenomics.com>", "Tim Fennell <tim@fulcrumgenomics.com>"]
 description = "High-performance tools for UMI-tagged sequencing data: extraction, grouping, and consensus calling"
-repository = "https://github.com/fulcrumgenomics/fgumi"
+repository.workspace = true
 homepage = "https://github.com/fulcrumgenomics/fgumi"
 documentation = "https://docs.rs/fgumi"
 readme = "README.md"
 categories = ["command-line-utilities", "science"]
 keywords = ["bioinformatics", "umi", "consensus", "sequencing", "ngs"]
-license = "MIT"
-edition = "2024"
-rust-version = "1.87.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 clap = { version = "4", features = ["derive", "string"] }
@@ -61,13 +77,13 @@ wide = "1.1"
 rand_distr = "0.6"
 flate2 = "1.1"
 dhat = { version = "0.3", optional = true }
-fgumi-raw-bam = { version = "0.1.1", path = "crates/fgumi-raw-bam", features = ["noodles"] }
-fgumi-dna = { version = "0.1.0", path = "crates/fgumi-dna" }
-fgumi-bgzf = { version = "0.1.0", path = "crates/fgumi-bgzf" }
-fgumi-metrics = { version = "0.1.1", path = "crates/fgumi-metrics" }
-fgumi-sam = { version = "0.1.1", path = "crates/fgumi-sam" }
-fgumi-umi = { version = "0.1.0", path = "crates/fgumi-umi" }
-fgumi-consensus = { version = "0.1.1", path = "crates/fgumi-consensus", default-features = false }
+fgumi-raw-bam = { workspace = true, features = ["noodles"] }
+fgumi-dna = { workspace = true }
+fgumi-bgzf = { workspace = true }
+fgumi-metrics = { workspace = true }
+fgumi-sam = { workspace = true }
+fgumi-umi = { workspace = true }
+fgumi-consensus = { workspace = true }
 
 [features]
 default = ["simplex", "duplex", "codec"]
@@ -90,7 +106,7 @@ stress-tests = []
 rstest = "0"
 proptest = "1.10"
 criterion = { version = "0.8", features = ["html_reports"] }
-fgumi-raw-bam = { version = "0.1.1", path = "crates/fgumi-raw-bam", features = ["test-utils"] }
+fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 
 [[bench]]
 name = "core_functions"

--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fgumi-bgzf"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "BGZF block reading, decompression, and compression utilities"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 libdeflater = "1.22"

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fgumi-consensus"
-version = "0.1.1"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Consensus calling algorithms for fgumi: simplex, duplex, and CODEC"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 ahash = "0.8"
@@ -16,13 +16,13 @@ log = "0"
 noodles = { version = "0.105.0", features = ["bam", "sam", "core"] }
 rand = "0.10"
 wide = "1.1"
-fgumi-dna = { version = "0.1.0", path = "../fgumi-dna" }
-fgumi-sam = { version = "0.1.1", path = "../fgumi-sam" }
-fgumi-metrics = { version = "0.1.1", path = "../fgumi-metrics" }
-fgumi-raw-bam = { version = "0.1.1", path = "../fgumi-raw-bam", features = ["noodles"] }
+fgumi-dna = { workspace = true }
+fgumi-sam = { workspace = true }
+fgumi-metrics = { workspace = true }
+fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 
 [dev-dependencies]
-fgumi-raw-bam = { version = "0.1.1", path = "../fgumi-raw-bam", features = ["test-utils"] }
+fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = ["simplex", "duplex", "codec"]

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fgumi-dna"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "DNA sequence utilities: complement, reverse-complement, 2-bit encoding"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fgumi-metrics"
-version = "0.1.1"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Structured metric types and TSV writer for fgumi operations"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -15,7 +15,7 @@ noodles = { version = "0.105.0", features = ["sam"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
-fgumi-sam = { version = "0.1.1", path = "../fgumi-sam" }
+fgumi-sam = { workspace = true }
 
 [features]
 default = ["clip"]

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fgumi-raw-bam"
-version = "0.1.1"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Raw byte-level operations on BAM alignment records"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 noodles = { version = "0.105.0", features = ["bam", "sam"], optional = true }

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "fgumi-sam"
-version = "0.1.1"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "SAM/BAM record utilities, CIGAR parsing, and read-pair clipping for fgumi"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 noodles = { version = "0.105.0", features = ["bam", "sam", "core"] }
-fgumi-raw-bam = { version = "0.1.1", path = "../fgumi-raw-bam", features = ["noodles"] }
+fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 bstr = "1.12.1"
 log = "0"
 anyhow = "1.0"
-fgumi-dna = { version = "0.1.0", path = "../fgumi-dna" }
+fgumi-dna = { workspace = true }
 tempfile = "3.3.0"
 
 [dev-dependencies]
-fgumi-raw-bam = { version = "0.1.1", path = "../fgumi-raw-bam", features = ["test-utils"] }
+fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-umi/Cargo.toml
+++ b/crates/fgumi-umi/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "fgumi-umi"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.87.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "UMI assignment strategies and utilities for fgumi"
-repository = "https://github.com/fulcrumgenomics/fgumi"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 ahash = "0.8"
 anyhow = "1.0"
 clap = { version = "4", features = ["derive"], optional = true }
 rayon = "1.10"
-fgumi-dna = { version = "0.1.0", path = "../fgumi-dna" }
+fgumi-dna = { workspace = true }
 
 [dev-dependencies]
 rstest = "0.26"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,9 +5,7 @@ changelog_config = "cliff.toml"
 dependencies_update = true
 # labels for the release PR
 pr_labels = ["release"]
-# create GitHub releases for each published crate
-git_release_enable = true
+# disable git releases (handled by publish workflow)
+git_release_enable = false
 # disable running `cargo-semver-checks` until after the first release
 semver_check = false
-# increase timeout to allow crates.io index propagation between dependent crates
-publish_timeout = "10m"


### PR DESCRIPTION
## Summary

- Introduce lockstep versioning: all workspace crates share a single version via `[workspace.package]` and `[workspace.dependencies]` inheritance
- Split the publish workflow into two independent jobs: `release-pr` (release-plz PR management) and `publish` (explicit crates.io publishing in dependency order + single GitHub release)
- Disable release-plz's built-in `git_release_enable` since the publish job now handles GitHub releases

## Motivation

The v0.1.1 release failed because `release-plz release` did not respect the full dependency graph — it tried to publish `fgumi-metrics` before `fgumi-sam` was available on crates.io (dev-dependency ordering issue). The v0.1.1 crates were published manually.

## Changes

**Cargo.toml (root):**
- Added `[workspace.package]` with shared `version`, `edition`, `rust-version`, `repository`, `license`
- Added `[workspace.dependencies]` centralizing all inter-crate dependency versions
- Root package fields and deps now use `.workspace = true`

**Sub-crate Cargo.toml files (all 7):**
- Inherit `version`, `edition`, `rust-version`, `repository`, `license` from workspace
- Inter-crate deps use `{ workspace = true }` with feature overrides where needed
- Three crates previously at v0.1.0 (`fgumi-dna`, `fgumi-bgzf`, `fgumi-umi`) are now v0.1.1 via workspace inheritance to bootstrap lockstep

**publish.yml:**
- `release-pr` job: runs `release-plz release-pr` only
- `publish` job: checks root crate version against crates.io, publishes all crates in topological order if needed, creates a single `v{version}` GitHub release
- Idempotent tag/release creation for safe retries after partial failures

**release-plz.toml:**
- `git_release_enable = false` (handled by publish job)
- Removed `publish_timeout` (no longer relevant)

## Test plan

- [x] `cargo check` passes
- [x] `cargo ci-test` passes (1834 tests)
- [x] `cargo ci-fmt` and `cargo ci-lint` pass (pre-commit hooks)
- [ ] Verify next release PR from release-plz bumps `[workspace.package].version` and all `[workspace.dependencies]` entries in lockstep