### PR TITLE
refactor(raw-bam): deduplicate aux iteration, use field accessors

### DIFF
--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -91,7 +91,8 @@ impl UnmappedBamRecordBuilder {
         self.sealed = false;
 
         assert!(name.len() < 255, "read name too long ({} bytes, max 254)", name.len());
-        let l_read_name = u8::try_from(name.len() + 1).expect("read name length overflow"); // +1 for NUL
+        #[expect(clippy::cast_possible_truncation, reason = "assert above guarantees name.len() < 255")]
+        let l_read_name = (name.len() + 1) as u8; // +1 for NUL
         let l_seq = u32::try_from(bases.len()).expect("sequence length overflow");
         let packed_seq_len = bases.len().div_ceil(2);
 

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -865,6 +865,129 @@ mod tests {
     // unclipped_start_from_cigar / unclipped_end_from_cigar tests
     // ========================================================================
 
+    // ========================================================================
+    // query_length_from_cigar tests
+    // ========================================================================
+
+    #[test]
+    fn test_query_length_from_cigar_simple_match() {
+        // 50M: query length = 50
+        let cigar = &[encode_op(0, 50)];
+        assert_eq!(query_length_from_cigar(cigar), 50);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_with_insertion() {
+        // 10M5I10M: M and I consume query
+        // query_len = 10 + 5 + 10 = 25
+        let cigar = &[encode_op(0, 10), encode_op(1, 5), encode_op(0, 10)];
+        assert_eq!(query_length_from_cigar(cigar), 25);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_with_soft_clip() {
+        // 5S10M3S: S and M consume query
+        // query_len = 5 + 10 + 3 = 18
+        let cigar = &[encode_op(4, 5), encode_op(0, 10), encode_op(4, 3)];
+        assert_eq!(query_length_from_cigar(cigar), 18);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_with_deletion() {
+        // 10M3D5M: D does not consume query
+        // query_len = 10 + 5 = 15
+        let cigar = &[encode_op(0, 10), encode_op(2, 3), encode_op(0, 5)];
+        assert_eq!(query_length_from_cigar(cigar), 15);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_with_eq_and_x() {
+        // 10=3X2I: =, X, and I consume query
+        // query_len = 10 + 3 + 2 = 15
+        let cigar = &[encode_op(7, 10), encode_op(8, 3), encode_op(1, 2)];
+        assert_eq!(query_length_from_cigar(cigar), 15);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_empty() {
+        assert_eq!(query_length_from_cigar(&[]), 0);
+    }
+
+    #[test]
+    fn test_query_length_from_cigar_hard_clip_only() {
+        // 5H: hard clips do not consume query
+        let cigar = &[encode_op(5, 5)];
+        assert_eq!(query_length_from_cigar(cigar), 0);
+    }
+
+    // ========================================================================
+    // read_pos_at_ref_pos_raw tests
+    // ========================================================================
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_simple_match() {
+        // 10M starting at ref pos 100 (1-based)
+        let cigar = &[encode_op(0, 10)];
+        // Position 100: first query base
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, false), Some(1));
+        // Position 105: 6th query base
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 105, false), Some(6));
+        // Position 109: last query base
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 109, false), Some(10));
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_before_alignment() {
+        let cigar = &[encode_op(0, 10)];
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 99, false), None);
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_past_alignment() {
+        let cigar = &[encode_op(0, 10)];
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 110, false), None);
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_in_deletion() {
+        // 5M3D5M: deletion at ref 105-107
+        let cigar = &[encode_op(0, 5), encode_op(2, 3), encode_op(0, 5)];
+        // Position 106 is in deletion
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 106, false), None);
+        // With return_last_base_if_deleted=true
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 106, true), Some(5));
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_with_insertion() {
+        // 5M3I5M: insertion between ref 104 and 105
+        let cigar = &[encode_op(0, 5), encode_op(1, 3), encode_op(0, 5)];
+        // Position 104: 5th query base (before insertion)
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 104, false), Some(5));
+        // Position 105: 9th query base (after 5M + 3I)
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 105, false), Some(9));
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_with_soft_clip() {
+        // 3S10M: soft clip consumes 3 query bases, then 10M
+        let cigar = &[encode_op(4, 3), encode_op(0, 10)];
+        // Position 100: 4th query base (after 3S)
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, false), Some(4));
+    }
+
+    #[test]
+    fn test_read_pos_at_ref_pos_raw_deletion_at_start() {
+        // 2D5M: deletion at ref 100-101
+        let cigar = &[encode_op(2, 2), encode_op(0, 5)];
+        // Position 100 is in the deletion with no prior query bases
+        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, true), Some(1));
+    }
+
+    // ========================================================================
+    // unclipped_start_from_cigar / unclipped_end_from_cigar tests
+    // ========================================================================
+
     #[test]
     fn test_unclipped_start_from_cigar_no_clips() {
         // 10M = (10 << 4)
@@ -1654,25 +1777,10 @@ mod tests {
     }
 
     #[test]
-    fn test_read_pos_at_ref_pos_raw_before_alignment() {
-        // ref_pos < alignment_start => None
-        let cigar = &[encode_op(0, 10)];
-        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 99, false), None);
-    }
-
-    #[test]
     fn test_read_pos_at_ref_pos_raw_after_alignment() {
         // ref_pos after alignment => None
         let cigar = &[encode_op(0, 10)];
         assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 110, false), None);
-    }
-
-    #[test]
-    fn test_read_pos_at_ref_pos_raw_in_deletion() {
-        // 5M3D5M: deletion at ref 105-107
-        // ref_pos=106 is in deletion => None (without return_last_base_if_deleted)
-        let cigar = &[encode_op(0, 5), encode_op(2, 3), encode_op(0, 5)];
-        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 106, false), None);
     }
 
     #[test]
@@ -1681,22 +1789,6 @@ mod tests {
         // ref_pos=106 is in deletion, return_last_base_if_deleted=true => returns 5
         let cigar = &[encode_op(0, 5), encode_op(2, 3), encode_op(0, 5)];
         assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 106, true), Some(5));
-    }
-
-    #[test]
-    fn test_read_pos_at_ref_pos_raw_with_insertion() {
-        // 5M3I5M: insertion doesn't consume reference
-        // ref 105 is first base of second 5M, query pos = 5 (from first M) + 3 (from I) + 1 = 9
-        let cigar = &[encode_op(0, 5), encode_op(1, 3), encode_op(0, 5)];
-        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 105, false), Some(9));
-    }
-
-    #[test]
-    fn test_read_pos_at_ref_pos_raw_with_soft_clip() {
-        // 3S10M: soft clip consumes query but not reference
-        // ref 100 = first ref base in 10M, query pos = 3 (from S) + 1 = 4
-        let cigar = &[encode_op(4, 3), encode_op(0, 10)];
-        assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, false), Some(4));
     }
 
     #[test]
@@ -1755,11 +1847,6 @@ mod tests {
         // 5=3X: both consume query, total 8
         let cigar = &[encode_op(7, 5), encode_op(8, 3)];
         assert_eq!(query_length_from_cigar(cigar), 8);
-    }
-
-    #[test]
-    fn test_query_length_from_cigar_empty() {
-        assert_eq!(query_length_from_cigar(&[]), 0);
     }
 
     // ========================================================================

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -736,4 +736,109 @@ mod tests {
         assert_eq!(ref_id(&rec), -1);
         assert_eq!(pos(&rec), -1);
     }
+
+    // ========================================================================
+    // TemplateCoordFlags tests
+    // ========================================================================
+
+    #[test]
+    fn test_template_coord_flags_all_set() {
+        let flag = flags::REVERSE
+            | flags::MATE_REVERSE
+            | flags::UNMAPPED
+            | flags::MATE_UNMAPPED
+            | flags::PAIRED;
+        let tcf = TemplateCoordFlags::from_flag(flag);
+        assert!(tcf.reverse());
+        assert!(tcf.mate_reverse());
+        assert!(tcf.unmapped());
+        assert!(tcf.mate_unmapped());
+        assert!(tcf.paired());
+    }
+
+    #[test]
+    fn test_template_coord_flags_none_set() {
+        let tcf = TemplateCoordFlags::from_flag(0);
+        assert!(!tcf.reverse());
+        assert!(!tcf.mate_reverse());
+        assert!(!tcf.unmapped());
+        assert!(!tcf.mate_unmapped());
+        assert!(!tcf.paired());
+    }
+
+    #[test]
+    fn test_template_coord_flags_individual_bits() {
+        let tcf = TemplateCoordFlags::from_flag(flags::REVERSE | flags::PAIRED);
+        assert!(tcf.reverse());
+        assert!(!tcf.mate_reverse());
+        assert!(!tcf.unmapped());
+        assert!(!tcf.mate_unmapped());
+        assert!(tcf.paired());
+    }
+
+    #[test]
+    fn test_template_coord_flags_default() {
+        let tcf = TemplateCoordFlags::default();
+        assert!(!tcf.reverse());
+        assert!(!tcf.mate_reverse());
+        assert!(!tcf.unmapped());
+        assert!(!tcf.mate_unmapped());
+        assert!(!tcf.paired());
+    }
+
+    // ========================================================================
+    // extract_template_coordinate_fields tests
+    // ========================================================================
+
+    #[test]
+    fn test_extract_template_coordinate_fields_basic() {
+        let rec = make_bam_bytes_with_tlen(
+            3,                                                     // tid
+            200,                                                   // pos
+            flags::PAIRED | flags::REVERSE | flags::MATE_REVERSE,  // flag
+            b"read1",                                              // name
+            &[encode_op(0, 10)],                                   // 10M cigar
+            6,                                                     // seq_len
+            5,                                                     // mate_tid
+            400,                                                   // mate_pos
+            150,                                                   // tlen
+            &[],                                                   // aux
+        );
+        let fields = extract_template_coordinate_fields(&rec);
+        assert_eq!(fields.tid, 3);
+        assert_eq!(fields.pos, 200);
+        assert_eq!(fields.mate_tid, 5);
+        assert_eq!(fields.mate_pos, 400);
+        assert!(fields.flags.reverse());
+        assert!(fields.flags.mate_reverse());
+        assert!(!fields.flags.unmapped());
+        assert!(!fields.flags.mate_unmapped());
+        assert!(fields.flags.paired());
+        assert_eq!(fields.name, b"read1");
+        assert_eq!(fields.l_read_name, 6); // "read1" + NUL
+        assert_eq!(fields.n_cigar_op, 1);
+        assert_eq!(fields.l_seq, 6);
+    }
+
+    #[test]
+    fn test_extract_template_coordinate_fields_unmapped() {
+        let rec = make_bam_bytes(
+            -1,
+            -1,
+            flags::UNMAPPED | flags::PAIRED | flags::MATE_UNMAPPED,
+            b"rd",
+            &[],
+            0,
+            -1,
+            -1,
+            &[],
+        );
+        let fields = extract_template_coordinate_fields(&rec);
+        assert_eq!(fields.tid, -1);
+        assert_eq!(fields.pos, -1);
+        assert!(fields.flags.unmapped());
+        assert!(fields.flags.mate_unmapped());
+        assert!(fields.flags.paired());
+        assert_eq!(fields.name, b"rd");
+    }
 }

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -128,14 +128,25 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
     }
 }
 
-/// Compute number of read bases at or past a reference position (for positive strand).
+/// Whether to return the read position at or past the target reference position,
+/// or the read position before it.
+#[derive(Clone, Copy)]
+enum RefPosMode {
+    /// Return the 1-based read position at the target (for positive strand clipping).
+    AtOrPast,
+    /// Return the 1-based read position before the target (for negative strand clipping).
+    Before,
+}
+
+/// Compute the read position relative to a reference position by walking the CIGAR.
 ///
-/// Returns the 1-based read position at the given reference position,
-/// or 0 if the position falls in a deletion or outside the alignment.
-fn compute_bases_past_ref_pos(
+/// Returns the 1-based read position at (or just before) the given reference position,
+/// or 0 if the position falls in a deletion/skip or outside the alignment.
+fn compute_read_pos_at_ref(
     cigar_ops: &[u32],
     alignment_start_1based: i32,
     target_ref_pos: i32,
+    mode: RefPosMode,
 ) -> usize {
     let mut ref_pos = alignment_start_1based;
     let mut read_pos: usize = 0;
@@ -150,7 +161,10 @@ fn compute_bases_past_ref_pos(
                 for _ in 0..op_len {
                     read_pos += 1;
                     if ref_pos == target_ref_pos {
-                        return read_pos;
+                        return match mode {
+                            RefPosMode::AtOrPast => read_pos,
+                            RefPosMode::Before => read_pos.saturating_sub(1),
+                        };
                     }
                     ref_pos += 1;
                 }
@@ -179,52 +193,25 @@ fn compute_bases_past_ref_pos(
     0
 }
 
+/// Compute number of read bases at or past a reference position (for positive strand).
+///
+/// Returns the 1-based read position at the given reference position,
+/// or 0 if the position falls in a deletion or outside the alignment.
+fn compute_bases_past_ref_pos(
+    cigar_ops: &[u32],
+    alignment_start_1based: i32,
+    target_ref_pos: i32,
+) -> usize {
+    compute_read_pos_at_ref(cigar_ops, alignment_start_1based, target_ref_pos, RefPosMode::AtOrPast)
+}
+
 /// Compute number of read bases before a reference position (for negative strand).
 fn compute_bases_before_ref_pos(
     cigar_ops: &[u32],
     alignment_start_1based: i32,
     target_ref_pos: i32,
 ) -> usize {
-    let mut ref_pos = alignment_start_1based;
-    let mut read_pos: usize = 0;
-
-    for &op in cigar_ops {
-        let op_type = op & 0xF;
-        let op_len = (op >> 4) as usize;
-
-        match op_type {
-            0 | 7 | 8 => {
-                // M, =, X: consume both query and reference
-                for _ in 0..op_len {
-                    read_pos += 1;
-                    if ref_pos == target_ref_pos {
-                        return read_pos.saturating_sub(1);
-                    }
-                    ref_pos += 1;
-                }
-            }
-            1 => {
-                // I: consume query only
-                read_pos += op_len;
-            }
-            4 => {
-                // S: consume query only
-                read_pos += op_len;
-            }
-            2 | 3 => {
-                // D, N: consume reference only
-                for _ in 0..op_len {
-                    if ref_pos == target_ref_pos {
-                        return 0;
-                    }
-                    ref_pos += 1;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    0
+    compute_read_pos_at_ref(cigar_ops, alignment_start_1based, target_ref_pos, RefPosMode::Before)
 }
 
 /// Count trailing soft clips from CIGAR ops.

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -31,9 +31,6 @@ const fn build_seq_codes() -> [u8; 256] {
     codes
 }
 
-/// Decode table: 4-bit BAM base code -> ASCII base.
-const BASE_DECODE: [u8; 16] = *b"=ACMGRSVTWYHKDBN";
-
 /// Extract a 4-bit base from packed sequence data.
 ///
 /// BAM packs two bases per byte: high nibble = even index, low nibble = odd index.
@@ -88,7 +85,7 @@ pub fn extract_sequence(bam: &[u8]) -> Vec<u8> {
     let mut bases = Vec::with_capacity(l);
     for i in 0..l {
         let code = get_base(bam, off, i);
-        bases.push(BASE_DECODE[code as usize]);
+        bases.push(BAM_BASE_TO_ASCII[code as usize]);
     }
     bases
 }
@@ -165,6 +162,47 @@ pub fn quality_scores_slice_mut(bam: &mut [u8]) -> &mut [u8] {
 mod tests {
     use super::*;
     use crate::testutil::*;
+
+    // ========================================================================
+    // is_base_n tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_base_n_true() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 4, -1, -1, &[]);
+        let so = seq_offset(&rec);
+        rec[so] = 0xFF; // N(15), N(15)
+        rec[so + 1] = 0xFF;
+        assert!(is_base_n(&rec, so, 0));
+        assert!(is_base_n(&rec, so, 1));
+        assert!(is_base_n(&rec, so, 2));
+        assert!(is_base_n(&rec, so, 3));
+    }
+
+    #[test]
+    fn test_is_base_n_false() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 4, -1, -1, &[]);
+        let so = seq_offset(&rec);
+        rec[so] = 0x12; // A(1), C(2)
+        rec[so + 1] = 0x48; // G(4), T(8)
+        assert!(!is_base_n(&rec, so, 0));
+        assert!(!is_base_n(&rec, so, 1));
+        assert!(!is_base_n(&rec, so, 2));
+        assert!(!is_base_n(&rec, so, 3));
+    }
+
+    #[test]
+    fn test_is_base_n_after_mask() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 4, -1, -1, &[]);
+        let so = seq_offset(&rec);
+        rec[so] = 0x12; // A(1), C(2)
+        rec[so + 1] = 0x48; // G(4), T(8)
+        assert!(!is_base_n(&rec, so, 1));
+        mask_base(&mut rec, so, 1);
+        assert!(is_base_n(&rec, so, 1));
+        // Other bases unaffected
+        assert!(!is_base_n(&rec, so, 0));
+    }
 
     // ========================================================================
     // get_base and mask_base tests

--- a/crates/fgumi-raw-bam/src/sort.rs
+++ b/crates/fgumi-raw-bam/src/sort.rs
@@ -2,20 +2,19 @@ use std::cmp::Ordering;
 
 use crate::cigar::mate_unclipped_5prime;
 use crate::cigar::unclipped_5prime_sort;
-use crate::fields::flags;
+use crate::fields::{self, flags, mate_pos, mate_ref_id, pos, read_name, ref_id};
 use crate::tags::{find_mc_tag_in_record, find_mi_tag_in_record};
 
 #[must_use]
 pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
-    // Extract fields at fixed offsets
-    let a_tid = i32::from_le_bytes([a[0], a[1], a[2], a[3]]);
-    let b_tid = i32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+    let a_tid = ref_id(a);
+    let b_tid = ref_id(b);
 
-    let a_pos = i32::from_le_bytes([a[4], a[5], a[6], a[7]]);
-    let b_pos = i32::from_le_bytes([b[4], b[5], b[6], b[7]]);
+    let a_pos = pos(a);
+    let b_pos = pos(b);
 
-    let a_flag = u16::from_le_bytes([a[14], a[15]]);
-    let b_flag = u16::from_le_bytes([b[14], b[15]]);
+    let a_flag = fields::flags(a);
+    let b_flag = fields::flags(b);
 
     // Handle reads with no reference (tid = -1) - sort last
     // Unmapped reads with a valid tid (mate's position) sort by that position
@@ -45,28 +44,14 @@ pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
 #[inline]
 #[must_use]
 pub fn compare_names_raw(a: &[u8], b: &[u8]) -> Ordering {
-    let a_name_len = a[8] as usize;
-    let b_name_len = b[8] as usize;
-
-    // Exclude null terminator
-    let a_len = if a_name_len > 0 { a_name_len - 1 } else { 0 };
-    let b_len = if b_name_len > 0 { b_name_len - 1 } else { 0 };
-
-    let a_name = &a[32..32 + a_len];
-    let b_name = &b[32..32 + b_len];
-
-    a_name.cmp(b_name)
+    read_name(a).cmp(read_name(b))
 }
 
 /// Compare for queryname ordering using raw bytes.
 #[inline]
 #[must_use]
 pub fn compare_queryname_raw(a: &[u8], b: &[u8]) -> Ordering {
-    compare_names_raw(a, b).then_with(|| {
-        let a_flag = u16::from_le_bytes([a[14], a[15]]);
-        let b_flag = u16::from_le_bytes([b[14], b[15]]);
-        a_flag.cmp(&b_flag)
-    })
+    compare_names_raw(a, b).then_with(|| fields::flags(a).cmp(&fields::flags(b)))
 }
 
 /// Compare for template-coordinate ordering using raw bytes.
@@ -76,17 +61,17 @@ pub fn compare_queryname_raw(a: &[u8], b: &[u8]) -> Ordering {
 #[must_use]
 pub fn compare_template_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
     // Extract all needed fields from both records
-    let a_tid = i32::from_le_bytes([a[0], a[1], a[2], a[3]]);
-    let a_pos = i32::from_le_bytes([a[4], a[5], a[6], a[7]]);
-    let a_flag = u16::from_le_bytes([a[14], a[15]]);
-    let a_mate_tid = i32::from_le_bytes([a[20], a[21], a[22], a[23]]);
-    let a_mate_pos = i32::from_le_bytes([a[24], a[25], a[26], a[27]]);
+    let a_tid = ref_id(a);
+    let a_pos = pos(a);
+    let a_flag = fields::flags(a);
+    let a_mate_tid = mate_ref_id(a);
+    let a_mate_pos = mate_pos(a);
 
-    let b_tid = i32::from_le_bytes([b[0], b[1], b[2], b[3]]);
-    let b_pos = i32::from_le_bytes([b[4], b[5], b[6], b[7]]);
-    let b_flag = u16::from_le_bytes([b[14], b[15]]);
-    let b_mate_tid = i32::from_le_bytes([b[20], b[21], b[22], b[23]]);
-    let b_mate_pos = i32::from_le_bytes([b[24], b[25], b[26], b[27]]);
+    let b_tid = ref_id(b);
+    let b_pos = pos(b);
+    let b_flag = fields::flags(b);
+    let b_mate_tid = mate_ref_id(b);
+    let b_mate_pos = mate_pos(b);
 
     // Extract strand information
     let a_reverse = (a_flag & flags::REVERSE) != 0;

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1,5 +1,5 @@
 use crate::fields::{
-    TAG_FIXED_SIZES, aux_data_offset, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+    TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size,
 };
 
 /// Find a string (Z-type) tag in auxiliary data, returning value bytes without null terminator.
@@ -288,17 +288,7 @@ fn parse_mi_bytes(s: &[u8]) -> Option<(u64, bool)> {
 /// Returns `(integer_value, is_A_suffix)` or `(0, true)` if not found.
 #[must_use]
 pub fn find_mi_tag_in_record(bam: &[u8]) -> (u64, bool) {
-    let l_read_name = bam[8] as usize;
-    let n_cigar_op = u16::from_le_bytes([bam[12], bam[13]]) as usize;
-    let l_seq = u32::from_le_bytes([bam[16], bam[17], bam[18], bam[19]]) as usize;
-
-    let aux_start = aux_data_offset(l_read_name, n_cigar_op, l_seq);
-
-    if aux_start >= bam.len() {
-        return (0, true);
-    }
-
-    find_mi_tag(&bam[aux_start..]).unwrap_or((0, true))
+    find_mi_tag(aux_data_slice(bam)).unwrap_or((0, true))
 }
 
 /// Find the MC (mate CIGAR) tag in auxiliary data.
@@ -306,45 +296,13 @@ pub fn find_mi_tag_in_record(bam: &[u8]) -> (u64, bool) {
 /// Returns the CIGAR string, or None if not found.
 #[must_use]
 pub fn find_mc_tag(aux_data: &[u8]) -> Option<&str> {
-    let mut pos = 0;
-    while pos + 3 <= aux_data.len() {
-        let tag = &aux_data[pos..pos + 2];
-        let val_type = aux_data[pos + 2];
-
-        if tag == b"MC" {
-            return match val_type {
-                b'Z' => {
-                    let start = pos + 3;
-                    let end = aux_data[start..].iter().position(|&b| b == 0)?;
-                    std::str::from_utf8(&aux_data[start..start + end]).ok()
-                }
-                _ => None,
-            };
-        }
-
-        if let Some(size) = tag_value_size(val_type, &aux_data[pos + 3..]) {
-            pos += 3 + size;
-        } else {
-            break;
-        }
-    }
-    None
+    find_string_tag(aux_data, b"MC").and_then(|v| std::str::from_utf8(v).ok())
 }
 
 /// Find MC tag in a complete BAM record.
 #[must_use]
 pub fn find_mc_tag_in_record(bam: &[u8]) -> Option<&str> {
-    let l_read_name = bam[8] as usize;
-    let n_cigar_op = u16::from_le_bytes([bam[12], bam[13]]) as usize;
-    let l_seq = u32::from_le_bytes([bam[16], bam[17], bam[18], bam[19]]) as usize;
-
-    let aux_start = aux_data_offset(l_read_name, n_cigar_op, l_seq);
-
-    if aux_start >= bam.len() {
-        return None;
-    }
-
-    find_mc_tag(&bam[aux_start..])
+    find_mc_tag(aux_data_slice(bam))
 }
 
 /// Result of a single-pass extraction of multiple string tags from aux data.
@@ -1842,6 +1800,280 @@ mod tests {
         assert_eq!(buf[5], b'?'); // 30 + 33
         assert_eq!(buf[6], b'I'); // 40 + 33
         assert_eq!(buf[7], 0); // NUL
+    }
+
+    // ========================================================================
+    // find_array_tag tests
+    // ========================================================================
+
+    #[test]
+    fn test_find_array_tag_int_array() {
+        let aux = make_b_int_array_tag(*b"cd", &[10, 20, 30]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(tag_ref.elem_type, b'i');
+        assert_eq!(tag_ref.count, 3);
+        assert_eq!(tag_ref.elem_size, 4);
+        assert_eq!(tag_ref.data.len(), 12);
+    }
+
+    #[test]
+    fn test_find_array_tag_uint8_array() {
+        let aux = make_b_uint8_array_tag(*b"XC", &[1, 2, 3, 4]);
+        let tag_ref = find_array_tag(&aux, b"XC").unwrap();
+        assert_eq!(tag_ref.elem_type, b'C');
+        assert_eq!(tag_ref.count, 4);
+        assert_eq!(tag_ref.elem_size, 1);
+    }
+
+    #[test]
+    fn test_find_array_tag_not_found() {
+        let aux = make_b_int_array_tag(*b"cd", &[10]);
+        assert!(find_array_tag(&aux, b"ZZ").is_none());
+    }
+
+    #[test]
+    fn test_find_array_tag_not_b_type() {
+        // Tag exists but as Z type, not B
+        let aux = b"cdZhello\x00";
+        assert!(find_array_tag(aux.as_ref(), b"cd").is_none());
+    }
+
+    #[test]
+    fn test_find_array_tag_after_other_tags() {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(&[b'N', b'M', b'C', 5]); // NM:C:5
+        aux.extend_from_slice(&make_b_int16_array_tag(*b"cd", &[10, 20]));
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(tag_ref.elem_type, b's');
+        assert_eq!(tag_ref.count, 2);
+    }
+
+    // ========================================================================
+    // array_tag_element_u16 tests
+    // ========================================================================
+
+    #[test]
+    fn test_array_tag_element_u16_uint8() {
+        let aux = make_b_uint8_array_tag(*b"cd", &[10, 200, 0]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_element_u16(&tag_ref, 0), 10);
+        assert_eq!(array_tag_element_u16(&tag_ref, 1), 200);
+        assert_eq!(array_tag_element_u16(&tag_ref, 2), 0);
+    }
+
+    #[test]
+    fn test_array_tag_element_u16_uint16() {
+        let aux = make_b_uint16_array_tag(*b"cd", &[100, 60000, 0]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_element_u16(&tag_ref, 0), 100);
+        assert_eq!(array_tag_element_u16(&tag_ref, 1), 60000);
+        assert_eq!(array_tag_element_u16(&tag_ref, 2), 0);
+    }
+
+    #[test]
+    fn test_array_tag_element_u16_int16_clamped() {
+        let aux = make_b_int16_array_tag(*b"cd", &[-5, 100, 0]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        // Negative values clamped to 0
+        assert_eq!(array_tag_element_u16(&tag_ref, 0), 0);
+        assert_eq!(array_tag_element_u16(&tag_ref, 1), 100);
+    }
+
+    #[test]
+    fn test_array_tag_element_u16_int8_clamped() {
+        let aux = make_b_int8_array_tag(*b"cd", &[-1, 42, 0]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_element_u16(&tag_ref, 0), 0); // clamped
+        assert_eq!(array_tag_element_u16(&tag_ref, 1), 42);
+    }
+
+    #[test]
+    fn test_array_tag_element_u16_out_of_bounds() {
+        let aux = make_b_uint8_array_tag(*b"cd", &[10]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_element_u16(&tag_ref, 1), 0); // out of bounds
+    }
+
+    #[test]
+    fn test_array_tag_element_u16_unsupported_type() {
+        // i32 array: not directly supported by array_tag_element_u16
+        let aux = make_b_int_array_tag(*b"cd", &[42]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_element_u16(&tag_ref, 0), 0); // unsupported returns 0
+    }
+
+    // ========================================================================
+    // array_tag_to_vec_u16 tests
+    // ========================================================================
+
+    #[test]
+    fn test_array_tag_to_vec_u16() {
+        let aux = make_b_uint8_array_tag(*b"cd", &[10, 20, 30]);
+        let tag_ref = find_array_tag(&aux, b"cd").unwrap();
+        assert_eq!(array_tag_to_vec_u16(&tag_ref), vec![10u16, 20, 30]);
+    }
+
+    // ========================================================================
+    // update_int_tag tests
+    // ========================================================================
+
+    #[test]
+    fn test_update_int_tag_existing_i32_in_place() {
+        // Create a record with NM:i:42 (4-byte int, in-place update)
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        // Manually append an i32 tag
+        rec.extend_from_slice(&[b'N', b'M', b'i']);
+        rec.extend_from_slice(&42i32.to_le_bytes());
+        update_int_tag(&mut rec, b"NM", 99);
+        let aux = aux_data_slice(&rec);
+        assert_eq!(find_int_tag(aux, b"NM"), Some(99));
+    }
+
+    #[test]
+    fn test_update_int_tag_existing_different_size() {
+        // Create a record with NM:c:5 (1-byte int), update to a value needing 2 bytes
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        rec.extend_from_slice(&[b'N', b'M', b'c', 5]);
+        update_int_tag(&mut rec, b"NM", 300);
+        let aux = aux_data_slice(&rec);
+        assert_eq!(find_int_tag(aux, b"NM"), Some(300));
+    }
+
+    #[test]
+    fn test_update_int_tag_absent() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        update_int_tag(&mut rec, b"NM", 42);
+        let aux = aux_data_slice(&rec);
+        assert_eq!(find_int_tag(aux, b"NM"), Some(42));
+    }
+
+    // ========================================================================
+    // reverse_array_tag_in_place tests
+    // ========================================================================
+
+    #[test]
+    fn test_reverse_array_tag_in_place_i16() {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(&make_b_int16_array_tag(*b"cd", &[10, 20, 30]));
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_array_tag_in_place(&mut rec, aux_offset, b"cd");
+        let tag_ref = find_array_tag(&rec[aux_offset..], b"cd").unwrap();
+        let values: Vec<i16> = (0..tag_ref.count)
+            .map(|i| {
+                let off = i * tag_ref.elem_size;
+                i16::from_le_bytes([tag_ref.data[off], tag_ref.data[off + 1]])
+            })
+            .collect();
+        assert_eq!(values, vec![30, 20, 10]);
+    }
+
+    #[test]
+    fn test_reverse_array_tag_in_place_uint8() {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(&make_b_uint8_array_tag(*b"cd", &[1, 2, 3, 4]));
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_array_tag_in_place(&mut rec, aux_offset, b"cd");
+        let tag_ref = find_array_tag(&rec[aux_offset..], b"cd").unwrap();
+        assert_eq!(tag_ref.data, &[4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn test_reverse_array_tag_in_place_not_found() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        // Should be a no-op
+        reverse_array_tag_in_place(&mut rec, aux_offset, b"cd");
+    }
+
+    #[test]
+    fn test_reverse_array_tag_in_place_offset_past_end() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        // aux_offset >= record.len() should be a no-op
+        reverse_array_tag_in_place(&mut rec, rec.len() + 10, b"cd");
+    }
+
+    // ========================================================================
+    // reverse_string_tag_in_place tests
+    // ========================================================================
+
+    #[test]
+    fn test_reverse_string_tag_in_place() {
+        let aux = b"RXZhello\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_string_tag_in_place(&mut rec, aux_offset, b"RX");
+        assert_eq!(find_string_tag(&rec[aux_offset..], b"RX"), Some(b"olleh".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_string_tag_in_place_single_char() {
+        let aux = b"RXZa\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_string_tag_in_place(&mut rec, aux_offset, b"RX");
+        assert_eq!(find_string_tag(&rec[aux_offset..], b"RX"), Some(b"a".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_string_tag_in_place_not_found() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        // No-op
+        reverse_string_tag_in_place(&mut rec, aux_offset, b"RX");
+    }
+
+    #[test]
+    fn test_reverse_string_tag_in_place_offset_past_end() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        reverse_string_tag_in_place(&mut rec, rec.len() + 10, b"RX");
+    }
+
+    // ========================================================================
+    // reverse_complement_string_tag_in_place tests
+    // ========================================================================
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place() {
+        let aux = b"RXZACGT\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_complement_string_tag_in_place(&mut rec, aux_offset, b"RX");
+        assert_eq!(find_string_tag(&rec[aux_offset..], b"RX"), Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place_lowercase() {
+        let aux = b"RXZacgt\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_complement_string_tag_in_place(&mut rec, aux_offset, b"RX");
+        // lowercase a->T, c->G, g->C, t->A, reversed: ACGT
+        assert_eq!(find_string_tag(&rec[aux_offset..], b"RX"), Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place_with_n() {
+        let aux = b"RXZANGT\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_complement_string_tag_in_place(&mut rec, aux_offset, b"RX");
+        // ANGT -> reverse TGNA -> complement ACNT
+        assert_eq!(find_string_tag(&rec[aux_offset..], b"RX"), Some(b"ACNT".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place_not_found() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        let aux_offset = aux_data_offset_from_record(&rec).unwrap();
+        reverse_complement_string_tag_in_place(&mut rec, aux_offset, b"RX");
+    }
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place_offset_past_end() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
+        reverse_complement_string_tag_in_place(&mut rec, rec.len() + 10, b"RX");
     }
 
     // ========================================================================

--- a/crates/fgumi-raw-bam/src/testutil.rs
+++ b/crates/fgumi-raw-bam/src/testutil.rs
@@ -84,163 +84,27 @@ impl ParsedBamRecord {
 }
 
 fn unpack_sequence_for_test(packed: &[u8], l_seq: usize) -> Vec<u8> {
-    const DECODE: [u8; 16] = *b"=ACMGRSVTWYHKDBN";
+    use crate::sequence::BAM_BASE_TO_ASCII;
     let mut bases = Vec::with_capacity(l_seq);
     for i in 0..l_seq {
         let byte = packed[i / 2];
         let code = if i % 2 == 0 { byte >> 4 } else { byte & 0x0F };
-        bases.push(DECODE[code as usize]);
+        bases.push(BAM_BASE_TO_ASCII[code as usize]);
     }
     bases
 }
 
 fn find_z_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> {
-    let mut i = 0;
-    while i + 3 <= aux.len() {
-        let t = [aux[i], aux[i + 1]];
-        let typ = aux[i + 2];
-        i += 3;
-        match typ {
-            b'Z' => {
-                let start = i;
-                while i < aux.len() && aux[i] != 0 {
-                    i += 1;
-                }
-                if t == tag {
-                    return Some(aux[start..i].to_vec());
-                }
-                i += 1; // skip NUL
-            }
-            b'c' => {
-                i += 1;
-            }
-            b's' => {
-                i += 2;
-            }
-            b'i' | b'f' => {
-                i += 4;
-            }
-            b'B' => {
-                let sub = aux[i];
-                i += 1;
-                let count =
-                    u32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]) as usize;
-                i += 4;
-                let elem_size = match sub {
-                    b's' | b'S' => 2,
-                    b'i' | b'I' | b'f' => 4,
-                    _ => 1,
-                };
-                i += count * elem_size;
-            }
-            _ => break,
-        }
-    }
-    None
+    crate::tags::find_string_tag(aux, &tag).map(<[u8]>::to_vec)
 }
 
+#[expect(clippy::cast_possible_truncation, reason = "test values always fit in i32")]
 fn find_int_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<i32> {
-    let mut i = 0;
-    while i + 3 <= aux.len() {
-        let t = [aux[i], aux[i + 1]];
-        let typ = aux[i + 2];
-        i += 3;
-        match typ {
-            b'c' => {
-                let v = i32::from(aux[i].cast_signed());
-                if t == tag {
-                    return Some(v);
-                }
-                i += 1;
-            }
-            b's' => {
-                let v = i32::from(i16::from_le_bytes([aux[i], aux[i + 1]]));
-                if t == tag {
-                    return Some(v);
-                }
-                i += 2;
-            }
-            b'i' => {
-                let v = i32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]);
-                if t == tag {
-                    return Some(v);
-                }
-                i += 4;
-            }
-            b'f' => {
-                i += 4;
-            }
-            b'Z' => {
-                while i < aux.len() && aux[i] != 0 {
-                    i += 1;
-                }
-                i += 1;
-            }
-            b'B' => {
-                let sub = aux[i];
-                i += 1;
-                let count =
-                    u32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]) as usize;
-                i += 4;
-                let elem_size = match sub {
-                    b's' | b'S' => 2,
-                    b'i' | b'I' | b'f' => 4,
-                    _ => 1,
-                };
-                i += count * elem_size;
-            }
-            _ => break,
-        }
-    }
-    None
+    crate::tags::find_int_tag(aux, &tag).map(|v| v as i32)
 }
 
 fn find_float_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<f32> {
-    let mut i = 0;
-    while i + 3 <= aux.len() {
-        let t = [aux[i], aux[i + 1]];
-        let typ = aux[i + 2];
-        i += 3;
-        match typ {
-            b'f' => {
-                let v = f32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]);
-                if t == tag {
-                    return Some(v);
-                }
-                i += 4;
-            }
-            b'c' => {
-                i += 1;
-            }
-            b's' => {
-                i += 2;
-            }
-            b'i' => {
-                i += 4;
-            }
-            b'Z' => {
-                while i < aux.len() && aux[i] != 0 {
-                    i += 1;
-                }
-                i += 1;
-            }
-            b'B' => {
-                let sub = aux[i];
-                i += 1;
-                let count =
-                    u32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]) as usize;
-                i += 4;
-                let elem_size = match sub {
-                    b's' | b'S' => 2,
-                    b'i' | b'I' | b'f' => 4,
-                    _ => 1,
-                };
-                i += count * elem_size;
-            }
-            _ => break,
-        }
-    }
-    None
+    crate::tags::find_float_tag(aux, &tag)
 }
 
 fn find_i16_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<i16>> {


### PR DESCRIPTION
## Summary

Seven simplification fixes reducing code by ~208 lines:

- **Consolidate base decode tables**: Remove duplicate `BASE_DECODE` and `DECODE` constants, use single `BAM_BASE_TO_ASCII` everywhere
- **Deduplicate `find_mc_tag`**: Rewrite as one-liner delegating to `find_string_tag` instead of duplicating the aux iteration loop
- **Use `aux_data_slice` in `find_*_in_record`**: Replace manual offset computation in `find_mc_tag_in_record` and `find_mi_tag_in_record`
- **Use `fields.rs` accessors in `sort.rs`**: Replace inline byte operations with named accessor functions (`ref_id`, `pos`, `flags`, `read_name`, etc.)
- **Unify `compute_bases_past/before_ref_pos`**: Extract `RefPosMode` enum and shared `compute_read_pos_at_ref` implementation, eliminating copy-pasted overlap logic
- **Remove redundant assert + expect in `builder.rs`**: Direct cast after length guard
- **Consolidate test aux-finders**: Replace 143 lines of duplicated test helpers with 3-line delegations to production `tags.rs` functions

## Test plan

- [x] `cargo nextest run -p fgumi-raw-bam` — all tests pass
- [x] `cargo clippy -p fgumi-raw-bam --all-features -- -D warnings` — no warnings
- [x] `cargo check` (full workspace) — clean
- [x] `cargo ci-fmt` — clean