### PR TITLE
feat(consensus): add EM-Seq methylation-aware consensus calling

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -333,6 +333,7 @@ impl CodecConsensusCaller {
             trim: false,
             min_consensus_base_quality: 0, // MIN - we handle quality masking
             cell_tag: None,
+            em_seq: false, // CODEC does not support EM-Seq
         };
 
         let ss_caller = VanillaUmiConsensusCaller::new(
@@ -450,7 +451,23 @@ impl CodecConsensusCaller {
             quals.reverse();
         }
 
-        SourceRead { original_idx, bases, quals, simplified_cigar: simplified, flags: flg }
+        let rid = bam_fields::ref_id(raw);
+        let astart = i64::from(bam_fields::pos(raw));
+        let original_cigar = {
+            let ops = bam_fields::get_cigar_ops(raw);
+            bam_fields::simplify_cigar_from_raw(&ops)
+        };
+
+        SourceRead {
+            original_idx,
+            bases,
+            quals,
+            simplified_cigar: simplified,
+            flags: flg,
+            ref_id: rid,
+            alignment_start: astart,
+            original_cigar,
+        }
     }
 
     /// Converts a `VanillaConsensusRead` to a `SingleStrandConsensus`.
@@ -3238,6 +3255,7 @@ mod tests {
             depths: vec![5, 6, 7, 8],
             errors: vec![0, 1, 0, 1],
             source_reads: None,
+            methylation: None,
         };
 
         let ss = CodecConsensusCaller::vanilla_to_single_strand(vcr.clone(), false, 10);
@@ -3261,6 +3279,7 @@ mod tests {
             depths: vec![5, 6],
             errors: vec![0, 1],
             source_reads: None,
+            methylation: None,
         };
 
         let ss = CodecConsensusCaller::vanilla_to_single_strand(vcr, true, 5);

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -237,6 +237,13 @@ pub struct DuplexConsensusRead {
 
     /// BA strand single-strand consensus (optional - may be absent for SS-only molecules)
     pub ba_consensus: Option<VanillaConsensusRead>,
+
+    /// Combined duplex methylation annotation (only populated when `em_seq` is enabled)
+    pub methylation: Option<crate::methylation::MethylationAnnotation>,
+
+    /// True when only the BA strand contributed (the BA consensus is stored in `ab_consensus`).
+    /// Used to emit methylation tags with the correct strand orientation.
+    pub is_ba_only: bool,
 }
 
 impl DuplexConsensusRead {
@@ -423,6 +430,18 @@ impl DuplexConsensusCaller {
             rejected_reads: Vec::new(),
             track_rejects,
         })
+    }
+
+    /// Configures the duplex caller for EM-Seq methylation-aware consensus calling.
+    ///
+    /// Passes the reference and contig name mapping through to the single-strand caller,
+    /// which enables EM-Seq mode.
+    pub fn set_reference(
+        &mut self,
+        reference: std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>,
+        ref_names: std::sync::Arc<Vec<String>>,
+    ) {
+        self.ss_caller.set_reference(reference, ref_names);
     }
 
     /// Returns the rejected reads as raw BAM bytes
@@ -814,6 +833,27 @@ impl DuplexConsensusCaller {
         source_base != NO_CALL && consensus_base != NO_CALL && source_base != consensus_base
     }
 
+    /// Returns true if two bases represent a C/T conversion pair (or G/A on reverse strand).
+    /// In EM-Seq, unmethylated C→T conversion creates C vs T disagreements at ref-C positions.
+    #[inline]
+    fn is_conversion_pair(base1: u8, base2: u8) -> bool {
+        matches!(
+            (base1.to_ascii_uppercase(), base2.to_ascii_uppercase()),
+            (b'C', b'T') | (b'T', b'C') | (b'G', b'A') | (b'A', b'G')
+        )
+    }
+
+    /// Returns the unconverted base from a conversion pair.
+    /// C/T → C, G/A → G (the reference/unconverted base).
+    #[inline]
+    fn unconverted_base(base1: u8, base2: u8) -> u8 {
+        match (base1.to_ascii_uppercase(), base2.to_ascii_uppercase()) {
+            (b'C', b'T') | (b'T', b'C') => b'C',
+            (b'G', b'A') | (b'A', b'G') => b'G',
+            _ => base1, // fallback, shouldn't happen after is_conversion_pair check
+        }
+    }
+
     /// Creates a duplex consensus read from AB and BA single-strand consensuses.
     ///
     /// This matches fgbio's `duplexConsensus` method exactly:
@@ -857,6 +897,8 @@ impl DuplexConsensusCaller {
                     errors: a.errors.clone(),
                     ab_consensus: a.clone(),
                     ba_consensus: None,
+                    methylation: a.methylation.clone(),
+                    is_ba_only: false,
                 })
             }
             (None, Some(b)) => {
@@ -868,6 +910,8 @@ impl DuplexConsensusCaller {
                     errors: b.errors.clone(),
                     ab_consensus: b.clone(),
                     ba_consensus: None,
+                    methylation: b.methylation.clone(),
+                    is_ba_only: true,
                 })
             }
             (Some(a), Some(b)) => {
@@ -883,8 +927,26 @@ impl DuplexConsensusCaller {
                     let a_qual = i32::from(a.quals[i]);
                     let b_qual = i32::from(b.quals[i]);
 
+                    // Check for EM-Seq conversion artifact: at a ref-C position,
+                    // one strand shows T (converted) and the other shows C (unconverted).
+                    // This is expected bisulfite/enzymatic conversion, not a real error.
+                    // Call the unconverted base (C) and sum qualities (treat as agreement).
+                    let is_ref_c = a
+                        .methylation
+                        .as_ref()
+                        .is_some_and(|m| m.evidence.get(i).is_some_and(|ev| ev.is_ref_c))
+                        || b.methylation
+                            .as_ref()
+                            .is_some_and(|m| m.evidence.get(i).is_some_and(|ev| ev.is_ref_c));
+                    let is_conversion_artifact =
+                        a_base != b_base && is_ref_c && Self::is_conversion_pair(a_base, b_base);
+
                     // Calculate raw consensus base and quality (fgbio algorithm)
-                    let (raw_base, raw_qual) = if a_base == b_base {
+                    let (raw_base, raw_qual) = if is_conversion_artifact {
+                        // Conversion artifact: call unconverted base, sum qualities
+                        let unconverted = Self::unconverted_base(a_base, b_base);
+                        (unconverted, Self::cap_quality(a_qual + b_qual))
+                    } else if a_base == b_base {
                         // Agreement: sum qualities (capped)
                         (a_base, Self::cap_quality(a_qual + b_qual))
                     } else if a_qual > b_qual {
@@ -913,7 +975,11 @@ impl DuplexConsensusCaller {
                         // Exact method: count disagreements with source reads
                         let mut num_errors = 0i32;
                         for sr in source_reads {
-                            if sr.bases.len() > i && Self::is_error(sr.bases[i], raw_base) {
+                            if sr.bases.len() > i
+                                && Self::is_error(sr.bases[i], raw_base)
+                                && !(is_conversion_artifact
+                                    && Self::is_conversion_pair(sr.bases[i], raw_base))
+                            {
                                 num_errors += 1;
                             }
                         }
@@ -925,7 +991,8 @@ impl DuplexConsensusCaller {
                         let a_dep = i32::from(a.depths[i]);
                         let b_dep = i32::from(b.depths[i]);
 
-                        let err = if a_base == b_base {
+                        let err = if is_conversion_artifact || a_base == b_base {
+                            // Agreement (or conversion artifact treated as agreement)
                             a_err + b_err
                         } else if raw_base == a_base {
                             a_err + (b_dep - b_err)
@@ -945,7 +1012,8 @@ impl DuplexConsensusCaller {
                     quals: a.quals[..len].to_vec(),
                     depths: a.depths[..len].to_vec(),
                     errors: a.errors[..len].to_vec(),
-                    source_reads: None, // Don't clone source reads
+                    source_reads: None,
+                    methylation: a.methylation.as_ref().map(|m| m.truncate(len)),
                 };
 
                 let ba_truncated = VanillaConsensusRead {
@@ -955,6 +1023,16 @@ impl DuplexConsensusCaller {
                     depths: b.depths[..len].to_vec(),
                     errors: b.errors[..len].to_vec(),
                     source_reads: None,
+                    methylation: b.methylation.as_ref().map(|m| m.truncate(len)),
+                };
+
+                // Combine methylation from both strands if present
+                let methylation = match (&a.methylation, &b.methylation) {
+                    (Some(ab_meth), Some(ba_meth)) => Some(
+                        crate::methylation::combine_methylation_annotations(ab_meth, ba_meth, len),
+                    ),
+                    (Some(m), None) | (None, Some(m)) => Some(m.truncate(len)),
+                    (None, None) => None,
                 };
 
                 Some(DuplexConsensusRead {
@@ -964,6 +1042,8 @@ impl DuplexConsensusCaller {
                     errors,
                     ab_consensus: ab_truncated,
                     ba_consensus: Some(ba_truncated),
+                    methylation,
+                    is_ba_only: false,
                 })
             }
             (None, None) => None,
@@ -1168,6 +1248,59 @@ impl DuplexConsensusCaller {
         if !all_umis.is_empty() {
             let consensus_umi = consensus_umis(&all_umis);
             builder.append_string_tag(b"RX", consensus_umi.as_bytes());
+        }
+
+        // 9b. Methylation tags (EM-Seq)
+        if let Some(combined_annot) = &consensus.methylation {
+            // When is_ba_only is true, the BA consensus was stored in ab_consensus
+            // (no AB strand existed), so per-strand tags must use bottom-strand orientation.
+            let is_top_strand = !consensus.is_ba_only;
+
+            // Per-strand methylation tags
+            if let Some(ab_annot) = &consensus.ab_consensus.methylation {
+                // Use correct strand tags: am/au/at for top strand, bm/bu/bt for bottom strand
+                let (mm_tag, u_tag, t_tag): (&[u8; 2], &[u8; 2], &[u8; 2]) =
+                    if is_top_strand { (b"am", b"au", b"at") } else { (b"bm", b"bu", b"bt") };
+                if let Some(mm_val) = crate::methylation::build_mm_tag_no_ml(
+                    &consensus.ab_consensus.bases,
+                    ab_annot,
+                    is_top_strand,
+                ) {
+                    builder.append_string_tag(mm_tag, mm_val.as_bytes());
+                }
+                let u_counts = ab_annot.unconverted_counts();
+                let t_counts = ab_annot.converted_counts();
+                builder.append_i16_array_tag(u_tag, &u_counts);
+                builder.append_i16_array_tag(t_tag, &t_counts);
+            }
+
+            if let Some(ba) = &consensus.ba_consensus {
+                if let Some(ba_annot) = &ba.methylation {
+                    if let Some(bm) =
+                        crate::methylation::build_mm_tag_no_ml(&ba.bases, ba_annot, false)
+                    {
+                        builder.append_string_tag(b"bm", bm.as_bytes());
+                    }
+                    let bu = ba_annot.unconverted_counts();
+                    let bt = ba_annot.converted_counts();
+                    builder.append_i16_array_tag(b"bu", &bu);
+                    builder.append_i16_array_tag(b"bt", &bt);
+                }
+            }
+
+            // Combined duplex methylation tags (MM/ML/cu/ct)
+            if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(
+                &consensus.bases,
+                combined_annot,
+                is_top_strand,
+            ) {
+                builder.append_string_tag(b"MM", mm.as_bytes());
+                builder.append_u8_array_tag(b"ML", &ml);
+            }
+            let cu = combined_annot.unconverted_counts();
+            let ct = combined_annot.converted_counts();
+            builder.append_i16_array_tag(b"cu", &cu);
+            builder.append_i16_array_tag(b"ct", &ct);
         }
 
         // 10. Write to output
@@ -2337,6 +2470,7 @@ mod tests {
                 trim: false,
                 min_consensus_base_quality: 40,
                 cell_tag: None,
+                em_seq: false,
             },
         )
     }
@@ -4255,6 +4389,7 @@ mod tests {
             depths: vec![5, 3, 4, 2],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba_consensus = VanillaConsensusRead {
@@ -4264,6 +4399,7 @@ mod tests {
             depths: vec![3, 4, 2, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4273,6 +4409,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
         };
 
         // Combined depths should be AB + BA at each position
@@ -4290,6 +4428,7 @@ mod tests {
             depths: vec![5, 3, 4, 2],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4299,6 +4438,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         // Combined depths should be just AB depths when BA is absent
@@ -4316,6 +4457,7 @@ mod tests {
             depths: vec![5, 3, 4, 2],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba_consensus = VanillaConsensusRead {
@@ -4325,6 +4467,7 @@ mod tests {
             depths: vec![3, 4, 2, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4334,6 +4477,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
         };
 
         // Combined depths: [8, 7, 6, 7]
@@ -4350,6 +4495,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4359,6 +4505,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         let mut builder = UnmappedBamRecordBuilder::new();
@@ -4400,6 +4548,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 1, 0, 1],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), None, None);
@@ -4422,6 +4571,7 @@ mod tests {
             depths: vec![4, 4, 4, 4],
             errors: vec![1, 0, 1, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(None, Some(&ba), None);
@@ -4451,6 +4601,7 @@ mod tests {
             depths: vec![5, 5, 5, 5, 5, 5],
             errors: vec![0, 0, 0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -4460,6 +4611,7 @@ mod tests {
             depths: vec![4, 4, 4, 4],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -4481,6 +4633,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![1, 0, 2, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -4490,6 +4643,7 @@ mod tests {
             depths: vec![4, 4, 4, 4],
             errors: vec![0, 1, 0, 2],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -4513,6 +4667,7 @@ mod tests {
             depths: vec![5, 5],
             errors: vec![1, 2],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -4522,6 +4677,7 @@ mod tests {
             depths: vec![4, 4],
             errors: vec![0, 1],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -4663,6 +4819,7 @@ mod tests {
             depths: vec![5, 6, 4, 5], // max_depth = 6
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba_consensus = VanillaConsensusRead {
@@ -4672,6 +4829,7 @@ mod tests {
             depths: vec![3, 4, 2, 3], // max_depth = 4
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4681,6 +4839,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus: ab_consensus.clone(),
             ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
         };
 
         // num_a=6, num_b=4, xy=6, yx=4, total=10
@@ -4698,6 +4858,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         // num_a=6, num_b=0, xy=6, yx=0, total=6
@@ -4725,6 +4887,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4734,6 +4897,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         let cell_tag = Tag::from(fgumi_sam::SamTag::CB);
@@ -4775,6 +4940,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4784,6 +4950,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         let mut builder = UnmappedBamRecordBuilder::new();
@@ -4821,6 +4989,7 @@ mod tests {
             depths: vec![0, 0, 0, 0, 5, 5], // First 4 positions have no coverage
             errors: vec![0, 0, 0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -4830,6 +4999,7 @@ mod tests {
             depths: vec![4, 4, 4, 4], // All positions have coverage
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         // After truncation to length 4, AB has no coverage (all depths are 0)
@@ -4900,6 +5070,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 1, 0, 1],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4909,6 +5080,8 @@ mod tests {
             errors: vec![0, 1, 0, 1],
             ab_consensus: ab_consensus.clone(),
             ba_consensus: None, // BA is None
+            methylation: None,
+            is_ba_only: false,
         };
 
         let mut builder = UnmappedBamRecordBuilder::new();
@@ -4980,6 +5153,7 @@ mod tests {
             depths: vec![5, 6, 7, 8],
             errors: vec![0, 1, 0, 2],
             source_reads: None,
+            methylation: None,
         };
 
         let ba_consensus = VanillaConsensusRead {
@@ -4989,6 +5163,7 @@ mod tests {
             depths: vec![3, 4, 5, 6],
             errors: vec![1, 0, 1, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -4998,6 +5173,8 @@ mod tests {
             errors: vec![1, 1, 1, 2],
             ab_consensus: ab_consensus.clone(),
             ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
         };
 
         let mut builder = UnmappedBamRecordBuilder::new();
@@ -5044,6 +5221,7 @@ mod tests {
             depths: vec![5, 5, 5, 5],
             errors: vec![0, 0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -5053,6 +5231,8 @@ mod tests {
             errors: vec![0, 0, 0, 0],
             ab_consensus: ab_consensus.clone(),
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         // Helper to build and parse a single record
@@ -5112,6 +5292,7 @@ mod tests {
             depths: vec![5, 5, 5],
             errors: vec![1, 0, 2], // Some errors in AB
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5121,6 +5302,7 @@ mod tests {
             depths: vec![3, 3, 3],
             errors: vec![0, 1, 1], // Some errors in BA
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -5143,6 +5325,7 @@ mod tests {
             depths: vec![5],
             errors: vec![1],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5152,6 +5335,7 @@ mod tests {
             depths: vec![4],
             errors: vec![0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -5173,6 +5357,7 @@ mod tests {
             depths: vec![5],
             errors: vec![0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5182,6 +5367,7 @@ mod tests {
             depths: vec![5],
             errors: vec![0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -5203,6 +5389,7 @@ mod tests {
             depths: vec![5, 5],
             errors: vec![0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5212,6 +5399,7 @@ mod tests {
             depths: vec![5, 5],
             errors: vec![0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -5233,6 +5421,7 @@ mod tests {
             depths: vec![0, 0], // All zero depths
             errors: vec![0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5242,6 +5431,7 @@ mod tests {
             depths: vec![5, 5], // Non-zero depths
             errors: vec![0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
@@ -5358,6 +5548,7 @@ mod tests {
             depths: vec![5, 4, 3], // max = 5
             errors: vec![0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let ba = VanillaConsensusRead {
@@ -5367,6 +5558,7 @@ mod tests {
             depths: vec![3, 2, 1], // max = 3
             errors: vec![0, 0, 0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -5376,6 +5568,8 @@ mod tests {
             errors: vec![0, 0, 0],
             ab_consensus: ab,
             ba_consensus: Some(ba),
+            methylation: None,
+            is_ba_only: false,
         };
 
         // max_a = 5, max_b = 3, xy = 5, yx = 3, total = 8
@@ -5403,6 +5597,7 @@ mod tests {
             depths: vec![5],
             errors: vec![0],
             source_reads: None,
+            methylation: None,
         };
 
         let duplex = DuplexConsensusRead {
@@ -5412,6 +5607,8 @@ mod tests {
             errors: vec![0],
             ab_consensus: ab,
             ba_consensus: None,
+            methylation: None,
+            is_ba_only: false,
         };
 
         // max_a = 5, max_b = 0, xy = 5, yx = 0, total = 5
@@ -5514,5 +5711,358 @@ mod tests {
         assert_eq!(base_mi.as_deref(), Some("UMI1"));
         assert_eq!(a_records.len(), 1);
         assert!(b_records.is_empty());
+    }
+
+    // ==================== EM-Seq duplex methylation tests ====================
+
+    /// Helper to create a `VanillaConsensusRead` with methylation annotation.
+    fn make_ss_consensus_with_methylation(
+        bases: Vec<u8>,
+        quals: Vec<u8>,
+        depths: Vec<u16>,
+        evidence: Vec<crate::methylation::MethylationEvidence>,
+    ) -> VanillaConsensusRead {
+        VanillaConsensusRead {
+            id: "test".to_string(),
+            bases,
+            quals,
+            depths,
+            errors: vec![0; evidence.len()],
+            source_reads: None,
+            methylation: Some(crate::methylation::MethylationAnnotation { evidence }),
+        }
+    }
+
+    #[test]
+    fn test_duplex_em_seq_unmethylated_no_penalty() {
+        // At a ref-C position:
+        // AB (top strand) shows T (converted), BA (bottom strand, after RC) shows C (unconverted)
+        // This is a conversion artifact — should call C and sum qualities (not penalize)
+        let ab = make_ss_consensus_with_methylation(
+            vec![b'T'], // AB sees T (converted)
+            vec![30],
+            vec![5],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 0,
+                converted_count: 5,
+            }],
+        );
+        let ba = make_ss_consensus_with_methylation(
+            vec![b'C'], // BA sees C (unconverted, after RC of bottom strand)
+            vec![25],
+            vec![3],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 3,
+                converted_count: 0,
+            }],
+        );
+
+        let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = result.expect("Should produce duplex consensus");
+
+        // Should call C (unconverted base), not T
+        assert_eq!(duplex.bases[0], b'C');
+        // Quality should be summed (30 + 25 = 55), not penalized
+        assert_eq!(duplex.quals[0], 55);
+        // Combined methylation should be present
+        let meth = duplex.methylation.as_ref().expect("Should have methylation");
+        assert!(meth.evidence[0].is_ref_c);
+        // Combined counts: 3 unconverted + 0 unconverted = 3, 0 converted + 5 converted = 5
+        assert_eq!(meth.evidence[0].unconverted_count, 3);
+        assert_eq!(meth.evidence[0].converted_count, 5);
+    }
+
+    #[test]
+    fn test_duplex_em_seq_methylated_agreement() {
+        // At a ref-C position, both strands show C (methylated) — normal agreement
+        let ab = make_ss_consensus_with_methylation(
+            vec![b'C'],
+            vec![30],
+            vec![5],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 5,
+                converted_count: 0,
+            }],
+        );
+        let ba = make_ss_consensus_with_methylation(
+            vec![b'C'],
+            vec![25],
+            vec![3],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 3,
+                converted_count: 0,
+            }],
+        );
+
+        let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = result.expect("Should produce duplex consensus");
+
+        assert_eq!(duplex.bases[0], b'C');
+        // Normal agreement: quality summed
+        assert_eq!(duplex.quals[0], 55);
+        let meth = duplex.methylation.as_ref().expect("Should have methylation");
+        assert_eq!(meth.evidence[0].unconverted_count, 8); // 5 + 3
+        assert_eq!(meth.evidence[0].converted_count, 0);
+    }
+
+    #[test]
+    fn test_duplex_em_seq_bottom_strand_conversion_artifact() {
+        // Bottom strand: ref=G (complement of C on bottom strand)
+        // AB shows G (unconverted), BA shows A (converted after RC)
+        // This is also a conversion artifact on the bottom strand
+        let ab = make_ss_consensus_with_methylation(
+            vec![b'G'],
+            vec![30],
+            vec![5],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 5,
+                converted_count: 0,
+            }],
+        );
+        let ba = make_ss_consensus_with_methylation(
+            vec![b'A'],
+            vec![25],
+            vec![3],
+            vec![crate::methylation::MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: 0,
+                converted_count: 3,
+            }],
+        );
+
+        let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = result.expect("Should produce duplex consensus");
+
+        // Should call G (unconverted), not A
+        assert_eq!(duplex.bases[0], b'G');
+        // Quality summed (conversion artifact path)
+        assert_eq!(duplex.quals[0], 55);
+    }
+
+    #[test]
+    fn test_duplex_em_seq_mixed_positions() {
+        // Multi-position test: pos0=ref-C unmethylated (artifact), pos1=non-ref-C (normal)
+        let ab = make_ss_consensus_with_methylation(
+            vec![b'T', b'A'],
+            vec![30, 30],
+            vec![5, 5],
+            vec![
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 0,
+                    converted_count: 5,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false,
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+            ],
+        );
+        let ba = make_ss_consensus_with_methylation(
+            vec![b'C', b'A'],
+            vec![25, 25],
+            vec![3, 3],
+            vec![
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 3,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false,
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+            ],
+        );
+
+        let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = result.expect("Should produce duplex consensus");
+
+        // Position 0: conversion artifact → C, summed quality
+        assert_eq!(duplex.bases[0], b'C');
+        assert_eq!(duplex.quals[0], 55);
+        // Position 1: normal agreement → A, summed quality
+        assert_eq!(duplex.bases[1], b'A');
+        assert_eq!(duplex.quals[1], 55);
+    }
+
+    #[test]
+    fn test_duplex_em_seq_no_methylation_normal_disagree() {
+        // Without methylation annotations, C/T disagreement is a real error (penalized)
+        let ab = VanillaConsensusRead {
+            id: "test".to_string(),
+            bases: vec![b'T'],
+            quals: vec![30],
+            depths: vec![5],
+            errors: vec![0],
+            source_reads: None,
+            methylation: None,
+        };
+        let ba = VanillaConsensusRead {
+            id: "test".to_string(),
+            bases: vec![b'C'],
+            quals: vec![25],
+            depths: vec![3],
+            errors: vec![0],
+            source_reads: None,
+            methylation: None,
+        };
+
+        let result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = result.expect("Should produce duplex consensus");
+
+        // Without methylation, C/T is a disagreement: take higher qual base (T at 30)
+        assert_eq!(duplex.bases[0], b'T');
+        // Quality = abs(30 - 25) = 5
+        assert_eq!(duplex.quals[0], 5);
+        assert!(duplex.methylation.is_none());
+    }
+
+    #[test]
+    fn test_duplex_em_seq_tag_emission() {
+        // Test that duplex_read_into emits all methylation tags correctly.
+        //
+        // Layout: 4 positions: [C, G, A, C]
+        //   pos 0: ref-C for top strand (AB tracks it)
+        //   pos 1: ref-G for bottom strand (BA tracks it)
+        //   pos 2: non-ref-C/G (no methylation)
+        //   pos 3: ref-C for top strand (AB tracks it)
+        //
+        // AB (top strand): C at ref-C positions (0, 3), non-informative at ref-G (1)
+        // BA (bottom strand after RC): G at ref-G position (1), non-informative at ref-C (0, 3)
+        let ab = make_ss_consensus_with_methylation(
+            vec![b'C', b'G', b'A', b'C'],
+            vec![30, 30, 30, 30],
+            vec![5, 5, 5, 5],
+            vec![
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 5,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false, // ref-G, not informative for top strand
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false,
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 1,
+                    converted_count: 4,
+                },
+            ],
+        );
+        let ba = make_ss_consensus_with_methylation(
+            vec![b'C', b'G', b'A', b'C'],
+            vec![25, 25, 25, 25],
+            vec![3, 3, 3, 3],
+            vec![
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false, // ref-C, not informative for bottom strand
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: true, // ref-G, informative for bottom strand
+                    unconverted_count: 3,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false,
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+                crate::methylation::MethylationEvidence {
+                    is_ref_c: false,
+                    unconverted_count: 0,
+                    converted_count: 0,
+                },
+            ],
+        );
+
+        // Build duplex — AB and BA agree at all positions
+        let duplex_result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
+        let duplex = duplex_result.expect("Should produce duplex consensus");
+
+        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut output = ConsensusOutput::default();
+        DuplexConsensusCaller::duplex_read_into(
+            &mut builder,
+            &mut output,
+            &duplex,
+            ReadType::Fragment,
+            "UMI123",
+            &[],
+            &[],
+            false,
+            "consensus",
+            "RG1",
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let records = ParsedBamRecord::parse_all(&output.data);
+        assert_eq!(records.len(), 1);
+        let rec = &records[0];
+
+        // Combined MM tag (C+m format, tracks C bases in duplex: pos 0 and 3)
+        let mm = rec.get_string_tag(b"MM").expect("Should have MM tag");
+        assert!(mm.starts_with(b"C+m"), "MM should start with C+m");
+
+        // ML tag: probabilities for 2 ref-C positions (0 and 3)
+        let ml = rec.get_u8_array_tag(b"ML").expect("Should have ML tag");
+        assert_eq!(ml.len(), 2);
+
+        // Combined cu/ct tags (length = 4)
+        let cu = rec.get_i16_array_tag(b"cu").expect("Should have cu tag");
+        let ct = rec.get_i16_array_tag(b"ct").expect("Should have ct tag");
+        assert_eq!(cu.len(), 4);
+        assert_eq!(ct.len(), 4);
+        // Pos 0: AB(5,0) + BA(0,0) = (5, 0)
+        assert_eq!(cu[0], 5);
+        assert_eq!(ct[0], 0);
+        // Pos 1: AB(0,0) + BA(3,0) = (3, 0)
+        assert_eq!(cu[1], 3);
+        assert_eq!(ct[1], 0);
+        // Pos 2: no ref-C
+        assert_eq!(cu[2], 0);
+        assert_eq!(ct[2], 0);
+        // Pos 3: AB(1,4) + BA(0,0) = (1, 4)
+        assert_eq!(cu[3], 1);
+        assert_eq!(ct[3], 4);
+
+        // Per-strand AB tags
+        let au = rec.get_i16_array_tag(b"au").expect("Should have au tag");
+        let at_tag = rec.get_i16_array_tag(b"at").expect("Should have at tag");
+        assert_eq!(au[0], 5); // pos 0 unconverted
+        assert_eq!(at_tag[0], 0); // pos 0 converted
+
+        // Per-strand BA tags
+        let bu = rec.get_i16_array_tag(b"bu").expect("Should have bu tag");
+        let bt = rec.get_i16_array_tag(b"bt").expect("Should have bt tag");
+        assert_eq!(bu[1], 3); // pos 1 unconverted (ref-G for bottom strand)
+        assert_eq!(bt[1], 0);
+
+        // am tag (C+m format for AB top strand)
+        let am = rec.get_string_tag(b"am").expect("Should have am tag");
+        assert!(am.starts_with(b"C+m"), "am should start with C+m");
+
+        // bm tag (G-m format for BA bottom strand, minus = opposite strand per SAM spec)
+        let bm = rec.get_string_tag(b"bm").expect("Should have bm tag");
+        assert!(bm.starts_with(b"G-m"), "bm should start with G-m");
     }
 }

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -31,6 +31,9 @@ pub mod duplex_caller;
 #[cfg(feature = "codec")]
 pub mod codec_caller;
 
+#[cfg(feature = "simplex")]
+pub mod methylation;
+
 mod vendored;
 
 // Re-export commonly used items

--- a/crates/fgumi-consensus/src/methylation.rs
+++ b/crates/fgumi-consensus/src/methylation.rs
@@ -1,0 +1,757 @@
+//! Methylation-aware consensus calling for EM-Seq data.
+//!
+//! EM-Seq enzymatically converts unmethylated cytosines to thymine before PCR.
+//! At a reference C position: methylated → reads show C; unmethylated → reads show T.
+//!
+//! This module provides:
+//! - Reference position mapping from consensus coordinates
+//! - Per-base methylation evidence tracking
+//! - SAM-spec MM/ML tag generation for methylation calls
+//! - Dense cu/ct count tags for unconverted/converted evidence
+
+use crate::vanilla_caller::SourceRead;
+use fgumi_raw_bam::flags;
+use noodles::sam::alignment::record::cigar::op::Kind;
+
+/// Per-base methylation evidence at a single consensus position.
+#[derive(Debug, Clone, Default)]
+pub struct MethylationEvidence {
+    /// Whether this position is a reference cytosine (eligible for methylation call).
+    /// For top-strand reads: ref=C. For bottom-strand reads (after RC): ref=G.
+    pub is_ref_c: bool,
+    /// Number of reads showing C (unconverted) at this ref-C position.
+    /// For bottom strand (after RC): number showing G (complement of unconverted C).
+    pub unconverted_count: i16,
+    /// Number of reads showing T (converted) at this ref-C position.
+    /// For bottom strand (after RC): number showing A (complement of converted T).
+    pub converted_count: i16,
+}
+
+/// Methylation annotation for an entire consensus read.
+#[derive(Debug, Clone)]
+pub struct MethylationAnnotation {
+    /// Per-base methylation evidence (same length as consensus read).
+    pub evidence: Vec<MethylationEvidence>,
+}
+
+impl MethylationAnnotation {
+    /// Returns the unconverted counts as an i16 array for the `cu` tag.
+    #[must_use]
+    pub fn unconverted_counts(&self) -> Vec<i16> {
+        self.evidence.iter().map(|e| e.unconverted_count).collect()
+    }
+
+    /// Returns the converted counts as an i16 array for the `ct` tag.
+    #[must_use]
+    pub fn converted_counts(&self) -> Vec<i16> {
+        self.evidence.iter().map(|e| e.converted_count).collect()
+    }
+
+    /// Returns a truncated copy of this annotation with only the first `len` positions.
+    #[must_use]
+    pub fn truncate(&self, len: usize) -> Self {
+        Self { evidence: self.evidence[..len.min(self.evidence.len())].to_vec() }
+    }
+}
+
+/// Maps each query position to a reference position using a simplified CIGAR.
+///
+/// For forward-strand reads, walks from `alignment_start` forward.
+/// For reverse-strand reads (where CIGAR and bases have been reversed in
+/// `create_source_read`), we reconstruct the original reference span and
+/// map positions from the rightmost position backward.
+///
+/// Returns `Vec<Option<i64>>` where `None` = insertion (no ref base).
+#[must_use]
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "CIGAR lengths are small enough that usize→i64 won't wrap"
+)]
+pub fn query_to_ref_positions(
+    simplified_cigar: &[(Kind, usize)],
+    alignment_start: i64,
+    is_reverse: bool,
+    original_cigar: &[(Kind, usize)],
+) -> Vec<Option<i64>> {
+    // Calculate total query length from the (possibly reversed) cigar
+    let query_len: usize =
+        simplified_cigar.iter().filter(|(k, _)| k.consumes_read()).map(|(_, len)| *len).sum();
+
+    let mut positions = Vec::with_capacity(query_len);
+
+    if is_reverse {
+        // For reverse strand: the CIGAR has been reversed in create_source_read.
+        // We need to compute the alignment end from the *original* cigar, then
+        // walk the reversed cigar mapping positions from right to left in reference space.
+        let ref_span: i64 = original_cigar
+            .iter()
+            .filter(|(k, _)| k.consumes_reference())
+            .map(|(_, len)| *len as i64)
+            .sum();
+        let alignment_end = alignment_start + ref_span - 1; // 0-based inclusive end
+
+        let mut ref_pos = alignment_end;
+        for &(kind, len) in simplified_cigar {
+            match kind {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for _ in 0..len {
+                        positions.push(Some(ref_pos));
+                        ref_pos -= 1;
+                    }
+                }
+                Kind::Insertion | Kind::SoftClip => {
+                    for _ in 0..len {
+                        positions.push(None);
+                    }
+                }
+                Kind::Deletion | Kind::Skip => {
+                    ref_pos -= len as i64;
+                }
+                _ => {}
+            }
+        }
+    } else {
+        // Forward strand: walk from alignment_start forward
+        let mut ref_pos = alignment_start;
+        for &(kind, len) in simplified_cigar {
+            match kind {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for _ in 0..len {
+                        positions.push(Some(ref_pos));
+                        ref_pos += 1;
+                    }
+                }
+                Kind::Insertion | Kind::SoftClip => {
+                    for _ in 0..len {
+                        positions.push(None);
+                    }
+                }
+                Kind::Deletion | Kind::Skip => {
+                    ref_pos += len as i64;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    positions
+}
+
+/// Annotates simplex consensus methylation from source reads and reference.
+///
+/// For each consensus position that aligns to a reference cytosine (top strand)
+/// or reference guanine (bottom strand, after RC):
+/// - Counts source reads showing unconverted vs converted bases
+/// - Replaces converted consensus bases with the unconverted reference base
+///
+/// # Arguments
+/// * `consensus_bases` - Mutable consensus bases (may be modified to unconverted form)
+/// * `source_reads` - Source reads used to build this consensus
+/// * `ref_bases` - Reference bases at aligned positions (`None` for insertions)
+/// * `is_top_strand` - Whether this consensus represents the top (forward) strand
+pub(crate) fn annotate_simplex_methylation(
+    consensus_bases: &mut [u8],
+    source_reads: &[SourceRead],
+    ref_bases_at_positions: &[Option<u8>],
+    is_top_strand: bool,
+) -> MethylationAnnotation {
+    let len = consensus_bases.len();
+    let mut evidence = vec![MethylationEvidence::default(); len];
+
+    // Determine which reference base indicates a C position and what conversion looks like
+    // Top strand: ref=C, unconverted=C, converted=T
+    // Bottom strand (after RC): ref=G (complement of C), unconverted=G, converted=A
+    let (ref_target, unconverted_base, converted_base) =
+        if is_top_strand { (b'C', b'C', b'T') } else { (b'G', b'G', b'A') };
+
+    for (i, ev) in evidence.iter_mut().enumerate() {
+        // Check if this position aligns to a reference C/G
+        let ref_base = ref_bases_at_positions.get(i).and_then(|b| *b);
+        let Some(rb) = ref_base else { continue };
+        let rb_upper = rb.to_ascii_uppercase();
+        if rb_upper != ref_target {
+            continue;
+        }
+
+        ev.is_ref_c = true;
+
+        // Count unconverted vs converted in source reads
+        for sr in source_reads {
+            if i >= sr.bases.len() {
+                continue;
+            }
+            let base = sr.bases[i].to_ascii_uppercase();
+            if base == unconverted_base {
+                ev.unconverted_count = ev.unconverted_count.saturating_add(1);
+            } else if base == converted_base {
+                ev.converted_count = ev.converted_count.saturating_add(1);
+            }
+        }
+
+        // Do NOT replace converted bases back to unconverted in the consensus sequence.
+        // When consensus reads are re-aligned through bwameth, replacement would cause
+        // bwameth to see C at every reference-C position and call everything as methylated.
+        // Methylation evidence is preserved in cu/ct per-base count tags and MM/ML tags.
+    }
+
+    MethylationAnnotation { evidence }
+}
+
+/// Builds SAM-spec MM:Z and ML:B:C tags from methylation annotation.
+///
+/// MM format: `C+m,skip1,skip2,...;` listing skip counts between modified C bases.
+/// ML companion array: one probability [0-255] per modification listed in MM.
+///
+/// For top-strand reads, we track `C+m` modifications (5mC on same strand as SEQ).
+/// For bottom-strand reads (after RC), the consensus has G bases where the original
+/// bottom-strand had C. Per the SAM spec, opposite-strand 5mC is encoded as `G-m`
+/// (minus marker indicates the modification is on the opposite strand from SEQ).
+///
+/// Returns `(mm_string, ml_array)`. Returns `None` if no ref-C positions exist.
+///
+/// # Panics
+///
+/// Panics if `consensus_bases` and `annotation.evidence` have different lengths.
+#[must_use]
+pub fn build_mm_ml_tags(
+    consensus_bases: &[u8],
+    annotation: &MethylationAnnotation,
+    is_top_strand: bool,
+) -> Option<(String, Vec<u8>)> {
+    assert_eq!(
+        consensus_bases.len(),
+        annotation.evidence.len(),
+        "consensus_bases and annotation.evidence must have the same length"
+    );
+
+    // The base we track in MM depends on strand
+    let track_base = if is_top_strand { b'C' } else { b'G' };
+
+    let mut skips = Vec::new();
+    let mut probs = Vec::new();
+    let mut skip_count: usize = 0;
+
+    for (i, ev) in annotation.evidence.iter().enumerate() {
+        let base_upper = consensus_bases[i].to_ascii_uppercase();
+        if base_upper != track_base {
+            continue;
+        }
+
+        if ev.is_ref_c {
+            // This is a ref-C position with a C/G in consensus
+            let total = i32::from(ev.unconverted_count) + i32::from(ev.converted_count);
+            if total > 0 {
+                // Methylation probability = unconverted / total, scaled to [0, 255]
+                #[expect(
+                    clippy::cast_sign_loss,
+                    reason = "values are known non-negative and bounded by 255"
+                )]
+                let prob = (i32::from(ev.unconverted_count) * 255 / total).clamp(0, 255) as u8;
+                skips.push(skip_count);
+                probs.push(prob);
+                skip_count = 0;
+            } else {
+                skip_count += 1;
+            }
+        } else {
+            // C/G in consensus but not at a ref-C position — just skip it
+            skip_count += 1;
+        }
+    }
+
+    if skips.is_empty() {
+        return None;
+    }
+
+    // Build MM string: "C+m,skip1,skip2,...;" (top) or "G-m,skip1,...;" (bottom)
+    let (base_char, strand_marker) = if is_top_strand { ('C', '+') } else { ('G', '-') };
+    let mut mm = format!("{base_char}{strand_marker}m");
+    for s in &skips {
+        use std::fmt::Write;
+        write!(mm, ",{s}").unwrap();
+    }
+    mm.push(';');
+
+    Some((mm, probs))
+}
+
+/// Builds an MM-format tag string without ML companion (for per-strand am/bm tags).
+///
+/// Same format as `build_mm_ml_tags` but returns only the MM:Z string.
+#[must_use]
+pub fn build_mm_tag_no_ml(
+    consensus_bases: &[u8],
+    annotation: &MethylationAnnotation,
+    is_top_strand: bool,
+) -> Option<String> {
+    build_mm_ml_tags(consensus_bases, annotation, is_top_strand).map(|(mm, _)| mm)
+}
+
+/// Fetches reference bases for aligned positions.
+///
+/// Given a set of query-to-ref position mappings and a reference fetch function,
+/// returns the reference base at each position (or `None` for insertions/unmapped).
+pub fn fetch_ref_bases_at_positions(
+    ref_positions: &[Option<i64>],
+    ref_name: &str,
+    reference: &dyn RefBaseProvider,
+) -> Vec<Option<u8>> {
+    // Use sequence_for for O(1) per-base access when available, falling back to
+    // per-base HashMap lookups only when the implementor doesn't provide it.
+    if let Some(seq) = reference.sequence_for(ref_name) {
+        ref_positions
+            .iter()
+            .map(|pos| pos.and_then(|p| usize::try_from(p).ok().and_then(|i| seq.get(i).copied())))
+            .collect()
+    } else {
+        ref_positions
+            .iter()
+            .map(|pos| {
+                pos.and_then(|p| {
+                    u64::try_from(p).ok().and_then(|pos| reference.base_at_0based(ref_name, pos))
+                })
+            })
+            .collect()
+    }
+}
+
+/// Trait for providing reference bases (allows testing without full `ReferenceReader`).
+pub trait RefBaseProvider {
+    /// Returns the base at a 0-based position, or None if out of bounds.
+    fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8>;
+
+    /// Returns the full sequence for a chromosome, or None if not found.
+    ///
+    /// Default implementation returns None (forcing per-base lookup fallback).
+    /// Implementors with in-memory sequences should override for O(1) access.
+    fn sequence_for(&self, _chrom: &str) -> Option<&[u8]> {
+        None
+    }
+}
+
+/// Determines whether a `SourceRead` was originally on the top (forward) strand.
+///
+/// In EM-Seq, the "top strand" is the forward strand of the original molecule.
+/// For paired-end reads:
+/// - R1 forward (not reverse) = top strand
+/// - R1 reverse = bottom strand
+/// - R2 follows mate orientation (opposite of R1)
+#[must_use]
+pub fn is_top_strand(source_read_flags: u16) -> bool {
+    let is_reverse = source_read_flags & flags::REVERSE != 0;
+    let is_r2 = source_read_flags & flags::LAST_SEGMENT != 0;
+    // Top strand: R1 forward or R2 reverse
+    // Bottom strand: R1 reverse or R2 forward
+    is_reverse == is_r2
+}
+
+/// Combines two strand methylation annotations into a duplex annotation.
+///
+/// Sums unconverted and converted counts from both strands at each position.
+#[must_use]
+pub fn combine_methylation_annotations(
+    ab: &MethylationAnnotation,
+    ba: &MethylationAnnotation,
+    len: usize,
+) -> MethylationAnnotation {
+    let mut evidence = Vec::with_capacity(len);
+    for i in 0..len {
+        let ab_ev = ab.evidence.get(i);
+        let ba_ev = ba.evidence.get(i);
+        let is_ref_c = ab_ev.is_some_and(|e| e.is_ref_c) || ba_ev.is_some_and(|e| e.is_ref_c);
+        let unconverted = ab_ev
+            .map_or(0, |e| e.unconverted_count)
+            .saturating_add(ba_ev.map_or(0, |e| e.unconverted_count));
+        let converted = ab_ev
+            .map_or(0, |e| e.converted_count)
+            .saturating_add(ba_ev.map_or(0, |e| e.converted_count));
+        evidence.push(MethylationEvidence {
+            is_ref_c,
+            unconverted_count: unconverted,
+            converted_count: converted,
+        });
+    }
+    MethylationAnnotation { evidence }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::needless_range_loop)]
+pub(crate) mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Simple in-memory reference for testing. Reused across crate tests.
+    pub(crate) struct TestRef {
+        sequences: HashMap<String, Vec<u8>>,
+    }
+
+    impl TestRef {
+        pub(crate) fn new(seqs: &[(&str, &[u8])]) -> Self {
+            let mut sequences = HashMap::new();
+            for (name, seq) in seqs {
+                sequences.insert((*name).to_string(), seq.to_vec());
+            }
+            Self { sequences }
+        }
+    }
+
+    impl RefBaseProvider for TestRef {
+        fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8> {
+            self.sequences.get(chrom).and_then(|seq| seq.get(pos as usize).copied())
+        }
+
+        fn sequence_for(&self, chrom: &str) -> Option<&[u8]> {
+            self.sequences.get(chrom).map(Vec::as_slice)
+        }
+    }
+
+    #[test]
+    fn test_query_to_ref_positions_all_matches() {
+        // 10M cigar, forward strand
+        let cigar = vec![(Kind::Match, 10)];
+        let positions = query_to_ref_positions(&cigar, 100, false, &cigar);
+        assert_eq!(positions.len(), 10);
+        for (i, pos) in positions.iter().enumerate() {
+            assert_eq!(*pos, Some(100 + i as i64));
+        }
+    }
+
+    #[test]
+    fn test_query_to_ref_positions_with_insertion() {
+        // 5M2I3M
+        let cigar = vec![(Kind::Match, 5), (Kind::Insertion, 2), (Kind::Match, 3)];
+        let positions = query_to_ref_positions(&cigar, 100, false, &cigar);
+        assert_eq!(positions.len(), 10);
+        // First 5: ref 100-104
+        for i in 0..5 {
+            assert_eq!(positions[i], Some(100 + i as i64));
+        }
+        // Insertions: None
+        assert_eq!(positions[5], None);
+        assert_eq!(positions[6], None);
+        // Next 3: ref 105-107
+        for i in 0..3 {
+            assert_eq!(positions[7 + i], Some(105 + i as i64));
+        }
+    }
+
+    #[test]
+    fn test_query_to_ref_positions_with_deletion() {
+        // 5M2D5M
+        let cigar = vec![(Kind::Match, 5), (Kind::Deletion, 2), (Kind::Match, 5)];
+        let positions = query_to_ref_positions(&cigar, 100, false, &cigar);
+        assert_eq!(positions.len(), 10);
+        for i in 0..5 {
+            assert_eq!(positions[i], Some(100 + i as i64));
+        }
+        // After 2D, ref skips to 107
+        for i in 0..5 {
+            assert_eq!(positions[5 + i], Some(107 + i as i64));
+        }
+    }
+
+    #[test]
+    fn test_query_to_ref_positions_reverse_strand() {
+        // Original cigar: 10M at position 100
+        // After reversal in create_source_read: cigar is still 10M (symmetric)
+        // Reverse strand should map positions from alignment_end backward
+        let original_cigar = vec![(Kind::Match, 10)];
+        let reversed_cigar = vec![(Kind::Match, 10)]; // Same since 10M reversed is 10M
+        let positions = query_to_ref_positions(&reversed_cigar, 100, true, &original_cigar);
+        assert_eq!(positions.len(), 10);
+        // Should map from 109 down to 100
+        for i in 0..10 {
+            assert_eq!(positions[i], Some(109 - i as i64));
+        }
+    }
+
+    #[test]
+    fn test_annotate_simplex_all_methylated() {
+        // All source reads show C at ref-C positions → methylated
+        let mut consensus = b"ACGT".to_vec();
+        let sr1 = make_test_source_read(b"ACGT", 0);
+        let sr2 = make_test_source_read(b"ACGT", 0);
+        let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
+
+        let annot = annotate_simplex_methylation(
+            &mut consensus,
+            &[sr1, sr2],
+            &ref_bases,
+            true, // top strand
+        );
+
+        // Position 1 (ref=C): both reads show C → methylated, count=2
+        assert!(annot.evidence[1].is_ref_c);
+        assert_eq!(annot.evidence[1].unconverted_count, 2);
+        assert_eq!(annot.evidence[1].converted_count, 0);
+        // Consensus base should remain C
+        assert_eq!(consensus[1], b'C');
+    }
+
+    #[test]
+    fn test_annotate_simplex_all_unmethylated() {
+        // All source reads show T at ref-C position → unmethylated
+        let mut consensus = b"ATGT".to_vec(); // consensus called T at pos 1
+        let sr1 = make_test_source_read(b"ATGT", 0);
+        let sr2 = make_test_source_read(b"ATGT", 0);
+        let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
+
+        let annot = annotate_simplex_methylation(&mut consensus, &[sr1, sr2], &ref_bases, true);
+
+        assert!(annot.evidence[1].is_ref_c);
+        assert_eq!(annot.evidence[1].unconverted_count, 0);
+        assert_eq!(annot.evidence[1].converted_count, 2);
+        // Consensus base is NOT replaced — methylation state is tracked in cu/ct tags and MM/ML,
+        // and base replacement would interfere with bwameth re-alignment
+        assert_eq!(consensus[1], b'T');
+    }
+
+    #[test]
+    fn test_annotate_simplex_mixed() {
+        // Some C, some T at ref-C position
+        let mut consensus = b"ACGT".to_vec();
+        let sr1 = make_test_source_read(b"ACGT", 0); // C at pos 1
+        let sr2 = make_test_source_read(b"ATGT", 0); // T at pos 1
+        let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
+
+        let annot = annotate_simplex_methylation(&mut consensus, &[sr1, sr2], &ref_bases, true);
+
+        assert!(annot.evidence[1].is_ref_c);
+        assert_eq!(annot.evidence[1].unconverted_count, 1);
+        assert_eq!(annot.evidence[1].converted_count, 1);
+    }
+
+    #[test]
+    fn test_annotate_simplex_non_c_positions() {
+        // Non-ref-C positions should not be annotated
+        let mut consensus = b"AGGT".to_vec();
+        let sr1 = make_test_source_read(b"AGGT", 0);
+        let ref_bases = vec![Some(b'A'), Some(b'G'), Some(b'G'), Some(b'T')];
+
+        let annot = annotate_simplex_methylation(&mut consensus, &[sr1], &ref_bases, true);
+
+        for ev in &annot.evidence {
+            assert!(!ev.is_ref_c);
+        }
+    }
+
+    #[test]
+    fn test_annotate_simplex_reverse_strand() {
+        // Bottom strand: ref=G (complement of C), unconverted=G, converted=A
+        let mut consensus = b"CAGT".to_vec(); // A at pos 1 = converted on bottom strand
+        let sr1 = make_test_source_read(b"CAGT", flags::REVERSE);
+        let ref_bases = vec![Some(b'T'), Some(b'G'), Some(b'C'), Some(b'A')]; // at reversed positions
+
+        let annot = annotate_simplex_methylation(
+            &mut consensus,
+            &[sr1],
+            &ref_bases,
+            false, // bottom strand
+        );
+
+        // Position 1: ref=G → eligible for bottom-strand methylation
+        assert!(annot.evidence[1].is_ref_c);
+        assert_eq!(annot.evidence[1].unconverted_count, 0); // A, not G
+        assert_eq!(annot.evidence[1].converted_count, 1); // A = converted on bottom strand
+        // Consensus base is NOT replaced — methylation state is tracked in cu/ct tags and MM/ML
+        assert_eq!(consensus[1], b'A');
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_basic() {
+        let consensus = b"ACGCAC".to_vec();
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // A
+                MethylationEvidence { is_ref_c: true, unconverted_count: 3, converted_count: 0 }, // C - methylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // G
+                MethylationEvidence { is_ref_c: true, unconverted_count: 0, converted_count: 3 }, // C - unmethylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // A
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // C - not ref-C
+            ],
+        };
+
+        let result = build_mm_ml_tags(&consensus, &annotation, true);
+        assert!(result.is_some());
+        let (mm, ml) = result.unwrap();
+        // Two C bases that are ref-C: skip 0 to first, skip 0 to second
+        // Third C is not ref-C
+        assert_eq!(mm, "C+m,0,0;");
+        assert_eq!(ml.len(), 2);
+        assert_eq!(ml[0], 255); // fully methylated
+        assert_eq!(ml[1], 0); // fully unmethylated
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_no_modifications() {
+        // No ref-C positions at all
+        let consensus = b"AGGT".to_vec();
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence::default(),
+                MethylationEvidence::default(),
+                MethylationEvidence::default(),
+                MethylationEvidence::default(),
+            ],
+        };
+
+        let result = build_mm_ml_tags(&consensus, &annotation, true);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_mm_tag_no_ml() {
+        let consensus = b"ACGT".to_vec();
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+                MethylationEvidence { is_ref_c: true, unconverted_count: 2, converted_count: 1 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+
+        let result = build_mm_tag_no_ml(&consensus, &annotation, true);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "C+m,0;");
+    }
+
+    #[test]
+    fn test_is_top_strand() {
+        // R1 forward = top strand
+        assert!(is_top_strand(flags::PAIRED | flags::FIRST_SEGMENT));
+        // R1 reverse = bottom strand
+        assert!(!is_top_strand(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE));
+        // R2 forward = bottom strand
+        assert!(!is_top_strand(flags::PAIRED | flags::LAST_SEGMENT));
+        // R2 reverse = top strand
+        assert!(is_top_strand(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE));
+    }
+
+    #[test]
+    fn test_combine_methylation_annotations() {
+        let ab = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 2, converted_count: 1 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let ba = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 1, converted_count: 2 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let combined = combine_methylation_annotations(&ab, &ba, 2);
+        assert!(combined.evidence[0].is_ref_c);
+        assert_eq!(combined.evidence[0].unconverted_count, 3);
+        assert_eq!(combined.evidence[0].converted_count, 3);
+        assert!(!combined.evidence[1].is_ref_c);
+    }
+
+    #[test]
+    fn test_fetch_ref_bases_at_positions() {
+        // Uses the sequence_for fast path (TestRef implements it)
+        let reference = TestRef::new(&[("chr1", b"ACGTACGT")]);
+        let positions = vec![Some(0), Some(1), None, Some(3), Some(7)];
+        let bases = fetch_ref_bases_at_positions(&positions, "chr1", &reference);
+        assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, Some(b'T'), Some(b'T')]);
+    }
+
+    /// A `RefBaseProvider` that only supports per-base lookups (no `sequence_for`).
+    struct PerBaseLookupRef {
+        sequences: HashMap<String, Vec<u8>>,
+    }
+
+    impl RefBaseProvider for PerBaseLookupRef {
+        fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8> {
+            self.sequences.get(chrom).and_then(|seq| seq.get(pos as usize).copied())
+        }
+        // sequence_for not overridden → returns None → fallback path
+    }
+
+    #[test]
+    fn test_fetch_ref_bases_fallback_path() {
+        let mut sequences = HashMap::new();
+        sequences.insert("chr1".to_string(), b"ACGTACGT".to_vec());
+        let reference = PerBaseLookupRef { sequences };
+        let positions = vec![Some(0), Some(1), None, Some(3), Some(7)];
+        let bases = fetch_ref_bases_at_positions(&positions, "chr1", &reference);
+        assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, Some(b'T'), Some(b'T')]);
+    }
+
+    #[test]
+    fn test_build_mm_ml_with_skips() {
+        // Consensus: CCACC — three C bases, but only positions 0 and 3 are ref-C
+        let consensus = b"CCACC".to_vec();
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 5, converted_count: 0 }, // C at 0: ref-C, methylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // C at 1: NOT ref-C
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // A at 2
+                MethylationEvidence { is_ref_c: true, unconverted_count: 0, converted_count: 5 }, // C at 3: ref-C, unmethylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // C at 4: NOT ref-C
+            ],
+        };
+
+        let (mm, ml) = build_mm_ml_tags(&consensus, &annotation, true).unwrap();
+        // First ref-C is the 1st C (skip 0), second ref-C is the 4th C (skip 1 non-ref C + skip 1 more)
+        // Walking: C at 0 (ref-C, skip=0), C at 1 (not ref-C, skip++), C at 3 (ref-C, skip=1), C at 4 (not ref-C)
+        assert_eq!(mm, "C+m,0,1;");
+        assert_eq!(ml, vec![255, 0]);
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_bottom_strand() {
+        // Bottom-strand consensus has G bases at methylation sites
+        let consensus = b"AGCGAG".to_vec();
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // A
+                MethylationEvidence { is_ref_c: true, unconverted_count: 3, converted_count: 0 }, // G - methylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // C
+                MethylationEvidence { is_ref_c: true, unconverted_count: 0, converted_count: 3 }, // G - unmethylated
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // A
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 }, // G - not ref-C
+            ],
+        };
+
+        let (mm, ml) = build_mm_ml_tags(&consensus, &annotation, false).expect("should have tags");
+        // Per SAM spec: opposite-strand 5mC uses G-m (minus = opposite strand of SEQ)
+        assert_eq!(mm, "G-m,0,0;");
+        assert_eq!(ml.len(), 2);
+        assert_eq!(ml[0], 255); // fully methylated
+        assert_eq!(ml[1], 0); // fully unmethylated
+    }
+
+    #[test]
+    fn test_methylation_counters_saturate() {
+        let annotation = MethylationAnnotation {
+            evidence: vec![MethylationEvidence {
+                is_ref_c: true,
+                unconverted_count: i16::MAX,
+                converted_count: i16::MAX,
+            }],
+        };
+        let ab = &annotation;
+        let ba = &annotation;
+        let combined = combine_methylation_annotations(ab, ba, 1);
+        // Should saturate at i16::MAX, not wrap or panic
+        assert_eq!(combined.evidence[0].unconverted_count, i16::MAX);
+        assert_eq!(combined.evidence[0].converted_count, i16::MAX);
+    }
+
+    /// Helper to create a `SourceRead` for testing.
+    fn make_test_source_read(bases: &[u8], flg: u16) -> SourceRead {
+        SourceRead {
+            original_idx: 0,
+            bases: bases.to_vec(),
+            quals: vec![30; bases.len()],
+            simplified_cigar: vec![(Kind::Match, bases.len())],
+            flags: flg,
+            ref_id: 0,
+            alignment_start: 0,
+            original_cigar: vec![(Kind::Match, bases.len())],
+        }
+    }
+}

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -138,6 +138,12 @@ pub(crate) struct SourceRead {
     pub(crate) simplified_cigar: SimplifiedCigar,
     /// Raw BAM flags from the original record (used by duplex caller for R1/R2 splitting)
     pub(crate) flags: u16,
+    /// Reference sequence ID from the original record (for methylation annotation)
+    pub(crate) ref_id: i32,
+    /// 0-based alignment start from the original record (for methylation annotation)
+    pub(crate) alignment_start: i64,
+    /// Original (pre-reversal) simplified CIGAR (for reverse-strand ref position mapping)
+    pub(crate) original_cigar: SimplifiedCigar,
 }
 
 /// Vanilla consensus read - matches fgbio's `VanillaConsensusRead`
@@ -164,6 +170,9 @@ pub struct VanillaConsensusRead {
 
     /// Optional source reads used for consensus (kept for tag preservation)
     pub(crate) source_reads: Option<Vec<SourceRead>>,
+
+    /// Methylation annotation (only populated when `em_seq` is enabled)
+    pub(crate) methylation: Option<crate::methylation::MethylationAnnotation>,
 }
 
 impl VanillaConsensusRead {
@@ -260,6 +269,7 @@ impl VanillaConsensusRead {
             depths,
             errors,
             source_reads: self.source_reads.clone(),
+            methylation: None, // Padding invalidates methylation annotation
         }
     }
 
@@ -305,6 +315,11 @@ pub struct VanillaUmiConsensusOptions {
 
     /// Optional cell barcode tag to preserve (e.g., "CB", "XX")
     pub cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
+
+    /// Whether to perform methylation-aware consensus calling for EM-Seq data.
+    /// When true, C→T conversions at reference cytosine positions are treated as
+    /// bisulfite/enzymatic conversion rather than errors, and MM/ML tags are emitted.
+    pub em_seq: bool,
 }
 
 impl Default for VanillaUmiConsensusOptions {
@@ -321,6 +336,7 @@ impl Default for VanillaUmiConsensusOptions {
             trim: false,
             min_consensus_base_quality: 40, // Match fgbio default
             cell_tag: None,
+            em_seq: false,
         }
     }
 }
@@ -361,6 +377,12 @@ pub struct VanillaUmiConsensusCaller {
 
     /// Reusable builder for raw-byte BAM record construction.
     bam_builder: UnmappedBamRecordBuilder,
+
+    /// Optional reference genome for EM-Seq methylation annotation.
+    reference: Option<std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>>,
+
+    /// Reference sequence names indexed by `ref_id` (for mapping `ref_id` → contig name).
+    ref_names: Option<std::sync::Arc<Vec<String>>>,
 }
 
 #[expect(
@@ -423,6 +445,8 @@ impl VanillaUmiConsensusCaller {
             track_rejects,
             single_input_consensus_quals,
             bam_builder: UnmappedBamRecordBuilder::new(),
+            reference: None,
+            ref_names: None,
         }
     }
 
@@ -465,6 +489,17 @@ impl VanillaUmiConsensusCaller {
         // Use the corrected implementations from phred.rs
         let ln_result = ln_error_prob_two_trials(ln_prob_one, ln_prob_two);
         ln_prob_to_phred(ln_result)
+    }
+
+    /// Sets the reference genome and contig names for EM-Seq methylation annotation.
+    pub fn set_reference(
+        &mut self,
+        reference: std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>,
+        ref_names: std::sync::Arc<Vec<String>>,
+    ) {
+        self.options.em_seq = true;
+        self.reference = Some(reference);
+        self.ref_names = Some(ref_names);
     }
 
     /// Returns the rejected reads
@@ -549,14 +584,27 @@ impl VanillaUmiConsensusCaller {
         bases.truncate(final_len);
         quals.truncate(final_len);
 
-        let mut simplified_cigar = cigar_utils::simplify_cigar(read.cigar());
+        let original_cigar = cigar_utils::simplify_cigar(read.cigar());
+        let mut simplified_cigar = original_cigar.clone();
         if is_negative_strand {
             simplified_cigar = Self::reverse_simplified_cigar(&simplified_cigar);
         }
         simplified_cigar = Self::truncate_simplified_cigar(&simplified_cigar, final_len);
 
         let flg = u16::from(read.flags());
-        Some(SourceRead { original_idx, bases, quals, simplified_cigar, flags: flg })
+        #[allow(clippy::cast_possible_truncation)] // ref IDs are always within i32 range
+        let rid = read.reference_sequence_id().map_or(-1, |id| id as i32);
+        let astart = read.alignment_start().map_or(-1, |p| usize::from(p) as i64 - 1);
+        Some(SourceRead {
+            original_idx,
+            bases,
+            quals,
+            simplified_cigar,
+            flags: flg,
+            ref_id: rid,
+            alignment_start: astart,
+            original_cigar,
+        })
     }
 
     /// Filters `SourceReads` by common alignment pattern.
@@ -585,8 +633,15 @@ impl VanillaUmiConsensusCaller {
         }
 
         // Build consensus from source reads
-        let (bases, quals, depths, errors) =
+        let (mut bases, quals, depths, errors) =
             self.create_consensus_from_source_reads(&source_reads)?;
+
+        // Apply methylation annotation if em_seq is enabled
+        let methylation = if self.options.em_seq {
+            self.annotate_methylation(&source_reads, &mut bases)
+        } else {
+            None
+        };
 
         // Build VanillaConsensusRead
         let consensus_read = VanillaConsensusRead {
@@ -596,9 +651,55 @@ impl VanillaUmiConsensusCaller {
             depths,
             errors,
             source_reads: Some(source_reads),
+            methylation,
         };
 
         Ok(Some(consensus_read))
+    }
+
+    /// Annotates methylation for a consensus read using reference and source reads.
+    fn annotate_methylation(
+        &self,
+        source_reads: &[SourceRead],
+        consensus_bases: &mut [u8],
+    ) -> Option<crate::methylation::MethylationAnnotation> {
+        use crate::methylation;
+
+        let reference = self.reference.as_ref()?;
+        let ref_names = self.ref_names.as_ref()?;
+
+        // Use the longest source read as the mapping template so that ref_positions
+        // covers the full consensus length (consensus_len <= max source read length).
+        // All reads share the same alignment pattern after filtering, so the longest
+        // read's CIGAR is a superset of any shorter read's positions.
+        let template = source_reads.iter().max_by_key(|sr| sr.bases.len())?;
+        if template.ref_id < 0 || template.alignment_start < 0 {
+            return None;
+        }
+        let ref_name = ref_names.get(usize::try_from(template.ref_id).ok()?)?;
+
+        // Determine strand from source reads
+        let is_top = methylation::is_top_strand(template.flags);
+
+        // Map consensus positions to reference positions
+        let ref_positions = methylation::query_to_ref_positions(
+            &template.simplified_cigar,
+            template.alignment_start,
+            template.flags & fgumi_raw_bam::flags::REVERSE != 0,
+            &template.original_cigar,
+        );
+
+        // Fetch reference bases at aligned positions
+        let ref_bases =
+            methylation::fetch_ref_bases_at_positions(&ref_positions, ref_name, reference.as_ref());
+
+        // Annotate methylation
+        Some(methylation::annotate_simplex_methylation(
+            consensus_bases,
+            source_reads,
+            &ref_bases,
+            is_top,
+        ))
     }
 
     /// Filters reads to remove secondary/supplementary alignments.
@@ -783,7 +884,8 @@ impl VanillaUmiConsensusCaller {
 
         // Get simplified CIGAR from raw ops
         let cigar_ops = bam_fields::get_cigar_ops(raw);
-        let mut simplified_cigar = bam_fields::simplify_cigar_from_raw(&cigar_ops);
+        let original_cigar = bam_fields::simplify_cigar_from_raw(&cigar_ops);
+        let mut simplified_cigar = original_cigar.clone();
 
         if is_negative_strand {
             simplified_cigar = Self::reverse_simplified_cigar(&simplified_cigar);
@@ -791,7 +893,19 @@ impl VanillaUmiConsensusCaller {
 
         simplified_cigar = Self::truncate_simplified_cigar(&simplified_cigar, final_len);
 
-        Some(SourceRead { original_idx, bases, quals, simplified_cigar, flags: flg })
+        let rid = bam_fields::ref_id(raw);
+        let astart = i64::from(bam_fields::pos(raw));
+
+        Some(SourceRead {
+            original_idx,
+            bases,
+            quals,
+            simplified_cigar,
+            flags: flg,
+            ref_id: rid,
+            alignment_start: astart,
+            original_cigar,
+        })
     }
 
     /// Filters `SourceReads` to only include those with the most common alignment pattern.
@@ -1059,8 +1173,15 @@ impl VanillaUmiConsensusCaller {
         };
 
         // Build consensus from source reads
-        let (bases, quals, depths, errors) =
+        let (mut bases, quals, depths, errors) =
             self.create_consensus_from_source_reads(&filtered_source_reads)?;
+
+        // Apply methylation annotation if em_seq is enabled
+        let methylation = if self.options.em_seq {
+            self.annotate_methylation(&filtered_source_reads, &mut bases)
+        } else {
+            None
+        };
 
         // Get raw records for tag extraction
         let original_raws: Vec<&[u8]> = filtered_source_reads
@@ -1077,6 +1198,7 @@ impl VanillaUmiConsensusCaller {
             &quals,
             &depths,
             &errors,
+            methylation.as_ref(),
         );
 
         Ok((true, surviving_count, surviving_reads))
@@ -1201,6 +1323,7 @@ impl VanillaUmiConsensusCaller {
         quals: &[u8],
         depths: &[u16],
         errors: &[u16],
+        methylation: Option<&crate::methylation::MethylationAnnotation>,
     ) {
         use fgumi_raw_bam as bam_fields;
 
@@ -1269,6 +1392,25 @@ impl VanillaUmiConsensusCaller {
         if !umis.is_empty() {
             let consensus_umi = consensus_umis(&umis);
             self.bam_builder.append_string_tag(b"RX", consensus_umi.as_bytes());
+        }
+
+        // Methylation tags (EM-Seq)
+        if let Some(annot) = methylation {
+            // Determine strand for MM tag format
+            let is_top = original_raws
+                .first()
+                .is_none_or(|raw| crate::methylation::is_top_strand(fgumi_raw_bam::flags(raw)));
+
+            if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(bases, annot, is_top) {
+                self.bam_builder.append_string_tag(b"MM", mm.as_bytes());
+                self.bam_builder.append_u8_array_tag(b"ML", &ml);
+            }
+
+            // Dense count tags
+            let cu = annot.unconverted_counts();
+            let ct = annot.converted_counts();
+            self.bam_builder.append_i16_array_tag(b"cu", &cu);
+            self.bam_builder.append_i16_array_tag(b"ct", &ct);
         }
 
         // Write record with block_size prefix
@@ -2466,9 +2608,12 @@ mod tests {
         SourceRead {
             bases: vec![b'A'; query_len],
             quals: vec![30u8; query_len],
-            simplified_cigar,
+            simplified_cigar: simplified_cigar.clone(),
             original_idx: 0,
             flags: 0,
+            ref_id: -1,
+            alignment_start: -1,
+            original_cigar: simplified_cigar,
         }
     }
 
@@ -3929,6 +4074,7 @@ mod tests {
             depths: vec![3u16; bases.len()],
             errors: vec![1u16; bases.len()],
             source_reads: None,
+            methylation: None,
         };
 
         // Same length should return self
@@ -3969,6 +4115,7 @@ mod tests {
             depths: vec![3u16; bases.len()],
             errors: vec![1u16; bases.len()],
             source_reads: None,
+            methylation: None,
         };
 
         // Same length should return self
@@ -4009,6 +4156,7 @@ mod tests {
             depths: vec![3u16; 8],
             errors: vec![1u16; 8],
             source_reads: None,
+            methylation: None,
         };
 
         // This should panic - can't pad to smaller length
@@ -4364,5 +4512,250 @@ mod tests {
             2,
             "OrphanConsensus should count 2 surviving R2 reads, not 3 original"
         );
+    }
+
+    // ========================================================================
+    // EM-Seq methylation-aware consensus tests
+    // ========================================================================
+
+    use crate::methylation::tests::TestRef;
+
+    /// Creates a caller configured for EM-Seq with a test reference.
+    fn create_em_seq_caller(ref_seq: &[u8]) -> VanillaUmiConsensusCaller {
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            min_consensus_base_quality: 0,
+            em_seq: true,
+            ..Default::default()
+        };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        // Set up reference: contig "chr1" with the given sequence
+        let reference = std::sync::Arc::new(TestRef::new(&[("chr1", ref_seq)]));
+        let ref_names = std::sync::Arc::new(vec!["chr1".to_string()]);
+        caller.set_reference(reference, ref_names);
+        caller
+    }
+
+    /// Test: All reads show C at ref-C → methylated, consensus=C, MM tag indicates methylation.
+    #[test]
+    fn test_simplex_em_seq_all_methylated() {
+        // Reference: ACGTACGT... at position 99 (0-based)
+        // Reads start at alignment_start=100 (1-based), so 0-based pos 99
+        // Ref at 0-based positions 99..109: we'll use "CCCCCCCCCC" (all C)
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_em_seq_caller(&ref_seq);
+
+        // All reads show C (methylated, unconverted)
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'C'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus bases should be C (methylated = unconverted)
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
+
+        // MM tag should be present (all positions are methylated C)
+        let mm = consensus.get_string_tag(b"MM").expect("MM tag should be present");
+        assert!(mm.starts_with(b"C+m"), "MM should start with C+m");
+
+        // ML tag should be present
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        // All positions methylated → all probabilities should be 255 (3/3 unconverted)
+        for &p in &ml {
+            assert_eq!(p, 255, "Expected methylation probability 255 for fully methylated");
+        }
+
+        // cu (unconverted counts) should all be 3
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![3i16; 10]);
+
+        // ct (converted counts) should all be 0
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![0i16; 10]);
+    }
+
+    /// Test: All reads show T at ref-C → unmethylated.
+    /// Consensus remains T since methylation annotation does not alter bases.
+    /// MM/ML tags are absent because there are no C bases in the consensus to report.
+    #[test]
+    fn test_simplex_em_seq_all_unmethylated() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_em_seq_caller(&ref_seq);
+
+        // All reads show T (unmethylated, converted C→T)
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'T'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus bases remain T (annotation doesn't replace bases)
+        assert_eq!(consensus.bases, vec![b'T'; 10]);
+
+        // MM/ML tags are absent (no C bases in consensus to reference)
+        assert!(consensus.get_string_tag(b"MM").is_none(), "MM tag should be absent");
+        assert!(consensus.get_u8_array_tag(b"ML").is_none(), "ML tag should be absent");
+
+        // cu should all be 0 (no reads showed C)
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![0i16; 10]);
+
+        // ct should all be 3 (all reads showed T)
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![3i16; 10]);
+    }
+
+    /// Test: Mixed methylation — some reads C, some T at ref-C positions.
+    #[test]
+    fn test_simplex_em_seq_mixed_methylation() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_em_seq_caller(&ref_seq);
+
+        // 2 reads show C (methylated), 1 shows T (unmethylated)
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus bases should be C (majority call + methylation annotation restores to C)
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
+
+        // ML probabilities should be ~170 (2/3 ≈ 0.667 * 255 = 170)
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        for &p in &ml {
+            assert_eq!(p, 170, "Expected ~170 for 2/3 methylation ratio");
+        }
+
+        // cu should be 2, ct should be 1
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![2i16; 10]);
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![1i16; 10]);
+    }
+
+    /// Test: Non-C reference positions are unaffected by EM-Seq annotation.
+    #[test]
+    fn test_simplex_em_seq_non_c_positions() {
+        let mut ref_seq = vec![b'N'; 99];
+        // Reference is all A — no C positions, so no methylation annotation
+        ref_seq.extend_from_slice(b"AAAAAAAAAA");
+        let mut caller = create_em_seq_caller(&ref_seq);
+
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'A'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'A'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus should be A
+        assert_eq!(consensus.bases, vec![b'A'; 10]);
+
+        // MM tag should not be present (no ref-C positions)
+        assert!(consensus.get_string_tag(b"MM").is_none(), "MM tag should be absent");
+
+        // cu/ct should still be present but all zeros
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![0i16; 10]);
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![0i16; 10]);
+    }
+
+    /// Test: EM-Seq disabled → no methylation tags, normal consensus behavior.
+    #[test]
+    fn test_simplex_em_seq_disabled() {
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            min_consensus_base_quality: 0,
+            em_seq: false,
+            ..Default::default()
+        };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'T'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Without em_seq, consensus should just be T (no reference correction)
+        assert_eq!(consensus.bases, vec![b'T'; 10]);
+
+        // No methylation tags
+        assert!(consensus.get_string_tag(b"MM").is_none());
+        assert!(consensus.get_u8_array_tag(b"ML").is_none());
+        assert!(consensus.get_i16_array_tag(b"cu").is_none());
+        assert!(consensus.get_i16_array_tag(b"ct").is_none());
+    }
+
+    /// Test: The longest source read is used as the mapping template, not the first.
+    /// When the first read is shorter than the consensus, methylation must still be
+    /// annotated at trailing positions covered by longer reads.
+    #[test]
+    fn test_simplex_em_seq_longest_read_used_for_mapping() {
+        // Reference: 10 C's starting at 0-based position 99
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_em_seq_caller(&ref_seq);
+
+        // read1 is SHORT (5 bases); read2 and read3 are LONG (10 bases).
+        // All show C (methylated). With min_reads=1 the consensus length = 10.
+        let read1 = create_consensus_test_read("r1", &[b'C'; 5], &[30u8; 5], "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'C'; 10], &[30u8; 10], "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'C'; 10], &[30u8; 10], "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        assert_eq!(consensus.bases.len(), 10);
+
+        // cu tag should have 10 entries: 3 for positions 0-4 (all reads), 2 for 5-9 (long reads)
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu.len(), 10, "cu tag should cover all 10 consensus positions");
+        for &c in &cu[0..5] {
+            assert_eq!(c, 3, "positions 0-4 covered by all 3 reads");
+        }
+        for &c in &cu[5..10] {
+            assert_eq!(c, 2, "positions 5-9 covered by 2 long reads");
+        }
+
+        // ct (converted counts) should all be 0
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![0i16; 10]);
+
+        // MM tag should cover all 10 positions
+        let mm = consensus.get_string_tag(b"MM").expect("MM tag should be present");
+        assert!(mm.starts_with(b"C+m"), "MM should start with C+m");
+
+        // ML tag should have 10 entries (one per C position)
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        assert_eq!(ml.len(), 10, "ML tag should cover all 10 consensus positions");
     }
 }

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::sequence::pack_sequence_into;
 use crate::tags::{
     append_float_tag, append_i16_array_tag, append_int_tag, append_phred33_string_tag,
-    append_string_tag,
+    append_string_tag, append_u8_array_tag,
 };
 
 // ============================================================================
@@ -159,6 +159,13 @@ impl UnmappedBamRecordBuilder {
     pub fn append_i16_array_tag(&mut self, tag: &[u8; 2], values: &[i16]) {
         debug_assert!(self.sealed, "must call build_record before appending tags");
         append_i16_array_tag(&mut self.buf, tag, values);
+    }
+
+    /// Append a `u8` array (`B:C`-type) tag.
+    #[inline]
+    pub fn append_u8_array_tag(&mut self, tag: &[u8; 2], values: &[u8]) {
+        debug_assert!(self.sealed, "must call build_record before appending tags");
+        append_u8_array_tag(&mut self.buf, tag, values);
     }
 
     /// Append a Phred+33 encoded quality string (`Z`-type) tag.

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -519,6 +519,24 @@ pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16])
     }
 }
 
+/// Append a `u8` array (`B:C`-type) tag to a BAM record.
+///
+/// Format: `[tag0, tag1, 'B', 'C', count_u32_le, values_u8...]`
+///
+/// # Panics
+///
+/// Panics if `values.len()` exceeds `u32::MAX`.
+pub fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
+    record.push(tag[0]);
+    record.push(tag[1]);
+    record.push(b'B');
+    record.push(b'C');
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
+    record.extend_from_slice(values);
+}
+
 /// Append a Phred+33 encoded quality string (`Z`-type) tag.
 ///
 /// Converts raw Phred scores (0-93) to ASCII (Phred+33) and writes
@@ -2418,5 +2436,30 @@ mod tests {
         let mut dest = Vec::new();
         copy_aux_tags(&[], &mut dest, &[]);
         assert!(dest.is_empty());
+    }
+
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::single(&[42u8])]
+    #[case::multiple(&[0u8, 128, 255])]
+    fn test_append_u8_array_tag_round_trip(#[case] values: &[u8]) {
+        let tag = b"ML";
+        let mut record = Vec::new();
+        append_u8_array_tag(&mut record, tag, values);
+
+        // Verify wire format: [tag0, tag1, 'B', 'C', count_u32_le, values...]
+        assert_eq!(record[0], b'M');
+        assert_eq!(record[1], b'L');
+        assert_eq!(record[2], b'B');
+        assert_eq!(record[3], b'C');
+        let count = u32::from_le_bytes([record[4], record[5], record[6], record[7]]) as usize;
+        assert_eq!(count, values.len());
+        assert_eq!(&record[8..], values);
+
+        // Round-trip through find_array_tag
+        let arr = find_array_tag(&record, tag).expect("tag should be found");
+        assert_eq!(arr.elem_type, b'C');
+        assert_eq!(arr.count, values.len());
+        assert_eq!(arr.data, values);
     }
 }

--- a/crates/fgumi-raw-bam/src/testutil.rs
+++ b/crates/fgumi-raw-bam/src/testutil.rs
@@ -81,6 +81,12 @@ impl ParsedBamRecord {
     pub fn get_i16_array_tag(&self, tag: &[u8; 2]) -> Option<Vec<i16>> {
         find_i16_array_tag_in_aux(&self.aux_data, *tag)
     }
+
+    /// Find a B:C (u8 array) tag value by tag name.
+    #[must_use]
+    pub fn get_u8_array_tag(&self, tag: &[u8; 2]) -> Option<Vec<u8>> {
+        find_u8_array_tag_in_aux(&self.aux_data, *tag)
+    }
 }
 
 fn unpack_sequence_for_test(packed: &[u8], l_seq: usize) -> Vec<u8> {
@@ -105,6 +111,11 @@ fn find_int_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<i32> {
 
 fn find_float_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<f32> {
     crate::tags::find_float_tag(aux, &tag)
+}
+
+fn find_u8_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> {
+    let arr = crate::tags::find_array_tag(aux, &tag)?;
+    (arr.elem_type == b'C').then(|| arr.data.to_vec())
 }
 
 fn find_i16_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<i16>> {

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -4,13 +4,59 @@
 //! command structs using `#[command(flatten)]`.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::bam_io::is_stdin_path;
+use crate::logging::OperationTimer;
 use crate::unified_pipeline::{BamPipelineConfig, SchedulerStrategy};
 use crate::validation::validate_file_exists;
 use bytesize::ByteSize;
 use clap::Args;
+use fgumi_consensus::methylation::RefBaseProvider;
+use log::info;
 use noodles::sam::Header;
+
+/// EM-Seq reference pair: reference base provider + contig name mapping.
+pub type EmSeqRef = Option<(
+    Arc<dyn fgumi_consensus::methylation::RefBaseProvider + Send + Sync>,
+    Arc<Vec<String>>,
+)>;
+
+/// Loads the reference FASTA and builds contig name mapping for EM-Seq mode.
+///
+/// Returns `None` if `em_seq` is false. Errors if `em_seq` is true but `reference` is `None`.
+pub fn load_em_seq_reference(
+    em_seq: bool,
+    reference: &Option<PathBuf>,
+    header: &Header,
+) -> anyhow::Result<EmSeqRef> {
+    if !em_seq {
+        return Ok(None);
+    }
+    let ref_path = reference
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("--ref is required when --em-seq is enabled"))?;
+    let ref_timer = OperationTimer::new("Loading reference FASTA");
+    let reference = Arc::new(crate::reference::ReferenceReader::new(ref_path)?);
+    ref_timer.log_completion(0);
+
+    let ref_names: Vec<String> =
+        header.reference_sequences().keys().map(|name| name.to_string()).collect();
+
+    // Fail fast if any BAM header contigs are missing from the reference FASTA
+    let missing_contigs: Vec<&String> =
+        ref_names.iter().filter(|name| reference.sequence_for(name).is_none()).collect();
+    if !missing_contigs.is_empty() {
+        anyhow::bail!(
+            "Reference FASTA is missing {} contig(s) from the BAM header: {}",
+            missing_contigs.len(),
+            missing_contigs.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+
+    info!("EM-Seq mode enabled with {} reference contigs", ref_names.len());
+    Ok(Some((reference, Arc::new(ref_names))))
+}
 
 /// Add a @PG record to an existing header, using the current fgumi version.
 ///
@@ -27,6 +73,21 @@ pub fn add_pg_to_builder(
     command_line: &str,
 ) -> anyhow::Result<noodles::sam::header::Builder> {
     crate::header::add_pg_to_builder(builder, crate::version::VERSION.as_str(), command_line)
+}
+
+/// EM-Seq methylation-aware consensus calling options.
+#[derive(Debug, Clone, Default, Args)]
+pub struct EmSeqOptions {
+    /// Enable EM-Seq (enzymatic methyl-seq) methylation-aware consensus calling.
+    /// Requires --ref. C→T conversions at reference cytosine positions are treated
+    /// as bisulfite/enzymatic conversion, and cu/ct per-base count tags
+    /// and MM/ML methylation tags are emitted on consensus reads.
+    #[arg(long = "em-seq", default_value_t = false, requires = "reference")]
+    pub em_seq: bool,
+
+    /// Path to the reference FASTA file (required when --em-seq is enabled)
+    #[arg(long = "ref")]
+    pub reference: Option<PathBuf>,
 }
 
 /// Common input/output options for commands that read a BAM and write a BAM.

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -49,6 +49,8 @@ use std::sync::Arc;
 
 use super::command::Command;
 
+use super::common::{EmSeqOptions, EmSeqRef, load_em_seq_reference};
+
 // ============================================================================
 // Types for 7-step pipeline processing
 // ============================================================================
@@ -193,6 +195,10 @@ pub struct Duplex {
     /// Queue memory options.
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
+
+    /// EM-Seq methylation-aware consensus options.
+    #[command(flatten)]
+    pub em_seq_opts: EmSeqOptions,
 }
 
 impl Command for Duplex {
@@ -253,6 +259,8 @@ impl Command for Duplex {
     ///     min_reads: vec![1],
     ///     max_reads_per_strand: None,
     ///     scheduler_opts: SchedulerOptions::default(),
+    ///     queue_memory: QueueMemoryOptions::default(),
+    ///     em_seq_opts: EmSeqOptions::default(),
     /// };
     ///
     /// duplex.execute("test")?;
@@ -300,6 +308,10 @@ impl Command for Duplex {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
+        // Load reference for EM-Seq methylation-aware consensus calling
+        let em_seq_ref: EmSeqRef =
+            load_em_seq_reference(self.em_seq_opts.em_seq, &self.em_seq_opts.reference, &header)?;
+
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
         if overlapping_enabled {
@@ -323,6 +335,7 @@ impl Command for Duplex {
                 read_name_prefix.clone(),
                 track_rejects,
                 command_line,
+                em_seq_ref.clone(),
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
@@ -366,6 +379,11 @@ impl Command for Duplex {
             self.consensus.error_rate_pre_umi,
             self.consensus.error_rate_post_umi,
         )?;
+
+        // Set reference for EM-Seq if enabled
+        if let Some((ref reference, ref ref_names)) = em_seq_ref {
+            consensus_caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        }
 
         // Accumulator for overlapping stats from parallel processing
         let mut merged_overlapping_stats = CorrectionStats::new();
@@ -506,6 +524,7 @@ impl Duplex {
     ///
     /// This method is called when `--threads N` is specified with N > 1.
     /// It uses the lock-free 7-step unified pipeline for maximum performance.
+    #[expect(clippy::too_many_arguments, reason = "pipeline setup needs all configuration")]
     fn execute_threads_mode(
         &self,
         num_threads: usize,
@@ -514,6 +533,7 @@ impl Duplex {
         read_name_prefix: String,
         track_rejects: bool,
         command_line: &str,
+        em_seq_ref: EmSeqRef,
     ) -> Result<()> {
         // Create output header (for duplex, output is unmapped like simplex)
         let output_header = create_unmapped_consensus_header(
@@ -615,6 +635,11 @@ impl Duplex {
                 .map_err(|e| {
                     io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}"))
                 })?;
+
+                // Set reference for EM-Seq if enabled
+                if let Some((ref reference, ref ref_names)) = em_seq_ref {
+                    caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+                }
 
                 // Create overlapping caller if enabled
                 let mut overlapping_caller = if overlapping_enabled {
@@ -869,6 +894,7 @@ mod tests {
             max_reads_per_strand: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            em_seq_opts: EmSeqOptions::default(),
         }
     }
 
@@ -1636,5 +1662,75 @@ mod tests {
         let estimate = batch.estimate_heap_size();
         assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
         assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
+    }
+
+    #[rstest]
+    #[case::single_threaded(ThreadingOptions::none())]
+    #[case::multi_threaded(ThreadingOptions::new(2))]
+    fn test_duplex_em_seq_command(#[case] threading: ThreadingOptions) -> Result<()> {
+        use std::io::Write;
+
+        // Create a FASTA with chr1 containing C bases at the aligned region
+        let ref_seq = "C".repeat(300);
+        let ref_file = {
+            let mut f = tempfile::NamedTempFile::new()?;
+            writeln!(f, ">chr1")?;
+            writeln!(f, "{ref_seq}")?;
+            f.flush()?;
+            f
+        };
+
+        // Create properly structured AB/BA duplex pairs
+        let mut records = Vec::new();
+
+        // AB reads: R1 forward at 100, R2 reverse at 100
+        for i in 0..3 {
+            let (r1, r2) =
+                build_duplex_pair(&format!("ab{i}"), 0, 100, 100, "1/A", "CCCCCCCCCC", None, None);
+            records.push(r1);
+            records.push(r2);
+        }
+
+        // BA reads: R1 reverse at 100, R2 forward at 100 (opposite strand orientation)
+        for i in 0..3 {
+            let flags1 = 0x53_u16; // paired, proper pair, first in pair, reverse
+            let flags2 = 0x83_u16; // paired, proper pair, second in pair, forward
+            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, "CCCCCCCCCC");
+            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, "CCCCCCCCCC");
+
+            *r1.mate_reference_sequence_id_mut() = Some(0);
+            *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
+            *r2.mate_reference_sequence_id_mut() = Some(0);
+            *r2.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
+
+            let mi = Tag::from([b'M', b'I']);
+            r1.data_mut().insert(mi, Value::String(b"1/B".into()));
+            r2.data_mut().insert(mi, Value::String(b"1/B".into()));
+
+            records.push(r1);
+            records.push(r2);
+        }
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let mut cmd = create_duplex_with_paths(input.path().to_path_buf(), paths.output.clone());
+        cmd.em_seq_opts.em_seq = true;
+        cmd.em_seq_opts.reference = Some(ref_file.path().to_path_buf());
+        cmd.threading = threading;
+        cmd.execute("test")?;
+
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 2, "Should have 2 duplex consensus reads");
+
+        // Verify methylation tags are present on output reads
+        for record in &output_records {
+            let cu_tag = Tag::from([b'c', b'u']);
+            assert!(record.data().get(&cu_tag).is_some(), "cu tag should be present with EM-Seq");
+            let ct_tag = Tag::from([b'c', b't']);
+            assert!(record.data().get(&ct_tag).is_some(), "ct tag should be present with EM-Seq");
+        }
+
+        Ok(())
     }
 }

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -48,6 +48,8 @@ use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
 };
 
+use super::common::{EmSeqOptions, EmSeqRef, load_em_seq_reference};
+
 // ============================================================================
 // Types for 7-step pipeline processing
 // ============================================================================
@@ -207,6 +209,10 @@ pub struct Simplex {
     /// Queue memory options.
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
+
+    /// EM-Seq methylation-aware consensus options.
+    #[command(flatten)]
+    pub em_seq_opts: EmSeqOptions,
 }
 
 impl Command for Simplex {
@@ -255,6 +261,10 @@ impl Command for Simplex {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
+        // Load reference for EM-Seq methylation-aware consensus calling
+        let em_seq_ref: EmSeqRef =
+            load_em_seq_reference(self.em_seq_opts.em_seq, &self.em_seq_opts.reference, &header)?;
+
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.is_enabled();
         if overlapping_enabled {
@@ -278,6 +288,7 @@ impl Command for Simplex {
                 output_header.clone(),
                 read_name_prefix.clone(),
                 track_rejects,
+                em_seq_ref.clone(),
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
@@ -318,6 +329,7 @@ impl Command for Simplex {
             trim: self.consensus.trim,
             min_consensus_base_quality: self.consensus.min_consensus_base_quality,
             cell_tag: Some(cell_tag),
+            em_seq: self.em_seq_opts.em_seq,
         };
 
         // Create a single-threaded caller for stats collection
@@ -327,6 +339,11 @@ impl Command for Simplex {
             options.clone(),
             track_rejects,
         );
+
+        // Set reference for EM-Seq if enabled
+        if let Some((ref reference, ref ref_names)) = em_seq_ref {
+            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        }
 
         // Accumulator for overlapping stats from parallel processing
         let mut merged_overlapping_stats = CorrectionStats::new();
@@ -441,6 +458,7 @@ impl Simplex {
     ///
     /// This method is called when `--threads N` is specified with N > 1.
     /// It uses the lock-free 7-step unified pipeline for maximum performance.
+    #[expect(clippy::too_many_arguments, reason = "pipeline setup needs all configuration")]
     fn execute_threads_mode(
         &self,
         num_threads: usize,
@@ -449,6 +467,7 @@ impl Simplex {
         output_header: Header,
         read_name_prefix: String,
         track_rejects: bool,
+        em_seq_ref: EmSeqRef,
     ) -> Result<()> {
         // Configure pipeline
         let mut pipeline_config = build_pipeline_config(
@@ -490,6 +509,7 @@ impl Simplex {
             trim,
             min_consensus_base_quality,
             cell_tag: Some(cell_tag),
+            em_seq: self.em_seq_opts.em_seq,
         };
 
         // Clone input_header before pipeline (needed for rejects writing)
@@ -520,6 +540,11 @@ impl Simplex {
                     options.clone(),
                     track_rejects,
                 );
+
+                // Set reference for EM-Seq if enabled
+                if let Some((ref reference, ref ref_names)) = em_seq_ref {
+                    caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+                }
 
                 // Create overlapping caller if enabled
                 let mut overlapping_caller = if overlapping_enabled {
@@ -728,6 +753,7 @@ mod tests {
             min_reads: 1,
             max_reads: None,
             scheduler_opts: SchedulerOptions::default(),
+            em_seq_opts: EmSeqOptions::default(),
         }
     }
 
@@ -1578,5 +1604,76 @@ mod tests {
         assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
         // Should also include Vec<Vec<u8>> overhead
         assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
+    }
+
+    #[rstest]
+    #[case::single_threaded(ThreadingOptions::none())]
+    #[case::multi_threaded(ThreadingOptions::new(2))]
+    fn test_simplex_em_seq_command(#[case] threading: ThreadingOptions) -> Result<()> {
+        use crate::sam::builder::{Strand, create_test_fasta};
+
+        // Create a FASTA with chr1 containing C bases at positions 0..20
+        let ref_seq = "C".repeat(200);
+        let ref_fasta = create_test_fasta(&[("chr1", &ref_seq)])?;
+
+        // Create mapped reads with MI tag showing C bases (methylated) at ref-C positions
+        let mut builder = SamBuilder::with_single_ref("chr1", 200);
+        let mut attrs = HashMap::new();
+        attrs.insert("MI", BufValue::from("1"));
+
+        // Add 3 fragment reads at position 1 (1-based), all showing C (methylated)
+        for i in 0..3 {
+            let _ = builder
+                .add_frag()
+                .name(&format!("r{i}"))
+                .start(1)
+                .strand(Strand::Plus)
+                .bases("CCCCCCCCCC")
+                .attr("MI", BufValue::from("1"))
+                .build();
+        }
+
+        let paths = TestPaths::new()?;
+        builder.write(&paths.input)?;
+
+        let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
+        cmd.em_seq_opts.em_seq = true;
+        cmd.em_seq_opts.reference = Some(ref_fasta.path().to_path_buf());
+        cmd.threading = threading;
+        cmd.execute("test")?;
+
+        let records = read_bam_records(&paths.output)?;
+        assert_eq!(records.len(), 1, "Should have 1 consensus read");
+
+        // Verify methylation tags are present and correct
+        use noodles::sam::alignment::record_buf::data::field::value::{
+            Array as BufArray, Value as BufValue,
+        };
+        let record = &records[0];
+        let cu_tag = Tag::from([b'c', b'u']);
+        let cu_value = record.data().get(&cu_tag).expect("cu tag should be present with EM-Seq");
+        // All 3 reads show C at ref-C positions → unconverted counts should be non-zero
+        if let BufValue::Array(BufArray::Int16(cu_vals)) = cu_value {
+            assert!(
+                cu_vals.iter().any(|&v| v > 0),
+                "cu should have non-zero values for methylated reads"
+            );
+        } else {
+            panic!("cu tag should be an i16 array");
+        }
+
+        let ct_tag = Tag::from([b'c', b't']);
+        let ct_value = record.data().get(&ct_tag).expect("ct tag should be present with EM-Seq");
+        // All reads show C (not T) → converted counts should be 0
+        if let BufValue::Array(BufArray::Int16(ct_vals)) = ct_value {
+            assert!(
+                ct_vals.iter().all(|&v| v == 0),
+                "ct should be all zeros for fully methylated reads"
+            );
+        } else {
+            panic!("ct tag should be an i16 array");
+        }
+
+        Ok(())
     }
 }

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -363,6 +363,18 @@ impl fgumi_sam::ReferenceProvider for ReferenceReader {
     }
 }
 
+#[cfg(feature = "simplex")]
+impl fgumi_consensus::methylation::RefBaseProvider for ReferenceReader {
+    fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8> {
+        let sequence = self.sequences.get(chrom)?;
+        sequence.get(usize::try_from(pos).ok()?).copied()
+    }
+
+    fn sequence_for(&self, chrom: &str) -> Option<&[u8]> {
+        self.sequences.get(chrom).map(Vec::as_slice)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- New `methylation.rs` module with `RefBaseProvider` trait and methylation annotation functions
- Simplex caller: `--em-seq` flag annotates per-base `cu`/`ct` methylation count tags, stores original CIGAR for post-consensus reference alignment
- Duplex caller: `--em-seq` flag annotates methylation from AB (`au`/`at`) and BA (`bu`/`bt`) strands with strand-aware conversion tracking
- Shared `load_em_seq_reference()` helper in `common.rs`
- Methylation tags track per-base counts of unconverted and converted bases relative to reference

## Stack
1/4 — EM-seq support (base of EM-seq stack)

## Test plan
- [x] Unit tests for `annotate_simplex_methylation` and `annotate_duplex_methylation`
- [x] Tests cover forward/reverse strand, insertions, deletions, mixed methylation
- [x] Existing simplex/duplex tests pass unchanged
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes