### PR TITLE
feat(filter): add --methylation-mode to filter for conversion fraction

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1593,26 +1593,38 @@ pub fn check_conversion_fraction_raw(
     min_fraction: f64,
     reference: &dyn crate::methylation::RefBaseProvider,
     ref_names: &[String],
+    methylation_mode: crate::MethylationMode,
 ) -> bool {
     let ref_base_map = resolve_ref_bases_for_record(record, reference, ref_names);
-    let tags = MethylationTags::from_record(record);
+    let meth_tags = MethylationTags::from_record(record);
     check_conversion_fraction_raw_with_ref_bases_and_tags(
         record,
         min_fraction,
         ref_base_map.as_deref(),
-        &tags,
+        &meth_tags,
+        methylation_mode,
     )
 }
 
 /// Like [`check_conversion_fraction_raw`] but accepts both pre-resolved reference bases
 /// and pre-parsed methylation tags, avoiding all redundant work.
+///
+/// For EM-Seq, checks `ct / (cu + ct) >= threshold` at non-CpG ref-C positions.
+/// For TAPs, checks `cu / (cu + ct) >= threshold` instead, since
+/// non-CpG Cs should NOT be converted in TAPs.
 #[must_use]
 pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
     record: &[u8],
     min_fraction: f64,
     ref_base_map: Option<&[Option<u8>]>,
-    tags: &MethylationTags,
+    methylation_tags: &MethylationTags,
+    methylation_mode: crate::MethylationMode,
 ) -> bool {
+    // Conversion fraction is meaningless without a methylation mode — pass through
+    if methylation_mode == crate::MethylationMode::Disabled {
+        return true;
+    }
+
     let Some(ref_base_map) = ref_base_map else {
         return true; // unmapped reads pass
     };
@@ -1620,11 +1632,11 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
     let len = bam_fields::l_seq(record) as usize;
 
     // If no methylation tags, pass
-    if tags.cu.is_none() && tags.ct.is_none() {
+    if methylation_tags.cu.is_none() && methylation_tags.ct.is_none() {
         return true;
     }
 
-    let mut total_converted: u64 = 0;
+    let mut total_numerator: u64 = 0;
     let mut total_evidence: u64 = 0;
 
     for i in 0..len {
@@ -1639,11 +1651,19 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
             continue;
         }
 
-        let cu = tags.cu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
-        let ct = tags.ct.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let cu = methylation_tags.cu.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
+        let ct = methylation_tags.ct.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
         let evidence = u64::from(cu) + u64::from(ct);
         if evidence > 0 {
-            total_converted += u64::from(ct);
+            // For EM-Seq: count converted (ct) — high conversion = good library quality
+            // For TAPs: count unconverted (cu) — high non-conversion at non-CpG = good specificity
+            // Safety: Disabled is handled by the early return at the top of this function
+            let numerator = match methylation_mode {
+                crate::MethylationMode::Taps => u64::from(cu),
+                crate::MethylationMode::EmSeq => u64::from(ct),
+                crate::MethylationMode::Disabled => return true,
+            };
+            total_numerator += numerator;
             total_evidence += evidence;
         }
     }
@@ -1657,7 +1677,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
         clippy::cast_precision_loss,
         reason = "precision loss is acceptable for fraction calculation"
     )]
-    let fraction = total_converted as f64 / total_evidence as f64;
+    let fraction = total_numerator as f64 / total_evidence as f64;
     fraction >= min_fraction
 }
 
@@ -3122,7 +3142,13 @@ mod tests {
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
         // 18 converted out of 20 = 90% conversion (positions 1 and 5)
         assert!(
-            check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
+            check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
             "Should pass with high conversion fraction"
         );
     }
@@ -3150,7 +3176,13 @@ mod tests {
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
         // 2 converted out of 20 = 10% conversion (positions 1 and 5)
         assert!(
-            !check_conversion_fraction_raw(&raw, 0.8, &reference, &ref_names),
+            !check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
             "Should fail with low conversion fraction"
         );
     }
@@ -3179,7 +3211,13 @@ mod tests {
 
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
         assert!(
-            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            check_conversion_fraction_raw(
+                &raw,
+                0.9,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
             "Should pass because CpG sites are excluded from conversion check"
         );
     }
@@ -3203,7 +3241,13 @@ mod tests {
         // No cu/ct tags
         let raw = build_raw_with_methylation_tags(&sam.header, &record);
         assert!(
-            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            check_conversion_fraction_raw(
+                &raw,
+                0.9,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
             "Should pass with no methylation tags"
         );
     }
@@ -3219,8 +3263,165 @@ mod tests {
         // Unmapped record (no ref_id, no cigar)
         let raw = build_raw_with_methylation_tags(&noodles::sam::Header::default(), &record);
         assert!(
-            check_conversion_fraction_raw(&raw, 0.9, &reference, &ref_names),
+            check_conversion_fraction_raw(
+                &raw,
+                0.9,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
             "Unmapped reads should pass"
+        );
+    }
+
+    // -- TAPs conversion fraction tests --
+
+    #[test]
+    fn test_conversion_fraction_taps_passes_high_non_conversion() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Non-CpG C at positions 1 and 5: high unconverted (cu >> ct) = good TAPs specificity
+        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // TAPs numerator = cu: 18 out of 20 = 90%
+        assert!(
+            check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::Taps
+            ),
+            "TAPs should pass with high non-conversion fraction"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_taps_fails_low_non_conversion() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Non-CpG C at positions 1 and 5: low unconverted (ct >> cu) = poor TAPs specificity
+        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // TAPs numerator = cu: 2 out of 20 = 10%
+        assert!(
+            !check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::Taps
+            ),
+            "TAPs should fail with low non-conversion fraction"
+        );
+    }
+
+    #[test]
+    fn test_conversion_fraction_taps_vs_emseq_inverted() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Non-CpG C at positions 1 and 5: cu=9, ct=1 at each
+        // EM-Seq numerator = ct: 2/20 = 10%, TAPs numerator = cu: 18/20 = 90%
+        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // EM-Seq should fail (10% < 80%), TAPs should pass (90% >= 80%)
+        assert!(
+            !check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::EmSeq
+            ),
+            "EM-Seq should fail with high unconverted fraction"
+        );
+        assert!(
+            check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::Taps
+            ),
+            "TAPs should pass with same data (inverted numerator)"
+        );
+    }
+
+    // -- Disabled mode tests --
+
+    #[test]
+    fn test_conversion_fraction_disabled_mode_passes() {
+        use crate::methylation::tests::TestRef;
+        let ref_seq = b"ACATACATA";
+        let reference = TestRef::new(&[("chr1", ref_seq)]);
+        let ref_names = vec!["chr1".to_string()];
+
+        let sam = sam_builder_for_methylation();
+        let mut record = RecordBuilder::new()
+            .sequence("ACATACATA")
+            .qualities(&[30; 9])
+            .reference_sequence_id(0)
+            .alignment_start(1)
+            .mapping_quality(60)
+            .cigar("9M")
+            .build();
+        // Data that would fail EM-Seq at 80% threshold
+        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+
+        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        // Disabled mode should always pass regardless of data
+        assert!(
+            check_conversion_fraction_raw(
+                &raw,
+                0.8,
+                &reference,
+                &ref_names,
+                crate::MethylationMode::Disabled
+            ),
+            "Disabled mode should always pass conversion fraction check"
         );
     }
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -175,24 +175,32 @@ pub struct Filter {
     #[arg(short = 's', long = "require-single-strand-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub require_single_strand_agreement: bool,
 
-    /// Minimum methylation depth (cu+ct) to keep a base call (EM-Seq only).
+    /// Minimum methylation depth (cu+ct) to keep a base call (EM-Seq/TAPs).
     /// For duplex: provide 1-3 values for [duplex, AB consensus, BA consensus]
     #[arg(long = "min-methylation-depth", value_delimiter = ',')]
     pub min_methylation_depth: Vec<usize>,
 
     #[allow(clippy::doc_markdown)]
-    /// Require strand methylation agreement at CpG sites for duplex consensus (EM-Seq only).
+    /// Require strand methylation agreement at CpG sites for duplex consensus (EM-Seq/TAPs).
     /// Masks both positions of a CpG dinucleotide when top and bottom strands disagree on
     /// methylation status. Requires --ref.
     #[arg(long = "require-strand-methylation-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub require_strand_methylation_agreement: bool,
 
     #[allow(clippy::doc_markdown)]
-    /// Minimum bisulfite/enzymatic conversion fraction at non-CpG cytosines (EM-Seq only).
-    /// Reads with conversion rate below this threshold are discarded.
-    /// Requires --ref. Uses cu/ct tags.
+    /// Minimum bisulfite/enzymatic conversion fraction at non-CpG cytosines.
+    /// For EM-Seq: checks converted/total >= threshold (high conversion = good).
+    /// For TAPs: checks unconverted/total >= threshold (low conversion = good).
+    /// Requires --ref and --methylation-mode. Uses cu/ct tags.
     #[arg(long = "min-conversion-fraction")]
     pub min_conversion_fraction: Option<f64>,
+
+    /// Methylation mode for conversion fraction filtering.
+    /// Required when using --min-conversion-fraction.
+    /// Controls whether the conversion fraction check uses converted (em-seq)
+    /// or unconverted (taps) counts as the numerator.
+    #[arg(long = "methylation-mode", value_enum)]
+    pub methylation_mode: Option<crate::commands::common::MethylationModeArg>,
 
     /// Compression options for output BAM.
     #[command(flatten)]
@@ -285,6 +293,7 @@ struct FilterProcessCaptures {
     methylation_depth_thresholds: Option<MethylationDepthThresholds>,
     require_strand_methylation_agreement: bool,
     min_conversion_fraction: Option<f64>,
+    methylation_mode: fgumi_consensus::MethylationMode,
     ref_names: Arc<Vec<String>>,
     progress: Arc<AtomicU64>,
     header: Header,
@@ -329,6 +338,9 @@ impl Command for Filter {
         }
         if let Some(frac) = self.min_conversion_fraction {
             info!("Min conversion fraction: {frac}");
+        }
+        if let Some(mode) = &self.methylation_mode {
+            info!("Methylation mode: {mode:?}");
         }
 
         // Open input using streaming-capable reader for pipeline use
@@ -425,6 +437,9 @@ impl Filter {
             },
             require_strand_methylation_agreement: self.require_strand_methylation_agreement,
             min_conversion_fraction: self.min_conversion_fraction,
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
             ref_names: Arc::new(ref_names),
             progress: Arc::clone(&setup.progress_counter),
             header: header.clone(),
@@ -559,6 +574,7 @@ impl Filter {
                 ctx.methylation_depth_thresholds.as_ref(),
                 ctx.require_strand_methylation_agreement,
                 ctx.min_conversion_fraction,
+                ctx.methylation_mode,
                 &ctx.ref_names,
             )
             .map_err(io::Error::other)?;
@@ -639,6 +655,7 @@ impl Filter {
                         ctx.methylation_depth_thresholds.as_ref(),
                         ctx.require_strand_methylation_agreement,
                         ctx.min_conversion_fraction,
+                        ctx.methylation_mode,
                         &ctx.ref_names,
                     )
                     .map_err(io::Error::other)?;
@@ -728,6 +745,7 @@ impl Filter {
         methylation_depth_thresholds: Option<&MethylationDepthThresholds>,
         require_strand_methylation_agreement: bool,
         min_conversion_fraction: Option<f64>,
+        methylation_mode: fgumi_consensus::MethylationMode,
         ref_names: &[String],
     ) -> Result<(u64, bool)> {
         // Fail fast if we encounter a mapped read without a reference, since masking
@@ -841,8 +859,7 @@ impl Filter {
             }
         };
 
-        // Conversion fraction filter (EM-Seq only — not applicable to TAPs where
-        // non-CpG cytosines are expected to remain unconverted)
+        // Conversion fraction filter (EM-Seq/TAPs read-level)
         if pass {
             if let Some(min_frac) = min_conversion_fraction {
                 if !check_conversion_fraction_raw_with_ref_bases_and_tags(
@@ -852,6 +869,7 @@ impl Filter {
                     methylation_tags
                         .as_ref()
                         .expect("methylation_tags set when conversion fraction enabled"),
+                    methylation_mode,
                 ) {
                     pass = false;
                 }
@@ -1060,6 +1078,9 @@ impl Filter {
             if self.reference.is_none() {
                 bail!("--min-conversion-fraction requires --ref to identify non-CpG cytosines");
             }
+            if self.methylation_mode.is_none() {
+                bail!("--min-conversion-fraction requires --methylation-mode to be set");
+            }
         }
 
         Ok(())
@@ -1096,6 +1117,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         }
@@ -1162,6 +1184,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1196,6 +1219,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1227,6 +1251,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1262,6 +1287,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1294,6 +1320,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1355,6 +1382,18 @@ mod tests {
         );
         cmd.reference = None;
         cmd.min_conversion_fraction = Some(0.9);
+        assert!(cmd.validate_parameters().is_err());
+    }
+
+    #[test]
+    fn test_validate_conversion_fraction_requires_methylation_mode() {
+        let mut cmd = create_filter_with_paths(
+            PathBuf::from("input.bam"),
+            PathBuf::from("output.bam"),
+            PathBuf::from("ref.fa"),
+        );
+        cmd.min_conversion_fraction = Some(0.9);
+        cmd.methylation_mode = None;
         assert!(cmd.validate_parameters().is_err());
     }
 
@@ -1716,6 +1755,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1754,6 +1794,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1790,6 +1831,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1823,6 +1865,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1856,6 +1899,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1888,6 +1932,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1920,6 +1965,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1952,6 +1998,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -1984,6 +2031,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2016,6 +2064,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2048,6 +2097,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2082,6 +2132,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2116,6 +2167,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2149,6 +2201,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2183,6 +2236,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2218,6 +2272,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2250,6 +2305,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2356,6 +2412,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2479,6 +2536,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2635,6 +2693,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2710,6 +2769,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2779,6 +2839,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2905,6 +2966,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -2976,6 +3038,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3045,6 +3108,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3118,6 +3182,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3144,6 +3209,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3210,6 +3276,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3267,6 +3334,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3327,6 +3395,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3396,6 +3465,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3422,6 +3492,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3506,6 +3577,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3618,6 +3690,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3736,6 +3809,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3775,6 +3849,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3809,6 +3884,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3867,6 +3943,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3930,6 +4007,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -3996,6 +4074,7 @@ mod tests {
             min_methylation_depth: vec![],
             require_strand_methylation_agreement: false,
             min_conversion_fraction: None,
+            methylation_mode: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         };
@@ -4247,7 +4326,8 @@ mod tests {
             None,  // no methylation depth thresholds
             false, // no strand methylation agreement
             None,  // no min conversion fraction
-            &[],   // no ref names
+            fgumi_consensus::MethylationMode::Disabled,
+            &[], // no ref names
         )?;
 
         assert_eq!(bases_masked, 0, "No bases should be masked with good tags");
@@ -4296,7 +4376,8 @@ mod tests {
             None,  // no methylation depth thresholds
             false, // no strand methylation agreement
             None,  // no min conversion fraction
-            &[],   // no ref names
+            fgumi_consensus::MethylationMode::Disabled,
+            &[], // no ref names
         );
 
         assert!(result.is_err(), "Should fail for mapped reads without reference");


### PR DESCRIPTION
## Summary

- Adds `--methylation-mode <em-seq|taps>` to the `filter` command
- Parameterizes conversion fraction check: EM-Seq checks ct/(cu+ct), TAPs checks cu/(cu+ct)
- Conversion fraction functions take `MethylationMode` instead of `is_taps: bool`

Stacked on #172.

## Test plan

- [x] Existing conversion fraction tests pass
- [x] `cargo ci-test && cargo ci-fmt && cargo ci-lint` passes
- [ ] Test with real TAPs data (pending)

> **Draft**: not yet validated with real TAPs sequencing data.