### PR TITLE
refactor(consensus): precompute phred threshold and eliminate redundant error-counting pass

### DIFF
--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -30,6 +30,9 @@ pub const MAX_PHRED: u8 = 93;
 /// Precision constant used in Phred score conversion (matching fgbio)
 const PHRED_PRECISION: f64 = 0.001;
 
+/// Precomputed `phred_to_ln_error_prob(MAX_PHRED)` used as a threshold in `ln_prob_to_phred`.
+const MAX_PHRED_AS_LN_ERROR: f64 = -(MAX_PHRED as f64) * LN_10 / 10.0;
+
 /// Phred score type
 pub type PhredScore = u8;
 
@@ -117,8 +120,7 @@ pub fn ln_prob_to_phred(ln_prob: LogProbability) -> PhredScore {
     // Match fgbio's PhredScore.fromLogProbability:
     // if (lnProbError < MaxValueAsLogDouble) MaxValue
     // else Math.floor(-10.0 * (lnProbError/ Ln10) + Precision).toByte
-    let max_value_as_log = phred_to_ln_error_prob(MAX_PHRED);
-    if ln_prob < max_value_as_log {
+    if ln_prob < MAX_PHRED_AS_LN_ERROR {
         return MAX_PHRED;
     }
     let phred = (-10.0 * ln_prob / LN_10 + PHRED_PRECISION).floor();

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -365,7 +365,6 @@ pub struct VanillaUmiConsensusCaller {
 
 #[expect(
     clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     reason = "consensus calling uses numeric casts for quality/position math"
 )]
@@ -1169,16 +1168,9 @@ impl VanillaUmiConsensusCaller {
             // Record depth
             depths.push(depth);
 
-            // Count errors (bases that disagree with consensus)
-            let error_count: usize = source_reads
-                .iter()
-                .filter(|sr| {
-                    pos < sr.bases.len() && sr.bases[pos] != NO_CALL_BASE && sr.bases[pos] != base
-                })
-                .count();
-            let error_u16 =
-                if error_count > u16::MAX as usize { u16::MAX } else { error_count as u16 };
-            errors.push(error_u16);
+            // Errors = total contributing bases minus those matching consensus
+            let error_count = depth - self.consensus_builder.observations_for_base(base);
+            errors.push(error_count);
 
             // Apply minimum depth and quality thresholds
             let (final_base, final_qual) = if (depth as usize) < min_reads {


### PR DESCRIPTION
## Summary
- Precompute `phred_to_ln_error_prob(MAX_PHRED)` as a compile-time constant (`MAX_PHRED_AS_LN_ERROR`) instead of recomputing on every `ln_prob_to_phred` call
- Replace O(n) second pass over source reads for error counting in vanilla consensus with `contributions() - observations_for_base(base)`, deriving the same value from data already computed by the consensus builder
- Fix pre-existing missing `bstr::ByteSlice` import in tags.rs tests

## Test plan
- [x] `cargo nextest run -p fgumi-consensus` — 493 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean