### PR TITLE
docs: improve cell barcode documentation

### DIFF
--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -1049,6 +1049,14 @@ Note: Using `samtools sort` will NOT work correctly because it doesn't use the
 
 - Mark only (default): Set duplicate flag (0x400) on non-representative reads
 - Remove (--remove-duplicates): Exclude duplicate reads from output entirely
+
+# Cell Barcodes
+
+If the input data contains cell barcodes (e.g. from single-cell sequencing), reads at the same
+genomic position are partitioned by cell barcode before deduplication. This ensures that reads from
+different cells are never marked as duplicates of each other, even if they share a UMI sequence and
+mapping position. The cell barcode is read from the tag specified by `--cell-tag` (default: CB). No
+correction or error-handling is performed on cell barcodes; they must be corrected upstream.
 "#
 )]
 pub struct MarkDuplicates {
@@ -1076,7 +1084,11 @@ pub struct MarkDuplicates {
     #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
     pub assign_tag: String,
 
-    /// SAM tag containing the cell barcode
+    /// SAM tag containing the cell barcode.
+    ///
+    /// When set, reads at the same genomic coordinates are partitioned by cell barcode before
+    /// deduplication, so reads from different cells are never grouped together even if they
+    /// share a UMI and position. No correction is performed on the cell barcode itself.
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: String,
 

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -714,6 +714,14 @@ not implemented for reads with UMI pairs (i.e. using the paired assigner).
 Note: the --min-map-q parameter defaults to 0 in duplicate marking mode and 1 otherwise, and is
 directly settable on the command line.
 
+# Cell Barcodes
+
+If the input data contains cell barcodes (e.g. from single-cell sequencing), reads at the same
+genomic position are partitioned by cell barcode before UMI grouping. This ensures that reads from
+different cells are never grouped together, even if they share a UMI sequence and mapping position.
+The cell barcode is read from the tag specified by `--cell-tag` (default: CB). No correction or
+error-handling is performed on cell barcodes; they must be corrected upstream.
+
 Multi-threaded operation is supported via --threads N which spawns exactly N threads.
 Threads are allocated based on the command's workload profile to optimize performance.
 
@@ -741,7 +749,11 @@ pub struct GroupReadsByUmi {
     #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
     pub assign_tag: String,
 
-    /// SAM tag containing the cell barcode
+    /// SAM tag containing the cell barcode.
+    ///
+    /// When set, reads at the same genomic coordinates are partitioned by cell barcode before
+    /// UMI assignment, so reads from different cells are never grouped together even if they
+    /// share a UMI and position. No correction is performed on the cell barcode itself.
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: String,
 


### PR DESCRIPTION
## Summary

- Expanded the `--cell-tag` option description for both `group` and `dedup` commands to explain that reads at the same genomic coordinates are partitioned by cell barcode before UMI assignment/deduplication, preventing reads from different cells from being grouped together
- Added a "Cell Barcodes" section to the command-level documentation for both `group` and `dedup` explaining the partitioning behavior and noting that no correction is performed on cell barcodes

## Test plan

- [x] `cargo check` passes
- [ ] Verify `fgumi group --help` and `fgumi dedup --help` display the updated documentation