### PR TITLE
feat(zipper): accept BAM input for mapped reads

### DIFF
--- a/src/commands/zipper.rs
+++ b/src/commands/zipper.rs
@@ -50,7 +50,9 @@ use crate::commands::command::Command;
 use crate::commands::common::CompressionOptions;
 use anyhow::{Context, Result};
 use clap::Parser;
-use fgumi_lib::bam_io::{create_bam_reader, create_bam_writer, is_stdin_path, is_stdout_path};
+use fgumi_lib::bam_io::{
+    BamReaderAuto, create_bam_reader, create_bam_writer, is_stdin_path, is_stdout_path,
+};
 use fgumi_lib::batched_sam_reader::BatchedSamReader;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::progress::ProgressTracker;
@@ -63,7 +65,7 @@ use fgumi_lib::sort::{PA_TAG, PrimaryAlignmentInfo};
 use fgumi_lib::template::{Template, TemplateIterator};
 use fgumi_lib::umi::TagInfo;
 use fgumi_lib::validation::validate_file_exists;
-use log::{debug, info};
+use log::{debug, info, warn};
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -114,7 +116,8 @@ workflows like:
 )]
 #[command(verbatim_doc_comment)]
 pub struct Zipper {
-    /// Input mapped SAM file (or `-` for stdin)
+    /// Input mapped SAM or BAM file (or `-` for stdin, SAM only). BAM input is
+    /// discouraged; prefer piping SAM directly from the aligner for best performance.
     #[arg(short = 'i', long, default_value = "-")]
     pub input: PathBuf,
 
@@ -735,6 +738,13 @@ impl Zipper {
     }
 }
 
+/// Wraps SAM and BAM readers so the mapped-reader thread can handle either format.
+/// Moved into the thread where `record_bufs()` is called, since it borrows `&self`.
+enum MappedReader {
+    Sam(noodles::sam::io::Reader<Box<dyn BufRead + Send>>),
+    Bam(BamReaderAuto),
+}
+
 impl Command for Zipper {
     /// Executes the `zipper` command
     ///
@@ -781,20 +791,35 @@ impl Command for Zipper {
 
         let (mut unmapped_reader, unmapped_header) = create_bam_reader(&self.unmapped, 1)?;
 
-        // For stdin, use BatchedSamReader that starts at 64MB and grows based on observed usage.
-        // This handles bwa mem's bursty output pattern (450-750MB SAM text per batch).
-        // The -K parameter (bwa_chunk_size) is used for batch tracking.
-        let mapped_reader: Box<dyn BufRead + Send> = if is_stdin_path(&self.input) {
+        // Read mapped input — detect format by extension.
+        // The reader and header are separated here; record_bufs() is called inside
+        // the spawned thread (it borrows &self, so the reader must live there).
+        let (mapped_reader, mapped_header) = if is_stdin_path(&self.input) {
+            // Stdin is always SAM (streaming from aligner)
             info!("Reading SAM from stdin with adaptive buffer (bwa -K {})", self.bwa_chunk_size);
-            Box::new(BatchedSamReader::new(std::io::stdin(), self.bwa_chunk_size))
+            let reader: Box<dyn BufRead + Send> =
+                Box::new(BatchedSamReader::new(std::io::stdin(), self.bwa_chunk_size));
+            let mut sam_reader = noodles::sam::io::Reader::new(reader);
+            let header = sam_reader.read_header()?;
+            (MappedReader::Sam(sam_reader), header)
+        } else if self.input.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("bam")) {
+            // BAM file input — functional but discouraged
+            warn!(
+                "BAM input detected for --input. For best performance, pipe SAM directly \
+                 from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
+            );
+            let (bam_reader, header) = create_bam_reader(&self.input, self.threads)?;
+            (MappedReader::Bam(bam_reader), header)
         } else {
-            Box::new(BufReader::with_capacity(
+            // SAM file input
+            let reader: Box<dyn BufRead + Send> = Box::new(BufReader::with_capacity(
                 256 * 1024,
                 std::fs::File::open(&self.input).context("Failed to open mapped SAM")?,
-            ))
+            ));
+            let mut sam_reader = noodles::sam::io::Reader::new(reader);
+            let header = sam_reader.read_header()?;
+            (MappedReader::Sam(sam_reader), header)
         };
-        let mut mapped_sam_reader = noodles::sam::io::Reader::new(mapped_reader);
-        let mapped_header = mapped_sam_reader.read_header()?;
 
         check_sort(&unmapped_header, &self.unmapped, "unmapped");
         check_sort(&mapped_header, &self.input, "mapped");
@@ -843,14 +868,30 @@ impl Command for Zipper {
         let (mapped_tx, mapped_rx) = std::sync::mpsc::sync_channel::<Result<Template>>(self.buffer);
         let mapped_header_for_reader = mapped_header.clone();
         std::thread::spawn(move || {
-            let mapped_iter = TemplateIterator::new(
-                mapped_sam_reader
-                    .record_bufs(&mapped_header_for_reader)
-                    .map(|r| r.map_err(anyhow::Error::from)),
-            );
-            for template in mapped_iter {
-                if mapped_tx.send(template).is_err() {
-                    break; // Receiver dropped, main thread done
+            // The reader must be owned for the full duration so that the iterator
+            // (which borrows it via record_bufs) remains valid.
+            match mapped_reader {
+                MappedReader::Sam(mut r) => {
+                    let mapped_iter = TemplateIterator::new(
+                        r.record_bufs(&mapped_header_for_reader)
+                            .map(|rec| rec.map_err(anyhow::Error::from)),
+                    );
+                    for template in mapped_iter {
+                        if mapped_tx.send(template).is_err() {
+                            break;
+                        }
+                    }
+                }
+                MappedReader::Bam(mut r) => {
+                    let mapped_iter = TemplateIterator::new(
+                        r.record_bufs(&mapped_header_for_reader)
+                            .map(|rec| rec.map_err(anyhow::Error::from)),
+                    );
+                    for template in mapped_iter {
+                        if mapped_tx.send(template).is_err() {
+                            break;
+                        }
+                    }
                 }
             }
         });

--- a/tests/integration/test_zipper_command.rs
+++ b/tests/integration/test_zipper_command.rs
@@ -40,6 +40,17 @@ fn create_mapped_sam(path: &Path, header: &sam::Header, records: &[RecordBuf]) {
     }
 }
 
+/// Create a mapped BAM file with aligned reads (same read names as unmapped).
+fn create_mapped_bam(path: &Path, header: &sam::Header, records: &[RecordBuf]) {
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create mapped BAM"));
+    writer.write_header(header).expect("Failed to write header");
+    for record in records {
+        writer.write_alignment_record(header, record).expect("Failed to write record");
+    }
+    writer.finish(header).expect("Failed to finish BAM");
+}
+
 /// Test basic zipper merge — unmapped tags are transferred to mapped reads.
 #[test]
 fn test_zipper_basic_merge() {
@@ -221,4 +232,96 @@ fn test_zipper_missing_input() {
         .expect("Failed to run zipper command");
 
     assert!(!status.success(), "Zipper should fail for nonexistent input");
+}
+
+/// Test zipper accepts BAM as mapped input (--input).
+#[test]
+fn test_zipper_bam_mapped_input() {
+    let temp_dir = TempDir::new().unwrap();
+    let unmapped_bam = temp_dir.path().join("unmapped.bam");
+    let mapped_bam = temp_dir.path().join("mapped.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+
+    let unmapped_records = vec![
+        RecordBuilder::new()
+            .name("read1")
+            .sequence("ACGTACGT")
+            .qualities(&[30; 8])
+            .unmapped(true)
+            .tag("RX", "AACCGGTT")
+            .tag("QX", "IIIIIIII")
+            .build(),
+        RecordBuilder::new()
+            .name("read2")
+            .sequence("TGCATGCA")
+            .qualities(&[30; 8])
+            .unmapped(true)
+            .tag("RX", "GGTTCCAA")
+            .tag("QX", "IIIIIIII")
+            .build(),
+    ];
+    create_unmapped_bam(&unmapped_bam, &unmapped_records);
+
+    let mapped_header = create_minimal_header("chr1", 10000);
+    let mapped_records = vec![
+        RecordBuilder::new()
+            .name("read1")
+            .sequence("ACGTACGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .cigar("8M")
+            .build(),
+        RecordBuilder::new()
+            .name("read2")
+            .sequence("TGCATGCA")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(200)
+            .mapping_quality(60)
+            .cigar("8M")
+            .build(),
+    ];
+    create_mapped_bam(&mapped_bam, &mapped_header, &mapped_records);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "zipper",
+            "--input",
+            mapped_bam.to_str().unwrap(),
+            "--unmapped",
+            unmapped_bam.to_str().unwrap(),
+            "--reference",
+            ref_path.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ])
+        .output()
+        .expect("Failed to run zipper command");
+
+    assert!(
+        output.status.success(),
+        "Zipper command failed with BAM input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_bam.exists(), "Output BAM not created");
+
+    // Verify output records have UMI tags transferred
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let header = reader.read_header().unwrap();
+    let records: Vec<RecordBuf> = reader.record_bufs(&header).map(|r| r.unwrap()).collect();
+    assert_eq!(records.len(), 2, "Should have 2 records in output");
+
+    let rx_tag = Tag::from([b'R', b'X']);
+    for record in &records {
+        assert!(record.data().get(&rx_tag).is_some(), "Output record should have RX tag");
+    }
+
+    // Verify warning about BAM input was emitted
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("BAM input detected"), "Should warn about BAM input. stderr: {stderr}");
 }


### PR DESCRIPTION
## Summary

- Detect BAM vs SAM by file extension for `--input` (mapped reads)
- Use noodles BAM reader with multi-threaded BGZF decompression for `.bam` files
- Emit a warning recommending piping SAM directly from the aligner
- Stdin remains SAM-only (streaming from aligner is the intended workflow)

Closes #181

## Test plan

- [x] New integration test: `test_zipper_bam_mapped_input` — creates mapped BAM, runs zipper, verifies tag transfer and warning output
- [x] Existing SAM input tests pass (no regression)
- [x] `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` all pass