### PR TITLE
feat(extract): add SIMD-accelerated FASTQ parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
  "fgumi-metrics",
  "fgumi-raw-bam",
  "fgumi-sam",
+ "fgumi-simd-fastq",
  "fgumi-umi",
  "flate2",
  "indexmap",
@@ -682,7 +683,6 @@ dependencies = [
  "rayon",
  "read-structure",
  "rstest",
- "seq_io",
  "serde",
  "statrs",
  "sysinfo",
@@ -757,6 +757,17 @@ dependencies = [
  "log",
  "noodles",
  "tempfile",
+]
+
+[[package]]
+name = "fgumi-simd-fastq"
+version = "0.1.2"
+dependencies = [
+ "criterion",
+ "memchr",
+ "proptest",
+ "rstest",
+ "seq_io",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-umi", "crates/fgumi-consensus"]
+members = [".", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-simd-fastq", "crates/fgumi-umi", "crates/fgumi-consensus"]
 resolver = "2"
 
 [workspace.package]
@@ -16,6 +16,7 @@ fgumi-dna = { version = "0.1.2", path = "crates/fgumi-dna" }
 fgumi-metrics = { version = "0.1.2", path = "crates/fgumi-metrics" }
 fgumi-raw-bam = { version = "0.1.2", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.1.2", path = "crates/fgumi-sam" }
+fgumi-simd-fastq = { version = "0.1.2", path = "crates/fgumi-simd-fastq" }
 fgumi-umi = { version = "0.1.2", path = "crates/fgumi-umi" }
 
 [package]
@@ -45,7 +46,6 @@ env_logger = "0.11.8"
 enum_dispatch = "0.3.13"
 anyhow = "1.0.102"
 read-structure = "0.2.0"
-seq_io = "0.3.4"
 bstr = "1.12.1"
 bytes = "1"
 fgoxide = "0.6.0"
@@ -82,6 +82,7 @@ fgumi-dna = { workspace = true }
 fgumi-bgzf = { workspace = true }
 fgumi-metrics = { workspace = true }
 fgumi-sam = { workspace = true }
+fgumi-simd-fastq = { workspace = true }
 fgumi-umi = { workspace = true }
 fgumi-consensus = { workspace = true }
 

--- a/crates/fgumi-simd-fastq/Cargo.toml
+++ b/crates/fgumi-simd-fastq/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fgumi-simd-fastq"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "SIMD-accelerated FASTQ parsing using Helicase-style bitmask operations"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+rstest = "0"
+proptest = "1.10"
+criterion = { version = "0.8", features = ["html_reports"] }
+memchr = "2"
+seq_io = "0.3.4"
+
+[[bench]]
+name = "fastq_parsing"
+harness = false
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-simd-fastq/benches/fastq_parsing.rs
+++ b/crates/fgumi-simd-fastq/benches/fastq_parsing.rs
@@ -1,0 +1,186 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_simd_fastq::{SimdFastqReader, find_record_offsets, parse_records};
+use seq_io::fastq::{Reader as SeqIoReader, Record};
+use std::io::Cursor;
+
+/// Generate synthetic FASTQ data with `n` records, each with a sequence of `seq_len` bases.
+fn generate_fastq(n: usize, seq_len: usize) -> Vec<u8> {
+    let mut data = Vec::with_capacity(n * (seq_len * 2 + 20));
+    let seq: Vec<u8> = (0..seq_len).map(|i| b"ACGT"[i % 4]).collect();
+    let qual: Vec<u8> = vec![b'I'; seq_len];
+
+    for i in 0..n {
+        data.push(b'@');
+        data.extend_from_slice(format!("read{i}").as_bytes());
+        data.push(b'\n');
+        data.extend_from_slice(&seq);
+        data.push(b'\n');
+        data.push(b'+');
+        data.push(b'\n');
+        data.extend_from_slice(&qual);
+        data.push(b'\n');
+    }
+    data
+}
+
+/// Previous boundary-finding implementation using memchr (4 calls per record).
+fn find_record_offsets_memchr(data: &[u8]) -> Vec<usize> {
+    if data.is_empty() {
+        return vec![0];
+    }
+
+    let mut offsets = vec![0];
+    let mut pos = 0;
+
+    while pos < data.len() {
+        if data[pos] != b'@' {
+            break;
+        }
+        let mut found = true;
+        for _ in 0..4 {
+            if let Some(nl) = memchr::memchr(b'\n', &data[pos..]) {
+                pos += nl + 1;
+            } else {
+                found = false;
+                break;
+            }
+        }
+        if found {
+            offsets.push(pos);
+        } else {
+            break;
+        }
+    }
+
+    offsets
+}
+
+fn bench_find_record_offsets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_record_offsets");
+
+    for &seq_len in &[150, 300] {
+        let num_records = 100_000;
+        let data = generate_fastq(num_records, seq_len);
+        let data_size = data.len();
+
+        group.throughput(Throughput::Bytes(data_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("simd", format!("{seq_len}bp")),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let offsets = find_record_offsets(data);
+                    assert_eq!(offsets.len(), num_records + 1);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("memchr", format!("{seq_len}bp")),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let offsets = find_record_offsets_memchr(data);
+                    assert_eq!(offsets.len(), num_records + 1);
+                });
+            },
+        );
+    }
+
+    // Benchmark with real FASTQ data if available
+    let real_fastq_path = "/Volumes/scratch-00001/work/rebgzf_test.fastq";
+    if std::path::Path::new(real_fastq_path).exists() {
+        let data = std::fs::read(real_fastq_path).unwrap();
+        let data_size = data.len();
+        group.throughput(Throughput::Bytes(data_size as u64));
+
+        group.bench_with_input(BenchmarkId::new("simd", "real_176MB"), &data, |b, data| {
+            b.iter(|| find_record_offsets(data));
+        });
+
+        group.bench_with_input(BenchmarkId::new("memchr", "real_176MB"), &data, |b, data| {
+            b.iter(|| find_record_offsets_memchr(data));
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark full record parsing: SIMD `parse_records` vs `seq_io` reader.
+/// Both iterate all records and access name/seq/qual fields.
+fn bench_record_parsing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("record_parsing");
+
+    for &seq_len in &[150, 300] {
+        let num_records = 100_000;
+        let data = generate_fastq(num_records, seq_len);
+        let data_size = data.len();
+
+        group.throughput(Throughput::Bytes(data_size as u64));
+
+        // SIMD: zero-copy parse from in-memory buffer
+        group.bench_with_input(
+            BenchmarkId::new("simd_parse_records", format!("{seq_len}bp")),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let mut count = 0;
+                    for rec in parse_records(data) {
+                        std::hint::black_box(rec.name);
+                        std::hint::black_box(rec.sequence);
+                        std::hint::black_box(rec.quality);
+                        count += 1;
+                    }
+                    assert_eq!(count, num_records);
+                });
+            },
+        );
+
+        // SIMD: SimdFastqReader from Cursor (simulates BufRead path)
+        group.bench_with_input(
+            BenchmarkId::new("simd_reader", format!("{seq_len}bp")),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = SimdFastqReader::new(Cursor::new(data));
+                    let mut count = 0;
+                    for result in reader {
+                        let rec = result.unwrap();
+                        std::hint::black_box(&rec.name);
+                        std::hint::black_box(&rec.sequence);
+                        std::hint::black_box(&rec.quality);
+                        count += 1;
+                    }
+                    assert_eq!(count, num_records);
+                });
+            },
+        );
+
+        // seq_io: the previous FASTQ reader
+        group.bench_with_input(
+            BenchmarkId::new("seq_io", format!("{seq_len}bp")),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = SeqIoReader::new(Cursor::new(data));
+                    let mut count = 0;
+                    for result in reader.into_records() {
+                        let rec = result.unwrap();
+                        // Access fields to prevent dead-code elimination
+                        std::hint::black_box(rec.head());
+                        std::hint::black_box(rec.seq());
+                        std::hint::black_box(rec.qual());
+                        count += 1;
+                    }
+                    assert_eq!(count, num_records);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_find_record_offsets, bench_record_parsing);
+criterion_main!(benches);

--- a/crates/fgumi-simd-fastq/src/bitmask.rs
+++ b/crates/fgumi-simd-fastq/src/bitmask.rs
@@ -1,0 +1,19 @@
+//! Bitmask type for SIMD-classified 64-byte blocks.
+
+/// Bitmask output from lexing a 64-byte block.
+///
+/// Each bit position corresponds to a byte in the block.
+/// Bit `i` is set if the byte at position `i` matches the target character.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FastqBitmask {
+    /// Bit `i` = 1 if byte `i` is `\n` (0x0A).
+    pub newlines: u64,
+    /// Bit `i` = 1 if byte `i` is ACGT (case-insensitive).
+    pub is_acgt: u64,
+    /// 2-bit packed encoding of each byte position, using fgumi's `BitEnc` mapping:
+    /// A/a=0b00, C/c=0b01, G/g=0b10, T/t=0b11.
+    ///
+    /// Bits `[2i, 2i+1]` encode byte position `i`. Only meaningful where `is_acgt`
+    /// is set; non-ACGT positions contain garbage.
+    pub two_bits: u128,
+}

--- a/crates/fgumi-simd-fastq/src/lexer.rs
+++ b/crates/fgumi-simd-fastq/src/lexer.rs
@@ -1,0 +1,585 @@
+//! SIMD lexer: classifies 64-byte blocks into newline and ACGT bitmasks
+//! with 2-bit DNA encoding.
+//!
+//! Three implementations are provided:
+//! - NEON (aarch64): primary target for Apple Silicon / Graviton
+//! - AVX2 (`x86_64`): for Intel/AMD servers
+//! - Scalar fallback: for testing and unsupported architectures
+
+use crate::bitmask::FastqBitmask;
+
+// ============================================================================
+// Public dispatch
+// ============================================================================
+
+/// Lex a 64-byte block, producing only the newline bitmask.
+///
+/// This is the fast path for record boundary detection. Use [`lex_block_full`]
+/// when ACGT classification and 2-bit encoding are also needed.
+#[inline]
+pub fn lex_block(block: &[u8; 64]) -> u64 {
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { lex_block_newlines_neon(block) }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx2") {
+            unsafe { lex_block_newlines_avx2(block) }
+        } else {
+            lex_block_newlines_scalar(block)
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        lex_block_newlines_scalar(block)
+    }
+}
+
+/// Lex a 64-byte block, producing newline bitmask, ACGT bitmask, and 2-bit encoding.
+///
+/// This is the full classification path for when 2-bit DNA encoding is needed
+/// (e.g., for UMI extraction in a fused pipeline).
+#[inline]
+#[must_use]
+pub fn lex_block_full(block: &[u8; 64]) -> FastqBitmask {
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { lex_block_neon(block) }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx2") {
+            unsafe { lex_block_avx2(block) }
+        } else {
+            lex_block_scalar(block)
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        lex_block_scalar(block)
+    }
+}
+
+// ============================================================================
+// Shared constants
+// ============================================================================
+
+/// 2-bit encoding table for fgumi's `BitEnc` mapping: A=0, C=1, G=2, T=3.
+///
+/// Indexed by `(ascii_byte >> 1) & 0x0F`. Only entries for A/C/G/T (and lowercase)
+/// produce valid encodings; all others are garbage (but masked out by `is_acgt`).
+///
+/// ASCII values:
+/// - A=0x41, a=0x61 → (>>1)&0xF = 0x0 → encode as 0
+/// - C=0x43, c=0x63 → (>>1)&0xF = 0x1 → encode as 1
+/// - G=0x47, g=0x67 → (>>1)&0xF = 0x3 → encode as 2
+/// - T=0x54, t=0x74 → (>>1)&0xF = 0xA → encode as 3
+const ENCODE_LUT: [u8; 16] = [
+    0, // 0x0: A/a
+    1, // 0x1: C/c
+    0, // 0x2: (unused)
+    2, // 0x3: G/g
+    0, // 0x4: (unused)
+    0, // 0x5: (unused)
+    0, // 0x6: (unused)
+    0, // 0x7: (unused)
+    0, // 0x8: (unused)
+    0, // 0x9: (unused)
+    3, // 0xA: T/t
+    0, // 0xB: (unused)
+    0, // 0xC: (unused)
+    0, // 0xD: (unused)
+    0, // 0xE: (unused)
+    0, // 0xF: (unused)
+];
+
+// ============================================================================
+// Scalar fallback
+// ============================================================================
+
+/// Scalar newline-only detection. Used as a fallback on `x86_64` without AVX2
+/// and on unsupported architectures, plus as a reference in tests.
+#[allow(dead_code)]
+#[inline]
+fn lex_block_newlines_scalar(block: &[u8; 64]) -> u64 {
+    let mut newlines: u64 = 0;
+    for (i, &byte) in block.iter().enumerate() {
+        if byte == b'\n' {
+            newlines |= 1u64 << i;
+        }
+    }
+    newlines
+}
+
+/// Scalar full classification. Used as a fallback on `x86_64` without AVX2,
+/// on unsupported architectures, and as a reference in tests.
+#[allow(dead_code)]
+#[inline]
+pub fn lex_block_scalar(block: &[u8; 64]) -> FastqBitmask {
+    let mut newlines: u64 = 0;
+    let mut is_acgt: u64 = 0;
+    let mut two_bits: u128 = 0;
+
+    for (i, &byte) in block.iter().enumerate() {
+        if byte == b'\n' {
+            newlines |= 1u64 << i;
+        }
+        let upper = byte & 0xDF; // case-insensitive
+        if upper == b'A' || upper == b'C' || upper == b'G' || upper == b'T' {
+            is_acgt |= 1u64 << i;
+            let enc = u128::from(ENCODE_LUT[((byte >> 1) & 0x0F) as usize]);
+            two_bits |= enc << (i * 2);
+        }
+    }
+    FastqBitmask { newlines, is_acgt, two_bits }
+}
+
+// ============================================================================
+// NEON (aarch64)
+// ============================================================================
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::uint8x16_t;
+
+/// Extract a 16-bit mask from a NEON comparison result (each byte is 0x00 or 0xFF).
+/// Returns the mask in the low 16 bits of a `u64`.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[inline]
+unsafe fn neon_movemask(cmp: uint8x16_t) -> u64 {
+    use std::arch::aarch64::{
+        vaddv_u8, vcreate_u8, vget_high_u8, vget_low_u8, vmul_u8, vshrq_n_u8,
+    };
+
+    // NEON intrinsics are safe to call inside a #[target_feature(enable = "neon")] function
+    let shifted = vshrq_n_u8(cmp, 7);
+    let weights = vcreate_u8(u64::from_le_bytes([1, 2, 4, 8, 16, 32, 64, 128]));
+    let low = vget_low_u8(shifted);
+    let high = vget_high_u8(shifted);
+    let low_sum = u64::from(vaddv_u8(vmul_u8(low, weights)));
+    let high_sum = u64::from(vaddv_u8(vmul_u8(high, weights)));
+    low_sum | (high_sum << 8)
+}
+
+#[cfg(target_arch = "aarch64")]
+/// NEON newline-only detection (fast path).
+///
+/// # Safety
+///
+/// Requires NEON support (mandatory on aarch64).
+#[target_feature(enable = "neon")]
+unsafe fn lex_block_newlines_neon(block: &[u8; 64]) -> u64 {
+    use std::arch::aarch64::{vceqq_u8, vdupq_n_u8, vld1q_u8};
+
+    unsafe {
+        let newline = vdupq_n_u8(b'\n');
+        let mut result: u64 = 0;
+
+        for chunk_idx in 0..4 {
+            let v = vld1q_u8(block.as_ptr().add(chunk_idx * 16));
+            result |= neon_movemask(vceqq_u8(v, newline)) << (chunk_idx * 16);
+        }
+
+        result
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+/// NEON full classification: newlines, ACGT, and 2-bit encoding.
+///
+/// # Safety
+///
+/// Requires NEON support (mandatory on aarch64).
+#[target_feature(enable = "neon")]
+unsafe fn lex_block_neon(block: &[u8; 64]) -> FastqBitmask {
+    use std::arch::aarch64::{
+        vandq_u8, vceqq_u8, vdupq_n_u8, vld1q_u8, vorrq_u8, vqtbl1q_u8, vshrq_n_u8,
+    };
+
+    /// Extract 2-bit encoding from 16 bytes, returning a u32 (16 bases * 2 bits = 32 bits).
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
+    unsafe fn neon_two_bits(v: uint8x16_t, lut: uint8x16_t) -> u32 {
+        unsafe {
+            let idx = vandq_u8(vshrq_n_u8::<1>(v), vdupq_n_u8(0x0F));
+            let encoded = vqtbl1q_u8(lut, idx);
+
+            let bit0_mask = vdupq_n_u8(0x01);
+            let bit0 = vandq_u8(encoded, bit0_mask);
+            let bit1 = vandq_u8(vshrq_n_u8::<1>(encoded), bit0_mask);
+
+            let bit0_packed = neon_movemask(vceqq_u8(bit0, bit0_mask)) as u32;
+            let bit1_packed = neon_movemask(vceqq_u8(bit1, bit0_mask)) as u32;
+
+            interleave_bits(bit0_packed as u16, bit1_packed as u16)
+        }
+    }
+
+    unsafe {
+        let newline_vec = vdupq_n_u8(b'\n');
+        let case_mask = vdupq_n_u8(0xDF);
+        let a_vec = vdupq_n_u8(b'A');
+        let c_vec = vdupq_n_u8(b'C');
+        let g_vec = vdupq_n_u8(b'G');
+        let t_vec = vdupq_n_u8(b'T');
+        let lut = vld1q_u8(ENCODE_LUT.as_ptr());
+
+        let mut newlines: u64 = 0;
+        let mut is_acgt: u64 = 0;
+        let mut two_bits: u128 = 0;
+
+        for chunk_idx in 0..4 {
+            let v = vld1q_u8(block.as_ptr().add(chunk_idx * 16));
+
+            let nl_cmp = vceqq_u8(v, newline_vec);
+            newlines |= neon_movemask(nl_cmp) << (chunk_idx * 16);
+
+            let upper = vandq_u8(v, case_mask);
+            let acgt_cmp = vorrq_u8(
+                vorrq_u8(vceqq_u8(upper, a_vec), vceqq_u8(upper, c_vec)),
+                vorrq_u8(vceqq_u8(upper, g_vec), vceqq_u8(upper, t_vec)),
+            );
+            is_acgt |= neon_movemask(acgt_cmp) << (chunk_idx * 16);
+
+            let chunk_two_bits = u128::from(neon_two_bits(v, lut));
+            two_bits |= chunk_two_bits << (chunk_idx * 32);
+        }
+
+        FastqBitmask { newlines, is_acgt, two_bits }
+    }
+}
+
+// ============================================================================
+// AVX2 (x86_64)
+// ============================================================================
+
+/// Reinterpret the low 32 bits of an `i32` movemask result as `u32`.
+/// `_mm256_movemask_epi8` returns `i32` but the value is a 32-bit bitmask.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn movemask_u32(mask: i32) -> u32 {
+    mask.cast_unsigned()
+}
+
+/// Convert a `u8` constant to `i8` for `_mm256_set1_epi8` without wrapping lint.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn byte_as_i8(b: u8) -> i8 {
+    i8::from_ne_bytes([b])
+}
+
+#[cfg(target_arch = "x86_64")]
+/// AVX2 newline-only detection (fast path).
+///
+/// # Safety
+///
+/// Requires AVX2 support.
+#[target_feature(enable = "avx2")]
+unsafe fn lex_block_newlines_avx2(block: &[u8; 64]) -> u64 {
+    use std::arch::x86_64::{
+        _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+    };
+
+    unsafe {
+        let newline = _mm256_set1_epi8(i8::from_ne_bytes([b'\n']));
+        let v1 = _mm256_loadu_si256(block.as_ptr().cast());
+        let v2 = _mm256_loadu_si256(block.as_ptr().add(32).cast());
+        let nl1 = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(v1, newline)));
+        let nl2 = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(v2, newline)));
+        u64::from(nl1) | (u64::from(nl2) << 32)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+/// AVX2 implementation: classifies newlines, ACGT bases, and produces 2-bit encoding.
+///
+/// # Safety
+///
+/// Requires AVX2 support (checked by caller via `is_x86_feature_detected!`).
+#[target_feature(enable = "avx2")]
+unsafe fn lex_block_avx2(block: &[u8; 64]) -> FastqBitmask {
+    use std::arch::x86_64::{
+        __m256i, _mm256_and_si256, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8,
+        _mm256_or_si256, _mm256_set1_epi8, _mm256_shuffle_epi8, _mm256_srli_epi16,
+    };
+
+    /// Extract 2-bit encoding from 32 bytes, returning a u64 (32 bases * 2 bits).
+    #[inline]
+    unsafe fn avx2_two_bits(v: __m256i, lut: __m256i, one_mask: __m256i) -> u64 {
+        unsafe {
+            let idx = _mm256_and_si256(_mm256_srli_epi16(v, 1), _mm256_set1_epi8(0x0F));
+            let encoded = _mm256_shuffle_epi8(lut, idx);
+
+            let bit0 = _mm256_and_si256(encoded, one_mask);
+            let bit1 = _mm256_and_si256(_mm256_srli_epi16(encoded, 1), one_mask);
+
+            let bit0_mask = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(bit0, one_mask)));
+            let bit1_mask = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(bit1, one_mask)));
+
+            interleave_bits_32(bit0_mask, bit1_mask)
+        }
+    }
+
+    unsafe {
+        let newline = _mm256_set1_epi8(byte_as_i8(b'\n'));
+        let case_mask = _mm256_set1_epi8(byte_as_i8(0xDF));
+        let a_vec = _mm256_set1_epi8(byte_as_i8(b'A'));
+        let c_vec = _mm256_set1_epi8(byte_as_i8(b'C'));
+        let g_vec = _mm256_set1_epi8(byte_as_i8(b'G'));
+        let t_vec = _mm256_set1_epi8(byte_as_i8(b'T'));
+
+        // Build LUT for both 128-bit lanes (AVX2 shuffle operates per-lane)
+        let lut = _mm256_loadu_si256([ENCODE_LUT, ENCODE_LUT].as_ptr().cast());
+        let one_mask = _mm256_set1_epi8(0x01);
+
+        let v1 = _mm256_loadu_si256(block.as_ptr().cast());
+        let v2 = _mm256_loadu_si256(block.as_ptr().add(32).cast());
+
+        // Newlines
+        let nl1 = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(v1, newline)));
+        let nl2 = movemask_u32(_mm256_movemask_epi8(_mm256_cmpeq_epi8(v2, newline)));
+        let newlines = u64::from(nl1) | (u64::from(nl2) << 32);
+
+        // ACGT classification
+        let upper1 = _mm256_and_si256(v1, case_mask);
+        let upper2 = _mm256_and_si256(v2, case_mask);
+        let acgt1 = _mm256_or_si256(
+            _mm256_or_si256(_mm256_cmpeq_epi8(upper1, a_vec), _mm256_cmpeq_epi8(upper1, c_vec)),
+            _mm256_or_si256(_mm256_cmpeq_epi8(upper1, g_vec), _mm256_cmpeq_epi8(upper1, t_vec)),
+        );
+        let acgt2 = _mm256_or_si256(
+            _mm256_or_si256(_mm256_cmpeq_epi8(upper2, a_vec), _mm256_cmpeq_epi8(upper2, c_vec)),
+            _mm256_or_si256(_mm256_cmpeq_epi8(upper2, g_vec), _mm256_cmpeq_epi8(upper2, t_vec)),
+        );
+        let acgt_mask1 = movemask_u32(_mm256_movemask_epi8(acgt1));
+        let acgt_mask2 = movemask_u32(_mm256_movemask_epi8(acgt2));
+        let is_acgt = u64::from(acgt_mask1) | (u64::from(acgt_mask2) << 32);
+
+        // 2-bit encoding
+        let tb1 = avx2_two_bits(v1, lut, one_mask);
+        let tb2 = avx2_two_bits(v2, lut, one_mask);
+        let two_bits = u128::from(tb1) | (u128::from(tb2) << 64);
+
+        FastqBitmask { newlines, is_acgt, two_bits }
+    }
+}
+
+// ============================================================================
+// Bit interleaving helpers
+// ============================================================================
+
+/// Interleave bits from `lo` and `hi`: bit `i` of `lo` goes to position `2*i`,
+/// bit `i` of `hi` goes to position `2*i+1`. Processes `N` bits from each input.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline]
+const fn interleave_bits_n<const N: usize>(lo: u64, hi: u64) -> u64 {
+    let mut result: u64 = 0;
+    let mut i = 0;
+    while i < N {
+        result |= ((lo >> i) & 1) << (i * 2);
+        result |= ((hi >> i) & 1) << (i * 2 + 1);
+        i += 1;
+    }
+    result
+}
+
+/// Interleave two 16-bit values into a 32-bit result.
+#[cfg(target_arch = "aarch64")]
+#[expect(clippy::cast_possible_truncation, reason = "16 interleaved bits fit in u32")]
+#[inline]
+const fn interleave_bits(lo: u16, hi: u16) -> u32 {
+    interleave_bits_n::<16>(lo as u64, hi as u64) as u32
+}
+
+/// Interleave two 32-bit values into a 64-bit result.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn interleave_bits_32(lo: u32, hi: u32) -> u64 {
+    interleave_bits_n::<32>(lo as u64, hi as u64)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_block(data: &[u8]) -> [u8; 64] {
+        let mut block = [0u8; 64];
+        let len = data.len().min(64);
+        block[..len].copy_from_slice(&data[..len]);
+        block
+    }
+
+    // --- Newline tests (unchanged) ---
+
+    #[test]
+    fn test_scalar_no_newlines() {
+        let block = make_block(b"ACGTACGTACGTACGTACGTACGTACGTACGT");
+        let bm = lex_block_scalar(&block);
+        assert_eq!(bm.newlines, 0);
+    }
+
+    #[test]
+    fn test_scalar_all_newlines() {
+        let block = [b'\n'; 64];
+        let bm = lex_block_scalar(&block);
+        assert_eq!(bm.newlines, u64::MAX);
+    }
+
+    #[test]
+    fn test_scalar_known_positions() {
+        let mut block = [b'A'; 64];
+        block[0] = b'\n';
+        block[3] = b'\n';
+        block[63] = b'\n';
+        let bm = lex_block_scalar(&block);
+        assert_eq!(bm.newlines, (1 << 0) | (1 << 3) | (1 << 63));
+    }
+
+    #[test]
+    fn test_scalar_fastq_record() {
+        let block = make_block(b"@r1\nACGT\n+\nIIII\n");
+        let bm = lex_block_scalar(&block);
+        assert_eq!(bm.newlines, (1 << 3) | (1 << 8) | (1 << 10) | (1 << 15));
+    }
+
+    // --- ACGT classification tests ---
+
+    #[test]
+    fn test_scalar_acgt_classification() {
+        let block = make_block(b"ACGTacgt");
+        let bm = lex_block_scalar(&block);
+        // All 8 bases should be classified as ACGT
+        assert_eq!(bm.is_acgt & 0xFF, 0xFF);
+        // Padding zeros are not ACGT
+        assert_eq!(bm.is_acgt >> 8, 0);
+    }
+
+    #[test]
+    fn test_scalar_non_acgt() {
+        let block = make_block(b"@+N\nIIII");
+        let bm = lex_block_scalar(&block);
+        // None of these are ACGT
+        assert_eq!(bm.is_acgt & 0xFF, 0);
+    }
+
+    #[test]
+    fn test_scalar_mixed_acgt() {
+        let block = make_block(b"@ACNGT\n");
+        let bm = lex_block_scalar(&block);
+        // Positions: @(0)=no, A(1)=yes, C(2)=yes, N(3)=no, G(4)=yes, T(5)=yes, \n(6)=no
+        assert_eq!(bm.is_acgt & 0x7F, 0b011_0110);
+    }
+
+    // --- 2-bit encoding tests ---
+
+    #[test]
+    fn test_scalar_two_bit_encoding() {
+        // A=0, C=1, G=2, T=3 (fgumi BitEnc mapping)
+        let block = make_block(b"ACGT");
+        let bm = lex_block_scalar(&block);
+
+        // Position 0: A → 0b00
+        assert_eq!(bm.two_bits & 0x3, 0);
+        // Position 1: C → 0b01
+        assert_eq!((bm.two_bits >> 2) & 0x3, 1);
+        // Position 2: G → 0b10
+        assert_eq!((bm.two_bits >> 4) & 0x3, 2);
+        // Position 3: T → 0b11
+        assert_eq!((bm.two_bits >> 6) & 0x3, 3);
+    }
+
+    #[test]
+    fn test_scalar_two_bit_case_insensitive() {
+        let upper = make_block(b"ACGT");
+        let lower = make_block(b"acgt");
+        let bm_upper = lex_block_scalar(&upper);
+        let bm_lower = lex_block_scalar(&lower);
+        // First 8 bits of two_bits should match (4 bases * 2 bits each)
+        assert_eq!(bm_upper.two_bits & 0xFF, bm_lower.two_bits & 0xFF);
+    }
+
+    // --- SIMD vs scalar consistency (newlines only) ---
+
+    #[test]
+    fn test_simd_matches_scalar_newlines() {
+        let mut block = [b'A'; 64];
+        for (i, byte) in block.iter_mut().enumerate() {
+            if i % 7 == 0 {
+                *byte = b'\n';
+            }
+        }
+        let simd_result = lex_block(&block);
+        let scalar_result = lex_block_scalar(&block).newlines;
+        assert_eq!(simd_result, scalar_result, "Newline bitmask mismatch");
+    }
+
+    #[test]
+    fn test_simd_newlines_every_position() {
+        for pos in 0..64 {
+            let mut block = [b'X'; 64];
+            block[pos] = b'\n';
+            let simd_result = lex_block(&block);
+            let scalar_result = lex_block_scalar(&block).newlines;
+            assert_eq!(simd_result, scalar_result, "Mismatch at position {pos}");
+        }
+    }
+
+    // --- SIMD vs scalar consistency (full classification) ---
+
+    #[test]
+    fn test_simd_full_matches_scalar_all_fields() {
+        let block = make_block(b"@read1\nACGTACGTacgtNNNN\n+\nIIIIIIIIIIIIIIII\n");
+        let simd_result = lex_block_full(&block);
+        let scalar_result = lex_block_scalar(&block);
+        assert_eq!(simd_result.newlines, scalar_result.newlines, "newlines mismatch");
+        assert_eq!(simd_result.is_acgt, scalar_result.is_acgt, "is_acgt mismatch");
+        assert_eq!(simd_result.two_bits, scalar_result.two_bits, "two_bits mismatch");
+    }
+
+    #[test]
+    fn test_simd_full_matches_scalar_all_acgt() {
+        let block = {
+            let mut b = [0u8; 64];
+            for (i, byte) in b.iter_mut().enumerate() {
+                *byte = b"ACGTacgt"[i % 8];
+            }
+            b
+        };
+        let simd_result = lex_block_full(&block);
+        let scalar_result = lex_block_scalar(&block);
+        assert_eq!(simd_result.is_acgt, scalar_result.is_acgt, "is_acgt mismatch");
+        assert_eq!(simd_result.two_bits, scalar_result.two_bits, "two_bits mismatch");
+    }
+
+    #[test]
+    fn test_simd_full_matches_scalar_every_position() {
+        for base in [b'A', b'C', b'G', b'T', b'a', b'c', b'g', b't'] {
+            for pos in 0..64 {
+                let mut block = [b'N'; 64];
+                block[pos] = base;
+                let simd = lex_block_full(&block);
+                let scalar = lex_block_scalar(&block);
+                assert_eq!(
+                    simd.is_acgt, scalar.is_acgt,
+                    "is_acgt mismatch for {base} at pos {pos}"
+                );
+                let mask = 0x3u128 << (pos * 2);
+                assert_eq!(
+                    simd.two_bits & mask,
+                    scalar.two_bits & mask,
+                    "two_bits mismatch for {} at pos {pos}",
+                    base as char,
+                );
+            }
+        }
+    }
+}

--- a/crates/fgumi-simd-fastq/src/lib.rs
+++ b/crates/fgumi-simd-fastq/src/lib.rs
@@ -1,0 +1,37 @@
+//! SIMD-accelerated FASTQ parsing using Helicase-style bitmask operations.
+//!
+//! This crate provides high-throughput FASTQ parsing by processing 64 bytes at a time
+//! through SIMD registers (NEON on ARM, AVX2 on `x86_64`), classifying newline characters
+//! via bitmask operations and finding record boundaries without per-byte branching.
+//!
+//! # Architecture
+//!
+//! 1. **Lexer**: Loads 64-byte blocks into SIMD registers, produces a `u64` bitmask where
+//!    bit `i` is set if byte `i` is a newline (`\n`).
+//! 2. **Parser**: Walks the newline bitmask with `trailing_zeros()` to find record
+//!    boundaries. Every 4th newline marks the end of a FASTQ record.
+//!
+//! # Example
+//!
+//! ```
+//! use fgumi_simd_fastq::{find_record_offsets, parse_records};
+//!
+//! let fastq = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+//! let offsets = find_record_offsets(fastq);
+//! assert_eq!(offsets, vec![0, 16, 32]);
+//!
+//! let records: Vec<_> = parse_records(fastq).collect();
+//! assert_eq!(records.len(), 2);
+//! assert_eq!(records[0].name, b"r1");
+//! assert_eq!(records[0].sequence, b"ACGT");
+//! ```
+
+mod bitmask;
+mod lexer;
+mod parser;
+mod reader;
+
+pub use bitmask::FastqBitmask;
+pub use lexer::lex_block_full;
+pub use parser::{FastqRecord, find_record_offsets, parse_records};
+pub use reader::SimdFastqReader;

--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -1,0 +1,327 @@
+//! FASTQ parser: uses SIMD-produced newline bitmasks to find record boundaries.
+
+use crate::lexer;
+
+/// A borrowed FASTQ record with zero-copy slices into the input buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FastqRecord<'a> {
+    /// Read name (without leading `@` or trailing newline).
+    pub name: &'a [u8],
+    /// Sequence bases.
+    pub sequence: &'a [u8],
+    /// Quality scores (Phred-encoded ASCII).
+    pub quality: &'a [u8],
+}
+
+/// Find FASTQ record boundary offsets in a byte buffer.
+///
+/// Returns a `Vec` of byte offsets marking the start of each complete record.
+/// The first offset is always 0 (if there are any records). The last offset
+/// points one byte past the final complete record.
+///
+/// Incomplete trailing records (fewer than 4 newlines) are excluded; the caller
+/// should treat `data[last_offset..]` as leftover bytes.
+///
+/// # Algorithm
+///
+/// Processes 64-byte blocks through the SIMD lexer to produce newline bitmasks.
+/// Walks each bitmask with `trailing_zeros()` to locate newlines. Every 4th
+/// newline marks a record boundary.
+///
+/// # Example
+///
+/// ```
+/// use fgumi_simd_fastq::find_record_offsets;
+///
+/// let data = b"@r1\nACGT\n+\nIIII\n@r2\nTT\n+\nJJ\n";
+/// let offsets = find_record_offsets(data);
+/// assert_eq!(offsets, vec![0, 16, 28]);
+/// ```
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn find_record_offsets(data: &[u8]) -> Vec<usize> {
+    if data.is_empty() {
+        return vec![0];
+    }
+
+    let mut offsets = Vec::with_capacity(data.len() / 300 + 2);
+    offsets.push(0);
+
+    let mut newline_count: u32 = 0;
+    let num_full_blocks = data.len() / 64;
+    let remainder = data.len() % 64;
+
+    // Process full 64-byte blocks
+    for block_idx in 0..num_full_blocks {
+        let block_start = block_idx * 64;
+        // Indexing is safe: block_start + 64 <= num_full_blocks * 64 <= data.len()
+        let block: &[u8; 64] = data[block_start..block_start + 64].try_into().unwrap();
+        let newlines = lexer::lex_block(block);
+        process_bitmask(newlines, block_start, &mut newline_count, &mut offsets);
+    }
+
+    // Process the remaining bytes (< 64) with zero-padding
+    if remainder > 0 {
+        let block_start = num_full_blocks * 64;
+        let mut padded = [0u8; 64];
+        padded[..remainder].copy_from_slice(&data[block_start..]);
+        let newlines = lexer::lex_block(&padded);
+        // Mask out padding positions — only consider bits 0..remainder
+        let valid_mask = if remainder < 64 { (1u64 << remainder) - 1 } else { u64::MAX };
+        let masked_newlines = newlines & valid_mask;
+        process_bitmask(masked_newlines, block_start, &mut newline_count, &mut offsets);
+    }
+
+    offsets
+}
+
+/// Process a newline bitmask from one 64-byte block, updating the record offsets.
+///
+/// Every 4th newline marks the end of a FASTQ record (the byte after the newline
+/// is the start of the next record).
+#[inline]
+fn process_bitmask(
+    mut newlines: u64,
+    block_start: usize,
+    newline_count: &mut u32,
+    offsets: &mut Vec<usize>,
+) {
+    while newlines != 0 {
+        let bit_pos = newlines.trailing_zeros() as usize;
+        *newline_count += 1;
+
+        if (*newline_count).is_multiple_of(4) {
+            // This newline ends a FASTQ record. The next record starts at bit_pos + 1.
+            offsets.push(block_start + bit_pos + 1);
+        }
+
+        // Clear the lowest set bit
+        newlines &= newlines - 1;
+    }
+}
+
+/// Iterator over zero-copy FASTQ records parsed from a byte buffer.
+///
+/// Uses [`find_record_offsets`] to locate record boundaries, then slices
+/// each record into name, sequence, and quality fields.
+///
+/// # Example
+///
+/// ```
+/// use fgumi_simd_fastq::parse_records;
+///
+/// let data = b"@read1\nACGT\n+\nIIII\n";
+/// let records: Vec<_> = parse_records(data).collect();
+/// assert_eq!(records[0].name, b"read1");
+/// assert_eq!(records[0].sequence, b"ACGT");
+/// assert_eq!(records[0].quality, b"IIII");
+/// ```
+pub fn parse_records(data: &[u8]) -> impl Iterator<Item = FastqRecord<'_>> {
+    let offsets = find_record_offsets(data);
+    RecordIter { data, offsets, idx: 0 }
+}
+
+/// Iterator over FASTQ records in a byte buffer.
+struct RecordIter<'a> {
+    data: &'a [u8],
+    offsets: Vec<usize>,
+    idx: usize,
+}
+
+impl<'a> Iterator for RecordIter<'a> {
+    type Item = FastqRecord<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx + 1 >= self.offsets.len() {
+            return None;
+        }
+        let start = self.offsets[self.idx];
+        let end = self.offsets[self.idx + 1];
+        self.idx += 1;
+        Some(parse_single_record(&self.data[start..end]))
+    }
+}
+
+/// Parse a single FASTQ record from a byte slice.
+///
+/// Expects format: `@name\nsequence\n+\nquality\n`
+///
+/// # Panics
+///
+/// Panics if the record does not contain exactly 4 newline-delimited lines
+/// or does not start with `@`.
+pub(crate) fn parse_single_record(record: &[u8]) -> FastqRecord<'_> {
+    assert!(!record.is_empty() && record[0] == b'@', "FASTQ record must start with @");
+
+    // Find the 3 internal newlines (the 4th newline is the last byte)
+    let mut newline_positions = [0usize; 3];
+    let mut count = 0;
+
+    // We only need to find the first 3 newlines; the 4th is at end-1
+    for (i, &byte) in record.iter().enumerate() {
+        if byte == b'\n' {
+            if count < 3 {
+                newline_positions[count] = i;
+                count += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(count, 3, "FASTQ record must have at least 3 internal newlines");
+
+    let name_end = newline_positions[0];
+    let seq_end = newline_positions[1];
+    let plus_end = newline_positions[2];
+
+    // name: skip '@', up to first newline
+    let name = &record[1..name_end];
+    // sequence: after first newline, up to second newline
+    let sequence = &record[name_end + 1..seq_end];
+    // quality: after third newline, up to end (excluding trailing newline if present)
+    let qual_start = plus_end + 1;
+    let qual_end = if record.last() == Some(&b'\n') { record.len() - 1 } else { record.len() };
+    let quality = &record[qual_start..qual_end];
+
+    FastqRecord { name, sequence, quality }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        let offsets = find_record_offsets(b"");
+        assert_eq!(offsets, vec![0]);
+    }
+
+    #[test]
+    fn test_single_record() {
+        let data = b"@r1\nACGT\n+\nIIII\n";
+        let offsets = find_record_offsets(data);
+        assert_eq!(offsets, vec![0, 16]);
+    }
+
+    #[test]
+    fn test_two_records() {
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+        let offsets = find_record_offsets(data);
+        assert_eq!(offsets, vec![0, 16, 32]);
+    }
+
+    #[test]
+    fn test_incomplete_trailing_record() {
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTT";
+        let offsets = find_record_offsets(data);
+        assert_eq!(offsets, vec![0, 16]);
+    }
+
+    #[test]
+    fn test_single_base_reads() {
+        // @r\nA\n+\nI\n = 9 bytes: @(0) r(1) \n(2) A(3) \n(4) +(5) \n(6) I(7) \n(8)
+        let data = b"@r\nA\n+\nI\n";
+        assert_eq!(data.len(), 9);
+        let offsets = find_record_offsets(data);
+        assert_eq!(offsets, vec![0, 9]);
+    }
+
+    #[test]
+    fn test_parse_single_record() {
+        let data = b"@read1\nACGT\n+\nIIII\n";
+        let records: Vec<_> = parse_records(data).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, b"read1");
+        assert_eq!(records[0].sequence, b"ACGT");
+        assert_eq!(records[0].quality, b"IIII");
+    }
+
+    #[test]
+    fn test_parse_multiple_records() {
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+        let records: Vec<_> = parse_records(data).collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].name, b"r1");
+        assert_eq!(records[0].sequence, b"ACGT");
+        assert_eq!(records[0].quality, b"IIII");
+        assert_eq!(records[1].name, b"r2");
+        assert_eq!(records[1].sequence, b"TTTT");
+        assert_eq!(records[1].quality, b"JJJJ");
+    }
+
+    #[test]
+    fn test_record_spanning_block_boundary() {
+        // Create a record that starts in one 64-byte block and ends in the next
+        // "@" + 60 chars name + "\n" = 62 bytes for header line
+        // "ACGT\n+\nIIII\n" = 13 bytes for remaining lines
+        // Total: 75 bytes — spans two 64-byte blocks
+        let name = "X".repeat(60);
+        let data = format!("@{name}\nACGT\n+\nIIII\n");
+        let offsets = find_record_offsets(data.as_bytes());
+        assert_eq!(offsets, vec![0, data.len()]);
+
+        let records: Vec<_> = parse_records(data.as_bytes()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, name.as_bytes());
+        assert_eq!(records[0].sequence, b"ACGT");
+        assert_eq!(records[0].quality, b"IIII");
+    }
+
+    #[test]
+    fn test_long_sequence_spanning_multiple_blocks() {
+        // 200-base sequence spans 4 blocks
+        let seq = "A".repeat(200);
+        let qual = "I".repeat(200);
+        let data = format!("@r1\n{seq}\n+\n{qual}\n");
+        let offsets = find_record_offsets(data.as_bytes());
+        assert_eq!(offsets, vec![0, data.len()]);
+
+        let records: Vec<_> = parse_records(data.as_bytes()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].sequence.len(), 200);
+    }
+
+    #[test]
+    fn test_n_bases_and_mixed_case() {
+        let data = b"@r1\nAcGtNn\n+\nIIIIII\n";
+        let records: Vec<_> = parse_records(data).collect();
+        assert_eq!(records[0].sequence, b"AcGtNn");
+    }
+
+    #[test]
+    fn test_many_small_records() {
+        // 10 minimal records
+        let mut data = Vec::new();
+        for i in 0..10 {
+            data.extend_from_slice(format!("@r{i}\nA\n+\nI\n").as_bytes());
+        }
+        let offsets = find_record_offsets(&data);
+        assert_eq!(offsets.len(), 11); // 10 records + initial 0
+        let records: Vec<_> = parse_records(&data).collect();
+        assert_eq!(records.len(), 10);
+        for (i, rec) in records.iter().enumerate() {
+            assert_eq!(rec.name, format!("r{i}").as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_exactly_64_bytes() {
+        // Craft a record that is exactly 64 bytes
+        // @name(55 chars)\nA\n+\nI\n = 55 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = hmm
+        // @(1) + name(53) + \n(1) + A(1) + \n(1) + +(1) + \n(1) + I(1) + \n(1) = 61
+        // Need 64: @(1) + name(56) + \n(1) + A(1) + \n(1) + +(1) + \n(1) + I(1) + \n(1) = 64
+        let name = "X".repeat(56);
+        let data = format!("@{name}\nA\n+\nI\n");
+        assert_eq!(data.len(), 64);
+        let offsets = find_record_offsets(data.as_bytes());
+        assert_eq!(offsets, vec![0, 64]);
+    }
+
+    #[test]
+    fn test_no_complete_records() {
+        let data = b"@r1\nACGT\n+\n";
+        let offsets = find_record_offsets(data);
+        assert_eq!(offsets, vec![0]);
+    }
+}

--- a/crates/fgumi-simd-fastq/src/reader.rs
+++ b/crates/fgumi-simd-fastq/src/reader.rs
@@ -1,0 +1,244 @@
+//! Buffered FASTQ reader using SIMD-accelerated parsing.
+//!
+//! [`SimdFastqReader`] wraps a `BufRead` and yields owned FASTQ records,
+//! serving as a drop-in replacement for `seq_io::fastq::Reader`.
+
+use std::io::{self, BufRead};
+
+use crate::parser::{self, parse_single_record};
+
+/// Default internal buffer size (1 MiB), matching `seq_io`'s default.
+const DEFAULT_BUFFER_SIZE: usize = 1 << 20;
+
+/// An owned FASTQ record with heap-allocated name, sequence, and quality.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedFastqRecord {
+    /// Read name (without leading `@`).
+    pub name: Vec<u8>,
+    /// Sequence bases.
+    pub sequence: Vec<u8>,
+    /// Quality scores (Phred-encoded ASCII).
+    pub quality: Vec<u8>,
+}
+
+/// Buffered FASTQ reader that uses SIMD-accelerated record boundary detection.
+///
+/// Reads chunks from the underlying `BufRead`, finds record boundaries with
+/// [`find_record_offsets`](crate::find_record_offsets), and yields owned records.
+///
+/// # Example
+///
+/// ```
+/// use fgumi_simd_fastq::SimdFastqReader;
+/// use std::io::Cursor;
+///
+/// let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+/// let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+///
+/// let rec = reader.next().unwrap().unwrap();
+/// assert_eq!(rec.name, b"r1");
+/// assert_eq!(rec.sequence, b"ACGT");
+/// ```
+pub struct SimdFastqReader<R: BufRead> {
+    inner: R,
+    /// Internal buffer holding data read from the source.
+    buffer: Vec<u8>,
+    /// Pre-computed record boundary offsets within `buffer[..valid]`.
+    offsets: Vec<usize>,
+    /// Index into `offsets` for the next record to yield.
+    next_record_idx: usize,
+    /// Number of valid bytes in `buffer`.
+    valid: usize,
+    /// True when the underlying reader has returned 0 bytes.
+    at_eof: bool,
+}
+
+impl<R: BufRead> SimdFastqReader<R> {
+    /// Create a new reader with the default buffer size (1 MiB).
+    pub fn new(inner: R) -> Self {
+        Self::with_capacity(inner, DEFAULT_BUFFER_SIZE)
+    }
+
+    /// Create a new reader with a custom buffer capacity.
+    pub fn with_capacity(inner: R, capacity: usize) -> Self {
+        Self {
+            inner,
+            buffer: Vec::with_capacity(capacity),
+            offsets: Vec::new(),
+            next_record_idx: 0,
+            valid: 0,
+            at_eof: false,
+        }
+    }
+
+    /// Fill the internal buffer, preserving any leftover bytes from incomplete records.
+    ///
+    /// Returns `true` if new data was read (or there are still records to yield).
+    fn fill_buffer(&mut self) -> io::Result<bool> {
+        // Determine leftover: bytes from the last complete record offset to end of valid data.
+        let leftover_start = if self.offsets.is_empty() {
+            0
+        } else {
+            // The last offset in `offsets` is the start of the first incomplete record
+            // (or the end of the last complete record, which is the same thing).
+            self.offsets.last().copied().unwrap_or(0)
+        };
+
+        // Move leftover bytes to the front of the buffer
+        if leftover_start > 0 && leftover_start < self.valid {
+            self.buffer.copy_within(leftover_start..self.valid, 0);
+            self.valid -= leftover_start;
+        } else if leftover_start >= self.valid {
+            self.valid = 0;
+        }
+
+        // If the buffer is full of leftover (no complete records found), grow it
+        // so we can read more data and find the end of the current record.
+        if self.valid >= self.buffer.capacity() {
+            self.buffer.reserve(self.buffer.capacity().max(4096));
+        }
+        self.buffer.resize(self.buffer.capacity(), 0);
+
+        // Read new data into the buffer after the leftover
+        let mut total_read = 0;
+        while self.valid + total_read < self.buffer.len() {
+            let buf = &mut self.buffer[self.valid + total_read..];
+            if buf.is_empty() {
+                break;
+            }
+            match self.inner.read(buf) {
+                Ok(0) => {
+                    self.at_eof = true;
+                    break;
+                }
+                Ok(n) => total_read += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        self.valid += total_read;
+        self.buffer.truncate(self.valid);
+
+        // Find record boundaries in the buffer
+        self.offsets = parser::find_record_offsets(&self.buffer[..self.valid]);
+        self.next_record_idx = 0;
+
+        // We have data if there are any complete records
+        Ok(self.offsets.len() > 1 || (!self.at_eof && self.valid > 0))
+    }
+}
+
+impl<R: BufRead> Iterator for SimdFastqReader<R> {
+    type Item = io::Result<OwnedFastqRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.next_record_idx + 1 < self.offsets.len() {
+                let start = self.offsets[self.next_record_idx];
+                let end = self.offsets[self.next_record_idx + 1];
+                self.next_record_idx += 1;
+
+                let borrowed = parse_single_record(&self.buffer[start..end]);
+                return Some(Ok(OwnedFastqRecord {
+                    name: borrowed.name.to_vec(),
+                    sequence: borrowed.sequence.to_vec(),
+                    quality: borrowed.quality.to_vec(),
+                }));
+            }
+
+            if self.at_eof {
+                // Check for leftover bytes that form an incomplete record
+                let leftover_start = self.offsets.last().copied().unwrap_or(0);
+                if leftover_start < self.valid {
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "Truncated FASTQ record at EOF ({} leftover bytes)",
+                            self.valid - leftover_start
+                        ),
+                    )));
+                }
+                return None;
+            }
+
+            match self.fill_buffer() {
+                Ok(true) => {}
+                Ok(false) => return None,
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_reader_single_record() {
+        let data = b"@r1\nACGT\n+\nIIII\n";
+        let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.name, b"r1");
+        assert_eq!(rec.sequence, b"ACGT");
+        assert_eq!(rec.quality, b"IIII");
+
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn test_reader_multiple_records() {
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+        let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+
+        let rec1 = reader.next().unwrap().unwrap();
+        assert_eq!(rec1.name, b"r1");
+
+        let rec2 = reader.next().unwrap().unwrap();
+        assert_eq!(rec2.name, b"r2");
+
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn test_reader_tiny_buffer() {
+        // Use a very small buffer to force multiple refills
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ\n";
+        let mut reader = SimdFastqReader::with_capacity(Cursor::new(&data[..]), 20);
+
+        let rec1 = reader.next().unwrap().unwrap();
+        assert_eq!(rec1.name, b"r1");
+        assert_eq!(rec1.sequence, b"ACGT");
+
+        let rec2 = reader.next().unwrap().unwrap();
+        assert_eq!(rec2.name, b"r2");
+        assert_eq!(rec2.sequence, b"TTTT");
+
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn test_reader_empty_input() {
+        let data = b"";
+        let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn test_reader_long_records() {
+        let seq = "A".repeat(500);
+        let qual = "I".repeat(500);
+        let data = format!("@longread\n{seq}\n+\n{qual}\n");
+        let mut reader = SimdFastqReader::with_capacity(Cursor::new(data.as_bytes()), 256);
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.name, b"longread");
+        assert_eq!(rec.sequence.len(), 500);
+        assert_eq!(rec.quality.len(), 500);
+
+        assert!(reader.next().is_none());
+    }
+}

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -38,6 +38,7 @@ use noodles_bgzf::io::MultithreadedReader;
 
 #[cfg(test)]
 use fgumi_lib::bam_io::create_bam_reader;
+use fgumi_simd_fastq::SimdFastqReader;
 use noodles::sam::header::Header;
 use noodles::sam::header::record::value::Map;
 use noodles::sam::header::record::value::map::ReadGroup;
@@ -50,8 +51,6 @@ use noodles::sam::header::record::value::{
     map::{Header as HeaderRecord, Tag as HeaderTag},
 };
 use read_structure::{ReadStructure, SegmentType};
-use seq_io::fastq::Reader as FastqReader;
-use seq_io::fastq::Record;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -1241,14 +1240,13 @@ impl Command for Extract {
         // Detect quality encoding from first 400 records
         // Use a separate reader for sampling to avoid consuming records from the main reader
         let mut sample_quals = Vec::new();
-        let temp_reader =
-            FastqReader::with_capacity(open_fastq_reader(&self.inputs[0], 1)?, BUFFER_SIZE);
-        for (i, result) in temp_reader.into_records().enumerate() {
-            if i >= QUALITY_DETECTION_SAMPLE_SIZE {
-                break;
-            }
-            if let Ok(rec) = result {
-                sample_quals.push(rec.qual().to_vec());
+        let mut temp_reader =
+            SimdFastqReader::with_capacity(open_fastq_reader(&self.inputs[0], 1)?, BUFFER_SIZE);
+        for _i in 0..QUALITY_DETECTION_SAMPLE_SIZE {
+            match temp_reader.next() {
+                Some(Ok(rec)) => sample_quals.push(rec.quality),
+                Some(Err(e)) => return Err(e.into()),
+                None => break,
             }
         }
 
@@ -1277,9 +1275,9 @@ impl Command for Extract {
                 .map(|p| open_fastq_reader(p, decomp_threads))
                 .collect::<Result<Vec<_>>>()?;
 
-            let fq_sources: Vec<FastqReader<Box<dyn BufRead + Send>>> = fq_readers
+            let fq_sources: Vec<SimdFastqReader<Box<dyn BufRead + Send>>> = fq_readers
                 .into_iter()
-                .map(|fq| FastqReader::with_capacity(fq, BUFFER_SIZE))
+                .map(|fq| SimdFastqReader::with_capacity(fq, BUFFER_SIZE))
                 .collect();
 
             // Create iterators

--- a/src/lib/fastq.rs
+++ b/src/lib/fastq.rs
@@ -15,13 +15,15 @@
 //!
 //! ```rust,ignore
 //! use read_structure::ReadStructure;
+//! use fgumi_simd_fastq::SimdFastqReader;
 //! use std::fs::File;
 //! use std::io::BufReader;
-//! use seq_io::fastq::Reader;
 //!
 //! let rs = ReadStructure::from_str("8M143T").unwrap();
 //! let file = File::open("reads.fq").unwrap();
-//! let reader = Reader::new(BufReader::new(file));
+//! let reader = SimdFastqReader::new(
+//!     Box::new(BufReader::new(file)) as Box<dyn std::io::BufRead + Send>
+//! );
 //! let mut iter = ReadSetIterator::new(rs, reader, vec![]);
 //!
 //! for read_set in iter {
@@ -30,10 +32,9 @@
 //! ```
 
 use anyhow::{Result, anyhow};
+use fgumi_simd_fastq::SimdFastqReader;
 use read_structure::ReadStructure;
 use read_structure::SegmentType;
-use seq_io::fastq::Reader as FastqReader;
-use seq_io::fastq::Record;
 use std::fmt::Display;
 use std::io::BufRead;
 use std::iter::Filter;
@@ -296,7 +297,9 @@ impl FastqSet {
 /// ```rust,ignore
 /// let read_structure = ReadStructure::from_str("8M143T")?;
 /// let file = File::open("reads.fq")?;
-/// let reader = Reader::new(BufReader::new(file));
+/// let reader = SimdFastqReader::new(
+///     Box::new(BufReader::new(file)) as Box<dyn std::io::BufRead + Send>
+/// );
 /// let mut iterator = ReadSetIterator::new(read_structure, reader, vec![]);
 ///
 /// for read_set in iterator {
@@ -306,8 +309,8 @@ impl FastqSet {
 pub struct ReadSetIterator {
     /// Read structure describing the layout of bases in each read
     read_structure: ReadStructure,
-    /// FASTQ file reader
-    source: FastqReader<Box<dyn BufRead + Send>>,
+    /// SIMD-accelerated FASTQ file reader
+    source: SimdFastqReader<Box<dyn BufRead + Send>>,
     /// Reasons to skip reads instead of panicking (e.g., too few bases)
     skip_reasons: Vec<SkipReason>,
 }
@@ -324,9 +327,9 @@ impl Iterator for ReadSetIterator {
             }
         };
         Some(FastqSet::from_record_with_structure(
-            record.head(),
-            record.seq(),
-            record.qual(),
+            &record.name,
+            &record.sequence,
+            &record.quality,
             &self.read_structure,
             &self.skip_reasons,
         ))
@@ -360,7 +363,7 @@ impl ReadSetIterator {
     #[must_use]
     pub fn new(
         read_structure: ReadStructure,
-        source: FastqReader<Box<dyn BufRead + Send>>,
+        source: SimdFastqReader<Box<dyn BufRead + Send>>,
         skip_reasons: Vec<SkipReason>,
     ) -> Self {
         Self { read_structure, source, skip_reasons }
@@ -544,7 +547,7 @@ mod tests {
         // Create a simple FASTQ record
         let fastq_data = b"@read1\nACGTACGT\n+\nIIIIIIII\n";
         let cursor = Cursor::new(fastq_data.to_vec());
-        let reader: FastqReader<Box<dyn BufRead + Send>> = FastqReader::new(Box::new(cursor));
+        let reader = SimdFastqReader::new(Box::new(cursor) as Box<dyn BufRead + Send>);
 
         // Simple read structure: 4M (molecular barcode) + 4T (template)
         let read_structure = ReadStructure::from_str("4M4T").unwrap();
@@ -577,7 +580,7 @@ mod tests {
         // Create a FASTQ record that's too short for the read structure
         let fastq_data = b"@read1\nACGT\n+\nIIII\n";
         let cursor = Cursor::new(fastq_data.to_vec());
-        let reader: FastqReader<Box<dyn BufRead + Send>> = FastqReader::new(Box::new(cursor));
+        let reader = SimdFastqReader::new(Box::new(cursor) as Box<dyn BufRead + Send>);
 
         // Read structure requires 10 bases total
         let read_structure = ReadStructure::from_str("4M6T").unwrap();
@@ -601,7 +604,7 @@ mod tests {
         // Create a FASTQ record that's too short
         let fastq_data = b"@read1\nACGT\n+\nIIII\n";
         let cursor = Cursor::new(fastq_data.to_vec());
-        let reader: FastqReader<Box<dyn BufRead + Send>> = FastqReader::new(Box::new(cursor));
+        let reader = SimdFastqReader::new(Box::new(cursor) as Box<dyn BufRead + Send>);
 
         // Read structure requires 10 bases total
         let read_structure = ReadStructure::from_str("4M6T").unwrap();
@@ -617,7 +620,7 @@ mod tests {
 
         let fastq_data = b"@read1\nACGTAAAA\n+\nIIIIIIII\n@read2\nTGCATTTT\n+\nIIIIIIII\n";
         let cursor = Cursor::new(fastq_data.to_vec());
-        let reader: FastqReader<Box<dyn BufRead + Send>> = FastqReader::new(Box::new(cursor));
+        let reader = SimdFastqReader::new(Box::new(cursor) as Box<dyn BufRead + Send>);
 
         let read_structure = ReadStructure::from_str("4M4T").unwrap();
         let mut iterator = ReadSetIterator::new(read_structure, reader, vec![]);
@@ -645,7 +648,7 @@ mod tests {
         // Test with variable-length template segment (last segment gets remaining bases)
         let fastq_data = b"@read1\nACGTTTTTTTTT\n+\nIIIIIIIIIIII\n";
         let cursor = Cursor::new(fastq_data.to_vec());
-        let reader: FastqReader<Box<dyn BufRead + Send>> = FastqReader::new(Box::new(cursor));
+        let reader = SimdFastqReader::new(Box::new(cursor) as Box<dyn BufRead + Send>);
 
         // 4M + variable T (remaining bases go to template)
         let read_structure = ReadStructure::from_str("4M+T").unwrap();

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -446,7 +446,7 @@ impl FastqFormat {
 // Boundary Finding Helper Functions
 // ============================================================================
 
-/// Find FASTQ record boundaries in data (allocation-reducing version).
+/// Find FASTQ record boundaries in data using SIMD-accelerated newline detection.
 ///
 /// Returns (`complete_data`, offsets, `leftover_start`).
 /// - `complete_data`: Bytes containing only complete records (owned)
@@ -459,53 +459,11 @@ fn find_fastq_boundaries_inplace(data: &[u8]) -> (Vec<u8>, Vec<usize>, usize) {
         return (Vec::new(), vec![0], 0);
     }
 
-    let mut offsets = vec![0];
-    let mut pos = 0;
+    let offsets = fgumi_simd_fastq::find_record_offsets(data);
+    let last_offset = offsets.last().copied().unwrap_or(0);
+    let complete_data = data[..last_offset].to_vec();
 
-    // Scan for complete FASTQ records (4 lines each)
-    while pos < data.len() {
-        // Find end of this record (4 newlines)
-        if let Some(record_end) = find_fastq_record_end(&data[pos..]) {
-            pos += record_end;
-            offsets.push(pos);
-        } else {
-            // Incomplete record - everything from pos onwards is leftover
-            break;
-        }
-    }
-
-    // Only allocate for the complete data (unavoidable - we return ownership)
-    let complete_data = data[..pos].to_vec();
-
-    (complete_data, offsets, pos)
-}
-
-/// Find the end of a complete FASTQ record starting at the given position.
-///
-/// Returns the number of bytes consumed (position after the last newline),
-/// or None if the record is incomplete.
-///
-/// FASTQ format:
-/// ```text
-/// @name
-/// ACGT...
-/// +
-/// IIII...
-/// ```
-fn find_fastq_record_end(data: &[u8]) -> Option<usize> {
-    if data.is_empty() || data[0] != b'@' {
-        return None;
-    }
-
-    // Find 4 newlines using SIMD-accelerated memchr
-    let mut pos = 0;
-    for _ in 0..4 {
-        match memchr::memchr(b'\n', &data[pos..]) {
-            Some(nl) => pos += nl + 1,
-            None => return None,
-        }
-    }
-    Some(pos)
+    (complete_data, offsets, last_offset)
 }
 
 /// Parse FASTQ records from boundary data.


### PR DESCRIPTION
## Summary

- Adds `fgumi-simd-fastq` crate implementing Helicase-style SIMD FASTQ parsing
- Replaces `seq_io` dependency with `SimdFastqReader` and SIMD-accelerated boundary finding
- Processes 64 bytes at a time via NEON (aarch64) / AVX2 (x86_64), classifying newlines via bitmask operations

### Two lexer modes
- `lex_block()` — newline-only detection (~18 GiB/s), used for record boundary finding
- `lex_block_full()` — newlines + ACGT classification + 2-bit encoding (BitEnc-compatible A=0/C=1/G=2/T=3), exported for future fused pipeline use

### Integration
- `find_fastq_boundaries_inplace()` in the unified pipeline delegates to SIMD `find_record_offsets()` — 3.3x faster than the previous memchr-based approach on real FASTQ data
- `ReadSetIterator` uses `SimdFastqReader` instead of `seq_io::fastq::Reader`
- `seq_io` dependency removed

### Benchmark results (Apple Silicon, NEON)

**Boundary finding (in-memory, `find_record_offsets`):**

| Input | SIMD | memchr (old) | Speedup |
|-------|------|-------------|---------|
| Synthetic 150bp | 18.0 GiB/s | 7.7 GiB/s | 2.3x |
| Synthetic 300bp | 18.3 GiB/s | 14.7 GiB/s | 1.3x |
| Real FASTQ 176MB | 14.5 GiB/s | 4.4 GiB/s | 3.3x |

**Full record parsing (`parse_records` / `SimdFastqReader` vs `seq_io`):**

| Input | SIMD parse_records | SimdFastqReader | seq_io | 
|-------|-------------------|----------------|--------|
| 150bp | 1.8 GiB/s | 1.4 GiB/s | 3.1 GiB/s |
| 300bp | 2.1 GiB/s | 1.5 GiB/s | 4.2 GiB/s |

Full record parsing is slower than seq_io because the SIMD pass finds record boundaries but discards internal newline positions — the per-record field extraction re-scans for newlines. A future optimization (recording internal newlines during the SIMD pass) would close this gap.

End-to-end `fgumi extract` shows no measurable wall-clock difference on compressed FASTQ inputs where decompression dominates. The boundary-finding speedup matters more in the planned fused pipeline where parsing is a larger fraction of total work.

## Test plan

- [x] 32 new tests in `fgumi-simd-fastq` (lexer, parser, reader, SIMD-vs-scalar consistency)
- [x] All 1652 existing tests pass
- [x] `cargo ci-fmt` and `cargo ci-lint` clean
- [x] Criterion benchmarks for boundary finding and full record parsing