### PR TITLE
feat(correct): add --allow-c-to-t flag for methylated UMI correction

### DIFF
--- a/crates/fgumi-dna/src/bitenc.rs
+++ b/crates/fgumi-dna/src/bitenc.rs
@@ -150,6 +150,43 @@ impl BitEnc {
         Self { bits: new_bits, len: self.len }
     }
 
+    /// Compute the Hamming distance, treating C→T conversions as zero cost.
+    ///
+    /// In EM-Seq, methylated UMI cytosines can be enzymatically converted to thymine.
+    /// `self` is the expected (whitelist) sequence and `other` is the observed sequence.
+    /// Positions where expected=C and observed=T are excluded from the mismatch count.
+    ///
+    /// This is asymmetric: expected=T observed=C is counted as a real mismatch.
+    #[inline]
+    #[must_use]
+    pub fn hamming_distance_allow_c_to_t(&self, other: &Self) -> u32 {
+        debug_assert_eq!(self.len, other.len, "Sequences must have equal length");
+
+        // XOR to find differing bits
+        let diff = self.bits ^ other.bits;
+
+        // Standard mismatch detection: a position differs if either of its 2 bits differ
+        let odd_bits = diff & 0xAAAA_AAAA_AAAA_AAAA;
+        let even_bits = diff & 0x5555_5555_5555_5555;
+        let differs = (odd_bits >> 1) | even_bits;
+
+        // Identify expected-C positions: even bit=1, odd bit=0 (C=01)
+        let exp_even = self.bits & 0x5555_5555_5555_5555;
+        let exp_odd = (self.bits & 0xAAAA_AAAA_AAAA_AAAA) >> 1;
+        let is_expected_c = exp_even & !exp_odd;
+
+        // Identify observed-T positions: even bit=1, odd bit=1 (T=11)
+        let obs_even = other.bits & 0x5555_5555_5555_5555;
+        let obs_odd = (other.bits & 0xAAAA_AAAA_AAAA_AAAA) >> 1;
+        let is_observed_t = obs_even & obs_odd;
+
+        // Mask out C→T conversion artifacts
+        let ct_artifacts = is_expected_c & is_observed_t;
+        let real_differs = differs & !ct_artifacts;
+
+        real_differs.count_ones()
+    }
+
     /// Extract bits for bases `[start_base, start_base + len)` as a u32.
     ///
     /// Each base is 2 bits, so this can extract up to 16 bases into a u32.
@@ -303,5 +340,60 @@ mod tests {
         let umi3 = BitEnc::from_umi_str("AAAGCGATGC-CCAGTTAACC").unwrap();
         let umi4 = BitEnc::from_umi_str("AAAGCGATGC-CCAGTTAACC").unwrap();
         assert_eq!(umi3.hamming_distance(&umi4), 0);
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_no_conversion() {
+        // No C→T positions, same result as standard hamming
+        let seq1 = BitEnc::from_bytes(b"AAGGTTAA").unwrap();
+        let seq2 = BitEnc::from_bytes(b"AAGGTTAA").unwrap();
+        assert_eq!(seq1.hamming_distance_allow_c_to_t(&seq2), 0);
+
+        let seq3 = BitEnc::from_bytes(b"AAGGTTAG").unwrap();
+        assert_eq!(seq1.hamming_distance_allow_c_to_t(&seq3), 1);
+        assert_eq!(seq1.hamming_distance(&seq3), 1);
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_single_ct() {
+        // Expected C, observed T → distance 0
+        let expected = BitEnc::from_bytes(b"ACGT").unwrap();
+        let observed = BitEnc::from_bytes(b"ATGT").unwrap(); // C→T at position 1
+        assert_eq!(expected.hamming_distance(&observed), 1); // standard counts it
+        assert_eq!(expected.hamming_distance_allow_c_to_t(&observed), 0); // em-seq ignores it
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_multiple_ct() {
+        // Multiple C→T conversions, all ignored
+        let expected = BitEnc::from_bytes(b"CCCC").unwrap();
+        let observed = BitEnc::from_bytes(b"TTTT").unwrap();
+        assert_eq!(expected.hamming_distance(&observed), 4);
+        assert_eq!(expected.hamming_distance_allow_c_to_t(&observed), 0);
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_mixed() {
+        // C→T artifacts + real mismatches → only real counted
+        let expected = BitEnc::from_bytes(b"ACGA").unwrap();
+        let observed = BitEnc::from_bytes(b"ATGG").unwrap(); // C→T at pos 1, A→G at pos 3
+        assert_eq!(expected.hamming_distance(&observed), 2);
+        assert_eq!(expected.hamming_distance_allow_c_to_t(&observed), 1); // only A→G counts
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_reverse_tc() {
+        // Expected T, observed C → real mismatch (asymmetric)
+        let expected = BitEnc::from_bytes(b"ATGT").unwrap();
+        let observed = BitEnc::from_bytes(b"ACGT").unwrap(); // T→C at position 1
+        assert_eq!(expected.hamming_distance_allow_c_to_t(&observed), 1);
+    }
+
+    #[test]
+    fn test_hamming_distance_allow_c_to_t_all_c_to_t() {
+        // Whitelist all-C, observed all-T → distance 0
+        let expected = BitEnc::from_bytes(b"CCCCCCCCCC").unwrap();
+        let observed = BitEnc::from_bytes(b"TTTTTTTTTT").unwrap();
+        assert_eq!(expected.hamming_distance_allow_c_to_t(&observed), 0);
     }
 }

--- a/src/commands/correct.rs
+++ b/src/commands/correct.rs
@@ -31,6 +31,7 @@
 //!     cache_size: 100_000,
 //!     min_corrected: None,
 //!     revcomp: false,
+//!     allow_c_to_t: false,
 //!     threading: ThreadingOptions::new(4),
 //!     compression: CompressionOptions::default(),
 //!     scheduler_opts: SchedulerOptions::default(),
@@ -136,6 +137,7 @@ pub struct UmiMatch {
 ///     cache_size: 100_000,
 ///     min_corrected: None,
 ///     revcomp: false,
+///     allow_c_to_t: false,
 ///     threading: ThreadingOptions::new(4),
 ///     compression: CompressionOptions::default(),
 ///     scheduler_opts: SchedulerOptions::default(),
@@ -245,6 +247,14 @@ pub struct CorrectUmis {
     /// Reverse complement UMIs before matching.
     #[arg(long)]
     pub revcomp: bool,
+
+    /// Treat C→T mismatches as zero cost (for EM-Seq methylated UMIs).
+    ///
+    /// When enabled, positions where the whitelist UMI has C and the observed UMI has T are not
+    /// counted as mismatches. This accounts for incomplete conversion protection of 5mC bases
+    /// in enzymatic methyl-seq (EM-Seq) library preparation.
+    #[arg(long)]
+    pub allow_c_to_t: bool,
 
     /// Threading options for parallel processing.
     #[command(flatten)]
@@ -407,6 +417,7 @@ impl Command for CorrectUmis {
     /// #   cache_size: 100_000,
     /// #   min_corrected: None,
     /// #   revcomp: false,
+    /// #   allow_c_to_t: false,
     /// #   threading: ThreadingOptions::new(4),
     /// };
     ///
@@ -541,7 +552,11 @@ impl CorrectUmis {
     ///
     /// * `umi_sequences` - Slice of UMI sequences to check
     fn check_umi_distances(&self, umi_sequences: &[String]) {
-        let pairs = find_umi_pairs_within_distance(umi_sequences, self.min_distance_diff - 1);
+        let pairs = find_umi_pairs_within_distance(
+            umi_sequences,
+            self.min_distance_diff - 1,
+            self.allow_c_to_t,
+        );
 
         if !pairs.is_empty() {
             warn!("###################################################################");
@@ -630,6 +645,7 @@ impl CorrectUmis {
         min_distance_diff: usize,
         encoded_umi_set: &EncodedUmiSet,
         cache: &mut Option<LruCache<Vec<u8>, UmiMatch>>,
+        allow_c_to_t: bool,
     ) -> TemplateCorrection {
         let original_umi = umi.to_string();
 
@@ -668,6 +684,7 @@ impl CorrectUmis {
                         encoded_umi_set,
                         max_mismatches,
                         min_distance_diff,
+                        allow_c_to_t,
                     );
                     c.put(seq_bytes, result.clone());
                     result
@@ -678,6 +695,7 @@ impl CorrectUmis {
                     encoded_umi_set,
                     max_mismatches,
                     min_distance_diff,
+                    allow_c_to_t,
                 )
             };
 
@@ -687,11 +705,12 @@ impl CorrectUmis {
         // Determine if all segments matched
         let all_matched = matches.iter().all(|m| m.matched);
         let has_mismatches = matches.iter().any(|m| m.mismatches > 0);
-        let needs_correction = has_mismatches || revcomp;
 
         if all_matched {
             let corrected_umi: String =
                 matches.iter().map(|m| m.umi.clone()).collect::<Vec<_>>().join("-");
+            // C→T-tolerant matches may have zero mismatches but still need canonical rewrite
+            let needs_correction = revcomp || corrected_umi != original_umi;
             TemplateCorrection {
                 matched: true,
                 corrected_umi: Some(corrected_umi),
@@ -901,6 +920,7 @@ impl CorrectUmis {
         let min_distance_diff = self.min_distance_diff;
         let umi_tag = Tag::new(self.umi_tag.as_bytes()[0], self.umi_tag.as_bytes()[1]);
         let revcomp = self.revcomp;
+        let allow_c_to_t = self.allow_c_to_t;
         let cache_size = self.cache_size;
         let dont_store_original_umis = self.dont_store_original_umis;
 
@@ -982,6 +1002,7 @@ impl CorrectUmis {
                                     min_distance_diff,
                                     &encoded_umi_set,
                                     &mut cache_ref,
+                                    allow_c_to_t,
                                 );
                                 let num_records = raw_records.len() as u64;
 
@@ -1064,6 +1085,7 @@ impl CorrectUmis {
                                     min_distance_diff,
                                     &encoded_umi_set,
                                     &mut cache_ref,
+                                    allow_c_to_t,
                                 );
                                 let num_records = records.len() as u64;
 
@@ -1362,6 +1384,7 @@ impl CorrectUmis {
         let max_mismatches = self.max_mismatches;
         let min_distance_diff = self.min_distance_diff;
         let revcomp = self.revcomp;
+        let allow_c_to_t = self.allow_c_to_t;
         let dont_store_original_umis = self.dont_store_original_umis;
 
         // Process templates
@@ -1398,6 +1421,7 @@ impl CorrectUmis {
                         min_distance_diff,
                         &encoded_umi_set,
                         &mut cache,
+                        allow_c_to_t,
                     );
 
                     if correction.matched {
@@ -1518,11 +1542,41 @@ impl CorrectUmis {
 /// ```
 #[must_use]
 pub fn count_mismatches_with_max(a: &[u8], b: &[u8], max_mismatches: usize) -> usize {
+    count_mismatches_inner(a, b, max_mismatches, false)
+}
+
+/// Count mismatches between two byte sequences, ignoring C→T conversions.
+///
+/// `a` is the expected (whitelist) sequence, `b` is the observed sequence.
+/// Positions where `a[i] == b'C' && b[i] == b'T'` are not counted.
+/// Early-exits when mismatch count exceeds `max_mismatches`.
+///
+/// # Example
+///
+/// ```
+/// # use fgumi_lib::correct_umis::count_mismatches_allow_c_to_t;
+/// assert_eq!(count_mismatches_allow_c_to_t(b"ACGA", b"ATGA", 10), 0); // C→T ignored
+/// assert_eq!(count_mismatches_allow_c_to_t(b"ACGA", b"ATGG", 10), 1); // C→T ignored, A→G counted
+/// assert_eq!(count_mismatches_allow_c_to_t(b"ATGA", b"ACGA", 10), 1); // T→C is real mismatch
+/// ```
+#[must_use]
+pub fn count_mismatches_allow_c_to_t(a: &[u8], b: &[u8], max_mismatches: usize) -> usize {
+    count_mismatches_inner(a, b, max_mismatches, true)
+}
+
+/// Inner implementation for mismatch counting with optional C→T tolerance.
+///
+/// When `allow_c_to_t` is true, positions where `a[i] == b'C' && b[i] == b'T'`
+/// are not counted as mismatches (EM-seq C→T conversion artifacts).
+fn count_mismatches_inner(a: &[u8], b: &[u8], max_mismatches: usize, allow_c_to_t: bool) -> usize {
     let mut mismatches = 0;
     let min_len = a.len().min(b.len());
 
     for i in 0..min_len {
         if a[i] != b[i] {
+            if allow_c_to_t && a[i] == b'C' && b[i] == b'T' {
+                continue;
+            }
             mismatches += 1;
             if mismatches > max_mismatches {
                 return mismatches;
@@ -1591,6 +1645,7 @@ fn find_best_match_encoded(
     umi_set: &EncodedUmiSet,
     max_mismatches: usize,
     min_distance_diff: usize,
+    allow_c_to_t: bool,
 ) -> UmiMatch {
     let mut best_index: Option<usize> = None;
     let mut best_mismatches = usize::MAX;
@@ -1605,10 +1660,26 @@ fn find_best_match_encoded(
             for (i, fixed_enc) in umi_set.encoded.iter().enumerate() {
                 let mismatches = if let Some(enc) = fixed_enc {
                     // Both can be compared with BitEnc
-                    enc.hamming_distance(&obs_enc) as usize
+                    if allow_c_to_t {
+                        enc.hamming_distance_allow_c_to_t(&obs_enc) as usize
+                    } else {
+                        enc.hamming_distance(&obs_enc) as usize
+                    }
                 } else {
                     // Fixed UMI couldn't be encoded, fall back to bytes
-                    count_mismatches_with_max(observed, &umi_set.bytes[i], second_best_mismatches)
+                    if allow_c_to_t {
+                        count_mismatches_allow_c_to_t(
+                            &umi_set.bytes[i],
+                            observed,
+                            second_best_mismatches,
+                        )
+                    } else {
+                        count_mismatches_with_max(
+                            observed,
+                            &umi_set.bytes[i],
+                            second_best_mismatches,
+                        )
+                    }
                 };
 
                 if mismatches < best_mismatches {
@@ -1623,8 +1694,11 @@ fn find_best_match_encoded(
         None => {
             // Slow path: observed UMI can't be encoded, use byte comparison
             for (i, fixed_umi) in umi_set.bytes.iter().enumerate() {
-                let mismatches =
-                    count_mismatches_with_max(observed, fixed_umi, second_best_mismatches);
+                let mismatches = if allow_c_to_t {
+                    count_mismatches_allow_c_to_t(fixed_umi, observed, second_best_mismatches)
+                } else {
+                    count_mismatches_with_max(observed, fixed_umi, second_best_mismatches)
+                };
 
                 if mismatches < best_mismatches {
                     second_best_mismatches = best_mismatches;
@@ -1671,18 +1745,35 @@ fn find_best_match_encoded(
 /// ```
 /// # use fgumi_lib::correct_umis::find_umi_pairs_within_distance;
 /// let umis = vec!["AAAA".to_string(), "AAAT".to_string()];
-/// let pairs = find_umi_pairs_within_distance(&umis, 2);
+/// let pairs = find_umi_pairs_within_distance(&umis, 2, false);
 /// assert_eq!(pairs.len(), 1);
 /// ```
 #[must_use]
 pub fn find_umi_pairs_within_distance(
     umis: &[String],
     distance: usize,
+    allow_c_to_t: bool,
 ) -> Vec<(String, String, usize)> {
     let mut pairs = Vec::new();
     for i in 0..umis.len() {
         for j in (i + 1)..umis.len() {
-            let d = count_mismatches_with_max(umis[i].as_bytes(), umis[j].as_bytes(), distance + 1);
+            // For EM-Seq, check both directions since C→T is asymmetric:
+            // either UMI could be the "expected" one from the observer's perspective.
+            let d = if allow_c_to_t {
+                let d1 = count_mismatches_allow_c_to_t(
+                    umis[i].as_bytes(),
+                    umis[j].as_bytes(),
+                    distance + 1,
+                );
+                let d2 = count_mismatches_allow_c_to_t(
+                    umis[j].as_bytes(),
+                    umis[i].as_bytes(),
+                    distance + 1,
+                );
+                d1.min(d2)
+            } else {
+                count_mismatches_with_max(umis[i].as_bytes(), umis[j].as_bytes(), distance + 1)
+            };
             if d <= distance {
                 pairs.push((umis[i].clone(), umis[j].clone(), d));
             }
@@ -1740,12 +1831,12 @@ mod tests {
     fn test_find_best_match_perfect() {
         let umi_set = get_encoded_umi_set();
 
-        let hit1 = find_best_match_encoded(b"AAAAAA", &umi_set, 2, 2);
+        let hit1 = find_best_match_encoded(b"AAAAAA", &umi_set, 2, 2, false);
         assert!(hit1.matched);
         assert_eq!(hit1.mismatches, 0);
         assert_eq!(hit1.umi, "AAAAAA");
 
-        let hit2 = find_best_match_encoded(b"CCCCCC", &umi_set, 2, 2);
+        let hit2 = find_best_match_encoded(b"CCCCCC", &umi_set, 2, 2, false);
         assert!(hit2.matched);
         assert_eq!(hit2.mismatches, 0);
         assert_eq!(hit2.umi, "CCCCCC");
@@ -1755,22 +1846,22 @@ mod tests {
     fn test_find_best_match_with_mismatches() {
         let umi_set = get_encoded_umi_set();
 
-        let m1 = find_best_match_encoded(b"AAAAAA", &umi_set, 2, 2);
+        let m1 = find_best_match_encoded(b"AAAAAA", &umi_set, 2, 2, false);
         assert!(m1.matched);
         assert_eq!(m1.umi, "AAAAAA");
         assert_eq!(m1.mismatches, 0);
 
-        let m2 = find_best_match_encoded(b"AAAAAT", &umi_set, 2, 2);
+        let m2 = find_best_match_encoded(b"AAAAAT", &umi_set, 2, 2, false);
         assert!(m2.matched);
         assert_eq!(m2.umi, "AAAAAA");
         assert_eq!(m2.mismatches, 1);
 
-        let m3 = find_best_match_encoded(b"AAAACT", &umi_set, 2, 2);
+        let m3 = find_best_match_encoded(b"AAAACT", &umi_set, 2, 2, false);
         assert!(m3.matched);
         assert_eq!(m3.umi, "AAAAAA");
         assert_eq!(m3.mismatches, 2);
 
-        let m4 = find_best_match_encoded(b"AAAGCT", &umi_set, 2, 2);
+        let m4 = find_best_match_encoded(b"AAAGCT", &umi_set, 2, 2, false);
         assert!(!m4.matched);
         assert_eq!(m4.mismatches, 3);
     }
@@ -1779,7 +1870,7 @@ mod tests {
     fn test_no_match_when_umis_too_similar() {
         let umi_set = EncodedUmiSet::new(&["AAAG".to_string(), "AAAT".to_string()]);
 
-        let m = find_best_match_encoded(b"AAAG", &umi_set, 2, 2);
+        let m = find_best_match_encoded(b"AAAG", &umi_set, 2, 2, false);
         assert!(!m.matched);
     }
 
@@ -1787,21 +1878,21 @@ mod tests {
     fn test_match_with_many_mismatches() {
         let umi_set = get_encoded_umi_set();
 
-        let m1 = find_best_match_encoded(b"AAAAAA", &umi_set, 3, 2);
+        let m1 = find_best_match_encoded(b"AAAAAA", &umi_set, 3, 2, false);
         assert!(m1.matched);
         assert_eq!(m1.umi, "AAAAAA");
         assert_eq!(m1.mismatches, 0);
 
-        let m2 = find_best_match_encoded(b"AAACGT", &umi_set, 3, 2);
+        let m2 = find_best_match_encoded(b"AAACGT", &umi_set, 3, 2, false);
         assert!(m2.matched);
         assert_eq!(m2.umi, "AAAAAA");
         assert_eq!(m2.mismatches, 3);
 
-        let m3 = find_best_match_encoded(b"AAACCC", &umi_set, 3, 2);
+        let m3 = find_best_match_encoded(b"AAACCC", &umi_set, 3, 2, false);
         assert!(!m3.matched);
         assert_eq!(m3.mismatches, 3);
 
-        let m4 = find_best_match_encoded(b"AAACCT", &umi_set, 3, 2);
+        let m4 = find_best_match_encoded(b"AAACCT", &umi_set, 3, 2, false);
         assert!(!m4.matched);
         assert_eq!(m4.mismatches, 3);
     }
@@ -1811,6 +1902,7 @@ mod tests {
         let pairs = find_umi_pairs_within_distance(
             &["AAAA".to_string(), "TTTT".to_string(), "CCCC".to_string(), "GGGG".to_string()],
             2,
+            false,
         );
         assert!(pairs.is_empty());
     }
@@ -1825,7 +1917,7 @@ mod tests {
             "ACAGAC".to_string(),
             "AGAGAG".to_string(),
         ];
-        let pairs = find_umi_pairs_within_distance(&umis, 2);
+        let pairs = find_umi_pairs_within_distance(&umis, 2, false);
         assert_eq!(pairs.len(), 2);
         assert!(pairs.contains(&("ACACAC".to_string(), "ACAGAC".to_string(), 1)));
         assert!(pairs.contains(&("ACAGAC".to_string(), "AGAGAG".to_string(), 2)));
@@ -1958,6 +2050,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -1993,6 +2086,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2022,6 +2116,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2074,6 +2169,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2136,6 +2232,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2193,6 +2290,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2214,6 +2312,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2256,6 +2355,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2296,6 +2396,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2337,6 +2438,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: true,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2391,6 +2493,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2441,6 +2544,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2492,6 +2596,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2534,6 +2639,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2575,6 +2681,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2615,6 +2722,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: Some(0.75), // Require 75% of reads to pass
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2649,6 +2757,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: Some(0.75), // Require 75% but only 25% will pass
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2687,6 +2796,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2741,6 +2851,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::new(4), // Multiple threads
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2800,6 +2911,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::new(8), // 8 threads
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -2911,7 +3023,7 @@ mod tests {
         let mut cache = None;
 
         let correction = CorrectUmis::compute_template_correction(
-            "AAAAAA", 6, false, 2, 2, &umi_set, &mut cache,
+            "AAAAAA", 6, false, 2, 2, &umi_set, &mut cache, false,
         );
 
         assert!(correction.matched);
@@ -2928,7 +3040,7 @@ mod tests {
         let mut cache = None;
 
         let correction = CorrectUmis::compute_template_correction(
-            "AAAAAT", 6, false, 2, 2, &umi_set, &mut cache,
+            "AAAAAT", 6, false, 2, 2, &umi_set, &mut cache, false,
         );
 
         assert!(correction.matched);
@@ -2944,8 +3056,9 @@ mod tests {
         let umi_set = get_encoded_umi_set();
         let mut cache = None;
 
-        let correction =
-            CorrectUmis::compute_template_correction("AAAA", 6, false, 2, 2, &umi_set, &mut cache);
+        let correction = CorrectUmis::compute_template_correction(
+            "AAAA", 6, false, 2, 2, &umi_set, &mut cache, false,
+        );
 
         assert!(!correction.matched);
         assert!(correction.corrected_umi.is_none());
@@ -2958,7 +3071,7 @@ mod tests {
         let mut cache = None;
 
         let correction = CorrectUmis::compute_template_correction(
-            "AAAGGG", 6, false, 2, 2, &umi_set, &mut cache,
+            "AAAGGG", 6, false, 2, 2, &umi_set, &mut cache, false,
         );
 
         assert!(!correction.matched);
@@ -2972,8 +3085,9 @@ mod tests {
         let mut cache = None;
 
         // TTTTTT revcomp -> AAAAAA
-        let correction =
-            CorrectUmis::compute_template_correction("TTTTTT", 6, true, 2, 2, &umi_set, &mut cache);
+        let correction = CorrectUmis::compute_template_correction(
+            "TTTTTT", 6, true, 2, 2, &umi_set, &mut cache, false,
+        );
 
         assert!(correction.matched);
         assert_eq!(correction.corrected_umi, Some("AAAAAA".to_string()));
@@ -2996,6 +3110,7 @@ mod tests {
             2,
             &umi_set,
             &mut cache,
+            false,
         );
 
         assert!(correction.matched);
@@ -3136,6 +3251,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -3196,6 +3312,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -3275,6 +3392,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading: ThreadingOptions::new(4), // Multi-threaded!
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -3342,6 +3460,7 @@ mod tests {
             cache_size: 100_000,
             min_corrected: None,
             revcomp: false,
+            allow_c_to_t: false,
             threading,
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
@@ -3569,5 +3688,71 @@ mod tests {
         // OX tag should NOT be present (dont_store_original_umis = true)
         let ox = bam_fields::find_string_tag_in_record(&raw, b"OX");
         assert!(ox.is_none());
+    }
+
+    // EM-Seq tests
+
+    #[test]
+    fn test_count_mismatches_allow_c_to_t() {
+        // C→T ignored
+        assert_eq!(count_mismatches_allow_c_to_t(b"ACGA", b"ATGA", 10), 0);
+        // C→T ignored, A→G counted
+        assert_eq!(count_mismatches_allow_c_to_t(b"ACGA", b"ATGG", 10), 1);
+        // T→C is real mismatch (asymmetric)
+        assert_eq!(count_mismatches_allow_c_to_t(b"ATGA", b"ACGA", 10), 1);
+        // No mismatches
+        assert_eq!(count_mismatches_allow_c_to_t(b"AAAA", b"AAAA", 10), 0);
+        // All C→T
+        assert_eq!(count_mismatches_allow_c_to_t(b"CCCC", b"TTTT", 10), 0);
+        // Early exit
+        assert_eq!(count_mismatches_allow_c_to_t(b"AAAAAA", b"GGGGGG", 2), 3);
+    }
+
+    #[test]
+    fn test_find_best_match_allow_c_to_t_basic() {
+        // Whitelist has "CCCCCC", observed is "TTTTTT" (all C→T)
+        let umi_set = EncodedUmiSet::new(&["CCCCCC".to_string()]);
+        let result = find_best_match_encoded(b"TTTTTT", &umi_set, 0, 1, true);
+        assert!(result.matched);
+        assert_eq!(result.umi, "CCCCCC");
+        assert_eq!(result.mismatches, 0);
+
+        // Without allow_c_to_t, same input should not match at max_mismatches=0
+        let result = find_best_match_encoded(b"TTTTTT", &umi_set, 0, 1, false);
+        assert!(!result.matched);
+    }
+
+    #[test]
+    fn test_find_best_match_allow_c_to_t_with_real_error() {
+        // Whitelist has "ACGTAC", observed is "ATGTAG" — C→T at pos 1 (ignored) + C→G at pos 5 (real)
+        let umi_set = EncodedUmiSet::new(&["ACGTAC".to_string()]);
+        let result = find_best_match_encoded(b"ATGTAG", &umi_set, 1, 1, true);
+        assert!(result.matched);
+        assert_eq!(result.mismatches, 1);
+    }
+
+    #[test]
+    fn test_find_best_match_allow_c_to_t_ambiguous() {
+        // Two whitelist UMIs that both match after C→T: "ACGT" and "ATGT"
+        // Observed "ATGT" matches "ATGT" at distance 0 and "ACGT" at distance 0 (C→T)
+        // Should fail min_distance_diff=1 since both are distance 0
+        let umi_set = EncodedUmiSet::new(&["ACGT".to_string(), "ATGT".to_string()]);
+        let result = find_best_match_encoded(b"ATGT", &umi_set, 1, 1, true);
+        // One matches perfectly (distance 0 standard), the other matches at distance 0 em-seq
+        // So second_best=0, best=0, distance_to_second=0 < min_distance_diff=1 → rejected
+        assert!(!result.matched);
+    }
+
+    #[test]
+    fn test_find_umi_pairs_allow_c_to_t() {
+        // "ACGT" and "ATGT" differ by 1 normally, but under EM-Seq "ACGT"→"ATGT" is distance 0
+        let umis = vec!["ACGT".to_string(), "ATGT".to_string()];
+        let pairs = find_umi_pairs_within_distance(&umis, 0, true);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].2, 0);
+
+        // Without allow_c_to_t, they are distance 1 apart, not within 0
+        let pairs = find_umi_pairs_within_distance(&umis, 0, false);
+        assert_eq!(pairs.len(), 0);
     }
 }

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -160,3 +160,73 @@ fn test_correct_command_with_rejects() {
     assert!(status.success(), "Correct command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 }
+
+/// Test correct command with --allow-c-to-t flag: C→T converted UMIs should match whitelist.
+#[test]
+fn test_correct_command_allow_c_to_t() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // Whitelist UMI has C at positions 1,3: "ACGCACGC"
+    // Observed UMI has C→T at those positions: "ATGTATGT"
+    // Without --allow-c-to-t this would be 4 mismatches; with --allow-c-to-t it should be 0
+    let exact_reads = create_umi_family("ACGCACGC", 3, "exact", "AAAAGGGG", 30);
+    let converted_reads = create_umi_family("ATGTATGT", 2, "converted", "AAAAGGGG", 30);
+    create_umi_bam(&input_bam, vec![exact_reads, converted_reads]);
+    create_whitelist(&whitelist, &["ACGCACGC"]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "correct",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--umi-files",
+            whitelist.to_str().unwrap(),
+            "--max-mismatches",
+            "0",
+            "--min-distance",
+            "1",
+            "--allow-c-to-t",
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run correct command");
+
+    assert!(status.success(), "Correct command with --allow-c-to-t failed");
+    assert!(output_bam.exists(), "Output BAM not created");
+
+    // All 5 reads should be in output (exact match + C→T match both pass at max_mismatches=0)
+    // and all reads should carry the canonical whitelist RX tag
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let header = reader.read_header().unwrap();
+    let rx_tag = [b'R', b'X'];
+    let mut output_count = 0;
+    for result in reader.record_bufs(&header) {
+        let record = result.expect("Failed to read record");
+        output_count += 1;
+        let rx = record.data().get(&rx_tag).expect("Record should have RX tag");
+        let rx_str = match rx {
+            noodles::sam::alignment::record_buf::data::field::Value::String(s) => s.to_string(),
+            _ => panic!("RX tag should be a string"),
+        };
+        assert_eq!(
+            rx_str, "ACGCACGC",
+            "All corrected reads should carry the canonical whitelist RX"
+        );
+    }
+    assert_eq!(output_count, 5, "Should have all 5 reads in output with --allow-c-to-t");
+
+    // Rejects should be empty
+    let mut reject_reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
+    let _header = reject_reader.read_header().unwrap();
+    let reject_count = reject_reader.records().count();
+    assert_eq!(reject_count, 0, "Should have 0 rejects with --allow-c-to-t");
+}


### PR DESCRIPTION
## Summary
- Adds `--allow-c-to-t` flag to `fgumi correct` for EM-seq workflows where enzymatic conversion creates expected C→T changes in UMI sequences
- When enabled, C→T mismatches (expected→observed) are not counted as errors during UMI correction
- Unifies `count_mismatches_with_max` and `count_mismatches_allow_c_to_t` into a single `count_mismatches_inner` function with an `allow_c_to_t` parameter
- Fixes `needs_correction` logic to detect when C→T-tolerant matching selected a different whitelist UMI (uses `corrected_umi != original_umi` instead of `has_mismatches`)

## Stack
1/6 — EM-seq support

## Test plan
- [x] New integration test `test_correct_command_allow_c_to_t` validates C→T tolerance and asserts corrected RX tag
- [x] Existing correct tests pass unchanged
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes