### PR TITLE
feat(filter): add EM-Seq methylation filters and performance improvements

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -13,6 +13,19 @@ use crate::phred::{MIN_PHRED, NO_CALL_BASE};
 use crate::tags::{per_base, per_read};
 use fgumi_metrics::rejection::RejectionReason;
 
+/// Expands a 1-3 element slice to a 3-element array, filling missing values from the last.
+///
+/// # Panics
+/// Panics if `values` is empty.
+fn expand_three_from_last<T: Copy>(values: &[T]) -> [T; 3] {
+    match values {
+        [a, b, c, ..] => [*a, *b, *c],
+        [a, b] => [*a, *b, *b],
+        [a] => [*a, *a, *a],
+        [] => panic!("at least one value required"),
+    }
+}
+
 /// Filter thresholds for consensus reads
 #[derive(Debug, Clone)]
 pub struct FilterThresholds {
@@ -229,53 +242,28 @@ impl FilterConfig {
         min_mean_base_quality: Option<f64>,
         max_no_call_fraction: f64,
     ) -> Self {
-        // Helper to get threshold at index with fallback
-        let get_threshold = |values: &[usize], index: usize| -> usize {
-            match values.len() {
-                2 => {
-                    if index == 0 {
-                        values[0]
-                    } else {
-                        values[1]
-                    }
-                }
-                3 => values[index],
-                _ => values[0],
-            }
-        };
-
-        let get_threshold_f64 = |values: &[f64], index: usize| -> f64 {
-            match values.len() {
-                2 => {
-                    if index == 0 {
-                        values[0]
-                    } else {
-                        values[1]
-                    }
-                }
-                3 => values[index],
-                _ => values[0],
-            }
-        };
+        let [cc_reads, ab_reads, ba_reads] = expand_three_from_last(min_reads);
+        let [cc_read_err, ab_read_err, ba_read_err] = expand_three_from_last(max_read_error_rate);
+        let [cc_base_err, ab_base_err, ba_base_err] = expand_three_from_last(max_base_error_rate);
 
         // Create thresholds for all levels - matching fgbio which always creates all three
         // when filtering either simplex or duplex reads. Single values are replicated to all levels.
         let duplex_thresholds = Some(FilterThresholds {
-            min_reads: get_threshold(min_reads, 0),
-            max_read_error_rate: get_threshold_f64(max_read_error_rate, 0),
-            max_base_error_rate: get_threshold_f64(max_base_error_rate, 0),
+            min_reads: cc_reads,
+            max_read_error_rate: cc_read_err,
+            max_base_error_rate: cc_base_err,
         });
 
         let ab_thresholds = Some(FilterThresholds {
-            min_reads: get_threshold(min_reads, 1),
-            max_read_error_rate: get_threshold_f64(max_read_error_rate, 1),
-            max_base_error_rate: get_threshold_f64(max_base_error_rate, 1),
+            min_reads: ab_reads,
+            max_read_error_rate: ab_read_err,
+            max_base_error_rate: ab_base_err,
         });
 
         let ba_thresholds = Some(FilterThresholds {
-            min_reads: get_threshold(min_reads, 2),
-            max_read_error_rate: get_threshold_f64(max_read_error_rate, 2),
-            max_base_error_rate: get_threshold_f64(max_base_error_rate, 2),
+            min_reads: ba_reads,
+            max_read_error_rate: ba_read_err,
+            max_base_error_rate: ba_base_err,
         });
 
         // Also create single-strand thresholds using the first value
@@ -905,6 +893,51 @@ pub fn is_duplex_consensus(record: &RecordBuf) -> bool {
 // ============================================================================
 
 use fgumi_raw_bam as bam_fields;
+use noodles::sam::alignment::record::cigar::op::Kind;
+
+/// Pre-parsed methylation aux tags from a raw BAM record.
+///
+/// Avoids repeated linear scans of the aux block when multiple filters
+/// need the same tag arrays.
+pub struct MethylationTags {
+    /// Unconverted counts (combined/simplex).
+    pub cu: Option<Vec<u16>>,
+    /// Converted counts (combined/simplex).
+    pub ct: Option<Vec<u16>>,
+    /// AB-strand unconverted counts (duplex).
+    pub au: Option<Vec<u16>>,
+    /// AB-strand converted counts (duplex).
+    pub at: Option<Vec<u16>>,
+    /// BA-strand unconverted counts (duplex).
+    pub bu: Option<Vec<u16>>,
+    /// BA-strand converted counts (duplex).
+    pub bt: Option<Vec<u16>>,
+}
+
+impl MethylationTags {
+    /// Parses all methylation tags from a raw BAM record's aux data.
+    #[must_use]
+    pub fn from_record(record: &[u8]) -> Self {
+        use crate::tags::per_base;
+
+        let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
+        let aux = &record[aux_off..];
+        Self {
+            cu: Self::find_tag(aux, per_base::UNCONVERTED_COUNT),
+            ct: Self::find_tag(aux, per_base::CONVERTED_COUNT),
+            au: Self::find_tag(aux, per_base::AB_UNCONVERTED_COUNT),
+            at: Self::find_tag(aux, per_base::AB_CONVERTED_COUNT),
+            bu: Self::find_tag(aux, per_base::BA_UNCONVERTED_COUNT),
+            bt: Self::find_tag(aux, per_base::BA_CONVERTED_COUNT),
+        }
+    }
+
+    /// Looks up a 2-character tag in the aux data and returns its values as `Vec<u16>`.
+    fn find_tag(aux: &[u8], tag: &str) -> Option<Vec<u16>> {
+        let tag_bytes: [u8; 2] = [tag.as_bytes()[0], tag.as_bytes()[1]];
+        bam_fields::find_array_tag(aux, &tag_bytes).map(|r| bam_fields::array_tag_to_vec_u16(&r))
+    }
+}
 
 /// Detects if a raw BAM record is a duplex consensus.
 ///
@@ -1232,6 +1265,400 @@ pub fn mask_duplex_bases_raw(
     }
 
     Ok(masked_count)
+}
+
+// ============================================================================
+// Methylation (EM-Seq) filter functions
+// ============================================================================
+
+/// Thresholds for methylation depth filtering.
+///
+/// Mirrors the 1-3 value pattern used by other duplex thresholds:
+/// `[duplex, AB, BA]` where missing values are filled from the last provided.
+#[derive(Debug, Clone)]
+pub struct MethylationDepthThresholds {
+    /// Minimum combined depth (cu+ct) for the final consensus.
+    pub duplex: usize,
+    /// Minimum depth (au+at) for the AB strand.
+    pub ab: usize,
+    /// Minimum depth (bu+bt) for the BA strand.
+    pub ba: usize,
+}
+
+impl MethylationDepthThresholds {
+    /// Creates thresholds from a 1-3 element slice, filling missing values from the last.
+    ///
+    /// # Panics
+    /// Panics if `values` is empty.
+    #[must_use]
+    pub fn from_values(values: &[usize]) -> Self {
+        assert!(!values.is_empty(), "min-methylation-depth must have at least 1 value");
+        let [duplex, ab, ba] = expand_three_from_last(values);
+        Self { duplex, ab, ba }
+    }
+}
+
+/// Masks bases in a raw simplex consensus read where methylation depth is too low.
+///
+/// At each position, checks if `cu[i] + ct[i] < min_depth` and masks if so.
+/// Returns the number of newly masked bases.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_methylation_depth_simplex_raw(record: &mut [u8], min_depth: usize) -> Result<usize> {
+    let tags = MethylationTags::from_record(record);
+    mask_methylation_depth_simplex_raw_with_tags(record, min_depth, &tags)
+}
+
+/// Like [`mask_methylation_depth_simplex_raw`] but accepts pre-parsed methylation tags.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_methylation_depth_simplex_raw_with_tags(
+    record: &mut [u8],
+    min_depth: usize,
+    tags: &MethylationTags,
+) -> Result<usize> {
+    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
+    let seq_off = bam_fields::seq_offset(record);
+    let qual_off = bam_fields::qual_offset(record);
+    let len = bam_fields::l_seq(record) as usize;
+
+    // If no methylation tags present, nothing to filter
+    if tags.cu.is_none() && tags.ct.is_none() {
+        return Ok(0);
+    }
+
+    let mut masked_count = 0;
+    for i in 0..len {
+        if bam_fields::is_base_n(record, seq_off, i) {
+            continue;
+        }
+        let cu = tags.cu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let ct = tags.ct.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let total = (cu as usize) + (ct as usize);
+        if total < min_depth {
+            masked_count += 1;
+            bam_fields::mask_base(record, seq_off, i);
+            bam_fields::set_qual(record, qual_off, i, MIN_PHRED);
+        }
+    }
+    Ok(masked_count)
+}
+
+/// Masks bases in a raw duplex consensus read where methylation depth is too low.
+///
+/// Checks combined (cu+ct), AB (au+at), and BA (bu+bt) depths against their
+/// respective thresholds.
+/// Returns the number of newly masked bases.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_methylation_depth_duplex_raw(
+    record: &mut [u8],
+    thresholds: &MethylationDepthThresholds,
+) -> Result<usize> {
+    let tags = MethylationTags::from_record(record);
+    mask_methylation_depth_duplex_raw_with_tags(record, thresholds, &tags)
+}
+
+/// Like [`mask_methylation_depth_duplex_raw`] but accepts pre-parsed methylation tags.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_methylation_depth_duplex_raw_with_tags(
+    record: &mut [u8],
+    thresholds: &MethylationDepthThresholds,
+    tags: &MethylationTags,
+) -> Result<usize> {
+    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
+    let seq_off = bam_fields::seq_offset(record);
+    let qual_off = bam_fields::qual_offset(record);
+    let len = bam_fields::l_seq(record) as usize;
+
+    // If no methylation tags present, nothing to filter
+    if tags.cu.is_none() && tags.ct.is_none() {
+        return Ok(0);
+    }
+
+    let mut masked_count = 0;
+    for i in 0..len {
+        if bam_fields::is_base_n(record, seq_off, i) {
+            continue;
+        }
+        let cu = tags.cu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let ct = tags.ct.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let au = tags.au.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let at = tags.at.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let bu = tags.bu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let bt = tags.bt.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+
+        let cc_total = (cu as usize) + (ct as usize);
+        let ab_total = (au as usize) + (at as usize);
+        let ba_total = (bu as usize) + (bt as usize);
+
+        if cc_total < thresholds.duplex || ab_total < thresholds.ab || ba_total < thresholds.ba {
+            masked_count += 1;
+            bam_fields::mask_base(record, seq_off, i);
+            bam_fields::set_qual(record, qual_off, i, MIN_PHRED);
+        }
+    }
+    Ok(masked_count)
+}
+
+/// Resolves the reference bases for a raw BAM record's alignment region.
+///
+/// Returns a vector of `Option<u8>` mapping each query position to its reference base
+/// (uppercased), or `None` for insertions/soft-clips. Returns `None` if the record is
+/// unmapped or the reference cannot be resolved.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "ref_id and pos are non-negative for mapped records (checked above)"
+)]
+pub fn resolve_ref_bases_for_record(
+    record: &[u8],
+    reference: &dyn crate::methylation::RefBaseProvider,
+    ref_names: &[String],
+) -> Option<Vec<Option<u8>>> {
+    let flags = bam_fields::flags(record);
+    if flags & bam_fields::flags::UNMAPPED != 0 {
+        return None;
+    }
+
+    let tid = bam_fields::ref_id(record);
+    if tid < 0 {
+        return None;
+    }
+    let ref_name = ref_names.get(tid as usize)?;
+    let alignment_start = bam_fields::pos(record) as u64; // 0-based
+
+    // Try to get the full sequence slice for O(1) indexed access per base,
+    // avoiding a HashMap lookup per position.
+    let ref_seq = reference.sequence_for(ref_name);
+
+    let cigar_ops = bam_fields::get_cigar_ops(record);
+    let len = bam_fields::l_seq(record) as usize;
+    let mut result = Vec::with_capacity(len);
+    let mut ref_pos = alignment_start;
+
+    for &op in &cigar_ops {
+        let op_len = (op >> 4) as usize;
+        let kind = bam_fields::cigar_op_kind(op);
+        match kind {
+            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                for _ in 0..op_len {
+                    let base = if let Some(seq) = ref_seq {
+                        usize::try_from(ref_pos)
+                            .ok()
+                            .and_then(|p| seq.get(p).copied())
+                            .map(|b| b.to_ascii_uppercase())
+                    } else {
+                        reference.base_at_0based(ref_name, ref_pos).map(|b| b.to_ascii_uppercase())
+                    };
+                    result.push(base);
+                    ref_pos += 1;
+                }
+            }
+            Kind::Insertion | Kind::SoftClip => {
+                for _ in 0..op_len {
+                    result.push(None);
+                }
+            }
+            Kind::Deletion | Kind::Skip => {
+                ref_pos += op_len as u64;
+            }
+            _ => {}
+        }
+    }
+
+    result.truncate(len);
+    while result.len() < len {
+        result.push(None);
+    }
+
+    Some(result)
+}
+
+/// Masks `CpG` positions in a raw duplex consensus where top and bottom strands disagree
+/// on methylation status.
+///
+/// At a `CpG` dinucleotide (ref positions X and `X+1`):
+/// - Position X (`ref=C`): top-strand methylation from `au`/`at` tags
+/// - Position `X+1` (`ref=G`): bottom-strand methylation from `bu`/`bt` tags (complement)
+///
+/// If one strand calls methylated and the other calls unmethylated, both positions
+/// are masked.
+///
+/// Returns the number of newly masked bases.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_strand_methylation_agreement_raw(
+    record: &mut [u8],
+    reference: &dyn crate::methylation::RefBaseProvider,
+    ref_names: &[String],
+) -> Result<usize> {
+    let ref_base_map = resolve_ref_bases_for_record(record, reference, ref_names);
+    let tags = MethylationTags::from_record(record);
+    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
+        record,
+        ref_base_map.as_deref(),
+        &tags,
+    )
+}
+
+/// Like [`mask_strand_methylation_agreement_raw`] but accepts both pre-resolved reference
+/// bases and pre-parsed methylation tags, avoiding all redundant work.
+///
+/// # Errors
+/// Returns an error if the record is too short.
+pub fn mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
+    record: &mut [u8],
+    ref_base_map: Option<&[Option<u8>]>,
+    tags: &MethylationTags,
+) -> Result<usize> {
+    anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
+
+    let Some(ref_base_map) = ref_base_map else {
+        return Ok(0);
+    };
+
+    let seq_off = bam_fields::seq_offset(record);
+    let qual_off = bam_fields::qual_offset(record);
+    let len = bam_fields::l_seq(record) as usize;
+
+    // If no per-strand methylation tags, nothing to check
+    if tags.au.is_none() && tags.bu.is_none() {
+        return Ok(0);
+    }
+
+    // Identify CpG dinucleotides and check strand agreement.
+    // A CpG is where ref_base[i] = C and ref_base[i+1] = G,
+    // and both positions are aligned (Some).
+    let mut should_mask = vec![false; len];
+
+    for i in 0..len.saturating_sub(1) {
+        let (Some(Some(b'C')), Some(Some(b'G'))) = (ref_base_map.get(i), ref_base_map.get(i + 1))
+        else {
+            continue;
+        };
+
+        // Position i: top-strand C -> check au/at for methylation
+        let top_unconverted = tags.au.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let top_converted = tags.at.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+
+        // Position i+1: bottom-strand G (complement of C) -> check bu/bt for methylation
+        let bot_unconverted = tags.bu.as_ref().map_or(0u16, |v| v.get(i + 1).copied().unwrap_or(0));
+        let bot_converted = tags.bt.as_ref().map_or(0u16, |v| v.get(i + 1).copied().unwrap_or(0));
+
+        let top_total = u32::from(top_unconverted) + u32::from(top_converted);
+        let bot_total = u32::from(bot_unconverted) + u32::from(bot_converted);
+
+        // Skip if either strand has no evidence
+        if top_total == 0 || bot_total == 0 {
+            continue;
+        }
+
+        // Call methylated if unconverted > converted (majority rule)
+        let top_methylated = top_unconverted > top_converted;
+        let bot_methylated = bot_unconverted > bot_converted;
+
+        if top_methylated != bot_methylated {
+            should_mask[i] = true;
+            should_mask[i + 1] = true;
+        }
+    }
+
+    let mut masked_count = 0;
+    for (i, &mask) in should_mask.iter().enumerate() {
+        if mask && !bam_fields::is_base_n(record, seq_off, i) {
+            masked_count += 1;
+            bam_fields::mask_base(record, seq_off, i);
+            bam_fields::set_qual(record, qual_off, i, MIN_PHRED);
+        }
+    }
+
+    Ok(masked_count)
+}
+
+/// Checks the bisulfite/enzymatic conversion fraction at non-CpG cytosines.
+///
+/// Returns `true` if the read passes (conversion fraction >= threshold), or if
+/// there are no non-CpG cytosine positions to evaluate.
+///
+/// At non-CpG ref-C positions, the expected behavior is conversion (C->T).
+/// A low conversion rate suggests incomplete enzymatic conversion.
+pub fn check_conversion_fraction_raw(
+    record: &[u8],
+    min_fraction: f64,
+    reference: &dyn crate::methylation::RefBaseProvider,
+    ref_names: &[String],
+) -> bool {
+    let ref_base_map = resolve_ref_bases_for_record(record, reference, ref_names);
+    let tags = MethylationTags::from_record(record);
+    check_conversion_fraction_raw_with_ref_bases_and_tags(
+        record,
+        min_fraction,
+        ref_base_map.as_deref(),
+        &tags,
+    )
+}
+
+/// Like [`check_conversion_fraction_raw`] but accepts both pre-resolved reference bases
+/// and pre-parsed methylation tags, avoiding all redundant work.
+#[must_use]
+pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
+    record: &[u8],
+    min_fraction: f64,
+    ref_base_map: Option<&[Option<u8>]>,
+    tags: &MethylationTags,
+) -> bool {
+    let Some(ref_base_map) = ref_base_map else {
+        return true; // unmapped reads pass
+    };
+
+    let len = bam_fields::l_seq(record) as usize;
+
+    // If no methylation tags, pass
+    if tags.cu.is_none() && tags.ct.is_none() {
+        return true;
+    }
+
+    let mut total_converted: u64 = 0;
+    let mut total_evidence: u64 = 0;
+
+    for i in 0..len {
+        // Only consider non-CpG ref-C positions
+        let Some(Some(b'C')) = ref_base_map.get(i) else {
+            continue;
+        };
+
+        // Check if this is a CpG (next base is G) -- skip CpG sites
+        let is_cpg = i + 1 < len && matches!(ref_base_map.get(i + 1), Some(Some(b'G')));
+        if is_cpg {
+            continue;
+        }
+
+        let cu = tags.cu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let ct = tags.ct.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let evidence = u64::from(cu) + u64::from(ct);
+        if evidence > 0 {
+            total_converted += u64::from(ct);
+            total_evidence += evidence;
+        }
+    }
+
+    // If no non-CpG C positions with evidence, pass
+    if total_evidence == 0 {
+        return true;
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is acceptable for fraction calculation"
+    )]
+    let fraction = total_converted as f64 / total_evidence as f64;
+    fraction >= min_fraction
 }
 
 #[cfg(test)]
@@ -2403,5 +2830,441 @@ mod tests {
 
         let result = super::find_string_or_uint8_array(&aux, *b"ac");
         assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // Methylation filter tests
+    // ========================================================================
+
+    /// Helper: build a raw BAM record with methylation tags from a `RecordBuf`.
+    fn build_raw_with_methylation_tags(
+        header: &noodles::sam::Header,
+        record: &RecordBuf,
+    ) -> Vec<u8> {
+        let mut raw = Vec::new();
+        crate::vendored::bam_codec::encoder::encode_record_buf(&mut raw, header, record)
+            .expect("encoding should succeed");
+        raw
+    }
+
+    /// Helper: create a `SamBuilder` for mapped record tests.
+    fn sam_builder_for_methylation() -> fgumi_sam::builder::SamBuilder {
+        //                  0123456789
+        // Reference:       ACGTCGATCG
+        fgumi_sam::builder::SamBuilder::with_single_ref("chr1", 1000)
+    }
+
+    /// Helper: add an i16 array tag to a `RecordBuf`.
+    fn add_i16_array_tag(record: &mut RecordBuf, tag_str: &str, values: &[i16]) {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+        let tag = Tag::from([tag_str.as_bytes()[0], tag_str.as_bytes()[1]]);
+        record.data_mut().insert(tag, Value::Array(Array::Int16(values.to_vec())));
+    }
+
+    // -- MethylationDepthThresholds tests --
+
+    #[test]
+    fn test_methylation_depth_thresholds_single_value() {
+        let t = MethylationDepthThresholds::from_values(&[5]);
+        assert_eq!(t.duplex, 5);
+        assert_eq!(t.ab, 5);
+        assert_eq!(t.ba, 5);
+    }
+
+    #[test]
+    fn test_methylation_depth_thresholds_two_values() {
+        let t = MethylationDepthThresholds::from_values(&[10, 3]);
+        assert_eq!(t.duplex, 10);
+        assert_eq!(t.ab, 3);
+        assert_eq!(t.ba, 3);
+    }
+
+    #[test]
+    fn test_methylation_depth_thresholds_three_values() {
+        let t = MethylationDepthThresholds::from_values(&[10, 5, 2]);
+        assert_eq!(t.duplex, 10);
+        assert_eq!(t.ab, 5);
+        assert_eq!(t.ba, 2);
+    }
+
+    // -- mask_methylation_depth_simplex_raw tests --
+
+    #[test]
+    fn test_mask_methylation_depth_simplex_all_pass() {
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        // cu+ct = 5+3=8 at each position, min_depth=5 -> all pass
+        add_i16_array_tag(&mut record, "cu", &[5, 5, 5, 5]);
+        add_i16_array_tag(&mut record, "ct", &[3, 3, 3, 3]);
+
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
+        assert_eq!(masked, 0);
+    }
+
+    #[test]
+    fn test_mask_methylation_depth_simplex_some_fail() {
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        // Position 0: cu+ct = 5+3=8 -> pass
+        // Position 1: cu+ct = 1+1=2 -> fail (< 5)
+        // Position 2: cu+ct = 0+0=0 -> fail
+        // Position 3: cu+ct = 10+0=10 -> pass
+        add_i16_array_tag(&mut record, "cu", &[5, 1, 0, 10]);
+        add_i16_array_tag(&mut record, "ct", &[3, 1, 0, 0]);
+
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
+        assert_eq!(masked, 2, "Positions 1 and 2 should be masked");
+    }
+
+    #[test]
+    fn test_mask_methylation_depth_simplex_no_tags_no_masking() {
+        let sam = sam_builder_for_methylation();
+        let record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        // No cu/ct tags
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
+        assert_eq!(masked, 0, "No methylation tags should mean no masking");
+    }
+
+    // -- mask_methylation_depth_duplex_raw tests --
+
+    #[test]
+    fn test_mask_methylation_depth_duplex_all_pass() {
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        add_i16_array_tag(&mut record, "cu", &[10, 10, 10, 10]);
+        add_i16_array_tag(&mut record, "ct", &[2, 2, 2, 2]);
+        add_i16_array_tag(&mut record, "au", &[5, 5, 5, 5]);
+        add_i16_array_tag(&mut record, "at", &[1, 1, 1, 1]);
+        add_i16_array_tag(&mut record, "bu", &[5, 5, 5, 5]);
+        add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
+
+        let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
+        assert_eq!(masked, 0);
+    }
+
+    #[test]
+    fn test_mask_methylation_depth_duplex_ab_fails() {
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        // Duplex passes (cu+ct=12), but AB fails at position 1 (au+at=1 < 3)
+        add_i16_array_tag(&mut record, "cu", &[10, 10, 10, 10]);
+        add_i16_array_tag(&mut record, "ct", &[2, 2, 2, 2]);
+        add_i16_array_tag(&mut record, "au", &[5, 0, 5, 5]);
+        add_i16_array_tag(&mut record, "at", &[1, 1, 1, 1]);
+        add_i16_array_tag(&mut record, "bu", &[5, 5, 5, 5]);
+        add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
+
+        let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
+        assert_eq!(masked, 1, "Position 1 should be masked (AB depth too low)");
+    }
+
+    // -- mask_strand_methylation_agreement_raw tests --
+
+    #[test]
+    fn test_strand_methylation_agreement_concordant() {
+        use crate::methylation::tests::TestRef;
+        // Reference: ...CG... at positions 5,6
+        // Both strands agree: methylated at CpG
+        let ref_seq = b"AAAAACGAAAA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("AAAAACGAAAA")
+            .qualities(&[30; 11])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("11M")
+            .build();
+        // au/at at position 5 (C): methylated (au=10, at=1)
+        // bu/bt at position 6 (G): methylated (bu=10, bt=1)
+        add_i16_array_tag(&mut record, "au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
+
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked =
+            mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
+        assert_eq!(masked, 0, "Concordant CpG should not be masked");
+    }
+
+    #[test]
+    fn test_strand_methylation_agreement_discordant() {
+        use crate::methylation::tests::TestRef;
+        // Reference: ...CG... at positions 5,6
+        // Top strand says methylated, bottom says unmethylated
+        let ref_seq = b"AAAAACGAAAA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("AAAAACGAAAA")
+            .qualities(&[30; 11])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("11M")
+            .build();
+        // au/at at position 5 (C): methylated (au=10, at=1)
+        // bu/bt at position 6 (G): unmethylated (bu=1, bt=10)
+        add_i16_array_tag(&mut record, "au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
+
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked =
+            mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
+        assert_eq!(masked, 2, "Both CpG positions should be masked when strands disagree");
+    }
+
+    #[test]
+    fn test_strand_methylation_agreement_non_cpg_ignored() {
+        use crate::methylation::tests::TestRef;
+        // Reference: no CpG sites, just scattered C and G
+        let ref_seq = b"ACAGTGCATGA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACAGTGCATGA")
+            .qualities(&[30; 11])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("11M")
+            .build();
+        add_i16_array_tag(&mut record, "au", &[0; 11]);
+        add_i16_array_tag(&mut record, "at", &[0; 11]);
+        add_i16_array_tag(&mut record, "bu", &[0; 11]);
+        add_i16_array_tag(&mut record, "bt", &[0; 11]);
+
+        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let masked =
+            mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
+        assert_eq!(masked, 0, "Non-CpG sites should not be masked");
+    }
+
+    // -- check_conversion_fraction_raw tests --
+
+    #[test]
+    fn test_conversion_fraction_passes_high_conversion() {
+        use crate::methylation::tests::TestRef;
+        // Reference: ACATACATA (non-CpG C at positions 1, 4 -- A before each C means not CpG)
+        //            012345678
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Non-CpG C at positions 1 and 4: high conversion (ct >> cu)
+        // cu: unconverted count, ct: converted count
+        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 1, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 9, 0, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // 18 converted out of 20 = 90% conversion
+        assert!(
+            check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
+            "Should pass with high conversion fraction"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_fails_low_conversion() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Non-CpG C at positions 1 and 4: low conversion (cu >> ct)
+        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 9, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 1, 0, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // 2 converted out of 20 = 10% conversion
+        assert!(
+            !check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
+            "Should fail with low conversion fraction"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_skips_cpg() {
+        use crate::methylation::tests::TestRef;
+        // Reference with CpG at position 4-5: AAAA CG AAA
+        let ref_seq = b"AAAACGAAA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("AAAACGAAA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // CpG C at position 4: high unconverted (methylated) -- should be EXCLUDED
+        // No non-CpG C positions -> should pass vacuously
+        add_i16_array_tag(&mut record, "cu", &[0, 0, 0, 0, 10, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        assert!(
+            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            "Should pass because CpG sites are excluded from conversion check"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_no_methylation_tags_passes() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // No cu/ct tags
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        assert!(
+            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            "Should pass with no methylation tags"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_unmapped_passes() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let record = RecordBuilder::new().sequence("ACATACATA").qualities(&[30; 9]).build();
+        // Unmapped record (no ref_id, no cigar)
+        let raw = build_raw_with_methylation_tags(&noodles::sam::Header::default(), &record);
+        assert!(
+            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            "Unmapped reads should pass"
+        );
+    }
+
+    // -- resolve_ref_bases_for_record tests --
+
+    #[test]
+    fn test_resolve_ref_bases_simple_match() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACGTACGTAC";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let record = RecordBuilder::new()
+            .sequence("ACGT")
+            .qualities(&[30; 4])
+            .reference_sequence_id(0)
+            .alignment_start(1) // 1-based -> 0-based pos=0
+            .mapping_quality(60)
+            .cigar("4M")
+            .build();
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
+        assert_eq!(bases, vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')]);
+    }
+
+    #[test]
+    fn test_resolve_ref_bases_with_insertion() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACGTACGTAC";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let record = RecordBuilder::new()
+            .sequence("ACNNGT") // 2M2I2M -> positions 2,3 are insertions
+            .qualities(&[30; 6])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("2M2I2M")
+            .build();
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
+        assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, None, Some(b'G'), Some(b'T')]);
     }
 }

--- a/crates/fgumi-consensus/src/tags.rs
+++ b/crates/fgumi-consensus/src/tags.rs
@@ -116,6 +116,25 @@ pub mod per_base {
     /// The phred-scaled qualities (as phred-33 ascii values) of the BA single-strand consensus
     pub const BA_CONSENSUS_QUALS: &str = "bq";
 
+    // EM-Seq methylation count tags
+    /// Per-base count of unconverted bases (combined/simplex consensus)
+    pub const UNCONVERTED_COUNT: &str = "cu";
+
+    /// Per-base count of converted bases (combined/simplex consensus)
+    pub const CONVERTED_COUNT: &str = "ct";
+
+    /// Per-base count of unconverted bases (AB strand, duplex)
+    pub const AB_UNCONVERTED_COUNT: &str = "au";
+
+    /// Per-base count of converted bases (AB strand, duplex)
+    pub const AB_CONVERTED_COUNT: &str = "at";
+
+    /// Per-base count of unconverted bases (BA strand, duplex)
+    pub const BA_UNCONVERTED_COUNT: &str = "bu";
+
+    /// Per-base count of converted bases (BA strand, duplex)
+    pub const BA_CONVERTED_COUNT: &str = "bt";
+
     /// All per-base tags that need to be reversed for negative-strand reads
     pub const TAGS_TO_REVERSE: &[&str] = &[
         RAW_READ_COUNT,
@@ -126,6 +145,12 @@ pub mod per_base {
         BA_RAW_READ_ERRORS,
         AB_CONSENSUS_QUALS,
         BA_CONSENSUS_QUALS,
+        UNCONVERTED_COUNT,
+        CONVERTED_COUNT,
+        AB_UNCONVERTED_COUNT,
+        AB_CONVERTED_COUNT,
+        BA_UNCONVERTED_COUNT,
+        BA_CONVERTED_COUNT,
     ];
 
     /// All per-base tags that need to be reverse complemented for negative-strand reads
@@ -143,6 +168,12 @@ pub mod per_base {
         BA_CONSENSUS_QUALS,
         AB_CONSENSUS_BASES,
         BA_CONSENSUS_BASES,
+        UNCONVERTED_COUNT,
+        CONVERTED_COUNT,
+        AB_UNCONVERTED_COUNT,
+        AB_CONVERTED_COUNT,
+        BA_UNCONVERTED_COUNT,
+        BA_CONVERTED_COUNT,
     ];
 
     /// Returns all per-base tags that need to be reversed for negative-strand reads
@@ -254,7 +285,6 @@ pub fn is_consensus(rec: &impl noodles::sam::alignment::Record) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bstr::ByteSlice;
     use fgumi_sam::builder::RecordBuilder;
 
     #[test]
@@ -373,7 +403,7 @@ mod tests {
         let value = qualities_to_tag_value(&quals);
         match value {
             noodles::sam::alignment::record_buf::data::field::value::Value::String(s) => {
-                assert_eq!(s.as_bytes(), &[33, 43, 63]);
+                assert_eq!(&**s, &[33, 43, 63]);
             }
             _ => panic!("Expected String value"),
         }

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -4,6 +4,27 @@ use crate::fields::{
     l_read_name, n_cigar_op, pos,
 };
 
+/// Converts a raw BAM CIGAR u32 op word to a noodles `Kind`.
+///
+/// Extracts the 4-bit op type from the raw u32 and maps it to the corresponding
+/// `Kind` variant. Returns `Kind::Pad` for unknown op types.
+#[inline]
+#[must_use]
+pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op::Kind {
+    use noodles::sam::alignment::record::cigar::op::Kind;
+    match raw_op & 0xF {
+        0 => Kind::Match,
+        1 => Kind::Insertion,
+        2 => Kind::Deletion,
+        3 => Kind::Skip,
+        4 => Kind::SoftClip,
+        5 => Kind::HardClip,
+        7 => Kind::SequenceMatch,
+        8 => Kind::SequenceMismatch,
+        _ => Kind::Pad,
+    }
+}
+
 /// Returns true if the CIGAR op type consumes the reference (M, D, N, =, X).
 #[inline]
 #[must_use]
@@ -1984,5 +2005,34 @@ mod tests {
     fn test_cigar_to_string_no_cigar() {
         let rec = make_bam_bytes(0, 0, 0, b"r1", &[], 4, -1, -1, &[]);
         assert_eq!(cigar_to_string_from_raw(&rec), "");
+    }
+
+    #[test]
+    fn test_cigar_op_kind_all_ops() {
+        use noodles::sam::alignment::record::cigar::op::Kind;
+        assert_eq!(cigar_op_kind(0), Kind::Match);
+        assert_eq!(cigar_op_kind(1), Kind::Insertion);
+        assert_eq!(cigar_op_kind(2), Kind::Deletion);
+        assert_eq!(cigar_op_kind(3), Kind::Skip);
+        assert_eq!(cigar_op_kind(4), Kind::SoftClip);
+        assert_eq!(cigar_op_kind(5), Kind::HardClip);
+        assert_eq!(cigar_op_kind(7), Kind::SequenceMatch);
+        assert_eq!(cigar_op_kind(8), Kind::SequenceMismatch);
+        // Unknown ops (6 = Pad, 9+ = Pad fallback)
+        assert_eq!(cigar_op_kind(6), Kind::Pad);
+        assert_eq!(cigar_op_kind(9), Kind::Pad);
+        assert_eq!(cigar_op_kind(15), Kind::Pad);
+    }
+
+    #[test]
+    fn test_cigar_op_kind_with_length_bits() {
+        use noodles::sam::alignment::record::cigar::op::Kind;
+        // Raw BAM encodes op_type in low 4 bits, length in upper 28 bits
+        // Verify cigar_op_kind masks correctly: 50M = (50 << 4) | 0
+        assert_eq!(cigar_op_kind(50 << 4), Kind::Match);
+        // 10I = (10 << 4) | 1
+        assert_eq!(cigar_op_kind(10 << 4 | 1), Kind::Insertion);
+        // 5D = (5 << 4) | 2
+        assert_eq!(cigar_op_kind(5 << 4 | 2), Kind::Deletion);
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -11,8 +11,13 @@
 use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::bam_io::create_bam_reader_for_pipeline;
 use crate::consensus_filter::{
-    FilterConfig, FilterResult, compute_read_stats_raw, filter_duplex_read_raw, filter_read_raw,
-    is_duplex_consensus_raw, mask_bases_raw, mask_duplex_bases_raw, template_passes_raw,
+    FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
+    check_conversion_fraction_raw_with_ref_bases_and_tags, compute_read_stats_raw,
+    filter_duplex_read_raw, filter_read_raw, is_duplex_consensus_raw, mask_bases_raw,
+    mask_duplex_bases_raw, mask_methylation_depth_duplex_raw_with_tags,
+    mask_methylation_depth_simplex_raw_with_tags,
+    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, resolve_ref_bases_for_record,
+    template_passes_raw,
 };
 use crate::grouper::{SingleRawRecordGrouper, TemplateGrouper};
 use crate::logging::OperationTimer;
@@ -170,6 +175,25 @@ pub struct Filter {
     #[arg(short = 's', long = "require-single-strand-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub require_single_strand_agreement: bool,
 
+    /// Minimum methylation depth (cu+ct) to keep a base call (EM-Seq only).
+    /// For duplex: provide 1-3 values for [duplex, AB consensus, BA consensus]
+    #[arg(long = "min-methylation-depth", value_delimiter = ',')]
+    pub min_methylation_depth: Vec<usize>,
+
+    #[allow(clippy::doc_markdown)]
+    /// Require strand methylation agreement at CpG sites for duplex consensus (EM-Seq only).
+    /// Masks both positions of a CpG dinucleotide when top and bottom strands disagree on
+    /// methylation status. Requires --ref.
+    #[arg(long = "require-strand-methylation-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub require_strand_methylation_agreement: bool,
+
+    #[allow(clippy::doc_markdown)]
+    /// Minimum bisulfite/enzymatic conversion fraction at non-CpG cytosines (EM-Seq only).
+    /// Reads with conversion rate below this threshold are discarded.
+    /// Requires --ref. Uses cu/ct tags.
+    #[arg(long = "min-conversion-fraction")]
+    pub min_conversion_fraction: Option<f64>,
+
     /// Compression options for output BAM.
     #[command(flatten)]
     pub compression: CompressionOptions,
@@ -258,6 +282,10 @@ struct FilterProcessCaptures {
     min_mean_base_quality: Option<f64>,
     max_no_call_fraction: f64,
     require_single_strand_agreement: bool,
+    methylation_depth_thresholds: Option<MethylationDepthThresholds>,
+    require_strand_methylation_agreement: bool,
+    min_conversion_fraction: Option<f64>,
+    ref_names: Arc<Vec<String>>,
     progress: Arc<AtomicU64>,
     header: Header,
 }
@@ -293,6 +321,15 @@ impl Command for Filter {
             info!("Min mean base quality: {q}");
         }
         info!("Max no-call fraction: {}", self.max_no_call_fraction);
+        if !self.min_methylation_depth.is_empty() {
+            info!("Min methylation depth: {:?}", self.min_methylation_depth);
+        }
+        if self.require_strand_methylation_agreement {
+            info!("Require strand methylation agreement: true");
+        }
+        if let Some(frac) = self.min_conversion_fraction {
+            info!("Min conversion fraction: {frac}");
+        }
 
         // Open input using streaming-capable reader for pipeline use
         let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
@@ -371,6 +408,8 @@ impl Filter {
         setup: &FilterPipelineSetup,
         header: &Header,
     ) -> FilterProcessCaptures {
+        let ref_names: Vec<String> =
+            header.reference_sequences().keys().map(|name| name.to_string()).collect();
         FilterProcessCaptures {
             config: Arc::clone(&setup.config),
             reference: setup.reference.clone(),
@@ -379,6 +418,14 @@ impl Filter {
             min_mean_base_quality: self.min_mean_base_quality,
             max_no_call_fraction: self.max_no_call_fraction,
             require_single_strand_agreement: self.require_single_strand_agreement,
+            methylation_depth_thresholds: if self.min_methylation_depth.is_empty() {
+                None
+            } else {
+                Some(MethylationDepthThresholds::from_values(&self.min_methylation_depth))
+            },
+            require_strand_methylation_agreement: self.require_strand_methylation_agreement,
+            min_conversion_fraction: self.min_conversion_fraction,
+            ref_names: Arc::new(ref_names),
             progress: Arc::clone(&setup.progress_counter),
             header: header.clone(),
         }
@@ -509,6 +556,10 @@ impl Filter {
                 ctx.require_single_strand_agreement,
                 ctx.min_mean_base_quality,
                 ctx.max_no_call_fraction,
+                ctx.methylation_depth_thresholds.as_ref(),
+                ctx.require_strand_methylation_agreement,
+                ctx.min_conversion_fraction,
+                &ctx.ref_names,
             )
             .map_err(io::Error::other)?;
 
@@ -585,6 +636,10 @@ impl Filter {
                         ctx.require_single_strand_agreement,
                         ctx.min_mean_base_quality,
                         ctx.max_no_call_fraction,
+                        ctx.methylation_depth_thresholds.as_ref(),
+                        ctx.require_strand_methylation_agreement,
+                        ctx.min_conversion_fraction,
+                        &ctx.ref_names,
                     )
                     .map_err(io::Error::other)?;
                     bases_masked += masked;
@@ -670,6 +725,10 @@ impl Filter {
         require_ss_agreement: bool,
         min_mean_base_quality: Option<f64>,
         max_no_call_fraction: f64,
+        methylation_depth_thresholds: Option<&MethylationDepthThresholds>,
+        require_strand_methylation_agreement: bool,
+        min_conversion_fraction: Option<f64>,
+        ref_names: &[String],
     ) -> Result<(u64, bool)> {
         // Fail fast if we encounter a mapped read without a reference, since masking
         // can invalidate NM/UQ/MD tags and we have no way to regenerate them.
@@ -692,7 +751,7 @@ impl Filter {
             is_duplex_consensus_raw(aux)
         };
 
-        let masked_count = if is_duplex {
+        let mut masked_count = if is_duplex {
             let (cc_thresh, ab_thresh, ba_thresh) = config
                 .duplex_thresholds()
                 .ok_or_else(|| anyhow::anyhow!("No duplex thresholds configured"))?;
@@ -711,11 +770,49 @@ impl Filter {
             mask_bases_raw(record, thresholds, min_base_quality)?
         };
 
+        // Parse methylation tags once for all EM-Seq filters
+        let needs_methylation_tags = methylation_depth_thresholds.is_some()
+            || (require_strand_methylation_agreement && is_duplex)
+            || min_conversion_fraction.is_some();
+        let methylation_tags =
+            if needs_methylation_tags { Some(MethylationTags::from_record(record)) } else { None };
+
+        // Methylation depth masking (EM-Seq)
+        if let Some(thresholds) = methylation_depth_thresholds {
+            let tags =
+                methylation_tags.as_ref().expect("methylation_tags set when thresholds present");
+            masked_count += if is_duplex {
+                mask_methylation_depth_duplex_raw_with_tags(record, thresholds, tags)?
+            } else {
+                mask_methylation_depth_simplex_raw_with_tags(record, thresholds.duplex, tags)?
+            };
+        }
+
+        // Resolve reference bases once for all reference-dependent filters
+        let needs_ref_bases = (require_strand_methylation_agreement && is_duplex)
+            || min_conversion_fraction.is_some();
+        let ref_base_map = if needs_ref_bases {
+            reference.and_then(|r| resolve_ref_bases_for_record(record, r, ref_names))
+        } else {
+            None
+        };
+
+        // Strand methylation agreement masking (EM-Seq, duplex only)
+        if require_strand_methylation_agreement && is_duplex {
+            masked_count += mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
+                record,
+                ref_base_map.as_deref(),
+                methylation_tags
+                    .as_ref()
+                    .expect("methylation_tags set when strand agreement enabled"),
+            )?;
+        }
+
         if let Some(reference) = reference {
             regenerate_alignment_tags_raw(record, header, reference)?;
         }
 
-        let pass = {
+        let mut pass = {
             let aux = bam_fields::aux_data_slice(record);
             if is_duplex {
                 let (cc_thresh, ab_thresh, ba_thresh) = config
@@ -743,6 +840,22 @@ impl Filter {
                 )?
             }
         };
+
+        // Conversion fraction filter (EM-Seq read-level)
+        if pass {
+            if let Some(min_frac) = min_conversion_fraction {
+                if !check_conversion_fraction_raw_with_ref_bases_and_tags(
+                    record,
+                    min_frac,
+                    ref_base_map.as_deref(),
+                    methylation_tags
+                        .as_ref()
+                        .expect("methylation_tags set when conversion fraction enabled"),
+                ) {
+                    pass = false;
+                }
+            }
+        }
 
         Ok((masked_count as u64, pass))
     }
@@ -905,6 +1018,49 @@ impl Filter {
             }
         }
 
+        // Validate min-methylation-depth
+        if self.min_methylation_depth.len() > 3 {
+            bail!(
+                "--min-methylation-depth must have 1-3 values, got {}",
+                self.min_methylation_depth.len()
+            );
+        }
+
+        // Validate min-methylation-depth ordering (same as min-reads: CC >= AB >= BA)
+        if self.min_methylation_depth.len() >= 2 {
+            let cc = self.min_methylation_depth[0];
+            let ab = self.min_methylation_depth[1];
+            if ab > cc {
+                bail!(
+                    "min-methylation-depth values must be specified high to low (duplex >= AB), got {cc} < {ab}"
+                );
+            }
+        }
+        if self.min_methylation_depth.len() == 3 {
+            let ab = self.min_methylation_depth[1];
+            let ba = self.min_methylation_depth[2];
+            if ba > ab {
+                bail!(
+                    "min-methylation-depth values must be specified high to low (AB >= BA), got {ab} < {ba}"
+                );
+            }
+        }
+
+        // Validate require-strand-methylation-agreement requires --ref
+        if self.require_strand_methylation_agreement && self.reference.is_none() {
+            bail!("--require-strand-methylation-agreement requires --ref to identify CpG sites");
+        }
+
+        // Validate min-conversion-fraction
+        if let Some(frac) = self.min_conversion_fraction {
+            if !(0.0..=1.0).contains(&frac) {
+                bail!("--min-conversion-fraction must be between 0.0 and 1.0, got {frac}");
+            }
+            if self.reference.is_none() {
+                bail!("--min-conversion-fraction requires --ref to identify non-CpG cytosines");
+            }
+        }
+
         Ok(())
     }
 }
@@ -936,6 +1092,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         }
@@ -999,6 +1158,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1030,6 +1192,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1058,6 +1223,9 @@ mod tests {
             rejects: Some(PathBuf::from("rejects.bam")),
             stats: Some(PathBuf::from("stats.txt")),
             require_single_strand_agreement: true,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1090,6 +1258,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1119,11 +1290,71 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
 
         assert!(filter.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_min_methylation_depth_too_many_values() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.min_methylation_depth = vec![4, 3, 2, 1]; // Too many values
+        assert!(cmd.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_min_methylation_depth_invalid_order() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.min_methylation_depth = vec![2, 5]; // AB > CC
+        assert!(cmd.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_strand_agreement_requires_ref() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.reference = None;
+        cmd.require_strand_methylation_agreement = true;
+        assert!(cmd.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_conversion_fraction_out_of_range() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.min_conversion_fraction = Some(1.5); // Out of range
+        assert!(cmd.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_conversion_fraction_requires_ref() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.reference = None;
+        cmd.min_conversion_fraction = Some(0.9);
+        assert!(cmd.validate_parameters().is_err());
     }
 
     // Integration tests for filtering logic
@@ -1481,6 +1712,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1516,6 +1750,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1549,6 +1786,9 @@ mod tests {
             rejects: Some(PathBuf::from("rejects.bam")),
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1579,6 +1819,9 @@ mod tests {
             rejects: None,
             stats: Some(PathBuf::from("stats.txt")),
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1609,6 +1852,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1638,6 +1884,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: true,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1667,6 +1916,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1696,6 +1948,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1725,6 +1980,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1754,6 +2012,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1783,6 +2044,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1814,6 +2078,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1845,6 +2112,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1875,6 +2145,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1906,6 +2179,9 @@ mod tests {
             rejects: Some(PathBuf::from("rejects.bam")),
             stats: Some(PathBuf::from("stats.txt")),
             require_single_strand_agreement: true,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1938,6 +2214,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1967,6 +2246,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2070,6 +2352,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2190,6 +2475,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2343,6 +2631,9 @@ mod tests {
             rejects: Some(rejects_path.clone()),
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2415,6 +2706,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2481,6 +2775,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2604,6 +2901,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2672,6 +2972,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2738,6 +3041,9 @@ mod tests {
             rejects: None,
             stats: Some(stats_path.clone()),
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2808,6 +3114,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2831,6 +3140,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2894,6 +3206,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2948,6 +3263,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3005,6 +3323,9 @@ mod tests {
             rejects: Some(rejects_path.clone()), // Enable rejects
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3071,6 +3392,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3094,6 +3418,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3175,6 +3502,9 @@ mod tests {
             rejects: Some(rejects_path.clone()),
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3284,6 +3614,9 @@ mod tests {
             rejects: Some(rejects_path.clone()),
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3399,6 +3732,9 @@ mod tests {
             rejects: Some(rejects_path.clone()),
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3435,6 +3771,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3466,6 +3805,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3521,6 +3863,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3581,6 +3926,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3644,6 +3992,9 @@ mod tests {
             rejects: None,
             stats: None,
             require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3883,12 +4234,19 @@ mod tests {
         let config = FilterConfig::new(&[1], &[0.025], &[0.1], None, None, 0.2);
 
         let (bases_masked, pass) = Filter::process_record_raw(
-            &mut raw, &config, None, // no reference
-            &header, false, // no tag reversal
+            &mut raw,
+            &config,
+            None, // no reference
+            &header,
+            false, // no tag reversal
             None,  // no min base quality
             false, // no single-strand agreement
             None,  // no min mean base quality
             0.2,   // max no-call fraction
+            None,  // no methylation depth thresholds
+            false, // no strand methylation agreement
+            None,  // no min conversion fraction
+            &[],   // no ref names
         )?;
 
         assert_eq!(bases_masked, 0, "No bases should be masked with good tags");
@@ -3934,6 +4292,10 @@ mod tests {
             false,
             None,
             0.2,
+            None,  // no methylation depth thresholds
+            false, // no strand methylation agreement
+            None,  // no min conversion fraction
+            &[],   // no ref names
         );
 
         assert!(result.is_err(), "Should fail for mapped reads without reference");


### PR DESCRIPTION
## Summary
- New EM-Seq filter options: `--min-methylation-depth`, `--require-strand-methylation-agreement`, `--min-conversion-fraction`
- Performance: resolve ref bases once per record (was 3x), parse methylation tags once via `MethylationTags` (was 12 scans), O(1) slice-based ref access via `sequence_for()` (was per-base HashMap)
- Compute `MethylationDepthThresholds` once at setup instead of per-record
- Add methylation tag constants (`cu`/`ct`/`au`/`at`/`bu`/`bt`) to `tags::per_base`
- Add `cigar_op_kind()` to fgumi-raw-bam; use `Kind` enum in `resolve_ref_bases_for_record`
- Extract `expand_three_from_last<T>` helper for 1-to-3 threshold expansion

## Stack
2/4 — EM-seq support (depends on #168)

## Test plan
- [x] New tests for methylation depth masking, strand agreement, conversion fraction filtering
- [x] Tests for MethylationTags parsing, MethylationDepthThresholds, expand_three_from_last
- [x] Existing filter tests pass unchanged
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes