### PR TITLE
refactor(pipeline): deduplicate scheduler constants and shared functions

### DIFF
--- a/src/lib/unified_pipeline/scheduler/backpressure_proportional.rs
+++ b/src/lib/unified_pipeline/scheduler/backpressure_proportional.rs
@@ -24,19 +24,6 @@ pub struct BackpressureProportionalScheduler {
 }
 
 impl BackpressureProportionalScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Default EMA alpha (10% per update).
     const DEFAULT_ALPHA: f64 = 0.1;
     /// High weight value.
@@ -55,7 +42,7 @@ impl BackpressureProportionalScheduler {
             num_threads,
             weights,
             alpha: Self::DEFAULT_ALPHA,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
     }
@@ -95,8 +82,9 @@ impl Scheduler for BackpressureProportionalScheduler {
         }
         weighted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
+        let all_steps = PipelineStep::all();
         for (priority, (_, step_idx)) in weighted.iter().enumerate() {
-            self.priority_buffer[priority] = Self::STEPS[*step_idx];
+            self.priority_buffer[priority] = all_steps[*step_idx];
         }
 
         let n = self.active_steps.filter_in_place(&mut self.priority_buffer);

--- a/src/lib/unified_pipeline/scheduler/balanced_chase.rs
+++ b/src/lib/unified_pipeline/scheduler/balanced_chase.rs
@@ -34,22 +34,10 @@ pub struct BalancedChaseScheduler {
 }
 
 impl BalancedChaseScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Create a new balanced chase scheduler.
     #[must_use]
     pub fn new(thread_id: usize, num_threads: usize, active_steps: ActiveSteps) -> Self {
+        assert!(num_threads > 0, "num_threads must be > 0");
         let (current_step, exclusive_role) = Self::determine_role(thread_id, num_threads);
 
         Self {
@@ -57,7 +45,7 @@ impl BalancedChaseScheduler {
             num_threads,
             current_step,
             direction: Direction::Forward,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             exclusive_role,
             active_steps,
         }
@@ -68,30 +56,7 @@ impl BalancedChaseScheduler {
         thread_id: usize,
         num_threads: usize,
     ) -> (PipelineStep, Option<PipelineStep>) {
-        use PipelineStep::{Compress, FindBoundaries, Group, Read, Serialize, Write};
-
-        if thread_id == 0 {
-            // T0 handles Read, but starts ready to help with Compress
-            (Compress, Some(Read))
-        } else if thread_id == num_threads - 1 && num_threads > 1 {
-            // T7 handles Write, but starts ready to help with Compress
-            (Compress, Some(Write))
-        } else if thread_id == 1 && num_threads > 2 {
-            // T1 handles FindBoundaries
-            (FindBoundaries, Some(FindBoundaries))
-        } else if thread_id == num_threads - 2 && num_threads > 3 {
-            // T6 handles Group
-            (Group, Some(Group))
-        } else {
-            // Middle threads start spread across bottleneck steps
-            let step = if thread_id.is_multiple_of(2) { Compress } else { Serialize };
-            (step, None)
-        }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
+        super::balanced_chase_determine_role(thread_id, num_threads)
     }
 
     /// Build priority list with bottleneck focus.
@@ -188,20 +153,20 @@ impl Scheduler for BalancedChaseScheduler {
             }
         } else {
             // On failure, move toward bottleneck steps
-            let idx = Self::step_index(self.current_step);
+            let idx = self.current_step.index();
 
             // Bias movement toward Compress (index 7) and Serialize (index 6)
             self.current_step = match self.direction {
                 Direction::Forward => {
                     if idx < 7 {
-                        Self::STEPS[idx + 1]
+                        PipelineStep::all()[idx + 1]
                     } else {
                         PipelineStep::Compress
                     }
                 }
                 Direction::Backward => {
                     if idx > 1 && idx != 7 && idx != 6 {
-                        Self::STEPS[idx - 1]
+                        PipelineStep::all()[idx - 1]
                     } else {
                         // Stay near bottleneck
                         PipelineStep::Serialize
@@ -289,5 +254,11 @@ mod tests {
         // Both should be in top 3
         assert!(compress_pos.unwrap() < 3);
         assert!(serialize_pos.unwrap() < 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "num_threads must be > 0")]
+    fn test_zero_threads_panics() {
+        let _ = BalancedChaseScheduler::new(0, 0, all());
     }
 }

--- a/src/lib/unified_pipeline/scheduler/balanced_chase_drain.rs
+++ b/src/lib/unified_pipeline/scheduler/balanced_chase_drain.rs
@@ -44,19 +44,6 @@ pub struct BalancedChaseDrainScheduler {
 }
 
 impl BalancedChaseDrainScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Create a new balanced chase drain scheduler.
     #[must_use]
     pub fn new(thread_id: usize, num_threads: usize, active_steps: ActiveSteps) -> Self {
@@ -69,7 +56,7 @@ impl BalancedChaseDrainScheduler {
             num_threads,
             current_step,
             direction: Direction::Forward,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             exclusive_role,
             drain_mode: false,
             memory_drain_mode: false,
@@ -100,30 +87,7 @@ impl BalancedChaseDrainScheduler {
         thread_id: usize,
         num_threads: usize,
     ) -> (PipelineStep, Option<PipelineStep>) {
-        use PipelineStep::{Compress, FindBoundaries, Group, Read, Serialize, Write};
-
-        if thread_id == 0 {
-            // T0 handles Read, but starts ready to help with Compress
-            (Compress, Some(Read))
-        } else if thread_id == num_threads - 1 && num_threads > 1 {
-            // TN-1 handles Write, but starts ready to help with Compress
-            (Compress, Some(Write))
-        } else if thread_id == 1 && num_threads > 2 {
-            // T1 handles FindBoundaries
-            (FindBoundaries, Some(FindBoundaries))
-        } else if thread_id == num_threads - 2 && num_threads > 3 {
-            // TN-2 handles Group
-            (Group, Some(Group))
-        } else {
-            // Middle threads start spread across bottleneck steps
-            let step = if thread_id.is_multiple_of(2) { Compress } else { Serialize };
-            (step, None)
-        }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
+        super::balanced_chase_determine_role(thread_id, num_threads)
     }
 
     /// Build priority list with drain mode support.
@@ -285,20 +249,20 @@ impl Scheduler for BalancedChaseDrainScheduler {
             }
 
             // Movement logic from balanced-chase
-            let idx = Self::step_index(self.current_step);
+            let idx = self.current_step.index();
 
             // Bias movement toward Compress (index 7) and Serialize (index 6)
             self.current_step = match self.direction {
                 Direction::Forward => {
                     if idx < 7 {
-                        Self::STEPS[idx + 1]
+                        PipelineStep::all()[idx + 1]
                     } else {
                         PipelineStep::Compress
                     }
                 }
                 Direction::Backward => {
                     if idx > 1 && idx != 7 && idx != 6 {
-                        Self::STEPS[idx - 1]
+                        PipelineStep::all()[idx - 1]
                     } else {
                         // Stay near bottleneck
                         PipelineStep::Serialize

--- a/src/lib/unified_pipeline/scheduler/chase_bottleneck.rs
+++ b/src/lib/unified_pipeline/scheduler/chase_bottleneck.rs
@@ -31,19 +31,6 @@ pub struct ChaseBottleneckScheduler {
 }
 
 impl ChaseBottleneckScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Create a new chase-bottleneck scheduler.
     #[must_use]
     pub fn new(thread_id: usize, num_threads: usize, active_steps: ActiveSteps) -> Self {
@@ -53,7 +40,7 @@ impl ChaseBottleneckScheduler {
             num_threads,
             current_step,
             direction: Direction::Forward,
-            priority_buffer: Self::STEPS, // Will be reordered in get_priorities
+            priority_buffer: PipelineStep::all(), // Will be reordered in get_priorities
             active_steps,
         }
     }
@@ -73,17 +60,12 @@ impl ChaseBottleneckScheduler {
         }
     }
 
-    /// Get the index of a step in the pipeline.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
-    }
-
     /// Build priority list starting from current step, expanding outward.
     /// If direction is Forward, prefer downstream steps (toward Write).
     /// If direction is Backward, prefer upstream steps (toward Read).
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn build_priorities(&mut self) {
-        let current_idx = Self::step_index(self.current_step);
+        let current_idx = self.current_step.index();
         let mut priorities = [PipelineStep::Read; 9];
         let mut idx = 0;
 
@@ -106,14 +88,14 @@ impl ChaseBottleneckScheduler {
             let first_idx = (current_idx as i32 + first_dir * forward_offset as i32) as usize;
             if first_dir > 0 && forward_offset <= 8 - current_idx {
                 if first_idx < 9 {
-                    priorities[idx] = Self::STEPS[first_idx];
+                    priorities[idx] = PipelineStep::all()[first_idx];
                     idx += 1;
                     forward_offset += 1;
                 }
             } else if first_dir < 0 && backward_offset <= current_idx {
                 let back_idx = current_idx - backward_offset;
                 if back_idx < 9 {
-                    priorities[idx] = Self::STEPS[back_idx];
+                    priorities[idx] = PipelineStep::all()[back_idx];
                     idx += 1;
                     backward_offset += 1;
                 }
@@ -127,14 +109,14 @@ impl ChaseBottleneckScheduler {
             let second_idx = (current_idx as i32 + second_dir * backward_offset as i32) as usize;
             if second_dir > 0 && forward_offset <= 8 - current_idx {
                 if second_idx < 9 {
-                    priorities[idx] = Self::STEPS[second_idx];
+                    priorities[idx] = PipelineStep::all()[second_idx];
                     idx += 1;
                     forward_offset += 1;
                 }
             } else if second_dir < 0 && backward_offset <= current_idx {
                 let back_idx = current_idx - backward_offset;
                 if back_idx < 9 {
-                    priorities[idx] = Self::STEPS[back_idx];
+                    priorities[idx] = PipelineStep::all()[back_idx];
                     idx += 1;
                     backward_offset += 1;
                 }
@@ -147,14 +129,14 @@ impl ChaseBottleneckScheduler {
                 if remaining_forward > 0 {
                     let fwd_idx = current_idx + forward_offset;
                     if fwd_idx < 9 {
-                        priorities[idx] = Self::STEPS[fwd_idx];
+                        priorities[idx] = PipelineStep::all()[fwd_idx];
                         idx += 1;
                         forward_offset += 1;
                     }
                 }
                 if idx < 9 && remaining_backward > 0 && backward_offset <= current_idx {
                     let back_idx = current_idx - backward_offset;
-                    priorities[idx] = Self::STEPS[back_idx];
+                    priorities[idx] = PipelineStep::all()[back_idx];
                     idx += 1;
                     backward_offset += 1;
                 }
@@ -188,22 +170,22 @@ impl Scheduler for ChaseBottleneckScheduler {
             self.current_step = step;
         } else {
             // On failure, move in current direction to find work
-            let idx = Self::step_index(self.current_step);
+            let idx = self.current_step.index();
             match self.direction {
                 Direction::Forward => {
                     // Move downstream
                     if idx < 8 {
-                        self.current_step = Self::STEPS[idx + 1];
+                        self.current_step = PipelineStep::all()[idx + 1];
                     } else {
-                        self.current_step = Self::STEPS[0]; // Wrap
+                        self.current_step = PipelineStep::all()[0]; // Wrap
                     }
                 }
                 Direction::Backward => {
                     // Move upstream
                     if idx > 0 {
-                        self.current_step = Self::STEPS[idx - 1];
+                        self.current_step = PipelineStep::all()[idx - 1];
                     } else {
-                        self.current_step = Self::STEPS[8]; // Wrap
+                        self.current_step = PipelineStep::all()[8]; // Wrap
                     }
                 }
             }

--- a/src/lib/unified_pipeline/scheduler/epsilon_greedy.rs
+++ b/src/lib/unified_pipeline/scheduler/epsilon_greedy.rs
@@ -38,19 +38,6 @@ pub struct EpsilonGreedyScheduler {
 }
 
 impl EpsilonGreedyScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Default epsilon (10% exploration).
     const DEFAULT_EPSILON: f64 = 0.1;
 
@@ -68,14 +55,9 @@ impl EpsilonGreedyScheduler {
             attempts: [0; 9],
             successes: [0; 9],
             rng: SmallRng::seed_from_u64(seed),
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
     }
 
     /// Get success rate for a step.
@@ -93,7 +75,7 @@ impl Scheduler for EpsilonGreedyScheduler {
     fn get_priorities(&mut self, _backpressure: BackpressureState) -> &[PipelineStep] {
         if self.rng.random::<f64>() < self.epsilon {
             // Explore: random order
-            self.priority_buffer = Self::STEPS;
+            self.priority_buffer = PipelineStep::all();
             self.priority_buffer.shuffle(&mut self.rng);
         } else {
             // Exploit: sort by success rate (descending)
@@ -104,7 +86,7 @@ impl Scheduler for EpsilonGreedyScheduler {
             rates.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
             for (priority, (_, step_idx)) in rates.iter().enumerate() {
-                self.priority_buffer[priority] = Self::STEPS[*step_idx];
+                self.priority_buffer[priority] = PipelineStep::all()[*step_idx];
             }
         }
 
@@ -113,7 +95,7 @@ impl Scheduler for EpsilonGreedyScheduler {
     }
 
     fn record_outcome(&mut self, step: PipelineStep, success: bool, _was_contention: bool) {
-        let idx = Self::step_index(step);
+        let idx = step.index();
         self.attempts[idx] += 1;
         if success {
             self.successes[idx] += 1;

--- a/src/lib/unified_pipeline/scheduler/learned_affinity.rs
+++ b/src/lib/unified_pipeline/scheduler/learned_affinity.rs
@@ -44,19 +44,6 @@ pub struct LearnedAffinityScheduler {
 }
 
 impl LearnedAffinityScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Initial exploration rate.
     const DEFAULT_EXPLORATION_RATE: f64 = 0.3;
     /// Decay factor per 1000 attempts.
@@ -81,14 +68,9 @@ impl LearnedAffinityScheduler {
             min_exploration_rate: Self::DEFAULT_MIN_EXPLORATION,
             total_attempts: 0,
             rng: SmallRng::seed_from_u64(seed),
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
     }
 
     /// Get affinity score for a step.
@@ -122,7 +104,7 @@ impl Scheduler for LearnedAffinityScheduler {
 
         if self.rng.random::<f64>() < explore_rate {
             // Explore: random order
-            self.priority_buffer = Self::STEPS;
+            self.priority_buffer = PipelineStep::all();
             self.priority_buffer.shuffle(&mut self.rng);
         } else {
             // Exploit: sort by learned affinity
@@ -133,7 +115,7 @@ impl Scheduler for LearnedAffinityScheduler {
             affinities.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
             for (priority, (_, step_idx)) in affinities.iter().enumerate() {
-                self.priority_buffer[priority] = Self::STEPS[*step_idx];
+                self.priority_buffer[priority] = PipelineStep::all()[*step_idx];
             }
         }
 
@@ -142,7 +124,7 @@ impl Scheduler for LearnedAffinityScheduler {
     }
 
     fn record_outcome(&mut self, step: PipelineStep, success: bool, _was_contention: bool) {
-        let idx = Self::step_index(step);
+        let idx = step.index();
         self.total_attempts += 1;
         self.attempts[idx] += 1;
         if success {

--- a/src/lib/unified_pipeline/scheduler/mod.rs
+++ b/src/lib/unified_pipeline/scheduler/mod.rs
@@ -354,6 +354,31 @@ pub trait Scheduler: Send {
     }
 }
 
+/// Determine thread role for balanced-chase schedulers.
+///
+/// Returns `(initial_step, exclusive_role)` where `initial_step` is the step the thread
+/// should start on, and `exclusive_role` is the exclusive step it owns (if any).
+fn balanced_chase_determine_role(
+    thread_id: usize,
+    num_threads: usize,
+) -> (PipelineStep, Option<PipelineStep>) {
+    use PipelineStep::{Compress, FindBoundaries, Group, Read, Serialize, Write};
+
+    if thread_id == 0 {
+        (Compress, Some(Read))
+    } else if thread_id == num_threads - 1 && num_threads > 1 {
+        (Compress, Some(Write))
+    } else if thread_id == 1 && num_threads > 2 {
+        (FindBoundaries, Some(FindBoundaries))
+    } else if thread_id == num_threads - 2 && num_threads > 3 {
+        (Group, Some(Group))
+    } else {
+        // Middle threads start spread across bottleneck steps
+        let step = if thread_id.is_multiple_of(2) { Compress } else { Serialize };
+        (step, None)
+    }
+}
+
 /// Create a scheduler based on strategy.
 #[must_use]
 pub fn create_scheduler(

--- a/src/lib/unified_pipeline/scheduler/optimized_chase.rs
+++ b/src/lib/unified_pipeline/scheduler/optimized_chase.rs
@@ -43,19 +43,6 @@ pub struct OptimizedChaseScheduler {
 }
 
 impl OptimizedChaseScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Exclusive steps that only one thread can execute at a time.
     const EXCLUSIVE_STEPS: [PipelineStep; 4] = [
         PipelineStep::Read,
@@ -84,7 +71,7 @@ impl OptimizedChaseScheduler {
             num_threads,
             current_step,
             direction: Direction::Forward,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             bottleneck_streak: 0,
             exclusive_backoff: 0,
             is_exclusive_specialist,
@@ -121,11 +108,6 @@ impl OptimizedChaseScheduler {
         }
     }
 
-    /// Get the index of a step in the pipeline.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
-    }
-
     /// Check if a step is exclusive.
     fn is_exclusive(step: PipelineStep) -> bool {
         Self::EXCLUSIVE_STEPS.contains(&step)
@@ -140,7 +122,7 @@ impl OptimizedChaseScheduler {
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn build_priorities(&mut self, _bp: BackpressureState) {
         let mut priorities = Vec::with_capacity(9);
-        let current_idx = Self::step_index(self.current_step);
+        let current_idx = self.current_step.index();
 
         // 1. Current step first (if not backing off from exclusive)
         let skip_current = Self::is_exclusive(self.current_step)
@@ -179,7 +161,7 @@ impl OptimizedChaseScheduler {
             // Primary direction
             let idx1 = current_idx as i32 + first_dir * distance;
             if (0..9).contains(&idx1) {
-                let step = Self::STEPS[idx1 as usize];
+                let step = PipelineStep::all()[idx1 as usize];
                 if !priorities.contains(&step) && self.should_include_step(step) {
                     priorities.push(step);
                 }
@@ -188,7 +170,7 @@ impl OptimizedChaseScheduler {
             // Secondary direction
             let idx2 = current_idx as i32 + second_dir * distance;
             if (0..9).contains(&idx2) {
-                let step = Self::STEPS[idx2 as usize];
+                let step = PipelineStep::all()[idx2 as usize];
                 if !priorities.contains(&step) && self.should_include_step(step) {
                     priorities.push(step);
                 }
@@ -196,7 +178,7 @@ impl OptimizedChaseScheduler {
         }
 
         // 5. Fill any remaining steps (shouldn't happen, but safety)
-        for &step in &Self::STEPS {
+        for &step in &PipelineStep::all() {
             if !priorities.contains(&step) {
                 priorities.push(step);
             }
@@ -277,11 +259,11 @@ impl Scheduler for OptimizedChaseScheduler {
             }
 
             // Normal movement: advance in current direction
-            let idx = Self::step_index(self.current_step);
+            let idx = self.current_step.index();
             self.current_step = match self.direction {
                 Direction::Forward => {
                     if idx < 8 {
-                        Self::STEPS[idx + 1]
+                        PipelineStep::all()[idx + 1]
                     } else {
                         // Wrap to first parallel step, not Read
                         PipelineStep::Decompress
@@ -289,7 +271,7 @@ impl Scheduler for OptimizedChaseScheduler {
                 }
                 Direction::Backward => {
                     if idx > 1 {
-                        Self::STEPS[idx - 1]
+                        PipelineStep::all()[idx - 1]
                     } else {
                         // Wrap to last parallel step, not Write
                         PipelineStep::Compress

--- a/src/lib/unified_pipeline/scheduler/sticky_work_stealing.rs
+++ b/src/lib/unified_pipeline/scheduler/sticky_work_stealing.rs
@@ -28,19 +28,6 @@ pub struct StickyWorkStealingScheduler {
 }
 
 impl StickyWorkStealingScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Steps to try before returning home.
     const DEFAULT_HOME_RETURN_THRESHOLD: usize = 10;
 
@@ -56,7 +43,7 @@ impl StickyWorkStealingScheduler {
             current_step: home_step,
             away_counter: 0,
             home_return_threshold: Self::DEFAULT_HOME_RETURN_THRESHOLD,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
     }
@@ -83,14 +70,9 @@ impl StickyWorkStealingScheduler {
         }
     }
 
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
-    }
-
     /// Build priorities: home first, then adjacent, then others.
     fn build_priorities(&mut self) {
-        let current_idx = Self::step_index(self.current_step);
+        let current_idx = self.current_step.index();
 
         let mut idx = 0;
 
@@ -106,14 +88,14 @@ impl StickyWorkStealingScheduler {
 
         // 3. Adjacent to current step
         if current_idx > 0 {
-            let prev = Self::STEPS[current_idx - 1];
+            let prev = PipelineStep::all()[current_idx - 1];
             if prev != self.home_step {
                 self.priority_buffer[idx] = prev;
                 idx += 1;
             }
         }
         if current_idx < 8 {
-            let next = Self::STEPS[current_idx + 1];
+            let next = PipelineStep::all()[current_idx + 1];
             if next != self.home_step {
                 self.priority_buffer[idx] = next;
                 idx += 1;
@@ -121,7 +103,7 @@ impl StickyWorkStealingScheduler {
         }
 
         // 4. Remaining steps
-        for step in Self::STEPS {
+        for step in PipelineStep::all() {
             if !self.priority_buffer[..idx].contains(&step) {
                 self.priority_buffer[idx] = step;
                 idx += 1;

--- a/src/lib/unified_pipeline/scheduler/thompson_sampling.rs
+++ b/src/lib/unified_pipeline/scheduler/thompson_sampling.rs
@@ -36,19 +36,6 @@ pub struct ThompsonSamplingScheduler {
 }
 
 impl ThompsonSamplingScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Create a new Thompson Sampling scheduler.
     #[must_use]
     pub fn new(thread_id: usize, num_threads: usize, active_steps: ActiveSteps) -> Self {
@@ -63,14 +50,9 @@ impl ThompsonSamplingScheduler {
             alphas: [1.0; 9], // Uniform prior Beta(1, 1)
             betas: [1.0; 9],
             rng: SmallRng::seed_from_u64(seed),
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
     }
 
     /// Sample from Beta distribution, clamping to avoid edge cases.
@@ -100,7 +82,7 @@ impl Scheduler for ThompsonSamplingScheduler {
 
         // Build priority buffer
         for (priority, (_, step_idx)) in samples.iter().enumerate() {
-            self.priority_buffer[priority] = Self::STEPS[*step_idx];
+            self.priority_buffer[priority] = PipelineStep::all()[*step_idx];
         }
 
         let n = self.active_steps.filter_in_place(&mut self.priority_buffer);
@@ -108,7 +90,7 @@ impl Scheduler for ThompsonSamplingScheduler {
     }
 
     fn record_outcome(&mut self, step: PipelineStep, success: bool, _was_contention: bool) {
-        let idx = Self::step_index(step);
+        let idx = step.index();
         if success {
             self.alphas[idx] += 1.0;
         } else {

--- a/src/lib/unified_pipeline/scheduler/thompson_with_priors.rs
+++ b/src/lib/unified_pipeline/scheduler/thompson_with_priors.rs
@@ -35,19 +35,6 @@ pub struct ThompsonWithPriorsScheduler {
 }
 
 impl ThompsonWithPriorsScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Prior strength for specialized threads.
     const STRONG_PRIOR: f64 = 20.0;
     /// Prior strength for secondary preferences.
@@ -95,14 +82,9 @@ impl ThompsonWithPriorsScheduler {
             alphas,
             betas,
             rng: SmallRng::seed_from_u64(seed),
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
     }
 
     /// Sample from Beta distribution.
@@ -128,7 +110,7 @@ impl Scheduler for ThompsonWithPriorsScheduler {
         samples.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
         for (priority, (_, step_idx)) in samples.iter().enumerate() {
-            self.priority_buffer[priority] = Self::STEPS[*step_idx];
+            self.priority_buffer[priority] = PipelineStep::all()[*step_idx];
         }
 
         let n = self.active_steps.filter_in_place(&mut self.priority_buffer);
@@ -136,7 +118,7 @@ impl Scheduler for ThompsonWithPriorsScheduler {
     }
 
     fn record_outcome(&mut self, step: PipelineStep, success: bool, _was_contention: bool) {
-        let idx = Self::step_index(step);
+        let idx = step.index();
         if success {
             self.alphas[idx] += 1.0;
         } else {

--- a/src/lib/unified_pipeline/scheduler/ucb.rs
+++ b/src/lib/unified_pipeline/scheduler/ucb.rs
@@ -31,19 +31,6 @@ pub struct UCBScheduler {
 }
 
 impl UCBScheduler {
-    /// All pipeline steps in order.
-    const STEPS: [PipelineStep; 9] = [
-        PipelineStep::Read,
-        PipelineStep::Decompress,
-        PipelineStep::FindBoundaries,
-        PipelineStep::Decode,
-        PipelineStep::Group,
-        PipelineStep::Process,
-        PipelineStep::Serialize,
-        PipelineStep::Compress,
-        PipelineStep::Write,
-    ];
-
     /// Default exploration constant (sqrt(2)).
     const DEFAULT_EXPLORATION_C: f64 = 1.414;
 
@@ -57,14 +44,9 @@ impl UCBScheduler {
             attempts: [0; 9],
             successes: [0; 9],
             exploration_c: Self::DEFAULT_EXPLORATION_C,
-            priority_buffer: Self::STEPS,
+            priority_buffer: PipelineStep::all(),
             active_steps,
         }
-    }
-
-    /// Get the index of a step.
-    fn step_index(step: PipelineStep) -> usize {
-        Self::STEPS.iter().position(|&s| s == step).unwrap_or(0)
     }
 
     /// Calculate UCB score for a step.
@@ -98,7 +80,7 @@ impl Scheduler for UCBScheduler {
 
         // Build priority buffer
         for (priority, (_, step_idx)) in scores.iter().enumerate() {
-            self.priority_buffer[priority] = Self::STEPS[*step_idx];
+            self.priority_buffer[priority] = PipelineStep::all()[*step_idx];
         }
 
         let n = self.active_steps.filter_in_place(&mut self.priority_buffer);
@@ -106,7 +88,7 @@ impl Scheduler for UCBScheduler {
     }
 
     fn record_outcome(&mut self, step: PipelineStep, success: bool, _was_contention: bool) {
-        let idx = Self::step_index(step);
+        let idx = step.index();
         self.total_attempts += 1;
         self.attempts[idx] += 1;
         if success {


### PR DESCRIPTION
## Summary
- Replace per-scheduler `STEPS` constant (11 copies) with existing `PipelineStep::all()` method
- Replace per-scheduler `step_index()` method (10 copies) with existing `PipelineStep::index()` method
- Extract shared `balanced_chase_determine_role()` to `scheduler/mod.rs`, replacing identical copies in `balanced_chase.rs` and `balanced_chase_drain.rs`

Net: -204 lines across 12 files.

## Test plan
- [x] `cargo nextest run -p fgumi --filter-expr 'test(scheduler) | test(pipeline) | test(unified)'` — 339 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean