### PR TITLE
perf(sort): improve multi-threaded sort scaling

### DIFF
--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -10,7 +10,7 @@
 //! - ~24 bytes overhead per record vs ~110 bytes
 
 use crate::sort::bam_fields;
-use crate::sort::keys::{RawSortKey, SortContext};
+use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use std::cmp::Ordering;
 use std::io::{Read, Write};
 
@@ -209,6 +209,54 @@ impl RecordBuffer {
         // Radix sort is already O(n×k), so parallelizing chunks provides
         // linear speedup without the merge overhead of comparison-based parallel sorts
         parallel_radix_sort_record_refs(&mut self.refs);
+    }
+
+    /// Sort in parallel and return each sub-array as a separate sorted chunk.
+    ///
+    /// Instead of merging the parallel sort sub-arrays back into one sorted
+    /// buffer (as `par_sort` does), this returns each sub-array as its own
+    /// `Vec<(RawCoordinateKey, Vec<u8>)>` so they can be passed as separate
+    /// merge sources to the k-way merge, avoiding the intermediate merge step.
+    ///
+    /// When `threads <= 1`, returns a single chunk.
+    pub fn par_sort_into_chunks(
+        &mut self,
+        threads: usize,
+    ) -> Vec<Vec<(RawCoordinateKey, Vec<u8>)>> {
+        use rayon::prelude::*;
+
+        let n = self.refs.len();
+
+        if threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
+            // Single-threaded path: sort everything, return one chunk
+            radix_sort_record_refs(&mut self.refs);
+            let chunk = self
+                .refs
+                .iter()
+                .map(|r| (RawCoordinateKey { sort_key: r.sort_key }, self.get_record(r).to_vec()))
+                .collect();
+            return vec![chunk];
+        }
+
+        let chunk_size = n.div_ceil(threads);
+
+        // Sort each chunk in parallel using radix sort
+        self.refs.par_chunks_mut(chunk_size).for_each(|chunk| {
+            radix_sort_record_refs(chunk);
+        });
+
+        // Collect each sorted sub-array into its own Vec<(RawCoordinateKey, Vec<u8>)>
+        self.refs
+            .chunks(chunk_size)
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|r| {
+                        (RawCoordinateKey { sort_key: r.sort_key }, self.get_record(r).to_vec())
+                    })
+                    .collect()
+            })
+            .collect()
     }
 
     /// Get record bytes by reference.
@@ -744,6 +792,40 @@ impl TemplateRecordBuffer {
     #[must_use]
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Sort in parallel and return each sub-array as a separate sorted chunk.
+    ///
+    /// Instead of merging the parallel sort sub-arrays back into one sorted
+    /// buffer (as `par_sort` does), this returns each sub-array as its own
+    /// `Vec<(TemplateKey, Vec<u8>)>` so they can be passed as separate merge
+    /// sources to the k-way merge, avoiding the intermediate merge step.
+    ///
+    /// When `threads <= 1`, returns a single chunk.
+    pub fn par_sort_into_chunks(&mut self, threads: usize) -> Vec<Vec<(TemplateKey, Vec<u8>)>> {
+        use rayon::prelude::*;
+
+        let n = self.refs.len();
+
+        if threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
+            // Single-threaded path: sort everything, return one chunk
+            radix_sort_template_refs(&mut self.refs);
+            let chunk = self.refs.iter().map(|r| (r.key, self.get_record(r).to_vec())).collect();
+            return vec![chunk];
+        }
+
+        let chunk_size = n.div_ceil(threads);
+
+        // Sort each chunk in parallel using radix sort
+        self.refs.par_chunks_mut(chunk_size).for_each(|chunk| {
+            radix_sort_template_refs(chunk);
+        });
+
+        // Collect each sorted sub-array into its own Vec<(TemplateKey, Vec<u8>)>
+        self.refs
+            .chunks(chunk_size)
+            .map(|chunk| chunk.iter().map(|r| (r.key, self.get_record(r).to_vec())).collect())
+            .collect()
     }
 }
 
@@ -1589,5 +1671,212 @@ mod tests {
     fn test_template_key_default_has_zero_cb_hash() {
         let key = TemplateKey::default();
         assert_eq!(key.cb_hash, 0);
+    }
+
+    /// Helper: build a minimal raw BAM record byte array with a distinguishing index.
+    fn make_bam_record(index: u16) -> Vec<u8> {
+        let mut record = vec![
+            0, 0, 0, 0, // ref_id = 0
+            100, 0, 0, 0, // pos = 100
+            2, // name_len = 2 (including null)
+            0, // mapq = 0
+            0, 0, // bin
+            0, 0, // n_cigar_op = 0
+            99, 0, // flag = 99 (paired, proper, mate reverse, first)
+            1, 0, 0, 0, // seq_len = 1
+            0, 0, 0, 0, // mate_ref_id = 0
+            200, 0, 0, 0, // mate_pos = 200
+            0, 0, 0, 0, // tlen = 0
+            b'A', 0, // read name "A\0"
+        ];
+        // Encode the index into two bytes so each record is distinguishable
+        record.push((index & 0xFF) as u8);
+        record.push((index >> 8) as u8);
+        record.push(0xFF); // qual
+        // Pad to at least 40 bytes
+        while record.len() < 40 {
+            record.push(0);
+        }
+        record
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_single_threaded_fallback() {
+        // With 1 thread, par_sort_into_chunks should return exactly 1 chunk.
+        let n = 100;
+        let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
+
+        for i in 0..n {
+            let key = TemplateKey::new(
+                0,
+                (n - i) as i32,
+                false,
+                0,
+                200,
+                false,
+                0,
+                0,
+                (1, true),
+                0,
+                false,
+            );
+            buffer.push(&make_bam_record(i as u16), key);
+        }
+
+        let chunks = buffer.par_sort_into_chunks(1);
+        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+
+        // Verify the chunk is sorted
+        for i in 1..chunks[0].len() {
+            assert!(
+                chunks[0][i - 1].0 <= chunks[0][i].0,
+                "single chunk should be sorted at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_parallel_path() {
+        // Use a dedicated rayon thread pool with multiple threads so that
+        // rayon::current_num_threads() > 1 inside par_sort_into_chunks.
+        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2 (512)
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("failed to build rayon thread pool");
+
+        let chunks = pool.install(|| {
+            let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
+
+            for i in 0..n {
+                // Vary the primary sort field so records are not all equal
+                let key = TemplateKey::new(
+                    0,
+                    (n - i) as i32,
+                    false,
+                    0,
+                    200,
+                    false,
+                    0,
+                    0,
+                    (1, true),
+                    0,
+                    false,
+                );
+                buffer.push(&make_bam_record(i as u16), key);
+            }
+
+            buffer.par_sort_into_chunks(4)
+        });
+
+        // With 4 threads and > 10_000 records we should get multiple chunks
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks from parallel path, got {}",
+            chunks.len()
+        );
+
+        // Verify each chunk is individually sorted
+        for (ci, chunk) in chunks.iter().enumerate() {
+            for i in 1..chunk.len() {
+                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
+            }
+        }
+
+        // Verify total record count across all chunks matches input
+        let total: usize = chunks.iter().map(Vec::len).sum();
+        assert_eq!(total, n, "total records across chunks should equal input count");
+    }
+
+    /// Helper: build a minimal raw BAM record for coordinate sort with a specific position.
+    fn make_coordinate_bam_record(tid: i32, pos: i32) -> Vec<u8> {
+        let mut record = Vec::with_capacity(40);
+        record.extend_from_slice(&tid.to_le_bytes()); // ref_id
+        record.extend_from_slice(&pos.to_le_bytes()); // pos
+        record.push(2); // name_len = 2 (including null)
+        record.push(0); // mapq = 0
+        record.extend_from_slice(&0u16.to_le_bytes()); // bin
+        record.extend_from_slice(&0u16.to_le_bytes()); // n_cigar_op = 0
+        record.extend_from_slice(&0u16.to_le_bytes()); // flags = 0 (forward)
+        record.extend_from_slice(&1u32.to_le_bytes()); // seq_len = 1
+        record.extend_from_slice(&(-1i32).to_le_bytes()); // mate_ref_id
+        record.extend_from_slice(&(-1i32).to_le_bytes()); // mate_pos
+        record.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        record.push(b'A'); // read name
+        record.push(0); // null terminator
+        // Pad to at least 34 bytes (bam_fields::flags reads at offset 14-15)
+        while record.len() < 40 {
+            record.push(0);
+        }
+        record
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_coordinate_single_threaded() {
+        let nref = 10u32;
+        let n = 100;
+        let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
+
+        for i in 0..n {
+            // Reverse order so sorting is non-trivial
+            let pos = (n - i) as i32;
+            buffer.push_coordinate(&make_coordinate_bam_record(0, pos));
+        }
+
+        let chunks = buffer.par_sort_into_chunks(1);
+        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+
+        // Verify the chunk is sorted by key
+        for i in 1..chunks[0].len() {
+            assert!(
+                chunks[0][i - 1].0 <= chunks[0][i].0,
+                "single chunk should be sorted at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_coordinate_parallel() {
+        let nref = 10u32;
+        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("failed to build rayon thread pool");
+
+        let chunks = pool.install(|| {
+            let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
+
+            for i in 0..n {
+                let pos = (n - i) as i32;
+                buffer.push_coordinate(&make_coordinate_bam_record(0, pos));
+            }
+
+            buffer.par_sort_into_chunks(4)
+        });
+
+        // With 4 threads and > 10_000 records we should get multiple chunks
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks from parallel path, got {}",
+            chunks.len()
+        );
+
+        // Verify each chunk is individually sorted
+        for (ci, chunk) in chunks.iter().enumerate() {
+            for i in 1..chunk.len() {
+                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
+            }
+        }
+
+        // Verify total record count across all chunks matches input
+        let total: usize = chunks.iter().map(Vec::len).sum();
+        assert_eq!(total, n, "total records across chunks should equal input count");
     }
 }

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -985,37 +985,35 @@ impl RawExternalSorter {
             }
             writer.finish()?;
         } else {
-            // Sort remaining records and prepare for merge
-            if self.threads > 1 {
-                buffer.par_sort();
+            // Sort remaining records into separate sub-array chunks (avoids
+            // intermediate merge back into a single sorted buffer)
+            let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
+                Vec::new()
+            } else if self.threads > 1 {
+                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
-            }
-
-            // Extract keyed pairs from the in-memory buffer
-            let memory_keyed: Vec<(RawCoordinateKey, Vec<u8>)> = if buffer.is_empty() {
-                Vec::new()
-            } else {
-                buffer
+                let chunk = buffer
                     .refs()
                     .iter()
                     .map(|r| {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r).to_vec();
-                        (key, record_bytes)
+                        (key, buffer.get_record(r).to_vec())
                     })
-                    .collect()
+                    .collect();
+                vec![chunk]
             };
 
+            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
-                chunk_files.len() + usize::from(!memory_keyed.is_empty())
+                chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory chunks using O(1) key comparisons
             self.merge_chunks_generic::<RawCoordinateKey>(
                 &chunk_files,
-                memory_keyed,
+                memory_chunks,
                 header,
                 output,
             )?;
@@ -1127,36 +1125,35 @@ impl RawExternalSorter {
             write_bai_index(&index_path, &index)?;
             info!("Wrote BAM index: {}", index_path.display());
         } else {
-            // Sort remaining records and prepare for merge
-            if self.threads > 1 {
-                buffer.par_sort();
+            // Sort remaining records into separate sub-array chunks (avoids
+            // intermediate merge back into a single sorted buffer)
+            let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
+                Vec::new()
+            } else if self.threads > 1 {
+                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
-            }
-
-            let memory_keyed: Vec<(RawCoordinateKey, Vec<u8>)> = if buffer.is_empty() {
-                Vec::new()
-            } else {
-                buffer
+                let chunk = buffer
                     .refs()
                     .iter()
                     .map(|r| {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r).to_vec();
-                        (key, record_bytes)
+                        (key, buffer.get_record(r).to_vec())
                     })
-                    .collect()
+                    .collect();
+                vec![chunk]
             };
 
+            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
                 "Phase 2: Merging {} chunks with index generation...",
-                chunk_files.len() + usize::from(!memory_keyed.is_empty())
+                chunk_files.len() + n_memory
             );
 
             // Merge with index generation
             let index = self.merge_chunks_with_index::<RawCoordinateKey>(
                 &chunk_files,
-                memory_keyed,
+                memory_chunks,
                 header,
                 output,
             )?;
@@ -1273,21 +1270,40 @@ impl RawExternalSorter {
             }
             writer.finish()?;
         } else {
-            // Sort remaining records
-            if self.threads > 1 {
+            // Sort remaining records into separate sub-array chunks (avoids
+            // intermediate merge back into a single sorted buffer)
+            let memory_chunks: Vec<Vec<(RawQuerynameKey, Vec<u8>)>> = if entries.is_empty() {
+                Vec::new()
+            } else if self.threads > 1 {
                 use rayon::prelude::*;
-                entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                let chunk_size = entries.len().div_ceil(self.threads.max(1));
+                entries.par_chunks_mut(chunk_size).for_each(|chunk| {
+                    chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                });
+                let mut chunks = Vec::new();
+                while !entries.is_empty() {
+                    let take = chunk_size.min(entries.len());
+                    chunks.push(entries.drain(..take).collect());
+                }
+                chunks
             } else {
                 entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-            }
+                vec![entries]
+            };
 
+            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
-                chunk_files.len() + usize::from(!entries.is_empty())
+                chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory records using keyed comparisons
-            self.merge_chunks_generic::<RawQuerynameKey>(&chunk_files, entries, header, output)?;
+            self.merge_chunks_generic::<RawQuerynameKey>(
+                &chunk_files,
+                memory_chunks,
+                header,
+                output,
+            )?;
         }
 
         stats.output_records = stats.total_records;
@@ -1400,27 +1416,23 @@ impl RawExternalSorter {
             }
             writer.finish()?;
         } else {
-            // Sort remaining records and prepare for merge
-            if self.threads > 1 {
-                buffer.par_sort();
+            // Sort remaining records into separate sub-array chunks (avoids
+            // intermediate merge back into a single sorted buffer)
+            let memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>> = if buffer.is_empty() {
+                Vec::new()
+            } else if self.threads > 1 {
+                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
-            }
-
-            // Collect keyed in-memory records for merge
-            let memory_keyed: Vec<(TemplateKey, Vec<u8>)> = if buffer.is_empty() {
-                Vec::new()
-            } else {
-                buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect()
+                let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
+                vec![chunk]
             };
 
-            info!(
-                "Phase 2: Merging {} chunks...",
-                chunk_files.len() + usize::from(!memory_keyed.is_empty())
-            );
+            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+            info!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
-            self.merge_chunks_keyed(&chunk_files, memory_keyed, header, output)?;
+            self.merge_chunks_keyed(&chunk_files, memory_chunks, header, output)?;
         }
 
         stats.output_records = stats.total_records;
@@ -1434,10 +1446,14 @@ impl RawExternalSorter {
     /// This is the fast path for template-coordinate sorting. Instead of parsing
     /// CIGAR/aux data on every comparison (`O(CIGAR_len` + `aux_scan`)), we compare
     /// pre-computed 32-byte keys (O(1) - just 4 u64 comparisons).
+    ///
+    /// `memory_chunks` is a list of sorted in-memory sub-arrays, each of which
+    /// becomes a separate merge source. This avoids merging parallel sort
+    /// sub-arrays back into one buffer before the k-way merge.
     fn merge_chunks_keyed(
         &self,
         chunk_files: &[PathBuf],
-        memory_keyed: Vec<(TemplateKey, Vec<u8>)>,
+        memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>>,
         header: &Header,
         output: &Path,
     ) -> Result<u64> {
@@ -1479,8 +1495,8 @@ impl RawExternalSorter {
         const OUTPUT_BUFFER_SIZE: usize = 2048;
 
         let num_disk = chunk_files.len();
-        let has_memory = !memory_keyed.is_empty();
-        info!("Merging from {} files and {} in-memory blocks...", num_disk, i32::from(has_memory));
+        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
 
         // Create output header with sort order tags
         let output_header = self.create_output_header(header);
@@ -1489,7 +1505,7 @@ impl RawExternalSorter {
         let sem = make_reader_semaphore(self.threads);
 
         // Create unified chunk sources
-        let mut sources: Vec<KeyedChunkSource> = Vec::with_capacity(num_disk + 1);
+        let mut sources: Vec<KeyedChunkSource> = Vec::with_capacity(num_disk + num_memory);
 
         // Add disk-based chunks with keyed readers
         for path in chunk_files {
@@ -1499,9 +1515,11 @@ impl RawExternalSorter {
             )?));
         }
 
-        // Add in-memory keyed chunk
-        if has_memory {
-            sources.push(KeyedChunkSource::Memory { records: memory_keyed, idx: 0 });
+        // Add each non-empty in-memory chunk as a separate merge source
+        for chunk in memory_chunks {
+            if !chunk.is_empty() {
+                sources.push(KeyedChunkSource::Memory { records: chunk, idx: 0 });
+            }
         }
 
         // Initialize heap with first record from each chunk
@@ -1592,7 +1610,7 @@ impl RawExternalSorter {
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_keyed: Vec<(K, Vec<u8>)>,
+        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
         header: &Header,
         output: &Path,
     ) -> Result<u64> {
@@ -1633,8 +1651,8 @@ impl RawExternalSorter {
         const OUTPUT_BUFFER_SIZE: usize = 2048;
 
         let num_disk = chunk_files.len();
-        let has_memory = !memory_keyed.is_empty();
-        info!("Merging from {} files and {} in-memory blocks...", num_disk, i32::from(has_memory));
+        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
 
         // Create output header with sort order tags
         let output_header = self.create_output_header(header);
@@ -1643,7 +1661,8 @@ impl RawExternalSorter {
         let sem = make_reader_semaphore(self.threads);
 
         // Create unified chunk sources
-        let mut sources: Vec<GenericKeyedChunkSource<K>> = Vec::with_capacity(num_disk + 1);
+        let mut sources: Vec<GenericKeyedChunkSource<K>> =
+            Vec::with_capacity(num_disk + num_memory);
 
         // Add disk-based chunks with keyed readers
         for path in chunk_files {
@@ -1653,9 +1672,11 @@ impl RawExternalSorter {
             )?));
         }
 
-        // Add in-memory keyed chunk
-        if has_memory {
-            sources.push(GenericKeyedChunkSource::Memory { records: memory_keyed, idx: 0 });
+        // Add each non-empty in-memory chunk as a separate merge source
+        for chunk in memory_chunks {
+            if !chunk.is_empty() {
+                sources.push(GenericKeyedChunkSource::Memory { records: chunk, idx: 0 });
+            }
         }
 
         // Initialize heap with first record from each chunk
@@ -1744,7 +1765,7 @@ impl RawExternalSorter {
     fn merge_chunks_with_index<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_keyed: Vec<(K, Vec<u8>)>,
+        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
         header: &Header,
         output: &Path,
     ) -> Result<noodles::bam::bai::Index> {
@@ -1781,8 +1802,8 @@ impl RawExternalSorter {
         }
 
         let num_disk = chunk_files.len();
-        let has_memory = !memory_keyed.is_empty();
-        info!("Merging from {} files and {} in-memory blocks...", num_disk, i32::from(has_memory));
+        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
 
         let output_header = self.create_output_header(header);
 
@@ -1790,15 +1811,18 @@ impl RawExternalSorter {
         let sem = make_reader_semaphore(self.threads);
 
         // Create chunk sources
-        let mut sources: Vec<KeyedSource<K>> = Vec::with_capacity(num_disk + 1);
+        let mut sources: Vec<KeyedSource<K>> = Vec::with_capacity(num_disk + num_memory);
         for path in chunk_files {
             sources.push(KeyedSource::Disk(GenericKeyedChunkReader::<K>::open(
                 path,
                 Some(Arc::clone(&sem)),
             )?));
         }
-        if has_memory {
-            sources.push(KeyedSource::Memory { records: memory_keyed, idx: 0 });
+        // Add each non-empty in-memory chunk as a separate merge source
+        for chunk in memory_chunks {
+            if !chunk.is_empty() {
+                sources.push(KeyedSource::Memory { records: chunk, idx: 0 });
+            }
         }
 
         // Initialize heap
@@ -2483,6 +2507,7 @@ mod tests {
     /// merge readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname(SortOrder::Queryname)]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_many_chunks_with_semaphore(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2523,6 +2548,105 @@ mod tests {
         let expected = (num_pairs * 2) as u64;
         let observed = count_bam_records(&output);
         assert_eq!(observed, expected, "semaphore-capped merge lost data");
+    }
+
+    // ========================================================================
+    // Sub-array merge source tests
+    // ========================================================================
+
+    /// Verifies that multi-threaded sort produces the same output as single-threaded
+    /// sort for each sort order, exercising the parallel sub-array merge path.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname(SortOrder::Queryname)]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_sort_sub_arrays_match_single_thread(#[case] sort_order: SortOrder) {
+        use crate::sam::builder::SamBuilder;
+
+        let num_pairs = 50;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:04}"))
+                .start1(i * 200 + 1)
+                .start2(i * 200 + 101)
+                .build();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("input.bam");
+        let output_st = dir.path().join("output_1t.bam");
+        let output_mt = dir.path().join("output_2t.bam");
+        builder.write_bam(&input).unwrap();
+
+        // Sort single-threaded
+        RawExternalSorter::new(sort_order)
+            .memory_limit(2048) // force spill so merge path is exercised
+            .threads(1)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output_st)
+            .unwrap();
+
+        // Sort multi-threaded (exercises par_sort_into_chunks / par_chunks_mut)
+        RawExternalSorter::new(sort_order)
+            .memory_limit(2048)
+            .threads(2)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output_mt)
+            .unwrap();
+
+        let names_st = collect_read_names(&output_st);
+        let names_mt = collect_read_names(&output_mt);
+
+        let expected = num_pairs * 2;
+        assert_eq!(names_st.len(), expected, "single-thread record count mismatch");
+        assert_eq!(names_mt.len(), expected, "multi-thread record count mismatch");
+
+        // Both outputs must have the same read names in the same order
+        assert_eq!(names_st, names_mt, "multi-thread sort order differs from single-thread");
+    }
+
+    /// Verifies that the in-memory-only path (no spill to disk) also works
+    /// correctly with multi-threaded sub-array chunks.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname(SortOrder::Queryname)]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_sort_sub_arrays_in_memory_only(#[case] sort_order: SortOrder) {
+        use crate::sam::builder::SamBuilder;
+
+        let num_pairs = 20;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:04}"))
+                .start1(i * 200 + 1)
+                .start2(i * 200 + 101)
+                .build();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("input.bam");
+        let output = dir.path().join("output.bam");
+        builder.write_bam(&input).unwrap();
+
+        // Large memory limit so everything stays in memory
+        let stats = RawExternalSorter::new(sort_order)
+            .memory_limit(10 * 1024 * 1024)
+            .threads(2)
+            .output_compression(0)
+            .sort(&input, &output)
+            .unwrap();
+
+        assert_eq!(stats.chunks_written, 0, "expected no spill to disk");
+
+        let expected = (num_pairs * 2) as u64;
+        let observed = count_bam_records(&output);
+        assert_eq!(observed, expected, "in-memory sub-array sort lost data");
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Two optimizations to improve fgumi sort's multi-threaded merge performance, addressing a regression where fgumi was slower than samtools at 4+ threads for template-coordinate sort.

### Cap concurrent merge reader threads

`GenericKeyedChunkReader::open()` spawns one background thread per chunk file. With 32+ chunks, all threads decompress simultaneously, competing for CPU. Added a counting semaphore (`ChunkReaderSemaphore`) that limits concurrent I/O to `self.threads` active readers. The semaphore holds a token for each 64-record batch during I/O, ensuring only N threads decompress concurrently.

Applied to all merge functions (`merge_chunks_keyed`, `merge_chunks_generic`, `merge_chunks_with_index`) and consolidation (`maybe_consolidate_temp_files`).

### Keep parallel sort sub-arrays as separate merge sources

After parallel radix sort, fgumi previously merged the rayon sub-arrays back into one sorted buffer (single-threaded O(n) merge + full data copy) before passing to the k-way merge. Now each sorted sub-array becomes a separate in-memory merge source, matching samtools' approach and eliminating the intermediate merge step. Template-coordinate sort only.

## Benchmarks

Kapa-UMI dataset, 89M records, `-m 768M`, `-l 1` (clean system, load < 3):

### Template-coordinate sort

| Threads | samtools | fgumi (main) | fgumi (this PR) |
|---|---|---|---|
| 1 thread | 4:41 | 3:59 | **3:03 (1.5x faster)** |
| 5 total (`-@ 4` / `--threads 5`) | 1:04 | 2:00 | **1:01 (1.05x faster)** |

Note: `samtools -@ N` = N+1 total threads; `fgumi --threads N` = N total.

### Known limitation

At 9+ threads, samtools scales better due to its shared htslib thread pool (work-stealing between decompression and compression). fgumi uses separate dedicated pools. The unified pipeline (separate PR) will address this.

## Test plan

- [x] Output verified IDENTICAL to main branch via `fgumi compare bams` (89M records, TC + coordinate)
- [x] New test: `test_sort_many_chunks_with_semaphore` (coordinate + TC)
- [x] All 920+ existing tests pass
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean