### PR TITLE
refactor(metrics): consolidate UmiCountTracker and remove ALL_REJECTIONS duplication

### DIFF
--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -149,27 +149,10 @@ const OPTIONAL_REJECTIONS: [RejectionReason; 14] = [
     RejectionReason::DuplicateUmi,
 ];
 
-/// All rejection reasons, combining core and optional.
-const ALL_REJECTIONS: [RejectionReason; 18] = [
-    RejectionReason::InsufficientSupport,
-    RejectionReason::MinorityAlignment,
-    RejectionReason::InsufficientStrandSupport,
-    RejectionReason::LowBaseQuality,
-    RejectionReason::ExcessiveNBases,
-    RejectionReason::NoValidAlignment,
-    RejectionReason::LowMappingQuality,
-    RejectionReason::NBasesInUmi,
-    RejectionReason::MissingUmi,
-    RejectionReason::NotPassingFilter,
-    RejectionReason::LowMeanQuality,
-    RejectionReason::InsufficientMinDepth,
-    RejectionReason::ExcessiveErrorRate,
-    RejectionReason::UmiTooShort,
-    RejectionReason::SameStrandOnly,
-    RejectionReason::DuplicateUmi,
-    RejectionReason::OrphanConsensus,
-    RejectionReason::ZeroBasesPostTrimming,
-];
+/// Returns an iterator over all rejection reasons (core + optional).
+fn all_rejections() -> impl Iterator<Item = RejectionReason> {
+    CORE_REJECTIONS.into_iter().chain(OPTIONAL_REJECTIONS)
+}
 
 impl ConsensusMetrics {
     /// Creates a new consensus metrics struct with all counts initialized to zero.
@@ -267,7 +250,7 @@ impl ConsensusMetrics {
     /// Returns the total number of rejections across all reasons.
     #[must_use]
     pub fn total_rejections(&self) -> u64 {
-        ALL_REJECTIONS.iter().map(|r| self.rejection_count(*r)).sum()
+        all_rejections().map(|r| self.rejection_count(r)).sum()
     }
 
     /// Returns a map of rejection reasons to their counts.
@@ -275,9 +258,8 @@ impl ConsensusMetrics {
     /// Only includes rejection reasons with non-zero counts.
     #[must_use]
     pub fn rejection_summary(&self) -> HashMap<RejectionReason, u64> {
-        ALL_REJECTIONS
-            .iter()
-            .filter_map(|&reason| {
+        all_rejections()
+            .filter_map(|reason| {
                 let count = self.rejection_count(reason);
                 if count > 0 { Some((reason, count)) } else { None }
             })

--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -273,50 +273,40 @@ impl Metric for DuplexUmiMetric {
 }
 
 /// Tracks raw, error, and unique UMI observation counts.
-#[allow(clippy::struct_field_names)]
 struct UmiCountTracker {
-    raw_counts: HashMap<String, usize>,
-    error_counts: HashMap<String, usize>,
-    unique_counts: HashMap<String, usize>,
+    /// Maps UMI string to `(raw_count, error_count, unique_count)`.
+    counts: HashMap<String, (usize, usize, usize)>,
 }
 
 impl UmiCountTracker {
     /// Creates an empty tracker.
     fn new() -> Self {
-        Self {
-            raw_counts: HashMap::new(),
-            error_counts: HashMap::new(),
-            unique_counts: HashMap::new(),
-        }
+        Self { counts: HashMap::new() }
     }
 
     /// Records an observation for a UMI.
     fn record(&mut self, umi: &str, raw_count: usize, error_count: usize, is_unique: bool) {
-        let key = umi.to_string();
-        *self.raw_counts.entry(key.clone()).or_insert(0) += raw_count;
-        *self.error_counts.entry(key.clone()).or_insert(0) += error_count;
+        let entry = self.counts.entry(umi.to_string()).or_insert((0, 0, 0));
+        entry.0 += raw_count;
+        entry.1 += error_count;
         if is_unique {
-            *self.unique_counts.entry(key).or_insert(0) += 1;
+            entry.2 += 1;
         }
     }
 
     /// Total raw observations across all UMIs.
     fn total_raw(&self) -> usize {
-        self.raw_counts.values().sum()
+        self.counts.values().map(|(raw, _, _)| raw).sum()
     }
 
     /// Total unique observations across all UMIs.
     fn total_unique(&self) -> usize {
-        self.unique_counts.values().sum()
+        self.counts.values().map(|(_, _, unique)| unique).sum()
     }
 
     /// Iterates over all tracked UMIs, yielding `(umi, raw_count, error_count, unique_count)`.
     fn iter(&self) -> impl Iterator<Item = (&str, usize, usize, usize)> {
-        self.raw_counts.iter().map(|(umi, &raw)| {
-            let errors = self.error_counts.get(umi).copied().unwrap_or(0);
-            let unique = self.unique_counts.get(umi).copied().unwrap_or(0);
-            (umi.as_str(), raw, errors, unique)
-        })
+        self.counts.iter().map(|(umi, &(raw, errors, unique))| (umi.as_str(), raw, errors, unique))
     }
 }
 


### PR DESCRIPTION
## Summary
- Consolidate `UmiCountTracker` from 3 separate HashMaps (raw counts, error counts, unique counts) into a single `HashMap<String, (usize, usize, usize)>`, eliminating redundant key cloning on each `record()` call
- Replace `ALL_REJECTIONS` const array (which manually listed CORE + OPTIONAL rejections) with `all_rejections()` function that chains the two source arrays

## Test plan
- [x] `cargo nextest run -p fgumi-metrics` — all tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean