### PR TITLE
docs(vendored): update bam_codec comments to reflect noodles#364 closure

### DIFF
--- a/crates/fgumi-consensus/src/vendored/bam_codec/mod.rs
+++ b/crates/fgumi-consensus/src/vendored/bam_codec/mod.rs
@@ -16,7 +16,11 @@
 //! encode_record_buf(&mut buf, &header, &record).unwrap();
 //! ```
 //!
-//! This is vendored code that will be removed once upstream PRs are merged.
+//! This is vendored from noodles-bam. The upstream PR to expose codec functions
+//! ([#364](https://github.com/zaeleus/noodles/pull/364)) was closed; `encode_record_buf` is
+//! retained here for the raw-byte-mode optimization path. This vendored code can be removed
+//! once [#367](https://github.com/zaeleus/noodles/pull/367) (optimized `RecordBuf` encoding)
+//! lands upstream, or an equivalent API becomes available.
 
 pub mod encoder;
 

--- a/crates/fgumi-consensus/src/vendored/mod.rs
+++ b/crates/fgumi-consensus/src/vendored/mod.rs
@@ -1,4 +1,4 @@
-// Vendored code from noodles — will be removed once upstream PRs are merged.
+// Vendored BAM codec from noodles — see bam_codec/mod.rs for details on why this is vendored.
 // Allow clippy lints and dead code in vendored modules.
 #[allow(dead_code, clippy::all, clippy::pedantic, clippy::nursery)]
 pub(crate) mod bam_codec;

--- a/src/lib/vendored/bam_codec/mod.rs
+++ b/src/lib/vendored/bam_codec/mod.rs
@@ -42,7 +42,10 @@
 //! decode(&mut &bam_bytes[..], &mut record).unwrap();
 //! ```
 //!
-//! This is vendored code that will be removed once upstream PRs are merged.
+//! This is vendored from noodles-bam. The upstream PR to expose codec functions
+//! ([#364](https://github.com/zaeleus/noodles/pull/364)) was closed; the maintainer recommended
+//! `Reader::from(src)` for decoding instead. The vendored `encode_record_buf` is still needed
+//! for the raw-byte-mode optimization path. See [`super`] module docs for full context.
 
 pub mod decoder;
 pub mod encoder;

--- a/src/lib/vendored/mod.rs
+++ b/src/lib/vendored/mod.rs
@@ -2,11 +2,23 @@
 //!
 //! This module contains temporary implementations that are waiting on:
 //! - noodles-bgzf: `MultithreadedWriter` with position tracking (<https://github.com/zaeleus/noodles/pull/371>)
-//! - noodles-bam: expose record codec encode/decode (<https://github.com/zaeleus/noodles/pull/364>)
 //! - noodles-bam: optimized `RecordBuf` encoding (<https://github.com/zaeleus/noodles/pull/367>)
 //! - noodles-bam: `Record::as_ref()` raw bytes access (<https://github.com/zaeleus/noodles/pull/373>)
 //!
-//! This module should be removed once the upstream PRs are merged and released.
+//! ## BAM codec (`bam_codec`)
+//!
+//! The vendored BAM codec provides `encode_record_buf` and `decode` functions used by the
+//! raw-byte-mode optimization path that avoids full `RecordBuf` round-tripping (~30% CPU savings).
+//!
+//! PR [#364](https://github.com/zaeleus/noodles/pull/364) proposed exposing these codec functions
+//! upstream but was closed — the maintainer recommended `Reader::from(src)` for decoding instead.
+//! That approach is sufficient for decode, but the vendored `encode_record_buf` is still needed
+//! for the encode side of raw-byte-mode. The vendored codec will remain until either:
+//! - PR [#367](https://github.com/zaeleus/noodles/pull/367) lands (providing optimized encoding upstream), or
+//! - an alternative upstream API for direct `RecordBuf` encoding becomes available.
+//!
+//! The remaining vendored modules (`bgzf_multithreaded`) should be removed once their
+//! respective upstream PRs are merged and released.
 
 pub mod bam_codec;
 pub mod bgzf_multithreaded;


### PR DESCRIPTION
## Summary

- Remove noodles#364 from the pending-upstream-PR list since it was closed (not merged)
- Update vendored bam_codec module docs to explain why the vendored code is retained: `encode_record_buf` is still needed for the raw-byte-mode optimization path
- Clarify that the vendored codec can be removed once #367 (optimized `RecordBuf` encoding) lands upstream

## Test plan

- [x] `cargo build --release` passes
- [x] Pre-commit hooks (ci-fmt, ci-lint) pass
- [ ] Doc-only changes — no behavioral impact