### PR TITLE
fix(commands): clamp compute_position fallback and validate sort-order

### DIFF
--- a/src/commands/clip.rs
+++ b/src/commands/clip.rs
@@ -92,7 +92,11 @@ pub struct Clip {
     pub clipping_mode: String,
 
     /// Output sort order (if not specified, output is in same order as input)
-    #[arg(short = 'S', long = "sort-order")]
+    #[arg(
+        short = 'S',
+        long = "sort-order",
+        value_parser = ["unknown", "unsorted", "queryname", "coordinate"]
+    )]
     pub sort_order: Option<String>,
 
     /// Clip overlapping read pairs

--- a/src/commands/simulate/common.rs
+++ b/src/commands/simulate/common.rs
@@ -229,15 +229,16 @@ pub(super) fn pad_sequence(mut seq: Vec<u8>, target_len: usize, rng: &mut impl R
 /// Compute the genomic position for a molecule based on its ID.
 #[inline]
 pub(super) fn compute_position(mol_id: usize, num_positions: usize, ref_length: usize) -> usize {
+    let fallback = ref_length.saturating_sub(1).min(100);
     if num_positions == 0 {
-        return 100;
+        return fallback;
     }
     let usable_span = ref_length.saturating_sub(1000);
     if usable_span == 0 {
-        return 100;
+        return fallback;
     }
     let position_idx = mol_id % num_positions;
-    ((position_idx as f64 / num_positions as f64) * usable_span as f64) as usize + 100
+    ((position_idx as f64 / num_positions as f64) * usable_span as f64) as usize + fallback
 }
 
 /// Lightweight molecule info for position-first sorting.
@@ -272,6 +273,7 @@ impl Eq for MoleculeInfo {}
 mod tests {
     use super::*;
     use fgumi_lib::simulate::create_rng;
+    use rstest::rstest;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -649,28 +651,29 @@ mod tests {
         let _ = args_lower.to_family_size_distribution().unwrap();
     }
 
-    #[test]
-    fn test_compute_position_zero_num_positions() {
-        // Should not panic on num_positions == 0
-        let pos = compute_position(5, 0, 250_000_000);
-        assert_eq!(pos, 100);
-    }
-
-    #[test]
-    fn test_compute_position_small_ref_length() {
-        // Should not underflow when ref_length < 1000
-        let pos = compute_position(0, 10, 500);
-        assert_eq!(pos, 100);
-    }
-
-    #[test]
-    fn test_compute_position_normal() {
-        // First position should be at offset 100
-        assert_eq!(compute_position(0, 10, 10_000), 100);
-        // Last position should be near ref_length - 900
-        let pos = compute_position(9, 10, 10_000);
-        assert!(pos > 100);
-        assert!(pos < 10_000);
+    #[rstest]
+    // num_positions == 0 should not panic
+    #[case(5, 0, 250_000_000, 0, 250_000_000)]
+    // ref_length < 1000 should not underflow
+    #[case(0, 10, 500, 0, 500)]
+    // Very small reference (ref_length <= 100) — fallback must stay within bounds
+    #[case(0, 10, 50, 0, 50)]
+    // Normal: first position
+    #[case(0, 10, 10_000, 0, 10_000)]
+    // Normal: last position in range
+    #[case(9, 10, 10_000, 101, 10_000)]
+    fn test_compute_position(
+        #[case] mol_id: usize,
+        #[case] num_positions: usize,
+        #[case] ref_length: usize,
+        #[case] min_expected: usize,
+        #[case] max_expected: usize,
+    ) {
+        let pos = compute_position(mol_id, num_positions, ref_length);
+        assert!(
+            pos >= min_expected && pos < max_expected,
+            "compute_position({mol_id}, {num_positions}, {ref_length}) = {pos}, expected [{min_expected}, {max_expected})"
+        );
     }
 
     fn make_molecule_info(mol_id: usize, tid1: i32, pos1: i64) -> MoleculeInfo {


### PR DESCRIPTION
## Summary
- Clamp `compute_position` fallback to `min(100, ref_length - 1)` so very small references (e.g. `ref_length <= 100`) don't produce out-of-range alignment positions
- Validate `--sort-order` values at parse time via clap `value_parser` (accepts: `unknown`, `unsorted`, `queryname`, `coordinate`)
- Convert `compute_position` tests to parameterized `rstest` with 5 cases including a regression case for small references

Follow-up to #155 addressing remaining CodeRabbitAI review feedback.

## Test plan
- [x] All 1854 tests pass (`cargo ci-test`)
- [x] Formatting clean (`cargo ci-fmt`)
- [x] Linting clean (`cargo ci-lint`)
- [x] Regression test for `ref_length=50` verifies position stays within bounds