### PR TITLE
feat(group): add --allow-c-to-t flag for methylated UMI grouping

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -560,7 +560,7 @@ impl Strategy {
     /// Panics if `edits` is non-zero when using the Identity strategy.
     #[must_use]
     pub fn new_assigner(&self, edits: u32) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, 1, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, 1, DEFAULT_INDEX_THRESHOLD, false)
     }
 
     /// Create a new UMI assigner with thread count specified
@@ -575,7 +575,7 @@ impl Strategy {
     /// A boxed trait object implementing the `UmiAssigner` trait
     #[must_use]
     pub fn new_assigner_with_threads(&self, edits: u32, threads: usize) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, threads, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, threads, DEFAULT_INDEX_THRESHOLD, false)
     }
 
     /// Create a new UMI assigner with all parameters specified
@@ -599,19 +599,23 @@ impl Strategy {
         edits: u32,
         threads: usize,
         index_threshold: usize,
+        allow_c_to_t: bool,
     ) -> Box<dyn UmiAssigner> {
         match self {
             Strategy::Identity => {
                 assert_eq!(edits, 0, "Edits should be zero when using the identity UMI assigner");
                 Box::new(IdentityUmiAssigner::new())
             }
-            Strategy::Edit => Box::new(SimpleErrorUmiAssigner::new(edits)),
+            Strategy::Edit => Box::new(SimpleErrorUmiAssigner::new(edits, allow_c_to_t)),
             Strategy::Adjacency => {
-                Box::new(AdjacencyUmiAssigner::new(edits, threads, index_threshold))
+                Box::new(AdjacencyUmiAssigner::new(edits, threads, index_threshold, allow_c_to_t))
             }
-            Strategy::Paired => {
-                Box::new(PairedUmiAssigner::new_with_threads(edits, threads, index_threshold))
-            }
+            Strategy::Paired => Box::new(PairedUmiAssigner::new_with_threads(
+                edits,
+                threads,
+                index_threshold,
+                allow_c_to_t,
+            )),
         }
     }
 }
@@ -716,6 +720,80 @@ pub fn matches_within_threshold(a: &str, b: &str, max_mismatches: usize) -> bool
     // Handle remaining bytes
     for i in (chunks * 8)..len {
         if a_bytes[i] != b_bytes[i] {
+            mismatches += 1;
+            if mismatches >= too_many {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Check if two UMI sequences match within a mismatch threshold, treating C→T as zero cost.
+///
+/// Uses the bidirectional minimum: the distance is the minimum of `a→b` and `b→a` C→T-aware
+/// distances. This is appropriate when there is no parent/child relationship between UMIs
+/// (e.g., in simple edit-distance clustering).
+///
+/// Returns `true` if the sequences are the same length and their bidirectional C→T-aware
+/// distance is at most `max_mismatches`.
+#[must_use]
+pub fn matches_within_threshold_allow_c_to_t(a: &str, b: &str, max_mismatches: usize) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+
+    // Count mismatches in both directions, skipping C→T conversions
+    let mut mismatches_ab = 0usize; // a=expected, b=observed
+    let mut mismatches_ba = 0usize; // b=expected, a=observed
+    let too_many = max_mismatches + 1;
+
+    for i in 0..a_bytes.len() {
+        if a_bytes[i] != b_bytes[i] {
+            // a→b direction: skip if a=C and b=T
+            if !(a_bytes[i] == b'C' && b_bytes[i] == b'T') {
+                mismatches_ab += 1;
+            }
+            // b→a direction: skip if b=C and a=T
+            if !(b_bytes[i] == b'C' && a_bytes[i] == b'T') {
+                mismatches_ba += 1;
+            }
+            // Early exit: if both directions exceed threshold, min also exceeds
+            if mismatches_ab >= too_many && mismatches_ba >= too_many {
+                return false;
+            }
+        }
+    }
+
+    mismatches_ab.min(mismatches_ba) <= max_mismatches
+}
+
+/// Check if two UMI sequences match within a mismatch threshold using directed C→T tolerance.
+///
+/// `a` is the expected (parent/whitelist) sequence, `b` is the observed (child) sequence.
+/// Positions where `a[i] == 'C'` and `b[i] == 'T'` are not counted as mismatches.
+/// This is asymmetric: `a=T, b=C` is a real mismatch.
+#[must_use]
+pub fn matches_within_threshold_ct_directed(a: &str, b: &str, max_mismatches: usize) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let too_many = max_mismatches + 1;
+    let mut mismatches = 0;
+
+    for i in 0..a_bytes.len() {
+        if a_bytes[i] != b_bytes[i] {
+            // Skip if expected=C and observed=T (conversion artifact)
+            if a_bytes[i] == b'C' && b_bytes[i] == b'T' {
+                continue;
+            }
             mismatches += 1;
             if mismatches >= too_many {
                 return false;
@@ -898,6 +976,7 @@ impl UmiAssigner for IdentityUmiAssigner {
 /// Uses atomic counter for ID generation, making it safe to use across threads.
 pub struct SimpleErrorUmiAssigner {
     max_mismatches: u32,
+    allow_c_to_t: bool,
     counter: AtomicU64,
 }
 
@@ -907,13 +986,14 @@ impl SimpleErrorUmiAssigner {
     /// # Arguments
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed between UMIs in the same group
+    /// * `allow_c_to_t` - If true, C→T mismatches are not counted (bidirectional min)
     ///
     /// # Returns
     ///
     /// A new `SimpleErrorUmiAssigner` instance
     #[must_use]
-    pub fn new(max_mismatches: u32) -> Self {
-        Self { max_mismatches, counter: AtomicU64::new(0) }
+    pub fn new(max_mismatches: u32, allow_c_to_t: bool) -> Self {
+        Self { max_mismatches, allow_c_to_t, counter: AtomicU64::new(0) }
     }
 
     /// Generate the next unique molecule ID
@@ -948,11 +1028,15 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
             let mut matched_sets = Vec::new();
 
             // Find all sets that match this UMI
+            let max_mm = self.max_mismatches as usize;
             for (idx, set) in umi_sets.iter().enumerate() {
-                if set
-                    .iter()
-                    .any(|other| matches_within_threshold(other, umi, self.max_mismatches as usize))
-                {
+                let matches = if self.allow_c_to_t {
+                    set.iter()
+                        .any(|other| matches_within_threshold_allow_c_to_t(other, umi, max_mm))
+                } else {
+                    set.iter().any(|other| matches_within_threshold(other, umi, max_mm))
+                };
+                if matches {
                     matched_sets.push(idx);
                 }
             }
@@ -1056,6 +1140,7 @@ pub struct AdjacencyUmiAssigner {
     max_mismatches: u32,
     threads: usize,
     index_threshold: usize,
+    allow_c_to_t: bool,
     counter: AtomicU64,
 }
 
@@ -1067,13 +1152,19 @@ impl AdjacencyUmiAssigner {
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching (default: 1)
     /// * `index_threshold` - Minimum UMIs per position to use N-gram/BK-tree index (default: 1000)
+    /// * `allow_c_to_t` - If true, C→T mismatches cost 0 (parent-as-expected direction)
     ///
     /// # Returns
     ///
     /// A new `AdjacencyUmiAssigner` instance
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
-        Self { max_mismatches, threads, index_threshold, counter: AtomicU64::new(0) }
+    pub fn new(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: usize,
+        allow_c_to_t: bool,
+    ) -> Self {
+        Self { max_mismatches, threads, index_threshold, allow_c_to_t, counter: AtomicU64::new(0) }
     }
 
     /// Generate the next unique molecule ID
@@ -1119,6 +1210,7 @@ impl AdjacencyUmiAssigner {
     }
 
     /// Build adjacency graph using `BitEnc` for efficient matching.
+    #[expect(clippy::too_many_lines, reason = "graph-building algorithm with index and C→T paths")]
     fn build_adjacency_graph_bitenc(
         &self,
         umi_counts: &[(BitEnc, usize, usize)], // (encoded, count, first_raw_index)
@@ -1157,8 +1249,13 @@ impl AdjacencyUmiAssigner {
             None
         };
 
-        // Try to build index for fast candidate search (if enough UMIs)
-        let ngram_index = if nodes.len() >= self.index_threshold && self.max_mismatches == 1 {
+        // Try to build index for fast candidate search (if enough UMIs).
+        // Skip index when allow_c_to_t is enabled — N-gram index uses standard Hamming
+        // distance and cannot correctly handle the asymmetric C→T tolerance.
+        let ngram_index = if !self.allow_c_to_t
+            && nodes.len() >= self.index_threshold
+            && self.max_mismatches == 1
+        {
             // For BitEnc-based matching, we need to use the original strings for NgramIndex
             // since it internally converts to BitEnc
             let umis: Vec<(usize, &str)> = umi_counts
@@ -1215,32 +1312,36 @@ impl AdjacencyUmiAssigner {
                                 }
                             })
                             .collect()
-                    } else if let Some(ref pool) = pool {
-                        // Parallel linear search using BitEnc hamming distance
-                        let start_idx = search_from;
-                        let max_mm = self.max_mismatches;
-                        pool.install(|| {
-                            (start_idx..nodes.len())
-                                .into_par_iter()
-                                .filter(|&child_idx| {
-                                    !nodes[child_idx].assigned
-                                        && nodes[child_idx].count <= max_child_count
-                                        && parent_enc.hamming_distance(&umi_counts[child_idx].0)
-                                            <= max_mm
-                                })
-                                .collect()
-                        })
                     } else {
-                        // Sequential linear search using BitEnc hamming distance
+                        // Filter predicate shared by parallel and sequential paths
+                        let max_mm = self.max_mismatches;
+                        let allow_ct = self.allow_c_to_t;
+                        let is_child_match = |child_idx: &usize| -> bool {
+                            let child_idx = *child_idx;
+                            if nodes[child_idx].assigned || nodes[child_idx].count > max_child_count
+                            {
+                                return false;
+                            }
+                            let child_enc = &umi_counts[child_idx].0;
+                            let dist = if allow_ct {
+                                parent_enc.hamming_distance_allow_c_to_t(child_enc)
+                            } else {
+                                parent_enc.hamming_distance(child_enc)
+                            };
+                            dist <= max_mm
+                        };
+
                         let start_idx = search_from;
-                        (start_idx..nodes.len())
-                            .filter(|&child_idx| {
-                                !nodes[child_idx].assigned
-                                    && nodes[child_idx].count <= max_child_count
-                                    && parent_enc.hamming_distance(&umi_counts[child_idx].0)
-                                        <= self.max_mismatches
+                        if let Some(ref pool) = pool {
+                            pool.install(|| {
+                                (start_idx..nodes.len())
+                                    .into_par_iter()
+                                    .filter(is_child_match)
+                                    .collect()
                             })
-                            .collect()
+                        } else {
+                            (start_idx..nodes.len()).filter(is_child_match).collect()
+                        }
                     };
 
                     // Add matching children
@@ -1312,9 +1413,10 @@ impl AdjacencyUmiAssigner {
             None
         };
 
-        // Try to build index for fast candidate search (if enough UMIs)
-        // Use N-gram index for k=1 (most efficient), BK-tree for k>1
-        let (ngram_index, bktree) = if nodes.len() >= self.index_threshold {
+        // Try to build index for fast candidate search (if enough UMIs).
+        // Skip indices when allow_c_to_t is enabled — they use standard Hamming distance
+        // and cannot handle the asymmetric C→T tolerance.
+        let (ngram_index, bktree) = if !self.allow_c_to_t && nodes.len() >= self.index_threshold {
             let umis: Vec<(usize, &str)> =
                 umi_counts.iter().enumerate().map(|(i, (umi, _))| (i, umi.as_str())).collect();
 
@@ -1599,7 +1701,7 @@ impl PairedUmiAssigner {
     /// A new `PairedUmiAssigner` instance
     #[must_use]
     pub fn new(max_mismatches: u32) -> Self {
-        Self::new_with_threads(max_mismatches, 1, DEFAULT_INDEX_THRESHOLD)
+        Self::new_with_threads(max_mismatches, 1, DEFAULT_INDEX_THRESHOLD, false)
     }
 
     /// Create a new paired UMI assigner with specified thread count
@@ -1609,15 +1711,26 @@ impl PairedUmiAssigner {
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching
     /// * `index_threshold` - Minimum UMIs per position to use N-gram/BK-tree index
+    /// * `allow_c_to_t` - If true, C→T mismatches cost 0 (parent-as-expected direction)
     ///
     /// # Returns
     ///
     /// A new `PairedUmiAssigner` instance
     #[must_use]
-    pub fn new_with_threads(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
+    pub fn new_with_threads(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: usize,
+        allow_c_to_t: bool,
+    ) -> Self {
         let prefix_len = max_mismatches as usize + 1;
         Self {
-            adjacency: AdjacencyUmiAssigner::new(max_mismatches, threads, index_threshold),
+            adjacency: AdjacencyUmiAssigner::new(
+                max_mismatches,
+                threads,
+                index_threshold,
+                allow_c_to_t,
+            ),
             lower_prefix: "a".repeat(prefix_len),
             higher_prefix: "b".repeat(prefix_len),
         }
@@ -1768,11 +1881,18 @@ impl PairedUmiAssigner {
     /// `true` if UMIs match (forward or reversed) within threshold
     fn matches_paired(&self, lhs: &str, rhs: &str) -> bool {
         let max_mismatches = self.adjacency.max_mismatches as usize;
-        if matches_within_threshold(lhs, rhs, max_mismatches) {
+        // In adjacency graph context, lhs=parent (expected), rhs=child (observed).
+        // Use directed C→T tolerance when enabled; standard threshold otherwise.
+        let matcher: fn(&str, &str, usize) -> bool = if self.adjacency.allow_c_to_t {
+            matches_within_threshold_ct_directed
+        } else {
+            matches_within_threshold
+        };
+        if matcher(lhs, rhs, max_mismatches) {
             return true;
         }
         if let Ok(lhs_rev) = Self::reverse(lhs) {
-            matches_within_threshold(&lhs_rev, rhs, max_mismatches)
+            matcher(&lhs_rev, rhs, max_mismatches)
         } else {
             false
         }
@@ -2013,7 +2133,7 @@ mod tests {
 
     #[test]
     fn test_simple_error_assigner_basic() {
-        let assigner = SimpleErrorUmiAssigner::new(1);
+        let assigner = SimpleErrorUmiAssigner::new(1, false);
         let umis = vec![
             "AAAAAA".to_string(),
             "AAAATT".to_string(),
@@ -2033,7 +2153,7 @@ mod tests {
     #[test]
     #[expect(clippy::similar_names, reason = "umi variable names intentionally similar")]
     fn test_simple_error_assigner_groups_by_mismatches() {
-        let assigner = SimpleErrorUmiAssigner::new(1);
+        let assigner = SimpleErrorUmiAssigner::new(1, false);
         let umis = vec![
             "AAAAAA".to_string(),
             "AAAATT".to_string(),
@@ -2067,7 +2187,7 @@ mod tests {
 
     #[test]
     fn test_simple_error_assigner_groups_everything_with_high_edits() {
-        let assigner = SimpleErrorUmiAssigner::new(6);
+        let assigner = SimpleErrorUmiAssigner::new(6, false);
         let umis = vec![
             "AAAAAA".to_string(),
             "AAAATT".to_string(),
@@ -2088,7 +2208,7 @@ mod tests {
 
     #[test]
     fn test_simple_error_with_zero_edits() {
-        let assigner = SimpleErrorUmiAssigner::new(0);
+        let assigner = SimpleErrorUmiAssigner::new(0, false);
         let umis = vec!["AAAAAA".to_string(), "AAAAAA".to_string(), "AAAAAT".to_string()];
         let assignments = assigner.assign(&umis);
         let groups = group_assignments(&umis, &assignments, false);
@@ -2099,7 +2219,7 @@ mod tests {
 
     #[test]
     fn test_adjacency_with_zero_edits() {
-        let assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD);
+        let assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD, false);
         let umis = vec!["AAAAAA".to_string(), "AAAAAA".to_string(), "AAAAAT".to_string()];
         let assignments = assigner.assign(&umis);
         let groups = group_assignments(&umis, &assignments, false);
@@ -2126,7 +2246,7 @@ mod tests {
     /// - Result: AAAA, ACAA, CCAA in same group; GGGG separate
     #[test]
     fn test_adjacency_backward_capture() {
-        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD);
+        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD, false);
 
         // Construct input with counts: AAAA(100), CCAA(1), GGGG(2), ACAA(2)
         // Note: CCAA count=1 so it satisfies count constraint: 1 < ACAA_count/2+1 = 2
@@ -2569,7 +2689,7 @@ mod tests {
         #[test]
         fn prop_adjacency_zero_edits_like_identity(umis in prop::collection::vec("[ACGT]{8}", 1..10)) {
             let identity_assigner = IdentityUmiAssigner::new();
-            let adjacency_assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD);
+            let adjacency_assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD, false);
 
             let identity_assignments = identity_assigner.assign(&umis);
             let adjacency_assignments = adjacency_assigner.assign(&umis);
@@ -2736,7 +2856,7 @@ mod tests {
     #[test]
     fn test_simple_error_assigner_deterministic() {
         // Verify that edit distance assigner produces consistent groupings on repeated runs
-        let assigner = SimpleErrorUmiAssigner::new(1);
+        let assigner = SimpleErrorUmiAssigner::new(1, false);
         let umis = vec![
             "GGGGGG".to_string(),
             "GGGGGC".to_string(), // 1 edit from GGGGGG
@@ -2775,7 +2895,7 @@ mod tests {
     #[test]
     fn test_adjacency_assigner_deterministic() {
         // Verify that adjacency assigner produces consistent groupings on repeated runs
-        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD);
+        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD, false);
         let umis = vec![
             "GGGGGG".to_string(),
             "GGGGGC".to_string(),
@@ -2811,7 +2931,7 @@ mod tests {
         // Both AAAAAA and AAAGAC are within 1 edit of AAAAAC (can capture it)
         // AAAGAC is 2 edits from AAAAAA (positions 3 and 5), so they won't be grouped together
         // With deterministic sorting, AAAAAA (lexicographically first) should capture AAAAAC
-        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD);
+        let assigner = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD, false);
         let umis = vec![
             "AAAAAA".to_string(),
             "AAAAAA".to_string(),
@@ -2841,7 +2961,8 @@ mod tests {
             "AAAGAC".to_string(),
             "AAAAAC".to_string(),
         ];
-        let assignments2 = AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD).assign(&umis2);
+        let assignments2 =
+            AdjacencyUmiAssigner::new(1, 1, DEFAULT_INDEX_THRESHOLD, false).assign(&umis2);
         assert!(
             assignments_structurally_equal(&umis, &assignments, &umis2, &assignments2),
             "Equal-count adjacency grouping should be deterministic across runs"
@@ -2868,10 +2989,10 @@ mod tests {
         }
 
         // With index (threshold = 100, so 200 UMIs will trigger indexing)
-        let indexed_assignments = AdjacencyUmiAssigner::new(1, 1, 100).assign(&umis);
+        let indexed_assignments = AdjacencyUmiAssigner::new(1, 1, 100, false).assign(&umis);
 
         // Without index (threshold = 1000, so 200 UMIs will use linear scan)
-        let linear_assignments = AdjacencyUmiAssigner::new(1, 1, 1000).assign(&umis);
+        let linear_assignments = AdjacencyUmiAssigner::new(1, 1, 1000, false).assign(&umis);
 
         // Both should produce structurally equivalent results
         assert!(
@@ -2888,7 +3009,7 @@ mod tests {
         umis.push("AAAAAAAC".to_string()); // Child with 1 read (1 < 10/2 + 1 = 6)
         umis.extend(vec!["TTTTTTTT".to_string(); 5]); // Distinct UMI
 
-        let assignments = AdjacencyUmiAssigner::new(1, 1, 0).assign(&umis);
+        let assignments = AdjacencyUmiAssigner::new(1, 1, 0, false).assign(&umis);
         let map = build_assignment_map(&umis, &assignments);
 
         // Should still produce correct results
@@ -2915,7 +3036,7 @@ mod tests {
         umis.extend(vec!["TTTTTT".to_string(); 5]); // Distinct UMI
 
         // Using Adjacency strategy with custom threshold
-        let assigner = UmiStrategy::Adjacency.new_assigner_full(1, 1, 100);
+        let assigner = UmiStrategy::Adjacency.new_assigner_full(1, 1, 100, false);
         let assignments = assigner.assign(&umis);
         let map = build_assignment_map(&umis, &assignments);
 
@@ -2943,7 +3064,8 @@ mod tests {
         let assignments1 = assigner1.assign(&umis);
 
         // new_assigner_full with explicit DEFAULT_INDEX_THRESHOLD should produce same result
-        let assigner2 = UmiStrategy::Adjacency.new_assigner_full(1, 1, DEFAULT_INDEX_THRESHOLD);
+        let assigner2 =
+            UmiStrategy::Adjacency.new_assigner_full(1, 1, DEFAULT_INDEX_THRESHOLD, false);
         let assignments2 = assigner2.assign(&umis);
 
         assert!(
@@ -2960,7 +3082,7 @@ mod tests {
         umis.push("AAAC-CCCC".to_string()); // Child with 1 read (1 mismatch in first half)
         umis.extend(vec!["TTTT-GGGG".to_string(); 5]); // Distinct UMI
 
-        let assigner = PairedUmiAssigner::new_with_threads(1, 1, 100);
+        let assigner = PairedUmiAssigner::new_with_threads(1, 1, 100, false);
         let assignments = assigner.assign(&umis);
         let assignment_map = build_assignment_map(&umis, &assignments);
 
@@ -2996,10 +3118,10 @@ mod tests {
         }
 
         // Run with indexing (threshold=100, we have 150 UMIs)
-        let assignments_indexed = AdjacencyUmiAssigner::new(1, 1, 100).assign(&umis);
+        let assignments_indexed = AdjacencyUmiAssigner::new(1, 1, 100, false).assign(&umis);
 
         // Run without indexing (threshold > 150)
-        let assignments_linear = AdjacencyUmiAssigner::new(1, 1, 200).assign(&umis);
+        let assignments_linear = AdjacencyUmiAssigner::new(1, 1, 200, false).assign(&umis);
 
         // Verify indexing produces same result as linear scan
         // (the actual number of groups depends on UMI edit distances)
@@ -3254,5 +3376,176 @@ mod tests {
                 "BkTree and NgramIndex should return same results for query {query}"
             );
         }
+    }
+
+    // ==================== C→T tolerance tests ====================
+
+    #[test]
+    fn test_matches_within_threshold_ct_directed_no_conversion() {
+        // No C→T, same result as standard
+        assert!(matches_within_threshold_ct_directed("AAGGTTAA", "AAGGTTAA", 1));
+        assert!(matches_within_threshold_ct_directed("AAGGTTAA", "AAGGTTAG", 1));
+        assert!(!matches_within_threshold_ct_directed("AAGGTTAA", "AAGGTTGG", 1));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_ct_directed_single_ct() {
+        // expected=C observed=T → ignored
+        assert!(matches_within_threshold_ct_directed("ACGT", "ATGT", 0));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_ct_directed_reverse_tc() {
+        // expected=T observed=C → real mismatch (asymmetric)
+        assert!(!matches_within_threshold_ct_directed("ATGT", "ACGT", 0));
+        assert!(matches_within_threshold_ct_directed("ATGT", "ACGT", 1));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_ct_directed_mixed() {
+        // C→T at pos 1 (ignored) + A→G at pos 3 (real) → distance 1
+        assert!(matches_within_threshold_ct_directed("ACGA", "ATGG", 1));
+        assert!(!matches_within_threshold_ct_directed("ACGA", "ATGG", 0));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_ct_directed_all_ct() {
+        // All C→T → distance 0
+        assert!(matches_within_threshold_ct_directed("CCCC", "TTTT", 0));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_allow_c_to_t_bidirectional() {
+        // Bidirectional: takes min of both directions
+        // a→b: C→T at pos 0 (ignored), distance=0
+        // b→a: T→C at pos 0 (real mismatch), distance=1
+        // min(0, 1) = 0
+        assert!(matches_within_threshold_allow_c_to_t("CAGT", "TAGT", 0));
+
+        // a→b: T→C at pos 0 (real mismatch), distance=1
+        // b→a: C→T at pos 0 (ignored), distance=0
+        // min(1, 0) = 0
+        assert!(matches_within_threshold_allow_c_to_t("TAGT", "CAGT", 0));
+    }
+
+    #[test]
+    fn test_matches_within_threshold_allow_c_to_t_real_mismatch() {
+        // A→G at pos 0 — real mismatch in both directions
+        assert!(!matches_within_threshold_allow_c_to_t("AAGT", "GAGT", 0));
+        assert!(matches_within_threshold_allow_c_to_t("AAGT", "GAGT", 1));
+    }
+
+    #[test]
+    fn test_simple_error_assigner_allow_c_to_t() {
+        // Two UMIs: ACGT and ATGT (C→T at pos 1)
+        let assigner = SimpleErrorUmiAssigner::new(0, true);
+        let umis = vec!["ACGT".to_string(), "ATGT".to_string()];
+        let assignments = assigner.assign(&umis);
+        assert_eq!(
+            assignments[0], assignments[1],
+            "C→T converted UMIs should be grouped with allow_c_to_t"
+        );
+    }
+
+    #[test]
+    fn test_simple_error_assigner_allow_c_to_t_real_mismatch_separate() {
+        // ACGT and AGGT differ at pos 1 (C→G), not C→T
+        let assigner = SimpleErrorUmiAssigner::new(0, true);
+        let umis = vec!["ACGT".to_string(), "AGGT".to_string()];
+        let assignments = assigner.assign(&umis);
+        assert_ne!(assignments[0], assignments[1], "Non-C→T mismatches should still separate UMIs");
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_parent_as_expected() {
+        // Parent (high-count) = ACGT (has C at pos 1)
+        // Child (low-count) = ATGT (T at pos 1 — C→T conversion)
+        // Parent-as-expected: parent=ACGT, child=ATGT → C→T ignored → grouped
+        let mut umis: Vec<String> = vec!["ACGT".to_string(); 10]; // Parent: 10 reads
+        umis.push("ATGT".to_string()); // Child: 1 read
+        let assigner = AdjacencyUmiAssigner::new(0, 1, 0, true);
+        let assignments = assigner.assign(&umis);
+        assert_eq!(
+            assignments[0], assignments[10],
+            "C→T child should be grouped with parent when allow_c_to_t=true"
+        );
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_reverse_not_grouped() {
+        // Parent (high-count) = ATGT (has T at pos 1)
+        // Child (low-count) = ACGT (has C at pos 1)
+        // Parent-as-expected: parent=ATGT, child=ACGT → T→C at pos 1 → real mismatch
+        // Should NOT be grouped at max_mismatches=0
+        let mut umis: Vec<String> = vec!["ATGT".to_string(); 10]; // Parent: 10 reads
+        umis.push("ACGT".to_string()); // Child: 1 read
+        let assigner = AdjacencyUmiAssigner::new(0, 1, 0, true);
+        let assignments = assigner.assign(&umis);
+        assert_ne!(
+            assignments[0], assignments[10],
+            "T→C (reverse direction) should NOT be ignored in parent-as-expected model"
+        );
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_with_real_error() {
+        // Parent = ACGA, Child = ATGG (C→T at pos 1, A→G at pos 3)
+        // C→T is ignored, but A→G is a real mismatch → distance 1
+        let mut umis: Vec<String> = vec!["ACGA".to_string(); 10];
+        umis.push("ATGG".to_string());
+        let assigner_0 = AdjacencyUmiAssigner::new(0, 1, 0, true);
+        let assignments_0 = assigner_0.assign(&umis);
+        assert_ne!(
+            assignments_0[0], assignments_0[10],
+            "Should not group when real mismatch exceeds max_mismatches=0"
+        );
+
+        let assigner_1 = AdjacencyUmiAssigner::new(1, 1, 0, true);
+        let assignments_1 = assigner_1.assign(&umis);
+        assert_eq!(
+            assignments_1[0], assignments_1[10],
+            "Should group when real mismatch within max_mismatches=1"
+        );
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_multiple_conversions() {
+        // Parent = CCCC, Child = TTTT (all C→T)
+        let mut umis: Vec<String> = vec!["CCCC".to_string(); 10];
+        umis.push("TTTT".to_string());
+        let assigner = AdjacencyUmiAssigner::new(0, 1, 0, true);
+        let assignments = assigner.assign(&umis);
+        assert_eq!(assignments[0], assignments[10], "All C→T conversions should be ignored");
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_disabled() {
+        // Same scenario but without allow_c_to_t → should NOT group
+        let mut umis: Vec<String> = vec!["ACGT".to_string(); 10];
+        umis.push("ATGT".to_string());
+        let assigner = AdjacencyUmiAssigner::new(0, 1, 0, false);
+        let assignments = assigner.assign(&umis);
+        assert_ne!(
+            assignments[0], assignments[10],
+            "Without allow_c_to_t, C→T should be a real mismatch at max_mismatches=0"
+        );
+    }
+
+    #[test]
+    fn test_adjacency_assigner_allow_c_to_t_three_tier_chain() {
+        // Test that C→T tolerance propagates through the adjacency graph:
+        // Grandparent (20 reads): CCCC
+        // Parent (5 reads): TCCC (T→C at pos 0 from grandparent's perspective, but
+        //   grandparent=CCCC, this=TCCC → at pos 0: expected=C, observed=T → C→T → ignored)
+        // Child (1 read): TTCC (from parent's perspective: parent=TCCC, child=TTCC →
+        //   pos 1: expected=C, observed=T → C→T → ignored)
+        let mut umis = vec!["CCCC".to_string(); 20];
+        umis.extend(vec!["TCCC".to_string(); 5]);
+        umis.push("TTCC".to_string());
+        let assigner = AdjacencyUmiAssigner::new(0, 1, 0, true);
+        let assignments = assigner.assign(&umis);
+        // All should be in the same group
+        assert_eq!(assignments[0], assignments[20], "Parent should group with grandparent");
+        assert_eq!(assignments[0], assignments[25], "Child should group via parent");
     }
 }

--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -1051,6 +1051,7 @@ Note: Using `samtools sort` will NOT work correctly because it doesn't use the
 - Remove (--remove-duplicates): Exclude duplicate reads from output entirely
 "#
 )]
+#[expect(clippy::struct_excessive_bools, reason = "CLI struct with boolean flags")]
 pub struct MarkDuplicates {
     /// Input and output BAM files
     #[command(flatten)]
@@ -1116,6 +1117,14 @@ pub struct MarkDuplicates {
     /// and ignores any existing UMI tags.
     #[arg(long = "no-umi")]
     pub no_umi: bool,
+
+    /// Treat C→T mismatches as zero cost (for EM-Seq methylated UMIs).
+    ///
+    /// When enabled, positions where the expected UMI has C and the observed UMI has T are not
+    /// counted as mismatches. This accounts for incomplete conversion protection of 5mC bases
+    /// in enzymatic methyl-seq (EM-Seq) library preparation.
+    #[arg(long)]
+    pub allow_c_to_t: bool,
 
     /// Scheduler and pipeline options
     #[command(flatten)]
@@ -1227,6 +1236,7 @@ impl Command for MarkDuplicates {
         let index_threshold = self.index_threshold;
         let min_umi_length = self.min_umi_length;
         let no_umi = self.no_umi;
+        let allow_c_to_t = self.allow_c_to_t;
         let remove_duplicates = self.remove_duplicates;
         let collected_metrics_clone = Arc::clone(&collected_metrics);
 
@@ -1262,7 +1272,8 @@ impl Command for MarkDuplicates {
             },
             // Process function (parallel) — builds templates from raw records
             move |group: RawPositionGroup| -> io::Result<ProcessedDedupGroup> {
-                let assigner = strategy.new_assigner_full(effective_edits, 1, index_threshold);
+                let assigner =
+                    strategy.new_assigner_full(effective_edits, 1, index_threshold, allow_c_to_t);
                 process_position_group(
                     group,
                     &filter_config,
@@ -1969,21 +1980,21 @@ mod tests {
 
     #[test]
     fn test_umi_for_read_identity_uppercase() {
-        let assigner = Strategy::Identity.new_assigner_full(0, 1, 100);
+        let assigner = Strategy::Identity.new_assigner_full(0, 1, 100, false);
         let result = umi_for_read("ACGTACGT", true, assigner.as_ref()).unwrap();
         assert_eq!(result, "ACGTACGT");
     }
 
     #[test]
     fn test_umi_for_read_identity_lowercase_gets_uppercased() {
-        let assigner = Strategy::Identity.new_assigner_full(0, 1, 100);
+        let assigner = Strategy::Identity.new_assigner_full(0, 1, 100, false);
         let result = umi_for_read("acgtacgt", true, assigner.as_ref()).unwrap();
         assert_eq!(result, "ACGTACGT");
     }
 
     #[test]
     fn test_umi_for_read_paired_r1_earlier() {
-        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100);
+        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100, false);
         // With max_mismatches=1, prefix_len=2, so lower_prefix="aa", higher_prefix="bb"
         let result = umi_for_read("ACGT-TGCA", true, assigner.as_ref()).unwrap();
         // is_r1_earlier=true => lower_prefix:parts[0]-higher_prefix:parts[1]
@@ -1992,7 +2003,7 @@ mod tests {
 
     #[test]
     fn test_umi_for_read_paired_r2_earlier() {
-        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100);
+        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100, false);
         // With max_mismatches=1, prefix_len=2, so lower_prefix="aa", higher_prefix="bb"
         let result = umi_for_read("ACGT-TGCA", false, assigner.as_ref()).unwrap();
         // is_r1_earlier=false => higher_prefix:parts[0]-lower_prefix:parts[1]
@@ -2001,7 +2012,7 @@ mod tests {
 
     #[test]
     fn test_umi_for_read_paired_missing_dash_error() {
-        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100);
+        let assigner = Strategy::Paired.new_assigner_full(1, 1, 100, false);
         let result = umi_for_read("ACGTACGT", true, assigner.as_ref());
         assert!(result.is_err());
         assert!(

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -386,6 +386,27 @@ fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
 // Static _impl functions - core logic used by both closures and &self methods
 // =============================================================================
 
+/// Creates a parallel UMI assigner for the given strategy and parameters.
+fn new_parallel_assigner(
+    strategy: Strategy,
+    effective_edits: u32,
+    threads: usize,
+    allow_c_to_t: bool,
+) -> Box<dyn UmiAssigner> {
+    match strategy {
+        Strategy::Identity => Box::new(ParallelIdentityAssigner::new(threads)),
+        Strategy::Edit => {
+            Box::new(ParallelEditAssigner::new(effective_edits, threads, allow_c_to_t))
+        }
+        Strategy::Adjacency => {
+            Box::new(ParallelAdjacencyAssigner::new(effective_edits, threads, allow_c_to_t))
+        }
+        Strategy::Paired => {
+            Box::new(ParallelPairedAssigner::new(effective_edits, threads, allow_c_to_t))
+        }
+    }
+}
+
 /// Extract UMI for a read, handling paired UMI strategies (static implementation).
 fn umi_for_read_impl(umi: &str, is_r1_earlier: bool, assigner: &dyn UmiAssigner) -> Result<String> {
     if assigner.split_templates_by_pair_orientation() {
@@ -720,6 +741,7 @@ Threads are allocated based on the command's workload profile to optimize perfor
 Example: --threads 8 spawns exactly 8 threads (2 reader, 4 workers, 2 writer)
 "#
 )]
+#[allow(clippy::struct_excessive_bools)]
 pub struct GroupReadsByUmi {
     /// Input and output BAM files
     #[command(flatten)]
@@ -799,6 +821,14 @@ pub struct GroupReadsByUmi {
     /// and ignores any existing UMI tags.
     #[arg(long = "no-umi")]
     pub no_umi: bool,
+
+    /// Treat C→T mismatches as zero cost (for EM-Seq methylated UMIs).
+    ///
+    /// When enabled, positions where the expected UMI has C and the observed UMI has T are not
+    /// counted as mismatches. This accounts for incomplete conversion protection of 5mC bases
+    /// in enzymatic methyl-seq (EM-Seq) library preparation.
+    #[arg(long)]
+    pub allow_c_to_t: bool,
 
     /// Scheduler and pipeline statistics options.
     #[command(flatten)]
@@ -1041,6 +1071,7 @@ impl Command for GroupReadsByUmi {
         let index_threshold = self.index_threshold;
         let no_umi = self.no_umi;
         let allow_unmapped = self.allow_unmapped;
+        let allow_c_to_t = self.allow_c_to_t;
         let collected_metrics_clone = Arc::clone(&collected_metrics);
 
         // Setup comprehensive memory monitoring first if debug mode is enabled
@@ -1242,23 +1273,10 @@ impl Command for GroupReadsByUmi {
                 // Create UMI assigner for this group
                 // Use parallel assigner when allow_unmapped is enabled (large single groups)
                 let assigner: Box<dyn UmiAssigner> = if allow_unmapped {
-                    match strategy {
-                        Strategy::Identity => {
-                            Box::new(ParallelIdentityAssigner::new(num_threads))
-                        }
-                        Strategy::Edit => {
-                            Box::new(ParallelEditAssigner::new(effective_edits, num_threads))
-                        }
-                        Strategy::Adjacency => {
-                            Box::new(ParallelAdjacencyAssigner::new(effective_edits, num_threads))
-                        }
-                        Strategy::Paired => {
-                            Box::new(ParallelPairedAssigner::new(effective_edits, num_threads))
-                        }
-                    }
+                    new_parallel_assigner(strategy, effective_edits, num_threads, allow_c_to_t)
                 } else {
                     // Use existing sequential assigner for mapped data
-                    strategy.new_assigner_full(effective_edits, 1, index_threshold)
+                    strategy.new_assigner_full(effective_edits, 1, index_threshold, allow_c_to_t)
                 };
 
                 // Assign UMI groups using the unified _impl function
@@ -1594,6 +1612,7 @@ impl GroupReadsByUmi {
                     effective_edits,
                     self.index_threshold,
                     1, // Single-threaded mode
+                    self.allow_c_to_t,
                     raw_tag,
                     assign_tag_bytes,
                     &mut total_filter_metrics,
@@ -1616,6 +1635,7 @@ impl GroupReadsByUmi {
                 effective_edits,
                 self.index_threshold,
                 1, // Single-threaded mode
+                self.allow_c_to_t,
                 raw_tag,
                 assign_tag_bytes,
                 &mut total_filter_metrics,
@@ -1671,6 +1691,7 @@ impl GroupReadsByUmi {
         effective_edits: u32,
         index_threshold: usize,
         threads: usize,
+        allow_c_to_t: bool,
         raw_tag: [u8; 2],
         assign_tag_bytes: [u8; 2],
         total_filter_metrics: &mut FilterMetrics,
@@ -1700,17 +1721,10 @@ impl GroupReadsByUmi {
         // Create UMI assigner
         // Use parallel assigner when allow_unmapped is enabled (large single groups)
         let assigner: Box<dyn UmiAssigner> = if filter_config.allow_unmapped {
-            match strategy {
-                Strategy::Identity => Box::new(ParallelIdentityAssigner::new(threads)),
-                Strategy::Edit => Box::new(ParallelEditAssigner::new(effective_edits, threads)),
-                Strategy::Adjacency => {
-                    Box::new(ParallelAdjacencyAssigner::new(effective_edits, threads))
-                }
-                Strategy::Paired => Box::new(ParallelPairedAssigner::new(effective_edits, threads)),
-            }
+            new_parallel_assigner(strategy, effective_edits, threads, allow_c_to_t)
         } else {
             // Use existing sequential assigner for mapped data
-            strategy.new_assigner_full(effective_edits, 1, index_threshold)
+            strategy.new_assigner_full(effective_edits, 1, index_threshold, allow_c_to_t)
         };
 
         // Assign UMI groups
@@ -1849,6 +1863,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             index_threshold: 100,
             no_umi: false,
+            allow_c_to_t: false,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions {
                 queue_memory: "768".to_string(),

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -22,6 +22,17 @@ use crate::template::MoleculeId;
 
 use super::{Umi, UmiAssigner};
 
+/// Creates a rayon thread pool with the given number of threads.
+///
+/// # Panics
+/// Panics if the thread pool cannot be created.
+fn build_thread_pool(threads: usize) -> rayon::ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .expect("Failed to build rayon thread pool")
+}
+
 /// Thread-safe union-find data structure for parallel connected component discovery.
 ///
 /// Uses path compression and union-by-rank for near-O(1) amortized operations.
@@ -210,7 +221,14 @@ pub fn discover_edges_parallel_k1(
 pub fn discover_edges_parallel_k(
     umis: &[(BitEnc, usize)],
     max_mismatches: u32,
+    allow_c_to_t: bool,
 ) -> Vec<(usize, usize)> {
+    // When allow_c_to_t is enabled, the neighbor-generation approach cannot correctly
+    // enumerate all C→T variant neighbors, so fall back to parallel pairwise comparison.
+    if allow_c_to_t {
+        return discover_edges_pairwise_c_to_t(umis, max_mismatches);
+    }
+
     if max_mismatches == 1 {
         return discover_edges_parallel_k1(umis);
     }
@@ -241,6 +259,37 @@ pub fn discover_edges_parallel_k(
         .collect()
 }
 
+/// Parallel pairwise edge discovery using C→T-aware Hamming distance.
+///
+/// Falls back to O(n²/P) pairwise comparison because the asymmetric C→T tolerance
+/// means neighbor generation (which enumerates symmetric Hamming neighbors) cannot
+/// correctly find all edges. The asymmetric distance is checked in both directions
+/// (a→b and b→a), matching the sequential assigner behavior.
+///
+/// # Complexity
+/// O(U² / P) where U = unique UMIs, P = threads
+#[must_use]
+fn discover_edges_pairwise_c_to_t(
+    umis: &[(BitEnc, usize)],
+    max_mismatches: u32,
+) -> Vec<(usize, usize)> {
+    umis.par_iter()
+        .enumerate()
+        .flat_map(|(i, (enc_i, _))| {
+            let mut edges = Vec::new();
+            for (j, (enc_j, _)) in umis.iter().enumerate().skip(i + 1) {
+                // Check both directions: i as parent of j, and j as parent of i
+                let dist_ij = enc_i.hamming_distance_allow_c_to_t(enc_j);
+                let dist_ji = enc_j.hamming_distance_allow_c_to_t(enc_i);
+                if dist_ij <= max_mismatches || dist_ji <= max_mismatches {
+                    edges.push((i, j));
+                }
+            }
+            edges
+        })
+        .collect()
+}
+
 /// Parallel UMI assigner for Identity strategy.
 ///
 /// Uses a partition-merge approach: splits UMIs into chunks, builds per-chunk
@@ -260,10 +309,7 @@ impl ParallelIdentityAssigner {
     /// Panics if the rayon thread pool cannot be created.
     #[must_use]
     pub fn new(threads: usize) -> Self {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .expect("Failed to build rayon thread pool");
+        let pool = build_thread_pool(threads);
         Self { pool }
     }
 }
@@ -326,6 +372,7 @@ impl UmiAssigner for ParallelIdentityAssigner {
 /// Produces identical results to `SimpleErrorUmiAssigner` in `assigner.rs`.
 pub struct ParallelEditAssigner {
     max_mismatches: u32,
+    allow_c_to_t: bool,
     pool: rayon::ThreadPool,
 }
 
@@ -335,16 +382,14 @@ impl ParallelEditAssigner {
     /// # Arguments
     /// * `max_mismatches` - Maximum Hamming distance for UMIs to be grouped
     /// * `threads` - Number of threads for the rayon thread pool
+    /// * `allow_c_to_t` - If true, C→T mismatches cost 0 (for EM-seq)
     ///
     /// # Panics
     /// Panics if the rayon thread pool cannot be created.
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize) -> Self {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .expect("Failed to build rayon thread pool");
-        Self { max_mismatches, pool }
+    pub fn new(max_mismatches: u32, threads: usize, allow_c_to_t: bool) -> Self {
+        let pool = build_thread_pool(threads);
+        Self { max_mismatches, allow_c_to_t, pool }
     }
 }
 
@@ -383,8 +428,9 @@ impl UmiAssigner for ParallelEditAssigner {
 
         // Discover edges and build components using the configured thread pool
         let max_mismatches = self.max_mismatches;
+        let allow_c_to_t = self.allow_c_to_t;
         let (edges, uf) = self.pool.install(|| {
-            let edges = discover_edges_parallel_k(&unique_umis, max_mismatches);
+            let edges = discover_edges_parallel_k(&unique_umis, max_mismatches, allow_c_to_t);
             let uf = UnionFind::new(unique_umis.len());
             uf.union_parallel(&edges);
             (edges, uf)
@@ -428,6 +474,7 @@ impl UmiAssigner for ParallelEditAssigner {
 /// Produces identical results to `AdjacencyUmiAssigner` in `assigner.rs`.
 pub struct ParallelAdjacencyAssigner {
     max_mismatches: u32,
+    allow_c_to_t: bool,
     pool: rayon::ThreadPool,
 }
 
@@ -437,16 +484,14 @@ impl ParallelAdjacencyAssigner {
     /// # Arguments
     /// * `max_mismatches` - Maximum Hamming distance for UMIs to be adjacent
     /// * `threads` - Number of threads for the rayon thread pool
+    /// * `allow_c_to_t` - If true, C→T mismatches cost 0 (for EM-seq)
     ///
     /// # Panics
     /// Panics if the rayon thread pool cannot be created.
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize) -> Self {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .expect("Failed to build rayon thread pool");
-        Self { max_mismatches, pool }
+    pub fn new(max_mismatches: u32, threads: usize, allow_c_to_t: bool) -> Self {
+        let pool = build_thread_pool(threads);
+        Self { max_mismatches, allow_c_to_t, pool }
     }
 }
 
@@ -488,7 +533,10 @@ impl UmiAssigner for ParallelAdjacencyAssigner {
 
         // Phase 1: Parallel edge discovery (using configured thread pool)
         let max_mismatches = self.max_mismatches;
-        let edges = self.pool.install(|| discover_edges_parallel_k(&unique_umis, max_mismatches));
+        let allow_c_to_t = self.allow_c_to_t;
+        let edges = self
+            .pool
+            .install(|| discover_edges_parallel_k(&unique_umis, max_mismatches, allow_c_to_t));
 
         // Build adjacency list
         let mut adj_list: Vec<Vec<usize>> = vec![Vec::new(); unique_umis.len()];
@@ -576,6 +624,7 @@ impl UmiAssigner for ParallelAdjacencyAssigner {
 /// Produces identical results to `PairedUmiAssigner` in `assigner.rs`.
 pub struct ParallelPairedAssigner {
     max_mismatches: u32,
+    allow_c_to_t: bool,
     pool: rayon::ThreadPool,
 }
 
@@ -585,16 +634,14 @@ impl ParallelPairedAssigner {
     /// # Arguments
     /// * `max_mismatches` - Maximum Hamming distance for UMIs to be adjacent
     /// * `threads` - Number of threads for the rayon thread pool
+    /// * `allow_c_to_t` - If true, C→T mismatches cost 0 (for EM-seq)
     ///
     /// # Panics
     /// Panics if the rayon thread pool cannot be created.
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize) -> Self {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .expect("Failed to build rayon thread pool");
-        Self { max_mismatches, pool }
+    pub fn new(max_mismatches: u32, threads: usize, allow_c_to_t: bool) -> Self {
+        let pool = build_thread_pool(threads);
+        Self { max_mismatches, allow_c_to_t, pool }
     }
 
     /// Reverse a paired UMI: "AAAA-CCCC" -> "CCCC-AAAA"
@@ -666,7 +713,10 @@ impl UmiAssigner for ParallelPairedAssigner {
         // and reversed orientations with the same threshold; canonicalization achieves the
         // same effect by ensuring reversed pairs share the same canonical form.
         let max_mismatches = self.max_mismatches;
-        let edges = self.pool.install(|| discover_edges_parallel_k(&unique_umis, max_mismatches));
+        let allow_c_to_t = self.allow_c_to_t;
+        let edges = self
+            .pool
+            .install(|| discover_edges_parallel_k(&unique_umis, max_mismatches, allow_c_to_t));
 
         // Build adjacency list
         let mut adj_list: Vec<Vec<usize>> = vec![Vec::new(); unique_umis.len()];
@@ -877,7 +927,7 @@ mod tests {
             (BitEnc::from_bytes(b"TTTT").unwrap(), 3), // 4 edits from AAAA, 2 from AATT
         ];
 
-        let edges = discover_edges_parallel_k(&umis, 2);
+        let edges = discover_edges_parallel_k(&umis, 2, false);
 
         // AAAA-AATT (2 edits) and AATT-TTTT (2 edits) should be connected
         assert_eq!(edges.len(), 2);
@@ -991,7 +1041,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_basic() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> =
             vec!["AAAA", "AAAT", "TTTT"].into_iter().map(String::from).collect();
 
@@ -1005,7 +1055,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_k2() {
-        let assigner = ParallelEditAssigner::new(2, 2);
+        let assigner = ParallelEditAssigner::new(2, 2, false);
         let umis: Vec<String> =
             vec!["AAAA", "AATT", "TTTT"].into_iter().map(String::from).collect();
 
@@ -1020,7 +1070,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_transitive() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         // A-B-C chain where A~B and B~C but A and C are 2 apart
         let umis: Vec<String> =
             vec!["AAAA", "AAAT", "AATT"].into_iter().map(String::from).collect();
@@ -1034,7 +1084,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_empty() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![];
         let assignments = assigner.assign(&umis);
         assert!(assignments.is_empty());
@@ -1042,7 +1092,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_single() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> = vec!["ACGT".to_string()];
         let assignments = assigner.assign(&umis);
         assert_eq!(assignments.len(), 1);
@@ -1050,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_identical_umis() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> =
             vec!["ACGT", "ACGT", "ACGT"].into_iter().map(String::from).collect();
 
@@ -1065,7 +1115,7 @@ mod tests {
     fn test_parallel_edit_paired_umis_with_dash() {
         // Test that paired UMIs with dashes (e.g., "ACGT-TGCA") are handled correctly
         // This is a regression test for the bug where dashes caused all UMIs to be invalid
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![
             "ACGTACGT-TGCATGCA".to_string(), // Same UMI, should be grouped
             "ACGTACGT-TGCATGCA".to_string(),
@@ -1088,7 +1138,7 @@ mod tests {
     #[test]
     fn test_parallel_adjacency_paired_umis_with_dash() {
         // Test that adjacency also handles paired UMIs with dashes
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![
             "ACGTACGT-TGCATGCA".to_string(),
             "ACGTACGT-TGCATGCA".to_string(),
@@ -1104,7 +1154,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_case_insensitive() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> =
             vec!["ACGT", "acgt", "AcGt"].into_iter().map(String::from).collect();
 
@@ -1117,7 +1167,7 @@ mod tests {
 
     #[test]
     fn test_parallel_edit_invalid_umis() {
-        let assigner = ParallelEditAssigner::new(1, 2);
+        let assigner = ParallelEditAssigner::new(1, 2, false);
         let umis: Vec<String> = vec!["ACGT", "ACGN", "ACGT"] // ACGN is invalid
             .into_iter()
             .map(String::from)
@@ -1135,7 +1185,7 @@ mod tests {
 
     #[test]
     fn test_parallel_adjacency_basic() {
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         let umis: Vec<String> =
             vec!["AAAA", "AAAA", "AAAT"].into_iter().map(String::from).collect(); // AAAA count=2, AAAT count=1
 
@@ -1148,7 +1198,7 @@ mod tests {
 
     #[test]
     fn test_parallel_adjacency_count_constraint() {
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         // AAAA appears 4x, AAAT appears 1x
         // max_child_count = 4/2 + 1 = 3
         // AAAT count (1) <= 3, so it will be captured by AAAA
@@ -1177,7 +1227,7 @@ mod tests {
 
     #[test]
     fn test_parallel_adjacency_cascade() {
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         // Test cascade: A(10) -> B(4) -> C(1)
         // B can be captured by A: 4 <= 10/2+1 = 6
         // C can be captured by B: 1 <= 4/2+1 = 3
@@ -1198,7 +1248,7 @@ mod tests {
     #[test]
     fn test_parallel_adjacency_deterministic_tiebreak() {
         // Test that equal-count UMIs are handled deterministically
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
 
         // AAAAAA and AAAGAC both have count=2, AAAAAC has count=1
         // Both are within 1 edit of AAAAAC
@@ -1224,7 +1274,7 @@ mod tests {
 
     #[test]
     fn test_parallel_adjacency_empty() {
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![];
         let assignments = assigner.assign(&umis);
         assert!(assignments.is_empty());
@@ -1232,7 +1282,7 @@ mod tests {
 
     #[test]
     fn test_parallel_adjacency_single() {
-        let assigner = ParallelAdjacencyAssigner::new(1, 2);
+        let assigner = ParallelAdjacencyAssigner::new(1, 2, false);
         let umis: Vec<String> = vec!["ACGT".to_string()];
         let assignments = assigner.assign(&umis);
         assert_eq!(assignments.len(), 1);
@@ -1242,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_parallel_paired_basic() {
-        let assigner = ParallelPairedAssigner::new(1, 2);
+        let assigner = ParallelPairedAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![
             "AAAA-CCCC".to_string(), // Top strand
             "CCCC-AAAA".to_string(), // Bottom strand (same molecule!)
@@ -1260,7 +1310,7 @@ mod tests {
 
     #[test]
     fn test_parallel_paired_with_errors() {
-        let assigner = ParallelPairedAssigner::new(1, 2);
+        let assigner = ParallelPairedAssigner::new(1, 2, false);
         let umis: Vec<String> = vec![
             "AAAA-CCCC".to_string(),
             "AAAA-CCCC".to_string(),
@@ -1321,7 +1371,7 @@ mod tests {
     #[test]
     fn test_edit_equivalence_with_sequential() {
         // This test verifies parallel Edit produces same groupings as expected
-        let parallel = ParallelEditAssigner::new(1, 4);
+        let parallel = ParallelEditAssigner::new(1, 4, false);
 
         let umis: Vec<String> = vec!["AAAAAA", "AAAAAT", "AAAATT", "TTTTTT", "TTTTTA", "GGGGGG"]
             .into_iter()
@@ -1384,8 +1434,8 @@ mod tests {
         .map(String::from)
         .collect();
 
-        let assigner1 = ParallelEditAssigner::new(1, 4);
-        let assigner2 = ParallelEditAssigner::new(1, 4);
+        let assigner1 = ParallelEditAssigner::new(1, 4, false);
+        let assigner2 = ParallelEditAssigner::new(1, 4, false);
 
         let result1 = assigner1.assign(&umis);
         let result2 = assigner2.assign(&umis);
@@ -1402,8 +1452,8 @@ mod tests {
         umis.extend(std::iter::repeat_n("TTTTTT".to_string(), 8));
         umis.extend(std::iter::repeat_n("TTTTTA".to_string(), 2));
 
-        let assigner1 = ParallelAdjacencyAssigner::new(1, 4);
-        let assigner2 = ParallelAdjacencyAssigner::new(1, 4);
+        let assigner1 = ParallelAdjacencyAssigner::new(1, 4, false);
+        let assigner2 = ParallelAdjacencyAssigner::new(1, 4, false);
 
         let result1 = assigner1.assign(&umis);
         let result2 = assigner2.assign(&umis);

--- a/tests/integration/test_simplex_pipeline.rs
+++ b/tests/integration/test_simplex_pipeline.rs
@@ -92,7 +92,7 @@ fn test_adjacency_assigner_with_error_correction() {
         .collect();
 
     // Apply adjacency assigner with 1 mismatch allowed
-    let assigner = AdjacencyUmiAssigner::new(1, 1, 100);
+    let assigner = AdjacencyUmiAssigner::new(1, 1, 100, false);
     let assignments = assigner.assign(&umis);
 
     // Helper to find the MoleculeId for a given UMI string
@@ -147,7 +147,7 @@ fn test_adjacency_respects_count_gradient() {
         .collect();
 
     // Apply adjacency assigner
-    let assigner = AdjacencyUmiAssigner::new(1, 1, 100);
+    let assigner = AdjacencyUmiAssigner::new(1, 1, 100, false);
     let assignments = assigner.assign(&umis);
 
     // Helper to find the MoleculeId for a given UMI string

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -78,7 +78,7 @@ fn test_adjacency_assigner_with_error_correction() {
     }
 
     // Apply adjacency assigner with 1 mismatch allowed
-    let assigner = AdjacencyUmiAssigner::new(1, 1, 100);
+    let assigner = AdjacencyUmiAssigner::new(1, 1, 100, false);
     let assignments = assigner.assign(&umis);
 
     // Helper to find the MoleculeId for a given UMI string
@@ -127,7 +127,7 @@ fn test_adjacency_respects_count_gradient() {
     }
 
     // Apply adjacency assigner
-    let assigner = AdjacencyUmiAssigner::new(1, 1, 100);
+    let assigner = AdjacencyUmiAssigner::new(1, 1, 100, false);
     let assignments = assigner.assign(&umis);
 
     // Helper to find the MoleculeId for a given UMI string


### PR DESCRIPTION
## Summary
- Plumbs `--allow-c-to-t` through UMI grouping pipeline (group, dedup) for EM-seq workflows
- Adds `hamming_distance_allow_c_to_t` to fgumi-umi assigner with asymmetric C→T tolerance
- Adds `allow_c_to_t` parameter to all assigner constructors (Edit, Adjacency, Paired) and parallel variants
- Extracts `build_thread_pool()` helper (was duplicated 4x in parallel assigner constructors)
- Extracts `new_parallel_assigner()` factory function (was duplicated 2x in group.rs)
- Adds 2-bit encoding support for C→T distance in bitenc

## Stack
2/6 — EM-seq support (depends on #166)

## Test plan
- [x] New tests for `hamming_distance_allow_c_to_t` and C→T-aware grouping
- [x] Existing group/dedup/assigner tests pass with `allow_c_to_t: false`
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes