### PR TITLE
Simplify fgumi-dna: remove redundant casts, use byte iteration

### DIFF
--- a/crates/fgumi-dna/src/bitenc.rs
+++ b/crates/fgumi-dna/src/bitenc.rs
@@ -55,7 +55,8 @@ impl BitEnc {
             bits |= encoded << (i * 2);
         }
 
-        let len = u8::try_from(seq.len()).ok()?;
+        #[expect(clippy::cast_possible_truncation, reason = "guarded by seq.len() <= 32")]
+        let len = seq.len() as u8;
         Some(Self { bits, len })
     }
 
@@ -83,7 +84,8 @@ impl BitEnc {
             // Dash is silently skipped
         }
 
-        let len = u8::try_from(base_count).ok()?;
+        #[expect(clippy::cast_possible_truncation, reason = "guarded by base_count <= 32")]
+        let len = base_count as u8;
         Some(Self { bits, len })
     }
 

--- a/crates/fgumi-dna/src/dna.rs
+++ b/crates/fgumi-dna/src/dna.rs
@@ -63,6 +63,11 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 ///
 /// Returns the reverse complement of the input string, preserving case.
 ///
+/// # Panics
+///
+/// Cannot panic in practice: the byte-level complement maps ASCII to ASCII,
+/// so `String::from_utf8` always succeeds.
+///
 /// # Examples
 ///
 /// ```
@@ -74,20 +79,22 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 /// ```
 #[must_use]
 pub fn reverse_complement_str(seq: &str) -> String {
-    seq.chars()
+    let bytes: Vec<u8> = seq
+        .bytes()
         .rev()
-        .map(|c| match c {
-            'A' => 'T',
-            'T' => 'A',
-            'C' => 'G',
-            'G' => 'C',
-            'a' => 't',
-            't' => 'a',
-            'c' => 'g',
-            'g' => 'c',
-            _ => c,
+        .map(|b| match b {
+            b'A' => b'T',
+            b'T' => b'A',
+            b'C' => b'G',
+            b'G' => b'C',
+            b'a' => b't',
+            b't' => b'a',
+            b'c' => b'g',
+            b'g' => b'c',
+            other => other,
         })
-        .collect()
+        .collect();
+    String::from_utf8(bytes).expect("complement of ASCII is ASCII")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Replace redundant `u8::try_from` casts with direct `as u8` in `BitEnc::from_bytes` and `BitEnc::from_umi_str` — the length guards already ensure the values fit
- Rewrite `reverse_complement_str` to use `.bytes()` instead of `.chars()` for ASCII DNA sequences, avoiding unnecessary char decode/encode overhead

## Test plan

- [x] `cargo nextest run -p fgumi-dna` — all tests pass
- [x] `cargo clippy -p fgumi-dna -- -D warnings` — no warnings
- [x] `cargo ci-fmt` — clean