### PR TITLE
feat(zipper): add --restore-unconverted-bases flag for EM-seq

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -970,16 +970,15 @@ impl DuplexConsensusCaller {
                     bases.push(final_base);
                     quals.push(final_qual);
 
-                    // Calculate errors
-                    let error_count = if let Some(source_reads) = source_reads {
+                    // Calculate errors — conversion artifacts are not counted
+                    let error_count = if is_conversion_artifact {
+                        // Conversion artifacts: treat as agreement, no errors
+                        0u16
+                    } else if let Some(source_reads) = source_reads {
                         // Exact method: count disagreements with source reads
                         let mut num_errors = 0i32;
                         for sr in source_reads {
-                            if sr.bases.len() > i
-                                && Self::is_error(sr.bases[i], raw_base)
-                                && !(is_conversion_artifact
-                                    && Self::is_conversion_pair(sr.bases[i], raw_base))
-                            {
+                            if sr.bases.len() > i && Self::is_error(sr.bases[i], raw_base) {
                                 num_errors += 1;
                             }
                         }
@@ -991,8 +990,7 @@ impl DuplexConsensusCaller {
                         let a_dep = i32::from(a.depths[i]);
                         let b_dep = i32::from(b.depths[i]);
 
-                        let err = if is_conversion_artifact || a_base == b_base {
-                            // Agreement (or conversion artifact treated as agreement)
+                        let err = if a_base == b_base {
                             a_err + b_err
                         } else if raw_base == a_base {
                             a_err + (b_dep - b_err)
@@ -5813,14 +5811,16 @@ mod tests {
     fn test_duplex_em_seq_bottom_strand_conversion_artifact() {
         // Bottom strand: ref=G (complement of C on bottom strand)
         // AB shows G (unconverted), BA shows A (converted after RC)
-        // This is also a conversion artifact on the bottom strand
+        // This is a conversion artifact on the bottom strand.
+        // AB (top strand) does not see this as a ref-C position.
+        // BA (bottom strand) sees it as ref-C (is_ref_c=true).
         let ab = make_ss_consensus_with_methylation(
             vec![b'G'],
             vec![30],
             vec![5],
             vec![crate::methylation::MethylationEvidence {
-                is_ref_c: true,
-                unconverted_count: 5,
+                is_ref_c: false,
+                unconverted_count: 0,
                 converted_count: 0,
             }],
         );
@@ -5842,6 +5842,8 @@ mod tests {
         assert_eq!(duplex.bases[0], b'G');
         // Quality summed (conversion artifact path)
         assert_eq!(duplex.quals[0], 55);
+        // Conversion artifacts should not be counted as duplex errors
+        assert_eq!(duplex.errors[0], 0);
     }
 
     #[test]

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -3099,7 +3099,7 @@ mod tests {
     #[test]
     fn test_conversion_fraction_passes_high_conversion() {
         use crate::methylation::tests::TestRef;
-        // Reference: ACATACATA (non-CpG C at positions 1, 4 -- A before each C means not CpG)
+        // Reference: ACATACATA (non-CpG C at positions 1, 5 — each C followed by A, not CpG)
         //            012345678
         let ref_seq = b"ACATACATA";
         let reference = TestRef::new(&[("chr1", ref_seq)]);
@@ -3114,13 +3114,13 @@ mod tests {
             .mapping_quality(60)
             .cigar("9M")
             .build();
-        // Non-CpG C at positions 1 and 4: high conversion (ct >> cu)
+        // Non-CpG C at positions 1 and 5: high conversion (ct >> cu)
         // cu: unconverted count, ct: converted count
-        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 1, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 9, 0, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
 
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
-        // 18 converted out of 20 = 90% conversion
+        // 18 converted out of 20 = 90% conversion (positions 1 and 5)
         assert!(
             check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
             "Should pass with high conversion fraction"
@@ -3143,12 +3143,12 @@ mod tests {
             .mapping_quality(60)
             .cigar("9M")
             .build();
-        // Non-CpG C at positions 1 and 4: low conversion (cu >> ct)
-        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 9, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 1, 0, 0, 0, 0]);
+        // Non-CpG C at positions 1 and 5: low conversion (cu >> ct)
+        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
 
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
-        // 2 converted out of 20 = 10% conversion
+        // 2 converted out of 20 = 10% conversion (positions 1 and 5)
         assert!(
             !check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
             "Should fail with low conversion fraction"

--- a/crates/fgumi-consensus/src/methylation.rs
+++ b/crates/fgumi-consensus/src/methylation.rs
@@ -21,10 +21,12 @@ pub struct MethylationEvidence {
     pub is_ref_c: bool,
     /// Number of reads showing C (unconverted) at this ref-C position.
     /// For bottom strand (after RC): number showing G (complement of unconverted C).
-    pub unconverted_count: i16,
+    /// Stored as u32 to avoid overflow at high coverage; clamped to i16 on output.
+    pub unconverted_count: u32,
     /// Number of reads showing T (converted) at this ref-C position.
     /// For bottom strand (after RC): number showing A (complement of converted T).
-    pub converted_count: i16,
+    /// Stored as u32 to avoid overflow at high coverage; clamped to i16 on output.
+    pub converted_count: u32,
 }
 
 /// Methylation annotation for an entire consensus read.
@@ -36,15 +38,20 @@ pub struct MethylationAnnotation {
 
 impl MethylationAnnotation {
     /// Returns the unconverted counts as an i16 array for the `cu` tag.
+    /// Values are clamped to `i16::MAX` to fit the BAM tag format.
     #[must_use]
     pub fn unconverted_counts(&self) -> Vec<i16> {
-        self.evidence.iter().map(|e| e.unconverted_count).collect()
+        self.evidence
+            .iter()
+            .map(|e| i16::try_from(e.unconverted_count).unwrap_or(i16::MAX))
+            .collect()
     }
 
     /// Returns the converted counts as an i16 array for the `ct` tag.
+    /// Values are clamped to `i16::MAX` to fit the BAM tag format.
     #[must_use]
     pub fn converted_counts(&self) -> Vec<i16> {
-        self.evidence.iter().map(|e| e.converted_count).collect()
+        self.evidence.iter().map(|e| i16::try_from(e.converted_count).unwrap_or(i16::MAX)).collect()
     }
 
     /// Returns a truncated copy of this annotation with only the first `len` positions.
@@ -140,17 +147,16 @@ pub fn query_to_ref_positions(
 /// Annotates simplex consensus methylation from source reads and reference.
 ///
 /// For each consensus position that aligns to a reference cytosine (top strand)
-/// or reference guanine (bottom strand, after RC):
-/// - Counts source reads showing unconverted vs converted bases
-/// - Replaces converted consensus bases with the unconverted reference base
+/// or reference guanine (bottom strand, after RC), counts source reads showing
+/// unconverted vs converted bases. Does not modify the consensus bases.
 ///
 /// # Arguments
-/// * `consensus_bases` - Mutable consensus bases (may be modified to unconverted form)
+/// * `consensus_bases` - Consensus bases (used for length/position mapping)
 /// * `source_reads` - Source reads used to build this consensus
-/// * `ref_bases` - Reference bases at aligned positions (`None` for insertions)
+/// * `ref_bases_at_positions` - Reference bases at aligned positions (`None` for insertions)
 /// * `is_top_strand` - Whether this consensus represents the top (forward) strand
 pub(crate) fn annotate_simplex_methylation(
-    consensus_bases: &mut [u8],
+    consensus_bases: &[u8],
     source_reads: &[SourceRead],
     ref_bases_at_positions: &[Option<u8>],
     is_top_strand: bool,
@@ -188,10 +194,9 @@ pub(crate) fn annotate_simplex_methylation(
             }
         }
 
-        // Do NOT replace converted bases back to unconverted in the consensus sequence.
-        // When consensus reads are re-aligned through bwameth, replacement would cause
-        // bwameth to see C at every reference-C position and call everything as methylated.
-        // Methylation evidence is preserved in cu/ct per-base count tags and MM/ML tags.
+        // Base normalization (T→C / A→G at ref-C positions) is NOT done here — it is
+        // handled by the caller (annotate_and_normalize) which normalizes source reads
+        // after annotation so that conversion events don't inflate consensus error counts.
     }
 
     MethylationAnnotation { evidence }
@@ -239,14 +244,10 @@ pub fn build_mm_ml_tags(
 
         if ev.is_ref_c {
             // This is a ref-C position with a C/G in consensus
-            let total = i32::from(ev.unconverted_count) + i32::from(ev.converted_count);
+            let total = u64::from(ev.unconverted_count) + u64::from(ev.converted_count);
             if total > 0 {
                 // Methylation probability = unconverted / total, scaled to [0, 255]
-                #[expect(
-                    clippy::cast_sign_loss,
-                    reason = "values are known non-negative and bounded by 255"
-                )]
-                let prob = (i32::from(ev.unconverted_count) * 255 / total).clamp(0, 255) as u8;
+                let prob = (u64::from(ev.unconverted_count) * 255 / total).min(255) as u8;
                 skips.push(skip_count);
                 probs.push(prob);
                 skip_count = 0;
@@ -468,13 +469,13 @@ pub(crate) mod tests {
     #[test]
     fn test_annotate_simplex_all_methylated() {
         // All source reads show C at ref-C positions → methylated
-        let mut consensus = b"ACGT".to_vec();
+        let consensus = b"ACGT".to_vec();
         let sr1 = make_test_source_read(b"ACGT", 0);
         let sr2 = make_test_source_read(b"ACGT", 0);
         let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
 
         let annot = annotate_simplex_methylation(
-            &mut consensus,
+            &consensus,
             &[sr1, sr2],
             &ref_bases,
             true, // top strand
@@ -491,12 +492,12 @@ pub(crate) mod tests {
     #[test]
     fn test_annotate_simplex_all_unmethylated() {
         // All source reads show T at ref-C position → unmethylated
-        let mut consensus = b"ATGT".to_vec(); // consensus called T at pos 1
+        let consensus = b"ATGT".to_vec(); // consensus called T at pos 1
         let sr1 = make_test_source_read(b"ATGT", 0);
         let sr2 = make_test_source_read(b"ATGT", 0);
         let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
 
-        let annot = annotate_simplex_methylation(&mut consensus, &[sr1, sr2], &ref_bases, true);
+        let annot = annotate_simplex_methylation(&consensus, &[sr1, sr2], &ref_bases, true);
 
         assert!(annot.evidence[1].is_ref_c);
         assert_eq!(annot.evidence[1].unconverted_count, 0);
@@ -509,12 +510,12 @@ pub(crate) mod tests {
     #[test]
     fn test_annotate_simplex_mixed() {
         // Some C, some T at ref-C position
-        let mut consensus = b"ACGT".to_vec();
+        let consensus = b"ACGT".to_vec();
         let sr1 = make_test_source_read(b"ACGT", 0); // C at pos 1
         let sr2 = make_test_source_read(b"ATGT", 0); // T at pos 1
         let ref_bases = vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')];
 
-        let annot = annotate_simplex_methylation(&mut consensus, &[sr1, sr2], &ref_bases, true);
+        let annot = annotate_simplex_methylation(&consensus, &[sr1, sr2], &ref_bases, true);
 
         assert!(annot.evidence[1].is_ref_c);
         assert_eq!(annot.evidence[1].unconverted_count, 1);
@@ -524,11 +525,11 @@ pub(crate) mod tests {
     #[test]
     fn test_annotate_simplex_non_c_positions() {
         // Non-ref-C positions should not be annotated
-        let mut consensus = b"AGGT".to_vec();
+        let consensus = b"AGGT".to_vec();
         let sr1 = make_test_source_read(b"AGGT", 0);
         let ref_bases = vec![Some(b'A'), Some(b'G'), Some(b'G'), Some(b'T')];
 
-        let annot = annotate_simplex_methylation(&mut consensus, &[sr1], &ref_bases, true);
+        let annot = annotate_simplex_methylation(&consensus, &[sr1], &ref_bases, true);
 
         for ev in &annot.evidence {
             assert!(!ev.is_ref_c);
@@ -538,12 +539,12 @@ pub(crate) mod tests {
     #[test]
     fn test_annotate_simplex_reverse_strand() {
         // Bottom strand: ref=G (complement of C), unconverted=G, converted=A
-        let mut consensus = b"CAGT".to_vec(); // A at pos 1 = converted on bottom strand
+        let consensus = b"CAGT".to_vec(); // A at pos 1 = converted on bottom strand
         let sr1 = make_test_source_read(b"CAGT", flags::REVERSE);
         let ref_bases = vec![Some(b'T'), Some(b'G'), Some(b'C'), Some(b'A')]; // at reversed positions
 
         let annot = annotate_simplex_methylation(
-            &mut consensus,
+            &consensus,
             &[sr1],
             &ref_bases,
             false, // bottom strand
@@ -729,16 +730,16 @@ pub(crate) mod tests {
         let annotation = MethylationAnnotation {
             evidence: vec![MethylationEvidence {
                 is_ref_c: true,
-                unconverted_count: i16::MAX,
-                converted_count: i16::MAX,
+                unconverted_count: u32::MAX,
+                converted_count: u32::MAX,
             }],
         };
         let ab = &annotation;
         let ba = &annotation;
         let combined = combine_methylation_annotations(ab, ba, 1);
-        // Should saturate at i16::MAX, not wrap or panic
-        assert_eq!(combined.evidence[0].unconverted_count, i16::MAX);
-        assert_eq!(combined.evidence[0].converted_count, i16::MAX);
+        // Should saturate at u32::MAX, not wrap or panic
+        assert_eq!(combined.evidence[0].unconverted_count, u32::MAX);
+        assert_eq!(combined.evidence[0].converted_count, u32::MAX);
     }
 
     /// Helper to create a `SourceRead` for testing.

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -632,16 +632,23 @@ impl VanillaUmiConsensusCaller {
             return Ok(None);
         }
 
-        // Build consensus from source reads
-        let (mut bases, quals, depths, errors) =
+        // For EM-seq: annotate methylation first (counts conversions), then normalize
+        // source read bases before consensus scoring so that C↔T / G↔A conversion
+        // events at ref-C positions don't inflate error counts or depress quality.
+        let (methylation, source_reads) = if self.options.em_seq {
+            let (annot, normalized) = self.annotate_and_normalize(source_reads);
+            (annot, normalized)
+        } else {
+            (None, source_reads)
+        };
+
+        // Build consensus from (possibly normalized) source reads
+        let (bases, quals, depths, errors) =
             self.create_consensus_from_source_reads(&source_reads)?;
 
-        // Apply methylation annotation if em_seq is enabled
-        let methylation = if self.options.em_seq {
-            self.annotate_methylation(&source_reads, &mut bases)
-        } else {
-            None
-        };
+        // Truncate methylation annotation to consensus length (the anchor read may be
+        // longer than the consensus when min_reads > 1 trims to shorter coverage).
+        let methylation = methylation.map(|m| m.truncate(bases.len()));
 
         // Build VanillaConsensusRead
         let consensus_read = VanillaConsensusRead {
@@ -657,49 +664,80 @@ impl VanillaUmiConsensusCaller {
         Ok(Some(consensus_read))
     }
 
-    /// Annotates methylation for a consensus read using reference and source reads.
-    fn annotate_methylation(
+    /// Annotates methylation evidence and normalizes source read bases at ref-C positions.
+    ///
+    /// Returns the methylation annotation (with conversion counts) and the source reads
+    /// with converted bases (T→C on top strand, A→G on bottom) normalized to unconverted
+    /// form, so that consensus scoring treats conversion events as agreement.
+    fn annotate_and_normalize(
         &self,
-        source_reads: &[SourceRead],
-        consensus_bases: &mut [u8],
-    ) -> Option<crate::methylation::MethylationAnnotation> {
+        mut source_reads: Vec<SourceRead>,
+    ) -> (Option<crate::methylation::MethylationAnnotation>, Vec<SourceRead>) {
         use crate::methylation;
 
-        let reference = self.reference.as_ref()?;
-        let ref_names = self.ref_names.as_ref()?;
+        let Some(reference) = self.reference.as_ref() else {
+            return (None, source_reads);
+        };
+        let Some(ref_names) = self.ref_names.as_ref() else {
+            return (None, source_reads);
+        };
 
-        // Use the longest source read as the mapping template so that ref_positions
+        // Use the longest source read as the mapping anchor so that ref_positions
         // covers the full consensus length (consensus_len <= max source read length).
         // All reads share the same alignment pattern after filtering, so the longest
         // read's CIGAR is a superset of any shorter read's positions.
-        let template = source_reads.iter().max_by_key(|sr| sr.bases.len())?;
-        if template.ref_id < 0 || template.alignment_start < 0 {
-            return None;
+        let anchor_idx = source_reads
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, sr)| sr.bases.len())
+            .map(|(idx, _)| idx);
+        let Some(anchor_idx) = anchor_idx else {
+            return (None, source_reads);
+        };
+        let anchor = &source_reads[anchor_idx];
+        if anchor.ref_id < 0 || anchor.alignment_start < 0 {
+            return (None, source_reads);
         }
-        let ref_name = ref_names.get(usize::try_from(template.ref_id).ok()?)?;
+        let Some(ref_name) = ref_names.get(usize::try_from(anchor.ref_id).unwrap_or(usize::MAX))
+        else {
+            return (None, source_reads);
+        };
 
-        // Determine strand from source reads
-        let is_top = methylation::is_top_strand(template.flags);
+        let is_top = methylation::is_top_strand(anchor.flags);
 
-        // Map consensus positions to reference positions
         let ref_positions = methylation::query_to_ref_positions(
-            &template.simplified_cigar,
-            template.alignment_start,
-            template.flags & fgumi_raw_bam::flags::REVERSE != 0,
-            &template.original_cigar,
+            &anchor.simplified_cigar,
+            anchor.alignment_start,
+            anchor.flags & fgumi_raw_bam::flags::REVERSE != 0,
+            &anchor.original_cigar,
         );
 
-        // Fetch reference bases at aligned positions
         let ref_bases =
             methylation::fetch_ref_bases_at_positions(&ref_positions, ref_name, reference.as_ref());
 
-        // Annotate methylation
-        Some(methylation::annotate_simplex_methylation(
-            consensus_bases,
-            source_reads,
+        // Annotate methylation to count conversions (before normalization)
+        let annotation = methylation::annotate_simplex_methylation(
+            &source_reads[anchor_idx].bases,
+            &source_reads,
             &ref_bases,
             is_top,
-        ))
+        );
+
+        // Normalize source read bases: at ref-C positions, replace converted bases
+        // with unconverted form so consensus scoring treats them as agreement
+        let (unconverted_base, converted_base) = if is_top { (b'C', b'T') } else { (b'G', b'A') };
+        for sr in &mut source_reads {
+            for (i, ev) in annotation.evidence.iter().enumerate() {
+                if ev.is_ref_c && i < sr.bases.len() {
+                    let base = sr.bases[i].to_ascii_uppercase();
+                    if base == converted_base {
+                        sr.bases[i] = unconverted_base;
+                    }
+                }
+            }
+        }
+
+        (Some(annotation), source_reads)
     }
 
     /// Filters reads to remove secondary/supplementary alignments.
@@ -1172,16 +1210,21 @@ impl VanillaUmiConsensusCaller {
             Vec::new()
         };
 
-        // Build consensus from source reads
-        let (mut bases, quals, depths, errors) =
+        // For EM-seq: annotate methylation first, then normalize source read bases
+        // before consensus scoring so conversion events don't inflate errors.
+        let (methylation, filtered_source_reads) = if self.options.em_seq {
+            let (annot, normalized) = self.annotate_and_normalize(filtered_source_reads);
+            (annot, normalized)
+        } else {
+            (None, filtered_source_reads)
+        };
+
+        // Build consensus from (possibly normalized) source reads
+        let (bases, quals, depths, errors) =
             self.create_consensus_from_source_reads(&filtered_source_reads)?;
 
-        // Apply methylation annotation if em_seq is enabled
-        let methylation = if self.options.em_seq {
-            self.annotate_methylation(&filtered_source_reads, &mut bases)
-        } else {
-            None
-        };
+        // Truncate methylation annotation to consensus length
+        let methylation = methylation.map(|m| m.truncate(bases.len()));
 
         // Get raw records for tag extraction
         let original_raws: Vec<&[u8]> = filtered_source_reads

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -12,16 +12,21 @@ use crate::fields::{
 #[must_use]
 pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op::Kind {
     use noodles::sam::alignment::record::cigar::op::Kind;
-    match raw_op & 0xF {
+    let op = raw_op & 0xF;
+    match op {
         0 => Kind::Match,
         1 => Kind::Insertion,
         2 => Kind::Deletion,
         3 => Kind::Skip,
         4 => Kind::SoftClip,
         5 => Kind::HardClip,
+        6 => Kind::Pad,
         7 => Kind::SequenceMatch,
         8 => Kind::SequenceMismatch,
-        _ => Kind::Pad,
+        _ => {
+            debug_assert!(false, "invalid BAM CIGAR op code: {op}");
+            Kind::Pad
+        }
     }
 }
 

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -52,7 +52,7 @@ use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::logging::OperationTimer;
 use crate::progress::ProgressTracker;
-use crate::reference::find_dict_path;
+use crate::reference::{ReferenceReader, find_dict_path};
 use crate::sam::{
     SamTag, buf_value_to_smallest_signed_int, check_sort, revcomp_buf_value, reverse_buf_value,
     unclipped_five_prime_position,
@@ -66,7 +66,10 @@ use anyhow::{Context, Result};
 use bstr::ByteSlice;
 use clap::Parser;
 use log::{debug, info, warn};
+use noodles::core::Position;
 use noodles::sam::Header;
+use noodles::sam::alignment::record::Cigar as CigarTrait;
+use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::Data;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -174,6 +177,19 @@ pub struct Zipper {
     /// deduplication of these reads. Use this flag if you don't need this functionality.
     #[arg(long = "skip-pa-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub skip_pa_tags: bool,
+
+    /// Restore unconverted bases in EM-seq consensus reads after bwameth re-alignment.
+    ///
+    /// In EM-seq, unmethylated cytosines are converted to thymine (top strand) or
+    /// adenine (bottom strand). After bwameth re-alignment, this flag replaces converted
+    /// bases back to their unconverted reference form at reference C (top strand) or
+    /// reference G (bottom strand) positions. Uses the bwameth `YD` tag to determine
+    /// the bisulfite strand.
+    ///
+    /// This produces a final BAM where the sequence shows the original (unconverted) bases,
+    /// while methylation state is preserved in MM/ML tags and cu/ct count tags.
+    #[arg(long = "restore-unconverted-bases", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub restore_unconverted_bases: bool,
 }
 
 /// Builds the output BAM header from unmapped and mapped headers
@@ -988,6 +1004,139 @@ fn encode_unmapped_template_records(template: &Template, header: &Header) -> Res
     Ok(raw)
 }
 
+/// YD tag used by bwameth to indicate the bisulfite conversion strand.
+const YD_TAG: Tag = Tag::new(b'Y', b'D');
+/// YD value for the forward (top) bisulfite strand.
+const YD_FORWARD: &[u8] = b"f";
+/// YD value for the reverse (bottom) bisulfite strand.
+const YD_REVERSE: &[u8] = b"r";
+
+/// Restore unconverted bases in EM-seq reads after bwameth re-alignment.
+///
+/// For each mapped record in the template, walks the CIGAR alignment and replaces
+/// converted bases back to their unconverted reference form:
+/// - Top strand (`YD:Z:f`): at reference-C positions, T→C
+/// - Bottom strand (`YD:Z:r`): at reference-G positions, A→G
+///
+/// Skips unmapped reads and reads without a `YD` tag.
+fn restore_unconverted_bases_in_template(
+    template: &mut Template,
+    reference: &ReferenceReader,
+    header: &Header,
+) -> Result<()> {
+    for record in &mut template.records {
+        restore_unconverted_bases_in_record(record, reference, header)?;
+    }
+    Ok(())
+}
+
+/// Restore unconverted bases in a single EM-seq record after bwameth re-alignment.
+fn restore_unconverted_bases_in_record(
+    record: &mut RecordBuf,
+    reference: &ReferenceReader,
+    header: &Header,
+) -> Result<()> {
+    // Skip unmapped reads
+    if record.flags().is_unmapped() {
+        return Ok(());
+    }
+
+    // Get the bisulfite strand from the bwameth YD tag
+    let yd_value = record.data().get(&YD_TAG);
+    let is_top = match yd_value {
+        Some(BufValue::String(s)) if AsRef::<[u8]>::as_ref(s) == YD_FORWARD => true,
+        Some(BufValue::String(s)) if AsRef::<[u8]>::as_ref(s) == YD_REVERSE => false,
+        _ => return Ok(()), // No YD tag or unexpected value; skip
+    };
+
+    // Get reference contig name
+    let ref_id = match record.reference_sequence_id() {
+        Some(id) => id,
+        None => return Ok(()),
+    };
+    let (ref_name, _) = header
+        .reference_sequences()
+        .get_index(ref_id)
+        .context("reference sequence ID not found in header")?;
+    let ref_name = ref_name.to_string();
+
+    // Get alignment start (1-based)
+    let alignment_start = match record.alignment_start().map(usize::from) {
+        Some(pos) => pos,
+        None => return Ok(()),
+    };
+
+    // Compute reference span from CIGAR
+    let ref_span = crate::sam::reference_length(&record.cigar());
+
+    if ref_span == 0 {
+        return Ok(());
+    }
+
+    // Fetch the entire aligned reference region at once
+    let ref_start = Position::try_from(alignment_start)?;
+    let ref_end = Position::try_from(alignment_start + ref_span - 1)?;
+    let ref_bases = reference.fetch(&ref_name, ref_start, ref_end)?;
+
+    // Determine replacement parameters, accounting for reverse-complemented SEQ.
+    // SAM stores SEQ reverse-complemented when 0x10 is set, so the base to find
+    // and replace flips on reverse-strand alignments.
+    let is_reverse = record.flags().is_reverse_complemented();
+    let (ref_target, converted_base, unconverted_base) = match (is_top, is_reverse) {
+        (true, false) | (false, true) => (b'C', b'T', b'C'),
+        (true, true) | (false, false) => (b'G', b'A', b'G'),
+    };
+
+    // Walk CIGAR and replace converted bases
+    let mut seq: Vec<u8> = record.sequence().as_ref().to_vec();
+    let mut modified = false;
+    let mut read_pos: usize = 0;
+    let mut ref_offset: usize = 0; // 0-based offset into ref_bases
+
+    for op_result in record.cigar().iter() {
+        let op = op_result?;
+        let len = op.len();
+
+        match op.kind() {
+            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                for i in 0..len {
+                    if ref_offset + i >= ref_bases.len() {
+                        break;
+                    }
+                    let rb = ref_bases[ref_offset + i].to_ascii_uppercase();
+                    if rb == ref_target
+                        && read_pos + i < seq.len()
+                        && seq[read_pos + i].to_ascii_uppercase() == converted_base
+                    {
+                        seq[read_pos + i] = unconverted_base;
+                        modified = true;
+                    }
+                }
+                read_pos += len;
+                ref_offset += len;
+            }
+            Kind::Insertion | Kind::SoftClip => {
+                read_pos += len;
+            }
+            Kind::Deletion | Kind::Skip => {
+                ref_offset += len;
+            }
+            Kind::HardClip | Kind::Pad => {}
+        }
+    }
+
+    if modified {
+        *record.sequence_mut() = seq.into();
+        // NM/MD tags are now stale since SEQ changed; remove them so downstream
+        // tools don't trust incorrect mismatch counts.
+        let data = record.data_mut();
+        data.remove(&Tag::new(b'N', b'M'));
+        data.remove(&Tag::new(b'M', b'D'));
+    }
+
+    Ok(())
+}
+
 impl Zipper {
     /// Process templates using raw-byte merge path with BGZF compression.
     ///
@@ -998,6 +1147,7 @@ impl Zipper {
         mut mapped_iter: M,
         output_header: &Header,
         tag_info: &TagInfo,
+        reference: Option<&ReferenceReader>,
     ) -> Result<u64>
     where
         U: Iterator<Item = Result<Template>>,
@@ -1023,8 +1173,25 @@ impl Zipper {
 
             if let Some(ref mut mapped_template) = mapped_peek {
                 if mapped_template.name == unmapped_template.name {
-                    convert_template_to_raw(mapped_template, output_header)?;
-                    merge_raw(&unmapped_template, mapped_template, tag_info, self.skip_pa_tags)?;
+                    if let Some(ref_reader) = reference {
+                        // RecordBuf path: merge tags, restore bases, then encode to raw
+                        merge(&unmapped_template, mapped_template, tag_info, self.skip_pa_tags)?;
+                        restore_unconverted_bases_in_template(
+                            mapped_template,
+                            ref_reader,
+                            output_header,
+                        )?;
+                        convert_template_to_raw(mapped_template, output_header)?;
+                    } else {
+                        // Fast raw-byte path
+                        convert_template_to_raw(mapped_template, output_header)?;
+                        merge_raw(
+                            &unmapped_template,
+                            mapped_template,
+                            tag_info,
+                            self.skip_pa_tags,
+                        )?;
+                    }
                     let rr = mapped_template.raw_records.as_ref().unwrap();
                     for rec in rr {
                         writer.write_raw_record(rec)?;
@@ -1210,6 +1377,14 @@ impl Command for Zipper {
             info!("Tags being reverse complemented: {:?}", tag_info.revcomp);
         }
 
+        // Load reference FASTA if restoring unconverted bases
+        let reference = if self.restore_unconverted_bases {
+            info!("Loading reference FASTA for unconverted base restoration");
+            Some(ReferenceReader::new(&self.reference)?)
+        } else {
+            None
+        };
+
         // Create async unmapped reader - spawn thread to read ahead
         let (unmapped_tx, unmapped_rx) =
             std::sync::mpsc::sync_channel::<Result<Template>>(self.buffer);
@@ -1262,8 +1437,13 @@ impl Command for Zipper {
         });
         let mapped_iter = std::iter::from_fn(move || mapped_rx.recv().ok());
 
-        let total_records =
-            self.process_raw(unmapped_iter, mapped_iter, &output_header, &tag_info)?;
+        let total_records = self.process_raw(
+            unmapped_iter,
+            mapped_iter,
+            &output_header,
+            &tag_info,
+            reference.as_ref(),
+        )?;
 
         info!("zipper completed successfully");
         timer.log_completion(total_records);
@@ -1340,6 +1520,7 @@ mod tests {
             bwa_chunk_size: 150_000_000,
             exclude_missing_reads: false,
             skip_pa_tags: false,
+            restore_unconverted_bases: false,
         };
 
         zipper.execute("test")?;
@@ -2077,6 +2258,7 @@ mod tests {
             bwa_chunk_size: 150_000_000,
             exclude_missing_reads: false,
             skip_pa_tags: false,
+            restore_unconverted_bases: false,
         };
 
         zipper.execute("test")?;
@@ -2327,6 +2509,7 @@ mod tests {
             bwa_chunk_size: 150_000_000,
             exclude_missing_reads,
             skip_pa_tags: false,
+            restore_unconverted_bases: false,
         };
 
         zipper.execute("test")?;
@@ -2413,6 +2596,7 @@ mod tests {
             bwa_chunk_size: 150_000_000,
             exclude_missing_reads: false,
             skip_pa_tags: false,
+            restore_unconverted_bases: false,
         };
 
         let result = zipper.execute("test");
@@ -3622,5 +3806,297 @@ mod tests {
     fn test_skip_pa_tags_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = Zipper::try_parse_from(args).expect("failed to parse Zipper arguments");
         assert_eq!(cmd.skip_pa_tags, expected);
+    }
+
+    #[rstest]
+    // --restore-unconverted-bases (default false)
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam"], false)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--restore-unconverted-bases"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--restore-unconverted-bases", "true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--restore-unconverted-bases", "false"], false)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--restore-unconverted-bases=true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--restore-unconverted-bases=false"], false)]
+    fn test_restore_unconverted_bases_parsing(#[case] args: &[&str], #[case] expected: bool) {
+        let cmd = Zipper::try_parse_from(args).expect("failed to parse Zipper arguments");
+        assert_eq!(cmd.restore_unconverted_bases, expected);
+    }
+
+    /// Tests that `restore_unconverted_bases_in_record` replaces T→C at ref-C positions
+    /// for top-strand reads (YD:Z:f).
+    #[test]
+    fn test_restore_unconverted_bases_top_strand() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: ACGTACGTACGT (chr1)
+        // Positions:  1234567890..
+        // C positions: 2, 6, 10
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        // Build a header with chr1
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
+
+        // Create a record aligned to pos 1 with 8M CIGAR
+        // Sequence: ATGTATGT (T at positions 2,6 = ref-C positions → should be restored to C)
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("ATGTATGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
+            .tag("YD", "f")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        // Position 1: A (ref=A, no change)
+        // Position 2: T→C (ref=C, top strand, T was converted)
+        // Position 3: G (ref=G, no change)
+        // Position 4: T (ref=T, no change)
+        // Position 5: A (ref=A, no change)
+        // Position 6: T→C (ref=C, top strand, T was converted)
+        // Position 7: G (ref=G, no change)
+        // Position 8: T (ref=T, no change)
+        assert_eq!(seq, b"ACGTACGT");
+
+        Ok(())
+    }
+
+    /// Tests that `restore_unconverted_bases_in_record` replaces A→G at ref-G positions
+    /// for bottom-strand reads (YD:Z:r).
+    #[test]
+    fn test_restore_unconverted_bases_bottom_strand() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: ACGTACGTACGT (chr1)
+        // G positions: 3, 7, 11
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
+
+        // Record at pos 1 with 8M. A at positions 3,7 = ref-G → should be restored to G
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("ACATACAT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2))
+            .tag("YD", "r")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        assert_eq!(seq, b"ACGTACGT");
+
+        Ok(())
+    }
+
+    /// Tests that `restore_unconverted_bases_in_record` handles insertions and deletions.
+    #[test]
+    fn test_restore_unconverted_bases_with_indels() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: ACGTACGTACGT
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
+
+        // CIGAR: 2M1I2M1D3M → 8 read bases, 8 ref bases consumed
+        // ref_bases (pos 1-8): A C G T A C G T
+        //
+        // Walk:
+        //   2M: read[0,1] vs ref[0,1](A,C) → T stays, T→C
+        //   1I: read[2] (insertion, no ref)
+        //   2M: read[3,4] vs ref[2,3](G,T) → no change (not ref-C)
+        //   1D: ref[4](A) skipped
+        //   3M: read[5,6,7] vs ref[5,6,7](C,G,T) → T→C, G stays, T stays
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("TTNATTGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("2M1I2M1D3M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
+            .tag("YD", "f")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        assert_eq!(seq, b"TCNATCGT");
+
+        Ok(())
+    }
+
+    /// Tests that `restore_unconverted_bases_in_record` skips unmapped reads.
+    #[test]
+    fn test_restore_unconverted_bases_skips_unmapped() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
+
+        // Unmapped read — should be left unchanged
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("TTTTTTTT")
+            .qualities(&[30; 8])
+            .flags(Flags::UNMAPPED)
+            .tag("YD", "f")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        assert_eq!(seq, b"TTTTTTTT"); // Unchanged
+
+        Ok(())
+    }
+
+    /// Tests that `restore_unconverted_bases_in_record` skips reads without YD tag.
+    #[test]
+    fn test_restore_unconverted_bases_skips_no_yd_tag() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
+
+        // Mapped read without YD tag — should be left unchanged
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("TTTTTTTT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        assert_eq!(seq, b"TTTTTTTT"); // Unchanged
+
+        Ok(())
+    }
+
+    /// Tests that non-converted bases at ref-C positions are left alone.
+    #[test]
+    fn test_restore_unconverted_bases_preserves_already_unconverted() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: CCCCCCCC (all C positions)
+        let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
+
+        // Top strand: some bases already C (unconverted), some T (converted), some other
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("CTCACTGC")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
+            .tag("YD", "f")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        // C stays C, T→C, C stays C, A stays A (not T→C), C stays C, T→C, G stays G, C stays C
+        assert_eq!(seq, b"CCCACCGC");
+
+        Ok(())
+    }
+
+    /// Tests restoration for a reverse-complemented top-strand read (YD:Z:f, 0x10 set).
+    /// SEQ is stored as the reverse complement, so at ref-G positions (complement of C),
+    /// converted A (complement of T) should be restored to G (complement of C).
+    #[test]
+    fn test_restore_unconverted_bases_top_strand_reverse() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: ACGTACGTACGT (chr1)
+        // G positions (1-based): 3, 7, 11
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
+
+        // Aligned at pos 1 with 8M, reverse-complemented (0x10).
+        // Reference region: ACGTACGT (pos 1-8)
+        // SEQ (stored RC'd): at ref-G positions 3,7 show A (converted) instead of G
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("ACATACGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE))
+            .tag("YD", "f")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        // Positions 3,7 (ref=G): A→G restored
+        assert_eq!(seq, b"ACGTACGT");
+
+        Ok(())
+    }
+
+    /// Tests restoration for a reverse-complemented bottom-strand read (YD:Z:r, 0x10 set).
+    /// SEQ is stored as the reverse complement, so at ref-C positions,
+    /// converted T (complement of A) should be restored to C (complement of G).
+    #[test]
+    fn test_restore_unconverted_bases_bottom_strand_reverse() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
+
+        // Reference: ACGTACGTACGT (chr1)
+        // C positions (1-based): 2, 6, 10
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
+
+        // Aligned at pos 1 with 8M, reverse-complemented (0x10).
+        // Reference region: ACGTACGT (pos 1-8)
+        // For (is_top=false, is_reverse=true): ref_target=C, converted=T, unconverted=C
+        // At ref-C positions 2,6: SEQ shows T (converted) instead of C
+        let mut record = RecordBuilder::new()
+            .name("q1")
+            .sequence("ATGTACGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .cigar("8M")
+            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE))
+            .tag("YD", "r")
+            .build();
+
+        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+
+        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
+        // Positions 2,6 (ref=C): T→C restored
+        assert_eq!(seq, b"ACGTACGT");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Adds `--restore-unconverted-bases` flag to `fgumi zipper` for EM-seq post-alignment base restoration
- After bwameth alignment (C→T converted reads), restores bases to unconverted state at reference positions: T→C for top-strand (YD=f), A→G for bottom-strand (YD=r)
- Ensures consensus calling sees original bases so methylation is determined by the consensus caller
- Defines `YD_FORWARD`/`YD_REVERSE` constants (was inline byte literals)
- Uses `reference_length()` utility for ref span computation (was manual CIGAR walk)

## Stack
3/4 — EM-seq support (depends on #169)

## Test plan
- [x] Tests for top-strand and bottom-strand base restoration
- [x] Tests for indels, unmapped reads, missing YD tag, already-unconverted bases
- [x] Existing zipper tests pass unchanged
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes