### PR TITLE
feat(consensus): add --methylation-mode for EM-Seq/TAPs consensus

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -333,7 +333,7 @@ impl CodecConsensusCaller {
             trim: false,
             min_consensus_base_quality: 0, // MIN - we handle quality masking
             cell_tag: None,
-            em_seq: false, // CODEC does not support EM-Seq
+            methylation_mode: crate::MethylationMode::Disabled, // CODEC does not support methylation
         };
 
         let ss_caller = VanillaUmiConsensusCaller::new(

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -238,7 +238,7 @@ pub struct DuplexConsensusRead {
     /// BA strand single-strand consensus (optional - may be absent for SS-only molecules)
     pub ba_consensus: Option<VanillaConsensusRead>,
 
-    /// Combined duplex methylation annotation (only populated when `em_seq` is enabled)
+    /// Combined duplex methylation annotation (only populated when methylation mode is enabled)
     pub methylation: Option<crate::methylation::MethylationAnnotation>,
 
     /// True when only the BA strand contributed (the BA consensus is stored in `ab_consensus`).
@@ -432,15 +432,17 @@ impl DuplexConsensusCaller {
         })
     }
 
-    /// Configures the duplex caller for EM-Seq methylation-aware consensus calling.
+    /// Configures the duplex caller for methylation-aware consensus calling.
     ///
-    /// Passes the reference and contig name mapping through to the single-strand caller,
-    /// which enables EM-Seq mode.
+    /// Sets the methylation mode on the single-strand caller options and passes the reference
+    /// and contig name mapping through to the SS caller.
     pub fn set_reference(
         &mut self,
         reference: std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>,
         ref_names: std::sync::Arc<Vec<String>>,
+        methylation_mode: crate::MethylationMode,
     ) {
+        self.ss_caller.options.methylation_mode = methylation_mode;
         self.ss_caller.set_reference(reference, ref_names);
     }
 
@@ -1091,6 +1093,7 @@ impl DuplexConsensusCaller {
         read_name_prefix: &str,
         read_group_id: &str,
         first_of_pair: bool,
+        methylation_mode: crate::MethylationMode,
         cell_tag: Option<Tag>,
         cell_barcode: Option<&str>,
     ) -> Result<()> {
@@ -1248,7 +1251,7 @@ impl DuplexConsensusCaller {
             builder.append_string_tag(b"RX", consensus_umi.as_bytes());
         }
 
-        // 9b. Methylation tags (EM-Seq)
+        // 9b. Methylation tags (EM-Seq/TAPs)
         if let Some(combined_annot) = &consensus.methylation {
             // When is_ba_only is true, the BA consensus was stored in ab_consensus
             // (no AB strand existed), so per-strand tags must use bottom-strand orientation.
@@ -1263,6 +1266,7 @@ impl DuplexConsensusCaller {
                     &consensus.ab_consensus.bases,
                     ab_annot,
                     is_top_strand,
+                    methylation_mode,
                 ) {
                     builder.append_string_tag(mm_tag, mm_val.as_bytes());
                 }
@@ -1274,9 +1278,12 @@ impl DuplexConsensusCaller {
 
             if let Some(ba) = &consensus.ba_consensus {
                 if let Some(ba_annot) = &ba.methylation {
-                    if let Some(bm) =
-                        crate::methylation::build_mm_tag_no_ml(&ba.bases, ba_annot, false)
-                    {
+                    if let Some(bm) = crate::methylation::build_mm_tag_no_ml(
+                        &ba.bases,
+                        ba_annot,
+                        false,
+                        methylation_mode,
+                    ) {
                         builder.append_string_tag(b"bm", bm.as_bytes());
                     }
                     let bu = ba_annot.unconverted_counts();
@@ -1287,10 +1294,12 @@ impl DuplexConsensusCaller {
             }
 
             // Combined duplex methylation tags (MM/ML/cu/ct)
+            // Use top strand (AB) orientation for MM tag format
             if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(
                 &consensus.bases,
                 combined_annot,
                 is_top_strand,
+                methylation_mode,
             ) {
                 builder.append_string_tag(b"MM", mm.as_bytes());
                 builder.append_u8_array_tag(b"ML", &ml);
@@ -1744,6 +1753,7 @@ impl DuplexConsensusCaller {
         let mut stats = ConsensusCallingStats::new();
         let mut builder = UnmappedBamRecordBuilder::new();
         let mut output = ConsensusOutput::default();
+        let methylation_mode = ss_caller.options.methylation_mode;
 
         // Check if we have both strands
         if a_records.is_empty() && b_records.is_empty() {
@@ -2044,6 +2054,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             true, // first of pair
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2059,6 +2070,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             false, // second of pair
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2093,6 +2105,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             true,
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2108,6 +2121,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             false,
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2138,6 +2152,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             true,
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2153,6 +2168,7 @@ impl DuplexConsensusCaller {
                             read_name_prefix,
                             read_group_id,
                             false,
+                            methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
@@ -2468,7 +2484,7 @@ mod tests {
                 trim: false,
                 min_consensus_base_quality: 40,
                 cell_tag: None,
-                em_seq: false,
+                methylation_mode: crate::MethylationMode::Disabled,
             },
         )
     }
@@ -4521,6 +4537,7 @@ mod tests {
             "consensus",
             "RG1",
             true,
+            crate::MethylationMode::Disabled,
             None,
             None,
         )
@@ -4916,6 +4933,7 @@ mod tests {
             "consensus",
             "RG1",
             true,
+            crate::MethylationMode::Disabled,
             Some(cell_tag),
             Some(cell_barcode),
         )
@@ -4966,6 +4984,7 @@ mod tests {
             "consensus",
             "RG1",
             true,
+            crate::MethylationMode::Disabled,
             None,
             None,
         )
@@ -5096,6 +5115,7 @@ mod tests {
             "consensus",
             "RG1",
             true,
+            crate::MethylationMode::Disabled,
             None,
             None,
         )
@@ -5189,6 +5209,7 @@ mod tests {
             "consensus",
             "RG1",
             true,
+            crate::MethylationMode::Disabled,
             None,
             None,
         )
@@ -5249,6 +5270,7 @@ mod tests {
                 "consensus",
                 "RG1",
                 true,
+                crate::MethylationMode::Disabled,
                 None,
                 None,
             )
@@ -6012,6 +6034,7 @@ mod tests {
             "consensus",
             "RG1",
             false,
+            crate::MethylationMode::EmSeq,
             None,
             None,
         )

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -36,6 +36,31 @@ pub mod methylation;
 
 mod vendored;
 
+/// Methylation chemistry mode for consensus calling.
+///
+/// Controls how C→T conversions at reference cytosine positions are interpreted
+/// during consensus calling and MM/ML tag generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MethylationMode {
+    /// No methylation-aware processing. C→T changes are treated as errors.
+    #[default]
+    Disabled,
+    /// EM-Seq (enzymatic methyl-seq): unmethylated C is converted to T.
+    /// C in read = methylated (protected), T in read = unmethylated (converted).
+    EmSeq,
+    /// TAPs/Illumina 5-base: methylated C is converted to T.
+    /// C in read = unmethylated (not a target), T in read = methylated (converted).
+    Taps,
+}
+
+impl MethylationMode {
+    /// Returns true if any methylation mode is enabled.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
+
 // Re-export commonly used items
 pub use base_builder::ConsensusBaseBuilder;
 pub use caller::{ConsensusCaller, calculate_error_rate, log_consensus_statistics};

--- a/crates/fgumi-consensus/src/methylation.rs
+++ b/crates/fgumi-consensus/src/methylation.rs
@@ -1,7 +1,14 @@
-//! Methylation-aware consensus calling for EM-Seq data.
+//! Methylation-aware consensus calling for EM-Seq and TAPs data.
 //!
 //! EM-Seq enzymatically converts unmethylated cytosines to thymine before PCR.
 //! At a reference C position: methylated → reads show C; unmethylated → reads show T.
+//!
+//! TAPs/Illumina 5-base converts methylated cytosines to thymine.
+//! At a reference C position: unmethylated → reads show C; methylated → reads show T.
+//!
+//! The base counting (unconverted C vs converted T) is identical in both chemistries.
+//! Only the MM/ML probability interpretation differs: EM-Seq uses unconverted/total,
+//! TAPs uses converted/total.
 //!
 //! This module provides:
 //! - Reference position mapping from consensus coordinates
@@ -212,6 +219,10 @@ pub(crate) fn annotate_simplex_methylation(
 /// bottom-strand had C. Per the SAM spec, opposite-strand 5mC is encoded as `G-m`
 /// (minus marker indicates the modification is on the opposite strand from SEQ).
 ///
+/// The `methylation_mode` parameter controls the probability calculation:
+/// - EM-Seq: prob = unconverted/total (C stayed as C because it was methylated)
+/// - TAPs: prob = converted/total (C was converted to T because it was methylated)
+///
 /// Returns `(mm_string, ml_array)`. Returns `None` if no ref-C positions exist.
 ///
 /// # Panics
@@ -222,6 +233,7 @@ pub fn build_mm_ml_tags(
     consensus_bases: &[u8],
     annotation: &MethylationAnnotation,
     is_top_strand: bool,
+    methylation_mode: crate::MethylationMode,
 ) -> Option<(String, Vec<u8>)> {
     assert_eq!(
         consensus_bases.len(),
@@ -246,8 +258,14 @@ pub fn build_mm_ml_tags(
             // This is a ref-C position with a C/G in consensus
             let total = u64::from(ev.unconverted_count) + u64::from(ev.converted_count);
             if total > 0 {
-                // Methylation probability = unconverted / total, scaled to [0, 255]
-                let prob = (u64::from(ev.unconverted_count) * 255 / total).min(255) as u8;
+                // EM-Seq: methylation prob = unconverted/total (C = methylated, stayed as C)
+                // TAPs:   methylation prob = converted/total  (T = methylated, converted from C)
+                let numerator = match methylation_mode {
+                    crate::MethylationMode::EmSeq => u64::from(ev.unconverted_count),
+                    crate::MethylationMode::Taps => u64::from(ev.converted_count),
+                    crate::MethylationMode::Disabled => return None,
+                };
+                let prob = (numerator * 255 / total).min(255) as u8;
                 skips.push(skip_count);
                 probs.push(prob);
                 skip_count = 0;
@@ -284,8 +302,9 @@ pub fn build_mm_tag_no_ml(
     consensus_bases: &[u8],
     annotation: &MethylationAnnotation,
     is_top_strand: bool,
+    methylation_mode: crate::MethylationMode,
 ) -> Option<String> {
-    build_mm_ml_tags(consensus_bases, annotation, is_top_strand).map(|(mm, _)| mm)
+    build_mm_ml_tags(consensus_bases, annotation, is_top_strand, methylation_mode).map(|(mm, _)| mm)
 }
 
 /// Fetches reference bases for aligned positions.
@@ -572,7 +591,7 @@ pub(crate) mod tests {
             ],
         };
 
-        let result = build_mm_ml_tags(&consensus, &annotation, true);
+        let result = build_mm_ml_tags(&consensus, &annotation, true, crate::MethylationMode::EmSeq);
         assert!(result.is_some());
         let (mm, ml) = result.unwrap();
         // Two C bases that are ref-C: skip 0 to first, skip 0 to second
@@ -596,7 +615,7 @@ pub(crate) mod tests {
             ],
         };
 
-        let result = build_mm_ml_tags(&consensus, &annotation, true);
+        let result = build_mm_ml_tags(&consensus, &annotation, true, crate::MethylationMode::EmSeq);
         assert!(result.is_none());
     }
 
@@ -612,7 +631,8 @@ pub(crate) mod tests {
             ],
         };
 
-        let result = build_mm_tag_no_ml(&consensus, &annotation, true);
+        let result =
+            build_mm_tag_no_ml(&consensus, &annotation, true, crate::MethylationMode::EmSeq);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "C+m,0;");
     }
@@ -695,7 +715,8 @@ pub(crate) mod tests {
             ],
         };
 
-        let (mm, ml) = build_mm_ml_tags(&consensus, &annotation, true).unwrap();
+        let (mm, ml) =
+            build_mm_ml_tags(&consensus, &annotation, true, crate::MethylationMode::EmSeq).unwrap();
         // First ref-C is the 1st C (skip 0), second ref-C is the 4th C (skip 1 non-ref C + skip 1 more)
         // Walking: C at 0 (ref-C, skip=0), C at 1 (not ref-C, skip++), C at 3 (ref-C, skip=1), C at 4 (not ref-C)
         assert_eq!(mm, "C+m,0,1;");
@@ -717,7 +738,9 @@ pub(crate) mod tests {
             ],
         };
 
-        let (mm, ml) = build_mm_ml_tags(&consensus, &annotation, false).expect("should have tags");
+        let (mm, ml) =
+            build_mm_ml_tags(&consensus, &annotation, false, crate::MethylationMode::EmSeq)
+                .expect("should have tags");
         // Per SAM spec: opposite-strand 5mC uses G-m (minus = opposite strand of SEQ)
         assert_eq!(mm, "G-m,0,0;");
         assert_eq!(ml.len(), 2);
@@ -740,6 +763,64 @@ pub(crate) mod tests {
         // Should saturate at u32::MAX, not wrap or panic
         assert_eq!(combined.evidence[0].unconverted_count, u32::MAX);
         assert_eq!(combined.evidence[0].converted_count, u32::MAX);
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_taps_all_methylated() {
+        // All converted (T) at ref-C → TAPs prob = converted/total = 255
+        let bases = vec![b'C'; 5]; // consensus restored to C
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 0,
+                    converted_count: 3
+                };
+                5
+            ],
+        };
+        let result = build_mm_ml_tags(&bases, &annotation, true, crate::MethylationMode::Taps);
+        let (mm, ml) = result.unwrap();
+        assert!(mm.starts_with("C+m"));
+        assert_eq!(ml, vec![255u8; 5]);
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_taps_all_unmethylated() {
+        // All unconverted (C) at ref-C → TAPs prob = converted/total = 0/3 = 0
+        let bases = vec![b'C'; 5];
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 3,
+                    converted_count: 0
+                };
+                5
+            ],
+        };
+        let result = build_mm_ml_tags(&bases, &annotation, true, crate::MethylationMode::Taps);
+        let (_, ml) = result.unwrap();
+        assert_eq!(ml, vec![0u8; 5]);
+    }
+
+    #[test]
+    fn test_build_mm_ml_tags_emseq_unchanged() {
+        // Verify EM-seq behavior is unchanged: unconverted/total
+        let bases = vec![b'C'; 5];
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: 3,
+                    converted_count: 0
+                };
+                5
+            ],
+        };
+        let result = build_mm_ml_tags(&bases, &annotation, true, crate::MethylationMode::EmSeq);
+        let (_, ml) = result.unwrap();
+        assert_eq!(ml, vec![255u8; 5]); // EM-seq: 3/3 unconverted = 255
     }
 
     /// Helper to create a `SourceRead` for testing.

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -171,7 +171,7 @@ pub struct VanillaConsensusRead {
     /// Optional source reads used for consensus (kept for tag preservation)
     pub(crate) source_reads: Option<Vec<SourceRead>>,
 
-    /// Methylation annotation (only populated when `em_seq` is enabled)
+    /// Methylation annotation (only populated when methylation mode is enabled)
     pub(crate) methylation: Option<crate::methylation::MethylationAnnotation>,
 }
 
@@ -316,10 +316,10 @@ pub struct VanillaUmiConsensusOptions {
     /// Optional cell barcode tag to preserve (e.g., "CB", "XX")
     pub cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
 
-    /// Whether to perform methylation-aware consensus calling for EM-Seq data.
-    /// When true, C→T conversions at reference cytosine positions are treated as
-    /// bisulfite/enzymatic conversion rather than errors, and MM/ML tags are emitted.
-    pub em_seq: bool,
+    /// Methylation mode for consensus calling (`Disabled`, `EmSeq`, or `Taps`).
+    /// When enabled, C→T conversions at reference cytosine positions are tracked
+    /// and MM/ML methylation tags are emitted on consensus reads.
+    pub methylation_mode: crate::MethylationMode,
 }
 
 impl Default for VanillaUmiConsensusOptions {
@@ -336,7 +336,7 @@ impl Default for VanillaUmiConsensusOptions {
             trim: false,
             min_consensus_base_quality: 40, // Match fgbio default
             cell_tag: None,
-            em_seq: false,
+            methylation_mode: crate::MethylationMode::Disabled,
         }
     }
 }
@@ -497,7 +497,6 @@ impl VanillaUmiConsensusCaller {
         reference: std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>,
         ref_names: std::sync::Arc<Vec<String>>,
     ) {
-        self.options.em_seq = true;
         self.reference = Some(reference);
         self.ref_names = Some(ref_names);
     }
@@ -632,10 +631,10 @@ impl VanillaUmiConsensusCaller {
             return Ok(None);
         }
 
-        // For EM-seq: annotate methylation first (counts conversions), then normalize
+        // For EM-seq/TAPs: annotate methylation first (counts conversions), then normalize
         // source read bases before consensus scoring so that C↔T / G↔A conversion
         // events at ref-C positions don't inflate error counts or depress quality.
-        let (methylation, source_reads) = if self.options.em_seq {
+        let (methylation, source_reads) = if self.options.methylation_mode.is_enabled() {
             let (annot, normalized) = self.annotate_and_normalize(source_reads);
             (annot, normalized)
         } else {
@@ -1210,9 +1209,8 @@ impl VanillaUmiConsensusCaller {
             Vec::new()
         };
 
-        // For EM-seq: annotate methylation first, then normalize source read bases
-        // before consensus scoring so conversion events don't inflate errors.
-        let (methylation, filtered_source_reads) = if self.options.em_seq {
+        // Apply methylation annotation if methylation mode is enabled
+        let (methylation, filtered_source_reads) = if self.options.methylation_mode.is_enabled() {
             let (annot, normalized) = self.annotate_and_normalize(filtered_source_reads);
             (annot, normalized)
         } else {
@@ -1437,14 +1435,19 @@ impl VanillaUmiConsensusCaller {
             self.bam_builder.append_string_tag(b"RX", consensus_umi.as_bytes());
         }
 
-        // Methylation tags (EM-Seq)
+        // Methylation tags (EM-Seq/TAPs)
         if let Some(annot) = methylation {
             // Determine strand for MM tag format
             let is_top = original_raws
                 .first()
                 .is_none_or(|raw| crate::methylation::is_top_strand(fgumi_raw_bam::flags(raw)));
 
-            if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(bases, annot, is_top) {
+            if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(
+                bases,
+                annot,
+                is_top,
+                self.options.methylation_mode,
+            ) {
                 self.bam_builder.append_string_tag(b"MM", mm.as_bytes());
                 self.bam_builder.append_u8_array_tag(b"ML", &ml);
             }
@@ -4563,22 +4566,28 @@ mod tests {
 
     use crate::methylation::tests::TestRef;
 
-    /// Creates a caller configured for EM-Seq with a test reference.
-    fn create_em_seq_caller(ref_seq: &[u8]) -> VanillaUmiConsensusCaller {
+    /// Creates a caller configured for the given methylation mode with a test reference.
+    fn create_methylation_caller(
+        ref_seq: &[u8],
+        mode: crate::MethylationMode,
+    ) -> VanillaUmiConsensusCaller {
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
             min_consensus_base_quality: 0,
-            em_seq: true,
+            methylation_mode: mode,
             ..Default::default()
         };
         let mut caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
-
-        // Set up reference: contig "chr1" with the given sequence
         let reference = std::sync::Arc::new(TestRef::new(&[("chr1", ref_seq)]));
         let ref_names = std::sync::Arc::new(vec!["chr1".to_string()]);
         caller.set_reference(reference, ref_names);
         caller
+    }
+
+    /// Convenience wrapper for EM-Seq caller.
+    fn create_em_seq_caller(ref_seq: &[u8]) -> VanillaUmiConsensusCaller {
+        create_methylation_caller(ref_seq, crate::MethylationMode::EmSeq)
     }
 
     /// Test: All reads show C at ref-C → methylated, consensus=C, MM tag indicates methylation.
@@ -4626,8 +4635,8 @@ mod tests {
     }
 
     /// Test: All reads show T at ref-C → unmethylated.
-    /// Consensus remains T since methylation annotation does not alter bases.
-    /// MM/ML tags are absent because there are no C bases in the consensus to report.
+    /// Normalization converts T→C before consensus, so consensus base = C.
+    /// MM/ML tags are present with prob = 0 (EM-Seq: unconverted/total = 0/3 = 0).
     #[test]
     fn test_simplex_em_seq_all_unmethylated() {
         let mut ref_seq = vec![b'N'; 99];
@@ -4645,12 +4654,15 @@ mod tests {
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
 
-        // Consensus bases remain T (annotation doesn't replace bases)
-        assert_eq!(consensus.bases, vec![b'T'; 10]);
+        // Consensus base is C — normalization converts T→C before consensus scoring
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
 
-        // MM/ML tags are absent (no C bases in consensus to reference)
-        assert!(consensus.get_string_tag(b"MM").is_none(), "MM tag should be absent");
-        assert!(consensus.get_u8_array_tag(b"ML").is_none(), "ML tag should be absent");
+        // MM/ML tags present — consensus is C at ref-C, prob = unconverted/total = 0/3 = 0
+        let mm = consensus.get_string_tag(b"MM").expect("MM tag should be present");
+        assert_eq!(mm, b"C+m,0,0,0,0,0,0,0,0,0,0;");
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        assert_eq!(ml.len(), 10);
+        assert!(ml.iter().all(|&p| p == 0), "all probs should be 0, got {ml:?}");
 
         // cu should all be 0 (no reads showed C)
         let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
@@ -4731,7 +4743,7 @@ mod tests {
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
             min_consensus_base_quality: 0,
-            em_seq: false,
+            methylation_mode: crate::MethylationMode::Disabled,
             ..Default::default()
         };
         let mut caller =
@@ -4746,7 +4758,7 @@ mod tests {
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
 
-        // Without em_seq, consensus should just be T (no reference correction)
+        // Without methylation mode, consensus should just be T (no reference correction)
         assert_eq!(consensus.bases, vec![b'T'; 10]);
 
         // No methylation tags
@@ -4800,5 +4812,154 @@ mod tests {
         // ML tag should have 10 entries (one per C position)
         let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
         assert_eq!(ml.len(), 10, "ML tag should cover all 10 consensus positions");
+    }
+
+    // ========================================================================
+    // TAPs methylation-aware consensus tests
+    // ========================================================================
+
+    /// Convenience wrapper for TAPs caller.
+    fn create_taps_caller(ref_seq: &[u8]) -> VanillaUmiConsensusCaller {
+        create_methylation_caller(ref_seq, crate::MethylationMode::Taps)
+    }
+
+    /// TAPs: All reads show C at ref-C → unmethylated. MM prob should be 0.
+    #[test]
+    fn test_simplex_taps_all_unmethylated() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_taps_caller(&ref_seq);
+
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'C'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus bases should be C (unmethylated in TAPs = unconverted)
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
+
+        let mm = consensus.get_string_tag(b"MM").expect("MM tag should be present");
+        assert!(mm.starts_with(b"C+m"), "MM should start with C+m");
+
+        // In TAPs: all C (unconverted) means 0 converted → methylation prob = 0/3 = 0
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        for &p in &ml {
+            assert_eq!(p, 0, "Expected methylation probability 0 for fully unmethylated TAPs");
+        }
+
+        // cu (unconverted) = 3, ct (converted) = 0
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![3i16; 10]);
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![0i16; 10]);
+    }
+
+    /// TAPs: All reads show T at ref-C → methylated (converted).
+    /// Normalization converts T→C before consensus, so consensus base = C.
+    /// MM/ML tags are emitted with high methylation probability (converted/total = 3/3 ≈ 255).
+    #[test]
+    fn test_simplex_taps_all_methylated() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_taps_caller(&ref_seq);
+
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'T'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus base is C — normalization converts T→C before consensus scoring
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
+
+        // MM/ML tags should be present — consensus is C at ref-C positions
+        let mm = consensus.get_string_tag(b"MM").expect("MM tag should be present");
+        assert_eq!(mm, b"C+m,0,0,0,0,0,0,0,0,0,0;");
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        // TAPs prob = converted/total = 3/3 → 255
+        assert_eq!(ml.len(), 10);
+        assert!(ml.iter().all(|&p| p == 255), "all probs should be 255, got {ml:?}");
+
+        // cu/ct tags should still be present with correct counts
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![0i16; 10]);
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![3i16; 10]);
+    }
+
+    /// TAPs: Mixed — 2 reads C (unmethylated), 1 read T (methylated). Prob = 1/3 ≈ 85.
+    /// Consensus base is C (all normalized to C before consensus scoring).
+    #[test]
+    fn test_simplex_taps_mixed_methylation() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+        let mut caller = create_taps_caller(&ref_seq);
+
+        let quals = vec![30u8; 10];
+        let read1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+
+        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        // Consensus base is C (2 C vs 1 T)
+        assert_eq!(consensus.bases, vec![b'C'; 10]);
+
+        // TAPs: prob = converted/total = 1/3 * 255 = 85
+        let ml = consensus.get_u8_array_tag(b"ML").expect("ML tag should be present");
+        for &p in &ml {
+            assert_eq!(p, 85, "Expected ~85 for 1/3 methylation ratio in TAPs");
+        }
+
+        let cu = consensus.get_i16_array_tag(b"cu").expect("cu tag should be present");
+        assert_eq!(cu, vec![2i16; 10]);
+        let ct = consensus.get_i16_array_tag(b"ct").expect("ct tag should be present");
+        assert_eq!(ct, vec![1i16; 10]);
+    }
+
+    /// TAPs: contrast with EM-seq for the same input data.
+    /// Same reads (2C + 1T) give OPPOSITE probabilities.
+    #[test]
+    fn test_taps_vs_emseq_inverted_probabilities() {
+        let mut ref_seq = vec![b'N'; 99];
+        ref_seq.extend_from_slice(b"CCCCCCCCCC");
+
+        // EM-seq: 2C + 1T → prob = unconverted/total = 2/3*255 = 170
+        let mut em_caller = create_em_seq_caller(&ref_seq);
+        let quals = vec![30u8; 10];
+        let r1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let r2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let r3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+        let em_output = consensus_reads_from_records(&mut em_caller, vec![r1, r2, r3]).unwrap();
+        let em_records = ParsedBamRecord::parse_all(&em_output.data);
+        let em_ml = em_records[0].get_u8_array_tag(b"ML").unwrap();
+
+        // TAPs: 2C + 1T → prob = converted/total = 1/3*255 = 85
+        let mut taps_caller = create_taps_caller(&ref_seq);
+        let r1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
+        let r2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
+        let r3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
+        let taps_output = consensus_reads_from_records(&mut taps_caller, vec![r1, r2, r3]).unwrap();
+        let taps_records = ParsedBamRecord::parse_all(&taps_output.data);
+        let taps_ml = taps_records[0].get_u8_array_tag(b"ML").unwrap();
+
+        // EM-seq: 170, TAPs: 85 — they sum to 255
+        for (&em_p, &taps_p) in em_ml.iter().zip(taps_ml.iter()) {
+            assert_eq!(em_p, 170);
+            assert_eq!(taps_p, 85);
+            assert_eq!(u16::from(em_p) + u16::from(taps_p), 255);
+        }
     }
 }

--- a/docs/src/guide/em-seq.md
+++ b/docs/src/guide/em-seq.md
@@ -35,8 +35,8 @@ Steps marked with EM-Seq-specific flags:
 
 | Step | Flag | Purpose |
 |------|------|---------|
-| `simplex` | `--em-seq --ref` | Methylation-aware consensus |
-| `duplex` | `--em-seq --ref` | Methylation-aware consensus |
+| `simplex` | `--methylation-mode em-seq --ref` | Methylation-aware consensus |
+| `duplex` | `--methylation-mode em-seq --ref` | Methylation-aware consensus |
 | `filter` | `--min-methylation-depth`, `--require-strand-methylation-agreement`, `--min-conversion-fraction` | Methylation-specific filtering |
 
 ---
@@ -121,7 +121,7 @@ fgumi group \
 
 ### Step 5: Consensus Calling
 
-Use `--em-seq` and `--ref` to enable methylation-aware consensus.
+Use `--methylation-mode em-seq` and `--ref` to enable methylation-aware consensus.
 
 **Simplex:**
 
@@ -132,7 +132,7 @@ fgumi simplex \
   --min-reads 1 \
   --min-input-base-quality 20 \
   --output-per-base-tags \
-  --em-seq \
+  --methylation-mode em-seq \
   --ref ref.fa \
   --threads 8
 ```
@@ -146,7 +146,7 @@ fgumi duplex \
   --min-reads 1 \
   --min-input-base-quality 20 \
   --output-per-base-tags \
-  --em-seq \
+  --methylation-mode em-seq \
   --ref ref.fa \
   --threads 8
 ```
@@ -251,7 +251,7 @@ After correction, the remaining steps are the same as Workflow A (steps 2–8).
 
 ## EM-Seq Output Tags
 
-When `--em-seq` is enabled, consensus reads carry additional BAM tags for methylation evidence.
+When `--methylation-mode em-seq` is enabled, consensus reads carry additional BAM tags for methylation evidence.
 
 ### Simplex Output Tags
 
@@ -281,7 +281,7 @@ The `MM`/`ML` tags follow the [SAM-spec methylation format](https://samtools.git
 
 ## EM-Seq Filter Options
 
-The `filter` command provides three methylation-specific options. These operate on the `cu`/`ct`/`au`/`at`/`bu`/`bt` count tags emitted by `--em-seq` consensus calling.
+The `filter` command provides three methylation-specific options. These operate on the `cu`/`ct`/`au`/`at`/`bu`/`bt` count tags emitted by `--methylation-mode em-seq` consensus calling.
 
 ### `--min-methylation-depth`
 
@@ -320,14 +320,14 @@ CpG positions are excluded from this calculation because they may be methylated 
 ### EM-Seq Simplex (Moderate Stringency)
 
 ```bash
-fgumi simplex --min-reads 1 --min-input-base-quality 20 --output-per-base-tags --em-seq --ref ref.fa
+fgumi simplex --min-reads 1 --min-input-base-quality 20 --output-per-base-tags --methylation-mode em-seq --ref ref.fa
 fgumi filter --ref ref.fa --min-reads 3 --max-base-error-rate 0.1 --min-methylation-depth 3 --min-conversion-fraction 0.9
 ```
 
 ### EM-Seq Duplex (High Specificity)
 
 ```bash
-fgumi duplex --min-reads 1 --min-input-base-quality 20 --output-per-base-tags --em-seq --ref ref.fa
+fgumi duplex --min-reads 1 --min-input-base-quality 20 --output-per-base-tags --methylation-mode em-seq --ref ref.fa
 fgumi filter --ref ref.fa --min-reads 10,5,3 --max-base-error-rate 0.1 --min-methylation-depth 10,5,3 \
   --require-single-strand-agreement --require-strand-methylation-agreement --min-conversion-fraction 0.9
 ```
@@ -357,7 +357,7 @@ If family size histograms show many singletons:
 
 ### Missing MM/ML Tags on Output
 
-Ensure both `--em-seq` and `--ref` are provided to the consensus caller. The reference FASTA must have an accompanying `.dict` file (generate with `samtools dict` if missing).
+Ensure both `--methylation-mode em-seq` and `--ref` are provided to the consensus caller. The reference FASTA must have an accompanying `.dict` file (generate with `samtools dict` if missing).
 
 ### Unexpected Masking from Strand Methylation Agreement
 

--- a/docs/theme/sidebar-brand.js
+++ b/docs/theme/sidebar-brand.js
@@ -39,10 +39,7 @@
     var FOOTER_HTML =
         '<div class="fg-visit-us fg-page-footer">' +
         '<a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener">' +
-        '<picture>' +
-        '<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fulcrumgenomics/fgumi/main/.github/logos/fulcrumgenomics-light.svg">' +
         '<img alt="Fulcrum Genomics" src="https://raw.githubusercontent.com/fulcrumgenomics/fgumi/main/.github/logos/fulcrumgenomics-dark.svg" height="50">' +
-        '</picture>' +
         '</a>' +
         '<p>Visit us at <a href="https://www.fulcrumgenomics.com" target="_blank" rel="noopener">Fulcrum Genomics</a> to learn more about how we can power your Bioinformatics with fgumi and beyond.</p>' +
         '<div class="fg-visit-buttons">' +

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -16,26 +16,67 @@ use fgumi_consensus::methylation::RefBaseProvider;
 use log::info;
 use noodles::sam::Header;
 
-/// EM-Seq reference pair: reference base provider + contig name mapping.
-pub type EmSeqRef = Option<(
+/// CLI argument value for `--methylation-mode`.
+///
+/// Maps to [`fgumi_consensus::MethylationMode`] variants (excluding `Disabled`,
+/// which is represented by the absence of the flag).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MethylationModeArg {
+    /// EM-Seq (enzymatic methyl-seq): unmethylated C is converted to T.
+    /// C in read at ref-C = methylated (protected); T = unmethylated (converted).
+    #[value(name = "em-seq")]
+    EmSeq,
+    /// TAPs/Illumina 5-base: methylated C is converted to T.
+    /// C in read at ref-C = unmethylated (not a target); T = methylated (converted).
+    #[value(name = "taps")]
+    Taps,
+}
+
+impl From<MethylationModeArg> for fgumi_consensus::MethylationMode {
+    fn from(arg: MethylationModeArg) -> Self {
+        match arg {
+            MethylationModeArg::EmSeq => Self::EmSeq,
+            MethylationModeArg::Taps => Self::Taps,
+        }
+    }
+}
+
+/// Resolves an optional `--methylation-mode` CLI arg to a [`MethylationMode`].
+///
+/// Returns `Disabled` when `None` (flag not provided).
+///
+/// [`MethylationMode`]: fgumi_consensus::MethylationMode
+pub fn resolve_methylation_mode(
+    arg: Option<MethylationModeArg>,
+) -> fgumi_consensus::MethylationMode {
+    arg.map_or(fgumi_consensus::MethylationMode::Disabled, Into::into)
+}
+
+/// Methylation reference pair: reference base provider + contig name mapping.
+pub type MethylationRef = Option<(
     Arc<dyn fgumi_consensus::methylation::RefBaseProvider + Send + Sync>,
     Arc<Vec<String>>,
 )>;
 
-/// Loads the reference FASTA and builds contig name mapping for EM-Seq mode.
+/// Loads the reference FASTA and builds contig name mapping for methylation-aware modes.
 ///
-/// Returns `None` if `em_seq` is false. Errors if `em_seq` is true but `reference` is `None`.
-pub fn load_em_seq_reference(
-    em_seq: bool,
+/// Returns `None` if methylation mode is disabled. Errors if enabled but `reference` is `None`.
+pub fn load_methylation_reference(
+    methylation_mode: fgumi_consensus::MethylationMode,
     reference: &Option<PathBuf>,
     header: &Header,
-) -> anyhow::Result<EmSeqRef> {
-    if !em_seq {
+) -> anyhow::Result<MethylationRef> {
+    if !methylation_mode.is_enabled() {
         return Ok(None);
     }
+    let mode_name = match methylation_mode {
+        fgumi_consensus::MethylationMode::EmSeq => "EM-Seq",
+        fgumi_consensus::MethylationMode::Taps => "TAPs",
+        fgumi_consensus::MethylationMode::Disabled => unreachable!(),
+    };
     let ref_path = reference
         .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("--ref is required when --em-seq is enabled"))?;
+        .ok_or_else(|| anyhow::anyhow!("--ref is required when --methylation-mode is set"))?;
     let ref_timer = OperationTimer::new("Loading reference FASTA");
     let reference = Arc::new(crate::reference::ReferenceReader::new(ref_path)?);
     ref_timer.log_completion(0);
@@ -54,7 +95,7 @@ pub fn load_em_seq_reference(
         );
     }
 
-    info!("EM-Seq mode enabled with {} reference contigs", ref_names.len());
+    info!("{mode_name} mode enabled with {} reference contigs", ref_names.len());
     Ok(Some((reference, Arc::new(ref_names))))
 }
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -9,7 +9,7 @@ use crate::bam_io::{
     create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
     create_raw_bam_reader,
 };
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 
@@ -49,7 +49,7 @@ use std::sync::Arc;
 
 use super::command::Command;
 
-use super::common::{EmSeqOptions, EmSeqRef, load_em_seq_reference};
+use super::common::{MethylationRef, load_methylation_reference};
 
 // ============================================================================
 // Types for 7-step pipeline processing
@@ -196,9 +196,16 @@ pub struct Duplex {
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
 
-    /// EM-Seq methylation-aware consensus options.
-    #[command(flatten)]
-    pub em_seq_opts: EmSeqOptions,
+    /// Methylation-aware consensus calling mode.
+    /// EM-Seq: C→T at ref-C = unmethylated (enzymatic conversion); TAPs: C→T at ref-C = methylated.
+    /// Emits MM/ML methylation tags and cu/ct per-base count tags on consensus reads.
+    /// Requires --ref.
+    #[arg(long = "methylation-mode", value_enum)]
+    pub methylation_mode: Option<crate::commands::common::MethylationModeArg>,
+
+    /// Path to the reference FASTA file (required when --methylation-mode is set).
+    #[arg(long = "ref")]
+    pub reference: Option<std::path::PathBuf>,
 }
 
 impl Command for Duplex {
@@ -260,7 +267,8 @@ impl Command for Duplex {
     ///     max_reads_per_strand: None,
     ///     scheduler_opts: SchedulerOptions::default(),
     ///     queue_memory: QueueMemoryOptions::default(),
-    ///     em_seq_opts: EmSeqOptions::default(),
+    ///     methylation_mode: None,
+    ///     reference: None,
     /// };
     ///
     /// duplex.execute("test")?;
@@ -308,9 +316,14 @@ impl Command for Duplex {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        // Load reference for EM-Seq methylation-aware consensus calling
-        let em_seq_ref: EmSeqRef =
-            load_em_seq_reference(self.em_seq_opts.em_seq, &self.em_seq_opts.reference, &header)?;
+        // Load reference for methylation-aware consensus calling
+        if self.reference.is_some() && self.methylation_mode.is_none() {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+        let methylation_mode =
+            crate::commands::common::resolve_methylation_mode(self.methylation_mode);
+        let methylation_ref: MethylationRef =
+            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
@@ -335,7 +348,8 @@ impl Command for Duplex {
                 read_name_prefix.clone(),
                 track_rejects,
                 command_line,
-                em_seq_ref.clone(),
+                methylation_ref.clone(),
+                methylation_mode,
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
@@ -380,9 +394,13 @@ impl Command for Duplex {
             self.consensus.error_rate_post_umi,
         )?;
 
-        // Set reference for EM-Seq if enabled
-        if let Some((ref reference, ref ref_names)) = em_seq_ref {
-            consensus_caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        // Set reference for methylation-aware consensus if enabled
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
+            consensus_caller.set_reference(
+                Arc::clone(reference),
+                Arc::clone(ref_names),
+                methylation_mode,
+            );
         }
 
         // Accumulator for overlapping stats from parallel processing
@@ -533,7 +551,8 @@ impl Duplex {
         read_name_prefix: String,
         track_rejects: bool,
         command_line: &str,
-        em_seq_ref: EmSeqRef,
+        methylation_ref: MethylationRef,
+        methylation_mode: fgumi_consensus::MethylationMode,
     ) -> Result<()> {
         // Create output header (for duplex, output is unmapped like simplex)
         let output_header = create_unmapped_consensus_header(
@@ -636,9 +655,13 @@ impl Duplex {
                     io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}"))
                 })?;
 
-                // Set reference for EM-Seq if enabled
-                if let Some((ref reference, ref ref_names)) = em_seq_ref {
-                    caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+                // Set reference for methylation-aware consensus if enabled
+                if let Some((ref reference, ref ref_names)) = methylation_ref {
+                    caller.set_reference(
+                        Arc::clone(reference),
+                        Arc::clone(ref_names),
+                        methylation_mode,
+                    );
                 }
 
                 // Create overlapping caller if enabled
@@ -894,7 +917,8 @@ mod tests {
             max_reads_per_strand: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
-            em_seq_opts: EmSeqOptions::default(),
+            methylation_mode: None,
+            reference: None,
         }
     }
 
@@ -1715,8 +1739,8 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = create_duplex_with_paths(input.path().to_path_buf(), paths.output.clone());
-        cmd.em_seq_opts.em_seq = true;
-        cmd.em_seq_opts.reference = Some(ref_file.path().to_path_buf());
+        cmd.methylation_mode = Some(crate::commands::common::MethylationModeArg::EmSeq);
+        cmd.reference = Some(ref_file.path().to_path_buf());
         cmd.threading = threading;
         cmd.execute("test")?;
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -841,7 +841,8 @@ impl Filter {
             }
         };
 
-        // Conversion fraction filter (EM-Seq read-level)
+        // Conversion fraction filter (EM-Seq only — not applicable to TAPs where
+        // non-CpG cytosines are expected to remain unconverted)
         if pass {
             if let Some(min_frac) = min_conversion_fraction {
                 if !check_conversion_fraction_raw_with_ref_bases_and_tags(

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -48,7 +48,7 @@ use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
 };
 
-use super::common::{EmSeqOptions, EmSeqRef, load_em_seq_reference};
+use super::common::{MethylationRef, load_methylation_reference};
 
 // ============================================================================
 // Types for 7-step pipeline processing
@@ -210,9 +210,16 @@ pub struct Simplex {
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
 
-    /// EM-Seq methylation-aware consensus options.
-    #[command(flatten)]
-    pub em_seq_opts: EmSeqOptions,
+    /// Methylation-aware consensus calling mode.
+    /// EM-Seq: C→T at ref-C = unmethylated (enzymatic conversion); TAPs: C→T at ref-C = methylated.
+    /// Emits MM/ML methylation tags and cu/ct per-base count tags on consensus reads.
+    /// Requires --ref.
+    #[arg(long = "methylation-mode", value_enum)]
+    pub methylation_mode: Option<crate::commands::common::MethylationModeArg>,
+
+    /// Path to the reference FASTA file (required when --methylation-mode is set).
+    #[arg(long = "ref")]
+    pub reference: Option<std::path::PathBuf>,
 }
 
 impl Command for Simplex {
@@ -261,9 +268,14 @@ impl Command for Simplex {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        // Load reference for EM-Seq methylation-aware consensus calling
-        let em_seq_ref: EmSeqRef =
-            load_em_seq_reference(self.em_seq_opts.em_seq, &self.em_seq_opts.reference, &header)?;
+        // Load reference for methylation-aware consensus calling
+        if self.reference.is_some() && self.methylation_mode.is_none() {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+        let methylation_mode =
+            crate::commands::common::resolve_methylation_mode(self.methylation_mode);
+        let methylation_ref: MethylationRef =
+            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.is_enabled();
@@ -288,7 +300,8 @@ impl Command for Simplex {
                 output_header.clone(),
                 read_name_prefix.clone(),
                 track_rejects,
-                em_seq_ref.clone(),
+                methylation_ref.clone(),
+                methylation_mode,
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
@@ -329,7 +342,7 @@ impl Command for Simplex {
             trim: self.consensus.trim,
             min_consensus_base_quality: self.consensus.min_consensus_base_quality,
             cell_tag: Some(cell_tag),
-            em_seq: self.em_seq_opts.em_seq,
+            methylation_mode,
         };
 
         // Create a single-threaded caller for stats collection
@@ -340,8 +353,8 @@ impl Command for Simplex {
             track_rejects,
         );
 
-        // Set reference for EM-Seq if enabled
-        if let Some((ref reference, ref ref_names)) = em_seq_ref {
+        // Set reference for methylation-aware consensus if enabled
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
             caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
         }
 
@@ -467,7 +480,8 @@ impl Simplex {
         output_header: Header,
         read_name_prefix: String,
         track_rejects: bool,
-        em_seq_ref: EmSeqRef,
+        methylation_ref: MethylationRef,
+        methylation_mode: fgumi_consensus::MethylationMode,
     ) -> Result<()> {
         // Configure pipeline
         let mut pipeline_config = build_pipeline_config(
@@ -509,7 +523,7 @@ impl Simplex {
             trim,
             min_consensus_base_quality,
             cell_tag: Some(cell_tag),
-            em_seq: self.em_seq_opts.em_seq,
+            methylation_mode,
         };
 
         // Clone input_header before pipeline (needed for rejects writing)
@@ -541,8 +555,8 @@ impl Simplex {
                     track_rejects,
                 );
 
-                // Set reference for EM-Seq if enabled
-                if let Some((ref reference, ref ref_names)) = em_seq_ref {
+                // Set reference for methylation-aware consensus if enabled
+                if let Some((ref reference, ref ref_names)) = methylation_ref {
                     caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
                 }
 
@@ -753,7 +767,8 @@ mod tests {
             min_reads: 1,
             max_reads: None,
             scheduler_opts: SchedulerOptions::default(),
-            em_seq_opts: EmSeqOptions::default(),
+            methylation_mode: None,
+            reference: None,
         }
     }
 
@@ -1637,8 +1652,8 @@ mod tests {
         builder.write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
-        cmd.em_seq_opts.em_seq = true;
-        cmd.em_seq_opts.reference = Some(ref_fasta.path().to_path_buf());
+        cmd.methylation_mode = Some(crate::commands::common::MethylationModeArg::EmSeq);
+        cmd.reference = Some(ref_fasta.path().to_path_buf());
         cmd.threading = threading;
         cmd.execute("test")?;
 


### PR DESCRIPTION
## Summary

- Adds `MethylationMode` enum (`Disabled`, `EmSeq`, `Taps`) to `fgumi-consensus`
- Adds `--methylation-mode <em-seq|taps>` CLI arg to `simplex` and `duplex` commands
- Parameterizes MM/ML probability calculation: EM-Seq uses unconverted/total, TAPs uses converted/total
- Includes TAPs consensus tests and EM-Seq/TAPs comparison test

Stacked on #171. Replaces the previous `--em-seq` boolean flag.

## Test plan

- [x] All existing EM-Seq tests pass with identical results
- [x] New TAPs tests verify inverted probabilities vs EM-Seq
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes
- [ ] Test with real TAPs data (pending)

> **Draft**: not yet validated with real TAPs sequencing data.