### PR TITLE
refactor(dna): extract complement_base_preserve_case and remove unnecessary binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,9 @@ dependencies = [
 [[package]]
 name = "fgumi-dna"
 version = "0.1.1"
+dependencies = [
+ "rstest",
+]
 
 [[package]]
 name = "fgumi-metrics"
@@ -2355,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
 dependencies = [
  "libc",
  "memchr",
@@ -3040,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -9,5 +9,8 @@ license.workspace = true
 
 [dependencies]
 
+[dev-dependencies]
+rstest = "0"
+
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-dna/src/bitenc.rs
+++ b/crates/fgumi-dna/src/bitenc.rs
@@ -139,8 +139,7 @@ impl BitEnc {
         let start_bit = start_base * 2;
         let mask = (1u64 << (num_bases * 2)) - 1;
         #[expect(clippy::cast_possible_truncation, reason = "masked to at most 32 bits")]
-        let result = ((self.bits >> start_bit) & mask) as u32;
-        result
+        { ((self.bits >> start_bit) & mask) as u32 }
     }
 }
 

--- a/crates/fgumi-dna/src/dna.rs
+++ b/crates/fgumi-dna/src/dna.rs
@@ -59,14 +59,41 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
     seq.iter().rev().map(|&base| complement_base(base)).collect()
 }
 
-/// Reverse complements a DNA string.
+/// Complements a single DNA base, preserving case.
 ///
-/// Returns the reverse complement of the input string, preserving case.
+/// Returns the Watson-Crick complement: A<->T, C<->G.
+/// Unlike [`complement_base`], this preserves the case of the input:
+/// uppercase input produces uppercase output, lowercase produces lowercase.
 ///
-/// # Panics
+/// # Examples
 ///
-/// Cannot panic in practice: the byte-level complement maps ASCII to ASCII,
-/// so `String::from_utf8` always succeeds.
+/// ```
+/// use fgumi_dna::dna::complement_base_preserve_case;
+///
+/// assert_eq!(complement_base_preserve_case(b'A'), b'T');
+/// assert_eq!(complement_base_preserve_case(b'a'), b't');
+/// ```
+#[inline]
+#[must_use]
+pub const fn complement_base_preserve_case(base: u8) -> u8 {
+    match base {
+        b'A' => b'T',
+        b'T' => b'A',
+        b'C' => b'G',
+        b'G' => b'C',
+        b'a' => b't',
+        b't' => b'a',
+        b'c' => b'g',
+        b'g' => b'c',
+        other => other,
+    }
+}
+
+/// Reverse complements a DNA string, preserving case.
+///
+/// Returns the reverse complement of the input string.
+/// Unlike [`reverse_complement`], this preserves the case of each base.
+/// Non-ASCII characters are passed through unchanged.
 ///
 /// # Examples
 ///
@@ -79,26 +106,22 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 /// ```
 #[must_use]
 pub fn reverse_complement_str(seq: &str) -> String {
-    let bytes: Vec<u8> = seq
-        .bytes()
+    seq.chars()
         .rev()
-        .map(|b| match b {
-            b'A' => b'T',
-            b'T' => b'A',
-            b'C' => b'G',
-            b'G' => b'C',
-            b'a' => b't',
-            b't' => b'a',
-            b'c' => b'g',
-            b'g' => b'c',
-            other => other,
+        .map(|c| {
+            if c.is_ascii() {
+                complement_base_preserve_case(c as u8) as char
+            } else {
+                c
+            }
         })
-        .collect();
-    String::from_utf8(bytes).expect("complement of ASCII is ASCII")
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -154,6 +177,26 @@ mod tests {
         assert_eq!(reverse_complement(&reverse_complement(seq)), seq.to_vec());
     }
 
+    #[rstest]
+    #[case(b'A', b'T')]
+    #[case(b'T', b'A')]
+    #[case(b'C', b'G')]
+    #[case(b'G', b'C')]
+    #[case(b'a', b't')]
+    #[case(b't', b'a')]
+    #[case(b'c', b'g')]
+    #[case(b'g', b'c')]
+    #[case(b'N', b'N')]
+    #[case(b'n', b'n')]
+    #[case(b'.', b'.')]
+    #[case(b'-', b'-')]
+    #[case(b'*', b'*')]
+    #[case(b'0', b'0')]
+    #[case(b'X', b'X')]
+    fn test_complement_base_preserve_case(#[case] input: u8, #[case] expected: u8) {
+        assert_eq!(complement_base_preserve_case(input), expected);
+    }
+
     #[test]
     fn test_reverse_complement_str() {
         // Basic cases
@@ -172,5 +215,13 @@ mod tests {
         for seq in ["ACGT", "acgt", "AcGt"] {
             assert_eq!(reverse_complement_str(&reverse_complement_str(seq)), seq);
         }
+    }
+
+    #[test]
+    fn test_reverse_complement_str_non_ascii() {
+        // Non-ASCII characters (e.g. multi-byte UTF-8) should pass through unchanged
+        let input = "A\u{00e9}T"; // 'é' is a 2-byte UTF-8 character
+        let result = reverse_complement_str(input);
+        assert_eq!(result, "A\u{00e9}T");
     }
 }

--- a/crates/fgumi-dna/src/lib.rs
+++ b/crates/fgumi-dna/src/lib.rs
@@ -12,7 +12,9 @@ pub mod dna;
 
 // Re-export submodule contents at crate root for convenience
 pub use bitenc::BitEnc;
-pub use dna::{complement_base, reverse_complement, reverse_complement_str};
+pub use dna::{
+    complement_base, complement_base_preserve_case, reverse_complement, reverse_complement_str,
+};
 
 /// No-call base character (matches fgbio's `NoCallBase`).
 pub const NO_CALL_BASE: u8 = b'N';


### PR DESCRIPTION
## Summary
- Extract `complement_base_preserve_case` helper from duplicated match arms in `reverse_complement` and `complement`
- Remove unnecessary `let complement =` binding in `complement` function, returning the match directly

## Test plan
- [x] `cargo nextest run -p fgumi-dna` — all tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean