### PR TITLE
feat(sort): add CB (cellular barcode) to template-coordinate sort key

### DIFF
--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -1039,7 +1039,7 @@ is selected as the representative; all others are marked as duplicates.
 # Input Requirements
 
 - Must be processed with `fgumi zipper` (adds `pa` tag for secondary/supplementary reads)
-- Must be sorted with `fgumi sort --order template-coordinate`
+- Must be sorted with `fgumi sort --order template-coordinate` (use matching `--cell-tag` value)
 - UMI tags on reads (default: RX tag)
 
 Note: Using `samtools sort` will NOT work correctly because it doesn't use the
@@ -1188,7 +1188,9 @@ impl Command for MarkDuplicates {
                 "Input BAM must be template-coordinate sorted.\n\n\
                 To prepare your BAM file, run:\n  \
                 fgumi zipper -u unmapped.bam -r reference.fa -o merged.bam\n  \
-                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
+                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate \
+                --cell-tag {}",
+                self.cell_tag
             );
         }
         info!("Template-coordinate sorted");
@@ -1398,9 +1400,11 @@ impl Command for MarkDuplicates {
                 `fgumi zipper` during the merge of unmapped and mapped BAMs.\n\n\
                 To fix this, re-run your pipeline starting from `fgumi zipper`:\n  \
                 fgumi zipper --unmapped unmapped.bam --mapped aligned.bam -o merged.bam\n  \
-                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate\n  \
+                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate \
+                --cell-tag {}\n  \
                 fgumi dedup -i sorted.bam -o deduped.bam",
-                final_metrics.missing_pa_tag
+                final_metrics.missing_pa_tag,
+                self.cell_tag
             );
         }
 

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -670,8 +670,9 @@ Accepts reads in any order (including unsorted) and outputs reads sorted by:
    4. Read Name
 
 It is recommended to sort the reads into template-coordinate order prior to running
-this tool to avoid re-sorting the input. Use `fgumi sort --order template-coordinate` for
-the pre-sorting. The output will always be written in template-coordinate order.
+this tool to avoid re-sorting the input. Use `fgumi sort --order template-coordinate`
+(with matching `--cell-tag`) for the pre-sorting. The output will always be written
+in template-coordinate order.
 
 During grouping, reads and templates are filtered out as follows:
 
@@ -965,7 +966,9 @@ impl Command for GroupReadsByUmi {
                 bail!(
                     "Input BAM must be template-coordinate sorted.\n\n\
                     To sort your BAM file, run:\n  \
-                    fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
+                    fgumi sort -i input.bam -o sorted.bam --order template-coordinate \
+                    --cell-tag {}",
+                    self.cell_tag
                 );
             }
         }

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -25,7 +25,7 @@ use clap::{Parser, ValueEnum};
 use fgumi_lib::bam_io::create_bam_reader;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::sort::{RawExternalSorter, SortOrder};
-use fgumi_lib::validation::validate_file_exists;
+use fgumi_lib::validation::{string_to_tag, validate_file_exists};
 use log::info;
 use std::path::PathBuf;
 
@@ -176,6 +176,15 @@ pub struct Sort {
     /// position tracking.
     #[arg(long = "write-index", default_value = "false")]
     pub write_index: bool,
+
+    /// Cell barcode tag for template-coordinate sort.
+    ///
+    /// When sorting in template-coordinate order, this tag is included in the
+    /// sort key so that templates from different cells at the same locus are
+    /// not interleaved. Use the same value as `--cell-tag` in `fgumi group`
+    /// and `fgumi dedup`. Only used for template-coordinate sort.
+    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    pub cell_tag: String,
 }
 
 /// Parse memory size string (e.g., "512M", "1G", "2G").
@@ -264,6 +273,17 @@ impl Command for Sort {
 }
 
 impl Sort {
+    /// Parse the cell tag for template-coordinate sort/verify, returning `None`
+    /// for other sort orders.
+    fn parse_cell_tag(&self) -> Result<Option<[u8; 2]>> {
+        if matches!(self.order, SortOrderArg::TemplateCoordinate) {
+            let tag = string_to_tag(&self.cell_tag, "cell-tag")?;
+            Ok(Some([tag.as_ref()[0], tag.as_ref()[1]]))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Execute sort mode: read, sort, and write output.
     fn execute_sort(&self, command_line: &str) -> Result<()> {
         let output = self.output.as_ref().expect("output required for sort mode");
@@ -286,10 +306,15 @@ impl Sort {
             self.max_memory
         };
 
+        let cell_tag = self.parse_cell_tag()?;
+
         info!("Starting Sort");
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
         info!("Sort order: {:?}", self.order);
+        if let Some(ct) = cell_tag {
+            info!("Cell tag: {}{}", ct[0] as char, ct[1] as char);
+        }
         if self.memory_per_thread {
             info!(
                 "Max memory: {} MB ({} MB/thread × {} threads)",
@@ -317,6 +342,10 @@ impl Sort {
             .temp_compression(self.temp_compression)
             .write_index(self.write_index)
             .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
+
+        if let Some(ct) = cell_tag {
+            sorter = sorter.cell_tag(ct);
+        }
 
         if let Some(ref tmp) = self.tmp_dir {
             sorter = sorter.temp_dir(tmp.clone());
@@ -349,11 +378,16 @@ impl Sort {
         use std::cmp::Ordering;
         use std::fs::File;
 
+        let cell_tag = self.parse_cell_tag()?;
+
         let timer = OperationTimer::new("Verifying BAM sort order");
 
         info!("Starting Sort Verification");
         info!("Input: {}", self.input.display());
         info!("Expected order: {:?}", self.order);
+        if let Some(ct) = cell_tag {
+            info!("Cell tag: {}{}", ct[0] as char, ct[1] as char);
+        }
 
         // Get header using noodles reader, then use raw reader for records
         let (_, header) = create_bam_reader(&self.input, 1)?;
@@ -383,7 +417,7 @@ impl Sort {
                 let lib_lookup = LibraryLookup::from_header(&header);
                 verify_sort_order(
                     raw_reader,
-                    |bam| extract_template_key_inline(bam, &lib_lookup),
+                    |bam| extract_template_key_inline(bam, &lib_lookup, cell_tag.as_ref()),
                     // Use core_cmp to ignore name_hash tie-breaker differences
                     // This allows both fgumi and samtools sorted files to pass
                     |key, prev| key.core_cmp(prev) == Ordering::Less,
@@ -416,6 +450,51 @@ impl Sort {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    /// Helper to construct a `Sort` struct with a given order and cell tag.
+    fn make_sort(order: SortOrderArg, cell_tag: &str) -> Sort {
+        Sort {
+            input: PathBuf::from("test.bam"),
+            output: None,
+            verify: false,
+            order,
+            max_memory: 512 * 1024 * 1024,
+            memory_per_thread: true,
+            tmp_dir: None,
+            threads: 1,
+            compression: CompressionOptions::default(),
+            temp_compression: 1,
+            write_index: false,
+            cell_tag: cell_tag.to_string(),
+        }
+    }
+
+    #[rstest]
+    #[case(SortOrderArg::TemplateCoordinate, "CB", Some(*b"CB"))]
+    #[case(SortOrderArg::TemplateCoordinate, "CR", Some(*b"CR"))]
+    #[case(SortOrderArg::Coordinate, "CB", None)]
+    #[case(SortOrderArg::Queryname, "CB", None)]
+    fn test_parse_cell_tag(
+        #[case] order: SortOrderArg,
+        #[case] cell_tag: &str,
+        #[case] expected: Option<[u8; 2]>,
+    ) {
+        let sort = make_sort(order, cell_tag);
+        assert_eq!(sort.parse_cell_tag().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_parse_cell_tag_invalid_single_char() {
+        let sort = make_sort(SortOrderArg::TemplateCoordinate, "X");
+        assert!(sort.parse_cell_tag().is_err());
+    }
+
+    #[test]
+    fn test_parse_cell_tag_invalid_too_long() {
+        let sort = make_sort(SortOrderArg::TemplateCoordinate, "ABC");
+        assert!(sort.parse_cell_tag().is_err());
+    }
 
     #[test]
     fn test_parse_memory_megabytes() {

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -302,9 +302,9 @@ pub fn extract_coordinate_key_inline(bam: &[u8], nref: u32) -> u64 {
 /// Extended key for template-coordinate sorting.
 ///
 /// Template-coordinate requires comparing multiple fields:
-/// tid1, tid2, pos1, pos2, neg1, neg2, library, MI, name, `is_upper`
+/// tid1, tid2, pos1, pos2, neg1, neg2, CB, library, MI, name, `is_upper`
 ///
-/// We pack these into 4 u64 values for efficient comparison.
+/// We pack these into 5 u64 values for efficient comparison.
 /// The `name_hash_upper` field packs both `name_hash` and `is_upper`:
 /// - Upper 63 bits: name hash (groups same names together)
 /// - Lowest bit: `is_upper` (false=0, true=1)
@@ -320,6 +320,10 @@ pub struct TemplateKey {
     /// Packed: (pos2 << 32) | (!neg1 << 1) | !neg2
     /// neg flags inverted so reverse (neg=true) sorts before forward (neg=false)
     pub secondary: u64,
+    /// Hash of the CB (cellular barcode) tag value.
+    /// Inserted between neg2 and MI to match fgbio's sort order.
+    /// 0 when no cell tag is present or `cell_tag` is disabled.
+    pub cb_hash: u64,
     /// Packed: (library << 48) | (`mi_value` << 1) | `mi_suffix`
     pub tertiary: u64,
     /// Packed: (`name_hash` << 1) | `is_upper`
@@ -338,6 +342,7 @@ impl TemplateKey {
         tid2: i32,
         pos2: i32,
         neg2: bool,
+        cb_hash: u64,
         library: u32,
         mi: (u64, bool),
         name_hash: u64,
@@ -371,15 +376,16 @@ impl TemplateKey {
         // This ensures same-name records group together, with is_upper=false before is_upper=true
         let p4 = (name_hash << 1) | u64::from(is_upper);
 
-        Self { primary: p1, secondary: p2, tertiary: p3, name_hash_upper: p4 }
+        Self { primary: p1, secondary: p2, cb_hash, tertiary: p3, name_hash_upper: p4 }
     }
 
     /// Create a key for completely unmapped records.
     #[must_use]
-    pub fn unmapped(name_hash: u64, is_read2: bool) -> Self {
+    pub fn unmapped(name_hash: u64, cb_hash: u64, is_read2: bool) -> Self {
         Self {
             primary: u64::MAX,
             secondary: u64::MAX,
+            cb_hash,
             tertiary: 0,
             name_hash_upper: (name_hash << 1) | u64::from(is_read2),
         }
@@ -389,7 +395,7 @@ impl TemplateKey {
     #[inline]
     #[must_use]
     pub fn zeroed() -> Self {
-        Self { primary: 0, secondary: 0, tertiary: 0, name_hash_upper: 0 }
+        Self { primary: 0, secondary: 0, cb_hash: 0, tertiary: 0, name_hash_upper: 0 }
     }
 }
 
@@ -403,19 +409,20 @@ impl TemplateKey {
     /// Serialize to bytes for storage in keyed temp files.
     #[inline]
     #[must_use]
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
+    pub fn to_bytes(&self) -> [u8; 40] {
+        let mut buf = [0u8; 40];
         buf[0..8].copy_from_slice(&self.primary.to_le_bytes());
         buf[8..16].copy_from_slice(&self.secondary.to_le_bytes());
-        buf[16..24].copy_from_slice(&self.tertiary.to_le_bytes());
-        buf[24..32].copy_from_slice(&self.name_hash_upper.to_le_bytes());
+        buf[16..24].copy_from_slice(&self.cb_hash.to_le_bytes());
+        buf[24..32].copy_from_slice(&self.tertiary.to_le_bytes());
+        buf[32..40].copy_from_slice(&self.name_hash_upper.to_le_bytes());
         buf
     }
 
     /// Deserialize from bytes read from keyed temp files.
     #[inline]
     #[must_use]
-    pub fn from_bytes(buf: &[u8; 32]) -> Self {
+    pub fn from_bytes(buf: &[u8; 40]) -> Self {
         Self {
             primary: u64::from_le_bytes([
                 buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
@@ -423,11 +430,14 @@ impl TemplateKey {
             secondary: u64::from_le_bytes([
                 buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
             ]),
-            tertiary: u64::from_le_bytes([
+            cb_hash: u64::from_le_bytes([
                 buf[16], buf[17], buf[18], buf[19], buf[20], buf[21], buf[22], buf[23],
             ]),
-            name_hash_upper: u64::from_le_bytes([
+            tertiary: u64::from_le_bytes([
                 buf[24], buf[25], buf[26], buf[27], buf[28], buf[29], buf[30], buf[31],
+            ]),
+            name_hash_upper: u64::from_le_bytes([
+                buf[32], buf[33], buf[34], buf[35], buf[36], buf[37], buf[38], buf[39],
             ]),
         }
     }
@@ -444,6 +454,7 @@ impl Ord for TemplateKey {
         self.primary
             .cmp(&other.primary)
             .then_with(|| self.secondary.cmp(&other.secondary))
+            .then_with(|| self.cb_hash.cmp(&other.cb_hash))
             .then_with(|| self.tertiary.cmp(&other.tertiary))
             // name_hash_upper comparison handles both name grouping AND is_upper ordering
             .then_with(|| self.name_hash_upper.cmp(&other.name_hash_upper))
@@ -451,7 +462,7 @@ impl Ord for TemplateKey {
 }
 
 impl TemplateKey {
-    /// Compare only core fields (tid1, tid2, pos1, pos2, neg1, neg2, library, MI).
+    /// Compare only core fields (tid1, tid2, pos1, pos2, neg1, neg2, CB, library, MI).
     ///
     /// This ignores the `name_hash` tie-breaker, allowing verification to accept
     /// both fgumi and samtools sorted files (which differ only in tie-breaking).
@@ -461,12 +472,13 @@ impl TemplateKey {
         self.primary
             .cmp(&other.primary)
             .then_with(|| self.secondary.cmp(&other.secondary))
+            .then_with(|| self.cb_hash.cmp(&other.cb_hash))
             .then_with(|| self.tertiary.cmp(&other.tertiary))
     }
 }
 
 impl RawSortKey for TemplateKey {
-    const SERIALIZED_SIZE: Option<usize> = Some(32);
+    const SERIALIZED_SIZE: Option<usize> = Some(40);
 
     fn extract(_bam: &[u8], _ctx: &SortContext) -> Self {
         // TemplateKey extraction requires LibraryLookup context not available through the
@@ -485,7 +497,7 @@ impl RawSortKey for TemplateKey {
 
     #[inline]
     fn read_from<R: Read>(reader: &mut R) -> std::io::Result<Self> {
-        let mut buf = [0u8; 32];
+        let mut buf = [0u8; 40];
         reader.read_exact(&mut buf)?;
         Ok(Self::from_bytes(&buf))
     }
@@ -495,9 +507,10 @@ impl RawSortKey for TemplateKey {
 /// This allows us to use a minimal ref structure while still having
 /// fast access to the full sort key.
 ///
-/// Layout (40 bytes total):
+/// Layout (48 bytes total):
 /// - primary: 8 bytes (u64)
 /// - secondary: 8 bytes (u64)
+/// - `cb_hash`: 8 bytes (u64)
 /// - tertiary: 8 bytes (u64)
 /// - `name_hash_upper`: 8 bytes (u64)
 /// - `record_len`: 4 bytes (u32)
@@ -514,7 +527,7 @@ pub struct TemplateInlineHeader {
 }
 
 /// Size of `TemplateInlineHeader` in bytes.
-pub const TEMPLATE_HEADER_SIZE: usize = 40; // 4 * 8 (key) + 4 + 4
+pub const TEMPLATE_HEADER_SIZE: usize = 48; // 5 * 8 (key) + 4 + 4
 
 impl TemplateInlineHeader {
     /// Write header to a byte buffer.
@@ -522,6 +535,7 @@ impl TemplateInlineHeader {
     pub fn write_to(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.key.primary.to_le_bytes());
         buf.extend_from_slice(&self.key.secondary.to_le_bytes());
+        buf.extend_from_slice(&self.key.cb_hash.to_le_bytes());
         buf.extend_from_slice(&self.key.tertiary.to_le_bytes());
         buf.extend_from_slice(&self.key.name_hash_upper.to_le_bytes());
         buf.extend_from_slice(&self.record_len.to_le_bytes());
@@ -538,16 +552,19 @@ impl TemplateInlineHeader {
         let secondary = u64::from_le_bytes([
             data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
         ]);
-        let tertiary = u64::from_le_bytes([
+        let cb_hash = u64::from_le_bytes([
             data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23],
         ]);
-        let name_hash_upper = u64::from_le_bytes([
+        let tertiary = u64::from_le_bytes([
             data[24], data[25], data[26], data[27], data[28], data[29], data[30], data[31],
         ]);
-        let record_len = u32::from_le_bytes([data[32], data[33], data[34], data[35]]);
+        let name_hash_upper = u64::from_le_bytes([
+            data[32], data[33], data[34], data[35], data[36], data[37], data[38], data[39],
+        ]);
+        let record_len = u32::from_le_bytes([data[40], data[41], data[42], data[43]]);
 
         Self {
-            key: TemplateKey { primary, secondary, tertiary, name_hash_upper },
+            key: TemplateKey { primary, secondary, cb_hash, tertiary, name_hash_upper },
             record_len,
             padding: 0,
         }
@@ -964,10 +981,11 @@ pub fn radix_sort_template_refs(refs: &mut [TemplateRecordRef]) {
     }
 
     // Sort by each field from least significant to most significant
-    // This ensures the final order is: primary → secondary → tertiary → name_hash_upper
+    // This ensures the final order is: primary → secondary → cb_hash → tertiary → name_hash_upper
     let fields = [
         |r: &TemplateRecordRef| r.key.name_hash_upper,
         |r: &TemplateRecordRef| r.key.tertiary,
+        |r: &TemplateRecordRef| r.key.cb_hash,
         |r: &TemplateRecordRef| r.key.secondary,
         |r: &TemplateRecordRef| r.key.primary,
     ];
@@ -1180,25 +1198,27 @@ mod tests {
 
     #[test]
     fn test_template_key_ordering() {
-        let k1 = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 0, false);
-        let k2 = TemplateKey::new(0, 100, false, 0, 200, false, 0, (2, true), 0, false);
+        let k1 = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 0, false);
+        let k2 = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (2, true), 0, false);
         assert!(k1 < k2);
 
         // /A suffix should come before /B
-        let ka = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 0, false);
-        let kb = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, false), 0, false);
+        let ka = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 0, false);
+        let kb = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, false), 0, false);
         assert!(ka < kb);
 
         // Same name hash: is_upper=false should come before is_upper=true
-        let lower = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 12345, false);
-        let upper = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 12345, true);
+        let lower = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 12345, false);
+        let upper = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 12345, true);
         assert!(lower < upper, "is_upper=false should sort before is_upper=true");
 
         // Different name hashes should group separately
         let first_hash_lo =
-            TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 100, false);
-        let first_hash_hi = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 100, true);
-        let second_hash = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 200, false);
+            TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 100, false);
+        let first_hash_hi =
+            TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 100, true);
+        let second_hash =
+            TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 200, false);
         // first_hash records should come before second_hash records
         assert!(first_hash_lo < second_hash);
         assert!(first_hash_hi < second_hash);
@@ -1366,7 +1386,7 @@ mod tests {
     fn test_radix_sort_template_refs_stability() {
         // Test that template radix sort is stable for equal keys
         // Create refs with identical TemplateKey but different offsets to track order
-        let key = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 12345, false);
+        let key = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 12345, false);
 
         let mut refs: Vec<TemplateRecordRef> = (0..500)
             .map(|i| TemplateRecordRef {
@@ -1408,6 +1428,7 @@ mod tests {
                     200,
                     false,
                     0,
+                    0,
                     (1, true),
                     group as u64, // Different hash per group
                     false,
@@ -1448,7 +1469,7 @@ mod tests {
         let mut buffer = TemplateRecordBuffer::with_capacity(100, 10000);
 
         // Add records with identical keys - they should maintain insertion order after sort
-        let key = TemplateKey::new(0, 100, false, 0, 200, false, 0, (1, true), 12345, false);
+        let key = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 12345, false);
 
         // Create distinct records (different sequence bytes) with same sort key
         for i in 0..100u8 {
@@ -1494,5 +1515,79 @@ mod tests {
             }
             prev_seq_byte = Some(seq_byte);
         }
+    }
+
+    // ========================================================================
+    // TemplateKey cb_hash tests
+    // ========================================================================
+
+    #[test]
+    fn test_template_key_cb_hash_ordering() {
+        // Same position but different cb_hash — lower hash sorts first
+        let k1 = TemplateKey::new(0, 100, false, 0, 200, false, 10, 0, (1, true), 0, false);
+        let k2 = TemplateKey::new(0, 100, false, 0, 200, false, 20, 0, (1, true), 0, false);
+        assert!(k1 < k2, "lower cb_hash should sort before higher cb_hash");
+    }
+
+    #[test]
+    fn test_template_key_cb_hash_zero_sorts_first() {
+        // cb_hash=0 (no CB) should sort before non-zero cb_hash
+        let k_no_cb = TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), 0, false);
+        let k_cb = TemplateKey::new(0, 100, false, 0, 200, false, 42, 0, (1, true), 0, false);
+        assert!(k_no_cb < k_cb, "cb_hash=0 should sort before non-zero cb_hash");
+    }
+
+    #[test]
+    fn test_template_key_cb_hash_between_secondary_and_tertiary() {
+        // Verify cb_hash is compared AFTER secondary but BEFORE tertiary.
+        // Same primary+secondary, different cb_hash and tertiary values
+        let k1 = TemplateKey::new(0, 100, false, 0, 200, false, 10, 0, (1, true), 0, false);
+        let k2 = TemplateKey::new(0, 100, false, 0, 200, false, 20, 0, (0, true), 0, false);
+        // k1 has lower cb_hash, so it should sort first regardless of tertiary
+        assert!(k1 < k2, "cb_hash should be compared before tertiary (library/MI)");
+    }
+
+    #[test]
+    fn test_template_key_serialization_with_cb_hash() {
+        let key =
+            TemplateKey::new(1, 500, true, 2, 600, false, 0xDEAD_BEEF, 3, (7, true), 999, false);
+        let bytes = key.to_bytes();
+        assert_eq!(bytes.len(), 40);
+        let roundtrip = TemplateKey::from_bytes(&bytes);
+        assert_eq!(key, roundtrip, "serialization roundtrip should preserve cb_hash");
+        assert_eq!(roundtrip.cb_hash, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn test_template_key_unmapped_with_cb_hash() {
+        let key = TemplateKey::unmapped(12345, 0xCAFE, false);
+        assert_eq!(key.primary, u64::MAX);
+        assert_eq!(key.secondary, u64::MAX);
+        assert_eq!(key.cb_hash, 0xCAFE, "unmapped should preserve cb_hash");
+        assert_eq!(key.tertiary, 0);
+    }
+
+    #[test]
+    fn test_template_key_core_cmp_includes_cb_hash() {
+        let k1 = TemplateKey::new(0, 100, false, 0, 200, false, 10, 0, (1, true), 0, false);
+        let k2 = TemplateKey::new(0, 100, false, 0, 200, false, 20, 0, (1, true), 0, false);
+        assert_eq!(k1.core_cmp(&k2), std::cmp::Ordering::Less, "core_cmp should include cb_hash");
+
+        // Same cb_hash, different name_hash — core_cmp should be Equal
+        let k3 = TemplateKey::new(0, 100, false, 0, 200, false, 10, 0, (1, true), 100, false);
+        let k4 = TemplateKey::new(0, 100, false, 0, 200, false, 10, 0, (1, true), 200, false);
+        assert_eq!(k3.core_cmp(&k4), std::cmp::Ordering::Equal, "core_cmp should ignore name_hash");
+    }
+
+    #[test]
+    fn test_template_key_zeroed_has_zero_cb_hash() {
+        let key = TemplateKey::zeroed();
+        assert_eq!(key.cb_hash, 0);
+    }
+
+    #[test]
+    fn test_template_key_default_has_zero_cb_hash() {
+        let key = TemplateKey::default();
+        assert_eq!(key.cb_hash, 0);
     }
 }

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -401,6 +401,9 @@ pub struct RawExternalSorter {
     pg_info: Option<(String, String)>,
     /// Maximum temp files before consolidation (0 = unlimited).
     max_temp_files: usize,
+    /// Cell barcode tag for template-coordinate sort (e.g., `[b'C', b'B']`).
+    /// When `Some`, CB hash is included in sort key for single-cell data.
+    cell_tag: Option<[u8; 2]>,
 }
 
 impl RawExternalSorter {
@@ -417,6 +420,7 @@ impl RawExternalSorter {
             write_index: false,
             pg_info: None,
             max_temp_files: DEFAULT_MAX_TEMP_FILES,
+            cell_tag: None,
         }
     }
 
@@ -485,6 +489,16 @@ impl RawExternalSorter {
     #[must_use]
     pub fn max_temp_files(mut self, max: usize) -> Self {
         self.max_temp_files = max;
+        self
+    }
+
+    /// Set the cell barcode tag for template-coordinate sort.
+    ///
+    /// When set, the CB hash is included in the sort key so that templates
+    /// from different cells at the same locus are not interleaved.
+    #[must_use]
+    pub fn cell_tag(mut self, tag: [u8; 2]) -> Self {
+        self.cell_tag = Some(tag);
         self
     }
 
@@ -1089,11 +1103,11 @@ impl RawExternalSorter {
 
         // Estimate capacity accounting for inline headers and cached-key refs
         // Memory layout per record:
-        //   - data: 40 bytes (inline header) + ~250 bytes (BAM record) = 290 bytes
-        //   - refs: 48 bytes (TemplateKey + u64 offset + u32 len + u32 pad)
-        //   - Total: ~338 bytes per record
+        //   - data: 48 bytes (inline header) + ~250 bytes (BAM record) = 298 bytes
+        //   - refs: 56 bytes (TemplateKey + u64 offset + u32 len + u32 pad)
+        //   - Total: ~354 bytes per record
         // The larger refs trade memory for cache locality during sort
-        let bytes_per_record = 338;
+        let bytes_per_record = 354;
         let estimated_records = self.memory_limit / bytes_per_record;
         // Allocate ~86% for data, ~14% for refs (48/338 ≈ 14%)
         let estimated_data_bytes = self.memory_limit * 86 / 100;
@@ -1112,7 +1126,7 @@ impl RawExternalSorter {
 
             // Extract template key and push to buffer
             let bam_bytes = record.as_ref();
-            let key = extract_template_key_inline(bam_bytes, &lib_lookup);
+            let key = extract_template_key_inline(bam_bytes, &lib_lookup, self.cell_tag.as_ref());
             buffer.push(bam_bytes, key);
 
             // Check memory usage
@@ -1687,12 +1701,19 @@ impl RawExternalSorter {
 ///
 /// This function computes the template-coordinate sort key inline, avoiding
 /// heap allocations for the read name by using a hash instead.
+///
+/// When `cell_tag` is `Some`, the CB (cellular barcode) tag value is hashed
+/// and included in the sort key between neg2 and MI, matching fgbio's order.
 #[must_use]
-pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup) -> TemplateKey {
+pub fn extract_template_key_inline(
+    bam_bytes: &[u8],
+    lib_lookup: &LibraryLookup,
+    cell_tag: Option<&[u8; 2]>,
+) -> TemplateKey {
     use crate::sort::bam_fields;
     use bam_fields::{
-        find_mc_tag_in_record, find_mi_tag_in_record, flags, get_cigar_ops, mate_unclipped_5prime,
-        unclipped_5prime,
+        find_mc_tag_in_record, find_mi_tag_in_record, find_string_tag_in_record, flags,
+        get_cigar_ops, mate_unclipped_5prime, unclipped_5prime,
     };
 
     // Extract MI tag using fast raw byte scan (bypasses noodles overhead)
@@ -1700,6 +1721,19 @@ pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup)
 
     // Get library ordinal
     let library = lib_lookup.get_ordinal(bam_bytes);
+
+    // Hash cell barcode tag if requested
+    let cb_hash = cell_tag.map_or(0u64, |tag| {
+        find_string_tag_in_record(bam_bytes, tag).map_or(0u64, |cb_bytes| {
+            let state = ahash::RandomState::with_seeds(
+                0xa1b2_c3d4_e5f6_0718,
+                0x9182_7364_5546_3728,
+                0xfede_dcba_0987_6543,
+                0x0011_2233_4455_6677,
+            );
+            state.hash_one(cb_bytes)
+        })
+    });
 
     // Extract fields from raw bytes
     let tid = bam_fields::ref_id(bam_bytes);
@@ -1739,6 +1773,7 @@ pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup)
                 i32::MAX,
                 i32::MAX,
                 false,
+                cb_hash,
                 library,
                 mi,
                 name_hash,
@@ -1748,7 +1783,7 @@ pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup)
 
         // Completely unmapped - sort to end
         let is_read2 = (flag & 0x80) != 0; // is_last_segment flag
-        return TemplateKey::unmapped(name_hash, is_read2);
+        return TemplateKey::unmapped(name_hash, cb_hash, is_read2);
     }
 
     // Calculate unclipped 5' position for this read
@@ -1781,7 +1816,7 @@ pub fn extract_template_key_inline(bam_bytes: &[u8], lib_lookup: &LibraryLookup)
         (tid, i32::MAX, this_pos, i32::MAX, is_reverse, false, false)
     };
 
-    TemplateKey::new(tid1, pos1, neg1, tid2, pos2, neg2, library, mi, name_hash, is_upper)
+    TemplateKey::new(tid1, pos1, neg1, tid2, pos2, neg2, cb_hash, library, mi, name_hash, is_upper)
 }
 
 // Use shared SortStats from the parent module.
@@ -2006,5 +2041,148 @@ mod tests {
             fgumi_raw_bam::tags::find_string_tag_in_record(&bam, b"RG"),
             Some(b"mygroup".as_slice())
         );
+    }
+
+    // ========================================================================
+    // RawExternalSorter cell_tag builder tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_sorter_cell_tag_default_is_none() {
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate);
+        assert!(sorter.cell_tag.is_none());
+    }
+
+    #[test]
+    fn test_raw_sorter_cell_tag_builder() {
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate).cell_tag(*b"CB");
+        assert_eq!(sorter.cell_tag, Some(*b"CB"));
+    }
+
+    // ========================================================================
+    // extract_template_key_inline cell_tag tests
+    // ========================================================================
+
+    /// Build minimal BAM bytes with mapped read at (tid, pos) on the forward strand,
+    /// with optional aux data appended.
+    #[allow(clippy::cast_possible_truncation)]
+    fn build_mapped_bam(tid: i32, pos: i32, name: &[u8], aux: &[u8]) -> Vec<u8> {
+        let l_read_name = (name.len() + 1) as u8; // +1 for null terminator
+        let mut bam = vec![0u8; 32];
+        // ref_id at offset 0..4
+        bam[0..4].copy_from_slice(&tid.to_le_bytes());
+        // pos at offset 4..8
+        bam[4..8].copy_from_slice(&pos.to_le_bytes());
+        // l_read_name at offset 8
+        bam[8] = l_read_name;
+        // flags at offset 14..16: paired + proper pair = 0x03
+        bam[14..16].copy_from_slice(&3u16.to_le_bytes());
+        // mate_ref_id at offset 20..24: same tid
+        bam[20..24].copy_from_slice(&tid.to_le_bytes());
+        // mate_pos at offset 24..28: same pos
+        bam[24..28].copy_from_slice(&pos.to_le_bytes());
+        // read name
+        bam.extend_from_slice(name);
+        bam.push(0); // null terminator
+        // no cigar, no seq, no qual
+        // aux data
+        bam.extend_from_slice(aux);
+        bam
+    }
+
+    /// Build CB:Z: aux tag bytes.
+    fn cb_aux(value: &[u8]) -> Vec<u8> {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"CBZ");
+        aux.extend_from_slice(value);
+        aux.push(0); // null terminator
+        aux
+    }
+
+    #[test]
+    fn test_extract_template_key_cb_present_has_nonzero_hash() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        let aux = cb_aux(b"ACGTACGT");
+        let bam = build_mapped_bam(0, 100, b"read1", &aux);
+
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"));
+        assert_ne!(key.cb_hash, 0, "CB present should produce non-zero cb_hash");
+    }
+
+    #[test]
+    fn test_extract_template_key_cb_absent_has_zero_hash() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        // No CB tag in aux data
+        let bam = build_mapped_bam(0, 100, b"read1", &[]);
+
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"));
+        assert_eq!(key.cb_hash, 0, "missing CB tag should produce cb_hash=0");
+    }
+
+    #[test]
+    fn test_extract_template_key_cell_tag_none_has_zero_hash() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        let aux = cb_aux(b"ACGTACGT");
+        let bam = build_mapped_bam(0, 100, b"read1", &aux);
+
+        let key = extract_template_key_inline(&bam, &lib_lookup, None);
+        assert_eq!(key.cb_hash, 0, "cell_tag=None should produce cb_hash=0");
+    }
+
+    #[test]
+    fn test_extract_template_key_different_cb_values_differ() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+
+        let aux1 = cb_aux(b"ACGTACGT");
+        let bam1 = build_mapped_bam(0, 100, b"read1", &aux1);
+        let key1 = extract_template_key_inline(&bam1, &lib_lookup, Some(b"CB"));
+
+        let aux2 = cb_aux(b"TGCATGCA");
+        let bam2 = build_mapped_bam(0, 100, b"read1", &aux2);
+        let key2 = extract_template_key_inline(&bam2, &lib_lookup, Some(b"CB"));
+
+        assert_ne!(
+            key1.cb_hash, key2.cb_hash,
+            "different CB values should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_extract_template_key_cb_hash_is_deterministic() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        let aux = cb_aux(b"ACGTACGT");
+        let bam = build_mapped_bam(0, 100, b"read1", &aux);
+
+        let key1 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"));
+        let key2 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"));
+        assert_eq!(key1.cb_hash, key2.cb_hash, "same input should produce same cb_hash");
+    }
+
+    #[test]
+    fn test_extract_template_key_unmapped_with_cb() {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        let aux = cb_aux(b"ACGTACGT");
+
+        // Build unmapped read (flag = PAIRED | UNMAPPED | MATE_UNMAPPED = 0x0D)
+        let mut bam = vec![0u8; 32];
+        bam[8] = 6; // l_read_name = 6 ("read1" + null)
+        bam[14..16].copy_from_slice(&0x000Du16.to_le_bytes()); // flags
+        // ref_id = -1 (unmapped)
+        bam[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        bam[4..8].copy_from_slice(&(-1i32).to_le_bytes()); // pos = -1
+        bam[20..24].copy_from_slice(&(-1i32).to_le_bytes()); // mate_ref_id = -1
+        bam[24..28].copy_from_slice(&(-1i32).to_le_bytes()); // mate_pos = -1
+        bam.extend_from_slice(b"read1\0");
+        bam.extend_from_slice(&aux);
+
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"));
+        assert_ne!(key.cb_hash, 0, "unmapped read with CB should have non-zero cb_hash");
+        assert_eq!(key.primary, u64::MAX, "unmapped both-mates should have MAX primary");
     }
 }


### PR DESCRIPTION
## Summary

Ports [fgbio PR #1142](https://github.com/fulcrumgenomics/fgbio/pull/1142) to include the CB (cellular barcode) tag in the template-coordinate sort order for single-cell data. Without CB in the sort, templates from different cells at the same locus are interleaved, breaking grouper adjacency assumptions.

The new comparison order is:
`tid1 → tid2 → pos1 → pos2 → neg1 → neg2 → **CB** → MI → name → library → is_upper`

### Changes

- **`inline_buffer.rs`**: Add `cb_hash: u64` to `TemplateKey` (5th packed field), expanding serialized key from 32→40 bytes and inline header from 40→48 bytes. Updated radix sort, `Ord`, `core_cmp`, and serialization.
- **`keys.rs`**: Add `cid: String` to `TemplateCoordinateKey` with length-first then lexicographic comparison (matching fgbio). Inserted after neg2, before MI in `Ord` impl.
- **`raw.rs`**: Add `cell_tag: Option<[u8; 2]>` to `RawExternalSorter` with builder method. `extract_template_key_inline` hashes CB tag with ahash (distinct fixed seeds for determinism).
- **`sort.rs` (fgumi-raw-bam crate)**: Add `cell_tag` parameter to `compare_template_coordinate_raw()` with CB comparison after neg2, before MI. `None` skips CB (backwards compatible).
- **`sort.rs` (command)**: Add `--cell-tag` / `-c` CLI arg (default `"CB"`), threaded to sorter and verify mode.
- **`group.rs` / `dedup.rs`**: Updated help text and error messages to mention `--cell-tag CB` in sort suggestions.

### Tests

- 3 new raw comparison tests (CB tiebreak, mixed presence, length-first ordering)
- CB-specific assertions added to `TemplateCoordinateKey` regression test (length-first, lexicographic, empty vs non-empty)
- All existing `TemplateKey` tests updated for new `cb_hash` parameter

## Test plan

- [x] `cargo ci-test` — all 1852 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [ ] End-to-end sort with CB-tagged single-cell BAM to verify output order