### PR TITLE
fix(sam): use safe conversions for CIGAR ref span and revcomp string

### DIFF
--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -294,7 +294,8 @@ pub fn regenerate_alignment_tags_raw(
     let cigar_ops = fgumi_raw_bam::get_cigar_ops(record);
 
     // Calculate reference span from CIGAR ops
-    let ref_span = fgumi_raw_bam::reference_length_from_cigar(&cigar_ops) as usize;
+    let ref_span = usize::try_from(fgumi_raw_bam::reference_length_from_cigar(&cigar_ops))
+        .context("CIGAR-derived reference span is negative")?;
 
     // Handle edge case: CIGAR with no reference-consuming operations
     if ref_span == 0 {

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -310,11 +310,6 @@ pub fn reverse_buf_value(value: &BufValue) -> BufValue {
 ///
 /// A new `BufValue` with reverse complemented sequence, or a clone if not a string
 ///
-/// # Panics
-///
-/// Cannot panic in practice: the byte-level complement maps ASCII to ASCII,
-/// so `String::from_utf8` always succeeds.
-///
 /// # Examples
 ///
 /// ```rust,ignore
@@ -328,7 +323,7 @@ pub fn revcomp_buf_value(value: &BufValue) -> BufValue {
     match value {
         BufValue::String(s) => {
             let revcomp = fgumi_dna::reverse_complement(s.as_bytes());
-            BufValue::from(String::from_utf8(revcomp).expect("complement of ASCII is ASCII"))
+            BufValue::from(String::from_utf8_lossy(&revcomp).into_owned())
         }
         _ => value.clone(),
     }


### PR DESCRIPTION
## Summary
- Use `usize::try_from()` instead of `as usize` cast for CIGAR-derived reference span in `regenerate_alignment_tags_raw` to avoid silent wrapping on negative values
- Replace `String::from_utf8().expect()` with `from_utf8_lossy()` in `revcomp_buf_value` to match `reverse_buf_value` pattern and prevent potential panics
- Remove stale `# Panics` doc section from `revcomp_buf_value`

Follow-up to #147 addressing CodeRabbitAI review feedback.

## Test plan
- [x] All 1852 tests pass (`cargo ci-test`)
- [x] Formatting clean (`cargo ci-fmt`)
- [x] Linting clean (`cargo ci-lint`)