### PR TITLE
docs(sort): add noodles PR links to vendored/raw-record comments

### DIFF
--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -30,7 +30,8 @@
 //! 32+     var   read_name, CIGAR, sequence, quality, aux data
 //! ```
 //!
-//! This module will be removed once noodles exposes raw bytes from Record.
+//! This module will be removed once noodles exposes raw bytes from Record
+//! (<https://github.com/zaeleus/noodles/pull/373>).
 
 use std::io::{self, Read};
 

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -23,9 +23,11 @@ use noodles::core::Position;
 use noodles::sam::Header;
 // Use noodles_bgzf for standard BGZF types
 use noodles_bgzf::io::{MultithreadedReader, Reader as BgzfReader, Writer as BgzfWriter};
-// Use vendored MultithreadedWriter with position tracking (until upstream PR merges)
+// Use vendored MultithreadedWriter with position tracking
+// (until https://github.com/zaeleus/noodles/pull/371 merges)
 use crate::vendored::{BlockInfoRx, MultithreadedWriter, MultithreadedWriterBuilder};
-// Use RawBamReader for raw byte access (until noodles exposes Record bytes)
+// Use RawBamReader for raw byte access
+// (until https://github.com/zaeleus/noodles/pull/373 merges)
 use fgumi_raw_bam::RawBamReader;
 // Use bgzf crate for CompressionLevel
 use bgzf::CompressionLevel;

--- a/src/lib/vendored/mod.rs
+++ b/src/lib/vendored/mod.rs
@@ -1,9 +1,10 @@
 //! Vendored code that will be removed once upstream PRs are merged.
 //!
 //! This module contains temporary implementations that are waiting on:
-//! - noodles-bgzf PR for `MultithreadedWriter` with position tracking
-//! - noodles-bam PR for BAM codec optimizations
-//! - noodles-bam PR for `Record::as_ref()` (raw bytes access)
+//! - noodles-bgzf: `MultithreadedWriter` with position tracking (<https://github.com/zaeleus/noodles/pull/371>)
+//! - noodles-bam: expose record codec encode/decode (<https://github.com/zaeleus/noodles/pull/364>)
+//! - noodles-bam: optimized `RecordBuf` encoding (<https://github.com/zaeleus/noodles/pull/367>)
+//! - noodles-bam: `Record::as_ref()` raw bytes access (<https://github.com/zaeleus/noodles/pull/373>)
 //!
 //! This module should be removed once the upstream PRs are merged and released.
 


### PR DESCRIPTION
## Summary
- Add links to upstream noodles PRs (#364, #367, #371, #373) in code comments that reference vendored code and `RawRecord` workarounds
- Makes it easy to check PR status and know when these can be removed

Files updated:
- `crates/fgumi-raw-bam/src/raw_bam_record.rs` — link to #373 (raw bytes access)
- `src/lib/vendored/mod.rs` — links to all four PRs
- `src/lib/bam_io.rs` — links to #371 and #373

## Test plan
- Comment-only change, no behavior changes