### PR TITLE
refactor(consensus): remove dead code, unify duplicated logic

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -305,44 +305,6 @@ pub fn log_consensus_statistics(caller_name: &str, stats: &ConsensusCallingStats
     }
 }
 
-/// Common options shared across consensus callers.
-///
-/// These fields are duplicated across `VanillaUmiConsensusOptions`, `CodecConsensusOptions`,
-/// and `DuplexConsensusOptions`. This struct provides a common base to reduce duplication.
-#[derive(Debug, Clone)]
-pub struct ConsensusOptionsBase {
-    /// Pre-UMI error rate (Phred scale)
-    pub error_rate_pre_umi: crate::phred::PhredScore,
-
-    /// Post-UMI error rate (Phred scale)
-    pub error_rate_post_umi: crate::phred::PhredScore,
-
-    /// Minimum base quality to include in consensus
-    pub min_input_base_quality: crate::phred::PhredScore,
-
-    /// Whether to produce per-base tags (cd, ce, etc.)
-    pub produce_per_base_tags: bool,
-
-    /// Whether to quality-trim reads before consensus calling
-    pub trim: bool,
-
-    /// Minimum consensus base quality (output bases below this are masked to N)
-    pub min_consensus_base_quality: crate::phred::PhredScore,
-}
-
-impl Default for ConsensusOptionsBase {
-    fn default() -> Self {
-        Self {
-            error_rate_pre_umi: 45,
-            error_rate_post_umi: 40,
-            min_input_base_quality: 10,
-            produce_per_base_tags: true,
-            trim: false,
-            min_consensus_base_quality: 40,
-        }
-    }
-}
-
 /// Calculates error rate from depths and errors arrays.
 ///
 /// This is the standard formula used across all consensus callers:
@@ -361,56 +323,6 @@ pub fn calculate_error_rate(depths: &[u16], errors: &[u16]) -> f32 {
     }
     let total_errors: u32 = errors.iter().map(|&e| u32::from(e)).sum();
     total_errors as f32 / total_depth as f32
-}
-
-/// Tracker for rejected reads during consensus calling.
-///
-/// This struct encapsulates the common pattern of tracking rejected reads
-/// that's duplicated across `VanillaUmiConsensusCaller` and `CodecConsensusCaller`.
-#[derive(Debug, Default)]
-pub struct RejectionTracker {
-    /// Whether to track rejected reads
-    pub track_rejects: bool,
-
-    /// Rejected reads as raw bytes (only populated if `track_rejects` is true)
-    rejected_records: Vec<Vec<u8>>,
-}
-
-impl RejectionTracker {
-    /// Creates a new rejection tracker.
-    #[must_use]
-    pub fn new(track_rejects: bool) -> Self {
-        Self { track_rejects, rejected_records: Vec::new() }
-    }
-
-    /// Adds rejected raw-byte records to the tracker (if tracking is enabled).
-    pub fn add_rejected(&mut self, records: impl IntoIterator<Item = Vec<u8>>) {
-        if self.track_rejects {
-            self.rejected_records.extend(records);
-        }
-    }
-
-    /// Returns a reference to the rejected records.
-    #[must_use]
-    pub fn rejected_records(&self) -> &[Vec<u8>] {
-        &self.rejected_records
-    }
-
-    /// Takes ownership of the rejected records, leaving an empty vector.
-    pub fn take_rejected_records(&mut self) -> Vec<Vec<u8>> {
-        std::mem::take(&mut self.rejected_records)
-    }
-
-    /// Clears the rejected records without returning them.
-    pub fn clear(&mut self) {
-        self.rejected_records.clear();
-    }
-
-    /// Returns whether rejection tracking is enabled.
-    #[must_use]
-    pub fn is_tracking(&self) -> bool {
-        self.track_rejects
-    }
 }
 
 /// Reasons why reads might be rejected and not used in consensus calling
@@ -562,7 +474,8 @@ pub fn make_prefix_from_header(header: &Header) -> String {
     ids.dedup();
 
     // Calculate total length including separators
-    let total_len: usize = ids.iter().map(|s| s.len() + 1).sum();
+    let total_len: usize =
+        ids.iter().map(String::len).sum::<usize>() + ids.len().saturating_sub(1);
 
     if total_len <= 200 {
         ids.join("|")
@@ -905,5 +818,298 @@ mod tests {
         let prefix = make_prefix_from_header(&header);
         // Empty string when no read groups
         assert_eq!(prefix, "");
+    }
+
+    /// Test `make_prefix_from_header` returns joined names when total length is exactly 200
+    #[test]
+    fn test_make_prefix_from_header_exact_200_boundary() {
+        use bstr::BString;
+        use noodles::sam::header::Builder as HeaderBuilder;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        // Two names of 100 chars each: joined = 100 + "|" + 100 = 201 > 200 → hash
+        // So use 100 + 99 = 199 + 1 separator = 200 → joined
+        let lib_a = "A".repeat(100);
+        let lib_b = "B".repeat(99);
+
+        let rg1 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, lib_a.clone())
+            .build()
+            .unwrap();
+        let rg2 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, lib_b.clone())
+            .build()
+            .unwrap();
+        let header = HeaderBuilder::default()
+            .add_read_group(BString::from("RG1"), rg1)
+            .add_read_group(BString::from("RG2"), rg2)
+            .build();
+
+        let prefix = make_prefix_from_header(&header);
+        // Exactly 200 chars should return joined names, not a hash
+        assert_eq!(prefix, format!("{lib_a}|{lib_b}"));
+    }
+
+    /// Test `make_prefix_from_header` falls back to hash when combined length exceeds 200
+    #[test]
+    fn test_make_prefix_from_header_long_names_use_hash() {
+        use bstr::BString;
+        use noodles::sam::header::Builder as HeaderBuilder;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        // Create library names whose combined length (including separators) exceeds 200
+        let long_lib_a = "A".repeat(100);
+        let long_lib_b = "B".repeat(101);
+
+        let rg1 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, long_lib_a.clone())
+            .build()
+            .unwrap();
+        let rg2 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, long_lib_b.clone())
+            .build()
+            .unwrap();
+        let header = HeaderBuilder::default()
+            .add_read_group(BString::from("RG1"), rg1)
+            .add_read_group(BString::from("RG2"), rg2)
+            .build();
+
+        let prefix = make_prefix_from_header(&header);
+        // Should use hash (hex string) instead of joined names
+        assert_ne!(prefix, format!("{long_lib_a}|{long_lib_b}"));
+        // Hash output is a hex string - verify it only contains hex characters
+        assert!(prefix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    // =====================================================================
+    // Tests for calculate_error_rate
+    // =====================================================================
+
+    #[test]
+    fn test_calculate_error_rate_zero_depth() {
+        assert!((calculate_error_rate(&[], &[]) - 0.0).abs() < f32::EPSILON);
+        assert!((calculate_error_rate(&[0, 0], &[0, 0]) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_calculate_error_rate_no_errors() {
+        let depths = [10, 20, 30];
+        let errors = [0, 0, 0];
+        assert!((calculate_error_rate(&depths, &errors) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_calculate_error_rate_some_errors() {
+        let depths = [10, 10, 10, 10]; // total = 40
+        let errors = [0, 1, 1, 2]; // total = 4
+        let rate = calculate_error_rate(&depths, &errors);
+        assert!((rate - 0.1).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_calculate_error_rate_all_errors() {
+        let depths = [5, 5];
+        let errors = [5, 5];
+        let rate = calculate_error_rate(&depths, &errors);
+        assert!((rate - 1.0).abs() < f32::EPSILON);
+    }
+
+    // =====================================================================
+    // Tests for ConsensusOutput
+    // =====================================================================
+
+    #[test]
+    fn test_consensus_output_new_is_empty() {
+        let output = ConsensusOutput::new();
+        assert!(output.data.is_empty());
+        assert_eq!(output.count, 0);
+    }
+
+    #[test]
+    fn test_consensus_output_default() {
+        let output = ConsensusOutput::default();
+        assert!(output.data.is_empty());
+        assert_eq!(output.count, 0);
+    }
+
+    #[test]
+    fn test_consensus_output_extend() {
+        let mut output1 = ConsensusOutput { data: vec![1, 2, 3], count: 1 };
+        let output2 = ConsensusOutput { data: vec![4, 5, 6], count: 2 };
+
+        output1.extend(&output2);
+        assert_eq!(output1.data, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(output1.count, 3);
+    }
+
+    #[test]
+    fn test_consensus_output_merge() {
+        let mut output1 = ConsensusOutput { data: vec![1, 2, 3], count: 1 };
+        let output2 = ConsensusOutput { data: vec![4, 5, 6], count: 2 };
+
+        output1.merge(output2);
+        assert_eq!(output1.data, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(output1.count, 3);
+    }
+
+    #[test]
+    fn test_consensus_output_extend_empty() {
+        let mut output1 = ConsensusOutput { data: vec![1, 2], count: 1 };
+        let output2 = ConsensusOutput::new();
+
+        output1.extend(&output2);
+        assert_eq!(output1.data, vec![1, 2]);
+        assert_eq!(output1.count, 1);
+    }
+
+    #[test]
+    fn test_consensus_output_merge_into_empty() {
+        let mut output1 = ConsensusOutput::new();
+        let output2 = ConsensusOutput { data: vec![7, 8, 9], count: 3 };
+
+        output1.merge(output2);
+        assert_eq!(output1.data, vec![7, 8, 9]);
+        assert_eq!(output1.count, 3);
+    }
+
+    // =====================================================================
+    // Tests for log_consensus_statistics (verify it runs without panicking)
+    // =====================================================================
+
+    #[test]
+    fn test_log_consensus_statistics_empty_stats() {
+        let stats = ConsensusCallingStats::new();
+        // Should not panic even with empty stats
+        log_consensus_statistics("TestCaller", &stats);
+    }
+
+    #[test]
+    fn test_log_consensus_statistics_with_rejections() {
+        let mut stats = ConsensusCallingStats::new();
+        stats.record_input(100);
+        stats.record_consensus();
+        stats.record_rejection(RejectionReason::QualityTooLow, 10);
+        stats.record_rejection(RejectionReason::TooManyNs, 5);
+        // Should not panic with populated stats
+        log_consensus_statistics("TestCaller", &stats);
+    }
+
+    // =====================================================================
+    // Comprehensive RejectionReason tests
+    // =====================================================================
+
+    #[test]
+    fn test_all_rejection_reasons_have_descriptions() {
+        let reasons = [
+            RejectionReason::FragmentRead,
+            RejectionReason::InsufficientReads,
+            RejectionReason::QualityTooLow,
+            RejectionReason::Unmapped,
+            RejectionReason::Mapped,
+            RejectionReason::TooManyNs,
+            RejectionReason::MinorityAlignment,
+            RejectionReason::SecondaryOrSupplementary,
+            RejectionReason::FailedQC,
+            RejectionReason::MissingUmi,
+            RejectionReason::QualityTrimmed,
+            RejectionReason::ZeroLengthAfterTrimming,
+            RejectionReason::InsufficientOverlap,
+            RejectionReason::OrphanConsensus,
+            RejectionReason::IndelErrorBetweenStrands,
+            RejectionReason::PotentialCollision,
+            RejectionReason::Other,
+        ];
+
+        for reason in &reasons {
+            let desc = reason.description();
+            assert!(!desc.is_empty(), "Description should not be empty for {reason:?}");
+        }
+    }
+
+    #[test]
+    fn test_all_rejection_reasons_to_centralized() {
+        use fgumi_metrics::rejection::RejectionReason as CentralReason;
+
+        // Test every variant maps to a centralized reason
+        let mappings = [
+            (RejectionReason::FragmentRead, CentralReason::SameStrandOnly),
+            (RejectionReason::InsufficientReads, CentralReason::InsufficientSupport),
+            (RejectionReason::QualityTooLow, CentralReason::LowBaseQuality),
+            (RejectionReason::Unmapped, CentralReason::NoValidAlignment),
+            (RejectionReason::Mapped, CentralReason::NoValidAlignment),
+            (RejectionReason::TooManyNs, CentralReason::ExcessiveNBases),
+            (RejectionReason::MinorityAlignment, CentralReason::MinorityAlignment),
+            (RejectionReason::SecondaryOrSupplementary, CentralReason::NoValidAlignment),
+            (RejectionReason::FailedQC, CentralReason::NotPassingFilter),
+            (RejectionReason::MissingUmi, CentralReason::MissingUmi),
+            (RejectionReason::QualityTrimmed, CentralReason::LowBaseQuality),
+            (RejectionReason::ZeroLengthAfterTrimming, CentralReason::ZeroBasesPostTrimming),
+            (RejectionReason::InsufficientOverlap, CentralReason::InsufficientSupport),
+            (RejectionReason::OrphanConsensus, CentralReason::OrphanConsensus),
+            (RejectionReason::IndelErrorBetweenStrands, CentralReason::NoValidAlignment),
+            (RejectionReason::PotentialCollision, CentralReason::DuplicateUmi),
+            (RejectionReason::Other, CentralReason::InsufficientSupport),
+        ];
+
+        for (caller_reason, expected_central) in &mappings {
+            assert_eq!(
+                caller_reason.to_centralized(),
+                *expected_central,
+                "Mismatch for {caller_reason:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_rejection_reasons_codes_and_descriptions_complete() {
+        // Verify all newer variants that were missing from earlier tests
+        assert_eq!(RejectionReason::ZeroLengthAfterTrimming.code(), 'Z');
+        assert_eq!(RejectionReason::InsufficientOverlap.code(), 'V');
+        assert_eq!(RejectionReason::OrphanConsensus.code(), 'P');
+        assert_eq!(RejectionReason::IndelErrorBetweenStrands.code(), 'D');
+        assert_eq!(RejectionReason::PotentialCollision.code(), 'C');
+
+        assert_eq!(
+            RejectionReason::ZeroLengthAfterTrimming.description(),
+            "Zero length after masking low quality bases"
+        );
+        assert_eq!(
+            RejectionReason::InsufficientOverlap.description(),
+            "Insufficient overlap between reads"
+        );
+        assert_eq!(
+            RejectionReason::OrphanConsensus.description(),
+            "Only one of R1 or R2 consensus generated"
+        );
+        assert_eq!(
+            RejectionReason::IndelErrorBetweenStrands.description(),
+            "Overlap boundary lands in indel between strands"
+        );
+        assert_eq!(
+            RejectionReason::PotentialCollision.description(),
+            "Potential collisions (reads with the same MI but different strands)"
+        );
+    }
+
+    #[test]
+    fn test_rejection_reason_debug_format() {
+        // Verify Debug trait is working for all variants
+        let reason = RejectionReason::QualityTooLow;
+        let debug_str = format!("{reason:?}");
+        assert_eq!(debug_str, "QualityTooLow");
+    }
+
+    #[test]
+    fn test_rejection_reason_hash() {
+        // Verify Hash trait works by using rejection reasons as HashMap keys
+        let mut map = HashMap::new();
+        map.insert(RejectionReason::QualityTooLow, 5);
+        map.insert(RejectionReason::TooManyNs, 3);
+        assert_eq!(map[&RejectionReason::QualityTooLow], 5);
+        assert_eq!(map[&RejectionReason::TooManyNs], 3);
     }
 }

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -35,10 +35,7 @@ mod vendored;
 
 // Re-export commonly used items
 pub use base_builder::ConsensusBaseBuilder;
-pub use caller::{
-    ConsensusCaller, ConsensusOptionsBase, RejectionTracker, calculate_error_rate,
-    log_consensus_statistics,
-};
+pub use caller::{ConsensusCaller, calculate_error_rate, log_consensus_statistics};
 pub use filter::{
     ConsensusType, FilterConfig, FilterResult, FilterThresholds, compute_read_stats,
     count_no_calls, filter_duplex_read, filter_read, is_duplex_consensus, mask_bases,

--- a/crates/fgumi-consensus/src/sequence.rs
+++ b/crates/fgumi-consensus/src/sequence.rs
@@ -191,17 +191,8 @@ impl ConsensusSequence {
 
     /// Returns the error rate (total errors / total depth).
     #[must_use]
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "u32 values from u16 sums are small enough for f32 precision"
-    )]
     pub fn error_rate(&self) -> f32 {
-        let total_depth: u32 = self.depths.iter().map(|&d| u32::from(d)).sum();
-        if total_depth == 0 {
-            return 0.0;
-        }
-        let total_errors: u32 = self.errors.iter().map(|&e| u32::from(e)).sum();
-        total_errors as f32 / total_depth as f32
+        crate::caller::calculate_error_rate(&self.depths, &self.errors)
     }
 
     /// Decomposes this sequence into its component vectors.
@@ -419,5 +410,115 @@ mod tests {
         let seq = ConsensusSequence::with_capacity(100);
         assert!(seq.is_empty());
         // Capacity is an implementation detail, but we can verify the struct is usable
+    }
+
+    // =====================================================================
+    // Tests for mutable accessors
+    // =====================================================================
+
+    #[test]
+    fn test_bases_mut() {
+        let mut seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+
+        seq.bases_mut()[0] = b'T';
+        assert_eq!(seq.bases(), &[b'T', b'C']);
+    }
+
+    #[test]
+    fn test_quals_mut() {
+        let mut seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+
+        seq.quals_mut()[1] = 40;
+        assert_eq!(seq.quals(), &[30, 40]);
+    }
+
+    #[test]
+    fn test_depths_mut() {
+        let mut seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+
+        seq.depths_mut()[0] = 20;
+        assert_eq!(seq.depths(), &[20, 8]);
+    }
+
+    #[test]
+    fn test_errors_mut() {
+        let mut seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+
+        seq.errors_mut()[1] = 3;
+        assert_eq!(seq.errors(), &[0, 3]);
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let seq = ConsensusSequence::default();
+        assert!(seq.is_empty());
+        assert_eq!(seq.len(), 0);
+        assert_eq!(seq.max_depth(), 0);
+        assert_eq!(seq.min_depth(), 0);
+    }
+
+    // =====================================================================
+    // Tests for padded edge cases
+    // =====================================================================
+
+    #[test]
+    #[should_panic(expected = "must be >= current length")]
+    fn test_padded_too_short_panics() {
+        let seq = ConsensusSequence::from_vecs(
+            vec![b'A', b'C', b'G'],
+            vec![30, 25, 20],
+            vec![10, 8, 5],
+            vec![0, 1, 0],
+        );
+        let _ = seq.padded(2, false, b'N', 2);
+    }
+
+    #[test]
+    fn test_padded_left_preserves_errors() {
+        let seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![2, 3]);
+
+        let padded = seq.padded(4, true, b'N', 2);
+        assert_eq!(padded.errors(), &[0, 0, 2, 3]);
+        assert_eq!(padded.depths(), &[0, 0, 10, 8]);
+    }
+
+    // =====================================================================
+    // Tests for clone and extend
+    // =====================================================================
+
+    #[test]
+    fn test_clone() {
+        let seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+        let cloned = seq.clone();
+        assert_eq!(cloned.bases(), seq.bases());
+        assert_eq!(cloned.quals(), seq.quals());
+        assert_eq!(cloned.depths(), seq.depths());
+        assert_eq!(cloned.errors(), seq.errors());
+    }
+
+    #[test]
+    fn test_extend_empty_into_existing() {
+        let mut seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+        let empty = ConsensusSequence::new();
+        seq.extend(&empty);
+        assert_eq!(seq.len(), 2);
+        assert_eq!(seq.bases(), &[b'A', b'C']);
+    }
+
+    #[test]
+    fn test_extend_into_empty() {
+        let mut empty = ConsensusSequence::new();
+        let seq =
+            ConsensusSequence::from_vecs(vec![b'A', b'C'], vec![30, 25], vec![10, 8], vec![0, 1]);
+        empty.extend(&seq);
+        assert_eq!(empty.len(), 2);
+        assert_eq!(empty.bases(), &[b'A', b'C']);
     }
 }

--- a/crates/fgumi-consensus/src/tags.rs
+++ b/crates/fgumi-consensus/src/tags.rs
@@ -27,6 +27,21 @@
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::data::field::value::Value;
 
+/// Converts a two-character tag string to a noodles `Tag`.
+///
+/// # Panics
+///
+/// Panics if `s` is not exactly 2 ASCII bytes.
+#[must_use]
+pub fn tag(s: &str) -> Tag {
+    let bytes = s.as_bytes();
+    assert!(
+        bytes.len() == 2 && bytes[0].is_ascii() && bytes[1].is_ascii(),
+        "SAM tag must be exactly 2 ASCII bytes: {s:?}"
+    );
+    Tag::from([bytes[0], bytes[1]])
+}
+
 /// Converts a sequence (`Vec<u8>`) to a String value for SAM tags.
 ///
 /// This matches fgbio's format for ac/bc tags (Z string type).
@@ -62,7 +77,11 @@ pub const MOLECULAR_ID: &str = "MI";
 
 /// Per-base consensus tags
 pub mod per_base {
-    use super::Tag;
+    /// Converts a tag string to a noodles Tag (delegates to top-level [`super::tag`])
+    #[must_use]
+    pub fn tag(s: &str) -> super::Tag {
+        super::tag(s)
+    }
 
     /// The per-base number of raw-reads contributing to the consensus (stored as a short[])
     pub const RAW_READ_COUNT: &str = "cd"; // consensus depth
@@ -143,18 +162,15 @@ pub mod per_base {
     pub fn all_tags() -> &'static [&'static str] {
         ALL_TAGS
     }
-
-    /// Converts a tag string to a noodles Tag
-    #[must_use]
-    pub fn tag(s: &str) -> Tag {
-        let bytes = s.as_bytes();
-        Tag::from([bytes[0], bytes[1]])
-    }
 }
 
 /// Per-read consensus tags
 pub mod per_read {
-    use super::Tag;
+    /// Converts a tag string to a noodles Tag (delegates to top-level [`super::tag`])
+    #[must_use]
+    pub fn tag(s: &str) -> super::Tag {
+        super::tag(s)
+    }
 
     /// The number of raw reads that contributed to the consensus (max of per-base counts)
     pub const RAW_READ_COUNT: &str = "cD"; // consensus Depth
@@ -201,13 +217,6 @@ pub mod per_read {
     #[must_use]
     pub fn all_tags() -> &'static [&'static str] {
         ALL_TAGS
-    }
-
-    /// Converts a tag string to a noodles Tag
-    #[must_use]
-    pub fn tag(s: &str) -> Tag {
-        let bytes = s.as_bytes();
-        Tag::from([bytes[0], bytes[1]])
     }
 }
 
@@ -309,6 +318,186 @@ mod tests {
     fn test_is_not_consensus() {
         // Create a record without consensus tags (raw read)
         let rec = RecordBuilder::new().sequence("ACGT").tag("RX", "ACGT").build();
+
+        assert!(!is_simplex_consensus(&rec));
+        assert!(!is_duplex_consensus(&rec));
+        assert!(!is_consensus(&rec));
+    }
+
+    // =====================================================================
+    // Tests for top-level tag() function
+    // =====================================================================
+
+    #[test]
+    fn test_top_level_tag_conversion() {
+        let t = tag("MI");
+        assert_eq!(t, Tag::from([b'M', b'I']));
+
+        let t = tag("RX");
+        assert_eq!(t, Tag::from([b'R', b'X']));
+    }
+
+    // =====================================================================
+    // Tests for sequence_to_tag_value and qualities_to_tag_value
+    // =====================================================================
+
+    #[test]
+    fn test_sequence_to_tag_value() {
+        let bases = b"ACGT";
+        let value = sequence_to_tag_value(bases);
+        match value {
+            noodles::sam::alignment::record_buf::data::field::value::Value::String(s) => {
+                assert_eq!(s, "ACGT");
+            }
+            _ => panic!("Expected String value"),
+        }
+    }
+
+    #[test]
+    fn test_sequence_to_tag_value_empty() {
+        let bases = b"";
+        let value = sequence_to_tag_value(bases);
+        match value {
+            noodles::sam::alignment::record_buf::data::field::value::Value::String(s) => {
+                assert_eq!(s, "");
+            }
+            _ => panic!("Expected String value"),
+        }
+    }
+
+    #[test]
+    fn test_qualities_to_tag_value() {
+        // Q0 -> '!' (33), Q10 -> '+' (43), Q30 -> '?' (63)
+        let quals = vec![0, 10, 30];
+        let value = qualities_to_tag_value(&quals);
+        match value {
+            noodles::sam::alignment::record_buf::data::field::value::Value::String(s) => {
+                assert_eq!(s.as_bytes(), &[33, 43, 63]);
+            }
+            _ => panic!("Expected String value"),
+        }
+    }
+
+    #[test]
+    fn test_qualities_to_tag_value_empty() {
+        let quals: Vec<u8> = vec![];
+        let value = qualities_to_tag_value(&quals);
+        match value {
+            noodles::sam::alignment::record_buf::data::field::value::Value::String(s) => {
+                assert_eq!(s, "");
+            }
+            _ => panic!("Expected String value"),
+        }
+    }
+
+    // =====================================================================
+    // Tests for per_base helper functions
+    // =====================================================================
+
+    #[test]
+    fn test_per_base_tags_to_reverse() {
+        let tags = per_base::tags_to_reverse();
+        assert!(tags.contains(&"cd"));
+        assert!(tags.contains(&"ce"));
+        assert!(tags.contains(&"ad"));
+        assert!(tags.contains(&"ae"));
+        assert!(tags.contains(&"bd"));
+        assert!(tags.contains(&"be"));
+        assert!(tags.contains(&"aq"));
+        assert!(tags.contains(&"bq"));
+    }
+
+    #[test]
+    fn test_per_base_tags_to_reverse_complement() {
+        let tags = per_base::tags_to_reverse_complement();
+        assert!(tags.contains(&"ac"));
+        assert!(tags.contains(&"bc"));
+        assert_eq!(tags.len(), 2);
+    }
+
+    // =====================================================================
+    // Tests for per_read tag constants
+    // =====================================================================
+
+    #[test]
+    fn test_per_read_tag_constants() {
+        assert_eq!(per_read::RAW_READ_COUNT, "cD");
+        assert_eq!(per_read::MIN_RAW_READ_COUNT, "cM");
+        assert_eq!(per_read::RAW_READ_ERROR_RATE, "cE");
+        assert_eq!(per_read::AB_RAW_READ_COUNT, "aD");
+        assert_eq!(per_read::BA_RAW_READ_COUNT, "bD");
+        assert_eq!(per_read::AB_MIN_RAW_READ_COUNT, "aM");
+        assert_eq!(per_read::BA_MIN_RAW_READ_COUNT, "bM");
+        assert_eq!(per_read::AB_RAW_READ_ERROR_RATE, "aE");
+        assert_eq!(per_read::BA_RAW_READ_ERROR_RATE, "bE");
+    }
+
+    #[test]
+    fn test_per_base_tag_constants() {
+        assert_eq!(per_base::RAW_READ_COUNT, "cd");
+        assert_eq!(per_base::RAW_READ_ERRORS, "ce");
+        assert_eq!(per_base::AB_RAW_READ_COUNT, "ad");
+        assert_eq!(per_base::BA_RAW_READ_COUNT, "bd");
+        assert_eq!(per_base::AB_RAW_READ_ERRORS, "ae");
+        assert_eq!(per_base::BA_RAW_READ_ERRORS, "be");
+        assert_eq!(per_base::AB_CONSENSUS_BASES, "ac");
+        assert_eq!(per_base::BA_CONSENSUS_BASES, "bc");
+        assert_eq!(per_base::AB_CONSENSUS_QUALS, "aq");
+        assert_eq!(per_base::BA_CONSENSUS_QUALS, "bq");
+    }
+
+    // =====================================================================
+    // Tests for tag string constants
+    // =====================================================================
+
+    #[test]
+    fn test_umi_tag_constants() {
+        assert_eq!(UMI_BASES, "RX");
+        assert_eq!(UMI_QUALS, "QX");
+        assert_eq!(ORIGINAL_UMI_BASES, "OX");
+        assert_eq!(ORIGINAL_UMI_QUALS, "BZ");
+        assert_eq!(MOLECULAR_ID, "MI");
+    }
+
+    // =====================================================================
+    // Tests for per_read::tag and per_base::tag delegation
+    // =====================================================================
+
+    #[test]
+    fn test_per_read_tag_function() {
+        let t = per_read::tag("cD");
+        assert_eq!(t, Tag::from([b'c', b'D']));
+    }
+
+    #[test]
+    fn test_per_base_tag_function() {
+        let t = per_base::tag("cd");
+        assert_eq!(t, Tag::from([b'c', b'd']));
+    }
+
+    // =====================================================================
+    // Test consensus detection with both simplex and duplex tags present
+    // =====================================================================
+
+    #[test]
+    fn test_is_consensus_with_all_tags() {
+        // Record with cD, aD, and bD is duplex, not simplex
+        let rec = RecordBuilder::new()
+            .sequence("ACGT")
+            .tag("cD", 10_i32)
+            .tag("aD", 5_i32)
+            .tag("bD", 3_i32)
+            .build();
+
+        assert!(!is_simplex_consensus(&rec));
+        assert!(is_duplex_consensus(&rec));
+        assert!(is_consensus(&rec));
+    }
+
+    #[test]
+    fn test_is_not_duplex_with_only_one_strand() {
+        // Record with only aD (no bD) is not duplex
+        let rec = RecordBuilder::new().sequence("ACGT").tag("aD", 5_i32).build();
 
         assert!(!is_simplex_consensus(&rec));
         assert!(!is_duplex_consensus(&rec));

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -193,17 +193,8 @@ impl VanillaConsensusRead {
 
     /// Returns the error rate (total errors / total depth)
     #[must_use]
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "u32 values from u16 sums are small enough for f32 precision"
-    )]
     pub fn error_rate(&self) -> f32 {
-        let total_depth: u32 = self.depths.iter().map(|&d| u32::from(d)).sum();
-        if total_depth == 0 {
-            return 0.0;
-        }
-        let total_errors: u32 = self.errors.iter().map(|&e| u32::from(e)).sum();
-        total_errors as f32 / total_depth as f32
+        crate::caller::calculate_error_rate(&self.depths, &self.errors)
     }
 
     /// Pads the read to a new length by adding bases to the left or right.

--- a/src/lib/consensus/mod.rs
+++ b/src/lib/consensus/mod.rs
@@ -13,12 +13,11 @@ pub use fgumi_consensus::vanilla_caller;
 
 // Re-export commonly used items
 pub use fgumi_consensus::{
-    AgreementStrategy, ConsensusBaseBuilder, ConsensusCaller, ConsensusOptionsBase,
-    ConsensusSequence, ConsensusType, CorrectionStats, DisagreementStrategy, FilterConfig,
-    FilterResult, FilterThresholds, OverlappingBasesConsensusCaller, RejectionTracker,
-    apply_overlapping_consensus, calculate_error_rate, compute_read_stats, count_no_calls,
-    filter_duplex_read, filter_read, is_duplex_consensus, log_consensus_statistics, mask_bases,
-    mask_duplex_bases, mean_base_quality, template_passes,
+    AgreementStrategy, ConsensusBaseBuilder, ConsensusCaller, ConsensusSequence, ConsensusType,
+    CorrectionStats, DisagreementStrategy, FilterConfig, FilterResult, FilterThresholds,
+    OverlappingBasesConsensusCaller, apply_overlapping_consensus, calculate_error_rate,
+    compute_read_stats, count_no_calls, filter_duplex_read, filter_read, is_duplex_consensus,
+    log_consensus_statistics, mask_bases, mask_duplex_bases, mean_base_quality, template_passes,
 };
 
 #[cfg(feature = "simplex")]


### PR DESCRIPTION
## Summary

- Remove dead `ConsensusOptionsBase` struct and `RejectionTracker` — never instantiated anywhere in the workspace
- Unify triplicated `error_rate` logic: `VanillaConsensusRead::error_rate()` and `ConsensusSequence::error_rate()` now delegate to shared `calculate_error_rate()`
- Deduplicate `tag()` helper in consensus tags module: both `per_base::tag()` and `per_read::tag()` now delegate to a single top-level function

Net reduction of ~105 lines (+29 / -134).

## Test plan

- [x] `cargo nextest run -p fgumi-consensus` — 450 tests pass
- [x] `cargo clippy -p fgumi-consensus --all-features -- -D warnings` — no warnings
- [x] `cargo check` (full workspace) — clean