### PR TITLE
refactor: promote shared third-party deps to workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,57 @@ repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [workspace.dependencies]
+# Internal crates
 fgumi-bgzf = { version = "0.1.2", path = "crates/fgumi-bgzf" }
 fgumi-consensus = { version = "0.1.2", path = "crates/fgumi-consensus", default-features = false }
 fgumi-dna = { version = "0.1.2", path = "crates/fgumi-dna" }
+fgumi-lib = { version = "0.1.2", path = "crates/fgumi-lib", default-features = false }
 fgumi-metrics = { version = "0.1.2", path = "crates/fgumi-metrics" }
 fgumi-raw-bam = { version = "0.1.2", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.1.2", path = "crates/fgumi-sam" }
 fgumi-simd-fastq = { version = "0.1.2", path = "crates/fgumi-simd-fastq" }
 fgumi-umi = { version = "0.1.2", path = "crates/fgumi-umi" }
-fgumi-lib = { version = "0.1.2", path = "crates/fgumi-lib", default-features = false }
+
+# Third-party dependencies shared across workspace crates
+ahash = "0.8"
+anyhow = "1.0.102"
+approx = "0.5.1"
+bgzf = "0.3.0"
+bstr = "1.12.1"
+bytemuck = { version = "1.14", features = ["derive"] }
+bytes = "1"
+clap = { version = "4", features = ["derive"] }
+crc32fast = "1.4"
+crossbeam-channel = "0.5"
+crossbeam-queue = "0.3"
+crossbeam-utils = "0.8.21"
+flate2 = "1.1"
+fgoxide = "0.6.0"
+libdeflater = "1.22"
+libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
+log = "0"
+lru = "0.16.3"
+memchr = "2"
+noodles = { version = "0.106.0" }
+noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
+noodles-csi = "0.54.0"
+parking_lot = "0.12"
+rand = "0.10"
+rand_distr = "0.6"
+rayon = "1.10"
+read-structure = "0.2.0"
+serde = { version = "1.0.228", features = ["derive"] }
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
+tempfile = "3.3.0"
+thiserror = "2"
+which = "7"
+wide = "1.1"
+seq_io = "0.3.4"
+
+# Shared dev-dependencies
+criterion = { version = "0.8", features = ["html_reports"] }
+proptest = "1.10"
+rstest = "0"
 
 [package]
 name = "fgumi"
@@ -36,48 +78,48 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-clap = { version = "4", features = ["derive", "string"] }
-log = "0"
-thiserror = "2"
-noodles = { version = "0.106.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
-noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
-mimalloc = { version = "0.1.48", default-features = false }
-libmimalloc-sys = { version = "0.1.44", features = ["extended"], optional = true }
+ahash = { workspace = true }
+anyhow = { workspace = true }
+approx = { workspace = true }
+bgzf = { workspace = true }
+bstr = { workspace = true }
+bytemuck = { workspace = true }
+bytes = { workspace = true }
+bytesize = "2.3"
+clap = { workspace = true, features = ["string"] }
+crc32fast = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
+csv = "1.1"
+dhat = { version = "0.3", optional = true }
 env_logger = "0.11.8"
 enum_dispatch = "0.3.13"
-anyhow = "1.0.102"
-read-structure = "0.2.0"
-bstr = "1.12.1"
-bytes = "1"
-fgoxide = "0.6.0"
-tempfile = "3.3.0"
-lru = "0.16.3"
-crc32fast = "1.4"
-crossbeam-channel = "0.5"
-crossbeam-queue = "0.3"
-crossbeam-utils = "0.8.21"
-parking_lot = "0.12"
-libdeflater = "1.22"
-serde = { version = "1.0.228", features = ["derive"] }
-itertools = "0.14.0"
+fgoxide = { workspace = true }
+flate2 = { workspace = true }
 indexmap = "2"
-rand = "0.10"
-csv = "1.1"
-memchr = "2"
+itertools = "0.14.0"
+libdeflater = { workspace = true }
+libmimalloc-sys = { workspace = true, optional = true }
+log = { workspace = true }
+lru = { workspace = true }
+memchr = { workspace = true }
+mimalloc = { version = "0.1.48", default-features = false }
 murmur3 = "0.5"
+noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
+noodles-bgzf = { workspace = true }
+noodles-csi = { workspace = true }
+parking_lot = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+rayon = { workspace = true }
+read-structure = { workspace = true }
+serde = { workspace = true }
 statrs = "0.18"
-bytesize = "2.3"
-sysinfo = { version = "0.38", default-features = false, features = ["system"], optional = true }
-rayon = "1.10"
-approx = "0.5.1"
-ahash = "0.8"
-bytemuck = { version = "1.14", features = ["derive"] }
-noodles-csi = "0.54.0"
-bgzf = "0.3.0"
-wide = "1.1"
-rand_distr = "0.6"
-flate2 = "1.1"
-dhat = { version = "0.3", optional = true }
+sysinfo = { workspace = true, optional = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+wide = { workspace = true }
 fgumi-lib = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-dna = { workspace = true }
@@ -106,9 +148,9 @@ profile-adjacency = ["fgumi-lib/profile-adjacency"]
 stress-tests = ["fgumi-lib/stress-tests"]
 
 [dev-dependencies]
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 
 [[bench]]
@@ -126,4 +168,3 @@ codegen-units = 1
 [profile.profiling]
 inherits = "release"
 debug = "line-tables-only"
-

--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -8,9 +8,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-libdeflater = "1.22"
-crc32fast = "1.4"
-bgzf = "0.3.0"
+libdeflater = { workspace = true }
+crc32fast = { workspace = true }
+bgzf = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -8,14 +8,14 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash = "0.8"
-anyhow = "1.0"
-approx = "0.5"
-bstr = "1.12.1"
-log = "0"
-noodles = { version = "0.106.0", features = ["bam", "sam", "core"] }
-rand = "0.10"
-wide = "1.1"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+approx = { workspace = true }
+bstr = { workspace = true }
+log = { workspace = true }
+noodles = { workspace = true, features = ["bam", "sam", "core"] }
+rand = { workspace = true }
+wide = { workspace = true }
 fgumi-dna = { workspace = true }
 fgumi-sam = { workspace = true }
 fgumi-metrics = { workspace = true }

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-rstest = "0"
+rstest = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-lib/Cargo.toml
+++ b/crates/fgumi-lib/Cargo.toml
@@ -10,34 +10,34 @@ description = "Core library for fgumi UMI processing"
 name = "fgumi_lib"
 
 [dependencies]
-anyhow = "1.0.102"
-log = "0"
-thiserror = "2"
-noodles = { version = "0.106.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
-noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
-noodles-csi = "0.54.0"
-clap = { version = "4", features = ["derive"] }
-read-structure = "0.2.0"
-bstr = "1.12.1"
-bytes = "1"
-tempfile = "3.3.0"
-crossbeam-channel = "0.5"
-crossbeam-queue = "0.3"
-crossbeam-utils = "0.8.21"
-parking_lot = "0.12"
-libdeflater = "1.22"
-serde = { version = "1.0.228", features = ["derive"] }
-rand = "0.10"
-rand_distr = "0.6"
-memchr = "2"
-ahash = "0.8"
-lru = "0.16.3"
-bytemuck = { version = "1.14", features = ["derive"] }
-bgzf = "0.3.0"
-flate2 = "1.1"
-rayon = "1.10"
-libmimalloc-sys = { version = "0.1.44", features = ["extended"], optional = true }
-sysinfo = { version = "0.38", default-features = false, features = ["system"], optional = true }
+ahash = { workspace = true }
+anyhow = { workspace = true }
+bgzf = { workspace = true }
+bstr = { workspace = true }
+bytemuck = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
+flate2 = { workspace = true }
+libdeflater = { workspace = true }
+libmimalloc-sys = { workspace = true, optional = true }
+log = { workspace = true }
+lru = { workspace = true }
+memchr = { workspace = true }
+noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
+noodles-bgzf = { workspace = true }
+noodles-csi = { workspace = true }
+parking_lot = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+rayon = { workspace = true }
+read-structure = { workspace = true }
+serde = { workspace = true }
+sysinfo = { workspace = true, optional = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-dna = { workspace = true }
 fgumi-bgzf = { workspace = true }
@@ -64,6 +64,6 @@ profile-adjacency = []
 stress-tests = []
 
 [dev-dependencies]
-proptest = "1.10"
-rstest = "0"
+proptest = { workspace = true }
+rstest = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -8,13 +8,13 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0"
-fgoxide = "0.6.0"
-noodles = { version = "0.106.0", features = ["sam"], optional = true }
+serde = { workspace = true }
+anyhow = { workspace = true }
+fgoxide = { workspace = true }
+noodles = { workspace = true, features = ["sam"], optional = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 fgumi-sam = { workspace = true }
 
 [features]

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-noodles = { version = "0.106.0", features = ["bam", "sam"], optional = true }
-anyhow = { version = "1.0.102", optional = true }
+noodles = { workspace = true, features = ["bam", "sam"], optional = true }
+anyhow = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -17,5 +17,5 @@ noodles = ["dep:noodles", "dep:anyhow"]
 test-utils = []
 
 [dev-dependencies]
-proptest = "1.10"
-rstest = "0"
+proptest = { workspace = true }
+rstest = { workspace = true }

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -8,14 +8,14 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-noodles = { version = "0.106.0", features = ["bam", "sam", "core"] }
+noodles = { workspace = true, features = ["bam", "sam", "core"] }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
-bstr = "1.12.1"
-clap = { version = "4", features = ["derive"] }
-log = "0"
-anyhow = "1.0"
+bstr = { workspace = true }
+clap = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
 fgumi-dna = { workspace = true }
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }

--- a/crates/fgumi-simd-fastq/Cargo.toml
+++ b/crates/fgumi-simd-fastq/Cargo.toml
@@ -10,11 +10,11 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
-memchr = "2"
-seq_io = "0.3.4"
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }
+memchr = { workspace = true }
+seq_io = { workspace = true }
 
 [[bench]]
 name = "fastq_parsing"

--- a/crates/fgumi-umi/Cargo.toml
+++ b/crates/fgumi-umi/Cargo.toml
@@ -8,15 +8,15 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash = "0.8"
-anyhow = "1.0"
-clap = { version = "4", features = ["derive"], optional = true }
-rayon = "1.10"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, optional = true }
+rayon = { workspace = true }
 fgumi-dna = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.26"
-proptest = "1"
+rstest = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 default = ["cli"]


### PR DESCRIPTION
## Summary
- Consolidate ~30 shared third-party dependency versions into `[workspace.dependencies]`
- All workspace crates now reference a single source of truth, preventing version drift
- Individual crates use `{ workspace = true }` and add crate-specific features as needed
- Covers noodles, anyhow, clap, serde, crossbeam-*, rand, rayon, and shared dev-deps (rstest, proptest, criterion)

**Stack:** 2/6 — depends on #201

## Test plan
- [ ] `cargo ci-test` passes
- [ ] `cargo ci-fmt` passes
- [ ] `cargo ci-lint` passes
- [ ] `Cargo.lock` changes are additive only (no version downgrades)