### PR TITLE
refactor(fgumi): deduplicate core lib modules and remove redundant state

### DIFF
--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -525,58 +525,13 @@ impl IndexingBamWriter {
 
         // Calculate alignment end from CIGAR using byte-safe access
         // (doesn't require 4-byte alignment like get_cigar_ops)
-        let ref_len = Self::calculate_reference_length(bam);
+        let ref_len = fgumi_raw_bam::reference_length_from_raw_bam(bam);
 
         // BAM positions are 0-based, Position is 1-based
         let start = Position::try_from((pos + 1) as usize).ok()?;
         let end = Position::try_from((pos + ref_len) as usize).ok()?;
 
         Some((tid as usize, start, end, true))
-    }
-
-    /// Calculate reference-consuming length from CIGAR using byte-safe access.
-    ///
-    /// This is similar to `reference_length_from_cigar` but reads CIGAR ops
-    /// byte-by-byte to avoid alignment requirements.
-    #[inline]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn calculate_reference_length(bam: &[u8]) -> i32 {
-        let l_read_name = bam[8] as usize;
-        let n_cigar_op = u16::from_le_bytes([bam[12], bam[13]]) as usize;
-
-        if n_cigar_op == 0 {
-            return 0;
-        }
-
-        let cigar_start = 32 + l_read_name;
-        let cigar_end = cigar_start + n_cigar_op * 4;
-
-        if cigar_end > bam.len() {
-            return 0;
-        }
-
-        let mut ref_len = 0i32;
-
-        // Read CIGAR ops byte-by-byte
-        for i in 0..n_cigar_op {
-            let offset = cigar_start + i * 4;
-            let op = u32::from_le_bytes([
-                bam[offset],
-                bam[offset + 1],
-                bam[offset + 2],
-                bam[offset + 3],
-            ]);
-
-            let op_len = (op >> 4) as i32;
-            let op_type = op & 0xF;
-
-            // M (0), D (2), N (3), = (7), X (8) consume reference bases
-            if matches!(op_type, 0 | 2 | 3 | 7 | 8) {
-                ref_len += op_len;
-            }
-        }
-
-        ref_len
     }
 
     /// Finish writing, flush the BGZF stream, and return the index.

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -90,25 +90,30 @@ fn read_sequence_raw(file: &mut File, record: &fai::Record) -> Result<Vec<u8>> {
     Ok(sequence)
 }
 
+/// Find a sibling file for a FASTA file by trying two naming conventions:
+/// 1. Replace extension (e.g., `ref.fasta` → `ref.<replace_ext>`)
+/// 2. Append extension to full path (e.g., `ref.fa` → `ref.fa.<append_ext>`)
+fn find_sibling_file(fasta_path: &Path, replace_ext: &str, append_ext: &str) -> Option<PathBuf> {
+    let replaced = fasta_path.with_extension(replace_ext);
+    if replaced.exists() {
+        return Some(replaced);
+    }
+
+    let appended = PathBuf::from(format!("{}.{append_ext}", fasta_path.display()));
+    if appended.exists() {
+        return Some(appended);
+    }
+
+    None
+}
+
 /// Find FAI index path for a FASTA file.
 ///
 /// Tries multiple naming conventions:
 /// 1. Replace extension with `.fa.fai` (e.g., `ref.fasta` → `ref.fa.fai`)
 /// 2. Append `.fai` to full path (e.g., `ref.fa` → `ref.fa.fai`, `ref.fasta` → `ref.fasta.fai`)
 fn find_fai_path(fasta_path: &Path) -> Option<PathBuf> {
-    // Try replacing extension with .fa.fai
-    let fai_path = fasta_path.with_extension("fa.fai");
-    if fai_path.exists() {
-        return Some(fai_path);
-    }
-
-    // Try appending .fai to full path (handles ref.fa -> ref.fa.fai and ref.fasta -> ref.fasta.fai)
-    let fai_path = PathBuf::from(format!("{}.fai", fasta_path.display()));
-    if fai_path.exists() {
-        return Some(fai_path);
-    }
-
-    None
+    find_sibling_file(fasta_path, "fa.fai", "fai")
 }
 
 /// Find sequence dictionary path for a FASTA file.
@@ -135,21 +140,7 @@ fn find_fai_path(fasta_path: &Path) -> Option<PathBuf> {
 /// ```
 #[must_use]
 pub fn find_dict_path(fasta_path: &Path) -> Option<PathBuf> {
-    // Try replacing extension with .dict (fgbio/HTSJDK/Picard convention)
-    // e.g., ref.fa -> ref.dict, ref.fasta -> ref.dict
-    let dict_path = fasta_path.with_extension("dict");
-    if dict_path.exists() {
-        return Some(dict_path);
-    }
-
-    // Try appending .dict to full path (GATK convention)
-    // e.g., ref.fa -> ref.fa.dict, ref.fasta -> ref.fasta.dict
-    let dict_path = PathBuf::from(format!("{}.dict", fasta_path.display()));
-    if dict_path.exists() {
-        return Some(dict_path);
-    }
-
-    None
+    find_sibling_file(fasta_path, "dict", "dict")
 }
 
 /// A thread-safe reference genome reader with all sequences preloaded into memory.

--- a/src/lib/reorder_buffer.rs
+++ b/src/lib/reorder_buffer.rs
@@ -43,12 +43,10 @@ use crate::unified_pipeline::MemoryEstimate;
 /// memory-bounded backpressure without expensive per-item size calculations.
 #[derive(Debug)]
 pub struct ReorderBuffer<T> {
-    /// Sparse buffer: index (seq - `base_seq`) maps to `Option<(T, usize)>` where
+    /// Sparse buffer: index (seq - `next_seq`) maps to `Option<(T, usize)>` where
     /// usize is the pre-computed heap size (0 if not tracked).
     buffer: VecDeque<Option<(T, usize)>>,
-    /// The sequence number corresponding to buffer[0].
-    base_seq: u64,
-    /// Next sequence number to release.
+    /// Next sequence number to release (also the sequence number corresponding to buffer[0]).
     next_seq: u64,
     /// Number of items currently stored.
     count: usize,
@@ -63,14 +61,7 @@ impl<T> ReorderBuffer<T> {
     /// Create a new reorder buffer.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            buffer: VecDeque::new(),
-            base_seq: 0,
-            next_seq: 0,
-            count: 0,
-            heap_bytes: 0,
-            can_pop: false,
-        }
+        Self { buffer: VecDeque::new(), next_seq: 0, count: 0, heap_bytes: 0, can_pop: false }
     }
 
     /// Insert an item with a sequence number (without memory tracking).
@@ -109,12 +100,12 @@ impl<T> ReorderBuffer<T> {
     #[allow(clippy::cast_possible_truncation)]
     pub fn insert_with_size(&mut self, seq: u64, item: T, heap_size: usize) {
         debug_assert!(
-            seq >= self.base_seq,
+            seq >= self.next_seq,
             "Sequence number {seq} is before base {}",
-            self.base_seq
+            self.next_seq
         );
 
-        let index = (seq - self.base_seq) as usize;
+        let index = (seq - self.next_seq) as usize;
 
         // Extend buffer with None entries if needed
         while self.buffer.len() <= index {
@@ -161,7 +152,6 @@ impl<T> ReorderBuffer<T> {
 
         // Pop the front item
         let (item, size) = self.buffer.pop_front().unwrap().unwrap();
-        self.base_seq += 1;
         self.next_seq += 1;
         self.count -= 1;
         self.heap_bytes = self.heap_bytes.saturating_sub(size as u64);
@@ -295,11 +285,10 @@ impl<T> ReorderBuffer<T> {
             .sum()
     }
 
-    /// Set the starting sequence numbers (for testing or reset scenarios).
+    /// Set the next expected sequence number (for testing or reset scenarios).
     #[cfg(test)]
-    pub fn set_base_seq(&mut self, base: u64) {
-        self.base_seq = base;
-        self.next_seq = base;
+    pub fn set_next_seq(&mut self, seq: u64) {
+        self.next_seq = seq;
     }
 }
 
@@ -426,7 +415,7 @@ mod tests {
 
         // Start from a large sequence number
         let start = 1_000_000u64;
-        buffer.set_base_seq(start);
+        buffer.set_next_seq(start);
 
         buffer.insert(start, 100);
         buffer.insert(start + 1, 200);

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -5,10 +5,8 @@
 
 use anyhow::{Result, bail};
 use noodles::sam::alignment::record_buf::RecordBuf;
-use noodles::sam::alignment::record_buf::data::field::Value;
 
 use crate::consensus_tags::per_base;
-use crate::dna::reverse_complement;
 use crate::sort::bam_fields;
 
 /// Reverses per-base tags for a negative-strand read
@@ -40,21 +38,8 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
         let tag = per_base::tag(tag_str);
 
         if let Some(value) = record.data().get(&tag) {
-            match value {
-                Value::String(s) => {
-                    // Z-type string tags (e.g. aq, bq quality strings) — reverse bytes
-                    let mut reversed: Vec<u8> = s.iter().copied().collect();
-                    reversed.reverse();
-                    record
-                        .data_mut()
-                        .insert(tag, Value::from(String::from_utf8_lossy(&reversed).to_string()));
-                }
-                _ => {
-                    if let Some(reversed_value) = reverse_array_value(value) {
-                        record.data_mut().insert(tag, reversed_value);
-                    }
-                }
-            }
+            let reversed = fgumi_sam::reverse_buf_value(value);
+            record.data_mut().insert(tag, reversed);
         }
     }
 
@@ -64,13 +49,9 @@ pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
     for tag_str in tags_to_revcomp {
         let tag = per_base::tag(tag_str);
 
-        if let Some(Value::String(bases)) = record.data().get(&tag) {
-            // Convert BString to Vec<u8>
-            let bases_vec: Vec<u8> = bases.iter().copied().collect();
-            let revcomp = reverse_complement(&bases_vec);
-            record
-                .data_mut()
-                .insert(tag, Value::from(String::from_utf8_lossy(&revcomp).to_string()));
+        if let Some(value) = record.data().get(&tag) {
+            let revcomp = fgumi_sam::revcomp_buf_value(value);
+            record.data_mut().insert(tag, revcomp);
         }
     }
 
@@ -133,62 +114,14 @@ pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
     Ok(true)
 }
 
-/// Reverses an array value
-fn reverse_array_value(value: &Value) -> Option<Value> {
-    match value {
-        Value::Array(arr) => {
-            use noodles::sam::alignment::record_buf::data::field::value::Array;
-
-            let reversed = match arr {
-                Array::Int8(values) => {
-                    let mut reversed: Vec<i8> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::UInt8(values) => {
-                    let mut reversed: Vec<u8> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::Int16(values) => {
-                    let mut reversed: Vec<i16> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::UInt16(values) => {
-                    let mut reversed: Vec<u16> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::Int32(values) => {
-                    let mut reversed: Vec<i32> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::UInt32(values) => {
-                    let mut reversed: Vec<u32> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-                Array::Float(values) => {
-                    let mut reversed: Vec<f32> = values.clone();
-                    reversed.reverse();
-                    Value::from(reversed)
-                }
-            };
-
-            Some(reversed)
-        }
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sam::builder::RecordBuilder;
     use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
     use noodles::sam::alignment::record_buf::data::field::value::Array;
+    use rstest::rstest;
 
     #[test]
     fn test_reverse_per_base_tags_positive_strand() {
@@ -238,30 +171,24 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_reverse_array_value_all_types() {
-        // Test all array types with same pattern
-        let test_cases: Vec<(Value, Value)> = vec![
-            (Value::from(vec![1i8, 2, 3]), Value::from(vec![3i8, 2, 1])),
-            (Value::from(vec![1u8, 2, 3]), Value::from(vec![3u8, 2, 1])),
-            (Value::from(vec![1i16, 2, 3]), Value::from(vec![3i16, 2, 1])),
-            (Value::from(vec![1u16, 2, 3]), Value::from(vec![3u16, 2, 1])),
-            (Value::from(vec![1i32, 2, 3]), Value::from(vec![3i32, 2, 1])),
-            (Value::from(vec![1u32, 2, 3]), Value::from(vec![3u32, 2, 1])),
-            (Value::from(vec![1.0f32, 2.0, 3.0]), Value::from(vec![3.0f32, 2.0, 1.0])),
-        ];
-
-        for (input, expected) in test_cases {
-            let reversed = reverse_array_value(&input).unwrap();
-            assert_eq!(reversed, expected);
-        }
+    #[rstest]
+    #[case(Value::from(vec![1i8, 2, 3]), Value::from(vec![3i8, 2, 1]))]
+    #[case(Value::from(vec![1u8, 2, 3]), Value::from(vec![3u8, 2, 1]))]
+    #[case(Value::from(vec![1i16, 2, 3]), Value::from(vec![3i16, 2, 1]))]
+    #[case(Value::from(vec![1u16, 2, 3]), Value::from(vec![3u16, 2, 1]))]
+    #[case(Value::from(vec![1i32, 2, 3]), Value::from(vec![3i32, 2, 1]))]
+    #[case(Value::from(vec![1u32, 2, 3]), Value::from(vec![3u32, 2, 1]))]
+    #[case(Value::from(vec![1.0f32, 2.0, 3.0]), Value::from(vec![3.0f32, 2.0, 1.0]))]
+    fn test_reverse_buf_value_all_array_types(#[case] input: Value, #[case] expected: Value) {
+        let reversed = fgumi_sam::reverse_buf_value(&input);
+        assert_eq!(reversed, expected);
     }
 
     #[test]
-    fn test_reverse_array_value_non_array() {
+    fn test_reverse_buf_value_non_array() {
         let value = Value::from(42i32);
-        let reversed = reverse_array_value(&value);
-        assert!(reversed.is_none());
+        let reversed = fgumi_sam::reverse_buf_value(&value);
+        assert_eq!(reversed, value); // Non-array values are returned unchanged
     }
 
     #[test]

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -337,84 +337,42 @@ impl Template {
         self.r2.map(|(i, _)| &self.records[i])
     }
 
-    /// Returns supplementary alignments for R1.
-    /// Returns empty in raw-byte mode.
-    ///
-    /// Supplementary alignments represent additional mapping locations for chimeric
-    /// reads (reads that map to multiple locations due to structural variants or
-    /// fusion events).
-    ///
-    /// # Returns
-    ///
-    /// Vector of references to R1 supplementary records
-    #[must_use]
-    pub fn r1_supplementals(&self) -> Vec<&RecordBuf> {
-        if let Some((start, end)) = self.r1_supplementals {
-            if end <= self.records.len() {
-                return self.records[start..end].iter().collect();
+    /// Returns the records in the given range, or an empty slice if the range is invalid.
+    fn records_in_range(&self, range: Option<(usize, usize)>) -> &[RecordBuf] {
+        if let Some((start, end)) = range {
+            if start <= end && end <= self.records.len() {
+                return &self.records[start..end];
             }
         }
-        Vec::new()
+        &[]
+    }
+
+    /// Returns supplementary alignments for R1.
+    /// Returns empty in raw-byte mode.
+    #[must_use]
+    pub fn r1_supplementals(&self) -> &[RecordBuf] {
+        self.records_in_range(self.r1_supplementals)
     }
 
     /// Returns supplementary alignments for R2.
     /// Returns empty in raw-byte mode.
-    ///
-    /// Supplementary alignments represent additional mapping locations for chimeric
-    /// reads (reads that map to multiple locations due to structural variants or
-    /// fusion events).
-    ///
-    /// # Returns
-    ///
-    /// Vector of references to R2 supplementary records
     #[must_use]
-    pub fn r2_supplementals(&self) -> Vec<&RecordBuf> {
-        if let Some((start, end)) = self.r2_supplementals {
-            if end <= self.records.len() {
-                return self.records[start..end].iter().collect();
-            }
-        }
-        Vec::new()
+    pub fn r2_supplementals(&self) -> &[RecordBuf] {
+        self.records_in_range(self.r2_supplementals)
     }
 
     /// Returns secondary alignments for R1.
     /// Returns empty in raw-byte mode.
-    ///
-    /// Secondary alignments represent alternative mapping locations for reads with
-    /// ambiguous alignments. These differ from supplementary alignments in that they
-    /// represent the full read aligned to multiple locations (not chimeric reads).
-    ///
-    /// # Returns
-    ///
-    /// Vector of references to R1 secondary records
     #[must_use]
-    pub fn r1_secondaries(&self) -> Vec<&RecordBuf> {
-        if let Some((start, end)) = self.r1_secondaries {
-            if end <= self.records.len() {
-                return self.records[start..end].iter().collect();
-            }
-        }
-        Vec::new()
+    pub fn r1_secondaries(&self) -> &[RecordBuf] {
+        self.records_in_range(self.r1_secondaries)
     }
 
     /// Returns secondary alignments for R2.
     /// Returns empty in raw-byte mode.
-    ///
-    /// Secondary alignments represent alternative mapping locations for reads with
-    /// ambiguous alignments. These differ from supplementary alignments in that they
-    /// represent the full read aligned to multiple locations (not chimeric reads).
-    ///
-    /// # Returns
-    ///
-    /// Vector of references to R2 secondary records
     #[must_use]
-    pub fn r2_secondaries(&self) -> Vec<&RecordBuf> {
-        if let Some((start, end)) = self.r2_secondaries {
-            if end <= self.records.len() {
-                return self.records[start..end].iter().collect();
-            }
-        }
-        Vec::new()
+    pub fn r2_secondaries(&self) -> &[RecordBuf] {
+        self.records_in_range(self.r2_secondaries)
     }
 
     /// Creates a new empty template with the given name
@@ -4004,5 +3962,33 @@ mod tests {
             let result = mi.write_with_offset(100, &mut buf);
             assert_eq!(result, expected.as_bytes(), "Mismatch for {mi:?}");
         }
+    }
+
+    #[test]
+    fn test_records_in_range_invalid_start_gt_end() {
+        let template = Template {
+            name: b"read1".to_vec(),
+            records: vec![
+                create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1),
+                create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2),
+            ],
+            raw_records: None,
+            r1: Some((0, 1)),
+            r2: Some((1, 2)),
+            r1_supplementals: None,
+            r2_supplementals: None,
+            r1_secondaries: None,
+            r2_secondaries: None,
+            mi: MoleculeId::None,
+        };
+
+        // start > end should return empty, not panic
+        assert!(template.records_in_range(Some((2, 1))).is_empty());
+        // valid range
+        assert_eq!(template.records_in_range(Some((0, 2))).len(), 2);
+        // None returns empty
+        assert!(template.records_in_range(None).is_empty());
+        // end > len returns empty
+        assert!(template.records_in_range(Some((0, 10))).is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Replace duplicated `calculate_reference_length` in `bam_io.rs` with `fgumi_raw_bam::reference_length_from_raw_bam` (-43 lines)
- Replace hand-rolled array/string reversal in `tag_reversal.rs` with `fgumi_sam::reverse_buf_value` and `revcomp_buf_value` (-64 lines)
- Extract shared `find_sibling_file` helper for `find_fai_path`/`find_dict_path` in `reference.rs` (-16 lines)
- Unify four identical template accessor methods via `records_in_range` helper, returning `&[RecordBuf]` instead of `Vec<&RecordBuf>` (-40 lines)
- Remove redundant `base_seq` field from `ReorderBuffer` that was always equal to `next_seq` (-12 lines)

## Test plan
- [x] All 1838 tests pass (`cargo ci-test`)
- [x] Formatting passes (`cargo ci-fmt`)
- [x] Linting passes (`cargo ci-lint`)