### PR TITLE
refactor(umi): use binary search for count_index and deduplicate MoleculeId formatting

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -1119,6 +1119,7 @@ impl AdjacencyUmiAssigner {
     }
 
     /// Build adjacency graph using `BitEnc` for efficient matching.
+    #[expect(clippy::too_many_lines, reason = "complex graph-building algorithm")]
     fn build_adjacency_graph_bitenc(
         &self,
         umi_counts: &[(BitEnc, usize, usize)], // (encoded, count, first_raw_index)
@@ -1188,11 +1189,16 @@ impl AdjacencyUmiAssigner {
 
                 let max_child_count = nodes[idx].count / 2 + 1;
 
-                // Find where to start searching (for count constraint)
-                let search_from = count_index
-                    .iter()
-                    .find(|(count, _)| *count <= max_child_count)
-                    .map_or(nodes.len(), |(_, idx)| *idx);
+                // Find where to start searching (for count constraint).
+                // count_index is sorted by descending count; binary search for the
+                // first entry with count <= max_child_count.
+                let ci_pos =
+                    count_index.partition_point(|(count, _)| *count > max_child_count);
+                let search_from = if ci_pos < count_index.len() {
+                    count_index[ci_pos].1
+                } else {
+                    nodes.len()
+                };
 
                 if search_from < nodes.len() {
                     let parent_enc = &umi_counts[idx].0;
@@ -1342,11 +1348,16 @@ impl AdjacencyUmiAssigner {
 
                 let max_child_count = nodes[idx].count / 2 + 1;
 
-                // Find where to start searching (for count constraint)
-                let search_from = count_index
-                    .iter()
-                    .find(|(count, _)| *count <= max_child_count)
-                    .map_or(nodes.len(), |(_, idx)| *idx);
+                // Find where to start searching (for count constraint).
+                // count_index is sorted by descending count; binary search for the
+                // first entry with count <= max_child_count.
+                let ci_pos =
+                    count_index.partition_point(|(count, _)| *count > max_child_count);
+                let search_from = if ci_pos < count_index.len() {
+                    count_index[ci_pos].1
+                } else {
+                    nodes.len()
+                };
 
                 if search_from < nodes.len() {
                     let parent_umi = &umi_counts[idx].0;

--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -59,12 +59,9 @@ impl MoleculeId {
     /// need to be converted to global IDs by adding the base offset.
     #[must_use]
     pub fn to_string_with_offset(&self, base: u64) -> String {
-        match self {
-            MoleculeId::None => String::new(),
-            MoleculeId::Single(id) => format!("{}", base + id),
-            MoleculeId::PairedA(id) => format!("{}/A", base + id),
-            MoleculeId::PairedB(id) => format!("{}/B", base + id),
-        }
+        let mut buf = String::new();
+        self.write_with_offset(base, &mut buf);
+        buf
     }
 
     /// Write string representation into a reusable buffer, returning the bytes.


### PR DESCRIPTION
## Summary
- Replace O(n) linear `.find()` scan on `count_index` with O(log n) `partition_point` binary search in both `build_adjacency_graph_bitenc` and `build_adjacency_graph` — the array is sorted descending by count, making binary search straightforward
- Simplify `MoleculeId::to_string_with_offset` to delegate to `write_with_offset`, removing duplicated format logic

## Test plan
- [x] `cargo nextest run -p fgumi-umi` — all tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean