### PR TITLE
refactor: extract shared logic into fgumi-lib and add defaults module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "rayon",
  "read-structure",
  "rstest",
+ "seq_io",
  "serde",
  "sysinfo",
  "tempfile",

--- a/crates/fgumi-lib/Cargo.toml
+++ b/crates/fgumi-lib/Cargo.toml
@@ -35,6 +35,7 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 read-structure = { workspace = true }
 serde = { workspace = true }
+seq_io = { workspace = true }
 sysinfo = { workspace = true, optional = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/fgumi-lib/src/correct.rs
+++ b/crates/fgumi-lib/src/correct.rs
@@ -1,0 +1,617 @@
+//! Core UMI correction logic for matching observed UMIs to a fixed set of known sequences.
+//!
+//! This module provides the pure-function core of UMI correction, extracted so that both
+//! the `correct` command and the `pipeline` command can call it directly without spawning
+//! a subprocess.
+//!
+//! # Overview
+//!
+//! The main workflow is:
+//! 1. Load known UMI sequences with [`load_umi_sequences`]
+//! 2. Build an [`EncodedUmiSet`] for efficient matching
+//! 3. For each template, extract the UMI with [`extract_and_validate_template_umi_raw`]
+//! 4. Compute the correction with [`compute_template_correction`]
+//! 5. Apply the correction with [`apply_correction_to_raw`]
+
+use anyhow::{Result, bail};
+use log::info;
+
+use crate::bitenc::BitEnc;
+use crate::dna::reverse_complement_str;
+use crate::sort::bam_fields;
+
+/// Result of matching an observed UMI to an expected UMI.
+///
+/// Contains information about whether the match was acceptable and the details
+/// of the best matching UMI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UmiMatch {
+    /// Whether the match is acceptable based on mismatch and distance thresholds.
+    pub matched: bool,
+
+    /// The fixed UMI sequence that was the closest match.
+    pub umi: String,
+
+    /// The number of mismatches between the observed and best matching UMI.
+    pub mismatches: usize,
+}
+
+/// Reason a UMI correction was rejected.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionReason {
+    /// UMI segments have the wrong length.
+    WrongLength,
+    /// No acceptable match found in the UMI set.
+    Mismatched,
+    /// Not rejected.
+    #[default]
+    None,
+}
+
+/// Result of UMI correction for a template.
+///
+/// This struct holds the result of correcting a UMI once for an entire template,
+/// which can then be applied to all records in that template.
+#[derive(Debug)]
+pub struct TemplateCorrection {
+    /// Whether the UMI matched successfully.
+    pub matched: bool,
+    /// The corrected UMI string (if matched).
+    pub corrected_umi: Option<String>,
+    /// The original UMI string.
+    pub original_umi: String,
+    /// Whether correction was needed (mismatches > 0 or revcomp).
+    pub needs_correction: bool,
+    /// Whether there were actual mismatches (not just revcomp).
+    pub has_mismatches: bool,
+    /// Match details for metrics.
+    pub matches: Vec<UmiMatch>,
+    /// Rejection reason if not matched.
+    pub rejection_reason: RejectionReason,
+}
+
+/// Pre-encoded set of known UMI sequences for fast matching.
+///
+/// Stores both the original byte sequences and their `BitEnc` representations
+/// for efficient Hamming distance computation.
+#[derive(Clone)]
+pub struct EncodedUmiSet {
+    /// Original byte sequences for fallback comparison
+    bytes: Vec<Vec<u8>>,
+    /// Bit-encoded sequences for fast comparison (None if encoding failed)
+    encoded: Vec<Option<BitEnc>>,
+    /// Original strings for output
+    strings: Vec<String>,
+}
+
+impl EncodedUmiSet {
+    /// Create a new `EncodedUmiSet` from string sequences.
+    ///
+    /// All sequences are converted to uppercase for case-insensitive matching.
+    /// Pre-encodes all sequences that contain only ACGT bases.
+    /// Sequences with other characters will use fallback byte comparison.
+    #[must_use]
+    pub fn new(sequences: &[String]) -> Self {
+        // Store uppercase bytes for comparison
+        let bytes: Vec<Vec<u8>> =
+            sequences.iter().map(|s| s.bytes().map(|b| b.to_ascii_uppercase()).collect()).collect();
+        let encoded: Vec<Option<BitEnc>> = bytes.iter().map(|b| BitEnc::from_bytes(b)).collect();
+        // Store uppercase strings for output
+        let strings: Vec<String> = sequences.iter().map(|s| s.to_uppercase()).collect();
+
+        Self { bytes, encoded, strings }
+    }
+
+    /// Get the number of UMIs in the set.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Check if the set is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Get the original UMI strings (uppercase).
+    #[inline]
+    #[must_use]
+    pub fn strings(&self) -> &[String] {
+        &self.strings
+    }
+}
+
+/// Count mismatches between two byte slices, stopping early once `max_mismatches` is exceeded.
+///
+/// # Arguments
+///
+/// * `a` - First sequence
+/// * `b` - Second sequence
+/// * `max_mismatches` - Stop counting after this many mismatches
+///
+/// # Returns
+///
+/// The number of mismatches, capped at `max_mismatches + 1`.
+#[must_use]
+pub fn count_mismatches_with_max(a: &[u8], b: &[u8], max_mismatches: usize) -> usize {
+    let mut mismatches = 0;
+    let min_len = a.len().min(b.len());
+
+    for i in 0..min_len {
+        if a[i] != b[i] {
+            mismatches += 1;
+            if mismatches > max_mismatches {
+                return mismatches;
+            }
+        }
+    }
+
+    // Count any remaining bases in the longer sequence as mismatches
+    mismatches += a.len().abs_diff(b.len());
+    mismatches
+}
+
+/// Find the best matching UMI using bit-encoded comparison.
+///
+/// Uses fast XOR + popcount comparison when both observed and expected UMIs
+/// can be bit-encoded. Falls back to byte comparison otherwise.
+///
+/// This function tracks the best match index during iteration and only clones
+/// the matching string once at the end, avoiding repeated string allocations.
+#[must_use]
+pub fn find_best_match_encoded(
+    observed: &[u8],
+    umi_set: &EncodedUmiSet,
+    max_mismatches: usize,
+    min_distance_diff: usize,
+) -> UmiMatch {
+    let mut best_index: Option<usize> = None;
+    let mut best_mismatches = usize::MAX;
+    let mut second_best_mismatches = usize::MAX;
+
+    // Try to encode the observed UMI
+    let observed_encoded = BitEnc::from_bytes(observed);
+
+    match observed_encoded {
+        Some(obs_enc) => {
+            // Fast path: use bit-encoded comparison
+            for (i, fixed_enc) in umi_set.encoded.iter().enumerate() {
+                let mismatches = if let Some(enc) = fixed_enc {
+                    // Both can be compared with BitEnc
+                    enc.hamming_distance(&obs_enc) as usize
+                } else {
+                    // Fixed UMI couldn't be encoded, fall back to bytes
+                    count_mismatches_with_max(observed, &umi_set.bytes[i], second_best_mismatches)
+                };
+
+                if mismatches < best_mismatches {
+                    second_best_mismatches = best_mismatches;
+                    best_mismatches = mismatches;
+                    best_index = Some(i);
+                } else if mismatches < second_best_mismatches {
+                    second_best_mismatches = mismatches;
+                }
+            }
+        }
+        None => {
+            // Slow path: observed UMI can't be encoded, use byte comparison
+            for (i, fixed_umi) in umi_set.bytes.iter().enumerate() {
+                let mismatches =
+                    count_mismatches_with_max(observed, fixed_umi, second_best_mismatches);
+
+                if mismatches < best_mismatches {
+                    second_best_mismatches = best_mismatches;
+                    best_mismatches = mismatches;
+                    best_index = Some(i);
+                } else if mismatches < second_best_mismatches {
+                    second_best_mismatches = mismatches;
+                }
+            }
+        }
+    }
+
+    // Build result with single clone at end
+    let Some(idx) = best_index else {
+        return UmiMatch { matched: false, umi: String::new(), mismatches: usize::MAX };
+    };
+
+    let matched = if best_mismatches <= max_mismatches {
+        let distance_to_second = second_best_mismatches.saturating_sub(best_mismatches);
+        distance_to_second >= min_distance_diff
+    } else {
+        false
+    };
+
+    UmiMatch { matched, umi: umi_set.strings[idx].clone(), mismatches: best_mismatches }
+}
+
+/// Finds pairs of UMIs within a specified edit distance.
+///
+/// Identifies all pairs of UMIs that are within `distance` edits of each other,
+/// which helps detect potentially ambiguous UMI sets.
+///
+/// # Arguments
+///
+/// * `umis` - Slice of UMI sequences to check
+/// * `distance` - Maximum edit distance threshold
+///
+/// # Returns
+///
+/// A vector of tuples `(umi1, umi2, actual_distance)` for pairs within the threshold.
+#[must_use]
+pub fn find_umi_pairs_within_distance(
+    umis: &[String],
+    distance: usize,
+) -> Vec<(String, String, usize)> {
+    let mut pairs = Vec::new();
+    for i in 0..umis.len() {
+        for j in (i + 1)..umis.len() {
+            let d = count_mismatches_with_max(umis[i].as_bytes(), umis[j].as_bytes(), distance + 1);
+            if d <= distance {
+                pairs.push((umis[i].clone(), umis[j].clone(), d));
+            }
+        }
+    }
+    pairs
+}
+
+/// Load UMI sequences from inline strings and/or files.
+///
+/// Collects UMIs from both inline values and files (one UMI per line), deduplicates them,
+/// validates that all UMIs have the same length, and returns the sorted list with its length.
+///
+/// # Arguments
+///
+/// * `umis` - Inline UMI sequence strings
+/// * `umi_files` - Paths to files containing UMI sequences (one per line)
+///
+/// # Returns
+///
+/// A tuple of (sorted UMI sequences, UMI length).
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - No UMIs are provided
+/// - UMI files cannot be read
+/// - UMIs have different lengths
+pub fn load_umi_sequences(
+    umis: &[String],
+    umi_files: &[std::path::PathBuf],
+) -> Result<(Vec<String>, usize)> {
+    let mut umi_set: std::collections::HashSet<String> =
+        umis.iter().map(|s| s.to_uppercase()).collect();
+
+    for file in umi_files {
+        let content = std::fs::read_to_string(file)?;
+        for line in content.lines() {
+            let umi = line.trim().to_uppercase();
+            if !umi.is_empty() {
+                umi_set.insert(umi);
+            }
+        }
+    }
+
+    if umi_set.is_empty() {
+        bail!("No UMIs provided.");
+    }
+
+    let mut umi_sequences: Vec<String> = umi_set.into_iter().collect();
+    umi_sequences.sort_unstable();
+
+    // Check all UMIs have the same length
+    let first_len = umi_sequences[0].len();
+    if !umi_sequences.iter().all(|u| u.len() == first_len) {
+        bail!("All UMIs must have the same length.");
+    }
+
+    info!("Loaded {} UMI sequences of length {}", umi_sequences.len(), first_len);
+    Ok((umi_sequences, first_len))
+}
+
+/// Compute UMI correction for a template (called once per template).
+///
+/// Splits the UMI by hyphens (for duplex UMIs), optionally reverse-complements each
+/// segment, and finds the best match in the `EncodedUmiSet` for each segment.
+///
+/// # Arguments
+///
+/// * `umi` - The observed UMI string (may be hyphen-separated for duplex)
+/// * `umi_length` - Expected length of each UMI segment
+/// * `revcomp` - Whether to reverse-complement UMI segments before matching
+/// * `max_mismatches` - Maximum allowed mismatches per segment
+/// * `min_distance_diff` - Minimum difference between best and second-best match
+/// * `encoded_umi_set` - Pre-encoded set of known UMI sequences
+/// * `cache` - Optional LRU cache for memoizing per-segment match results
+#[allow(clippy::too_many_arguments)]
+pub fn compute_template_correction(
+    umi: &str,
+    umi_length: usize,
+    revcomp: bool,
+    max_mismatches: usize,
+    min_distance_diff: usize,
+    encoded_umi_set: &EncodedUmiSet,
+    cache: &mut Option<lru::LruCache<Vec<u8>, UmiMatch>>,
+) -> TemplateCorrection {
+    let original_umi = umi.to_string();
+
+    // Split and optionally reverse complement
+    let sequences: Vec<String> = if revcomp {
+        umi.split('-').map(reverse_complement_str).rev().collect()
+    } else {
+        umi.split('-').map(std::string::ToString::to_string).collect()
+    };
+
+    // Check length
+    if sequences.iter().any(|s| s.len() != umi_length) {
+        return TemplateCorrection {
+            matched: false,
+            corrected_umi: None,
+            original_umi,
+            needs_correction: false,
+            has_mismatches: false,
+            matches: Vec::new(),
+            rejection_reason: RejectionReason::WrongLength,
+        };
+    }
+
+    // Find matches for each UMI segment
+    let mut matches = Vec::with_capacity(sequences.len());
+    for seq in &sequences {
+        // Uppercase using bytes directly - avoids String allocation
+        let seq_bytes: Vec<u8> = seq.bytes().map(|b| b.to_ascii_uppercase()).collect();
+
+        let umi_match = if let Some(c) = cache {
+            if let Some(cached) = c.get(&seq_bytes[..]) {
+                cached.clone()
+            } else {
+                let result = find_best_match_encoded(
+                    &seq_bytes,
+                    encoded_umi_set,
+                    max_mismatches,
+                    min_distance_diff,
+                );
+                c.put(seq_bytes, result.clone());
+                result
+            }
+        } else {
+            find_best_match_encoded(&seq_bytes, encoded_umi_set, max_mismatches, min_distance_diff)
+        };
+
+        matches.push(umi_match);
+    }
+
+    // Determine if all segments matched
+    let all_matched = matches.iter().all(|m| m.matched);
+    let has_mismatches = matches.iter().any(|m| m.mismatches > 0);
+    let needs_correction = has_mismatches || revcomp;
+
+    if all_matched {
+        let corrected_umi: String =
+            matches.iter().map(|m| m.umi.clone()).collect::<Vec<_>>().join("-");
+        TemplateCorrection {
+            matched: true,
+            corrected_umi: Some(corrected_umi),
+            original_umi,
+            needs_correction,
+            has_mismatches,
+            matches,
+            rejection_reason: RejectionReason::None,
+        }
+    } else {
+        TemplateCorrection {
+            matched: false,
+            corrected_umi: None,
+            original_umi,
+            needs_correction: false,
+            has_mismatches: false,
+            matches,
+            rejection_reason: RejectionReason::Mismatched,
+        }
+    }
+}
+
+/// Extract and validate UMI from raw-byte records in a template.
+///
+/// Reads the UMI tag from the first record and validates that all other records
+/// in the template have the same UMI value.
+///
+/// # Arguments
+///
+/// * `raw_records` - Slice of raw BAM record byte vectors
+/// * `umi_tag` - Two-byte UMI tag (e.g., `b"RX"`)
+///
+/// # Returns
+///
+/// `Some(umi)` if a UMI was found, `None` if no records have the tag.
+///
+/// # Errors
+///
+/// Returns an error if records have mismatched UMIs, inconsistent UMI presence,
+/// or a non-string UMI tag type.
+pub fn extract_and_validate_template_umi_raw(
+    raw_records: &[Vec<u8>],
+    umi_tag: [u8; 2],
+) -> anyhow::Result<Option<String>> {
+    if raw_records.is_empty() {
+        return Ok(None);
+    }
+
+    // Guard against truncated records
+    if raw_records.iter().any(|r| r.len() < 32) {
+        return Ok(None);
+    }
+
+    let first_aux = bam_fields::aux_data_slice(&raw_records[0]);
+    // Work with &[u8] slices to avoid per-record String allocation
+    let first_umi_bytes = bam_fields::find_string_tag(first_aux, &umi_tag);
+
+    // If tag exists but is not a Z-type string, return an error
+    if first_umi_bytes.is_none() {
+        if let Some(tag_type) = bam_fields::find_tag_type(first_aux, &umi_tag) {
+            anyhow::bail!(
+                "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
+                std::str::from_utf8(&umi_tag).unwrap_or("??"),
+                tag_type as char,
+            );
+        }
+    }
+
+    for raw in &raw_records[1..] {
+        let aux = bam_fields::aux_data_slice(raw);
+        let current_umi_bytes = bam_fields::find_string_tag(aux, &umi_tag);
+
+        match (first_umi_bytes, current_umi_bytes) {
+            (Some(first), Some(current)) if first != current => {
+                anyhow::bail!(
+                    "Template has mismatched UMIs: first={:?}, current={:?}",
+                    String::from_utf8_lossy(first),
+                    String::from_utf8_lossy(current)
+                );
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                anyhow::bail!("Template has inconsistent UMI presence across records");
+            }
+            _ => {}
+        }
+    }
+
+    // Only allocate String once at the end
+    Ok(first_umi_bytes.map(|b| String::from_utf8_lossy(b).into_owned()))
+}
+
+/// Apply UMI correction to a raw BAM record.
+///
+/// Updates the UMI tag in-place with the corrected value, and optionally stores
+/// the original UMI in the `OX` tag.
+///
+/// # Arguments
+///
+/// * `record` - Mutable raw BAM record bytes
+/// * `correction` - The computed correction result
+/// * `umi_tag` - Two-byte UMI tag (e.g., `b"RX"`)
+/// * `dont_store_original_umis` - If true, skip storing the original UMI in `OX`
+pub fn apply_correction_to_raw(
+    record: &mut Vec<u8>,
+    correction: &TemplateCorrection,
+    umi_tag: [u8; 2],
+    dont_store_original_umis: bool,
+) {
+    if correction.needs_correction {
+        // Write corrected UMI first (in-place update avoids scanning past OX)
+        if let Some(ref corrected) = correction.corrected_umi {
+            bam_fields::update_string_tag(record, &umi_tag, corrected.as_bytes());
+        }
+
+        // Store original UMI if there were actual mismatches
+        // Use update_string_tag to avoid duplicate OX tags
+        if !dont_store_original_umis && correction.has_mismatches {
+            bam_fields::update_string_tag(record, b"OX", correction.original_umi.as_bytes());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXED_UMIS: &[&str] = &["AAAAAA", "CCCCCC", "GGGGGG", "TTTTTT"];
+
+    fn get_encoded_umi_set() -> EncodedUmiSet {
+        let strings: Vec<String> = FIXED_UMIS.iter().map(|s| (*s).to_string()).collect();
+        EncodedUmiSet::new(&strings)
+    }
+
+    #[test]
+    fn test_find_best_match_perfect() {
+        let umi_set = get_encoded_umi_set();
+
+        let hit = find_best_match_encoded(b"AAAAAA", &umi_set, 2, 2);
+        assert!(hit.matched);
+        assert_eq!(hit.mismatches, 0);
+        assert_eq!(hit.umi, "AAAAAA");
+    }
+
+    #[test]
+    fn test_find_best_match_with_mismatches() {
+        let umi_set = get_encoded_umi_set();
+
+        let hit = find_best_match_encoded(b"AAAAAC", &umi_set, 2, 2);
+        assert!(hit.matched);
+        assert_eq!(hit.mismatches, 1);
+        assert_eq!(hit.umi, "AAAAAA");
+    }
+
+    #[test]
+    fn test_find_best_match_too_many_mismatches() {
+        let umi_set = get_encoded_umi_set();
+
+        let hit = find_best_match_encoded(b"ACGTAC", &umi_set, 1, 1);
+        assert!(!hit.matched);
+    }
+
+    #[test]
+    fn test_count_mismatches_identical() {
+        assert_eq!(count_mismatches_with_max(b"AAAAAA", b"AAAAAA", 10), 0);
+    }
+
+    #[test]
+    fn test_count_mismatches_one() {
+        assert_eq!(count_mismatches_with_max(b"AAAAAA", b"AAAAAT", 10), 1);
+    }
+
+    #[test]
+    fn test_count_mismatches_early_exit() {
+        assert_eq!(count_mismatches_with_max(b"AAAAAA", b"CCCCCC", 2), 3);
+    }
+
+    #[test]
+    fn test_find_umi_pairs_within_distance_finds_close_pair() {
+        let umis = vec!["AAAA".to_string(), "AAAT".to_string()];
+        let pairs = find_umi_pairs_within_distance(&umis, 2);
+        assert_eq!(pairs.len(), 1);
+    }
+
+    #[test]
+    fn test_find_umi_pairs_within_distance_no_close_pair() {
+        let umis = vec!["AAAA".to_string(), "CCCC".to_string()];
+        let pairs = find_umi_pairs_within_distance(&umis, 1);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn test_compute_template_correction_match() {
+        let umi_set = get_encoded_umi_set();
+        let result = compute_template_correction("AAAAAC", 6, false, 2, 2, &umi_set, &mut None);
+        assert!(result.matched);
+        assert_eq!(result.corrected_umi, Some("AAAAAA".to_string()));
+        assert!(result.has_mismatches);
+        assert!(result.needs_correction);
+    }
+
+    #[test]
+    fn test_compute_template_correction_wrong_length() {
+        let umi_set = get_encoded_umi_set();
+        let result = compute_template_correction("AAA", 6, false, 2, 2, &umi_set, &mut None);
+        assert!(!result.matched);
+        assert_eq!(result.rejection_reason, RejectionReason::WrongLength);
+    }
+
+    #[test]
+    fn test_load_umi_sequences_from_strings() {
+        let umis = vec!["AAAA".to_string(), "CCCC".to_string(), "aaaa".to_string()];
+        let (seqs, len) = load_umi_sequences(&umis, &[]).unwrap();
+        assert_eq!(len, 4);
+        // Should deduplicate AAAA and aaaa (both uppercase to AAAA)
+        assert_eq!(seqs.len(), 2);
+    }
+
+    #[test]
+    fn test_load_umi_sequences_empty_fails() {
+        let result = load_umi_sequences(&[], &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/fgumi-lib/src/defaults.rs
+++ b/crates/fgumi-lib/src/defaults.rs
@@ -1,0 +1,96 @@
+//! Shared default values for CLI options.
+//!
+//! These constants are the single source of truth for default values used by both
+//! standalone commands and the runall pipeline. Both places import from here.
+
+// -- SAM Tags --
+
+/// Default UMI tag.
+pub const UMI_TAG: &str = "RX";
+/// Default molecule identifier tag.
+pub const MI_TAG: &str = "MI";
+/// Default cell barcode tag.
+pub const CELL_TAG: &str = "CB";
+
+// -- Extract --
+
+/// Default read group ID (used by both extract and consensus stages).
+pub const READ_GROUP_ID: &str = "A";
+/// Default sequencing platform.
+pub const PLATFORM: &str = "illumina";
+
+// -- Correct --
+
+/// Default maximum mismatches for UMI correction.
+pub const CORRECT_MAX_MISMATCHES: usize = 2;
+/// Default LRU cache size for UMI matching.
+pub const CORRECT_CACHE_SIZE: usize = 100_000;
+
+// -- Fastq / Aligner --
+
+/// Default SAM flags to exclude when converting to FASTQ.
+pub const FASTQ_EXCLUDE_FLAGS: u16 = 0x900;
+/// Default SAM flags to require when converting to FASTQ.
+pub const FASTQ_REQUIRE_FLAGS: u16 = 0;
+/// Default BWA chunk size in bases (BWA `-K` parameter).
+pub const BWA_CHUNK_SIZE: u64 = 150_000_000;
+
+// -- Sort --
+
+/// Default memory limit for external sort in bytes (768 MiB).
+pub const SORT_MEMORY_LIMIT: usize = 768 * 1024 * 1024;
+/// Display string for the sort memory limit (for `--help` text in standalone).
+pub const SORT_MEMORY_LIMIT_DISPLAY: &str = "768M";
+/// Default: scale memory limit per thread.
+pub const SORT_MEMORY_PER_THREAD: bool = true;
+/// Default compression level for sort temporary files.
+pub const SORT_TEMP_COMPRESSION: u32 = 1;
+
+// -- Group --
+
+/// Default maximum edit distance between UMIs for grouping.
+pub const GROUP_MAX_EDITS: u32 = 1;
+/// Default minimum UMIs per position to use index-based grouping.
+pub const GROUP_INDEX_THRESHOLD: usize = 100;
+
+// -- Consensus --
+
+/// Default Phred-scaled error rate prior to UMI integration.
+pub const CONSENSUS_ERROR_RATE_PRE_UMI: u8 = 45;
+/// Default Phred-scaled error rate after UMI integration.
+pub const CONSENSUS_ERROR_RATE_POST_UMI: u8 = 40;
+/// Default minimum input base quality for consensus calling.
+pub const CONSENSUS_MIN_INPUT_BASE_QUALITY: u8 = 10;
+/// Default: produce per-base tags (cd, ce) in consensus output.
+pub const CONSENSUS_OUTPUT_PER_BASE_TAGS: bool = true;
+/// Default: do not trim reads before consensus calling.
+pub const CONSENSUS_TRIM: bool = false;
+/// Default: consensus-call overlapping bases in read pairs.
+pub const CONSENSUS_CALL_OVERLAPPING_BASES: bool = true;
+/// Default minimum consensus base quality (bases below are masked to N).
+pub const CONSENSUS_MIN_BASE_QUALITY: u8 = 2;
+
+// -- Codec --
+
+/// Default minimum reads per UMI group for codec consensus.
+pub const CODEC_MIN_READS: usize = 1;
+/// Default minimum duplex length for codec consensus.
+pub const CODEC_MIN_DUPLEX_LENGTH: usize = 1;
+/// Default outer bases length for codec consensus.
+pub const CODEC_OUTER_BASES_LENGTH: usize = 5;
+/// Default maximum duplex disagreement rate for codec consensus.
+pub const CODEC_MAX_DUPLEX_DISAGREEMENT_RATE: f64 = 1.0;
+
+// -- Filter --
+
+/// Default maximum per-read error rate (string form for `Vec<f64>` defaults).
+pub const FILTER_MAX_READ_ERROR_RATE: &str = "0.025";
+/// Default maximum per-base error rate (string form for `Vec<f64>` defaults).
+pub const FILTER_MAX_BASE_ERROR_RATE: &str = "0.1";
+/// Default maximum fraction of no-call (N) bases.
+pub const FILTER_MAX_NO_CALL_FRACTION: f64 = 0.2;
+
+// -- Compression --
+
+/// Default BAM compression level.
+pub const COMPRESSION_LEVEL: u32 = 1;

--- a/crates/fgumi-lib/src/extract/mod.rs
+++ b/crates/fgumi-lib/src/extract/mod.rs
@@ -1,0 +1,821 @@
+//! Core UMI extraction logic for building unmapped BAM records from FASTQ data.
+//!
+//! This module contains the pure-function core of the `extract` command, extracted
+//! from the binary crate so that the pipeline can call it directly without spawning
+//! a subprocess.
+//!
+//! # Overview
+//!
+//! The main entry point is [`make_raw_records`], which takes a [`FastqSet`] (with
+//! segments already split by read structure) and an [`ExtractParams`] configuration,
+//! and produces raw BAM record bytes suitable for writing to a BAM file or parsing
+//! into `Template` objects.
+//!
+//! # Quality Encoding
+//!
+//! The [`QualityEncoding`] enum handles automatic detection and conversion between
+//! Phred+33 (standard/Sanger) and Phred+64 (Illumina 1.3-1.7) quality encodings.
+
+use anyhow::{Result, bail, ensure};
+use bstr::{BString, ByteSlice};
+use fgumi_raw_bam::UnmappedBamRecordBuilder;
+use fgumi_raw_bam::fields::flags;
+use noodles::sam::Header;
+use noodles::sam::alignment::record::Flags;
+use noodles::sam::alignment::record::data::field::Tag;
+use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+use noodles::sam::alignment::record_buf::{QualityScores, RecordBuf, Sequence};
+use noodles::sam::header::record::value::Map;
+use noodles::sam::header::record::value::map::ReadGroup;
+use noodles::sam::header::record::value::map::header::{group_order, sort_order};
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+use noodles::sam::header::record::value::{
+    Map as HeaderRecordMap,
+    map::{Header as HeaderRecord, Tag as HeaderTag},
+};
+
+use crate::fastq::{FastqSegment, FastqSet};
+use crate::template::{self, Template};
+
+/// Number of FASTQ records to sample for quality encoding detection.
+pub const QUALITY_DETECTION_SAMPLE_SIZE: usize = 400;
+
+/// Quality encoding type detected from FASTQ quality scores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QualityEncoding {
+    /// Phred+33 (Sanger/Illumina 1.8+) -- the modern standard.
+    Standard,
+    /// Phred+64 (Illumina 1.3-1.7) -- legacy encoding.
+    Illumina,
+}
+
+impl QualityEncoding {
+    /// Convert quality scores to standard numeric format (Phred+33 offset removed).
+    ///
+    /// For `Standard` encoding, subtracts 33 from each quality byte.
+    /// For `Illumina` encoding, subtracts 64 from each quality byte.
+    /// Uses saturating subtraction to avoid underflow.
+    #[must_use]
+    pub fn to_standard_numeric(self, quals: &[u8]) -> Vec<u8> {
+        match self {
+            QualityEncoding::Standard => quals.iter().map(|&q| q.saturating_sub(33)).collect(),
+            QualityEncoding::Illumina => quals.iter().map(|&q| q.saturating_sub(64)).collect(),
+        }
+    }
+
+    /// Detect quality encoding from a sample of quality score records.
+    ///
+    /// Uses heuristics based on the observed quality score range:
+    /// - Scores below 59: definitely Phred+33
+    /// - Scores >= 64 with a reasonable range (max >= 75): likely Phred+64
+    /// - Ambiguous ranges: defaults to Phred+33 (more common in modern data)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - No records are provided
+    /// - Quality scores fall outside the printable ASCII range (33-126)
+    pub fn detect(records: &[Vec<u8>]) -> Result<Self> {
+        if records.is_empty() {
+            bail!("Cannot detect quality encoding: no records provided");
+        }
+
+        let mut min_qual = u8::MAX;
+        let mut max_qual = u8::MIN;
+        let mut total_bases = 0;
+
+        for qual in records {
+            if qual.is_empty() {
+                continue;
+            }
+            for &q in qual {
+                min_qual = min_qual.min(q);
+                max_qual = max_qual.max(q);
+                total_bases += 1;
+            }
+        }
+
+        // If all reads were empty, default to Standard
+        if total_bases == 0 {
+            return Ok(QualityEncoding::Standard);
+        }
+
+        if min_qual < 33 || max_qual > 126 {
+            bail!(
+                "Invalid quality scores detected: range [{min_qual}, {max_qual}]. \
+                Quality scores must be in the printable ASCII range (33-126)"
+            );
+        }
+
+        if min_qual < 59 {
+            Ok(QualityEncoding::Standard)
+        } else if min_qual >= 64 {
+            if max_qual >= 75 {
+                Ok(QualityEncoding::Illumina)
+            } else {
+                Ok(QualityEncoding::Standard)
+            }
+        } else {
+            // Ambiguous range (59-63), default to Phred+33
+            Ok(QualityEncoding::Standard)
+        }
+    }
+}
+
+/// Configuration for UMI extraction, capturing all user-configurable options
+/// needed by [`make_raw_records`].
+///
+/// This is the library-side equivalent of the CLI `ExtractConfig`, renamed to
+/// avoid confusion with CLI argument structs.
+#[derive(Clone, Debug)]
+pub struct ExtractParams {
+    /// BAM read group ID to assign to all records.
+    pub read_group_id: String,
+    /// Two-byte BAM tag for storing UMI sequences (e.g., `RX`).
+    pub umi_tag: [u8; 2],
+    /// Two-byte BAM tag for storing cell barcode sequences (e.g., `CB`).
+    pub cell_tag: [u8; 2],
+    /// Optional two-byte BAM tag for UMI quality scores.
+    pub umi_qual_tag: Option<[u8; 2]>,
+    /// Optional two-byte BAM tag for cell barcode quality scores.
+    pub cell_qual_tag: Option<[u8; 2]>,
+    /// Optional two-byte BAM tag for storing all concatenated UMIs.
+    pub single_tag: Option<[u8; 2]>,
+    /// Whether to append UMI sequences to read names (e.g., `readname+ACGT`).
+    pub annotate_read_names: bool,
+    /// Whether to extract UMIs from the 8th colon-delimited field of read names.
+    pub extract_umis_from_read_names: bool,
+    /// Whether to store sample barcode quality scores in the `QT` tag.
+    pub store_sample_barcode_qualities: bool,
+}
+
+/// Optional read group metadata fields beyond the required sample/library.
+///
+/// All fields default to `None` (omitted from the header). The `platform` field
+/// defaults to `"illumina"` when `None`, matching SAM spec conventions.
+#[derive(Clone, Debug, Default)]
+pub struct ReadGroupMetadata {
+    /// Sequencing platform (default: `"illumina"`).
+    pub platform: Option<String>,
+    /// Platform unit (e.g. `flowcell-barcode.lane.sample-barcode`).
+    pub platform_unit: Option<String>,
+    /// Platform model (e.g. `miseq`, `hiseq2500`).
+    pub platform_model: Option<String>,
+    /// Library or sample barcode sequence.
+    pub barcode: Option<String>,
+    /// Sequencing center name.
+    pub sequencing_center: Option<String>,
+    /// Predicted median insert size.
+    pub predicted_insert_size: Option<u32>,
+    /// Read group description.
+    pub description: Option<String>,
+    /// Date the run was produced.
+    pub run_date: Option<String>,
+}
+
+/// Build a minimal unmapped BAM header with sort order, read group, and optional
+/// metadata fields.
+///
+/// This is the shared header construction logic used by both the `extract` command
+/// and the pipeline's in-process extract path. It produces a header with:
+/// - `SO:unsorted GO:query`
+/// - A read group with sample, library, platform, and any additional metadata
+///
+/// The caller is responsible for adding `@PG` records and any extra comments.
+///
+/// # Errors
+///
+/// Returns an error if the header builder fails.
+pub fn build_unmapped_bam_header(
+    read_group_id: &str,
+    sample: &str,
+    library: &str,
+    metadata: &ReadGroupMetadata,
+) -> Result<Header> {
+    let mut header = Header::builder();
+
+    let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+    let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+    let map = HeaderRecordMap::<HeaderRecord>::builder()
+        .insert(so_tag, sort_order::UNSORTED)
+        .insert(go_tag, group_order::QUERY)
+        .build()?;
+    header = header.set_header(map);
+
+    let platform = metadata.platform.clone().unwrap_or_else(|| String::from("illumina"));
+    let mut rg = Map::<ReadGroup>::builder()
+        .insert(rg_tag::SAMPLE, sample.to_owned())
+        .insert(rg_tag::LIBRARY, library.to_owned())
+        .insert(rg_tag::PLATFORM, platform);
+
+    if let Some(ref v) = metadata.platform_unit {
+        rg = rg.insert(rg_tag::PLATFORM_UNIT, v.clone());
+    }
+    if let Some(ref v) = metadata.platform_model {
+        rg = rg.insert(rg_tag::PLATFORM_MODEL, v.clone());
+    }
+    if let Some(ref v) = metadata.barcode {
+        rg = rg.insert(rg_tag::BARCODE, v.clone());
+    }
+    if let Some(ref v) = metadata.sequencing_center {
+        rg = rg.insert(rg_tag::SEQUENCING_CENTER, v.clone());
+    }
+    if let Some(v) = metadata.predicted_insert_size {
+        rg = rg.insert(rg_tag::PREDICTED_MEDIAN_INSERT_SIZE, v.to_string());
+    }
+    if let Some(ref v) = metadata.description {
+        rg = rg.insert(rg_tag::DESCRIPTION, v.clone());
+    }
+    if let Some(ref v) = metadata.run_date {
+        rg = rg.insert(rg_tag::PRODUCED_AT, v.clone());
+    }
+
+    header = header.add_read_group(read_group_id.to_owned(), rg.build()?);
+
+    Ok(header.build())
+}
+
+/// Output of [`make_raw_records`]: raw BAM record bytes and a record count.
+///
+/// The `data` field contains BAM records with `block_size` prefixes, ready for
+/// writing to a BAM file via a raw writer.
+pub struct RawExtractedRecords {
+    /// BAM records with `block_size` prefixes, ready for the compress step.
+    pub data: Vec<u8>,
+    /// Number of BAM records in this batch.
+    pub num_records: u64,
+}
+
+/// Joins byte slices with a separator, pre-allocating capacity.
+///
+/// Returns an empty `BString` if the iterator yields no items.
+///
+/// # Examples
+///
+/// ```
+/// use fgumi_lib::extract::join_bytes_with_separator;
+/// use bstr::BString;
+///
+/// let result = join_bytes_with_separator(
+///     [b"ACG".as_slice(), b"TTA".as_slice()].into_iter(),
+///     b'-',
+/// );
+/// assert_eq!(result, BString::from("ACG-TTA"));
+/// ```
+pub fn join_bytes_with_separator<'a>(
+    segments: impl Iterator<Item = &'a [u8]>,
+    separator: u8,
+) -> BString {
+    let segments: Vec<&[u8]> = segments.collect();
+    if segments.is_empty() {
+        return BString::default();
+    }
+    let total_len: usize = segments.iter().map(|s| s.len()).sum();
+    let capacity = total_len + segments.len().saturating_sub(1);
+    let mut result = Vec::with_capacity(capacity);
+    for (i, seg) in segments.iter().enumerate() {
+        if i > 0 {
+            result.push(separator);
+        }
+        result.extend_from_slice(seg);
+    }
+    BString::from(result)
+}
+
+/// Extracts the read name and optionally a UMI from the 8th colon-delimited field.
+///
+/// The read name is cleaned by:
+/// 1. Removing the leading `@` prefix (if present)
+/// 2. Truncating at the first space (removing comment/description fields)
+///
+/// If `extract_umis` is true, the 8th colon-delimited field of the read name is
+/// extracted as the UMI. Any `+` characters in the UMI are normalized to `-`.
+///
+/// # Returns
+///
+/// A tuple of `(read_name_bytes, optional_umi_bytes)`.
+#[must_use]
+pub fn extract_read_name_and_umi(header: &[u8], extract_umis: bool) -> (Vec<u8>, Option<Vec<u8>>) {
+    // Remove @ prefix if present
+    let name_bytes = if header.starts_with(b"@") { &header[1..] } else { header };
+
+    // Split on space to get just the name part
+    let name_part = name_bytes.find_byte(b' ').map_or(name_bytes, |pos| &name_bytes[..pos]);
+
+    if !extract_umis {
+        return (name_part.to_vec(), None);
+    }
+
+    // Count colons to find 8th field (UMI)
+    let parts: Vec<&[u8]> = name_part.split(|&b| b == b':').collect();
+
+    if parts.len() >= 8 {
+        let mut umi = parts[7].to_vec();
+        if !umi.is_empty() {
+            // Normalize '+' to '-' in UMI
+            for byte in &mut umi {
+                if *byte == b'+' {
+                    *byte = b'-';
+                }
+            }
+            return (name_part.to_vec(), Some(umi));
+        }
+    }
+
+    (name_part.to_vec(), None)
+}
+
+/// Collected barcode sequences, qualities, and final read name for a single template.
+///
+/// Produced by [`extract_barcodes`] and consumed by both [`make_raw_records`] and
+/// [`extract_template_and_fastq`] to avoid duplicating the barcode collection and
+/// UMI merge logic.
+pub struct ExtractedBarcodes<'a> {
+    /// Joined cell barcode sequences (hyphen-separated).
+    pub cell_barcode: BString,
+    /// Joined sample barcode sequences (hyphen-separated).
+    pub sample_barcode: BString,
+    /// Final UMI after merging read-name and read-structure UMIs.
+    pub umi: BString,
+    /// Joined UMI quality strings (space-separated).
+    pub umi_qual: BString,
+    /// Joined cell barcode quality strings (space-separated).
+    pub cell_qual: BString,
+    /// Joined sample barcode quality strings (space-separated).
+    pub sample_qual: BString,
+    /// Read name bytes (cleaned, without `@` prefix or comments).
+    /// Borrows from `read_name_bytes` when annotation is off; owned when annotation is on.
+    pub final_read_name: std::borrow::Cow<'a, [u8]>,
+    /// UMI extracted from the read name, if any (used to suppress UMI qual output).
+    pub umi_from_name: Option<Vec<u8>>,
+}
+
+/// Extract barcodes, UMI, and final read name from a [`FastqSet`].
+///
+/// Collects cell barcodes, sample barcodes, molecular barcodes, and the UMI from
+/// the read name (if requested). Merges UMIs from the read structure and read name
+/// according to fgumi conventions. Returns an [`ExtractedBarcodes`] that both
+/// [`make_raw_records`] and [`extract_template_and_fastq`] consume.
+#[must_use]
+pub fn extract_barcodes<'a>(
+    read_set: &FastqSet,
+    params: &ExtractParams,
+    read_name_bytes: &'a [u8],
+) -> ExtractedBarcodes<'a> {
+    let cell_barcode =
+        join_bytes_with_separator(read_set.cell_barcode_segments().map(|s| s.seq.as_slice()), b'-');
+    let cell_qual = join_bytes_with_separator(
+        read_set.cell_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+    let sample_barcode = join_bytes_with_separator(
+        read_set.sample_barcode_segments().map(|s| s.seq.as_slice()),
+        b'-',
+    );
+    let sample_qual = join_bytes_with_separator(
+        read_set.sample_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+    let umi_bs = join_bytes_with_separator(
+        read_set.molecular_barcode_segments().map(|s| s.seq.as_slice()),
+        b'-',
+    );
+    let umi_qual = join_bytes_with_separator(
+        read_set.molecular_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+
+    let (_, umi_from_name) =
+        extract_read_name_and_umi(&read_set.header, params.extract_umis_from_read_names);
+
+    let umi: BString = match (umi_bs.is_empty(), &umi_from_name) {
+        (true, Some(from_name)) => BString::from(from_name.as_slice()),
+        (true, None) => BString::default(),
+        (false, Some(from_name)) => {
+            let mut combined = Vec::with_capacity(from_name.len() + 1 + umi_bs.len());
+            combined.extend_from_slice(from_name);
+            combined.push(b'-');
+            combined.extend_from_slice(umi_bs.as_bytes());
+            BString::from(combined)
+        }
+        (false, None) => umi_bs,
+    };
+
+    let final_read_name = if params.annotate_read_names && !umi.is_empty() {
+        let mut name = Vec::with_capacity(read_name_bytes.len() + 1 + umi.len());
+        name.extend_from_slice(read_name_bytes);
+        name.push(b'+');
+        name.extend_from_slice(umi.as_bytes());
+        std::borrow::Cow::Owned(name)
+    } else {
+        std::borrow::Cow::Borrowed(read_name_bytes)
+    };
+
+    ExtractedBarcodes {
+        cell_barcode,
+        sample_barcode,
+        umi,
+        umi_qual,
+        cell_qual,
+        sample_qual,
+        final_read_name,
+        umi_from_name,
+    }
+}
+
+/// Build raw BAM records from a [`FastqSet`] with UMI extraction applied.
+///
+/// This is the core extraction function that converts a combined FASTQ read set
+/// (with segments already split by read structure) into raw BAM record bytes.
+/// Each template segment in the read set produces one BAM record.
+///
+/// For paired-end data (2 template segments), records are flagged as paired with
+/// appropriate first/last segment flags.
+///
+/// # Arguments
+///
+/// * `read_set` - Combined FASTQ segments from all input files for one template
+/// * `encoding` - Quality encoding detected from the input FASTQ files
+/// * `params` - Extraction configuration (tags, read group, etc.)
+///
+/// # Returns
+///
+/// A [`RawExtractedRecords`] containing the raw BAM bytes and record count.
+///
+/// # Errors
+///
+/// Returns an error if the read set contains no template segments.
+pub fn make_raw_records(
+    read_set: &FastqSet,
+    encoding: QualityEncoding,
+    params: &ExtractParams,
+) -> Result<RawExtractedRecords> {
+    let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
+
+    let read_name = String::from_utf8_lossy(&read_set.header);
+    ensure!(!templates.is_empty(), "No template segments found for read: {read_name}");
+
+    let (read_name_bytes, _) =
+        extract_read_name_and_umi(&read_set.header, params.extract_umis_from_read_names);
+    let barcodes = extract_barcodes(read_set, params, &read_name_bytes);
+
+    let num_templates = templates.len();
+    let mut builder = UnmappedBamRecordBuilder::new();
+    let mut data = Vec::new();
+
+    for (index, template) in templates.iter().enumerate() {
+        let mut flag = flags::UNMAPPED;
+        if num_templates == 2 {
+            flag |= flags::PAIRED | flags::MATE_UNMAPPED;
+            if index == 0 {
+                flag |= flags::FIRST_SEGMENT;
+            } else {
+                flag |= flags::LAST_SEGMENT;
+            }
+        }
+
+        if template.seq.is_empty() {
+            builder.build_record(&barcodes.final_read_name, flag, b"N", &[2u8]);
+        } else {
+            let numeric_quals = encoding.to_standard_numeric(&template.quals);
+            builder.build_record(&barcodes.final_read_name, flag, &template.seq, &numeric_quals);
+        }
+
+        builder.append_string_tag(b"RG", params.read_group_id.as_bytes());
+
+        if !barcodes.cell_barcode.is_empty() {
+            builder.append_string_tag(&params.cell_tag, barcodes.cell_barcode.as_bytes());
+        }
+
+        if !barcodes.cell_qual.is_empty() {
+            if let Some(ref qt) = params.cell_qual_tag {
+                builder.append_string_tag(qt, barcodes.cell_qual.as_bytes());
+            }
+        }
+
+        if !barcodes.sample_barcode.is_empty() {
+            builder.append_string_tag(b"BC", barcodes.sample_barcode.as_bytes());
+        }
+
+        if params.store_sample_barcode_qualities && !barcodes.sample_qual.is_empty() {
+            builder.append_string_tag(b"QT", barcodes.sample_qual.as_bytes());
+        }
+
+        if !barcodes.umi.is_empty() {
+            builder.append_string_tag(&params.umi_tag, barcodes.umi.as_bytes());
+
+            if let Some(ref st) = params.single_tag {
+                builder.append_string_tag(st, barcodes.umi.as_bytes());
+            }
+
+            if barcodes.umi_from_name.is_none() && !barcodes.umi_qual.is_empty() {
+                if let Some(ref qt) = params.umi_qual_tag {
+                    builder.append_string_tag(qt, barcodes.umi_qual.as_bytes());
+                }
+            }
+        }
+
+        builder.write_with_block_size(&mut data);
+        builder.clear();
+    }
+
+    Ok(RawExtractedRecords { data, num_records: num_templates as u64 })
+}
+
+/// Output of [`extract_template_and_fastq`]: an unmapped [`Template`] for zipper merge
+/// and interleaved FASTQ text for the aligner.
+pub struct ExtractedTemplateAndFastq {
+    /// Unmapped template with UMI/barcode tags set, for zipper merge.
+    pub template: Template,
+    /// Interleaved FASTQ text (R1 then R2) for piping to the aligner stdin.
+    /// Each record is formatted as `@name/N\nSEQ\n+\nQUAL\n`.
+    pub fastq_bytes: Vec<u8>,
+}
+
+/// Build an unmapped [`Template`] and interleaved FASTQ text from a [`FastqSet`].
+///
+/// This is the in-process alternative to running `fgumi extract` followed by
+/// `fgumi fastq`. It produces both outputs in a single pass:
+///
+/// 1. A `Template` containing unmapped `RecordBuf` objects with UMI/barcode tags
+///    (identical to what `fgumi extract` would produce as a BAM file).
+/// 2. Interleaved FASTQ text suitable for piping to an aligner's stdin.
+///
+/// The FASTQ text uses the same read name as the BAM records (including UMI
+/// annotation if `params.annotate_read_names` is set) and appends `/1` or `/2`
+/// suffixes for paired-end reads.
+///
+/// # Arguments
+///
+/// * `read_set` - Combined FASTQ segments from all input files for one template
+/// * `encoding` - Quality encoding detected from the input FASTQ files
+/// * `params` - Extraction configuration (tags, read group, etc.)
+///
+/// # Errors
+///
+/// Returns an error if the read set contains no template segments.
+// single-pass extraction must handle all barcode/tag/FASTQ logic together
+#[allow(clippy::too_many_lines)]
+pub fn extract_template_and_fastq(
+    read_set: &FastqSet,
+    encoding: QualityEncoding,
+    params: &ExtractParams,
+) -> Result<ExtractedTemplateAndFastq> {
+    let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
+
+    let read_name_display = String::from_utf8_lossy(&read_set.header);
+    ensure!(!templates.is_empty(), "No template segments found for read: {read_name_display}");
+
+    let (read_name_bytes, _) =
+        extract_read_name_and_umi(&read_set.header, params.extract_umis_from_read_names);
+    let barcodes = extract_barcodes(read_set, params, &read_name_bytes);
+
+    let num_templates = templates.len();
+    let mut template_builder = template::Builder::default();
+    let mut fastq_bytes = Vec::new();
+
+    for (index, tmpl_seg) in templates.iter().enumerate() {
+        let mut sam_flags = Flags::UNMAPPED;
+        if num_templates == 2 {
+            sam_flags |= Flags::SEGMENTED | Flags::MATE_UNMAPPED;
+            if index == 0 {
+                sam_flags |= Flags::FIRST_SEGMENT;
+            } else {
+                sam_flags |= Flags::LAST_SEGMENT;
+            }
+        }
+
+        let mut record = RecordBuf::default();
+        *record.name_mut() = Some(BString::from(barcodes.final_read_name.as_ref()));
+        *record.flags_mut() = sam_flags;
+
+        // Build seq/qual, write FASTQ from them FIRST, then move into RecordBuf
+        let (seq_bytes, qual_values): (Vec<u8>, Vec<u8>) = if tmpl_seg.seq.is_empty() {
+            (b"N".to_vec(), vec![2u8])
+        } else {
+            (tmpl_seg.seq.clone(), encoding.to_standard_numeric(&tmpl_seg.quals))
+        };
+
+        // Build FASTQ text before moving seq/qual into the RecordBuf
+        fastq_bytes.push(b'@');
+        fastq_bytes.extend_from_slice(&barcodes.final_read_name);
+        if num_templates == 2 {
+            if index == 0 {
+                fastq_bytes.extend_from_slice(b"/1");
+            } else {
+                fastq_bytes.extend_from_slice(b"/2");
+            }
+        }
+        fastq_bytes.push(b'\n');
+
+        fastq_bytes.extend_from_slice(&seq_bytes);
+        fastq_bytes.extend_from_slice(b"\n+\n");
+
+        if tmpl_seg.seq.is_empty() {
+            fastq_bytes.push(b'#'); // Q2 in Phred+33
+        } else {
+            for &q in &qual_values {
+                fastq_bytes.push(q + 33);
+            }
+        }
+        fastq_bytes.push(b'\n');
+
+        // Move seq/qual into RecordBuf (no clone needed)
+        *record.sequence_mut() = Sequence::from(seq_bytes);
+        *record.quality_scores_mut() = QualityScores::from(qual_values);
+
+        let data = record.data_mut();
+
+        let rg_tag = Tag::new(b'R', b'G');
+        data.insert(rg_tag, BufValue::from(params.read_group_id.as_str()));
+
+        if !barcodes.cell_barcode.is_empty() {
+            let tag = Tag::new(params.cell_tag[0], params.cell_tag[1]);
+            data.insert(tag, BufValue::from(barcodes.cell_barcode.to_str_lossy().as_ref()));
+        }
+        if !barcodes.cell_qual.is_empty() {
+            if let Some(ref qt) = params.cell_qual_tag {
+                let tag = Tag::new(qt[0], qt[1]);
+                data.insert(tag, BufValue::from(barcodes.cell_qual.to_str_lossy().as_ref()));
+            }
+        }
+
+        if !barcodes.sample_barcode.is_empty() {
+            let tag = Tag::new(b'B', b'C');
+            data.insert(tag, BufValue::from(barcodes.sample_barcode.to_str_lossy().as_ref()));
+        }
+        if params.store_sample_barcode_qualities && !barcodes.sample_qual.is_empty() {
+            let tag = Tag::new(b'Q', b'T');
+            data.insert(tag, BufValue::from(barcodes.sample_qual.to_str_lossy().as_ref()));
+        }
+
+        if !barcodes.umi.is_empty() {
+            let tag = Tag::new(params.umi_tag[0], params.umi_tag[1]);
+            data.insert(tag, BufValue::from(barcodes.umi.to_str_lossy().as_ref()));
+
+            if let Some(ref st) = params.single_tag {
+                let tag = Tag::new(st[0], st[1]);
+                data.insert(tag, BufValue::from(barcodes.umi.to_str_lossy().as_ref()));
+            }
+
+            if barcodes.umi_from_name.is_none() && !barcodes.umi_qual.is_empty() {
+                if let Some(ref qt) = params.umi_qual_tag {
+                    let tag = Tag::new(qt[0], qt[1]);
+                    data.insert(tag, BufValue::from(barcodes.umi_qual.to_str_lossy().as_ref()));
+                }
+            }
+        }
+
+        template_builder.push(record)?;
+    }
+
+    let template = template_builder.build()?;
+    Ok(ExtractedTemplateAndFastq { template, fastq_bytes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fastq::FastqSet;
+    use read_structure::ReadStructure;
+    use std::str::FromStr;
+
+    /// Helper to build a simple `ExtractParams` for testing.
+    fn test_params() -> ExtractParams {
+        ExtractParams {
+            read_group_id: "A".to_string(),
+            umi_tag: *b"RX",
+            cell_tag: *b"CB",
+            umi_qual_tag: None,
+            cell_qual_tag: None,
+            single_tag: None,
+            annotate_read_names: false,
+            extract_umis_from_read_names: false,
+            store_sample_barcode_qualities: false,
+        }
+    }
+
+    #[test]
+    fn test_quality_encoding_standard_detection() {
+        // Typical Phred+33 qualities (ASCII 33-73 = Q0-Q40)
+        let records = vec![b"IIIIIFFFF".to_vec(), b"HHHHH!!!!".to_vec()];
+        let encoding = QualityEncoding::detect(&records).unwrap();
+        assert_eq!(encoding, QualityEncoding::Standard);
+    }
+
+    #[test]
+    fn test_quality_encoding_illumina_detection() {
+        // Phred+64 qualities (ASCII 64-126)
+        let records = vec![vec![100u8; 10], vec![110u8; 10]];
+        let encoding = QualityEncoding::detect(&records).unwrap();
+        assert_eq!(encoding, QualityEncoding::Illumina);
+    }
+
+    #[test]
+    fn test_quality_encoding_empty_records() {
+        let records: Vec<Vec<u8>> = vec![];
+        assert!(QualityEncoding::detect(&records).is_err());
+    }
+
+    #[test]
+    fn test_quality_encoding_all_empty_reads() {
+        let records = vec![Vec::new(), Vec::new()];
+        let encoding = QualityEncoding::detect(&records).unwrap();
+        assert_eq!(encoding, QualityEncoding::Standard);
+    }
+
+    #[test]
+    fn test_quality_encoding_to_standard_numeric() {
+        let standard = QualityEncoding::Standard;
+        assert_eq!(standard.to_standard_numeric(&[33, 53, 73]), vec![0, 20, 40]);
+
+        let illumina = QualityEncoding::Illumina;
+        assert_eq!(illumina.to_standard_numeric(&[64, 84, 104]), vec![0, 20, 40]);
+    }
+
+    #[test]
+    fn test_join_bytes_with_separator() {
+        let result =
+            join_bytes_with_separator([b"ACG".as_slice(), b"TTA".as_slice()].into_iter(), b'-');
+        assert_eq!(result, BString::from("ACG-TTA"));
+
+        // Single segment
+        let result = join_bytes_with_separator([b"ACG".as_slice()].into_iter(), b'-');
+        assert_eq!(result, BString::from("ACG"));
+
+        // Empty iterator
+        let result = join_bytes_with_separator(std::iter::empty(), b'-');
+        assert_eq!(result, BString::default());
+    }
+
+    #[test]
+    fn test_extract_read_name_and_umi_no_extract() {
+        let header = b"@INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y:UMI extra";
+        let (name, umi) = extract_read_name_and_umi(header, false);
+        assert_eq!(name, b"INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y:UMI");
+        assert!(umi.is_none());
+    }
+
+    #[test]
+    fn test_extract_read_name_and_umi_with_extract() {
+        let header = b"@INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y:ACGT+TGCA";
+        let (name, umi) = extract_read_name_and_umi(header, true);
+        assert_eq!(name, b"INSTRUMENT:RUN:FLOWCELL:LANE:TILE:X:Y:ACGT+TGCA");
+        // '+' should be normalized to '-'
+        assert_eq!(umi, Some(b"ACGT-TGCA".to_vec()));
+    }
+
+    #[test]
+    fn test_extract_read_name_and_umi_no_umi_field() {
+        let header = b"@SHORT:NAME:ONLY";
+        let (name, umi) = extract_read_name_and_umi(header, true);
+        assert_eq!(name, b"SHORT:NAME:ONLY");
+        assert!(umi.is_none());
+    }
+
+    #[test]
+    fn test_make_raw_records_simple_paired() {
+        let rs = ReadStructure::from_str("+T").unwrap();
+        let r1 =
+            FastqSet::from_record_with_structure(b"@read1", b"ACGT", b"IIII", &rs, &[]).unwrap();
+        let r2 =
+            FastqSet::from_record_with_structure(b"@read1", b"TGCA", b"FFFF", &rs, &[]).unwrap();
+        let combined = FastqSet::combine_readsets(vec![r1, r2]);
+
+        let result = make_raw_records(&combined, QualityEncoding::Standard, &test_params());
+        assert!(result.is_ok());
+        let batch = result.unwrap();
+        assert_eq!(batch.num_records, 2);
+        assert!(!batch.data.is_empty());
+    }
+
+    #[test]
+    fn test_make_raw_records_with_umi() {
+        let rs_umi = ReadStructure::from_str("4M+T").unwrap();
+        let rs_template = ReadStructure::from_str("+T").unwrap();
+        let r1 =
+            FastqSet::from_record_with_structure(b"@read1", b"ACGTTTTT", b"IIIIFFFF", &rs_umi, &[])
+                .unwrap();
+        let r2 =
+            FastqSet::from_record_with_structure(b"@read1", b"TGCA", b"FFFF", &rs_template, &[])
+                .unwrap();
+        let combined = FastqSet::combine_readsets(vec![r1, r2]);
+
+        let params = test_params();
+        let result = make_raw_records(&combined, QualityEncoding::Standard, &params);
+        assert!(result.is_ok());
+        let batch = result.unwrap();
+        assert_eq!(batch.num_records, 2);
+    }
+
+    #[test]
+    fn test_make_raw_records_no_templates_fails() {
+        // A read set with only UMI segments and no template segments
+        let rs = ReadStructure::from_str("+M").unwrap();
+        let r1 =
+            FastqSet::from_record_with_structure(b"@read1", b"ACGT", b"IIII", &rs, &[]).unwrap();
+
+        let result = make_raw_records(&r1, QualityEncoding::Standard, &test_params());
+        assert!(result.is_err());
+    }
+}

--- a/crates/fgumi-lib/src/grouper.rs
+++ b/crates/fgumi-lib/src/grouper.rs
@@ -338,12 +338,6 @@ pub struct FilterMetrics {
 }
 
 impl FilterMetrics {
-    /// Create new empty metrics.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Merge another `FilterMetrics` into this one.
     pub fn merge(&mut self, other: &FilterMetrics) {
         self.total_templates += other.total_templates;
@@ -714,6 +708,319 @@ pub fn build_templates_from_records(records: Vec<DecodedRecord>) -> io::Result<V
             Template::from_records,
         )
     }
+}
+
+// ============================================================================
+// Shared UMI Grouping Helpers
+// ============================================================================
+
+/// Group consecutive raw BAM records by queryname.
+///
+/// Records within a position group are sorted by template-coordinate key, which
+/// includes a name hash. Records with the same queryname are adjacent but name-hash
+/// collisions are possible, so actual queryname comparison is required.
+#[must_use]
+pub fn group_by_queryname(records: Vec<Vec<u8>>) -> Vec<Vec<Vec<u8>>> {
+    use fgumi_raw_bam::fields::read_name;
+
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    let mut groups: Vec<Vec<Vec<u8>>> = Vec::new();
+    let mut current_group: Vec<Vec<u8>> = Vec::new();
+
+    for rec in records {
+        let name = read_name(&rec);
+        // Compare against the last record in the current group to avoid allocating
+        // a separate name buffer: records are sorted by template-coordinate key, so
+        // same-name records are always adjacent.
+        let current_name_matches = current_group.last().is_some_and(|last| read_name(last) == name);
+        if !current_name_matches && !current_group.is_empty() {
+            groups.push(std::mem::take(&mut current_group));
+        }
+        current_group.push(rec);
+    }
+
+    if !current_group.is_empty() {
+        groups.push(current_group);
+    }
+
+    groups
+}
+
+/// Extract the UMI string from a raw-byte template's primary R1 (or R2 as fallback).
+///
+/// Returns an empty string if the UMI tag is not found, which the assigner
+/// will handle appropriately.
+///
+/// # Errors
+///
+/// Returns an error if the UMI tag value is not valid UTF-8.
+pub fn extract_umi_from_template(
+    template: &crate::template::Template,
+    umi_tag: [u8; 2],
+) -> Result<fgumi_umi::Umi, anyhow::Error> {
+    use fgumi_raw_bam::fields::aux_data_slice;
+    use fgumi_raw_bam::tags::find_string_tag;
+
+    let raw = template.raw_r1().or_else(|| template.raw_r2());
+    let Some(raw) = raw else {
+        return Ok(String::new());
+    };
+
+    let aux = aux_data_slice(raw);
+    match find_string_tag(aux, &umi_tag) {
+        Some(umi_bytes) => {
+            let umi_str = std::str::from_utf8(umi_bytes)
+                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI tag {umi_tag:?}: {e}"))?;
+            Ok(umi_str.to_owned())
+        }
+        None => Ok(String::new()),
+    }
+}
+
+/// Get the pair orientation from a raw-byte template.
+///
+/// Returns `(r1_positive, r2_positive)` where `true` means the read is on the
+/// forward strand (REVERSE flag not set). If R1 or R2 is absent, the corresponding
+/// value defaults to `true` (forward).
+#[must_use]
+pub fn get_pair_orientation_raw(template: &crate::template::Template) -> (bool, bool) {
+    use fgumi_raw_bam::fields;
+
+    let r1_positive =
+        template.raw_r1().is_none_or(|r| (fields::flags(r) & fields::flags::REVERSE) == 0);
+    let r2_positive =
+        template.raw_r2().is_none_or(|r| (fields::flags(r) & fields::flags::REVERSE) == 0);
+    (r1_positive, r2_positive)
+}
+
+// ============================================================================
+// Template Filtering (shared between standalone group and runall pipeline)
+// ============================================================================
+
+/// Configuration for template filtering during group processing.
+///
+/// Controls which templates are discarded before UMI assignment:
+/// unmapped pairs, low MAPQ, non-PF, and UMI validation.
+#[derive(Clone, Debug)]
+pub struct GroupFilterConfig {
+    /// UMI tag bytes (e.g., `[b'R', b'X']`).
+    pub umi_tag: [u8; 2],
+    /// Minimum mapping quality.
+    pub min_mapq: u8,
+    /// Whether to include non-PF reads.
+    pub include_non_pf: bool,
+    /// Minimum UMI length (`None` to disable).
+    pub min_umi_length: Option<usize>,
+    /// Skip UMI validation (position-only grouping).
+    pub no_umi: bool,
+    /// Whether to allow fully unmapped templates (both reads unmapped).
+    pub allow_unmapped: bool,
+}
+
+impl GroupFilterConfig {
+    /// Create a default config suitable for the runall pipeline.
+    ///
+    /// Uses the given UMI tag, `min_mapq = 1`, no UMI length check, and
+    /// disallows unmapped templates.
+    #[must_use]
+    pub fn with_defaults(umi_tag: [u8; 2]) -> Self {
+        Self {
+            umi_tag,
+            min_mapq: 1,
+            include_non_pf: false,
+            min_umi_length: None,
+            no_umi: false,
+            allow_unmapped: false,
+        }
+    }
+}
+
+/// Filter a template in raw-byte mode based on filtering criteria.
+///
+/// Returns `true` if the template should be kept, `false` if it should be discarded.
+/// Updates `metrics` with the reason for filtering.
+///
+/// Checks performed (in order):
+/// 1. At least one primary read exists.
+/// 2. Both-unmapped check (unless `allow_unmapped`).
+/// 3. QC-fail flag (unless `include_non_pf`).
+/// 4. MAPQ < `min_mapq` on mapped reads.
+/// 5. Mate MAPQ via the `MQ` aux tag.
+/// 6. UMI validation: N-content and minimum length.
+pub fn filter_template_raw(
+    template: &crate::template::Template,
+    config: &GroupFilterConfig,
+    metrics: &mut FilterMetrics,
+) -> bool {
+    let raw_r1 = template.raw_r1().filter(|r| r.len() >= fgumi_raw_bam::MIN_BAM_RECORD_LEN);
+    let raw_r2 = template.raw_r2().filter(|r| r.len() >= fgumi_raw_bam::MIN_BAM_RECORD_LEN);
+
+    metrics.total_templates += 1;
+
+    if raw_r1.is_none() && raw_r2.is_none() {
+        metrics.discarded_poor_alignment += 1;
+        return false;
+    }
+
+    // Check if both reads are unmapped
+    let both_unmapped = raw_r1
+        .is_none_or(|r| (fgumi_raw_bam::flags(r) & fgumi_raw_bam::flags::UNMAPPED) != 0)
+        && raw_r2.is_none_or(|r| (fgumi_raw_bam::flags(r) & fgumi_raw_bam::flags::UNMAPPED) != 0);
+    if both_unmapped && !config.allow_unmapped {
+        metrics.discarded_poor_alignment += 1;
+        return false;
+    }
+
+    // Phase 1: Cheap flag-based checks
+    if !filter_template_raw_flags(raw_r1, raw_r2, config, metrics) {
+        return false;
+    }
+
+    // Phase 2: Tag-based checks (MQ + UMI in one aux scan per read)
+    filter_template_raw_tags(raw_r1, raw_r2, config, metrics)
+}
+
+/// Phase 1 of template filtering: flag-based checks (QC-fail, MAPQ).
+fn filter_template_raw_flags(
+    raw_r1: Option<&[u8]>,
+    raw_r2: Option<&[u8]>,
+    config: &GroupFilterConfig,
+    metrics: &mut FilterMetrics,
+) -> bool {
+    for raw in [raw_r1, raw_r2].into_iter().flatten() {
+        let flg = fgumi_raw_bam::flags(raw);
+
+        if !config.include_non_pf && (flg & fgumi_raw_bam::flags::QC_FAIL) != 0 {
+            metrics.discarded_non_pf += 1;
+            return false;
+        }
+
+        if (flg & fgumi_raw_bam::flags::UNMAPPED) == 0 && fgumi_raw_bam::mapq(raw) < config.min_mapq
+        {
+            metrics.discarded_poor_alignment += 1;
+            return false;
+        }
+    }
+    true
+}
+
+/// Phase 2 of template filtering: single-pass aux tag lookups (MQ + UMI).
+#[expect(
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "BAM aux tag parsing: MQ is stored as various integer types but always fits in u8"
+)]
+fn filter_template_raw_tags(
+    raw_r1: Option<&[u8]>,
+    raw_r2: Option<&[u8]>,
+    config: &GroupFilterConfig,
+    metrics: &mut FilterMetrics,
+) -> bool {
+    for raw in [raw_r1, raw_r2].into_iter().flatten() {
+        let flg = fgumi_raw_bam::flags(raw);
+        let aux = fgumi_raw_bam::aux_data_slice(raw);
+        let check_mq = (flg & fgumi_raw_bam::flags::MATE_UNMAPPED) == 0;
+        let check_umi = !config.no_umi;
+
+        let mut found_mq: Option<i64> = None;
+        let mut found_umi: Option<&[u8]> = None;
+        let mut p = 0;
+        while p + 3 <= aux.len() {
+            let t = [aux[p], aux[p + 1]];
+            let val_type = aux[p + 2];
+
+            if check_umi && t == config.umi_tag && val_type == b'Z' {
+                let start = p + 3;
+                if let Some(end) = aux[start..].iter().position(|&b| b == 0) {
+                    found_umi = Some(&aux[start..start + end]);
+                    p = start + end + 1;
+                } else {
+                    break;
+                }
+                if !check_mq || found_mq.is_some() {
+                    break;
+                }
+                continue;
+            }
+
+            if check_mq && t == *b"MQ" {
+                // Extract MQ value (common types: C/c/S/s/I/i)
+                found_mq = match val_type {
+                    b'C' if p + 3 < aux.len() => Some(i64::from(aux[p + 3])),
+                    b'c' if p + 3 < aux.len() => Some(i64::from(aux[p + 3] as i8)),
+                    b'S' if p + 5 <= aux.len() => {
+                        Some(i64::from(u16::from_le_bytes([aux[p + 3], aux[p + 4]])))
+                    }
+                    b's' if p + 5 <= aux.len() => {
+                        Some(i64::from(i16::from_le_bytes([aux[p + 3], aux[p + 4]])))
+                    }
+                    b'I' if p + 7 <= aux.len() => Some(i64::from(u32::from_le_bytes([
+                        aux[p + 3],
+                        aux[p + 4],
+                        aux[p + 5],
+                        aux[p + 6],
+                    ]))),
+                    b'i' if p + 7 <= aux.len() => Some(i64::from(i32::from_le_bytes([
+                        aux[p + 3],
+                        aux[p + 4],
+                        aux[p + 5],
+                        aux[p + 6],
+                    ]))),
+                    _ => None,
+                };
+            }
+
+            if let Some(size) = fgumi_raw_bam::tag_value_size(val_type, &aux[p + 3..]) {
+                p += 3 + size;
+            } else {
+                break;
+            }
+            if (!check_umi || found_umi.is_some()) && (!check_mq || found_mq.is_some()) {
+                break;
+            }
+        }
+
+        if check_mq {
+            if let Some(mq) = found_mq {
+                if (mq as u8) < config.min_mapq {
+                    metrics.discarded_poor_alignment += 1;
+                    return false;
+                }
+            }
+        }
+
+        // Skip UMI validation in no-umi mode
+        if config.no_umi {
+            continue;
+        }
+
+        if let Some(umi_bytes) = found_umi {
+            match fgumi_umi::validate_umi(umi_bytes) {
+                fgumi_umi::UmiValidation::ContainsN => {
+                    metrics.discarded_ns_in_umi += 1;
+                    return false;
+                }
+                fgumi_umi::UmiValidation::Valid(base_count) => {
+                    if let Some(min_len) = config.min_umi_length {
+                        if base_count < min_len {
+                            metrics.discarded_umi_too_short += 1;
+                            return false;
+                        }
+                    }
+                }
+            }
+        } else {
+            metrics.discarded_poor_alignment += 1;
+            return false;
+        }
+    }
+
+    metrics.accepted_templates += 1;
+    true
 }
 
 // ============================================================================

--- a/crates/fgumi-lib/src/lib.rs
+++ b/crates/fgumi-lib/src/lib.rs
@@ -133,8 +133,11 @@ pub use fgumi_bgzf::writer as bgzf_writer;
 pub use fgumi_dna::bitenc;
 pub use fgumi_sam::clipper;
 pub mod consensus;
+pub mod correct;
+pub mod defaults;
 pub use fgumi_dna::dna;
 pub mod errors;
+pub mod extract;
 pub mod fastq;
 pub mod grouper;
 pub mod header;
@@ -172,9 +175,11 @@ pub use umi::assigner;
 
 // Re-export consensus items for backward compatibility
 pub use consensus::caller as consensus_caller;
+#[cfg(feature = "duplex")]
 pub use consensus::duplex_caller as duplex_consensus_caller;
 pub use consensus::filter as consensus_filter;
 pub use consensus::overlapping as overlapping_consensus;
 pub use consensus::simple_umi as simple_umi_consensus;
 pub use consensus::tags as consensus_tags;
+#[cfg(feature = "simplex")]
 pub use consensus::vanilla_caller as vanilla_consensus_caller;

--- a/crates/fgumi-lib/src/sort/mod.rs
+++ b/crates/fgumi-lib/src/sort/mod.rs
@@ -42,12 +42,13 @@ pub mod radix;
 pub mod raw;
 pub mod raw_bam_reader;
 pub mod read_ahead;
+pub mod sink;
 
 /// Buffer size for `BufReader` during merge phase.
 const MERGE_BUFFER_SIZE: usize = 64 * 1024;
 
 /// Statistics from a sort operation.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct SortStats {
     /// Total records read from input.
     pub total_records: u64,
@@ -140,7 +141,11 @@ pub use keys::{
     SortOrder, natural_compare, normalize_natural_key,
 };
 pub use pipeline::{ParallelMergeConfig, parallel_merge, parallel_merge_buffered};
-pub use raw::{LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline};
+pub use raw::{
+    LibraryLookup, RawExternalSorter, SortedChunks, cb_hasher, extract_template_key_inline,
+    merge_sorted_chunks_to_sink,
+};
+pub use sink::{BamWriterSink, SortedRecordSink};
 
 #[cfg(test)]
 mod tests {
@@ -199,7 +204,7 @@ mod tests {
             .expect("valid header");
         let header = Header::builder().set_header(hd).build();
 
-        // Re-sort as coordinate — GO and SS should be removed.
+        // Re-sort as coordinate -- GO and SS should be removed.
         let output = create_output_header(keys::SortOrder::Coordinate, &header);
 
         let hd = output.header().expect("should have @HD");

--- a/crates/fgumi-lib/src/sort/raw.rs
+++ b/crates/fgumi-lib/src/sort/raw.rs
@@ -18,9 +18,9 @@
 //! 4. Write raw record bytes to output
 
 use crate::bam_io::create_raw_bam_reader;
-use crate::progress::ProgressTracker;
 use crate::sort::inline_buffer::{RecordBuffer, TemplateKey, TemplateRecordBuffer};
-use crate::sort::keys::{QuerynameComparator, SortOrder};
+use crate::sort::keys::SortOrder;
+use crate::sort::radix::{heap_make, heap_sift_down};
 use crate::sort::read_ahead::RawReadAheadReader;
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, bounded};
@@ -31,6 +31,7 @@ use noodles_bgzf::io::{
     MultithreadedWriter, Reader as BgzfReader, Writer as BgzfWriter, multithreaded_writer,
     writer::CompressionLevel,
 };
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::num::NonZero;
@@ -42,20 +43,6 @@ use tempfile::TempDir;
 // ============================================================================
 // Library Lookup for Template-Coordinate Sort
 // ============================================================================
-
-/// Deterministic hasher for cell barcode hashing in template-coordinate sort.
-///
-/// Uses arbitrary fixed seeds so that hash values are reproducible across runs.
-#[must_use]
-pub fn cb_hasher() -> ahash::RandomState {
-    // Arbitrary fixed seeds — chosen for uniqueness, not cryptographic strength.
-    ahash::RandomState::with_seeds(
-        0xa1b2_c3d4_e5f6_0718,
-        0x9182_7364_5546_3728,
-        0xfede_dcba_0987_6543,
-        0x0011_2233_4455_6677,
-    )
-}
 
 /// Maps read group ID -> library ordinal for O(1) comparison.
 ///
@@ -109,7 +96,6 @@ impl LibraryLookup {
             })
             .collect();
 
-        // Arbitrary fixed seeds — chosen for uniqueness, not cryptographic strength.
         let hasher = ahash::RandomState::with_seeds(
             0x517c_c1b7_2722_0a95,
             0x1234_5678_90ab_cdef,
@@ -128,23 +114,13 @@ impl LibraryLookup {
     }
 
     /// Get library ordinal for a record (from RG tag in aux data).
-    ///
-    /// Only used in tests; production code uses [`ordinal_from_rg`](Self::ordinal_from_rg)
-    /// with pre-extracted RG bytes from the single-pass aux scan.
-    #[cfg(test)]
+    #[inline]
     #[must_use]
     pub fn get_ordinal(&self, bam: &[u8]) -> u32 {
         fgumi_raw_bam::tags::find_string_tag_in_record(bam, b"RG")
             .and_then(|rg| self.rg_to_ordinal.get(rg))
             .copied()
             .unwrap_or(0)
-    }
-
-    /// Get library ordinal from pre-extracted RG tag bytes.
-    #[inline]
-    #[must_use]
-    pub fn ordinal_from_rg(&self, rg: Option<&[u8]>) -> u32 {
-        rg.and_then(|rg| self.rg_to_ordinal.get(rg)).copied().unwrap_or(0)
     }
 }
 
@@ -158,17 +134,27 @@ const DEFAULT_MAX_TEMP_FILES: usize = 64;
 
 /// Counting semaphore for limiting concurrent chunk reader I/O.
 /// Pre-filled with N tokens; readers acquire before decompressing, release after.
-pub(crate) type ChunkReaderSemaphore = (Sender<()>, Receiver<()>);
+type ChunkReaderSemaphore = (Sender<()>, Receiver<()>);
 
 /// Create a counting semaphore that allows `threads` concurrent readers.
-pub(crate) fn make_reader_semaphore(threads: usize) -> Arc<ChunkReaderSemaphore> {
+fn make_reader_semaphore(threads: usize) -> Arc<ChunkReaderSemaphore> {
     let limit = threads.max(1);
     let (tx, rx) = bounded(limit);
     for _ in 0..limit {
-        tx.send(()).expect("semaphore channel must not be disconnected during initialization");
+        tx.send(()).unwrap();
     }
     Arc::new((tx, rx))
 }
+
+/// Estimated bytes per record in the template record buffer.
+///
+/// Includes 48-byte inline header + ~250 bytes average record data (298 bytes data)
+/// plus 56 bytes for the `TemplateKey` ref entry (key + offset + len + pad).
+const TEMPLATE_RECORD_BYTES_ESTIMATE: usize = 354;
+
+/// Fraction of memory budget (as percentage) allocated to raw record data
+/// vs. ref/index overhead. The remaining ~14% covers the per-record ref entries.
+const TEMPLATE_DATA_FRACTION_PERCENT: usize = 86;
 
 // ============================================================================
 // Generic Keyed Temp File I/O (works with any RawSortKey)
@@ -269,9 +255,8 @@ impl<K: RawSortKey> GenericKeyedChunkWriter<K> {
         } else {
             // Single-threaded BGZF with specified compression level
             #[allow(clippy::cast_possible_truncation)]
-            let level = CompressionLevel::new(compression_level as u8).unwrap_or_else(|| {
-                CompressionLevel::new(6).expect("compression level 6 is always valid")
-            });
+            let level = CompressionLevel::new(compression_level as u8)
+                .unwrap_or_else(|| CompressionLevel::new(6).unwrap());
             let writer = noodles_bgzf::io::writer::Builder::default()
                 .set_compression_level(level)
                 .build_from_writer(buf);
@@ -283,19 +268,13 @@ impl<K: RawSortKey> GenericKeyedChunkWriter<K> {
 
     /// Write a keyed record.
     ///
-    /// When `K::EMBEDDED_IN_RECORD` is true, the key is embedded in the record
-    /// bytes so only the record is written. Otherwise, the key prefix is written
-    /// followed by the record.
-    ///
     /// # Errors
     ///
     /// Returns an error if writing to the underlying writer fails.
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
     pub fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
-        if !K::EMBEDDED_IN_RECORD {
-            key.write_to(&mut self.writer)?;
-        }
+        key.write_to(&mut self.writer)?;
         self.writer.write_all(&(record.len() as u32).to_le_bytes())?;
         self.writer.write_all(record)?;
         Ok(())
@@ -311,45 +290,12 @@ impl<K: RawSortKey> GenericKeyedChunkWriter<K> {
     }
 }
 
-/// Result of reading a keyed record from a chunk: `Ok(Some(...))` for a record,
-/// `Ok(None)` for EOF, or `Err(...)` for an I/O error.
-type ChunkReadResult<K> = Result<Option<(K, Vec<u8>)>>;
-
-/// Read exactly `buf.len()` bytes, distinguishing clean EOF from truncation.
-///
-/// Returns `Ok(true)` when `buf` is fully filled, `Ok(false)` when zero bytes are
-/// available (clean EOF), and `Err` for any partial read or I/O error.
-fn read_exact_or_eof<R: Read>(reader: &mut R, buf: &mut [u8]) -> std::io::Result<bool> {
-    let mut offset = 0;
-    while offset < buf.len() {
-        match reader.read(&mut buf[offset..]) {
-            Ok(0) => {
-                return if offset == 0 {
-                    Ok(false) // clean EOF
-                } else {
-                    Err(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        format!("truncated chunk: read {} of {} bytes", offset, buf.len()),
-                    ))
-                };
-            }
-            Ok(n) => offset += n,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(true)
-}
-
 /// Generic reader for keyed temp chunks with background prefetching.
 ///
 /// Works with any type implementing `RawSortKey`.
 /// Auto-detects BGZF compression via magic bytes.
 pub struct GenericKeyedChunkReader<K: RawSortKey + 'static> {
-    receiver: Receiver<ChunkReadResult<K>>,
-    /// Return channel for empty buffers — the consumer sends its old buffer
-    /// back so the producer can reuse the allocation instead of allocating.
-    buf_return: Sender<Vec<u8>>,
+    receiver: Receiver<Option<(K, Vec<u8>)>>,
     _handle: JoinHandle<()>,
 }
 
@@ -366,21 +312,18 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
     /// Returns an error if the file cannot be opened.
     pub fn open(path: &Path, concurrency_limit: Option<Arc<ChunkReaderSemaphore>>) -> Result<Self> {
         let (tx, rx) = bounded(MERGE_PREFETCH_SIZE);
-        let (buf_tx, buf_rx) = bounded::<Vec<u8>>(MERGE_PREFETCH_SIZE);
         let path = path.to_path_buf();
 
         let handle = thread::spawn(move || {
             let file = match std::fs::File::open(&path) {
                 Ok(f) => f,
                 Err(e) => {
-                    let _ = tx.send(Err(anyhow::anyhow!(
-                        "Failed to open keyed chunk {}: {e}",
-                        path.display()
-                    )));
+                    log::error!("Failed to open keyed chunk {}: {}", path.display(), e);
+                    let _ = tx.send(None);
                     return;
                 }
             };
-            let mut buf_reader = BufReader::with_capacity(2 * 1024 * 1024, file);
+            let mut buf_reader = BufReader::with_capacity(256 * 1024, file);
 
             // Check for gzip/BGZF magic bytes: 0x1f 0x8b
             let mut magic = [0u8; 2];
@@ -392,21 +335,21 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 
             // Seek back to start
             if buf_reader.seek(SeekFrom::Start(0)).is_err() {
-                let _ = tx
-                    .send(Err(anyhow::anyhow!("Failed to seek in keyed chunk {}", path.display())));
+                log::error!("Failed to seek in keyed chunk {}", path.display());
+                let _ = tx.send(None);
                 return;
             }
 
             // Read using appropriate decoder
             if is_compressed {
                 let bgzf_reader = BgzfReader::new(buf_reader);
-                Self::read_records(bgzf_reader, tx, buf_rx, concurrency_limit);
+                Self::read_records(bgzf_reader, tx, concurrency_limit);
             } else {
-                Self::read_records(buf_reader, tx, buf_rx, concurrency_limit);
+                Self::read_records(buf_reader, tx, concurrency_limit);
             }
         });
 
-        Ok(Self { receiver: rx, buf_return: buf_tx, _handle: handle })
+        Ok(Self { receiver: rx, _handle: handle })
     }
 
     /// Read records from a reader and send them through the channel.
@@ -418,8 +361,7 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
     #[allow(clippy::needless_pass_by_value)]
     fn read_records<R: Read>(
         mut reader: R,
-        tx: crossbeam_channel::Sender<ChunkReadResult<K>>,
-        buf_pool: crossbeam_channel::Receiver<Vec<u8>>,
+        tx: crossbeam_channel::Sender<Option<(K, Vec<u8>)>>,
         semaphore: Option<Arc<ChunkReaderSemaphore>>,
     ) {
         const BATCH_SIZE: usize = 64;
@@ -432,67 +374,38 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 
             let mut batch: Vec<(K, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
             let mut eof = false;
-            let mut read_error: Option<String> = None;
+            let mut error = false;
 
             for _ in 0..BATCH_SIZE {
-                if K::EMBEDDED_IN_RECORD {
-                    // Keyless format: read record, extract key from BAM bytes.
-                    let mut len_buf = [0u8; 4];
-                    match read_exact_or_eof(&mut reader, &mut len_buf) {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            eof = true;
-                            break;
-                        }
-                        Err(e) => {
-                            read_error = Some(format!("Error reading chunk record length: {e}"));
-                            break;
-                        }
-                    }
-                    let len = u32::from_le_bytes(len_buf) as usize;
-                    let mut record = buf_pool.try_recv().unwrap_or_default();
-                    record.clear();
-                    record.resize(len, 0);
-                    if let Err(e) = reader.read_exact(&mut record) {
-                        read_error = Some(format!("Error reading chunk record: {e}"));
+                let key = match K::read_from(&mut reader) {
+                    Ok(k) => k,
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        eof = true;
                         break;
                     }
-                    let key = K::extract_from_record(&record);
-                    batch.push((key, record));
-                } else {
-                    // Keyed format: read key prefix, then record.
-                    let key = match K::read_from(&mut reader) {
-                        Ok(k) => k,
-                        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                            eof = true;
-                            break;
-                        }
-                        Err(e) => {
-                            read_error = Some(format!("Error reading keyed chunk key: {e}"));
-                            break;
-                        }
-                    };
-
-                    let mut len_buf = [0u8; 4];
-                    match reader.read_exact(&mut len_buf) {
-                        Ok(()) => {}
-                        Err(e) => {
-                            read_error = Some(format!("Error reading keyed chunk length: {e}"));
-                            break;
-                        }
-                    }
-                    let len = u32::from_le_bytes(len_buf) as usize;
-
-                    let mut record = buf_pool.try_recv().unwrap_or_default();
-                    record.clear();
-                    record.resize(len, 0);
-                    if let Err(e) = reader.read_exact(&mut record) {
-                        read_error = Some(format!("Error reading keyed chunk record: {e}"));
+                    Err(e) => {
+                        log::error!("Error reading keyed chunk key: {e}");
+                        error = true;
                         break;
                     }
+                };
 
-                    batch.push((key, record));
+                let mut len_buf = [0u8; 4];
+                if reader.read_exact(&mut len_buf).is_err() {
+                    log::error!("Error reading keyed chunk length");
+                    error = true;
+                    break;
                 }
+                let len = u32::from_le_bytes(len_buf) as usize;
+
+                let mut record = vec![0u8; len];
+                if reader.read_exact(&mut record).is_err() {
+                    log::error!("Error reading keyed chunk record");
+                    error = true;
+                    break;
+                }
+
+                batch.push((key, record));
             }
 
             // Phase 2: Release token before any blocking channel sends.
@@ -502,89 +415,23 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 
             // Phase 3: Send the batch through the channel (may block).
             for record in batch {
-                if tx.send(Ok(Some(record))).is_err() {
+                if tx.send(Some(record)).is_err() {
                     return; // Receiver dropped
                 }
             }
 
-            if let Some(msg) = read_error {
-                let _ = tx.send(Err(anyhow::anyhow!("{msg}")));
-                break;
-            }
-
-            if eof {
-                let _ = tx.send(Ok(None));
+            if eof || error {
+                let _ = tx.send(None);
                 break;
             }
         }
     }
 
-    /// Read the next keyed record from the prefetch buffer into `buf`.
-    ///
-    /// On success the record bytes are swapped into `buf` and the sort key is
-    /// returned. The old contents of `buf` are returned to the producer thread
-    /// for reuse, avoiding per-record allocation on the disk path.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the background reader encountered an I/O error.
-    pub fn next_record(&mut self, buf: &mut Vec<u8>) -> Result<Option<K>> {
+    /// Read the next keyed record from the prefetch buffer.
+    pub fn next_record(&mut self) -> Option<(K, Vec<u8>)> {
         match self.receiver.recv() {
-            Ok(Ok(Some((key, mut data)))) => {
-                std::mem::swap(buf, &mut data);
-                // Return the old buffer to the producer for reuse.
-                let _ = self.buf_return.try_send(data);
-                Ok(Some(key))
-            }
-            Ok(Ok(None)) => Ok(None),
-            Ok(Err(e)) => Err(e),
-            // Channel disconnected — the producer thread panicked or was dropped
-            // without sending an EOF sentinel. Treat as an error, not clean EOF.
-            Err(_) => Err(anyhow::anyhow!("chunk reader thread terminated unexpectedly")),
-        }
-    }
-
-    /// Try to read the next record without blocking.
-    ///
-    /// Returns `Some(Ok(Some(...)))` if a record is available, `Some(Ok(None))` if the
-    /// stream is exhausted, `Some(Err(...))` on read error, or `None` if no record is
-    /// currently available (channel empty).
-    pub fn try_next_record(&mut self) -> Option<ChunkReadResult<K>> {
-        match self.receiver.try_recv() {
-            Ok(result) => Some(result),
-            Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                Some(Err(anyhow::anyhow!("chunk reader thread terminated unexpectedly")))
-            }
-            Err(crossbeam_channel::TryRecvError::Empty) => None,
-        }
-    }
-}
-
-/// Source for keyed chunks during merge (disk or in-memory).
-enum ChunkSource<K: RawSortKey + Default + 'static> {
-    /// Disk-based chunk with prefetching reader.
-    Disk(GenericKeyedChunkReader<K>),
-    /// In-memory sorted records.
-    Memory { records: Vec<(K, Vec<u8>)>, idx: usize },
-}
-
-impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
-    /// Fill `buf` with the next record's bytes and return the sort key,
-    /// or `None` at EOF.
-    fn next_record(&mut self, buf: &mut Vec<u8>) -> Result<Option<K>> {
-        match self {
-            ChunkSource::Disk(reader) => reader.next_record(buf),
-            ChunkSource::Memory { records, idx } => {
-                if *idx < records.len() {
-                    let (ref mut key, ref mut data) = records[*idx];
-                    std::mem::swap(buf, data);
-                    let key = std::mem::take(key);
-                    *idx += 1;
-                    Ok(Some(key))
-                } else {
-                    Ok(None)
-                }
-            }
+            Ok(Some(entry)) => Some(entry),
+            Ok(None) | Err(_) => None,
         }
     }
 }
@@ -754,7 +601,11 @@ impl RawExternalSorter {
         chunk_files: &mut Vec<PathBuf>,
         namer: &mut ChunkNamer<'_>,
     ) -> Result<()> {
-        use crate::sort::loser_tree::LoserTree;
+        struct HeapEntry<K> {
+            key: K,
+            record: Vec<u8>,
+            reader_idx: usize,
+        }
 
         if self.max_temp_files == 0 || chunk_files.len() < self.max_temp_files {
             return Ok(());
@@ -792,21 +643,16 @@ impl RawExternalSorter {
             self.threads,
         )?;
 
-        // Initialize loser tree with first record from each reader
-        let mut initial_keys: Vec<K> = Vec::with_capacity(readers.len());
-        let mut records: Vec<Vec<u8>> = Vec::with_capacity(readers.len());
-        let mut source_map: Vec<usize> = Vec::with_capacity(readers.len());
-
+        // Initialize heap with first record from each reader
+        let mut heap: Vec<HeapEntry<K>> = Vec::with_capacity(readers.len());
         for (reader_idx, reader) in readers.iter_mut().enumerate() {
-            let mut record = Vec::new();
-            if let Some(key) = reader.next_record(&mut record)? {
-                initial_keys.push(key);
-                records.push(record);
-                source_map.push(reader_idx);
+            if let Some((key, record)) = reader.next_record() {
+                heap.push(HeapEntry { key, record, reader_idx });
             }
         }
 
-        if initial_keys.is_empty() {
+        let mut heap_size = heap.len();
+        if heap_size == 0 {
             writer.finish()?;
             // Insert at beginning to preserve stable order
             chunk_files.insert(0, merged_path);
@@ -817,17 +663,31 @@ impl RawExternalSorter {
             return Ok(());
         }
 
-        let mut tree = LoserTree::new(initial_keys);
+        // Use chunk_idx as tie-breaker for stable merge
+        let lt = |a: &HeapEntry<K>, b: &HeapEntry<K>| -> bool {
+            a.key.cmp(&b.key).then_with(|| a.reader_idx.cmp(&b.reader_idx)) == Ordering::Greater
+        };
 
-        while tree.winner_is_active() {
-            let winner = tree.winner();
-            let reader_idx = source_map[winner];
-            writer.write_record(tree.winner_key(), &records[winner])?;
+        heap_make(&mut heap, &lt);
 
-            if let Some(next_key) = readers[reader_idx].next_record(&mut records[winner])? {
-                tree.replace_winner(next_key);
+        // Merge loop
+        while heap_size > 0 {
+            let reader_idx = heap[0].reader_idx;
+            let key = std::mem::take(&mut heap[0].key);
+            let record = std::mem::take(&mut heap[0].record);
+
+            writer.write_record(&key, &record)?;
+
+            if let Some((next_key, next_record)) = readers[reader_idx].next_record() {
+                heap[0].key = next_key;
+                heap[0].record = next_record;
+                heap_sift_down(&mut heap, 0, heap_size, &lt);
             } else {
-                tree.remove_winner();
+                heap_size -= 1;
+                if heap_size > 0 {
+                    heap.swap(0, heap_size);
+                    heap_sift_down(&mut heap, 0, heap_size, &lt);
+                }
             }
         }
 
@@ -857,7 +717,6 @@ impl RawExternalSorter {
         info!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
         info!("Threads: {}", self.threads);
 
-        // Open input BAM with lazy record reading
         let (reader, header) = create_raw_bam_reader(input, self.threads)?;
 
         // Add @PG record if pg_info was provided
@@ -867,7 +726,6 @@ impl RawExternalSorter {
             header
         };
 
-        // Create temp directory
         let temp_dir = self.create_temp_dir()?;
         let temp_path = temp_dir.path();
 
@@ -893,10 +751,7 @@ impl RawExternalSorter {
     /// Returns an error if any input cannot be opened, or writing fails.
     pub fn merge_bams(&self, inputs: &[PathBuf], header: &Header, output: &Path) -> Result<u64> {
         use crate::sort::inline_buffer::extract_coordinate_key_inline;
-        use crate::sort::keys::{
-            QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
-            SortContext,
-        };
+        use crate::sort::keys::{RawCoordinateKey, RawQuerynameKey, RawSortKey, SortContext};
 
         info!("Starting k-way merge of {} BAM files", inputs.len());
 
@@ -919,13 +774,7 @@ impl RawExternalSorter {
                     sort_key: extract_coordinate_key_inline(bam, nref),
                 })
             }
-            SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
-                let ctx = SortContext::from_header(header);
-                self.run_merge_loop(&mut readers, &output_header, output, |bam| {
-                    RawQuerynameLexKey::extract(bam, &ctx)
-                })
-            }
-            SortOrder::Queryname(QuerynameComparator::Natural) => {
+            SortOrder::Queryname(_) => {
                 let ctx = SortContext::from_header(header);
                 self.run_merge_loop(&mut readers, &output_header, output, |bam| {
                     RawQuerynameKey::extract(bam, &ctx)
@@ -946,9 +795,6 @@ impl RawExternalSorter {
     }
 
     /// K-way merge loop: extract keys on the merge thread, write to output.
-    ///
-    /// Uses reusable per-source record buffers to avoid per-record heap
-    /// allocations during the merge.
     fn run_merge_loop<K: Ord>(
         &self,
         readers: &mut [RawReadAheadReader],
@@ -958,18 +804,18 @@ impl RawExternalSorter {
     ) -> Result<u64> {
         use crate::sort::loser_tree::LoserTree;
 
-        // Initialize: collect first record + key from each reader using
-        // reusable per-source buffers (one allocation per source, not per record).
+        const OUTPUT_BUFFER_SIZE: usize = 2048;
+
+        // Initialize: collect first record + key from each reader
         let mut initial_keys: Vec<K> = Vec::with_capacity(readers.len());
         let mut records: Vec<Vec<u8>> = Vec::with_capacity(readers.len());
         let mut source_map: Vec<usize> = Vec::with_capacity(readers.len());
 
         for (idx, reader) in readers.iter_mut().enumerate() {
             if let Some(raw_record) = reader.next() {
-                let mut buf = Vec::with_capacity(raw_record.as_ref().len());
-                buf.extend_from_slice(raw_record.as_ref());
-                initial_keys.push(extract_key(&buf));
-                records.push(buf);
+                let record_bytes = raw_record.as_ref().to_vec();
+                initial_keys.push(extract_key(&record_bytes));
+                records.push(record_bytes);
                 source_map.push(idx);
             }
         }
@@ -987,6 +833,7 @@ impl RawExternalSorter {
         }
 
         let mut tree = LoserTree::new(initial_keys);
+        let k = tree.len();
 
         let mut writer = crate::bam_io::create_raw_bam_writer(
             output,
@@ -996,30 +843,40 @@ impl RawExternalSorter {
         )?;
 
         let mut records_merged = 0u64;
-        let merge_progress = ProgressTracker::new("Merged records").with_interval(1_000_000);
+        let mut output_buffer: Vec<Vec<u8>> = Vec::with_capacity(OUTPUT_BUFFER_SIZE);
 
         while tree.winner_is_active() {
             let winner = tree.winner();
+            let record_bytes = std::mem::take(&mut records[winner]);
 
-            writer.write_raw_record(&records[winner])?;
+            output_buffer.push(record_bytes);
             records_merged += 1;
-            merge_progress.log_if_needed(1);
 
+            if output_buffer.len() >= OUTPUT_BUFFER_SIZE {
+                for rec in output_buffer.drain(..) {
+                    writer.write_raw_record(&rec)?;
+                }
+            }
+
+            // Fetch next record from the same source
             let reader_idx = source_map[winner];
             if let Some(raw_record) = readers[reader_idx].next() {
-                let buf = &mut records[winner];
-                buf.clear();
-                buf.extend_from_slice(raw_record.as_ref());
-                let new_key = extract_key(buf);
+                let next_rec = raw_record.as_ref().to_vec();
+                let new_key = extract_key(&next_rec);
+                records[winner] = next_rec;
                 tree.replace_winner(new_key);
             } else {
                 tree.remove_winner();
             }
         }
 
-        writer.finish()?;
-        merge_progress.log_final();
+        for rec in output_buffer {
+            writer.write_raw_record(&rec)?;
+        }
 
+        writer.finish()?;
+
+        info!("Merge complete: {records_merged} records merged (loser tree, k={k})",);
         Ok(records_merged)
     }
 
@@ -1066,12 +923,10 @@ impl RawExternalSorter {
 
         let read_ahead = RawReadAheadReader::new(reader);
 
-        let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
 
         for record in read_ahead {
             stats.total_records += 1;
-            progress.log_if_needed(1);
 
             // Push directly to buffer - key extracted inline from raw bytes
             buffer.push_coordinate(record.as_ref());
@@ -1113,7 +968,7 @@ impl RawExternalSorter {
             }
         }
 
-        progress.log_final();
+        info!("Read {} records total", stats.total_records);
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
@@ -1169,7 +1024,6 @@ impl RawExternalSorter {
                 memory_chunks,
                 header,
                 output,
-                stats.total_records,
             )?;
         }
 
@@ -1310,7 +1164,6 @@ impl RawExternalSorter {
                 memory_chunks,
                 header,
                 output,
-                stats.total_records,
             )?;
 
             // Write the index file
@@ -1327,7 +1180,8 @@ impl RawExternalSorter {
 
     /// Sort by queryname order using keyed temp files for O(1) merge comparisons.
     ///
-    /// Dispatches to the appropriate key type based on the comparator:
+    /// Dispatches to lexicographic or natural queryname sort based on comparator.
+    ///
     /// - `Lexicographic`: uses `RawQuerynameLexKey` (byte comparison)
     /// - `Natural`: uses `RawQuerynameKey` (natural numeric comparison)
     fn sort_queryname(
@@ -1336,9 +1190,9 @@ impl RawExternalSorter {
         header: &Header,
         output: &Path,
         temp_path: &Path,
-        comparator: QuerynameComparator,
+        comparator: crate::sort::keys::QuerynameComparator,
     ) -> Result<RawSortStats> {
-        use crate::sort::keys::{RawQuerynameKey, RawQuerynameLexKey};
+        use crate::sort::keys::{QuerynameComparator, RawQuerynameKey, RawQuerynameLexKey};
         info!("Using queryname sort with {comparator} comparator");
         match comparator {
             QuerynameComparator::Lexicographic => {
@@ -1351,7 +1205,7 @@ impl RawExternalSorter {
     }
 
     /// Generic queryname sort using a specific key type.
-    fn sort_queryname_keyed<K: RawSortKey + Default + 'static>(
+    fn sort_queryname_keyed<K: crate::sort::keys::RawSortKey + Default + 'static>(
         &self,
         reader: crate::bam_io::RawBamReaderAuto,
         header: &Header,
@@ -1373,19 +1227,17 @@ impl RawExternalSorter {
 
         let read_ahead = RawReadAheadReader::new(reader);
 
-        let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (keyed output)...");
 
         for record in read_ahead {
             stats.total_records += 1;
-            progress.log_if_needed(1);
 
             // Extract key from raw bytes
             let bam_bytes = record.as_ref();
             let key = K::extract(bam_bytes, &ctx);
 
             // Estimate memory: record bytes + key overhead
-            let record_size = bam_bytes.len() + 50; // approximate key size
+            let record_size = bam_bytes.len() + 50;
             memory_used += record_size;
 
             entries.push((key, bam_bytes.to_vec()));
@@ -1423,7 +1275,7 @@ impl RawExternalSorter {
             }
         }
 
-        progress.log_final();
+        info!("Read {} records total", stats.total_records);
 
         if chunk_files.is_empty() {
             // All records fit in memory
@@ -1477,13 +1329,7 @@ impl RawExternalSorter {
             );
 
             // Merge disk chunks + in-memory records using keyed comparisons
-            self.merge_chunks_generic::<K>(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            self.merge_chunks_generic::<K>(&chunk_files, memory_chunks, header, output)?;
         }
 
         stats.output_records = stats.total_records;
@@ -1506,59 +1352,255 @@ impl RawExternalSorter {
         output: &Path,
         temp_path: &Path,
     ) -> Result<RawSortStats> {
-        let mut stats = RawSortStats::default();
+        let output_header = self.create_output_header(header);
+        let writer = crate::bam_io::create_raw_bam_writer(
+            output,
+            &output_header,
+            self.threads,
+            self.output_compression,
+        )?;
+        let mut sink = super::sink::BamWriterSink::new(writer);
 
-        // Build library lookup ONCE before sorting for O(1) ordinal lookups
+        let stats = self.sort_template_coordinate_to_sink_inner(
+            RawReadAheadReader::new(reader),
+            header,
+            temp_path,
+            &mut sink,
+        )?;
+
+        Ok(stats)
+    }
+
+    /// Sort a BAM file by template-coordinate and emit records to a sink.
+    ///
+    /// Like [`sort_template_coordinate`](Self::sort_template_coordinate) but writes sorted records
+    /// to a [`SortedRecordSink`](super::sink::SortedRecordSink) instead of a BAM file. Each
+    /// record is emitted with its pre-computed [`TemplateKey`] for downstream processing.
+    ///
+    /// Internally delegates to [`sort_accumulate_template`](Self::sort_accumulate_template) +
+    /// [`merge_sorted_chunks_to_sink`] so that callers who need to split the two phases can
+    /// use those methods directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading, sorting, or emitting records fails.
+    pub fn sort_template_to_sink(
+        &self,
+        input: &Path,
+        header: &Header,
+        sink: &mut dyn super::sink::SortedRecordSink,
+    ) -> Result<RawSortStats> {
+        let chunks = self.sort_accumulate_template(input, header)?;
+        let stats = chunks.stats.clone();
+        merge_sorted_chunks_to_sink(chunks, sink)?;
+        sink.finish()?;
+        info!("Sort complete: {} records processed", stats.total_records);
+        Ok(stats)
+    }
+
+    /// Sort records from an iterator by template-coordinate and emit to a sink.
+    ///
+    /// Like [`sort_template_to_sink`](Self::sort_template_to_sink) but accepts raw BAM bytes from
+    /// an iterator instead of reading from a file. Used for pipeline integration where
+    /// records come from an upstream stage in memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if sorting or emitting records fails.
+    pub fn sort_from_iter<I>(
+        &self,
+        records: I,
+        header: &Header,
+        sink: &mut dyn super::sink::SortedRecordSink,
+    ) -> Result<RawSortStats>
+    where
+        I: Iterator<Item = Vec<u8>>,
+    {
+        let temp_dir = self.create_temp_dir()?;
+
+        self.sort_template_coordinate_to_sink_inner(records, header, temp_dir.path(), sink)
+    }
+
+    /// Sort-accumulate phase only: read input BAM, sort chunks to disk/memory.
+    ///
+    /// Performs Phase 1 of the external merge-sort (read, chunk, sort, spill) without
+    /// the K-way merge.  Returns a [`SortedChunks`] that the caller can merge later
+    /// — for example on a separate feeder thread while the calling thread participates
+    /// in downstream work-stealing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading or sorting records fails.
+    pub fn sort_accumulate_template(&self, input: &Path, header: &Header) -> Result<SortedChunks> {
+        let (reader, _input_header) = create_raw_bam_reader(input, self.threads)?;
+        let read_ahead = RawReadAheadReader::new(reader);
+        self.sort_accumulate_inner(read_ahead, header)
+    }
+
+    /// Sort-accumulate phase from an iterator of raw BAM record bytes.
+    ///
+    /// Like [`sort_accumulate_template`](Self::sort_accumulate_template) but takes records
+    /// from an iterator instead of reading from a BAM file. Returns sorted chunks for
+    /// later merging via [`merge_sorted_chunks_to_sink`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if sorting records fails.
+    pub fn sort_accumulate_from_iter(
+        &self,
+        records: impl Iterator<Item = impl AsRef<[u8]>>,
+        header: &Header,
+    ) -> Result<SortedChunks> {
+        self.sort_accumulate_inner(records, header)
+    }
+
+    /// Shared accumulate logic for both file-based and iterator-based sort-accumulate.
+    ///
+    /// Reads records from the iterator, sorts them into chunks on disk/memory, and
+    /// returns `SortedChunks` without performing the K-way merge phase.
+    fn sort_accumulate_inner(
+        &self,
+        records: impl Iterator<Item = impl AsRef<[u8]>>,
+        header: &Header,
+    ) -> Result<SortedChunks> {
+        let temp_dir = self.create_temp_dir()?;
+        let temp_path = temp_dir.path();
+
         let lib_lookup = LibraryLookup::from_header(header);
-        let cb_hasher = cb_hasher();
-
-        // Estimate capacity accounting for inline headers and cached-key refs
-        // Memory layout per record:
-        //   - data: 48 bytes (inline header) + ~250 bytes (BAM record) = 298 bytes
-        //   - refs: 56 bytes (TemplateKey + u64 offset + u32 len + u32 pad)
-        //   - Total: ~354 bytes per record
-        // The larger refs trade memory for cache locality during sort
-        let bytes_per_record = 354;
-        let estimated_records = self.memory_limit / bytes_per_record;
-        // Allocate ~86% for data, ~14% for refs (48/338 ≈ 14%)
-        let estimated_data_bytes = self.memory_limit * 86 / 100;
+        let hasher = cb_hasher();
+        let estimated_records = self.memory_limit / TEMPLATE_RECORD_BYTES_ESTIMATE;
+        let estimated_data_bytes = self.memory_limit * TEMPLATE_DATA_FRACTION_PERCENT / 100;
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer =
             TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
         let mut namer = ChunkNamer::new(temp_path);
+        let mut stats = RawSortStats::default();
 
-        let read_ahead = RawReadAheadReader::new(reader);
+        info!("Phase 1 (accumulate): Reading and sorting chunks (inline buffer)...");
 
-        let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
-        info!("Phase 1: Reading and sorting chunks (inline buffer)...");
-
-        for record in read_ahead {
+        for record in records {
             stats.total_records += 1;
-            progress.log_if_needed(1);
 
-            // Extract template key and push to buffer
             let bam_bytes = record.as_ref();
             let key = extract_template_key_inline(
                 bam_bytes,
                 &lib_lookup,
                 self.cell_tag.as_ref(),
-                &cb_hasher,
+                &hasher,
             );
             buffer.push(bam_bytes, key);
 
-            // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
                 let chunk_path = namer.next_chunk_path();
 
-                // Sort in place using parallel sort for large buffers
                 if self.threads > 1 {
                     buffer.par_sort();
                 } else {
                     buffer.sort();
                 }
 
-                // Write keyed chunk preserving sort keys for O(1) merge comparisons
+                let mut keyed_writer = GenericKeyedChunkWriter::<TemplateKey>::create(
+                    &chunk_path,
+                    self.temp_compression,
+                    self.threads,
+                )?;
+                for (key, record) in buffer.iter_sorted_keyed() {
+                    keyed_writer.write_record(&key, record)?;
+                }
+                keyed_writer.finish()?;
+
+                stats.chunks_written += 1;
+                chunk_files.push(chunk_path);
+
+                self.maybe_consolidate_temp_files::<TemplateKey>(&mut chunk_files, &mut namer)?;
+                buffer.clear();
+            }
+        }
+
+        info!("Accumulate phase read {} records total", stats.total_records);
+
+        // Sort the remaining in-memory buffer into memory chunks.
+        let memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>> = if buffer.is_empty() {
+            Vec::new()
+        } else if chunk_files.is_empty() {
+            // All records fit in memory — produce a single memory chunk.
+            if self.threads > 1 {
+                buffer.par_sort();
+            } else {
+                buffer.sort();
+            }
+            let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
+            vec![chunk]
+        } else {
+            // Spill happened — split remaining buffer into sub-array chunks.
+            if self.threads > 1 {
+                buffer.par_sort_into_chunks(self.threads)
+            } else {
+                buffer.sort();
+                let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
+                vec![chunk]
+            }
+        };
+
+        stats.output_records = stats.total_records;
+
+        Ok(SortedChunks { chunk_files, memory_chunks, stats, _temp_dir: temp_dir })
+    }
+
+    /// Core implementation for template-coordinate sort-to-sink.
+    ///
+    /// Both [`sort_template_to_sink`](Self::sort_template_to_sink) and
+    /// [`sort_from_iter`](Self::sort_from_iter) delegate to this method.
+    /// `sort_template_coordinate` also delegates here using a `BamWriterSink`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading, sorting, or emitting records fails.
+    fn sort_template_coordinate_to_sink_inner(
+        &self,
+        records: impl Iterator<Item = impl AsRef<[u8]>>,
+        header: &Header,
+        temp_path: &Path,
+        sink: &mut dyn super::sink::SortedRecordSink,
+    ) -> Result<RawSortStats> {
+        let mut stats = RawSortStats::default();
+
+        // Build library lookup ONCE before sorting for O(1) ordinal lookups
+        let lib_lookup = LibraryLookup::from_header(header);
+        let hasher = cb_hasher();
+
+        let estimated_records = self.memory_limit / TEMPLATE_RECORD_BYTES_ESTIMATE;
+        let estimated_data_bytes = self.memory_limit * TEMPLATE_DATA_FRACTION_PERCENT / 100;
+
+        let mut chunk_files: Vec<PathBuf> = Vec::new();
+        let mut buffer =
+            TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
+        let mut namer = ChunkNamer::new(temp_path);
+
+        info!("Phase 1: Reading and sorting chunks (inline buffer)...");
+
+        for record in records {
+            stats.total_records += 1;
+
+            let bam_bytes = record.as_ref();
+            let key = extract_template_key_inline(
+                bam_bytes,
+                &lib_lookup,
+                self.cell_tag.as_ref(),
+                &hasher,
+            );
+            buffer.push(bam_bytes, key);
+
+            if buffer.memory_usage() >= self.memory_limit {
+                let chunk_path = namer.next_chunk_path();
+
+                if self.threads > 1 {
+                    buffer.par_sort();
+                } else {
+                    buffer.sort();
+                }
+
                 let mut keyed_writer = GenericKeyedChunkWriter::<TemplateKey>::create(
                     &chunk_path,
                     self.temp_compression,
@@ -1579,10 +1621,10 @@ impl RawExternalSorter {
             }
         }
 
-        progress.log_final();
+        info!("Read {} records total", stats.total_records);
 
         if chunk_files.is_empty() {
-            // All records fit in memory
+            // All records fit in memory — emit directly to sink
             info!("All records fit in memory, performing in-memory sort");
 
             if self.threads > 1 {
@@ -1591,18 +1633,9 @@ impl RawExternalSorter {
                 buffer.sort();
             }
 
-            let output_header = self.create_output_header(header);
-            let mut writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
-
-            for record_bytes in buffer.iter_sorted() {
-                writer.write_raw_record(record_bytes)?;
+            for (key, record_bytes) in buffer.iter_sorted_keyed() {
+                sink.emit(&key, record_bytes.to_vec())?;
             }
-            writer.finish()?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
@@ -1619,69 +1652,18 @@ impl RawExternalSorter {
             let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
-            // Merge using O(1) key comparisons
-            self.merge_chunks_keyed(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            // Merge using O(1) key comparisons, emitting to sink.
+            // Each memory chunk is a separate sorted source (NOT flattened —
+            // flattening would destroy sub-chunk ordering from par_sort_into_chunks).
+            merge_chunks_keyed_to_sink(&chunk_files, memory_chunks, sink)?;
         }
+
+        sink.finish()?;
 
         stats.output_records = stats.total_records;
         info!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
-    }
-
-    /// Build chunk sources from disk files and in-memory chunks.
-    fn build_chunk_sources<K: RawSortKey + Default + 'static>(
-        chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
-        threads: usize,
-    ) -> Result<Vec<ChunkSource<K>>> {
-        let sem = make_reader_semaphore(threads);
-        let num_disk = chunk_files.len();
-        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
-
-        let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
-
-        for path in chunk_files {
-            sources.push(ChunkSource::Disk(GenericKeyedChunkReader::<K>::open(
-                path,
-                Some(Arc::clone(&sem)),
-            )?));
-        }
-
-        for chunk in memory_chunks {
-            if !chunk.is_empty() {
-                sources.push(ChunkSource::Memory { records: chunk, idx: 0 });
-            }
-        }
-
-        Ok(sources)
-    }
-
-    /// Merge keyed chunks using O(1) key comparisons (delegates to generic merge).
-    ///
-    /// `memory_chunks` is a list of sorted in-memory sub-arrays, each of which
-    /// becomes a separate merge source.
-    fn merge_chunks_keyed(
-        &self,
-        chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>>,
-        header: &Header,
-        output: &Path,
-        total_records: u64,
-    ) -> Result<u64> {
-        self.merge_chunks_generic::<TemplateKey>(
-            chunk_files,
-            memory_chunks,
-            header,
-            output,
-            total_records,
-        )
     }
 
     /// Generic merge for keyed chunks using `O(1)` key comparisons.
@@ -1695,44 +1677,90 @@ impl RawExternalSorter {
         memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
         header: &Header,
         output: &Path,
-        total_records: u64,
     ) -> Result<u64> {
-        use crate::sort::loser_tree::LoserTree;
+        /// Source for keyed chunks during merge.
+        enum GenericKeyedChunkSource<K: RawSortKey + Default + 'static> {
+            /// Disk-based chunk with prefetching reader.
+            Disk(GenericKeyedChunkReader<K>),
+            /// In-memory sorted records.
+            Memory { records: Vec<(K, Vec<u8>)>, idx: usize },
+        }
 
-        let mut sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, self.threads)?;
-
-        let num_sources = sources.len();
-        info!("Merging from {num_sources} sources...");
-
-        let output_header = self.create_output_header(header);
-
-        // Initialize loser tree with first record from each source
-        let mut initial_keys: Vec<K> = Vec::with_capacity(sources.len());
-        let mut records: Vec<Vec<u8>> = Vec::with_capacity(sources.len());
-        let mut source_map: Vec<usize> = Vec::with_capacity(sources.len());
-
-        for (idx, source) in sources.iter_mut().enumerate() {
-            let mut record = Vec::new();
-            if let Some(key) = source.next_record(&mut record)? {
-                initial_keys.push(key);
-                records.push(record);
-                source_map.push(idx);
+        impl<K: RawSortKey + Default + 'static> GenericKeyedChunkSource<K> {
+            fn next_record(&mut self) -> Option<(K, Vec<u8>)> {
+                match self {
+                    GenericKeyedChunkSource::Disk(reader) => reader.next_record(),
+                    GenericKeyedChunkSource::Memory { records, idx } => {
+                        if *idx < records.len() {
+                            // Take ownership of the record
+                            let entry = std::mem::take(&mut records[*idx]);
+                            *idx += 1;
+                            Some(entry)
+                        } else {
+                            None
+                        }
+                    }
+                }
             }
         }
 
-        if initial_keys.is_empty() {
+        /// Heap entry for keyed merge - stores pre-computed key for O(1) comparison.
+        struct GenericKeyedHeapEntry<K> {
+            key: K,
+            record: Vec<u8>,
+            chunk_idx: usize,
+        }
+
+        // Output buffer to reduce write syscalls
+        const OUTPUT_BUFFER_SIZE: usize = 2048;
+
+        let num_disk = chunk_files.len();
+        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
+
+        let output_header = self.create_output_header(header);
+
+        // Create semaphore to limit concurrent reader I/O threads
+        let sem = make_reader_semaphore(self.threads);
+
+        // Create unified chunk sources
+        let mut sources: Vec<GenericKeyedChunkSource<K>> =
+            Vec::with_capacity(num_disk + num_memory);
+
+        // Add disk-based chunks with keyed readers
+        for path in chunk_files {
+            sources.push(GenericKeyedChunkSource::Disk(GenericKeyedChunkReader::<K>::open(
+                path,
+                Some(Arc::clone(&sem)),
+            )?));
+        }
+
+        // Add each non-empty in-memory chunk as a separate merge source
+        for chunk in memory_chunks {
+            if !chunk.is_empty() {
+                sources.push(GenericKeyedChunkSource::Memory { records: chunk, idx: 0 });
+            }
+        }
+
+        let mut heap: Vec<GenericKeyedHeapEntry<K>> = Vec::with_capacity(sources.len());
+        for (chunk_idx, source) in sources.iter_mut().enumerate() {
+            if let Some((key, record)) = source.next_record() {
+                heap.push(GenericKeyedHeapEntry { key, record, chunk_idx });
+            }
+        }
+
+        let mut heap_size = heap.len();
+        if heap_size == 0 {
             info!("Merge complete: 0 records merged");
-            let writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
-            writer.finish()?;
             return Ok(0);
         }
 
-        let mut tree = LoserTree::new(initial_keys);
+        // chunk_idx is the tie-breaker for stable merge (preserves input order for equal keys)
+        let lt = |a: &GenericKeyedHeapEntry<K>, b: &GenericKeyedHeapEntry<K>| -> bool {
+            a.key.cmp(&b.key).then_with(|| a.chunk_idx.cmp(&b.chunk_idx)) == Ordering::Greater
+        };
+
+        heap_make(&mut heap, &lt);
 
         let mut writer = crate::bam_io::create_raw_bam_writer(
             output,
@@ -1742,47 +1770,51 @@ impl RawExternalSorter {
         )?;
 
         let mut records_merged = 0u64;
-        let merge_progress = ProgressTracker::new("Merged records")
-            .with_interval(1_000_000)
-            .with_total(total_records);
+        let mut output_buffer: Vec<Vec<u8>> = Vec::with_capacity(OUTPUT_BUFFER_SIZE);
 
-        while tree.winner_is_active() {
-            let winner = tree.winner();
-            writer.write_raw_record(&records[winner])?;
+        // Merge loop using fixed-array heap with key comparisons
+        while heap_size > 0 {
+            // Get the minimum record (at heap[0])
+            let chunk_idx = heap[0].chunk_idx;
+            let record_bytes = std::mem::take(&mut heap[0].record);
+
+            // Buffer the raw bytes directly (no Record conversion)
+            output_buffer.push(record_bytes);
             records_merged += 1;
-            merge_progress.log_if_needed(1);
 
-            let src_idx = source_map[winner];
-            if let Some(key) = sources[src_idx].next_record(&mut records[winner])? {
-                tree.replace_winner(key);
+            // Flush buffer when full
+            if output_buffer.len() >= OUTPUT_BUFFER_SIZE {
+                for rec in output_buffer.drain(..) {
+                    writer.write_raw_record(&rec)?;
+                }
+            }
+
+            // Get next record from the same chunk
+            if let Some((key, next_record)) = sources[chunk_idx].next_record() {
+                // Replace top with new record and sift down
+                heap[0].key = key;
+                heap[0].record = next_record;
+                heap_sift_down(&mut heap, 0, heap_size, &lt);
             } else {
-                tree.remove_winner();
+                // Chunk exhausted - remove from heap
+                heap_size -= 1;
+                if heap_size > 0 {
+                    // Move last element to top and sift down
+                    heap.swap(0, heap_size);
+                    heap_sift_down(&mut heap, 0, heap_size, &lt);
+                }
             }
         }
 
+        // Flush remaining buffered records
+        for rec in output_buffer {
+            writer.write_raw_record(&rec)?;
+        }
+
         writer.finish()?;
-        merge_progress.log_final();
 
+        info!("Merge complete: {records_merged} records merged");
         Ok(records_merged)
-    }
-
-    /// Test helper: merge keyed chunk files into a BAM.
-    ///
-    /// Exposes `merge_chunks_generic` for use in tests where the spill pipeline
-    /// produces chunk files that need merging.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if merging fails.
-    #[cfg(test)]
-    pub fn merge_chunks_for_test<K: RawSortKey + Default + 'static>(
-        &self,
-        chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
-        header: &Header,
-        output: &Path,
-    ) -> Result<u64> {
-        self.merge_chunks_generic::<K>(chunk_files, memory_chunks, header, output, 0)
     }
 
     /// Merge keyed chunks with BAM index generation.
@@ -1795,33 +1827,73 @@ impl RawExternalSorter {
         memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
         header: &Header,
         output: &Path,
-        total_records: u64,
     ) -> Result<noodles::bam::bai::Index> {
         use crate::bam_io::create_indexing_bam_writer;
-        use crate::sort::loser_tree::LoserTree;
 
-        let mut sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, self.threads)?;
+        // Source for keyed chunks during merge
+        enum KeyedSource<K: RawSortKey + Default + 'static> {
+            Disk(GenericKeyedChunkReader<K>),
+            Memory { records: Vec<(K, Vec<u8>)>, idx: usize },
+        }
 
-        let num_sources = sources.len();
-        info!("Merging from {num_sources} sources...");
-
-        let output_header = self.create_output_header(header);
-
-        // Initialize loser tree with first record from each source
-        let mut initial_keys: Vec<K> = Vec::with_capacity(sources.len());
-        let mut records: Vec<Vec<u8>> = Vec::with_capacity(sources.len());
-        let mut source_map: Vec<usize> = Vec::with_capacity(sources.len());
-
-        for (idx, source) in sources.iter_mut().enumerate() {
-            let mut record = Vec::new();
-            if let Some(key) = source.next_record(&mut record)? {
-                initial_keys.push(key);
-                records.push(record);
-                source_map.push(idx);
+        impl<K: RawSortKey + Default + 'static> KeyedSource<K> {
+            fn next_record(&mut self) -> Option<(K, Vec<u8>)> {
+                match self {
+                    KeyedSource::Disk(reader) => reader.next_record(),
+                    KeyedSource::Memory { records, idx } => {
+                        if *idx < records.len() {
+                            let entry = std::mem::take(&mut records[*idx]);
+                            *idx += 1;
+                            Some(entry)
+                        } else {
+                            None
+                        }
+                    }
+                }
             }
         }
 
-        if initial_keys.is_empty() {
+        // Heap entry for merge
+        struct HeapEntry<K> {
+            key: K,
+            record: Vec<u8>,
+            chunk_idx: usize,
+        }
+
+        let num_disk = chunk_files.len();
+        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
+
+        let output_header = self.create_output_header(header);
+
+        // Create semaphore to limit concurrent reader I/O threads
+        let sem = make_reader_semaphore(self.threads);
+
+        // Create chunk sources
+        let mut sources: Vec<KeyedSource<K>> = Vec::with_capacity(num_disk + num_memory);
+        for path in chunk_files {
+            sources.push(KeyedSource::Disk(GenericKeyedChunkReader::<K>::open(
+                path,
+                Some(Arc::clone(&sem)),
+            )?));
+        }
+        // Add each non-empty in-memory chunk as a separate merge source
+        for chunk in memory_chunks {
+            if !chunk.is_empty() {
+                sources.push(KeyedSource::Memory { records: chunk, idx: 0 });
+            }
+        }
+
+        let mut heap: Vec<HeapEntry<K>> = Vec::with_capacity(sources.len());
+        for (chunk_idx, source) in sources.iter_mut().enumerate() {
+            if let Some((key, record)) = source.next_record() {
+                heap.push(HeapEntry { key, record, chunk_idx });
+            }
+        }
+
+        let mut heap_size = heap.len();
+        if heap_size == 0 {
+            // Empty input - create empty indexed BAM
             let writer = create_indexing_bam_writer(
                 output,
                 &output_header,
@@ -1833,33 +1905,45 @@ impl RawExternalSorter {
             return Ok(index);
         }
 
-        let mut tree = LoserTree::new(initial_keys);
+        // Use chunk_idx as tie-breaker for stable merge (preserves input order for equal keys)
+        let lt = |a: &HeapEntry<K>, b: &HeapEntry<K>| -> bool {
+            a.key.cmp(&b.key).then_with(|| a.chunk_idx.cmp(&b.chunk_idx)) == Ordering::Greater
+        };
+        heap_make(&mut heap, &lt);
 
+        // Use IndexingBamWriter (single-threaded for accurate virtual positions)
         let mut writer = create_indexing_bam_writer(
             output,
             &output_header,
             self.output_compression,
             self.threads,
         )?;
-        let merge_progress = ProgressTracker::new("Merged records")
-            .with_interval(1_000_000)
-            .with_total(total_records);
+        let mut records_merged = 0u64;
 
-        while tree.winner_is_active() {
-            let winner = tree.winner();
-            writer.write_raw_record(&records[winner])?;
-            merge_progress.log_if_needed(1);
+        // No buffering needed - IndexingBamWriter needs accurate virtual positions
+        // for each record, so we write directly
+        while heap_size > 0 {
+            let chunk_idx = heap[0].chunk_idx;
+            let record_bytes = std::mem::take(&mut heap[0].record);
 
-            let src_idx = source_map[winner];
-            if let Some(key) = sources[src_idx].next_record(&mut records[winner])? {
-                tree.replace_winner(key);
+            writer.write_raw_record(&record_bytes)?;
+            records_merged += 1;
+
+            if let Some((key, next_record)) = sources[chunk_idx].next_record() {
+                heap[0].key = key;
+                heap[0].record = next_record;
+                heap_sift_down(&mut heap, 0, heap_size, &lt);
             } else {
-                tree.remove_winner();
+                heap_size -= 1;
+                if heap_size > 0 {
+                    heap.swap(0, heap_size);
+                    heap_sift_down(&mut heap, 0, heap_size, &lt);
+                }
             }
         }
 
         let index = writer.finish()?;
-        merge_progress.log_final();
+        info!("Merge complete: {records_merged} records merged");
         Ok(index)
     }
 
@@ -1872,6 +1956,120 @@ impl RawExternalSorter {
     fn create_temp_dir(&self) -> Result<TempDir> {
         super::create_temp_dir(self.temp_dir.as_deref())
     }
+}
+
+/// K-way merge of sorted template-coordinate chunks, emitting records to a sink.
+///
+/// Merges pre-sorted disk chunks and an optional in-memory chunk using a min-heap
+/// with O(1) key comparisons (pre-computed 32-byte `TemplateKey`, no CIGAR/aux parsing).
+///
+/// # Errors
+///
+/// Returns an error if reading chunks or emitting records fails.
+fn merge_chunks_keyed_to_sink(
+    chunk_files: &[PathBuf],
+    memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>>,
+    sink: &mut dyn super::sink::SortedRecordSink,
+) -> Result<u64> {
+    use crate::sort::loser_tree::LoserTree;
+
+    /// Source for keyed chunks during merge.
+    enum KeyedChunkSource {
+        /// Disk-based chunk with prefetching reader.
+        Disk(GenericKeyedChunkReader<TemplateKey>),
+        /// In-memory sorted records.
+        Memory { records: Vec<(TemplateKey, Vec<u8>)>, idx: usize },
+    }
+
+    impl KeyedChunkSource {
+        fn next_record(&mut self) -> Option<(TemplateKey, Vec<u8>)> {
+            match self {
+                KeyedChunkSource::Disk(reader) => reader.next_record(),
+                KeyedChunkSource::Memory { records, idx } => {
+                    if *idx < records.len() {
+                        let dummy = (TemplateKey::zeroed(), Vec::new());
+                        let entry = std::mem::replace(&mut records[*idx], dummy);
+                        *idx += 1;
+                        Some(entry)
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    let num_disk = chunk_files.len();
+    let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+    info!("Merging from {num_disk} files and {num_memory} in-memory blocks...");
+
+    let mut sources: Vec<KeyedChunkSource> = Vec::with_capacity(num_disk + num_memory);
+    for path in chunk_files {
+        sources.push(KeyedChunkSource::Disk(GenericKeyedChunkReader::<TemplateKey>::open(
+            path, None,
+        )?));
+    }
+    for chunk in memory_chunks {
+        if !chunk.is_empty() {
+            sources.push(KeyedChunkSource::Memory { records: chunk, idx: 0 });
+        }
+    }
+
+    // Initialize LoserTree with first key from each source (stable merge, matching run_merge_loop)
+    let mut initial_keys: Vec<TemplateKey> = Vec::with_capacity(sources.len());
+    let mut records: Vec<Vec<u8>> = Vec::with_capacity(sources.len());
+    let mut source_map: Vec<usize> = Vec::with_capacity(sources.len());
+
+    for (idx, source) in sources.iter_mut().enumerate() {
+        if let Some((key, record)) = source.next_record() {
+            initial_keys.push(key);
+            records.push(record);
+            source_map.push(idx);
+        }
+    }
+
+    if initial_keys.is_empty() {
+        info!("Merge complete: 0 records merged");
+        return Ok(0);
+    }
+
+    let mut tree = LoserTree::new(initial_keys);
+    let mut records_merged = 0u64;
+
+    while tree.winner_is_active() {
+        let winner = tree.winner();
+        let key = tree.winner_key();
+        let record_bytes = std::mem::take(&mut records[winner]);
+
+        sink.emit(key, record_bytes)?;
+        records_merged += 1;
+
+        // Fetch next record from the same source
+        let source_idx = source_map[winner];
+        if let Some((next_key, next_record)) = sources[source_idx].next_record() {
+            records[winner] = next_record;
+            tree.replace_winner(next_key);
+        } else {
+            tree.remove_winner();
+        }
+    }
+
+    info!("Merge complete: {records_merged} records merged");
+    Ok(records_merged)
+}
+
+/// Deterministic hasher for cell barcode hashing in template-coordinate sort.
+///
+/// Uses arbitrary fixed seeds so that hash values are reproducible across runs.
+#[must_use]
+pub fn cb_hasher() -> ahash::RandomState {
+    // Arbitrary fixed seeds -- chosen for uniqueness, not cryptographic strength.
+    ahash::RandomState::with_seeds(
+        0xa1b2_c3d4_e5f6_0718,
+        0x9182_7364_5546_3728,
+        0xfede_dcba_0987_6543,
+        0x0011_2233_4455_6677,
+    )
 }
 
 /// Extract a packed `TemplateKey` directly from BAM record bytes.
@@ -1889,13 +2087,22 @@ pub fn extract_template_key_inline(
     cb_hasher: &ahash::RandomState,
 ) -> TemplateKey {
     use crate::sort::bam_fields;
-    use bam_fields::{flags, mate_unclipped_5prime, unclipped_5prime_raw};
+    use bam_fields::{
+        find_mc_tag_in_record, find_mi_tag_in_record, find_string_tag_in_record, flags,
+        get_cigar_ops, mate_unclipped_5prime, unclipped_5prime,
+    };
 
-    // Single-pass extraction of all aux tags (MI, RG, cell barcode, MC)
-    let aux = bam_fields::extract_template_aux_tags(bam_bytes, cell_tag);
-    let mi = aux.mi;
-    let library = lib_lookup.ordinal_from_rg(aux.rg);
-    let cb_hash = aux.cell.map_or(0u64, |cb_bytes| cb_hasher.hash_one(cb_bytes));
+    // Extract MI tag using fast raw byte scan (bypasses noodles overhead)
+    let mi = find_mi_tag_in_record(bam_bytes);
+
+    // Get library ordinal
+    let library = lib_lookup.get_ordinal(bam_bytes);
+
+    // Hash cell barcode tag if requested
+    let cb_hash = cell_tag.map_or(0u64, |tag| {
+        find_string_tag_in_record(bam_bytes, tag)
+            .map_or(0u64, |cb_bytes| cb_hasher.hash_one(cb_bytes))
+    });
 
     // Extract fields from raw bytes
     let tid = bam_fields::ref_id(bam_bytes);
@@ -1925,8 +2132,8 @@ pub fn extract_template_key_inline(
     if is_unmapped {
         if is_paired && !mate_unmapped {
             // Unmapped read with mapped mate - use mate's position as primary key
-            let mate_unclipped =
-                aux.mc.map_or(mate_pos, |mc| mate_unclipped_5prime(mate_pos, mate_reverse, mc));
+            let mate_unclipped = find_mc_tag_in_record(bam_bytes)
+                .map_or(mate_pos, |mc| mate_unclipped_5prime(mate_pos, mate_reverse, mc));
 
             return TemplateKey::new(
                 mate_tid,
@@ -1948,12 +2155,14 @@ pub fn extract_template_key_inline(
         return TemplateKey::unmapped(name_hash, cb_hash, is_read2);
     }
 
-    // Calculate unclipped 5' position for this read (zero-alloc: reads cigar directly)
-    let this_pos = unclipped_5prime_raw(bam_bytes, pos, is_reverse);
+    // Calculate unclipped 5' position for this read
+    let cigar_ops = get_cigar_ops(bam_bytes);
+    let this_pos = unclipped_5prime(pos, is_reverse, &cigar_ops);
 
     // Calculate mate's unclipped 5' position
     let mate_unclipped = if is_paired && !mate_unmapped {
-        aux.mc.map_or(mate_pos, |mc| mate_unclipped_5prime(mate_pos, mate_reverse, mc))
+        find_mc_tag_in_record(bam_bytes)
+            .map_or(mate_pos, |mc| mate_unclipped_5prime(mate_pos, mate_reverse, mc))
     } else {
         mate_pos
     };
@@ -1982,11 +2191,60 @@ pub fn extract_template_key_inline(
 // Use shared SortStats from the parent module.
 pub use super::SortStats as RawSortStats;
 
+/// Result of the sort-accumulate phase: sorted chunks ready for K-way merging.
+///
+/// Holds references to sorted disk chunks (temp files) and any remaining in-memory
+/// sorted chunks.  The caller controls when and where the merge happens — e.g. on a
+/// dedicated feeder thread so that the calling thread can participate in work-stealing.
+///
+/// **Important:** The [`TempDir`] is owned here.  Dropping a `SortedChunks` removes
+/// the temporary directory and all spill files.  Keep this value alive until the merge
+/// is complete.
+pub struct SortedChunks {
+    /// Paths to sorted keyed chunk files on disk.
+    pub chunk_files: Vec<PathBuf>,
+    /// Sorted in-memory chunks (from the last partial buffer that didn't spill).
+    /// Each inner `Vec` is independently sorted; the merge treats them as separate sources.
+    pub memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>>,
+    /// Accumulation-phase statistics (total records read, chunks written to disk).
+    pub stats: RawSortStats,
+    /// Temporary directory owning the spill files.  Must outlive the merge phase.
+    _temp_dir: TempDir,
+}
+
+/// Merge pre-sorted chunks into a [`SortedRecordSink`] using K-way merge.
+///
+/// This is a public wrapper around the internal LoserTree-based merge.  It consumes
+/// both disk chunks and in-memory chunks from a [`SortedChunks`], emitting records
+/// in template-coordinate order.
+///
+/// **Note:** This does NOT call [`SortedRecordSink::finish`] on the sink — the caller
+/// is responsible for calling `finish()` after the merge returns.
+///
+/// # Errors
+///
+/// Returns an error if reading chunks or emitting records to the sink fails.
+pub fn merge_sorted_chunks_to_sink(
+    chunks: SortedChunks,
+    sink: &mut dyn super::sink::SortedRecordSink,
+) -> Result<u64> {
+    if chunks.chunk_files.is_empty() && chunks.memory_chunks.is_empty() {
+        return Ok(0);
+    }
+    // Delegate to the existing internal merge function.
+    // Takes ownership of chunks to avoid deep-cloning memory_chunks.
+    // The _temp_dir field is kept alive by the owned SortedChunks until
+    // merge completes, ensuring spill files aren't cleaned up early.
+    merge_chunks_keyed_to_sink(&chunks.chunk_files, chunks.memory_chunks, sink)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sam::builder::SamBuilder;
+    use crate::sort::keys::QuerynameComparator;
     use bstr::BString;
+    use noodles::sam::Header;
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReadGroup;
 
@@ -2012,10 +2270,7 @@ mod tests {
         let lookup = LibraryLookup::from_header(&header);
         assert_eq!(lookup.rg_to_ordinal.len(), 1);
         // LibA is the only library, so it gets ordinal 1 (0 is reserved for empty/unknown)
-        assert_eq!(
-            *lookup.rg_to_ordinal.get(b"rg1".as_slice()).expect("rg1 should be in ordinal map"),
-            1
-        );
+        assert_eq!(*lookup.rg_to_ordinal.get(b"rg1".as_slice()).unwrap(), 1);
     }
 
     #[test]
@@ -2043,12 +2298,9 @@ mod tests {
         assert_eq!(lookup.rg_to_ordinal.len(), 3);
 
         // Libraries sorted alphabetically: LibA=1, LibB=2, LibC=3
-        let rg2 = *lookup.rg_to_ordinal.get(b"rg2".as_slice()).expect("rg2");
-        let rg3 = *lookup.rg_to_ordinal.get(b"rg3".as_slice()).expect("rg3");
-        let rg1 = *lookup.rg_to_ordinal.get(b"rg1".as_slice()).expect("rg1");
-        assert_eq!(rg2, 1); // LibA
-        assert_eq!(rg3, 2); // LibB
-        assert_eq!(rg1, 3); // LibC
+        assert_eq!(*lookup.rg_to_ordinal.get(b"rg2".as_slice()).unwrap(), 1); // LibA
+        assert_eq!(*lookup.rg_to_ordinal.get(b"rg3".as_slice()).unwrap(), 2); // LibB
+        assert_eq!(*lookup.rg_to_ordinal.get(b"rg1".as_slice()).unwrap(), 3); // LibC
     }
 
     #[test]
@@ -2087,15 +2339,16 @@ mod tests {
 
     #[test]
     fn test_raw_sorter_builder_chain() {
-        let sorter = RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::default()))
-            .memory_limit(1024)
-            .temp_dir(PathBuf::from("/tmp/test"))
-            .threads(8)
-            .output_compression(9)
-            .temp_compression(3)
-            .write_index(true)
-            .pg_info("1.0".to_string(), "fgumi sort".to_string())
-            .max_temp_files(128);
+        let sorter =
+            RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::Lexicographic))
+                .memory_limit(1024)
+                .temp_dir(PathBuf::from("/tmp/test"))
+                .threads(8)
+                .output_compression(9)
+                .temp_compression(3)
+                .write_index(true)
+                .pg_info("1.0".to_string(), "fgumi sort".to_string())
+                .max_temp_files(128);
 
         assert_eq!(sorter.memory_limit, 1024);
         assert_eq!(sorter.temp_dir, Some(PathBuf::from("/tmp/test")));
@@ -2142,7 +2395,8 @@ mod tests {
 
     #[test]
     fn test_create_output_header_queryname() {
-        let sorter = RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::default()));
+        let sorter =
+            RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::Lexicographic));
         let header = Header::builder().build();
         let output_header = sorter.create_output_header(&header);
 
@@ -2232,10 +2486,6 @@ mod tests {
     // extract_template_key_inline cell_tag tests
     // ========================================================================
 
-    fn test_cb_hasher() -> ahash::RandomState {
-        cb_hasher()
-    }
-
     /// Build minimal BAM bytes with mapped read at (tid, pos) on the forward strand,
     /// with optional aux data appended.
     #[allow(clippy::cast_possible_truncation)]
@@ -2279,7 +2529,7 @@ mod tests {
         let aux = cb_aux(b"ACGTACGT");
         let bam = build_mapped_bam(0, 100, b"read1", &aux);
 
-        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &cb_hasher());
         assert_ne!(key.cb_hash, 0, "CB present should produce non-zero cb_hash");
     }
 
@@ -2290,7 +2540,7 @@ mod tests {
         // No CB tag in aux data
         let bam = build_mapped_bam(0, 100, b"read1", &[]);
 
-        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &cb_hasher());
         assert_eq!(key.cb_hash, 0, "missing CB tag should produce cb_hash=0");
     }
 
@@ -2301,7 +2551,7 @@ mod tests {
         let aux = cb_aux(b"ACGTACGT");
         let bam = build_mapped_bam(0, 100, b"read1", &aux);
 
-        let key = extract_template_key_inline(&bam, &lib_lookup, None, &test_cb_hasher());
+        let key = extract_template_key_inline(&bam, &lib_lookup, None, &cb_hasher());
         assert_eq!(key.cb_hash, 0, "cell_tag=None should produce cb_hash=0");
     }
 
@@ -2312,11 +2562,11 @@ mod tests {
 
         let aux1 = cb_aux(b"ACGTACGT");
         let bam1 = build_mapped_bam(0, 100, b"read1", &aux1);
-        let key1 = extract_template_key_inline(&bam1, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key1 = extract_template_key_inline(&bam1, &lib_lookup, Some(b"CB"), &cb_hasher());
 
         let aux2 = cb_aux(b"TGCATGCA");
         let bam2 = build_mapped_bam(0, 100, b"read1", &aux2);
-        let key2 = extract_template_key_inline(&bam2, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key2 = extract_template_key_inline(&bam2, &lib_lookup, Some(b"CB"), &cb_hasher());
 
         assert_ne!(
             key1.cb_hash, key2.cb_hash,
@@ -2331,8 +2581,8 @@ mod tests {
         let aux = cb_aux(b"ACGTACGT");
         let bam = build_mapped_bam(0, 100, b"read1", &aux);
 
-        let key1 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &test_cb_hasher());
-        let key2 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key1 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &cb_hasher());
+        let key2 = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &cb_hasher());
         assert_eq!(key1.cb_hash, key2.cb_hash, "same input should produce same cb_hash");
     }
 
@@ -2354,7 +2604,7 @@ mod tests {
         bam.extend_from_slice(b"read1\0");
         bam.extend_from_slice(&aux);
 
-        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &test_cb_hasher());
+        let key = extract_template_key_inline(&bam, &lib_lookup, Some(b"CB"), &cb_hasher());
         assert_ne!(key.cb_hash, 0, "unmapped read with CB should have non-zero cb_hash");
         assert_eq!(key.primary, u64::MAX, "unmapped both-mates should have MAX primary");
     }
@@ -2366,7 +2616,7 @@ mod tests {
     /// Count records in a BAM file by reading with the raw BAM reader.
     fn count_bam_records(path: &std::path::Path) -> u64 {
         use crate::sort::read_ahead::RawReadAheadReader;
-        let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        let (reader, _) = create_raw_bam_reader(path, 1).unwrap();
         RawReadAheadReader::new(reader).count() as u64
     }
 
@@ -2379,7 +2629,7 @@ mod tests {
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate, false)]
     #[case::coordinate_with_index(SortOrder::Coordinate, true)]
-    #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()), false)]
+    #[case::queryname(SortOrder::Queryname(QuerynameComparator::Lexicographic), false)]
     #[case::template_coordinate(SortOrder::TemplateCoordinate, false)]
     fn test_sort_with_consolidation_preserves_all_records(
         #[case] sort_order: SortOrder,
@@ -2398,10 +2648,10 @@ mod tests {
                 .build();
         }
 
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("input.bam");
         let output = dir.path().join("output.bam");
-        builder.write_bam(&input).expect("failed to write BAM");
+        builder.write_bam(&input).unwrap();
 
         // Tiny memory limit forces many chunks; low max_temp_files triggers consolidation
         let stats = RawExternalSorter::new(sort_order)
@@ -2411,7 +2661,7 @@ mod tests {
             .output_compression(0)
             .write_index(write_index)
             .sort(&input, &output)
-            .expect("sort should succeed");
+            .unwrap();
 
         assert!(
             stats.chunks_written >= 5,
@@ -2429,12 +2679,12 @@ mod tests {
     /// merge readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
-    #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_many_chunks_with_semaphore(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
 
-        let num_pairs = 200;
+        let num_pairs = 50;
         let mut builder = SamBuilder::new();
         for i in 0..num_pairs {
             let _ = builder
@@ -2445,25 +2695,25 @@ mod tests {
                 .build();
         }
 
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("input.bam");
         let output = dir.path().join("output.bam");
-        builder.write_bam(&input).expect("failed to write BAM");
+        builder.write_bam(&input).unwrap();
 
-        // Small memory limit + many records = guaranteed spill to multiple chunks
+        // Small memory limit + high max_temp_files = many chunks at final merge
         // (no consolidation, so the semaphore must cap concurrent readers)
         let stats = RawExternalSorter::new(sort_order)
-            .memory_limit(4096)
+            .memory_limit(1024)
             .max_temp_files(0) // disable consolidation
             .threads(2) // semaphore allows 2 concurrent readers
             .temp_compression(0)
             .output_compression(0)
             .sort(&input, &output)
-            .expect("sort should succeed");
+            .unwrap();
 
         assert!(
-            stats.chunks_written >= 2,
-            "expected multiple chunks to exercise merge, got {}",
+            stats.chunks_written >= 8,
+            "expected many chunks to exercise semaphore, got {}",
             stats.chunks_written
         );
 
@@ -2480,7 +2730,7 @@ mod tests {
     /// sort for each sort order, exercising the parallel sub-array merge path.
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
-    #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_sub_arrays_match_single_thread(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2496,11 +2746,11 @@ mod tests {
                 .build();
         }
 
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("input.bam");
         let output_st = dir.path().join("output_1t.bam");
         let output_mt = dir.path().join("output_2t.bam");
-        builder.write_bam(&input).expect("failed to write BAM");
+        builder.write_bam(&input).unwrap();
 
         // Sort single-threaded
         RawExternalSorter::new(sort_order)
@@ -2509,7 +2759,7 @@ mod tests {
             .temp_compression(0)
             .output_compression(0)
             .sort(&input, &output_st)
-            .expect("sort should succeed");
+            .unwrap();
 
         // Sort multi-threaded (exercises par_sort_into_chunks / par_chunks_mut)
         RawExternalSorter::new(sort_order)
@@ -2518,7 +2768,7 @@ mod tests {
             .temp_compression(0)
             .output_compression(0)
             .sort(&input, &output_mt)
-            .expect("sort should succeed");
+            .unwrap();
 
         let names_st = collect_read_names(&output_st);
         let names_mt = collect_read_names(&output_mt);
@@ -2535,7 +2785,7 @@ mod tests {
     /// correctly with multi-threaded sub-array chunks.
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
-    #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_sub_arrays_in_memory_only(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2551,22 +2801,24 @@ mod tests {
                 .build();
         }
 
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("input.bam");
         let output = dir.path().join("output.bam");
-        builder.write_bam(&input).expect("failed to write BAM");
+        builder.write_bam(&input).unwrap();
 
-        // Large memory limit so everything stays in memory (no spill chunks).
-        RawExternalSorter::new(sort_order)
+        // Large memory limit so everything stays in memory
+        let stats = RawExternalSorter::new(sort_order)
             .memory_limit(10 * 1024 * 1024)
             .threads(2)
             .output_compression(0)
             .sort(&input, &output)
-            .expect("sort should succeed");
+            .unwrap();
+
+        assert_eq!(stats.chunks_written, 0, "expected no spill to disk");
 
         let expected = (num_pairs * 2) as u64;
         let observed = count_bam_records(&output);
-        assert_eq!(observed, expected, "sort lost data");
+        assert_eq!(observed, expected, "in-memory sub-array sort lost data");
     }
 
     // ========================================================================
@@ -2597,22 +2849,19 @@ mod tests {
         }
         let unsorted = dir.join(format!("{prefix}_unsorted.bam"));
         let sorted = dir.join(format!("{prefix}_sorted.bam"));
-        builder.write_bam(&unsorted).expect("failed to write BAM");
-        RawExternalSorter::new(sort_order)
-            .output_compression(0)
-            .sort(&unsorted, &sorted)
-            .expect("sort should succeed");
+        builder.write_bam(&unsorted).unwrap();
+        RawExternalSorter::new(sort_order).output_compression(0).sort(&unsorted, &sorted).unwrap();
         (sorted, names)
     }
 
     /// Collect all read names from a BAM file as strings.
     fn collect_read_names(path: &Path) -> Vec<String> {
         use crate::sort::read_ahead::RawReadAheadReader;
-        let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        let (reader, _) = create_raw_bam_reader(path, 1).unwrap();
         RawReadAheadReader::new(reader)
             .map(|rec| {
                 let name_bytes = fgumi_raw_bam::fields::read_name(rec.as_ref());
-                String::from_utf8(name_bytes.to_vec()).expect("read name should be valid UTF-8")
+                String::from_utf8(name_bytes.to_vec()).unwrap()
             })
             .collect()
     }
@@ -2620,7 +2869,7 @@ mod tests {
     /// Collect (`ref_id`, pos) tuples for every record in a BAM.
     fn collect_positions(path: &Path) -> Vec<(i32, i32)> {
         use crate::sort::read_ahead::RawReadAheadReader;
-        let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        let (reader, _) = create_raw_bam_reader(path, 1).unwrap();
         RawReadAheadReader::new(reader)
             .map(|rec| {
                 let bytes = rec.as_ref();
@@ -2636,7 +2885,7 @@ mod tests {
 
     #[test]
     fn test_merge_bams_coordinate_sort() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let (bam_a, _) = create_sorted_bam(dir.path(), "a", 10, 0, SortOrder::Coordinate);
         let (bam_b, _) = create_sorted_bam(dir.path(), "b", 10, 10_000, SortOrder::Coordinate);
 
@@ -2645,7 +2894,7 @@ mod tests {
         let count = RawExternalSorter::new(SortOrder::Coordinate)
             .output_compression(0)
             .merge_bams(&[bam_a, bam_b], &header, &merged)
-            .expect("sort should succeed");
+            .unwrap();
 
         // 10 pairs * 2 records * 2 inputs = 40
         assert_eq!(count, 40);
@@ -2658,9 +2907,168 @@ mod tests {
         }
     }
 
+    // ========================================================================
+    // sort_template_to_sink tests
+    // ========================================================================
+
+    use crate::sort::sink::CollectingSink;
+
+    /// Build a minimal unpaired mapped BAM record at (tid, pos) with given name.
+    ///
+    /// The record is unpaired (flag=0) to simplify template-coordinate key comparison:
+    /// tid2/pos2 are set to MAX, so ordering depends only on (tid, pos).
+    #[allow(clippy::cast_possible_truncation)]
+    fn build_unpaired_mapped_bam(tid: i32, pos: i32, name: &[u8]) -> Vec<u8> {
+        let l_read_name = (name.len() + 1) as u8; // +1 for null terminator
+        let mut bam = vec![0u8; 32];
+        // ref_id at offset 0..4
+        bam[0..4].copy_from_slice(&tid.to_le_bytes());
+        // pos at offset 4..8
+        bam[4..8].copy_from_slice(&pos.to_le_bytes());
+        // l_read_name at offset 8
+        bam[8] = l_read_name;
+        // flags at offset 14..16: 0 (unpaired, mapped, forward strand)
+        bam[14..16].copy_from_slice(&0u16.to_le_bytes());
+        // mate_ref_id at offset 20..24: -1 (no mate)
+        bam[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        // mate_pos at offset 24..28: -1 (no mate)
+        bam[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+        // read name
+        bam.extend_from_slice(name);
+        bam.push(0); // null terminator
+        bam
+    }
+
+    /// Write raw BAM records to a temporary BAM file and return the path.
+    fn write_temp_bam(header: &Header, records: &[Vec<u8>]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let bam_path = dir.path().join("input.bam");
+        let mut writer =
+            crate::bam_io::create_raw_bam_writer(&bam_path, header, 1, 1).expect("create writer");
+        for rec in records {
+            writer.write_raw_record(rec).expect("write record");
+        }
+        writer.finish().expect("finish writer");
+        dir
+    }
+
+    #[test]
+    fn test_sort_template_to_sink_in_memory() {
+        // Create records in reverse position order
+        let rec_c = build_unpaired_mapped_bam(0, 300, b"readC");
+        let rec_a = build_unpaired_mapped_bam(0, 100, b"readA");
+        let rec_b = build_unpaired_mapped_bam(0, 200, b"readB");
+
+        let header = Header::builder()
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(1000).unwrap(),
+                ),
+            )
+            .build();
+
+        let dir = write_temp_bam(&header, &[rec_c.clone(), rec_a.clone(), rec_b.clone()]);
+        let bam_path = dir.path().join("input.bam");
+
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate);
+        let mut sink = CollectingSink::new();
+
+        let stats =
+            sorter.sort_template_to_sink(&bam_path, &header, &mut sink).expect("sort to sink");
+
+        assert_eq!(stats.total_records, 3);
+        assert_eq!(stats.output_records, 3);
+        assert_eq!(sink.records.len(), 3);
+        assert!(sink.finished);
+
+        // Verify records are in sorted order by key
+        for window in sink.records.windows(2) {
+            assert!(window[0].0 <= window[1].0, "records should be in non-decreasing key order");
+        }
+    }
+
+    #[test]
+    fn test_sort_template_to_sink_with_spill() {
+        // Use a very small memory limit to force spilling to disk
+        let header = Header::builder()
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(10_000).unwrap(),
+                ),
+            )
+            .build();
+
+        // Create enough records to exceed the tiny memory limit
+        let records: Vec<Vec<u8>> = (0..20)
+            .map(|i| build_unpaired_mapped_bam(0, i * 100, format!("read{i:04}").as_bytes()))
+            .collect();
+
+        let dir = write_temp_bam(&header, &records);
+        let bam_path = dir.path().join("input.bam");
+
+        // Set memory limit very low to force chunking (each record is ~40 bytes, limit to ~200)
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate).memory_limit(200);
+        let mut sink = CollectingSink::new();
+
+        let stats =
+            sorter.sort_template_to_sink(&bam_path, &header, &mut sink).expect("sort to sink");
+
+        assert_eq!(stats.total_records, 20);
+        assert_eq!(stats.output_records, 20);
+        assert_eq!(sink.records.len(), 20);
+        assert!(sink.finished);
+        assert!(stats.chunks_written > 0, "should have written chunks to disk");
+
+        // Verify sorted order
+        for window in sink.records.windows(2) {
+            assert!(window[0].0 <= window[1].0, "records should be in non-decreasing key order");
+        }
+    }
+
+    // ========================================================================
+    // sort_from_iter tests
+    // ========================================================================
+
+    #[test]
+    fn test_sort_from_iter_in_memory() {
+        let header = Header::builder()
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(1000).unwrap(),
+                ),
+            )
+            .build();
+
+        // Records in reverse order
+        let records = vec![
+            build_unpaired_mapped_bam(0, 300, b"readC"),
+            build_unpaired_mapped_bam(0, 100, b"readA"),
+            build_unpaired_mapped_bam(0, 200, b"readB"),
+        ];
+
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate);
+        let mut sink = CollectingSink::new();
+
+        let stats =
+            sorter.sort_from_iter(records.into_iter(), &header, &mut sink).expect("sort from iter");
+
+        assert_eq!(stats.total_records, 3);
+        assert_eq!(stats.output_records, 3);
+        assert_eq!(sink.records.len(), 3);
+        assert!(sink.finished);
+
+        // Verify sorted order
+        for window in sink.records.windows(2) {
+            assert!(window[0].0 <= window[1].0, "records should be in non-decreasing key order");
+        }
+    }
+
     #[test]
     fn test_merge_bams_template_coordinate_sort() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let (bam_a, _) = create_sorted_bam(dir.path(), "a", 10, 0, SortOrder::TemplateCoordinate);
         let (bam_b, _) =
             create_sorted_bam(dir.path(), "b", 10, 10_000, SortOrder::TemplateCoordinate);
@@ -2670,7 +3078,7 @@ mod tests {
         let count = RawExternalSorter::new(SortOrder::TemplateCoordinate)
             .output_compression(0)
             .merge_bams(&[bam_a, bam_b], &header, &merged)
-            .expect("sort should succeed");
+            .unwrap();
 
         assert_eq!(count, 40);
         assert_eq!(count_bam_records(&merged), 40);
@@ -2678,28 +3086,29 @@ mod tests {
 
     #[test]
     fn test_merge_bams_queryname_sort() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let (bam_a, _) = create_sorted_bam(
             dir.path(),
             "a",
             10,
             0,
-            SortOrder::Queryname(QuerynameComparator::default()),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
         );
         let (bam_b, _) = create_sorted_bam(
             dir.path(),
             "b",
             10,
             10_000,
-            SortOrder::Queryname(QuerynameComparator::default()),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
         );
 
         let merged = dir.path().join("merged.bam");
         let header = default_merge_header();
-        let count = RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::default()))
-            .output_compression(0)
-            .merge_bams(&[bam_a, bam_b], &header, &merged)
-            .expect("sort should succeed");
+        let count =
+            RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::Lexicographic))
+                .output_compression(0)
+                .merge_bams(&[bam_a, bam_b], &header, &merged)
+                .unwrap();
 
         assert_eq!(count, 40);
         assert_eq!(count_bam_records(&merged), 40);
@@ -2712,8 +3121,41 @@ mod tests {
     }
 
     #[test]
+    fn test_sort_from_iter_with_spill() {
+        let header = Header::builder()
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(10_000).unwrap(),
+                ),
+            )
+            .build();
+
+        let records: Vec<Vec<u8>> = (0..20)
+            .map(|i| build_unpaired_mapped_bam(0, i * 100, format!("read{i:04}").as_bytes()))
+            .collect();
+
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate).memory_limit(200);
+        let mut sink = CollectingSink::new();
+
+        let stats =
+            sorter.sort_from_iter(records.into_iter(), &header, &mut sink).expect("sort from iter");
+
+        assert_eq!(stats.total_records, 20);
+        assert_eq!(stats.output_records, 20);
+        assert_eq!(sink.records.len(), 20);
+        assert!(sink.finished);
+        assert!(stats.chunks_written > 0, "should have written chunks to disk");
+
+        // Verify sorted order
+        for window in sink.records.windows(2) {
+            assert!(window[0].0 <= window[1].0, "records should be in non-decreasing key order");
+        }
+    }
+
+    #[test]
     fn test_merge_bams_single_input() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let (bam_a, _) = create_sorted_bam(dir.path(), "a", 15, 0, SortOrder::Coordinate);
 
         let merged = dir.path().join("merged.bam");
@@ -2721,7 +3163,7 @@ mod tests {
         let count = RawExternalSorter::new(SortOrder::Coordinate)
             .output_compression(0)
             .merge_bams(&[bam_a], &header, &merged)
-            .expect("sort should succeed");
+            .unwrap();
 
         // 15 pairs * 2 = 30
         assert_eq!(count, 30);
@@ -2730,28 +3172,28 @@ mod tests {
 
     #[test]
     fn test_merge_bams_preserves_all_records() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let (bam_a, names_a) = create_sorted_bam(
             dir.path(),
             "a",
             5,
             0,
-            SortOrder::Queryname(QuerynameComparator::default()),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
         );
         let (bam_b, names_b) = create_sorted_bam(
             dir.path(),
             "b",
             5,
             10_000,
-            SortOrder::Queryname(QuerynameComparator::default()),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
         );
 
         let merged = dir.path().join("merged.bam");
         let header = default_merge_header();
-        RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::default()))
+        RawExternalSorter::new(SortOrder::Queryname(QuerynameComparator::Lexicographic))
             .output_compression(0)
             .merge_bams(&[bam_a, bam_b], &header, &merged)
-            .expect("sort should succeed");
+            .unwrap();
 
         let merged_names: std::collections::HashSet<String> =
             collect_read_names(&merged).into_iter().collect();
@@ -2764,7 +3206,7 @@ mod tests {
 
     #[test]
     fn test_merge_bams_many_inputs() {
-        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dir = tempfile::tempdir().unwrap();
         let k = 8;
         let pairs_per_input = 5;
         let mut inputs = Vec::with_capacity(k);
@@ -2785,7 +3227,7 @@ mod tests {
         let count = RawExternalSorter::new(SortOrder::Coordinate)
             .output_compression(0)
             .merge_bams(&inputs, &header, &merged)
-            .expect("sort should succeed");
+            .unwrap();
 
         let expected = (k * pairs_per_input * 2) as u64; // 8 * 5 * 2 = 80
         assert_eq!(count, expected);
@@ -2796,5 +3238,44 @@ mod tests {
         for w in positions.windows(2) {
             assert!(w[0] <= w[1], "coordinate sort violated with k={k}: {:?} > {:?}", w[0], w[1]);
         }
+    }
+
+    #[test]
+    fn test_sort_from_iter_empty() {
+        let header = Header::builder().build();
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate);
+        let mut sink = CollectingSink::new();
+
+        let stats = sorter
+            .sort_from_iter(std::iter::empty(), &header, &mut sink)
+            .expect("sort from iter empty");
+
+        assert_eq!(stats.total_records, 0);
+        assert_eq!(stats.output_records, 0);
+        assert!(sink.records.is_empty());
+        assert!(sink.finished);
+    }
+
+    #[test]
+    fn test_sort_from_iter_preserves_record_bytes() {
+        let header = Header::builder()
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(1000).unwrap(),
+                ),
+            )
+            .build();
+
+        let rec = build_unpaired_mapped_bam(0, 42, b"onlyread");
+        let expected_bytes = rec.clone();
+
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate);
+        let mut sink = CollectingSink::new();
+
+        sorter.sort_from_iter(std::iter::once(rec), &header, &mut sink).expect("sort");
+
+        assert_eq!(sink.records.len(), 1);
+        assert_eq!(sink.records[0].1, expected_bytes, "record bytes should be preserved exactly");
     }
 }

--- a/crates/fgumi-lib/src/sort/sink.rs
+++ b/crates/fgumi-lib/src/sort/sink.rs
@@ -1,0 +1,134 @@
+//! Sink abstraction for consuming sorted records from the merge loop.
+//!
+//! The [`SortedRecordSink`] trait decouples the sort/merge phase from the output destination,
+//! allowing sorted records to flow into a BAM writer, a downstream pipeline stage, or a
+//! test collector without changing the merge logic.
+
+use anyhow::Result;
+
+use super::inline_buffer::TemplateKey;
+use crate::bam_io::RawBamWriter;
+
+/// Consumes sorted records one at a time from the sort merge loop.
+///
+/// Implementations receive each record in sorted order along with its sort key.
+/// After all records have been emitted, [`finish`](SortedRecordSink::finish) is called
+/// to finalize any underlying resources (e.g. flush and close a BAM writer).
+pub trait SortedRecordSink {
+    /// Write a single sorted record.
+    ///
+    /// `key` is the sort key that was used to order this record.
+    /// `record_bytes` contains the raw BAM record bytes (without the 4-byte `block_size` prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be written to the underlying destination.
+    fn emit(&mut self, key: &TemplateKey, record_bytes: Vec<u8>) -> Result<()>;
+
+    /// Finalize the sink, flushing any buffered data and releasing resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if finalization fails (e.g. flushing or closing the output).
+    fn finish(&mut self) -> Result<()>;
+}
+
+/// Default sink that writes sorted records directly to a BAM file.
+///
+/// Wraps a [`RawBamWriter`] and forwards each emitted record as raw BAM bytes.
+/// The writer is consumed on [`finish`](SortedRecordSink::finish) to ensure the
+/// BGZF EOF block is written.
+pub struct BamWriterSink {
+    writer: Option<RawBamWriter>,
+    records_written: u64,
+}
+
+impl BamWriterSink {
+    /// Create a new sink backed by the given BAM writer.
+    ///
+    /// The writer should already have its BAM header written before records are emitted.
+    #[must_use]
+    pub fn new(writer: RawBamWriter) -> Self {
+        Self { writer: Some(writer), records_written: 0 }
+    }
+
+    /// Returns the number of records written so far.
+    #[must_use]
+    pub fn records_written(&self) -> u64 {
+        self.records_written
+    }
+}
+
+impl SortedRecordSink for BamWriterSink {
+    fn emit(&mut self, _key: &TemplateKey, record_bytes: Vec<u8>) -> Result<()> {
+        self.writer.as_mut().expect("emit called after finish").write_raw_record(&record_bytes)?;
+        self.records_written += 1;
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        if let Some(writer) = self.writer.take() {
+            writer.finish()?;
+        }
+        Ok(())
+    }
+}
+
+/// Test sink that collects emitted records for verification.
+///
+/// Available as `pub(crate)` so that other modules (e.g. `raw.rs`) can reuse the
+/// same sink in their tests without duplicating the definition.
+#[cfg(test)]
+pub(crate) struct CollectingSink {
+    pub(crate) records: Vec<(TemplateKey, Vec<u8>)>,
+    pub(crate) finished: bool,
+}
+
+#[cfg(test)]
+impl CollectingSink {
+    pub(crate) fn new() -> Self {
+        Self { records: Vec::new(), finished: false }
+    }
+}
+
+#[cfg(test)]
+impl SortedRecordSink for CollectingSink {
+    fn emit(&mut self, key: &TemplateKey, record_bytes: Vec<u8>) -> Result<()> {
+        self.records.push((*key, record_bytes));
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.finished = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collecting_sink_stores_records() {
+        let mut sink = CollectingSink::new();
+        let key = TemplateKey::default();
+
+        sink.emit(&key, vec![1, 2, 3]).unwrap();
+        sink.emit(&key, vec![4, 5, 6]).unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(sink.records.len(), 2);
+        assert_eq!(sink.records[0].1, vec![1, 2, 3]);
+        assert_eq!(sink.records[1].1, vec![4, 5, 6]);
+        assert_eq!(sink.records[0].0, TemplateKey::default());
+        assert!(sink.finished);
+    }
+
+    #[test]
+    fn test_collecting_sink_finish_is_idempotent() {
+        let mut sink = CollectingSink::new();
+        sink.finish().unwrap();
+        sink.finish().unwrap();
+        assert!(sink.finished);
+    }
+}

--- a/crates/fgumi-simd-fastq/src/lexer.rs
+++ b/crates/fgumi-simd-fastq/src/lexer.rs
@@ -41,7 +41,7 @@ pub fn lex_block(block: &[u8; 64]) -> u64 {
 /// Lex a 64-byte block, producing newline bitmask, ACGT bitmask, and 2-bit encoding.
 ///
 /// This is the full classification path for when 2-bit DNA encoding is needed
-/// (e.g., for UMI extraction in a fused pipeline).
+/// (e.g., for UMI extraction in a pipeline).
 #[inline]
 #[must_use]
 pub fn lex_block_full(block: &[u8; 64]) -> FastqBitmask {

--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -16,6 +16,7 @@ use fgumi_lib::bam_io::{
     create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
     create_raw_bam_reader,
 };
+use fgumi_lib::defaults;
 
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, QueueMemoryOptions,
@@ -188,7 +189,7 @@ pub struct Codec {
 
     // --- CODEC-specific options below ---
     /// Minimum read pairs per strand to form consensus (same as --min-reads)
-    #[arg(short = 'M', long = "min-reads", default_value = "1")]
+    #[arg(short = 'M', long = "min-reads", default_value_t = defaults::CODEC_MIN_READS)]
     pub min_reads: usize,
 
     /// Maximum read pairs per strand (downsample if exceeded)
@@ -196,7 +197,7 @@ pub struct Codec {
     pub max_reads: Option<usize>,
 
     /// Minimum duplex overlap length in bases
-    #[arg(short = 'd', long = "min-duplex-length", default_value = "1")]
+    #[arg(short = 'd', long = "min-duplex-length", default_value_t = defaults::CODEC_MIN_DUPLEX_LENGTH)]
     pub min_duplex_length: usize,
 
     /// Reduce single-strand region quality to this value (0-93).
@@ -209,11 +210,11 @@ pub struct Codec {
     pub outer_bases_qual: Option<u8>,
 
     /// Number of outer bases to reduce quality for
-    #[arg(short = 'O', long = "outer-bases-length", default_value = "5")]
+    #[arg(short = 'O', long = "outer-bases-length", default_value_t = defaults::CODEC_OUTER_BASES_LENGTH)]
     pub outer_bases_length: usize,
 
     /// Maximum duplex disagreement rate (0.0-1.0)
-    #[arg(short = 'x', long = "max-duplex-disagreement-rate", default_value = "1.0")]
+    #[arg(short = 'x', long = "max-duplex-disagreement-rate", default_value_t = defaults::CODEC_MAX_DUPLEX_DISAGREEMENT_RATE)]
     pub max_duplex_disagreement_rate: f64,
 
     /// Maximum number of duplex disagreements
@@ -221,7 +222,7 @@ pub struct Codec {
     pub max_duplex_disagreements: Option<usize>,
 
     /// SAM tag containing the cell barcode
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: Option<String>,
 
     /// Scheduler and pipeline statistics options.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use bytesize::ByteSize;
 use clap::Args;
 use fgumi_lib::bam_io::is_stdin_path;
+use fgumi_lib::defaults;
 use fgumi_lib::unified_pipeline::{BamPipelineConfig, SchedulerStrategy};
 use fgumi_lib::validation::validate_file_exists;
 use noodles::sam::Header;
@@ -92,39 +93,39 @@ impl StatsOptions {
 #[derive(Debug, Clone, Args)]
 pub struct ConsensusCallingOptions {
     /// Phred-scaled error rate prior to UMI integration
-    #[arg(short = '1', long = "error-rate-pre-umi", default_value = "45")]
+    #[arg(short = '1', long = "error-rate-pre-umi", default_value_t = defaults::CONSENSUS_ERROR_RATE_PRE_UMI)]
     pub error_rate_pre_umi: u8,
 
     /// Phred-scaled error rate post UMI integration
-    #[arg(short = '2', long = "error-rate-post-umi", default_value = "40")]
+    #[arg(short = '2', long = "error-rate-post-umi", default_value_t = defaults::CONSENSUS_ERROR_RATE_POST_UMI)]
     pub error_rate_post_umi: u8,
 
     /// Minimum base quality in raw reads to use for consensus
-    #[arg(short = 'm', long = "min-input-base-quality", default_value = "10")]
+    #[arg(short = 'm', long = "min-input-base-quality", default_value_t = defaults::CONSENSUS_MIN_INPUT_BASE_QUALITY)]
     pub min_input_base_quality: u8,
 
     /// Produce per-base tags (cd, ce) in addition to per-read tags
-    #[arg(short = 'B', long = "output-per-base-tags", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
+    #[arg(short = 'B', long = "output-per-base-tags", default_value_t = defaults::CONSENSUS_OUTPUT_PER_BASE_TAGS, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub output_per_base_tags: bool,
 
     /// Quality-trim reads before consensus calling (removes low-quality bases from ends)
-    #[arg(long = "trim", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
+    #[arg(long = "trim", default_value_t = defaults::CONSENSUS_TRIM, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub trim: bool,
 
     /// Minimum consensus base quality (output consensus bases below this are masked to N)
-    #[arg(long = "min-consensus-base-quality", default_value = "2")]
+    #[arg(long = "min-consensus-base-quality", default_value_t = defaults::CONSENSUS_MIN_BASE_QUALITY)]
     pub min_consensus_base_quality: u8,
 }
 
 impl Default for ConsensusCallingOptions {
     fn default() -> Self {
         Self {
-            error_rate_pre_umi: 45,
-            error_rate_post_umi: 40,
-            min_input_base_quality: 10,
-            output_per_base_tags: true,
-            trim: false,
-            min_consensus_base_quality: 2,
+            error_rate_pre_umi: defaults::CONSENSUS_ERROR_RATE_PRE_UMI,
+            error_rate_post_umi: defaults::CONSENSUS_ERROR_RATE_POST_UMI,
+            min_input_base_quality: defaults::CONSENSUS_MIN_INPUT_BASE_QUALITY,
+            output_per_base_tags: defaults::CONSENSUS_OUTPUT_PER_BASE_TAGS,
+            trim: defaults::CONSENSUS_TRIM,
+            min_consensus_base_quality: defaults::CONSENSUS_MIN_BASE_QUALITY,
         }
     }
 }
@@ -190,7 +191,7 @@ pub struct ReadGroupOptions {
     pub read_name_prefix: Option<String>,
 
     /// Read group ID for consensus reads
-    #[arg(short = 'R', long = "read-group-id", default_value = "A")]
+    #[arg(short = 'R', long = "read-group-id", default_value = defaults::READ_GROUP_ID)]
     pub read_group_id: String,
 }
 
@@ -206,7 +207,7 @@ impl ReadGroupOptions {
 
 impl Default for ReadGroupOptions {
     fn default() -> Self {
-        Self { read_name_prefix: None, read_group_id: "A".to_string() }
+        Self { read_name_prefix: None, read_group_id: defaults::READ_GROUP_ID.to_string() }
     }
 }
 
@@ -214,13 +215,13 @@ impl Default for ReadGroupOptions {
 #[derive(Debug, Clone, Args)]
 pub struct OverlappingConsensusOptions {
     /// Consensus call overlapping bases in read pairs before UMI consensus calling
-    #[arg(long = "consensus-call-overlapping-bases", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
+    #[arg(long = "consensus-call-overlapping-bases", default_value_t = defaults::CONSENSUS_CALL_OVERLAPPING_BASES, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub consensus_call_overlapping_bases: bool,
 }
 
 impl Default for OverlappingConsensusOptions {
     fn default() -> Self {
-        Self { consensus_call_overlapping_bases: true }
+        Self { consensus_call_overlapping_bases: defaults::CONSENSUS_CALL_OVERLAPPING_BASES }
     }
 }
 
@@ -284,14 +285,20 @@ pub struct ThreadingOptions {
 /// Options for output compression.
 ///
 /// Controls BGZF compression level for BAM output files.
-#[derive(Debug, Clone, Default, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct CompressionOptions {
     /// Compression level for output BAM (1-12).
     ///
     /// Level 1 is fastest with larger files.
     /// Level 12 produces smallest files but is slowest.
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, default_value_t = defaults::COMPRESSION_LEVEL)]
     pub compression_level: u32,
+}
+
+impl Default for CompressionOptions {
+    fn default() -> Self {
+        Self { compression_level: defaults::COMPRESSION_LEVEL }
+    }
 }
 
 /// Options for pipeline scheduler configuration.

--- a/src/commands/correct.rs
+++ b/src/commands/correct.rs
@@ -45,24 +45,29 @@ use anyhow::{Result, bail};
 use clap::Parser;
 use crossbeam_queue::SegQueue;
 use fgumi_lib::bam_io::{
-    BamWriter, create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader,
+    create_bam_reader, create_bam_reader_for_pipeline, create_bam_writer,
+    create_optional_bam_writer,
 };
-use fgumi_lib::bitenc::BitEnc;
-use fgumi_lib::dna::reverse_complement_str;
+use fgumi_lib::correct::{
+    EncodedUmiSet, RejectionReason, TemplateCorrection, UmiMatch, apply_correction_to_raw,
+    compute_template_correction, extract_and_validate_template_umi_raw,
+    find_umi_pairs_within_distance, load_umi_sequences,
+};
 use fgumi_lib::grouper::TemplateGrouper;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::metrics::correct::UmiCorrectionMetrics;
 use fgumi_lib::progress::ProgressTracker;
-use fgumi_lib::sort::bam_fields;
-use fgumi_lib::template::TemplateBatch;
-use fgumi_lib::unified_pipeline::{Grouper, MemoryEstimate, run_bam_pipeline_from_reader};
+use fgumi_lib::template::{TemplateBatch, TemplateIterator};
+use fgumi_lib::unified_pipeline::{
+    Grouper, MemoryEstimate, run_bam_pipeline_from_reader, serialize_bam_records_into,
+};
 use fgumi_lib::validation::validate_file_exists;
-use fgumi_raw_bam::RawRecord;
 use log::{info, warn};
 use lru::LruCache;
-use noodles::sam::Header;
+use noodles::sam::alignment::io::Write as SamWrite;
 use noodles::sam::alignment::record::data::field::Tag;
+use noodles::sam::alignment::record_buf::RecordBuf;
+use noodles::sam::{self, Header};
 use std::io;
 use std::num::NonZero;
 use std::path::PathBuf;
@@ -74,22 +79,7 @@ use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions, SchedulerOptions,
     ThreadingOptions, build_pipeline_config,
 };
-
-/// Result of matching an observed UMI to an expected UMI.
-///
-/// Contains information about whether the match was acceptable and the details
-/// of the best matching UMI.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UmiMatch {
-    /// Whether the match is acceptable based on mismatch and distance thresholds.
-    pub matched: bool,
-
-    /// The fixed UMI sequence that was the closest match.
-    pub umi: String,
-
-    /// The number of mismatches between the observed and best matching UMI.
-    pub mismatches: usize,
-}
+use fgumi_lib::defaults;
 
 /// Corrects UMIs in BAM files to a fixed set of known UMI sequences.
 ///
@@ -209,7 +199,7 @@ pub struct CorrectUmis {
     pub metrics: Option<PathBuf>,
 
     /// Maximum number of mismatches allowed.
-    #[arg(long, default_value = "2")]
+    #[arg(long, default_value_t = defaults::CORRECT_MAX_MISMATCHES)]
     pub max_mismatches: usize,
 
     /// Minimum difference between best and second-best match.
@@ -225,7 +215,7 @@ pub struct CorrectUmis {
     pub umi_files: Vec<PathBuf>,
 
     /// SAM tag for the UMI field.
-    #[arg(long, default_value = "RX")]
+    #[arg(long, default_value = defaults::UMI_TAG)]
     pub umi_tag: String,
 
     /// Don't store original UMIs in a separate tag.
@@ -233,7 +223,7 @@ pub struct CorrectUmis {
     pub dont_store_original_umis: bool,
 
     /// Size of the LRU cache for UMI matching.
-    #[arg(long, default_value = "100000")]
+    #[arg(long, default_value_t = defaults::CORRECT_CACHE_SIZE)]
     pub cache_size: usize,
 
     /// Minimum fraction of reads that must pass correction.
@@ -261,45 +251,19 @@ pub struct CorrectUmis {
     pub queue_memory: QueueMemoryOptions,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum RejectionReason {
-    WrongLength,
-    Mismatched,
-    #[default]
-    None,
-}
-
-/// Result of UMI correction for a template.
-///
-/// This struct holds the result of correcting a UMI once for an entire template,
-/// which can then be applied to all records in that template.
-#[derive(Debug)]
-struct TemplateCorrection {
-    /// Whether the UMI matched successfully.
-    matched: bool,
-    /// The corrected UMI string (if matched).
-    corrected_umi: Option<String>,
-    /// The original UMI string.
-    original_umi: String,
-    /// Whether correction was needed (mismatches > 0 or revcomp).
-    needs_correction: bool,
-    /// Whether there were actual mismatches (not just revcomp).
-    has_mismatches: bool,
-    /// Match details for metrics.
-    matches: Vec<UmiMatch>,
-    /// Rejection reason if not matched.
-    rejection_reason: RejectionReason,
-}
-
 // ============================================================================
 // 7-Step Pipeline Types
 // ============================================================================
 
 /// Result from processing a batch of templates through UMI correction.
 struct CorrectProcessedBatch {
-    /// Raw-byte kept records.
+    /// Records to write (kept records with corrected UMIs).
+    kept_records: Vec<RecordBuf>,
+    /// Rejected records (if tracking rejects).
+    rejected_records: Vec<RecordBuf>,
+    /// Raw-byte kept records (raw-byte mode).
     kept_raw_records: Vec<Vec<u8>>,
-    /// Raw-byte rejected records.
+    /// Raw-byte rejected records (raw-byte mode).
     rejected_raw_records: Vec<Vec<u8>>,
     /// Number of templates processed.
     templates_count: u64,
@@ -315,6 +279,15 @@ struct CorrectProcessedBatch {
 
 impl MemoryEstimate for CorrectProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
+        let recordbuf_size: usize = self
+            .kept_records
+            .iter()
+            .chain(self.rejected_records.iter())
+            .map(MemoryEstimate::estimate_heap_size)
+            .sum();
+        let recordbuf_vec_overhead = (self.kept_records.capacity()
+            + self.rejected_records.capacity())
+            * std::mem::size_of::<RecordBuf>();
         let raw_size: usize = self
             .kept_raw_records
             .iter()
@@ -324,7 +297,7 @@ impl MemoryEstimate for CorrectProcessedBatch {
         let raw_vec_overhead = (self.kept_raw_records.capacity()
             + self.rejected_raw_records.capacity())
             * std::mem::size_of::<Vec<u8>>();
-        raw_size + raw_vec_overhead
+        recordbuf_size + recordbuf_vec_overhead + raw_size + raw_vec_overhead
     }
 }
 
@@ -341,7 +314,9 @@ struct CollectedCorrectMetrics {
     mismatched: u64,
     /// Per-UMI match counts (for metrics file).
     umi_matches: AHashMap<String, UmiCorrectionMetrics>,
-    /// Rejected raw records (if tracking).
+    /// Rejected records (if tracking).
+    rejects: Vec<RecordBuf>,
+    /// Rejected raw records (if tracking, for raw-byte mode).
     raw_rejects: Vec<Vec<u8>>,
 }
 
@@ -485,34 +460,7 @@ impl CorrectUmis {
     /// - UMI files cannot be read
     /// - UMIs have different lengths
     fn load_umi_sequences(&self) -> Result<(Vec<String>, usize)> {
-        let mut umi_set: std::collections::HashSet<String> =
-            self.umis.iter().map(|s| s.to_uppercase()).collect();
-
-        for file in &self.umi_files {
-            let content = std::fs::read_to_string(file)?;
-            for line in content.lines() {
-                let umi = line.trim().to_uppercase();
-                if !umi.is_empty() {
-                    umi_set.insert(umi);
-                }
-            }
-        }
-
-        if umi_set.is_empty() {
-            bail!("No UMIs provided.");
-        }
-
-        let mut umi_sequences: Vec<String> = umi_set.into_iter().collect();
-        umi_sequences.sort_unstable();
-
-        // Check all UMIs have the same length
-        let first_len = umi_sequences[0].len();
-        if !umi_sequences.iter().all(|u| u.len() == first_len) {
-            bail!("All UMIs must have the same length.");
-        }
-
-        info!("Loaded {} UMI sequences of length {}", umi_sequences.len(), first_len);
-        Ok((umi_sequences, first_len))
+        load_umi_sequences(&self.umis, &self.umi_files)
     }
 
     /// Checks distances between UMI pairs and warns about ambiguities.
@@ -537,7 +485,75 @@ impl CorrectUmis {
         }
     }
 
+    /// Extracts and validates that all records in a template have the same UMI.
+    ///
+    /// Returns:
+    /// - `Some(umi)` if all records have the same UMI
+    /// - `None` if no records have a UMI (all missing)
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - Records have different UMIs
+    /// - Some records have UMIs and others don't
+    /// - UMI tag has non-string value
+    fn extract_and_validate_template_umi(records: &[RecordBuf], umi_tag: Tag) -> Option<String> {
+        if records.is_empty() {
+            return None;
+        }
+
+        // Extract UMI from first record
+        let first_umi = records[0].data().get(&umi_tag).map(|v| {
+            if let sam::alignment::record_buf::data::field::Value::String(s) = v {
+                String::from_utf8_lossy(s).to_string()
+            } else {
+                panic!(
+                    "UMI tag {:?} has non-string value in record {:?}",
+                    umi_tag,
+                    records[0].name()
+                );
+            }
+        });
+
+        // Validate all other records have the same UMI
+        for record in &records[1..] {
+            let current_umi = record.data().get(&umi_tag).map(|v| {
+                if let sam::alignment::record_buf::data::field::Value::String(s) = v {
+                    String::from_utf8_lossy(s).to_string()
+                } else {
+                    panic!(
+                        "UMI tag {:?} has non-string value in record {:?}",
+                        umi_tag,
+                        record.name()
+                    );
+                }
+            });
+
+            match (&first_umi, &current_umi) {
+                (Some(first), Some(current)) if first != current => {
+                    panic!(
+                        "Template {:?} has mismatched UMIs: first={:?}, current={:?}",
+                        records[0].name(),
+                        first,
+                        current
+                    );
+                }
+                (Some(_), None) | (None, Some(_)) => {
+                    panic!(
+                        "Template {:?} has inconsistent UMI presence across records",
+                        records[0].name()
+                    );
+                }
+                _ => {} // Both None or both Some with matching values
+            }
+        }
+
+        first_umi
+    }
+
     /// Compute UMI correction for a template (called once per template).
+    ///
+    /// Delegates to [`correct::compute_template_correction`] in the library crate.
     #[allow(clippy::too_many_arguments)]
     fn compute_template_correction(
         umi: &str,
@@ -548,174 +564,69 @@ impl CorrectUmis {
         encoded_umi_set: &EncodedUmiSet,
         cache: &mut Option<LruCache<Vec<u8>, UmiMatch>>,
     ) -> TemplateCorrection {
-        let original_umi = umi.to_string();
+        compute_template_correction(
+            umi,
+            umi_length,
+            revcomp,
+            max_mismatches,
+            min_distance_diff,
+            encoded_umi_set,
+            cache,
+        )
+    }
 
-        // Split and optionally reverse complement
-        let sequences: Vec<String> = if revcomp {
-            umi.split('-').map(reverse_complement_str).rev().collect()
-        } else {
-            umi.split('-').map(std::string::ToString::to_string).collect()
-        };
-
-        // Check length
-        if sequences.iter().any(|s| s.len() != umi_length) {
-            return TemplateCorrection {
-                matched: false,
-                corrected_umi: None,
-                original_umi,
-                needs_correction: false,
-                has_mismatches: false,
-                matches: Vec::new(),
-                rejection_reason: RejectionReason::WrongLength,
-            };
-        }
-
-        // Find matches for each UMI segment
-        let mut matches = Vec::with_capacity(sequences.len());
-        for seq in &sequences {
-            // Uppercase using bytes directly - avoids String allocation
-            let seq_bytes: Vec<u8> = seq.bytes().map(|b| b.to_ascii_uppercase()).collect();
-
-            let umi_match = if let Some(c) = cache {
-                if let Some(cached) = c.get(&seq_bytes[..]) {
-                    cached.clone()
-                } else {
-                    let result = find_best_match_encoded(
-                        &seq_bytes,
-                        encoded_umi_set,
-                        max_mismatches,
-                        min_distance_diff,
-                    );
-                    c.put(seq_bytes, result.clone());
-                    result
-                }
-            } else {
-                find_best_match_encoded(
-                    &seq_bytes,
-                    encoded_umi_set,
-                    max_mismatches,
-                    min_distance_diff,
-                )
-            };
-
-            matches.push(umi_match);
-        }
-
-        // Determine if all segments matched
-        let all_matched = matches.iter().all(|m| m.matched);
-        let has_mismatches = matches.iter().any(|m| m.mismatches > 0);
-        let needs_correction = has_mismatches || revcomp;
-
-        if all_matched {
-            let corrected_umi: String =
-                matches.iter().map(|m| m.umi.clone()).collect::<Vec<_>>().join("-");
-            TemplateCorrection {
-                matched: true,
-                corrected_umi: Some(corrected_umi),
-                original_umi,
-                needs_correction,
-                has_mismatches,
-                matches,
-                rejection_reason: RejectionReason::None,
+    /// Apply a computed correction to a record.
+    fn apply_correction_to_record(
+        mut record: RecordBuf,
+        correction: &TemplateCorrection,
+        umi_tag: Tag,
+        dont_store_original_umis: bool,
+    ) -> RecordBuf {
+        if correction.needs_correction {
+            // Store original UMI if there were actual mismatches
+            if !dont_store_original_umis && correction.has_mismatches {
+                record.data_mut().insert(
+                    Tag::ORIGINAL_UMI_BARCODE_SEQUENCE,
+                    sam::alignment::record_buf::data::field::Value::String(
+                        correction.original_umi.clone().into(),
+                    ),
+                );
             }
-        } else {
-            TemplateCorrection {
-                matched: false,
-                corrected_umi: None,
-                original_umi,
-                needs_correction: false,
-                has_mismatches: false,
-                matches,
-                rejection_reason: RejectionReason::Mismatched,
+
+            // Write corrected UMI
+            if let Some(ref corrected) = correction.corrected_umi {
+                record.data_mut().insert(
+                    umi_tag,
+                    sam::alignment::record_buf::data::field::Value::String(
+                        corrected.clone().into(),
+                    ),
+                );
             }
         }
+        record
     }
 
     /// Extract and validate UMI from raw-byte records in a template.
     ///
-    /// Returns `Ok(None)` if no records have a UMI, including when any record is
-    /// truncated (< 32 bytes), which is treated as missing UMI data.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Records have different UMIs
-    /// - Some records have UMIs and others don't
-    /// - UMI tag has non-string type
+    /// Delegates to [`correct::extract_and_validate_template_umi_raw`] in the library
+    /// crate.
     fn extract_and_validate_template_umi_raw(
         raw_records: &[Vec<u8>],
         umi_tag: [u8; 2],
     ) -> anyhow::Result<Option<String>> {
-        use fgumi_lib::sort::bam_fields;
-
-        if raw_records.is_empty() {
-            return Ok(None);
-        }
-
-        // Guard against truncated records
-        if raw_records.iter().any(|r| r.len() < 32) {
-            return Ok(None);
-        }
-
-        let first_aux = bam_fields::aux_data_slice(&raw_records[0]);
-        // Work with &[u8] slices to avoid per-record String allocation
-        let first_umi_bytes = bam_fields::find_string_tag(first_aux, &umi_tag);
-
-        // If tag exists but is not a Z-type string, return an error
-        if first_umi_bytes.is_none() {
-            if let Some(tag_type) = bam_fields::find_tag_type(first_aux, &umi_tag) {
-                anyhow::bail!(
-                    "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
-                    std::str::from_utf8(&umi_tag).unwrap_or("??"),
-                    tag_type as char,
-                );
-            }
-        }
-
-        for raw in &raw_records[1..] {
-            let aux = bam_fields::aux_data_slice(raw);
-            let current_umi_bytes = bam_fields::find_string_tag(aux, &umi_tag);
-
-            match (first_umi_bytes, current_umi_bytes) {
-                (Some(first), Some(current)) if first != current => {
-                    anyhow::bail!(
-                        "Template has mismatched UMIs: first={:?}, current={:?}",
-                        String::from_utf8_lossy(first),
-                        String::from_utf8_lossy(current)
-                    );
-                }
-                (Some(_), None) | (None, Some(_)) => {
-                    anyhow::bail!("Template has inconsistent UMI presence across records");
-                }
-                _ => {}
-            }
-        }
-
-        // Only allocate String once at the end
-        Ok(first_umi_bytes.map(|b| String::from_utf8_lossy(b).into_owned()))
+        extract_and_validate_template_umi_raw(raw_records, umi_tag)
     }
 
     /// Apply UMI correction to a raw BAM record.
+    ///
+    /// Delegates to [`correct::apply_correction_to_raw`] in the library crate.
     fn apply_correction_to_raw(
         record: &mut Vec<u8>,
         correction: &TemplateCorrection,
         umi_tag: [u8; 2],
         dont_store_original_umis: bool,
     ) {
-        use fgumi_lib::sort::bam_fields;
-
-        if correction.needs_correction {
-            // Write corrected UMI first (in-place update avoids scanning past OX)
-            if let Some(ref corrected) = correction.corrected_umi {
-                bam_fields::update_string_tag(record, &umi_tag, corrected.as_bytes());
-            }
-
-            // Store original UMI if there were actual mismatches
-            // Use update_string_tag to avoid duplicate OX tags
-            if !dont_store_original_umis && correction.has_mismatches {
-                bam_fields::update_string_tag(record, b"OX", correction.original_umi.as_bytes());
-            }
-        }
+        apply_correction_to_raw(record, correction, umi_tag, dont_store_original_umis);
     }
 
     fn finalize_metrics(
@@ -827,11 +738,11 @@ impl CorrectUmis {
             CACHE.with(|cache_cell| {
                 let mut cache_ref = cache_cell.borrow_mut();
                 if cache_ref.is_none() && cache_size > 0 {
-                    *cache_ref = Some(LruCache::new(
-                        NonZero::new(cache_size).expect("cache_size > 0 checked above"),
-                    ));
+                    *cache_ref = Some(LruCache::new(NonZero::new(cache_size).unwrap()));
                 }
 
+                let mut kept_records = Vec::new();
+                let mut rejected_records = Vec::new();
                 let mut kept_raw_records = Vec::new();
                 let mut rejected_raw_records: Vec<Vec<u8>> = Vec::new();
                 let mut missing_umis = 0u64;
@@ -847,17 +758,14 @@ impl CorrectUmis {
                     // Count input records BEFORE processing
                     total_input_records += template.read_count() as u64;
 
-                    debug_assert!(
-                        template.is_raw_byte_mode(),
-                        "Expected raw-byte mode template in pipeline; RecordBuf mode is no longer supported"
-                    );
-                    {
+                    if template.is_raw_byte_mode() {
+                        // Raw-byte mode - take ownership to avoid deep clone
                         let raw_records = template.into_raw_records().unwrap_or_default();
                         let umi_opt = Self::extract_and_validate_template_umi_raw(
                             &raw_records,
                             umi_tag_bytes,
                         )
-                        .map_err(io::Error::other)?;
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
                         match umi_opt {
                             None => {
@@ -936,6 +844,88 @@ impl CorrectUmis {
                                 }
                             }
                         }
+                    } else {
+                        // RecordBuf mode
+                        let records: Vec<RecordBuf> = template.into_records();
+                        let umi_opt = Self::extract_and_validate_template_umi(&records, umi_tag);
+
+                        match umi_opt {
+                            None => {
+                                let num_records = records.len() as u64;
+                                missing_umis += num_records;
+                                let entry = umi_matches_map
+                                    .entry(unmatched_umi_for_process.clone())
+                                    .or_insert_with(|| {
+                                        UmiCorrectionMetrics::new(unmatched_umi_for_process.clone())
+                                    });
+                                entry.total_matches += num_records;
+                                if track_rejects {
+                                    rejected_records.extend(records);
+                                }
+                            }
+                            Some(umi) => {
+                                let correction = Self::compute_template_correction(
+                                    &umi,
+                                    umi_length,
+                                    revcomp,
+                                    max_mismatches,
+                                    min_distance_diff,
+                                    &encoded_umi_set,
+                                    &mut cache_ref,
+                                );
+                                let num_records = records.len() as u64;
+
+                                if correction.matched {
+                                    for m in &correction.matches {
+                                        if m.matched {
+                                            let entry = umi_matches_map
+                                                .entry(m.umi.clone())
+                                                .or_insert_with(|| {
+                                                    UmiCorrectionMetrics::new(m.umi.clone())
+                                                });
+                                            entry.total_matches += num_records;
+                                            match m.mismatches {
+                                                0 => entry.perfect_matches += num_records,
+                                                1 => entry.one_mismatch_matches += num_records,
+                                                2 => entry.two_mismatch_matches += num_records,
+                                                _ => entry.other_matches += num_records,
+                                            }
+                                        }
+                                    }
+
+                                    for record in records {
+                                        let corrected = Self::apply_correction_to_record(
+                                            record,
+                                            &correction,
+                                            umi_tag,
+                                            dont_store_original_umis,
+                                        );
+                                        kept_records.push(corrected);
+                                    }
+                                } else {
+                                    match correction.rejection_reason {
+                                        RejectionReason::WrongLength => {
+                                            wrong_length += num_records;
+                                        }
+                                        RejectionReason::Mismatched => {
+                                            mismatched += num_records;
+                                        }
+                                        RejectionReason::None => {}
+                                    }
+                                    let entry = umi_matches_map
+                                        .entry(unmatched_umi_for_process.clone())
+                                        .or_insert_with(|| {
+                                            UmiCorrectionMetrics::new(
+                                                unmatched_umi_for_process.clone(),
+                                            )
+                                        });
+                                    entry.total_matches += num_records;
+                                    if track_rejects {
+                                        rejected_records.extend(records);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -946,6 +936,8 @@ impl CorrectUmis {
                 }
 
                 Ok(CorrectProcessedBatch {
+                    kept_records,
+                    rejected_records,
                     kept_raw_records,
                     rejected_raw_records,
                     templates_count,
@@ -959,7 +951,7 @@ impl CorrectUmis {
 
         // Serialize function: convert records to bytes and collect metrics
         let serialize_fn = move |processed: CorrectProcessedBatch,
-                                 _header: &Header,
+                                 header: &Header,
                                  output: &mut Vec<u8>|
               -> io::Result<u64> {
             // Push metrics to lock-free queue
@@ -969,16 +961,23 @@ impl CorrectUmis {
                 wrong_length: processed.wrong_length,
                 mismatched: processed.mismatched,
                 umi_matches: processed.umi_matches,
+                rejects: processed.rejected_records,
                 raw_rejects: processed.rejected_raw_records,
             });
 
-            // Serialize kept records
+            // Serialize kept records: raw-byte path or RecordBuf path
             let mut kept_count = 0u64;
-            for raw in &processed.kept_raw_records {
-                let block_size = raw.len() as u32;
-                output.extend_from_slice(&block_size.to_le_bytes());
-                output.extend_from_slice(raw);
-                kept_count += 1;
+            if !processed.kept_raw_records.is_empty() {
+                for raw in &processed.kept_raw_records {
+                    let block_size = raw.len() as u32;
+                    output.extend_from_slice(&block_size.to_le_bytes());
+                    output.extend_from_slice(raw);
+                    kept_count += 1;
+                }
+            }
+            if !processed.kept_records.is_empty() {
+                kept_count += processed.kept_records.len() as u64;
+                serialize_bam_records_into(&processed.kept_records, header, output)?;
             }
             // Return KEPT record count (not input count, to avoid double-counting)
             Ok(kept_count)
@@ -1005,6 +1004,7 @@ impl CorrectUmis {
         let mut total_wrong_length = 0u64;
         let mut total_mismatched = 0u64;
         let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+        let mut all_rejects: Vec<RecordBuf> = Vec::new();
         let mut all_raw_rejects: Vec<Vec<u8>> = Vec::new();
 
         while let Some(metrics) = collected_metrics.pop() {
@@ -1025,12 +1025,14 @@ impl CorrectUmis {
             }
 
             if track_rejects {
+                all_rejects.extend(metrics.rejects);
                 all_raw_rejects.extend(metrics.raw_rejects);
             }
         }
 
         // Write rejects file if requested
-        if track_rejects && !all_raw_rejects.is_empty() {
+        let has_rejects = !all_rejects.is_empty() || !all_raw_rejects.is_empty();
+        if track_rejects && has_rejects {
             if let Some(rejects_path) = &self.rejects_opts.rejects {
                 let writer_threads = self.threading.num_threads();
                 let mut rejects_writer = create_optional_bam_writer(
@@ -1039,8 +1041,19 @@ impl CorrectUmis {
                     writer_threads,
                     self.compression.compression_level,
                 )?
-                .expect("create_optional_bam_writer returns Some when given Some path");
+                .expect("rejects path is Some");
 
+                // Ensure we never mix RecordBuf and raw rejects in the same run
+                debug_assert!(
+                    all_rejects.is_empty() || all_raw_rejects.is_empty(),
+                    "mixed RecordBuf and raw-byte rejects in same run"
+                );
+
+                // Write RecordBuf rejects
+                for record in &all_rejects {
+                    rejects_writer.write_alignment_record(&header_for_rejects, record)?;
+                }
+                // Write raw-byte rejects
                 for raw in &all_raw_rejects {
                     use std::io::Write;
                     let block_size = raw.len() as u32;
@@ -1049,13 +1062,14 @@ impl CorrectUmis {
                 }
 
                 rejects_writer.into_inner().finish()?;
-                let total_reject_records = all_raw_rejects.len();
+                let total_reject_records = all_rejects.len() + all_raw_rejects.len();
                 info!("Wrote {total_reject_records} rejected records to rejects file");
             }
         }
 
         // Ensure ALL UMI rows are present (even with zero counts) - matches fgbio behavior
-        for umi in encoded_umi_set_for_metrics.strings.iter().chain(std::iter::once(&unmatched_umi))
+        for umi in
+            encoded_umi_set_for_metrics.strings().iter().chain(std::iter::once(&unmatched_umi))
         {
             merged_umi_matches
                 .entry(umi.clone())
@@ -1102,7 +1116,7 @@ impl CorrectUmis {
     /// Execute using single-threaded mode with template-level UMI correction.
     ///
     /// This method runs entirely on the main thread with no pipeline overhead.
-    /// It reads raw BAM records and groups them by QNAME, applying UMI correction
+    /// It uses `TemplateBatchReader` to read templates and applies UMI correction
     /// once per template, then applies the correction to all records in the template.
     #[allow(clippy::too_many_lines)]
     fn execute_single_thread_mode(
@@ -1114,8 +1128,10 @@ impl CorrectUmis {
     ) -> Result<u64> {
         info!("Using single-threaded mode with template-level UMI correction");
 
-        // Open input BAM reader (raw-byte reader for zero-copy processing)
-        let (mut bam_reader, _) = create_raw_bam_reader(&self.io.input, 1)?;
+        // Open input BAM reader and create template iterator
+        let (mut bam_reader, _) = create_bam_reader(&self.io.input, 1)?;
+        let record_iter = bam_reader.record_bufs(&header).map(|r| r.map_err(Into::into));
+        let template_iter = TemplateIterator::new(record_iter);
 
         // Open output writer (single-threaded)
         let mut writer =
@@ -1129,16 +1145,14 @@ impl CorrectUmis {
 
         // LRU cache (single thread, no thread_local needed)
         let mut cache: Option<LruCache<Vec<u8>, UmiMatch>> = if self.cache_size > 0 {
-            Some(LruCache::new(
-                NonZero::new(self.cache_size).expect("cache_size > 0 checked above"),
-            ))
+            Some(LruCache::new(NonZero::new(self.cache_size).unwrap()))
         } else {
             None
         };
 
         // Initialize metrics
         let unmatched_umi = "N".repeat(umi_length);
-        let umi_sequences = encoded_umi_set.strings.clone();
+        let umi_sequences = encoded_umi_set.strings().to_vec();
         let mut umi_metrics: AHashMap<String, UmiCorrectionMetrics> = umi_sequences
             .iter()
             .chain(std::iter::once(&unmatched_umi))
@@ -1153,143 +1167,94 @@ impl CorrectUmis {
         let mut mismatched = 0u64;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        let umi_tag_bytes: [u8; 2] = [self.umi_tag.as_bytes()[0], self.umi_tag.as_bytes()[1]];
+        let umi_tag = Tag::new(self.umi_tag.as_bytes()[0], self.umi_tag.as_bytes()[1]);
         let max_mismatches = self.max_mismatches;
         let min_distance_diff = self.min_distance_diff;
         let revcomp = self.revcomp;
         let dont_store_original_umis = self.dont_store_original_umis;
 
-        // Helper to write a raw BAM record to a noodles BamWriter
-        #[allow(clippy::cast_possible_truncation)]
-        fn write_raw(writer: &mut BamWriter, raw: &[u8]) -> Result<()> {
-            use std::io::Write;
-            let block_size = raw.len() as u32;
-            writer.get_mut().write_all(&block_size.to_le_bytes())?;
-            writer.get_mut().write_all(raw)?;
-            Ok(())
-        }
+        // Process templates
+        for template_result in template_iter {
+            let template = template_result?;
+            let records: Vec<RecordBuf> = template.into_records();
+            let num_records = records.len() as u64;
+            total_records += num_records;
+            total_templates += 1;
 
-        // Read raw records and group by QNAME
-        let mut record = RawRecord::new();
-        let mut current_template: Vec<Vec<u8>> = Vec::new();
-        let mut current_name: Option<Vec<u8>> = None;
+            // Template-level UMI correction
+            let umi_opt = Self::extract_and_validate_template_umi(&records, umi_tag);
 
-        loop {
-            let bytes_read = bam_reader.read_record(&mut record)?;
-            let eof = bytes_read == 0;
-
-            // Determine if we need to flush the current template
-            let flush = if eof {
-                !current_template.is_empty()
-            } else {
-                let name = bam_fields::read_name(record.as_ref());
-                current_name.as_deref().is_some_and(|cn| cn != name)
-            };
-
-            if flush {
-                let mut raw_records = std::mem::take(&mut current_template);
-
-                #[allow(clippy::cast_possible_truncation)]
-                let num_records = raw_records.len() as u64;
-                total_records += num_records;
-                total_templates += 1;
-
-                // Template-level UMI correction
-                let umi_opt = CorrectUmis::extract_and_validate_template_umi_raw(
-                    &raw_records,
-                    umi_tag_bytes,
-                )?;
-
-                match umi_opt {
-                    None => {
-                        // No UMI in any record - reject all records
-                        missing_umis += num_records;
-                        umi_metrics
-                            .get_mut(&unmatched_umi)
-                            .expect("unmatched_umi key initialized in metrics map")
-                            .total_matches += num_records;
-
-                        if track_rejects {
-                            if let Some(rw) = reject_writer.as_mut() {
-                                for raw in raw_records.drain(..) {
-                                    write_raw(rw, &raw)?;
-                                }
+            match umi_opt {
+                None => {
+                    // No UMI in any record - reject all records
+                    missing_umis += num_records;
+                    umi_metrics.get_mut(&unmatched_umi).unwrap().total_matches += num_records;
+                    if track_rejects {
+                        if let Some(ref mut rw) = reject_writer {
+                            for record in records {
+                                rw.write_alignment_record(&header, &record)?;
                             }
                         }
                     }
-                    Some(umi) => {
-                        // Correct UMI once for the template
-                        let correction = CorrectUmis::compute_template_correction(
-                            &umi,
-                            umi_length,
-                            revcomp,
-                            max_mismatches,
-                            min_distance_diff,
-                            &encoded_umi_set,
-                            &mut cache,
-                        );
+                }
+                Some(umi) => {
+                    // Correct UMI once for the template
+                    let correction = Self::compute_template_correction(
+                        &umi,
+                        umi_length,
+                        revcomp,
+                        max_mismatches,
+                        min_distance_diff,
+                        &encoded_umi_set,
+                        &mut cache,
+                    );
 
-                        if correction.matched {
-                            // Update metrics for matched UMIs (count per-read, not per-template)
-                            for m in &correction.matches {
-                                if m.matched {
-                                    let entry = umi_metrics.get_mut(&m.umi).expect(
-                                        "UMI key initialized in metrics map from allowed UMIs",
-                                    );
-                                    entry.total_matches += num_records;
-                                    match m.mismatches {
-                                        0 => entry.perfect_matches += num_records,
-                                        1 => entry.one_mismatch_matches += num_records,
-                                        2 => entry.two_mismatch_matches += num_records,
-                                        _ => entry.other_matches += num_records,
-                                    }
+                    if correction.matched {
+                        // Update metrics for matched UMIs (count per-read, not per-template)
+                        for m in &correction.matches {
+                            if m.matched {
+                                let entry = umi_metrics.get_mut(&m.umi).unwrap();
+                                entry.total_matches += num_records;
+                                match m.mismatches {
+                                    0 => entry.perfect_matches += num_records,
+                                    1 => entry.one_mismatch_matches += num_records,
+                                    2 => entry.two_mismatch_matches += num_records,
+                                    _ => entry.other_matches += num_records,
                                 }
                             }
+                        }
 
-                            // Apply correction to all records in template and write
-                            for mut raw in raw_records.drain(..) {
-                                CorrectUmis::apply_correction_to_raw(
-                                    &mut raw,
-                                    &correction,
-                                    umi_tag_bytes,
-                                    dont_store_original_umis,
-                                );
-                                write_raw(&mut writer, &raw)?;
-                            }
-                        } else {
-                            // Rejection - update counters based on reason
-                            match correction.rejection_reason {
-                                RejectionReason::WrongLength => wrong_length += num_records,
-                                RejectionReason::Mismatched => mismatched += num_records,
-                                RejectionReason::None => {}
-                            }
-                            umi_metrics
-                                .get_mut(&unmatched_umi)
-                                .expect("unmatched_umi key initialized in metrics map")
-                                .total_matches += num_records;
+                        // Apply correction to all records in template and write
+                        for record in records {
+                            let corrected = Self::apply_correction_to_record(
+                                record,
+                                &correction,
+                                umi_tag,
+                                dont_store_original_umis,
+                            );
+                            writer.write_alignment_record(&header, &corrected)?;
+                        }
+                    } else {
+                        // Rejection - update counters based on reason
+                        match correction.rejection_reason {
+                            RejectionReason::WrongLength => wrong_length += num_records,
+                            RejectionReason::Mismatched => mismatched += num_records,
+                            RejectionReason::None => {}
+                        }
+                        umi_metrics.get_mut(&unmatched_umi).unwrap().total_matches += num_records;
 
-                            if track_rejects {
-                                if let Some(rw) = reject_writer.as_mut() {
-                                    for raw in raw_records.drain(..) {
-                                        write_raw(rw, &raw)?;
-                                    }
+                        if track_rejects {
+                            if let Some(ref mut rw) = reject_writer {
+                                for record in records {
+                                    rw.write_alignment_record(&header, &record)?;
                                 }
                             }
                         }
                     }
                 }
-
-                progress.log_if_needed(num_records);
             }
 
-            if eof {
-                break;
-            }
-
-            // Accumulate current record
-            let raw: &[u8] = record.as_ref();
-            current_name = Some(bam_fields::read_name(raw).to_vec());
-            current_template.push(raw.to_vec());
+            progress.log_if_needed(num_records);
         }
 
         progress.log_final();
@@ -1336,211 +1301,14 @@ impl CorrectUmis {
     }
 }
 
-/// Counts mismatches between two sequences, stopping early if max is exceeded.
-///
-/// Efficiently counts mismatches between two byte sequences, stopping as soon as
-/// `max_mismatches + 1` is reached. This early stopping is crucial for performance
-/// when processing many sequences.
-///
-/// # Arguments
-///
-/// * `a` - First sequence
-/// * `b` - Second sequence
-/// * `max_mismatches` - Stop counting after this many mismatches
-///
-/// # Returns
-///
-/// The number of mismatches, capped at `max_mismatches + 1`.
-///
-/// # Example
-///
-/// ```
-/// # use fgumi_lib::correct_umis::count_mismatches_with_max;
-/// assert_eq!(count_mismatches_with_max(b"AAAAAA", b"AAAAAA", 10), 0);
-/// assert_eq!(count_mismatches_with_max(b"AAAAAA", b"AAAAAT", 10), 1);
-/// assert_eq!(count_mismatches_with_max(b"AAAAAA", b"CCCCCC", 2), 3);
-/// ```
-#[must_use]
-pub fn count_mismatches_with_max(a: &[u8], b: &[u8], max_mismatches: usize) -> usize {
-    let mut mismatches = 0;
-    let min_len = a.len().min(b.len());
-
-    for i in 0..min_len {
-        if a[i] != b[i] {
-            mismatches += 1;
-            if mismatches > max_mismatches {
-                return mismatches;
-            }
-        }
-    }
-
-    // Account for length differences
-    mismatches += a.len().abs_diff(b.len());
-    mismatches
-}
-
-/// A set of UMIs with pre-computed bit encodings for fast comparison.
-///
-/// Stores both the original byte sequences and their `BitEnc` representations
-/// for efficient Hamming distance computation.
-#[derive(Clone)]
-pub struct EncodedUmiSet {
-    /// Original byte sequences for fallback comparison
-    bytes: Vec<Vec<u8>>,
-    /// Bit-encoded sequences for fast comparison (None if encoding failed)
-    encoded: Vec<Option<BitEnc>>,
-    /// Original strings for output
-    strings: Vec<String>,
-}
-
-impl EncodedUmiSet {
-    /// Create a new `EncodedUmiSet` from string sequences.
-    ///
-    /// All sequences are converted to uppercase for case-insensitive matching.
-    /// Pre-encodes all sequences that contain only ACGT bases.
-    /// Sequences with other characters will use fallback byte comparison.
-    pub fn new(sequences: &[String]) -> Self {
-        // Store uppercase bytes for comparison
-        let bytes: Vec<Vec<u8>> =
-            sequences.iter().map(|s| s.bytes().map(|b| b.to_ascii_uppercase()).collect()).collect();
-        let encoded: Vec<Option<BitEnc>> = bytes.iter().map(|b| BitEnc::from_bytes(b)).collect();
-        // Store uppercase strings for output
-        let strings: Vec<String> = sequences.iter().map(|s| s.to_uppercase()).collect();
-
-        Self { bytes, encoded, strings }
-    }
-
-    /// Get the number of UMIs in the set.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.bytes.len()
-    }
-
-    /// Check if the set is empty.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.bytes.is_empty()
-    }
-}
-
-/// Find the best matching UMI using bit-encoded comparison.
-///
-/// Uses fast XOR + popcount comparison when both observed and expected UMIs
-/// can be bit-encoded. Falls back to byte comparison otherwise.
-///
-/// This function tracks the best match index during iteration and only clones
-/// the matching string once at the end, avoiding repeated string allocations.
-fn find_best_match_encoded(
-    observed: &[u8],
-    umi_set: &EncodedUmiSet,
-    max_mismatches: usize,
-    min_distance_diff: usize,
-) -> UmiMatch {
-    let mut best_index: Option<usize> = None;
-    let mut best_mismatches = usize::MAX;
-    let mut second_best_mismatches = usize::MAX;
-
-    // Try to encode the observed UMI
-    let observed_encoded = BitEnc::from_bytes(observed);
-
-    match observed_encoded {
-        Some(obs_enc) => {
-            // Fast path: use bit-encoded comparison
-            for (i, fixed_enc) in umi_set.encoded.iter().enumerate() {
-                let mismatches = if let Some(enc) = fixed_enc {
-                    // Both can be compared with BitEnc
-                    enc.hamming_distance(&obs_enc) as usize
-                } else {
-                    // Fixed UMI couldn't be encoded, fall back to bytes
-                    count_mismatches_with_max(observed, &umi_set.bytes[i], second_best_mismatches)
-                };
-
-                if mismatches < best_mismatches {
-                    second_best_mismatches = best_mismatches;
-                    best_mismatches = mismatches;
-                    best_index = Some(i);
-                } else if mismatches < second_best_mismatches {
-                    second_best_mismatches = mismatches;
-                }
-            }
-        }
-        None => {
-            // Slow path: observed UMI can't be encoded, use byte comparison
-            for (i, fixed_umi) in umi_set.bytes.iter().enumerate() {
-                let mismatches =
-                    count_mismatches_with_max(observed, fixed_umi, second_best_mismatches);
-
-                if mismatches < best_mismatches {
-                    second_best_mismatches = best_mismatches;
-                    best_mismatches = mismatches;
-                    best_index = Some(i);
-                } else if mismatches < second_best_mismatches {
-                    second_best_mismatches = mismatches;
-                }
-            }
-        }
-    }
-
-    // Build result with single clone at end
-    let Some(idx) = best_index else {
-        return UmiMatch { matched: false, umi: String::new(), mismatches: usize::MAX };
-    };
-
-    let matched = if best_mismatches <= max_mismatches {
-        let distance_to_second = second_best_mismatches.saturating_sub(best_mismatches);
-        distance_to_second >= min_distance_diff
-    } else {
-        false
-    };
-
-    UmiMatch { matched, umi: umi_set.strings[idx].clone(), mismatches: best_mismatches }
-}
-
-/// Finds pairs of UMIs within a specified edit distance.
-///
-/// Identifies all pairs of UMIs that are within `distance` edits of each other,
-/// which helps detect potentially ambiguous UMI sets.
-///
-/// # Arguments
-///
-/// * `umis` - Slice of UMI sequences to check
-/// * `distance` - Maximum edit distance threshold
-///
-/// # Returns
-///
-/// A vector of tuples `(umi1, umi2, actual_distance)` for pairs within the threshold.
-///
-/// # Example
-///
-/// ```
-/// # use fgumi_lib::correct_umis::find_umi_pairs_within_distance;
-/// let umis = vec!["AAAA".to_string(), "AAAT".to_string()];
-/// let pairs = find_umi_pairs_within_distance(&umis, 2);
-/// assert_eq!(pairs.len(), 1);
-/// ```
-#[must_use]
-pub fn find_umi_pairs_within_distance(
-    umis: &[String],
-    distance: usize,
-) -> Vec<(String, String, usize)> {
-    let mut pairs = Vec::new();
-    for i in 0..umis.len() {
-        for j in (i + 1)..umis.len() {
-            let d = count_mismatches_with_max(umis[i].as_bytes(), umis[j].as_bytes(), distance + 1);
-            if d <= distance {
-                pairs.push((umis[i].clone(), umis[j].clone(), d));
-            }
-        }
-    }
-    pairs
-}
+// Core UMI correction types and functions are now defined in `fgumi_lib::correct`
+// and re-imported at the top of this module.
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noodles::sam;
-    use noodles::sam::alignment::io::Write as SamWrite;
-    use noodles::sam::alignment::record_buf::RecordBuf;
+    use fgumi_lib::correct::{count_mismatches_with_max, find_best_match_encoded};
+    use fgumi_lib::dna::reverse_complement_str;
     use rstest::rstest;
     use std::{io::Write as IoWrite, path::Path};
     use tempfile::{NamedTempFile, TempDir};
@@ -1726,7 +1494,7 @@ mod tests {
             .add_reference_sequence(
                 "chr1",
                 Map::<sam::header::record::value::map::ReferenceSequence>::new(
-                    std::num::NonZero::new(1000).expect("non-zero reference length"),
+                    std::num::NonZero::new(1000).unwrap(),
                 ),
             )
             .build();
@@ -1821,8 +1589,8 @@ mod tests {
 
     #[test]
     fn test_validation_different_length_umis() {
-        let temp_input = NamedTempFile::new().expect("failed to create temp file");
-        let temp_output = NamedTempFile::new().expect("failed to create temp file");
+        let temp_input = NamedTempFile::new().unwrap();
+        let temp_output = NamedTempFile::new().unwrap();
 
         let corrector = CorrectUmis {
             io: BamIoOptions {
@@ -1941,8 +1709,7 @@ mod tests {
 
         // Check metrics
         let metrics_data = UmiCorrectionMetrics::read_metrics(&metrics)?;
-        let aaaaaa =
-            metrics_data.iter().find(|m| m.umi == "AAAAAA").expect("AAAAAA metric not found");
+        let aaaaaa = metrics_data.iter().find(|m| m.umi == "AAAAAA").unwrap();
         assert_eq!(aaaaaa.total_matches, 5);
         assert_eq!(aaaaaa.perfect_matches, 2);
         assert_eq!(aaaaaa.one_mismatch_matches, 1);
@@ -2674,6 +2441,85 @@ mod tests {
     // Tests for template-level UMI correction functions
     // ============================================================================
 
+    /// Helper to create a `RecordBuf` with a name and optional RX tag
+    fn create_record_with_umi(name: &str, umi: Option<&str>) -> RecordBuf {
+        use fgumi_lib::sam::builder::RecordBuilder;
+
+        let mut builder = RecordBuilder::new().name(name).sequence("ACGT").qualities(&[40u8; 4]); // 'I' is Phred+33 = 40
+
+        if let Some(umi_seq) = umi {
+            builder = builder.tag("RX", umi_seq);
+        }
+
+        builder.build()
+    }
+
+    #[test]
+    fn test_extract_and_validate_template_umi_empty() {
+        let records: Vec<RecordBuf> = vec![];
+        let umi_tag = Tag::new(b'R', b'X');
+        let result = CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_and_validate_template_umi_single_record_with_umi() {
+        let records = vec![create_record_with_umi("read1", Some("AAAAAA"))];
+        let umi_tag = Tag::new(b'R', b'X');
+        let result = CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+        assert_eq!(result, Some("AAAAAA".to_string()));
+    }
+
+    #[test]
+    fn test_extract_and_validate_template_umi_single_record_without_umi() {
+        let records = vec![create_record_with_umi("read1", None)];
+        let umi_tag = Tag::new(b'R', b'X');
+        let result = CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_and_validate_template_umi_paired_matching() {
+        let records = vec![
+            create_record_with_umi("read1", Some("AAAAAA")),
+            create_record_with_umi("read1", Some("AAAAAA")),
+        ];
+        let umi_tag = Tag::new(b'R', b'X');
+        let result = CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+        assert_eq!(result, Some("AAAAAA".to_string()));
+    }
+
+    #[test]
+    #[should_panic(expected = "mismatched UMIs")]
+    fn test_extract_and_validate_template_umi_paired_mismatched() {
+        let records = vec![
+            create_record_with_umi("read1", Some("AAAAAA")),
+            create_record_with_umi("read1", Some("CCCCCC")),
+        ];
+        let umi_tag = Tag::new(b'R', b'X');
+        CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+    }
+
+    #[test]
+    #[should_panic(expected = "inconsistent UMI presence")]
+    fn test_extract_and_validate_template_umi_inconsistent_presence() {
+        let records = vec![
+            create_record_with_umi("read1", Some("AAAAAA")),
+            create_record_with_umi("read1", None),
+        ];
+        let umi_tag = Tag::new(b'R', b'X');
+        CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+    }
+
+    #[test]
+    fn test_extract_and_validate_template_umi_paired_no_umi() {
+        let records =
+            vec![create_record_with_umi("read1", None), create_record_with_umi("read1", None)];
+        let umi_tag = Tag::new(b'R', b'X');
+        let result = CorrectUmis::extract_and_validate_template_umi(&records, umi_tag);
+        assert!(result.is_none());
+    }
+
     #[test]
     fn test_compute_template_correction_perfect_match() {
         let umi_set = get_encoded_umi_set();
@@ -2772,6 +2618,109 @@ mod tests {
         assert!(!correction.needs_correction);
     }
 
+    #[test]
+    fn test_apply_correction_to_record_no_correction_needed() {
+        let record = create_record_with_umi("read1", Some("AAAAAA"));
+        let correction = TemplateCorrection {
+            matched: true,
+            corrected_umi: Some("AAAAAA".to_string()),
+            original_umi: "AAAAAA".to_string(),
+            needs_correction: false,
+            has_mismatches: false,
+            matches: vec![],
+            rejection_reason: RejectionReason::None,
+        };
+
+        let result = CorrectUmis::apply_correction_to_record(
+            record,
+            &correction,
+            Tag::new(b'R', b'X'),
+            false,
+        );
+
+        // UMI should remain unchanged
+        let rx_tag = Tag::new(b'R', b'X');
+        let umi = result.data().get(&rx_tag);
+        assert!(umi.is_some());
+    }
+
+    #[test]
+    fn test_apply_correction_to_record_with_correction() {
+        let record = create_record_with_umi("read1", Some("AAAAAT"));
+        let correction = TemplateCorrection {
+            matched: true,
+            corrected_umi: Some("AAAAAA".to_string()),
+            original_umi: "AAAAAT".to_string(),
+            needs_correction: true,
+            has_mismatches: true,
+            matches: vec![],
+            rejection_reason: RejectionReason::None,
+        };
+
+        let result = CorrectUmis::apply_correction_to_record(
+            record,
+            &correction,
+            Tag::new(b'R', b'X'),
+            false,
+        );
+
+        // Check RX tag was updated
+        let rx_tag = Tag::new(b'R', b'X');
+        if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
+            result.data().get(&rx_tag)
+        {
+            assert_eq!(String::from_utf8_lossy(s), "AAAAAA");
+        } else {
+            panic!("RX tag not found or wrong type");
+        }
+
+        // Check OX tag was added
+        let ox_tag = Tag::ORIGINAL_UMI_BARCODE_SEQUENCE;
+        if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
+            result.data().get(&ox_tag)
+        {
+            assert_eq!(String::from_utf8_lossy(s), "AAAAAT");
+        } else {
+            panic!("OX tag not found or wrong type");
+        }
+    }
+
+    #[test]
+    fn test_apply_correction_to_record_dont_store_original() {
+        let record = create_record_with_umi("read1", Some("AAAAAT"));
+        let correction = TemplateCorrection {
+            matched: true,
+            corrected_umi: Some("AAAAAA".to_string()),
+            original_umi: "AAAAAT".to_string(),
+            needs_correction: true,
+            has_mismatches: true,
+            matches: vec![],
+            rejection_reason: RejectionReason::None,
+        };
+
+        // dont_store_original_umis = true
+        let result = CorrectUmis::apply_correction_to_record(
+            record,
+            &correction,
+            Tag::new(b'R', b'X'),
+            true,
+        );
+
+        // Check RX tag was updated
+        let rx_tag = Tag::new(b'R', b'X');
+        if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
+            result.data().get(&rx_tag)
+        {
+            assert_eq!(String::from_utf8_lossy(s), "AAAAAA");
+        } else {
+            panic!("RX tag not found or wrong type");
+        }
+
+        // OX tag should NOT be added
+        let ox_tag = Tag::ORIGINAL_UMI_BARCODE_SEQUENCE;
+        assert!(result.data().get(&ox_tag).is_none());
+    }
+
     // ============================================================================
     // Tests for metrics output - unmatched UMI row and zero-count rows
     // ============================================================================
@@ -2820,7 +2769,7 @@ mod tests {
         let unmatched = metrics_data.iter().find(|m| m.umi == "NNNNNN");
         assert!(unmatched.is_some(), "Unmatched UMI row (NNNNNN) not found in metrics");
 
-        let unmatched = unmatched.expect("unmatched UMI row (NNNNNN) should be present");
+        let unmatched = unmatched.unwrap();
         // 3 uncorrectable reads: q2, q4, q5
         assert_eq!(
             unmatched.total_matches, 3,
@@ -2892,16 +2841,13 @@ mod tests {
         );
 
         // Verify counts
-        let cccccc =
-            metrics_data.iter().find(|m| m.umi == "CCCCCC").expect("CCCCCC metric not found");
+        let cccccc = metrics_data.iter().find(|m| m.umi == "CCCCCC").unwrap();
         assert_eq!(cccccc.total_matches, 0, "CCCCCC should have 0 total_matches");
 
-        let gggggg =
-            metrics_data.iter().find(|m| m.umi == "GGGGGG").expect("GGGGGG metric not found");
+        let gggggg = metrics_data.iter().find(|m| m.umi == "GGGGGG").unwrap();
         assert_eq!(gggggg.total_matches, 0, "GGGGGG should have 0 total_matches");
 
-        let aaaaaa =
-            metrics_data.iter().find(|m| m.umi == "AAAAAA").expect("AAAAAA metric not found");
+        let aaaaaa = metrics_data.iter().find(|m| m.umi == "AAAAAA").unwrap();
         assert_eq!(aaaaaa.total_matches, 2, "AAAAAA should have 2 total_matches");
 
         Ok(())
@@ -2959,23 +2905,18 @@ mod tests {
         assert_eq!(metrics_data.len(), 3, "Expected 3 UMI rows in metrics");
 
         // Verify unmatched row
-        let unmatched = metrics_data
-            .iter()
-            .find(|m| m.umi == "NNNNNN")
-            .expect("unmatched UMI row (NNNNNN) not found");
+        let unmatched = metrics_data.iter().find(|m| m.umi == "NNNNNN").unwrap();
         // 20 uncorrectable reads (i % 5 == 3 or 4, so 10 + 10 = 20)
         assert_eq!(unmatched.total_matches, 20, "Unmatched row should have 20 total_matches");
 
         // Verify matched UMIs
-        let aaaaaa =
-            metrics_data.iter().find(|m| m.umi == "AAAAAA").expect("AAAAAA metric not found");
+        let aaaaaa = metrics_data.iter().find(|m| m.umi == "AAAAAA").unwrap();
         // i % 5 == 0: 10 perfect, i % 5 == 2: 10 with 1 mismatch = 20 total
         assert_eq!(aaaaaa.total_matches, 20, "AAAAAA should have 20 total_matches");
         assert_eq!(aaaaaa.perfect_matches, 10);
         assert_eq!(aaaaaa.one_mismatch_matches, 10);
 
-        let cccccc =
-            metrics_data.iter().find(|m| m.umi == "CCCCCC").expect("CCCCCC metric not found");
+        let cccccc = metrics_data.iter().find(|m| m.umi == "CCCCCC").unwrap();
         assert_eq!(cccccc.total_matches, 10, "CCCCCC should have 10 total_matches");
         assert_eq!(cccccc.perfect_matches, 10);
 
@@ -3113,7 +3054,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_and_validate_template_umi_raw_mismatch_errors() {
+    fn test_extract_and_validate_template_umi_raw_mismatch_returns_error() {
         let r1 = make_raw_bam_for_correct(
             b"rea",
             fgumi_lib::sort::bam_fields::flags::PAIRED
@@ -3126,9 +3067,9 @@ mod tests {
                 | fgumi_lib::sort::bam_fields::flags::LAST_SEGMENT,
             b"CCCCCC",
         );
-        let err = CorrectUmis::extract_and_validate_template_umi_raw(&[r1, r2], [b'R', b'X'])
-            .unwrap_err();
-        assert!(err.to_string().contains("mismatched UMIs"));
+        let result = CorrectUmis::extract_and_validate_template_umi_raw(&[r1, r2], [b'R', b'X']);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("mismatched UMIs"));
     }
 
     #[test]
@@ -3216,144 +3157,6 @@ mod tests {
         assert_eq!(raw.len(), orig_len);
         let umi = bam_fields::find_string_tag_in_record(&raw, b"RX");
         assert_eq!(umi, Some(b"AAAAAA".as_ref()));
-    }
-
-    /// Characterization test for the single-thread mode (`execute_single_thread_mode`).
-    ///
-    /// Exercises the streaming path triggered by `threads: None` with paired-end reads,
-    /// verifying that UMI correction produces the expected output:
-    /// - Template 1 ("t1"): UMI "AAAAAG" (1 mismatch from "AAAAAA") is corrected, OX tag set
-    /// - Template 2 ("t2"): UMI "CCCCCC" (exact match) is unchanged, no OX tag
-    #[test]
-    fn test_single_thread_mode_produces_correct_output() -> Result<()> {
-        use fgumi_lib::sam::builder::SamBuilder;
-        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
-
-        let mut builder = SamBuilder::new();
-        let _ = builder
-            .add_pair()
-            .name("t1")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .attr("RX", BufValue::from("AAAAAG"))
-            .build();
-        let _ = builder
-            .add_pair()
-            .name("t2")
-            .contig(0)
-            .start1(300)
-            .start2(400)
-            .attr("RX", BufValue::from("CCCCCC"))
-            .build();
-
-        let input = builder.to_temp_file()?;
-        let paths = TestPaths::new()?;
-
-        let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
-            metrics: Some(paths.metrics.clone()),
-            max_mismatches: 2,
-            min_distance_diff: 2,
-            umis: FIXED_UMIS.iter().map(|s| (*s).to_string()).collect(),
-            umi_files: vec![],
-            umi_tag: "RX".to_string(),
-            dont_store_original_umis: false,
-            cache_size: 100_000,
-            min_corrected: None,
-            revcomp: false,
-            threading: ThreadingOptions::none(),
-            compression: CompressionOptions { compression_level: 1 },
-            scheduler_opts: SchedulerOptions::default(),
-            queue_memory: QueueMemoryOptions::default(),
-        };
-
-        corrector.execute("test")?;
-
-        // All 4 records should be in the output (both templates correctable)
-        let output_names = read_bam_record_names(&paths.output)?;
-        assert_eq!(output_names.len(), 4, "Expected 4 records in output");
-        assert_eq!(
-            output_names.iter().filter(|n| *n == "t1").count(),
-            2,
-            "Expected 2 records for template t1"
-        );
-        assert_eq!(
-            output_names.iter().filter(|n| *n == "t2").count(),
-            2,
-            "Expected 2 records for template t2"
-        );
-
-        // No rejects expected
-        let reject_names = read_bam_record_names(&paths.rejects)?;
-        assert_eq!(reject_names.len(), 0, "Expected no rejected records");
-
-        // Read output records and verify UMI tags
-        let mut reader = noodles::bam::io::reader::Builder.build_from_path(&paths.output)?;
-        let header = reader.read_header()?;
-
-        let rx_tag = Tag::new(b'R', b'X');
-        let ox_tag = Tag::ORIGINAL_UMI_BARCODE_SEQUENCE;
-
-        for result in reader.records() {
-            let record = result?;
-            let record_buf = RecordBuf::try_from_alignment_record(&header, &record)?;
-            let name = record_buf.name().map(std::string::ToString::to_string).unwrap_or_default();
-
-            match name.as_str() {
-                "t1" => {
-                    // UMI should be corrected from AAAAAG to AAAAAA
-                    if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
-                        record_buf.data().get(&rx_tag)
-                    {
-                        assert_eq!(
-                            String::from_utf8_lossy(s),
-                            "AAAAAA",
-                            "t1 RX tag should be corrected to AAAAAA"
-                        );
-                    } else {
-                        panic!("t1: RX tag not found or wrong type");
-                    }
-
-                    // OX tag should store the original UMI
-                    if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
-                        record_buf.data().get(&ox_tag)
-                    {
-                        assert_eq!(
-                            String::from_utf8_lossy(s),
-                            "AAAAAG",
-                            "t1 OX tag should store original UMI AAAAAG"
-                        );
-                    } else {
-                        panic!("t1: OX tag not found or wrong type");
-                    }
-                }
-                "t2" => {
-                    // UMI should remain CCCCCC (exact match)
-                    if let Some(sam::alignment::record_buf::data::field::Value::String(s)) =
-                        record_buf.data().get(&rx_tag)
-                    {
-                        assert_eq!(
-                            String::from_utf8_lossy(s),
-                            "CCCCCC",
-                            "t2 RX tag should remain CCCCCC"
-                        );
-                    } else {
-                        panic!("t2: RX tag not found or wrong type");
-                    }
-
-                    // No OX tag for exact matches
-                    assert!(
-                        record_buf.data().get(&ox_tag).is_none(),
-                        "t2 should not have an OX tag (exact match)"
-                    );
-                }
-                other => panic!("Unexpected record name: {other}"),
-            }
-        }
-
-        Ok(())
     }
 
     #[test]

--- a/src/commands/dedup.rs
+++ b/src/commands/dedup.rs
@@ -28,8 +28,10 @@ use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_lib::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use fgumi_lib::bam_io::{create_bam_reader_for_pipeline, is_stdin_path};
+use fgumi_lib::defaults;
 use fgumi_lib::grouper::{
-    FilterMetrics, RawPositionGroup, RecordPositionGrouper, build_templates_from_records,
+    FilterMetrics, GroupFilterConfig, RawPositionGroup, RecordPositionGrouper,
+    build_templates_from_records, filter_template_raw, get_pair_orientation_raw,
 };
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::metrics::group::FamilySizeMetrics;
@@ -211,6 +213,23 @@ struct DedupFilterConfig {
     no_umi: bool,
 }
 
+impl From<&DedupFilterConfig> for GroupFilterConfig {
+    /// Convert to a [`GroupFilterConfig`] for use with lib filter functions.
+    ///
+    /// Deduplication never allows fully unmapped templates, so `allow_unmapped`
+    /// is always `false`.
+    fn from(c: &DedupFilterConfig) -> Self {
+        Self {
+            umi_tag: c.umi_tag,
+            min_mapq: c.min_mapq,
+            include_non_pf: c.include_non_pf,
+            min_umi_length: c.min_umi_length,
+            no_umi: c.no_umi,
+            allow_unmapped: false,
+        }
+    }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Duplicate scoring
 //////////////////////////////////////////////////////////////////////////////
@@ -277,159 +296,13 @@ fn sum_base_qualities(record: &noodles::sam::alignment::RecordBuf) -> u32 {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Template filtering (adapted from group command)
+// Template filtering (parsed-record mode)
 //////////////////////////////////////////////////////////////////////////////
 
-/// Raw-byte version of `filter_template`.
-fn filter_template_raw(
-    template: &Template,
-    config: &DedupFilterConfig,
-    metrics: &mut FilterMetrics,
-) -> bool {
-    use fgumi_lib::sort::bam_fields;
-
-    let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-    let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-
-    metrics.total_templates += 1;
-
-    if raw_r1.is_none() && raw_r2.is_none() {
-        metrics.discarded_poor_alignment += 1;
-        return false;
-    }
-
-    let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
-    if both_unmapped {
-        metrics.discarded_poor_alignment += 1;
-        return false;
-    }
-
-    // Phase 1: Flag-based checks
-    for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
-
-        if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
-            metrics.discarded_non_pf += 1;
-            return false;
-        }
-
-        if (flg & bam_fields::flags::UNMAPPED) == 0 {
-            let mapq = bam_fields::mapq(raw);
-            if mapq < config.min_mapq {
-                metrics.discarded_poor_alignment += 1;
-                return false;
-            }
-        }
-    }
-
-    // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
-    for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
-        let aux = bam_fields::aux_data_slice(raw);
-        let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
-        let check_umi = !config.no_umi;
-
-        let mut found_mq: Option<i64> = None;
-        let mut found_umi: Option<&[u8]> = None;
-        let mut p = 0;
-        while p + 3 <= aux.len() {
-            let t = [aux[p], aux[p + 1]];
-            let val_type = aux[p + 2];
-
-            if check_umi && t == config.umi_tag && val_type == b'Z' {
-                let start = p + 3;
-                if let Some(end) = aux[start..].iter().position(|&b| b == 0) {
-                    found_umi = Some(&aux[start..start + end]);
-                    p = start + end + 1;
-                } else {
-                    break;
-                }
-                if !check_mq || found_mq.is_some() {
-                    break;
-                }
-                continue;
-            }
-
-            if check_mq && t == *b"MQ" {
-                found_mq = match val_type {
-                    b'C' if p + 3 < aux.len() => Some(i64::from(aux[p + 3])),
-                    b'c' if p + 3 < aux.len() => Some(i64::from(aux[p + 3] as i8)),
-                    b'S' if p + 5 <= aux.len() => {
-                        Some(i64::from(u16::from_le_bytes([aux[p + 3], aux[p + 4]])))
-                    }
-                    b's' if p + 5 <= aux.len() => {
-                        Some(i64::from(i16::from_le_bytes([aux[p + 3], aux[p + 4]])))
-                    }
-                    b'I' if p + 7 <= aux.len() => Some(i64::from(u32::from_le_bytes([
-                        aux[p + 3],
-                        aux[p + 4],
-                        aux[p + 5],
-                        aux[p + 6],
-                    ]))),
-                    b'i' if p + 7 <= aux.len() => Some(i64::from(i32::from_le_bytes([
-                        aux[p + 3],
-                        aux[p + 4],
-                        aux[p + 5],
-                        aux[p + 6],
-                    ]))),
-                    _ => None,
-                };
-            }
-
-            if let Some(size) = bam_fields::tag_value_size(val_type, &aux[p + 3..]) {
-                p += 3 + size;
-            } else {
-                break;
-            }
-            if (!check_umi || found_umi.is_some()) && (!check_mq || found_mq.is_some()) {
-                break;
-            }
-        }
-
-        if check_mq {
-            if let Some(mq) = found_mq {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                if (mq as u8) < config.min_mapq {
-                    metrics.discarded_poor_alignment += 1;
-                    return false;
-                }
-            }
-        }
-
-        // Skip UMI validation in no-umi mode
-        if config.no_umi {
-            continue;
-        }
-
-        if let Some(umi_bytes) = found_umi {
-            match validate_umi(umi_bytes) {
-                UmiValidation::ContainsN => {
-                    metrics.discarded_ns_in_umi += 1;
-                    return false;
-                }
-                UmiValidation::Valid(base_count) => {
-                    if let Some(min_len) = config.min_umi_length {
-                        if base_count < min_len {
-                            metrics.discarded_umi_too_short += 1;
-                            return false;
-                        }
-                    }
-                }
-            }
-        } else {
-            metrics.discarded_poor_alignment += 1;
-            return false;
-        }
-    }
-
-    metrics.accepted_templates += 1;
-    true
-}
-
-/// Filter a template based on filtering criteria.
-/// Returns true if the template should be kept.
+/// Filter a parsed-record template based on filtering criteria.
+///
+/// Returns `true` if the template should be kept, `false` if discarded.
+/// The raw-byte equivalent is `fgumi_lib::grouper::filter_template_raw`.
 fn filter_template(
     template: &Template,
     config: &DedupFilterConfig,
@@ -440,32 +313,26 @@ fn filter_template(
 
     metrics.total_templates += 1;
 
-    // Need at least one primary read
     if r1.is_none() && r2.is_none() {
         metrics.discarded_poor_alignment += 1;
         return false;
     }
 
-    // Check if both reads are unmapped
     let both_unmapped =
         r1.is_none_or(|r| r.flags().is_unmapped()) && r2.is_none_or(|r| r.flags().is_unmapped());
-
     if both_unmapped {
         metrics.discarded_poor_alignment += 1;
         return false;
     }
 
-    // Phase 1: Flag-based checks
     for record in [r1, r2].into_iter().flatten() {
         let flags = record.flags();
 
-        // Filter non-PF if requested
         if !config.include_non_pf && flags.is_qc_fail() {
             metrics.discarded_non_pf += 1;
             return false;
         }
 
-        // Check MAPQ for mapped reads
         if !flags.is_unmapped() {
             let mapq = record.mapping_quality().map_or(0, u8::from);
             if mapq < config.min_mapq {
@@ -475,11 +342,9 @@ fn filter_template(
         }
     }
 
-    // Phase 2: Tag-based checks
     for record in [r1, r2].into_iter().flatten() {
         let flags = record.flags();
 
-        // Check mate MAPQ via MQ tag
         if !flags.is_mate_unmapped() {
             if let Some(data) = record.data().get(b"MQ") {
                 if let Some(mq) = data.as_int() {
@@ -492,12 +357,10 @@ fn filter_template(
             }
         }
 
-        // Skip UMI validation in no-umi mode
         if config.no_umi {
             continue;
         }
 
-        // Check UMI for Ns and minimum length using common validation
         if let Some(DataValue::String(umi)) = record.data().get(&config.umi_tag) {
             match validate_umi(umi) {
                 UmiValidation::ContainsN => {
@@ -574,15 +437,6 @@ fn get_pair_orientation(template: &Template) -> (bool, bool) {
     }
     let r1_positive = template.r1().is_none_or(|r| !r.flags().is_reverse_complemented());
     let r2_positive = template.r2().is_none_or(|r| !r.flags().is_reverse_complemented());
-    (r1_positive, r2_positive)
-}
-
-/// Raw-byte pair orientation using `bam_fields::flags()`.
-fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 
@@ -860,13 +714,14 @@ fn process_position_group(
     let all_templates = build_templates_from_records(group.records)?;
 
     // Filter templates
-    let mut filter_metrics = FilterMetrics::new();
+    let mut filter_metrics = FilterMetrics::default();
     let raw_mode = all_templates.first().is_some_and(Template::is_raw_byte_mode);
+    let group_filter_config = GroupFilterConfig::from(filter_config);
     let filtered_templates: Vec<Template> = all_templates
         .into_iter()
         .filter(|t| {
             if raw_mode {
-                filter_template_raw(t, filter_config, &mut filter_metrics)
+                filter_template_raw(t, &group_filter_config, &mut filter_metrics)
             } else {
                 filter_template(t, filter_config, &mut filter_metrics)
             }
@@ -1027,7 +882,7 @@ fn set_mi_tag_on_record(
 #[derive(Debug, Parser)]
 #[command(
     name = "dedup",
-    about = "\x1b[38;5;151m[DEDUP]\x1b[0m         \x1b[36mMark or remove PCR duplicates using UMI information\x1b[0m",
+    about = "\x1b[38;5;151m[DEDUP]\x1b[0m          \x1b[36mMark or remove PCR duplicates using UMI information\x1b[0m",
     long_about = r#"
 Marks or removes PCR duplicates from a BAM file using UMI information.
 Requires template-coordinate sorted input with `pa` tags on secondary/supplementary
@@ -1077,11 +932,11 @@ pub struct MarkDuplicates {
     pub remove_duplicates: bool,
 
     /// The tag containing the raw UMI sequence
-    #[arg(short = 't', long = "raw-tag", default_value = "RX")]
+    #[arg(short = 't', long = "raw-tag", default_value = defaults::UMI_TAG)]
     pub raw_tag: String,
 
     /// The output tag for the assigned molecule ID
-    #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
+    #[arg(short = 'T', long = "assign-tag", default_value = defaults::MI_TAG)]
     pub assign_tag: String,
 
     /// SAM tag containing the cell barcode.
@@ -1089,7 +944,7 @@ pub struct MarkDuplicates {
     /// When set, reads at the same genomic coordinates are partitioned by cell barcode before
     /// deduplication, so reads from different cells are never grouped together even if they
     /// share a UMI and position. No correction is performed on the cell barcode itself.
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: String,
 
     /// Minimum mapping quality for a read to be included
@@ -1105,7 +960,7 @@ pub struct MarkDuplicates {
     pub strategy: Strategy,
 
     /// Maximum edit distance for UMI grouping
-    #[arg(short = 'e', long = "edits", default_value = "1")]
+    #[arg(short = 'e', long = "edits", default_value_t = defaults::GROUP_MAX_EDITS)]
     pub edits: u32,
 
     /// Minimum UMI length (UMIs shorter than this are discarded)
@@ -1121,7 +976,7 @@ pub struct MarkDuplicates {
     pub compression: CompressionOptions,
 
     /// Minimum UMIs per position to use index for faster grouping
-    #[arg(long = "index-threshold", default_value = "100")]
+    #[arg(long = "index-threshold", default_value_t = defaults::GROUP_INDEX_THRESHOLD)]
     pub index_threshold: usize,
 
     /// Skip UMI-based grouping; group by position only. Forces identity strategy
@@ -1840,7 +1695,7 @@ mod tests {
     #[test]
     fn test_filter_template_accepts_valid_template() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACGTACGT", 30);
 
         assert!(filter_template(&template, &config, &mut metrics));
@@ -1850,7 +1705,7 @@ mod tests {
     #[test]
     fn test_filter_template_rejects_low_mapq() {
         let config = default_filter_config(); // min_mapq = 20
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACGTACGT", 10); // MAPQ 10 < 20
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -1860,7 +1715,7 @@ mod tests {
     #[test]
     fn test_filter_template_rejects_umi_with_n() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACNTACGT", 30); // N in UMI
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -1871,7 +1726,7 @@ mod tests {
     fn test_filter_template_rejects_short_umi() {
         let mut config = default_filter_config();
         config.min_umi_length = Some(8); // Require 8 bases
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACGT", 30); // Only 4 bases
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -1881,7 +1736,7 @@ mod tests {
     #[test]
     fn test_filter_template_rejects_missing_umi_tag() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // Create template without RX tag
         let record = RecordBuilder::new()
@@ -1904,7 +1759,7 @@ mod tests {
     #[test]
     fn test_filter_template_rejects_qc_fail() {
         let config = default_filter_config(); // include_non_pf = false
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         let record = RecordBuilder::new()
             .name("q1")
@@ -1928,7 +1783,7 @@ mod tests {
     fn test_filter_template_accepts_qc_fail_when_included() {
         let mut config = default_filter_config();
         config.include_non_pf = true; // Include QC-fail reads
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         let record = RecordBuilder::new()
             .name("q1")
@@ -1951,7 +1806,7 @@ mod tests {
     #[test]
     fn test_filter_template_rejects_unmapped() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         let record = RecordBuilder::new()
             .name("q1")
@@ -1971,7 +1826,7 @@ mod tests {
     fn test_filter_template_accepts_paired_umi_with_dash() {
         // Paired UMIs have format "ACGT-TGCA" with a dash separator
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACGT-TGCA", 30);
 
         assert!(filter_template(&template, &config, &mut metrics));
@@ -2328,7 +2183,7 @@ mod tests {
     #[test]
     fn test_filter_paired_template_accepts_valid() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_paired_mapped_template_with_umi("q1", "ACGTACGT", 30, 30);
 
         assert!(filter_template(&template, &config, &mut metrics));
@@ -2338,7 +2193,7 @@ mod tests {
     #[test]
     fn test_filter_paired_template_rejects_r2_low_mapq() {
         let config = default_filter_config(); // min_mapq = 20
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_paired_mapped_template_with_umi("q1", "ACGTACGT", 30, 10);
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -2348,7 +2203,7 @@ mod tests {
     #[test]
     fn test_filter_paired_template_rejects_r2_umi_with_n() {
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         // R1 has valid UMI, but R2 has N in UMI
         let r1 = RecordBuilder::new()
             .name("q1")
@@ -2383,7 +2238,7 @@ mod tests {
     fn test_filter_paired_no_reads_rejected() {
         // Template with no primary reads (empty records list)
         let config = default_filter_config();
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = Template::new(b"empty".to_vec());
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -2521,10 +2376,11 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // Should not panic; should reject gracefully due to missing UMI
-        let result = filter_template_raw(&template, &config, &mut metrics);
+        let result =
+            filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics);
         assert!(!result, "Truncated record should be rejected");
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
@@ -2565,11 +2421,12 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // After fix: filter_template_raw now uses find_int_tag which handles all integer types.
         // The template should be REJECTED because mate MAPQ=10 < min_mapq=20.
-        let result = filter_template_raw(&template, &config, &mut metrics);
+        let result =
+            filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics);
 
         assert!(!result, "Template with low mate MAPQ should be rejected");
         assert_eq!(metrics.accepted_templates, 0);
@@ -2745,8 +2602,8 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 
@@ -2771,8 +2628,8 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(!filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
 
@@ -2798,8 +2655,8 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(!filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.discarded_non_pf, 1);
     }
 
@@ -2824,8 +2681,8 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(!filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.discarded_ns_in_umi, 1);
     }
 
@@ -2850,8 +2707,8 @@ mod tests {
             min_umi_length: Some(6),
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(!filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.discarded_umi_too_short, 1);
     }
 
@@ -2875,8 +2732,8 @@ mod tests {
             min_umi_length: None,
             no_umi: false,
         };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
+        let mut metrics = FilterMetrics::default();
+        assert!(!filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
 
@@ -2934,7 +2791,7 @@ mod tests {
     fn test_filter_template_accepts_missing_umi_when_no_umi_mode() {
         let mut config = default_filter_config();
         config.no_umi = true;
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // Create template without RX tag
         let record = RecordBuilder::new()
@@ -2959,7 +2816,7 @@ mod tests {
     fn test_filter_template_accepts_umi_with_n_when_no_umi_mode() {
         let mut config = default_filter_config();
         config.no_umi = true;
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACNTACGT", 30);
 
         // In no_umi mode, UMIs with N should be accepted (UMI validation is skipped)
@@ -2972,7 +2829,7 @@ mod tests {
         let mut config = default_filter_config();
         config.min_umi_length = Some(8);
         config.no_umi = true;
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let template = create_mapped_template_with_umi("q1", "ACGT", 30);
 
         // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
@@ -3049,10 +2906,10 @@ mod tests {
             min_umi_length: None,
             no_umi: true,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // In no_umi mode, templates without UMI tags should be accepted
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 
@@ -3077,10 +2934,10 @@ mod tests {
             min_umi_length: None,
             no_umi: true,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // In no_umi mode, UMIs with N should be accepted (UMI validation is skipped)
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 
@@ -3105,10 +2962,10 @@ mod tests {
             min_umi_length: Some(6),
             no_umi: true,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
 
         // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template_raw(&template, &GroupFilterConfig::from(&config), &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 

--- a/src/commands/duplex.rs
+++ b/src/commands/duplex.rs
@@ -12,6 +12,7 @@ use fgumi_lib::bam_io::{
     create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
     create_raw_bam_reader,
 };
+use fgumi_lib::defaults;
 
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
@@ -185,7 +186,7 @@ pub struct Duplex {
     pub max_reads_per_strand: Option<usize>,
 
     /// SAM tag containing the cell barcode
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: Option<String>,
 
     /// Scheduler and pipeline stats options

--- a/src/commands/duplex_metrics.rs
+++ b/src/commands/duplex_metrics.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use fgoxide::io::DelimFile;
+use fgumi_lib::defaults;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric};
 use fgumi_lib::simple_umi_consensus::SimpleUmiConsensusCaller;
@@ -112,11 +113,11 @@ pub struct DuplexMetrics {
     pub description: Option<String>,
 
     /// SAM tag containing the raw UMI sequence
-    #[arg(long = "umi-tag", default_value = "RX")]
+    #[arg(long = "umi-tag", default_value = defaults::UMI_TAG)]
     pub umi_tag: String,
 
     /// SAM tag containing the molecular identifier (assigned by `group`)
-    #[arg(long = "mi-tag", default_value = "MI")]
+    #[arg(long = "mi-tag", default_value = defaults::MI_TAG)]
     pub mi_tag: String,
 }
 

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -19,11 +19,11 @@ use crate::commands::common::{
     CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
 };
 use anyhow::{Result, bail, ensure};
-use bstr::{BString, ByteSlice};
 use clap::Parser;
 use fgoxide::io::Io;
 use fgumi_lib::bam_io::{RawBamWriter, create_raw_bam_writer};
-use fgumi_lib::fastq::FastqSegment;
+use fgumi_lib::defaults;
+use fgumi_lib::extract::{self, ExtractParams, QualityEncoding};
 use fgumi_lib::fastq::FastqSet;
 use fgumi_lib::fastq::ReadSetIterator;
 use fgumi_lib::grouper::FastqTemplate;
@@ -31,8 +31,6 @@ use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::unified_pipeline::{FastqPipelineConfig, MemoryEstimate, run_fastq_pipeline};
 use fgumi_lib::validation::validate_file_exists;
-use fgumi_raw_bam::UnmappedBamRecordBuilder;
-use fgumi_raw_bam::fields::flags;
 use log::{debug, info};
 use noodles_bgzf::io::MultithreadedReader;
 
@@ -57,7 +55,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 const BUFFER_SIZE: usize = 1024 * 1024;
-const QUALITY_DETECTION_SAMPLE_SIZE: usize = 400;
 
 /// Pre-serialized batch of BAM records for the pipeline output type.
 ///
@@ -166,94 +163,6 @@ fn open_fastq_reader(path: &Path, threads: usize) -> Result<Box<dyn BufRead + Se
         CompressionFormat::Plain => {
             debug!("Detected uncompressed FASTQ");
             Ok(fgio.new_reader(path)?)
-        }
-    }
-}
-
-/// Quality encoding type
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum QualityEncoding {
-    Standard, // Phred+33 (Sanger)
-    Illumina, // Phred+64 (Illumina 1.3-1.7)
-}
-
-impl QualityEncoding {
-    /// Convert quality scores to standard numeric format (Phred+33)
-    fn to_standard_numeric(self, quals: &[u8]) -> Vec<u8> {
-        match self {
-            QualityEncoding::Standard => quals.iter().map(|&q| q.saturating_sub(33)).collect(),
-            QualityEncoding::Illumina => quals.iter().map(|&q| q.saturating_sub(64)).collect(),
-        }
-    }
-
-    /// Detect encoding from sample records using robust heuristics
-    ///
-    /// This implements a more robust detection algorithm that:
-    /// - Checks for quality scores in the Illumina 1.3-1.7 range (64-126)
-    /// - Checks for quality scores in the Sanger/Illumina 1.8+ range (33-126)
-    /// - Handles edge cases like empty reads or very short reads
-    /// - Provides informative error messages for invalid encodings
-    fn detect(records: &[Vec<u8>]) -> Result<Self> {
-        if records.is_empty() {
-            bail!("Cannot detect quality encoding: no records provided");
-        }
-
-        let mut min_qual = u8::MAX;
-        let mut max_qual = u8::MIN;
-        let mut total_bases = 0;
-
-        // Collect statistics from all quality scores
-        for qual in records {
-            if qual.is_empty() {
-                continue; // Skip empty reads
-            }
-            for &q in qual {
-                min_qual = min_qual.min(q);
-                max_qual = max_qual.max(q);
-                total_bases += 1;
-            }
-        }
-
-        // If all reads were empty, we can't detect encoding but we'll default to Standard
-        if total_bases == 0 {
-            return Ok(QualityEncoding::Standard);
-        }
-
-        // Quality scores should be printable ASCII (33-126)
-        if min_qual < 33 || max_qual > 126 {
-            bail!(
-                "Invalid quality scores detected: range [{min_qual}, {max_qual}]. \
-                Quality scores must be in the printable ASCII range (33-126)"
-            );
-        }
-
-        // Detect encoding based on observed range
-        // Phred+64 (Illumina 1.3-1.7) uses range 64-126
-        // Phred+33 (Sanger/Illumina 1.8+) uses range 33-126
-        // If we see scores below 59, it's definitely Phred+33
-        // If we see scores in 59-63, it could be either (low quality Phred+33 or very low Phred+64)
-        // If we only see scores >= 64, it's likely Phred+64 (but could be high-quality Phred+33)
-
-        if min_qual < 59 {
-            // Definitely Phred+33 (Sanger/Illumina 1.8+)
-            Ok(QualityEncoding::Standard)
-        } else if min_qual >= 64 {
-            // Likely Phred+64 (Illumina 1.3-1.7), but warn if range suggests otherwise
-            // Note: Modern data should be Phred+33, so this is increasingly rare
-            if max_qual >= 75 {
-                // Has a reasonable range for Phred+64
-                Ok(QualityEncoding::Illumina)
-            } else {
-                // Narrow range, could be high-quality Phred+33
-                // Default to Phred+33 for modern data
-                Ok(QualityEncoding::Standard)
-            }
-        } else {
-            // Ambiguous range (59-63). This is very unlikely in real data.
-            // Low quality Phred+33 would be in this range (Q26-Q30)
-            // Very low quality Phred+64 would also be here (Q-5 to Q-1)
-            // Default to Phred+33 as it's more common and these are reasonable quality scores
-            Ok(QualityEncoding::Standard)
         }
     }
 }
@@ -389,7 +298,7 @@ pub(crate) struct Extract {
     read_structures: Vec<ReadStructure>,
 
     /// Tag in which to store molecular barcodes/UMIs
-    #[arg(long, short = 'u', default_value = "RX")]
+    #[arg(long, short = 'u', default_value = defaults::UMI_TAG)]
     umi_tag: String,
 
     /// Tag in which to store molecular barcode/UMI qualities
@@ -397,7 +306,7 @@ pub(crate) struct Extract {
     umi_qual_tag: Option<String>,
 
     /// SAM tag containing the cell barcode
-    #[arg(long = "cell-tag", short = 'c', default_value = "CB")]
+    #[arg(long = "cell-tag", short = 'c', default_value = defaults::CELL_TAG)]
     cell_tag: String,
 
     /// Tag in which to store the cellular barcode qualities
@@ -426,7 +335,7 @@ pub(crate) struct Extract {
     clipping_attribute: Option<String>,
 
     /// Read group ID to use in the file header
-    #[arg(long, default_value = "A")]
+    #[arg(long, default_value = defaults::READ_GROUP_ID)]
     read_group_id: String,
 
     /// The name of the sequenced sample
@@ -442,7 +351,7 @@ pub(crate) struct Extract {
     barcode: Option<String>,
 
     /// Sequencing Platform
-    #[arg(long, default_value = "illumina")]
+    #[arg(long, default_value = defaults::PLATFORM)]
     platform: String,
 
     /// Platform unit (e.g. 'flowcell-barcode.lane.sample-barcode')
@@ -586,6 +495,30 @@ impl Extract {
         if let Some(v) = value { rg.insert(tag, v.clone()) } else { rg }
     }
 
+    /// Build [`ExtractParams`] from the command's CLI options.
+    fn build_extract_params(&self) -> ExtractParams {
+        ExtractParams {
+            read_group_id: self.read_group_id.clone(),
+            umi_tag: self.umi_tag.as_bytes().try_into().expect("validated in validate()"),
+            cell_tag: self.cell_tag.as_bytes().try_into().expect("validated in validate()"),
+            umi_qual_tag: self
+                .umi_qual_tag
+                .as_ref()
+                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
+            cell_qual_tag: self
+                .cell_qual_tag
+                .as_ref()
+                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
+            single_tag: self
+                .single_tag
+                .as_ref()
+                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
+            annotate_read_names: self.annotate_read_names,
+            extract_umis_from_read_names: self.extract_umis_from_read_names,
+            store_sample_barcode_qualities: self.store_sample_barcode_qualities,
+        }
+    }
+
     /// Create SAM header
     fn create_header(&self, command_line: &str) -> Result<Header> {
         let mut header = Header::builder();
@@ -630,63 +563,6 @@ impl Extract {
         Ok(header.build())
     }
 
-    /// Joins byte slices with a separator, pre-allocating capacity.
-    /// Returns empty `BString` if iterator is empty.
-    fn join_bytes_with_separator<'a>(
-        segments: impl Iterator<Item = &'a [u8]>,
-        separator: u8,
-    ) -> BString {
-        let segments: Vec<&[u8]> = segments.collect();
-        if segments.is_empty() {
-            return BString::default();
-        }
-        // Calculate total capacity needed
-        let total_len: usize = segments.iter().map(|s| s.len()).sum();
-        let capacity = total_len + segments.len().saturating_sub(1); // separators
-        let mut result = Vec::with_capacity(capacity);
-        for (i, seg) in segments.iter().enumerate() {
-            if i > 0 {
-                result.push(separator);
-            }
-            result.extend_from_slice(seg);
-        }
-        BString::from(result)
-    }
-
-    /// Extracts read name, optionally extracting UMI from the 8th colon-delimited field
-    fn extract_read_name_and_umi(
-        header: &Vec<u8>,
-        extract_umis: bool,
-    ) -> (Vec<u8>, Option<Vec<u8>>) {
-        // Remove @ prefix if present
-        let name_bytes = if header.starts_with(b"@") { &header[1..] } else { header.as_slice() };
-
-        // Split on space to get just the name part
-        let name_part = name_bytes.find_byte(b' ').map_or(name_bytes, |pos| &name_bytes[..pos]);
-
-        if !extract_umis {
-            return (name_part.to_vec(), None);
-        }
-
-        // Count colons to find 8th field (UMI)
-        let parts: Vec<&[u8]> = name_part.split(|&b| b == b':').collect();
-
-        if parts.len() >= 8 {
-            let mut umi = parts[7].to_vec();
-            if !umi.is_empty() {
-                // Normalize '+' to '-' in UMI
-                for byte in &mut umi {
-                    if *byte == b'+' {
-                        *byte = b'-';
-                    }
-                }
-                return (name_part.to_vec(), Some(umi));
-            }
-        }
-
-        (name_part.to_vec(), None)
-    }
-
     /// Validates that all read names match across the read sets
     fn validate_read_names_match(read_sets: &[FastqSet]) -> Result<()> {
         if read_sets.is_empty() {
@@ -724,164 +600,6 @@ impl Extract {
         Ok(())
     }
 
-    /// Write raw BAM records from a read set directly to a writer.
-    ///
-    /// Uses `UnmappedBamRecordBuilder` to construct records as raw bytes,
-    /// bypassing `RecordBuf` allocation and encoding overhead.
-    ///
-    /// Returns the number of records written.
-    #[allow(clippy::too_many_lines)]
-    fn make_raw_records(
-        &self,
-        read_set: &FastqSet,
-        encoding: QualityEncoding,
-        builder: &mut UnmappedBamRecordBuilder,
-        writer: &mut RawBamWriter,
-    ) -> Result<u64> {
-        let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
-
-        let read_name = String::from_utf8_lossy(&read_set.header);
-        ensure!(!templates.is_empty(), "No template segments found for read: {read_name}");
-
-        // Extract various barcode types as BString - use optimized join
-        let cell_barcode_bs = Self::join_bytes_with_separator(
-            read_set.cell_barcode_segments().map(|s| s.seq.as_slice()),
-            b'-',
-        );
-        let cell_quals_bs = Self::join_bytes_with_separator(
-            read_set.cell_barcode_segments().map(|s| s.quals.as_slice()),
-            b' ',
-        );
-        let sample_barcode_bs = Self::join_bytes_with_separator(
-            read_set.sample_barcode_segments().map(|s| s.seq.as_slice()),
-            b'-',
-        );
-        let sample_quals_bs = Self::join_bytes_with_separator(
-            read_set.sample_barcode_segments().map(|s| s.quals.as_slice()),
-            b' ',
-        );
-        let umi_bs = Self::join_bytes_with_separator(
-            read_set.molecular_barcode_segments().map(|s| s.seq.as_slice()),
-            b'-',
-        );
-        let umi_qual_bs = Self::join_bytes_with_separator(
-            read_set.molecular_barcode_segments().map(|s| s.quals.as_slice()),
-            b' ',
-        );
-
-        // Extract UMI from read name if requested
-        let (read_name_bytes, umi_from_name) =
-            Self::extract_read_name_and_umi(&read_set.header, self.extract_umis_from_read_names);
-
-        // Prepare final UMI as BString - avoid format! and unnecessary allocations
-        let final_umi_bs: BString = match (umi_bs.is_empty(), &umi_from_name) {
-            (true, Some(from_name)) => BString::from(from_name.as_slice()),
-            (true, None) => BString::default(),
-            (false, Some(from_name)) => {
-                let mut combined = Vec::with_capacity(from_name.len() + 1 + umi_bs.len());
-                combined.extend_from_slice(from_name);
-                combined.push(b'-');
-                combined.extend_from_slice(umi_bs.as_bytes());
-                BString::from(combined)
-            }
-            (false, None) => umi_bs,
-        };
-
-        let num_templates = templates.len();
-        let umi_tag: &[u8; 2] =
-            self.umi_tag.as_bytes().try_into().expect("umi_tag must be 2 bytes");
-        let cell_tag: &[u8; 2] =
-            self.cell_tag.as_bytes().try_into().expect("cell_tag must be 2 bytes");
-
-        for (index, template) in templates.iter().enumerate() {
-            // Compute flags for unmapped reads
-            let mut flag = flags::UNMAPPED;
-            if num_templates == 2 {
-                flag |= flags::PAIRED | flags::MATE_UNMAPPED;
-                if index == 0 {
-                    flag |= flags::FIRST_SEGMENT;
-                } else {
-                    flag |= flags::LAST_SEGMENT;
-                }
-            }
-
-            // Set read name (optionally with UMI annotation)
-            let annotated_name: Option<Vec<u8>> = if self.annotate_read_names
-                && !final_umi_bs.is_empty()
-            {
-                let mut name = Vec::with_capacity(read_name_bytes.len() + 1 + final_umi_bs.len());
-                name.extend_from_slice(&read_name_bytes);
-                name.push(b'+');
-                name.extend_from_slice(final_umi_bs.as_bytes());
-                Some(name)
-            } else {
-                None
-            };
-            let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
-
-            // Build the record - if empty seq, substitute with single N @ Q2
-            if template.seq.is_empty() {
-                builder.build_record(final_read_name, flag, b"N", &[2u8]);
-            } else {
-                let numeric_quals = encoding.to_standard_numeric(&template.quals);
-                builder.build_record(final_read_name, flag, &template.seq, &numeric_quals);
-            }
-
-            // Append tags
-            // Read group
-            builder.append_string_tag(b"RG", self.read_group_id.as_bytes());
-
-            // Cell barcode
-            if !cell_barcode_bs.is_empty() {
-                builder.append_string_tag(cell_tag, cell_barcode_bs.as_bytes());
-            }
-
-            if !cell_quals_bs.is_empty() {
-                if let Some(ref qual_tag) = self.cell_qual_tag {
-                    let qt: &[u8; 2] =
-                        qual_tag.as_bytes().try_into().expect("cell_qual_tag must be 2 bytes");
-                    builder.append_string_tag(qt, cell_quals_bs.as_bytes());
-                }
-            }
-
-            // Sample barcode
-            if !sample_barcode_bs.is_empty() {
-                builder.append_string_tag(b"BC", sample_barcode_bs.as_bytes());
-            }
-
-            if self.store_sample_barcode_qualities && !sample_quals_bs.is_empty() {
-                builder.append_string_tag(b"QT", sample_quals_bs.as_bytes());
-            }
-
-            // UMI
-            if !final_umi_bs.is_empty() {
-                builder.append_string_tag(umi_tag, final_umi_bs.as_bytes());
-
-                // Single tag for all concatenated UMIs (if specified)
-                if let Some(ref single_tag) = self.single_tag {
-                    let st: &[u8; 2] =
-                        single_tag.as_bytes().try_into().expect("single_tag must be 2 bytes");
-                    builder.append_string_tag(st, final_umi_bs.as_bytes());
-                }
-
-                // Only add UMI qualities if not extracted from read names
-                if umi_from_name.is_none() && !umi_qual_bs.is_empty() {
-                    if let Some(ref qual_tag) = self.umi_qual_tag {
-                        let qt: &[u8; 2] =
-                            qual_tag.as_bytes().try_into().expect("umi_qual_tag must be 2 bytes");
-                        builder.append_string_tag(qt, umi_qual_bs.as_bytes());
-                    }
-                }
-            }
-
-            // Write the record directly
-            writer.write_raw_record(builder.as_bytes())?;
-            builder.clear();
-        }
-
-        Ok(num_templates as u64)
-    }
-
     /// Process records in single-threaded mode
     ///
     /// Returns the number of records written.
@@ -893,7 +611,7 @@ impl Extract {
     ) -> Result<u64> {
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
         let mut read_pair_count: u64 = 0;
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let extract_params = self.build_extract_params();
 
         loop {
             let mut next_read_sets = Vec::with_capacity(fq_iterators.len());
@@ -915,14 +633,14 @@ impl Extract {
                 break;
             }
 
-            //  Validate read names match across all FASTQs
             Self::validate_read_names_match(&next_read_sets)?;
 
             let read_set = FastqSet::combine_readsets(next_read_sets);
-            let num_records = self.make_raw_records(&read_set, encoding, &mut builder, writer)?;
+            let records = extract::make_raw_records(&read_set, encoding, &extract_params)?;
 
-            read_pair_count += num_records;
-            progress.log_if_needed(num_records);
+            writer.write_raw_bytes(&records.data)?;
+            read_pair_count += records.num_records;
+            progress.log_if_needed(records.num_records);
         }
 
         progress.log_final();
@@ -975,27 +693,7 @@ impl Extract {
         // Clone read_structures for the closure
         let read_structures = read_structures.to_vec();
 
-        // Build config capturing all user options for the pipeline closure
-        let extract_config = ExtractConfig {
-            read_group_id: self.read_group_id.clone(),
-            umi_tag: self.umi_tag.as_bytes().try_into().expect("validated in validate()"),
-            cell_tag: self.cell_tag.as_bytes().try_into().expect("validated in validate()"),
-            umi_qual_tag: self
-                .umi_qual_tag
-                .as_ref()
-                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
-            cell_qual_tag: self
-                .cell_qual_tag
-                .as_ref()
-                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
-            single_tag: self
-                .single_tag
-                .as_ref()
-                .map(|t| t.as_bytes().try_into().expect("validated in validate()")),
-            annotate_read_names: self.annotate_read_names,
-            extract_umis_from_read_names: self.extract_umis_from_read_names,
-            store_sample_barcode_qualities: self.store_sample_barcode_qualities,
-        };
+        let extract_config = self.build_extract_params();
 
         let records_written = run_fastq_pipeline(
             config,
@@ -1041,30 +739,30 @@ impl Extract {
                         &record.quality,
                         rs,
                         &[], // No skip reasons
-                    )
-                    .map_err(std::io::Error::other)?;
-                    fastq_sets.push(fastq_set);
+                    );
+                    fastq_sets.push(fastq_set.map_err(|e| {
+                        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+                    })?);
                 }
 
                 // Combine all FastqSets into one
                 let combined = FastqSet::combine_readsets(fastq_sets);
 
                 // Build raw BAM records
-                let result = make_raw_records_static(&combined, encoding, &extract_config)
-                    .map_err(|e| {
-                        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
-                    })?;
+                let raw = extract::make_raw_records(&combined, encoding, &extract_config).map_err(
+                    |e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+                )?;
 
                 // Debug: Check if we produce fewer records than template has
-                if result.num_records as usize != template.records.len() {
+                if raw.num_records as usize != template.records.len() {
                     log::warn!(
                         "Template with {} FASTQ records produced {} BAM records",
                         template.records.len(),
-                        result.num_records
+                        raw.num_records
                     );
                 }
 
-                Ok(result)
+                Ok(ExtractedBatch { data: raw.data, num_records: raw.num_records })
             },
             // serialize_fn: ExtractedBatch → copy pre-serialized bytes to buffer
             |batch: ExtractedBatch, _header: &Header, buffer: &mut Vec<u8>| {
@@ -1076,162 +774,6 @@ impl Extract {
         info!("Wrote {records_written} records via 7-step pipeline");
         Ok(records_written)
     }
-}
-
-/// Cloneable config for the extract pipeline closure, capturing all user options
-/// needed by `make_raw_records_static` so they aren't hardcoded.
-#[derive(Clone)]
-struct ExtractConfig {
-    read_group_id: String,
-    umi_tag: [u8; 2],
-    cell_tag: [u8; 2],
-    umi_qual_tag: Option<[u8; 2]>,
-    cell_qual_tag: Option<[u8; 2]>,
-    single_tag: Option<[u8; 2]>,
-    annotate_read_names: bool,
-    extract_umis_from_read_names: bool,
-    store_sample_barcode_qualities: bool,
-}
-
-/// Build raw BAM records from a `FastqSet` without requiring `&self`.
-/// Uses the provided `ExtractConfig` for all user-configurable options.
-fn make_raw_records_static(
-    read_set: &FastqSet,
-    encoding: QualityEncoding,
-    cfg: &ExtractConfig,
-) -> Result<ExtractedBatch> {
-    let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
-
-    let read_name = String::from_utf8_lossy(&read_set.header);
-    ensure!(!templates.is_empty(), "No template segments found for read: {read_name}");
-
-    // Extract various barcode types as BString
-    let cell_barcode_bs = Extract::join_bytes_with_separator(
-        read_set.cell_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let cell_quals_bs = Extract::join_bytes_with_separator(
-        read_set.cell_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-    let sample_barcode_bs = Extract::join_bytes_with_separator(
-        read_set.sample_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let sample_quals_bs = Extract::join_bytes_with_separator(
-        read_set.sample_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-    let umi_bs = Extract::join_bytes_with_separator(
-        read_set.molecular_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let umi_qual_bs = Extract::join_bytes_with_separator(
-        read_set.molecular_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-
-    // Extract UMI from read name if requested
-    let (read_name_bytes, umi_from_name) =
-        Extract::extract_read_name_and_umi(&read_set.header, cfg.extract_umis_from_read_names);
-
-    // Prepare final UMI
-    let final_umi_bs: BString = match (umi_bs.is_empty(), &umi_from_name) {
-        (true, Some(from_name)) => BString::from(from_name.as_slice()),
-        (true, None) => BString::default(),
-        (false, Some(from_name)) => {
-            let mut combined = Vec::with_capacity(from_name.len() + 1 + umi_bs.len());
-            combined.extend_from_slice(from_name);
-            combined.push(b'-');
-            combined.extend_from_slice(umi_bs.as_bytes());
-            BString::from(combined)
-        }
-        (false, None) => umi_bs,
-    };
-
-    let num_templates = templates.len();
-    let mut builder = UnmappedBamRecordBuilder::new();
-    let mut data = Vec::new();
-
-    for (index, template) in templates.iter().enumerate() {
-        // Compute flags for unmapped reads
-        let mut flag = flags::UNMAPPED;
-        if num_templates == 2 {
-            flag |= flags::PAIRED | flags::MATE_UNMAPPED;
-            if index == 0 {
-                flag |= flags::FIRST_SEGMENT;
-            } else {
-                flag |= flags::LAST_SEGMENT;
-            }
-        }
-
-        // Set read name (optionally with UMI annotation)
-        let annotated_name: Option<Vec<u8>> = if cfg.annotate_read_names && !final_umi_bs.is_empty()
-        {
-            let mut name = Vec::with_capacity(read_name_bytes.len() + 1 + final_umi_bs.len());
-            name.extend_from_slice(&read_name_bytes);
-            name.push(b'+');
-            name.extend_from_slice(final_umi_bs.as_bytes());
-            Some(name)
-        } else {
-            None
-        };
-        let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
-
-        // Build the record - if empty seq, substitute with single N @ Q2
-        if template.seq.is_empty() {
-            builder.build_record(final_read_name, flag, b"N", &[2u8]);
-        } else {
-            let numeric_quals = encoding.to_standard_numeric(&template.quals);
-            builder.build_record(final_read_name, flag, &template.seq, &numeric_quals);
-        }
-
-        // Append tags
-        // Read group
-        builder.append_string_tag(b"RG", cfg.read_group_id.as_bytes());
-
-        // Cell barcode
-        if !cell_barcode_bs.is_empty() {
-            builder.append_string_tag(&cfg.cell_tag, cell_barcode_bs.as_bytes());
-        }
-
-        if !cell_quals_bs.is_empty() {
-            if let Some(ref qt) = cfg.cell_qual_tag {
-                builder.append_string_tag(qt, cell_quals_bs.as_bytes());
-            }
-        }
-
-        // Sample barcode
-        if !sample_barcode_bs.is_empty() {
-            builder.append_string_tag(b"BC", sample_barcode_bs.as_bytes());
-        }
-
-        if cfg.store_sample_barcode_qualities && !sample_quals_bs.is_empty() {
-            builder.append_string_tag(b"QT", sample_quals_bs.as_bytes());
-        }
-
-        // UMI
-        if !final_umi_bs.is_empty() {
-            builder.append_string_tag(&cfg.umi_tag, final_umi_bs.as_bytes());
-
-            // Single tag for all concatenated UMIs (if specified)
-            if let Some(ref st) = cfg.single_tag {
-                builder.append_string_tag(st, final_umi_bs.as_bytes());
-            }
-
-            // Only add UMI qualities if not extracted from read names
-            if umi_from_name.is_none() && !umi_qual_bs.is_empty() {
-                if let Some(ref qt) = cfg.umi_qual_tag {
-                    builder.append_string_tag(qt, umi_qual_bs.as_bytes());
-                }
-            }
-        }
-
-        builder.write_with_block_size(&mut data);
-        builder.clear();
-    }
-
-    Ok(ExtractedBatch { data, num_records: num_templates as u64 })
 }
 
 impl Command for Extract {
@@ -1247,7 +789,7 @@ impl Command for Extract {
         let mut sample_quals = Vec::new();
         let mut temp_reader =
             SimdFastqReader::with_capacity(open_fastq_reader(&self.inputs[0], 1)?, BUFFER_SIZE);
-        for _i in 0..QUALITY_DETECTION_SAMPLE_SIZE {
+        for _i in 0..extract::QUALITY_DETECTION_SAMPLE_SIZE {
             match temp_reader.next() {
                 Some(Ok(rec)) => sample_quals.push(rec.quality),
                 Some(Err(e)) => return Err(e.into()),
@@ -1345,7 +887,7 @@ fn strip_read_suffix_extract(name: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bstr::BString;
+    use bstr::{BString, ByteSlice};
     use noodles::sam::alignment::RecordBuf;
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::data::field::Value as RecordBufValue;
@@ -1365,12 +907,12 @@ mod tests {
     /// Path to the created FASTQ file
     fn create_fastq(dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) -> PathBuf {
         let path = dir.path().join(name);
-        let mut file = File::create(&path).expect("failed to create file");
+        let mut file = File::create(&path).unwrap();
         for (name, seq, qual) in records {
-            writeln!(file, "@{name}").expect("failed to write line");
-            writeln!(file, "{seq}").expect("failed to write line");
-            writeln!(file, "+").expect("failed to write line");
-            writeln!(file, "{qual}").expect("failed to write line");
+            writeln!(file, "@{name}").unwrap();
+            writeln!(file, "{seq}").unwrap();
+            writeln!(file, "+").unwrap();
+            writeln!(file, "{qual}").unwrap();
         }
         path
     }
@@ -1383,11 +925,11 @@ mod tests {
     /// # Returns
     /// Vector of all BAM records in the file
     fn read_bam_records(path: &PathBuf) -> Vec<RecordBuf> {
-        let (mut reader, header) = create_bam_reader(path, 1).expect("failed to create BAM reader");
+        let (mut reader, header) = create_bam_reader(path, 1).unwrap();
 
         let mut records = Vec::new();
         for result in reader.record_bufs(&header) {
-            records.push(result.expect("failed to read BAM record"));
+            records.push(result.unwrap());
         }
         records
     }
@@ -1411,7 +953,7 @@ mod tests {
 
     #[test]
     fn test_single_fastq_no_read_structure() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -1450,7 +992,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1470,7 +1012,7 @@ mod tests {
 
     #[test]
     fn test_paired_end_no_read_structures() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -1506,7 +1048,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1530,7 +1072,7 @@ mod tests {
 
     #[test]
     fn test_paired_end_ignore_umi_qual_tag_when_no_umis() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -1566,7 +1108,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1577,7 +1119,7 @@ mod tests {
 
     #[test]
     fn test_paired_end_with_inline_umi() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -1586,8 +1128,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("4M+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("4M+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -1616,7 +1158,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1636,7 +1178,7 @@ mod tests {
 
     #[test]
     fn test_paired_end_with_inline_umi_keep_qualities() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -1645,8 +1187,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("4M+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("4M+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: Some("QX".to_string()),
@@ -1675,7 +1217,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1688,7 +1230,7 @@ mod tests {
 
     #[test]
     fn test_complex_read_structures_multiple_segments() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAACCCTTTAAAAA", "==============")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "GGGTTTAAACCCCC", "##############")]);
         let output = tmp.path().join("output.bam");
@@ -1697,8 +1239,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -1727,7 +1269,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1747,7 +1289,7 @@ mod tests {
 
     #[test]
     fn test_complex_read_structures_with_umi_qualities() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAACCCTTTAAAAA", "===III========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "GGGTTTAAACCCCC", "###JJJ########")]);
         let output = tmp.path().join("output.bam");
@@ -1756,8 +1298,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: Some("QX".to_string()),
@@ -1786,7 +1328,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1799,7 +1341,7 @@ mod tests {
 
     #[test]
     fn test_four_fastqs() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let r3 = create_fastq(&tmp, "r3.fq", &[("q1", "ACGT", "????")]);
@@ -1810,10 +1352,10 @@ mod tests {
             inputs: vec![r1, r2, r3, r4],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
-                ReadStructure::from_str("4B").expect("valid read structure"),
-                ReadStructure::from_str("4M").expect("valid read structure"),
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("4B").unwrap(),
+                ReadStructure::from_str("4M").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -1842,7 +1384,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1862,7 +1404,7 @@ mod tests {
 
     #[test]
     fn test_four_fastqs_with_umi_qualities() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let r3 = create_fastq(&tmp, "r3.fq", &[("q1", "ACGT", "????")]);
@@ -1873,10 +1415,10 @@ mod tests {
             inputs: vec![r1, r2, r3, r4],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
-                ReadStructure::from_str("4B").expect("valid read structure"),
-                ReadStructure::from_str("4M").expect("valid read structure"),
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("4B").unwrap(),
+                ReadStructure::from_str("4M").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: Some("QX".to_string()),
@@ -1905,7 +1447,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -1918,14 +1460,14 @@ mod tests {
 
     #[test]
     fn test_header_metadata() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let output = tmp.path().join("output.bam");
 
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("10T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("10T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -1953,9 +1495,9 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
-        let (_reader, header) = create_bam_reader(&output, 1).expect("failed to create BAM reader");
+        let (_reader, header) = create_bam_reader(&output, 1).unwrap();
 
         // Check comments
         let comments: Vec<String> =
@@ -1977,7 +1519,7 @@ mod tests {
     fn test_zero_length_reads() {
         // Test that zero-length reads are handled gracefully with variable-length read structures
         // (matching Scala/fgbio behavior where empty reads become "N" @ Q2)
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -1994,8 +1536,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("+T").expect("valid read structure"), // Variable length to allow zero-length
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("+T").unwrap(), // Variable length to allow zero-length
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2024,7 +1566,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         // Verify the output BAM was created and contains records
         let records = read_bam_records(&output);
@@ -2051,10 +1593,11 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_length_reads_with_fixed_structure_errors() {
-        // Test that zero-length reads with fixed-length read structures return an error
-        // (you can't have 0 bases when 10T are required)
-        let tmp = TempDir::new().expect("failed to create temp dir");
+    #[should_panic(expected = "had too few bases to demux")]
+    fn test_zero_length_reads_with_fixed_structure_should_panic() {
+        // Test that zero-length reads with fixed-length read structures still panic
+        // (as they should - you can't have 0 bases when 10T are required)
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "", "")]);
         let output = tmp.path().join("output.bam");
 
@@ -2062,7 +1605,7 @@ mod tests {
             inputs: vec![r1],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("10T").expect("valid read structure"), // Fixed length - should error
+                ReadStructure::from_str("10T").unwrap(), // Fixed length - should panic
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2091,15 +1634,12 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        let err = extract
-            .execute("test")
-            .expect_err("should error for zero-length read with fixed structure");
-        assert!(err.to_string().contains("had too few bases to demux"));
+        extract.execute("test").unwrap();
     }
 
     #[test]
     fn test_extract_sample_barcode_qualities() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2115,9 +1655,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1.clone()],
             output: output.clone(),
-            read_structures: vec![
-                ReadStructure::from_str("3B3M3B+T").expect("valid read structure"),
-            ],
+            read_structures: vec![ReadStructure::from_str("3B3M3B+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2145,7 +1683,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 3);
@@ -2162,9 +1700,7 @@ mod tests {
         let extract2 = Extract {
             inputs: vec![r1],
             output: output2.clone(),
-            read_structures: vec![
-                ReadStructure::from_str("3B3M3B+T").expect("valid read structure"),
-            ],
+            read_structures: vec![ReadStructure::from_str("3B3M3B+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2192,7 +1728,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract2.execute("test").expect("execute should succeed");
+        extract2.execute("test").unwrap();
 
         let recs2 = read_bam_records(&output2);
         assert_eq!(recs2.len(), 3);
@@ -2203,7 +1739,7 @@ mod tests {
 
     #[test]
     fn test_extract_umis_from_read_names() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2246,7 +1782,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 3);
@@ -2257,7 +1793,7 @@ mod tests {
 
     #[test]
     fn test_extract_umis_from_read_names_and_sequences() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2271,9 +1807,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![
-                ReadStructure::from_str("2M1S2M+T").expect("valid read structure"),
-            ],
+            read_structures: vec![ReadStructure::from_str("2M1S2M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2301,7 +1835,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -2311,7 +1845,7 @@ mod tests {
 
     #[test]
     fn test_extract_cell_barcodes() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2325,9 +1859,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![
-                ReadStructure::from_str("2C1S2C+T").expect("valid read structure"),
-            ],
+            read_structures: vec![ReadStructure::from_str("2C1S2C+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2355,7 +1887,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -2368,7 +1900,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Read names do not match")]
     fn test_fail_mismatched_read_names() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("x1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -2404,13 +1936,13 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
     }
 
     #[test]
     #[should_panic(expected = "out of sync")]
     fn test_fail_mismatched_read_counts() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2450,13 +1982,13 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
     }
 
     #[test]
     #[should_panic(expected = "must be supplied the same number of times")]
     fn test_fail_mismatched_inputs_and_read_structures() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let output = tmp.path().join("output.bam");
 
@@ -2464,8 +1996,8 @@ mod tests {
             inputs: vec![r1],
             output,
             read_structures: vec![
-                ReadStructure::from_str("+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2494,12 +2026,12 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
     }
 
     #[test]
     fn test_annotate_read_names_with_umis() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -2508,8 +2040,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("4M+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("4M+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2538,7 +2070,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -2555,7 +2087,7 @@ mod tests {
 
     #[test]
     fn test_annotate_read_names_no_umis() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let output = tmp.path().join("output.bam");
 
@@ -2590,7 +2122,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 1);
@@ -2602,7 +2134,7 @@ mod tests {
 
     #[test]
     fn test_single_tag() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAACCCTTTAAAAA", "==============")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "GGGTTTAAACCCCC", "##############")]);
         let output = tmp.path().join("output.bam");
@@ -2611,8 +2143,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
-                ReadStructure::from_str("3B3M3B5T").expect("valid read structure"),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
+                ReadStructure::from_str("3B3M3B5T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2641,7 +2173,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -2659,14 +2191,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Single tag must be exactly 2 characters")]
     fn test_single_tag_invalid_length() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let output = tmp.path().join("output.bam");
 
         let extract = Extract {
             inputs: vec![r1],
             output,
-            read_structures: vec![ReadStructure::from_str("4M+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("4M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2694,20 +2226,20 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
     }
 
     #[test]
     #[should_panic(expected = "Single tag cannot be the same as umi-tag")]
     fn test_single_tag_same_as_umi_tag() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let output = tmp.path().join("output.bam");
 
         let extract = Extract {
             inputs: vec![r1],
             output,
-            read_structures: vec![ReadStructure::from_str("4M+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("4M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2735,12 +2267,12 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
     }
 
     #[test]
     fn test_combined_annotate_read_names_and_single_tag() {
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "CCCCCCCCCC", "##########")]);
         let output = tmp.path().join("output.bam");
@@ -2749,8 +2281,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("4M+T").expect("valid read structure"),
-                ReadStructure::from_str("+T").expect("valid read structure"),
+                ReadStructure::from_str("4M+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -2779,7 +2311,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 2);
@@ -2799,17 +2331,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "had too few bases to demux")]
     fn test_fail_read_too_short_for_structure() {
         // Test that we fail when a read is not long enough for the read structure
         // Read is 10 bases, but structure requires 8M + 8S = 16 bases minimum
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAAAAAAA", "==========")]);
         let output = tmp.path().join("output.bam");
 
         let extract = Extract {
             inputs: vec![r1],
             output,
-            read_structures: vec![ReadStructure::from_str("8M8S+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("8M8S+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2837,15 +2370,14 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        let err =
-            extract.execute("test").expect_err("should error for read too short for structure");
-        assert!(err.to_string().contains("had too few bases to demux"));
+        // Should panic because read is too short
+        extract.execute("test").unwrap();
     }
 
     #[test]
     fn test_variable_length_reads_with_plus() {
         // Test that the '+' operator in read structures handles variable-length reads
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -2860,9 +2392,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![
-                ReadStructure::from_str("4M4B4S+T").expect("valid read structure"),
-            ],
+            read_structures: vec![ReadStructure::from_str("4M4B4S+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -2890,7 +2420,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let recs = read_bam_records(&output);
         assert_eq!(recs.len(), 3);
@@ -2921,8 +2451,7 @@ mod tests {
             vec![40u8, 50, 60, 70, 80, 90], // Medium to high quality
         ];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         assert_eq!(encoding, QualityEncoding::Standard);
     }
 
@@ -2936,8 +2465,7 @@ mod tests {
             vec![70u8, 80, 90, 100, 110], // Higher quality scores
         ];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         assert_eq!(encoding, QualityEncoding::Illumina);
     }
 
@@ -2950,8 +2478,7 @@ mod tests {
             vec![64u8, 65, 66, 67, 69], // High quality, narrow range
         ];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         // Should be Standard because range is too narrow for typical Phred+64
         assert_eq!(encoding, QualityEncoding::Standard);
     }
@@ -2961,8 +2488,7 @@ mod tests {
         // Test that all empty reads default to Standard encoding
         let records = vec![vec![], vec![], vec![]];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         assert_eq!(encoding, QualityEncoding::Standard);
     }
 
@@ -2976,8 +2502,7 @@ mod tests {
             vec![45u8, 55, 65], // Valid Phred+33
         ];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         assert_eq!(encoding, QualityEncoding::Standard);
     }
 
@@ -3024,8 +2549,7 @@ mod tests {
             vec![60u8, 61, 62],         // Also ambiguous
         ];
 
-        let encoding =
-            QualityEncoding::detect(&records).expect("quality encoding detection should succeed");
+        let encoding = QualityEncoding::detect(&records).unwrap();
         // Should default to Standard (Phred+33) as it's more common
         assert_eq!(encoding, QualityEncoding::Standard);
     }
@@ -3060,7 +2584,7 @@ mod tests {
     #[test]
     fn test_zero_length_reads_integration_with_quality_detection() {
         // Integration test: verify zero-length reads work correctly with quality detection
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let r1 = create_fastq(
             &tmp,
             "r1.fq",
@@ -3075,7 +2599,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -3104,7 +2628,7 @@ mod tests {
         };
 
         // Should succeed without panicking
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 3);
@@ -3123,7 +2647,7 @@ mod tests {
     #[test]
     fn test_phred64_fastq_end_to_end() {
         // End-to-end test with actual Phred+64 encoded FASTQ
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
 
         // Create FASTQ with Phred+64 quality scores
         // ASCII 64 = Q0, ASCII 70 = Q6, ASCII 80 = Q16, etc.
@@ -3140,7 +2664,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -3168,7 +2692,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 2);
@@ -3184,7 +2708,7 @@ mod tests {
     #[test]
     fn test_paired_end_with_different_read_structures() {
         // Test paired-end with different read structures for R1 and R2
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
 
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAATTTTCCCCGGGG", "IIIIIIIIIIIIIIII")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("q1", "TTTTGGGG", "IIIIIIII")]);
@@ -3194,8 +2718,8 @@ mod tests {
             inputs: vec![r1, r2],
             output: output.clone(),
             read_structures: vec![
-                ReadStructure::from_str("4M4S+T").expect("valid read structure"), // R1: 4M UMI, 4S skip, rest template
-                ReadStructure::from_str("4M+T").expect("valid read structure"), // R2: 4M UMI, rest template
+                ReadStructure::from_str("4M4S+T").unwrap(), // R1: 4M UMI, 4S skip, rest template
+                ReadStructure::from_str("4M+T").unwrap(),   // R2: 4M UMI, rest template
             ],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
@@ -3224,7 +2748,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 2); // R1 and R2
@@ -3237,8 +2761,8 @@ mod tests {
 
         // Both should have same UMI: AAAA-TTTT
         let rx_tag = noodles::sam::alignment::record::data::field::Tag::from([b'R', b'X']);
-        let r1_umi = records[0].data().get(&rx_tag).expect("expected tag not found");
-        let r2_umi = records[1].data().get(&rx_tag).expect("expected tag not found");
+        let r1_umi = records[0].data().get(&rx_tag).unwrap();
+        let r2_umi = records[1].data().get(&rx_tag).unwrap();
 
         if let noodles::sam::alignment::record_buf::data::field::Value::String(s) = r1_umi {
             assert_eq!(<bstr::BString as AsRef<[u8]>>::as_ref(s), b"AAAA-TTTT");
@@ -3251,7 +2775,7 @@ mod tests {
     #[test]
     fn test_multithreaded_extraction() {
         // Test that multi-threaded extraction works correctly
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
 
         let r1 = create_fastq(
             &tmp,
@@ -3267,7 +2791,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("5M+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("5M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -3295,7 +2819,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 3);
@@ -3310,7 +2834,7 @@ mod tests {
     fn test_multithreaded_extraction_preserves_order() {
         // Test that multi-threaded extraction preserves input order
         // This is critical for downstream tools that expect ordered output
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
 
         // Create 100 reads with sequential names for easy order verification
         let reads: Vec<(&str, &str, &str)> = (0..100)
@@ -3330,7 +2854,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("5M+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("5M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),
@@ -3358,7 +2882,7 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
         };
 
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 100);
@@ -3379,7 +2903,7 @@ mod tests {
     #[test]
     fn test_sample_barcode_with_quality_tags_specified() {
         // Test that extract works with barcode and quality tag parameters
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
 
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "AAAAACGTACGT", "IIIIIIIIIIII")]);
         let output = tmp.path().join("output.bam");
@@ -3387,7 +2911,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("5B+T").expect("valid read structure")], // 5B for barcode
+            read_structures: vec![ReadStructure::from_str("5B+T").unwrap()], // 5B for barcode
             umi_tag: "RX".to_string(),
             umi_qual_tag: Some("QX".to_string()),
             cell_tag: "CB".to_string(),
@@ -3416,7 +2940,7 @@ mod tests {
         };
 
         // Should succeed with all quality tag parameters specified
-        extract.execute("test").expect("execute should succeed");
+        extract.execute("test").unwrap();
 
         let records = read_bam_records(&output);
         assert_eq!(records.len(), 1);
@@ -3474,7 +2998,7 @@ mod tests {
         for record in &records {
             let mapq = record.mapping_quality();
             assert!(mapq.is_some(), "Mapping quality should be set (not None/255)");
-            let mapq_value: u8 = mapq.expect("mapping quality should be set").into();
+            let mapq_value: u8 = mapq.unwrap().into();
             assert_eq!(mapq_value, 0, "Mapping quality should be 0 for unmapped reads");
         }
 
@@ -3484,17 +3008,16 @@ mod tests {
     #[test]
     fn test_compression_format_detection_plain() {
         // Create a plain FASTQ file (not compressed)
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let plain_path = tmp.path().join("test.fq");
-        let mut file = File::create(&plain_path).expect("failed to create file");
+        let mut file = File::create(&plain_path).unwrap();
         use std::io::Write;
-        writeln!(file, "@read1").expect("failed to write line");
-        writeln!(file, "ACGT").expect("failed to write line");
-        writeln!(file, "+").expect("failed to write line");
-        writeln!(file, "IIII").expect("failed to write line");
+        writeln!(file, "@read1").unwrap();
+        writeln!(file, "ACGT").unwrap();
+        writeln!(file, "+").unwrap();
+        writeln!(file, "IIII").unwrap();
 
-        let format = detect_compression_format(&plain_path)
-            .expect("compression format detection should succeed");
+        let format = detect_compression_format(&plain_path).unwrap();
         assert_eq!(format, CompressionFormat::Plain);
     }
 
@@ -3505,20 +3028,19 @@ mod tests {
         use std::io::Write;
 
         // Create a gzip-compressed FASTQ file
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let gz_path = tmp.path().join("test.fq.gz");
 
         // Use flate2 to create a proper gzip file
-        let file = File::create(&gz_path).expect("failed to create file");
+        let file = File::create(&gz_path).unwrap();
         let mut encoder = GzEncoder::new(file, Compression::default());
-        writeln!(encoder, "@read1").expect("failed to write line");
-        writeln!(encoder, "ACGT").expect("failed to write line");
-        writeln!(encoder, "+").expect("failed to write line");
-        writeln!(encoder, "IIII").expect("failed to write line");
-        encoder.finish().expect("failed to finish gzip encoding");
+        writeln!(encoder, "@read1").unwrap();
+        writeln!(encoder, "ACGT").unwrap();
+        writeln!(encoder, "+").unwrap();
+        writeln!(encoder, "IIII").unwrap();
+        encoder.finish().unwrap();
 
-        let format = detect_compression_format(&gz_path)
-            .expect("compression format detection should succeed");
+        let format = detect_compression_format(&gz_path).unwrap();
         assert_eq!(format, CompressionFormat::Gzip);
     }
 
@@ -3528,19 +3050,18 @@ mod tests {
         use std::io::Write;
 
         // Create a BGZF-compressed file using noodles
-        let tmp = TempDir::new().expect("failed to create temp dir");
+        let tmp = TempDir::new().unwrap();
         let bgzf_path = tmp.path().join("test.fq.bgz");
 
-        let file = File::create(&bgzf_path).expect("failed to create file");
+        let file = File::create(&bgzf_path).unwrap();
         let mut writer = BgzfWriter::new(file);
-        writeln!(writer, "@read1").expect("failed to write line");
-        writeln!(writer, "ACGT").expect("failed to write line");
-        writeln!(writer, "+").expect("failed to write line");
-        writeln!(writer, "IIII").expect("failed to write line");
-        writer.finish().expect("failed to finish BGZF writing");
+        writeln!(writer, "@read1").unwrap();
+        writeln!(writer, "ACGT").unwrap();
+        writeln!(writer, "+").unwrap();
+        writeln!(writer, "IIII").unwrap();
+        writer.finish().unwrap();
 
-        let format = detect_compression_format(&bgzf_path)
-            .expect("compression format detection should succeed");
+        let format = detect_compression_format(&bgzf_path).unwrap();
         assert_eq!(format, CompressionFormat::Bgzf);
     }
 
@@ -3568,7 +3089,7 @@ mod tests {
         let extract = Extract {
             inputs: vec![r1],
             output: output.clone(),
-            read_structures: vec![ReadStructure::from_str("5M+T").expect("valid read structure")],
+            read_structures: vec![ReadStructure::from_str("5M+T").unwrap()],
             umi_tag: "RX".to_string(),
             umi_qual_tag: None,
             cell_tag: "CB".to_string(),

--- a/src/commands/fastq.rs
+++ b/src/commands/fastq.rs
@@ -14,6 +14,8 @@ use noodles::sam::alignment::record::Flags;
 use std::io::{BufWriter, Write, stdout};
 use std::path::PathBuf;
 
+use fgumi_lib::defaults;
+
 use crate::commands::command::Command;
 
 /// Lookup table for Phred to Phred+33 ASCII conversion (clamped to 126)
@@ -77,11 +79,11 @@ pub struct Fastq {
     pub no_suffix: bool,
 
     /// Exclude reads with any of these flags present [0x900 = secondary|supplementary].
-    #[arg(short = 'F', long = "exclude-flags", default_value_t = 0x900, value_parser = parse_flags)]
+    #[arg(short = 'F', long = "exclude-flags", default_value_t = defaults::FASTQ_EXCLUDE_FLAGS, value_parser = parse_flags)]
     pub exclude_flags: u16,
 
     /// Only include reads with all of these flags present.
-    #[arg(short = 'f', long = "require-flags", default_value_t = 0, value_parser = parse_flags)]
+    #[arg(short = 'f', long = "require-flags", default_value_t = defaults::FASTQ_REQUIRE_FLAGS, value_parser = parse_flags)]
     pub require_flags: u16,
 
     /// Number of threads for BAM decompression.
@@ -90,7 +92,7 @@ pub struct Fastq {
 
     /// BWA -K parameter value (bases per batch). Sizes output buffer to match bwa's
     /// batch size for optimal pipe throughput. Default matches common bwa mem usage.
-    #[arg(short = 'K', long = "bwa-chunk-size", default_value = "150000000")]
+    #[arg(short = 'K', long = "bwa-chunk-size", default_value_t = defaults::BWA_CHUNK_SIZE)]
     pub bwa_chunk_size: u64,
 }
 
@@ -183,7 +185,7 @@ impl Command for Fastq {
 
 /// Write a single FASTQ record to the writer.
 #[inline]
-fn write_fastq_record<W: Write>(
+pub(crate) fn write_fastq_record<W: Write>(
     writer: &mut W,
     record: &bam::Record,
     flags: Flags,

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -38,6 +38,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use fgumi_lib::defaults;
+
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
@@ -122,13 +124,13 @@ pub struct Filter {
         short = 'E',
         long = "max-read-error-rate",
         value_delimiter = ',',
-        default_value = "0.025"
+        default_value = defaults::FILTER_MAX_READ_ERROR_RATE
     )]
     pub max_read_error_rate: Vec<f64>,
 
     /// Maximum base error rate across raw reads (0.0-1.0).
     /// For duplex: provide 1-3 values for [duplex, AB consensus, BA consensus]
-    #[arg(short = 'e', long = "max-base-error-rate", value_delimiter = ',', default_value = "0.1")]
+    #[arg(short = 'e', long = "max-base-error-rate", value_delimiter = ',', default_value = defaults::FILTER_MAX_BASE_ERROR_RATE)]
     pub max_base_error_rate: Vec<f64>,
 
     /// Minimum base quality score (after masking)
@@ -143,7 +145,7 @@ pub struct Filter {
     ///
     /// If < 1.0, treated as a fraction of read length (e.g. 0.2 = 20% Ns allowed).
     /// If >= 1.0, treated as an absolute base count (must be integer, e.g. 5 = max 5 Ns).
-    #[arg(short = 'n', long = "max-no-call-fraction", default_value = "0.2")]
+    #[arg(short = 'n', long = "max-no-call-fraction", default_value_t = defaults::FILTER_MAX_NO_CALL_FRACTION)]
     pub max_no_call_fraction: f64,
 
     /// Reverse per-base tags for negative strand reads

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -13,12 +13,14 @@ use crossbeam_queue::SegQueue;
 use fgoxide::io::DelimFile;
 use fgumi_lib::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use fgumi_lib::bam_io::{create_bam_reader_for_pipeline, create_bam_writer, is_stdin_path};
+use fgumi_lib::defaults;
 use fgumi_lib::grouper::{
-    FilterMetrics, ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper,
-    build_templates_from_records,
+    FilterMetrics, GroupFilterConfig, ProcessedPositionGroup, RawPositionGroup,
+    RecordPositionGrouper, build_templates_from_records, filter_template_raw,
+    get_pair_orientation_raw,
 };
 use fgumi_lib::logging::{OperationTimer, log_umi_grouping_summary};
-use fgumi_lib::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
+use fgumi_lib::metrics::group::{FamilySizeMetrics, UmiGroupingMetrics};
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::read_info::{LibraryIndex, compute_group_key};
 use fgumi_lib::sam::{is_sorted, is_template_coordinate_sorted, unclipped_five_prime_position};
@@ -42,7 +44,7 @@ use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Estimate total heap size of a template slice using sampling for large batches.
@@ -68,26 +70,7 @@ fn estimate_templates_heap_size(templates: &[Template]) -> usize {
 #[derive(Default, Debug)]
 struct CollectedMetrics {
     family_sizes: AHashMap<usize, u64>,
-    /// Number of UMI families in this position group.
-    position_group_size: usize,
     filter_metrics: FilterMetrics,
-}
-
-/// Configuration for template filtering during group processing.
-#[derive(Clone)]
-struct GroupFilterConfig {
-    /// UMI tag bytes (e.g., [b'R', b'X']).
-    umi_tag: [u8; 2],
-    /// Minimum mapping quality.
-    min_mapq: u8,
-    /// Whether to include non-PF reads.
-    include_non_pf: bool,
-    /// Minimum UMI length (None to disable).
-    min_umi_length: Option<usize>,
-    /// Skip UMI validation (position-only grouping).
-    no_umi: bool,
-    /// Whether to allow fully unmapped templates (both reads unmapped).
-    allow_unmapped: bool,
 }
 
 /// Filter a template based on filtering criteria.
@@ -202,159 +185,8 @@ fn filter_template(
 }
 
 // =============================================================================
-// Raw-byte filter and helper functions
+// Raw-byte helper functions
 // =============================================================================
-
-/// Filter a template in raw-byte mode based on filtering criteria.
-/// Returns true if the template should be kept, false if it should be discarded.
-fn filter_template_raw(
-    template: &Template,
-    config: &GroupFilterConfig,
-    metrics: &mut FilterMetrics,
-) -> bool {
-    use fgumi_lib::sort::bam_fields;
-
-    let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-    let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-
-    let num_primary_reads = raw_r1.is_some() as u64 + raw_r2.is_some() as u64;
-    metrics.total_templates += num_primary_reads;
-
-    if raw_r1.is_none() && raw_r2.is_none() {
-        metrics.discarded_poor_alignment += num_primary_reads;
-        return false;
-    }
-
-    // Check if both reads are unmapped
-    let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
-    if both_unmapped && !config.allow_unmapped {
-        metrics.discarded_poor_alignment += num_primary_reads;
-        return false;
-    }
-
-    // Phase 1: Cheap flag-based checks
-    for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
-
-        if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
-            metrics.discarded_non_pf += num_primary_reads;
-            return false;
-        }
-
-        if (flg & bam_fields::flags::UNMAPPED) == 0 && bam_fields::mapq(raw) < config.min_mapq {
-            metrics.discarded_poor_alignment += num_primary_reads;
-            return false;
-        }
-    }
-
-    // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
-    for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
-        let aux = bam_fields::aux_data_slice(raw);
-        let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
-        let check_umi = !config.no_umi;
-
-        // Single pass over aux data to find both MQ and UMI tags
-        let mut found_mq: Option<i64> = None;
-        let mut found_umi: Option<&[u8]> = None;
-        let mut p = 0;
-        while p + 3 <= aux.len() {
-            let t = [aux[p], aux[p + 1]];
-            let val_type = aux[p + 2];
-
-            if check_umi && t == config.umi_tag && val_type == b'Z' {
-                let start = p + 3;
-                if let Some(end) = aux[start..].iter().position(|&b| b == 0) {
-                    found_umi = Some(&aux[start..start + end]);
-                    p = start + end + 1;
-                } else {
-                    break;
-                }
-                if !check_mq || found_mq.is_some() {
-                    break;
-                }
-                continue;
-            }
-
-            if check_mq && t == *b"MQ" {
-                // Extract MQ value (common types: C/c/S/s/I/i)
-                found_mq = match val_type {
-                    b'C' if p + 3 < aux.len() => Some(i64::from(aux[p + 3])),
-                    b'c' if p + 3 < aux.len() => Some(i64::from(aux[p + 3] as i8)),
-                    b'S' if p + 5 <= aux.len() => {
-                        Some(i64::from(u16::from_le_bytes([aux[p + 3], aux[p + 4]])))
-                    }
-                    b's' if p + 5 <= aux.len() => {
-                        Some(i64::from(i16::from_le_bytes([aux[p + 3], aux[p + 4]])))
-                    }
-                    b'I' if p + 7 <= aux.len() => Some(i64::from(u32::from_le_bytes([
-                        aux[p + 3],
-                        aux[p + 4],
-                        aux[p + 5],
-                        aux[p + 6],
-                    ]))),
-                    b'i' if p + 7 <= aux.len() => Some(i64::from(i32::from_le_bytes([
-                        aux[p + 3],
-                        aux[p + 4],
-                        aux[p + 5],
-                        aux[p + 6],
-                    ]))),
-                    _ => None,
-                };
-            }
-
-            if let Some(size) = bam_fields::tag_value_size(val_type, &aux[p + 3..]) {
-                p += 3 + size;
-            } else {
-                break;
-            }
-            if (!check_umi || found_umi.is_some()) && (!check_mq || found_mq.is_some()) {
-                break;
-            }
-        }
-
-        // Check mate MAPQ
-        if check_mq {
-            if let Some(mq) = found_mq {
-                if (mq as u8) < config.min_mapq {
-                    metrics.discarded_poor_alignment += num_primary_reads;
-                    return false;
-                }
-            }
-        }
-
-        // Skip UMI validation in no-umi mode
-        if config.no_umi {
-            continue;
-        }
-
-        // Check UMI for Ns and minimum length
-        if let Some(umi_bytes) = found_umi {
-            match validate_umi(umi_bytes) {
-                UmiValidation::ContainsN => {
-                    metrics.discarded_ns_in_umi += num_primary_reads;
-                    return false;
-                }
-                UmiValidation::Valid(base_count) => {
-                    if let Some(min_len) = config.min_umi_length {
-                        if base_count < min_len {
-                            metrics.discarded_umi_too_short += num_primary_reads;
-                            return false;
-                        }
-                    }
-                }
-            }
-        } else {
-            metrics.discarded_poor_alignment += num_primary_reads;
-            return false;
-        }
-    }
-
-    metrics.accepted_templates += num_primary_reads;
-    true
-}
 
 /// Check if R1 is genomically earlier than R2 using raw bytes.
 ///
@@ -371,17 +203,6 @@ fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
     let r1_pos = bam_fields::unclipped_5prime_from_raw_bam(r1);
     let r2_pos = bam_fields::unclipped_5prime_from_raw_bam(r2);
     r1_pos <= r2_pos
-}
-
-/// Get pair orientation from raw-byte template.
-fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
-    use fgumi_lib::sort::bam_fields;
-
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    (r1_positive, r2_positive)
 }
 
 // =============================================================================
@@ -743,20 +564,12 @@ pub struct GroupReadsByUmi {
     #[arg(short = 'g', long = "grouping-metrics")]
     pub grouping_metrics: Option<PathBuf>,
 
-    /// Output prefix for all group metrics files.
-    ///
-    /// Writes `PREFIX.family_sizes.txt`, `PREFIX.grouping_metrics.txt`,
-    /// and `PREFIX.position_group_sizes.txt`. Can be used alongside
-    /// `--family-size-histogram` and `--grouping-metrics`.
-    #[arg(short = 'M', long = "metrics")]
-    pub metrics: Option<PathBuf>,
-
     /// The tag containing the raw UMI
-    #[arg(short = 't', long = "raw-tag", default_value = "RX")]
+    #[arg(short = 't', long = "raw-tag", default_value = defaults::UMI_TAG)]
     pub raw_tag: String,
 
     /// The output tag for UMI grouping
-    #[arg(short = 'T', long = "assign-tag", default_value = "MI")]
+    #[arg(short = 'T', long = "assign-tag", default_value = defaults::MI_TAG)]
     pub assign_tag: String,
 
     /// SAM tag containing the cell barcode.
@@ -764,7 +577,7 @@ pub struct GroupReadsByUmi {
     /// When set, reads at the same genomic coordinates are partitioned by cell barcode before
     /// UMI assignment, so reads from different cells are never grouped together even if they
     /// share a UMI and position. No correction is performed on the cell barcode itself.
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: String,
 
     /// Minimum mapping quality for mapped reads
@@ -797,7 +610,7 @@ pub struct GroupReadsByUmi {
     pub strategy: Strategy,
 
     /// The allowable number of edits between UMIs
-    #[arg(short = 'e', long = "edits", default_value = "1")]
+    #[arg(short = 'e', long = "edits", default_value_t = defaults::GROUP_MAX_EDITS)]
     pub edits: u32,
 
     /// The minimum UMI length
@@ -814,7 +627,7 @@ pub struct GroupReadsByUmi {
 
     /// Minimum UMIs per position to use N-gram/BK-tree index for faster grouping.
     /// Set to 0 to always use linear scan. Only affects Adjacency/Paired strategies.
-    #[arg(long = "index-threshold", default_value = "100")]
+    #[arg(long = "index-threshold", default_value_t = defaults::GROUP_INDEX_THRESHOLD)]
     pub index_threshold: usize,
 
     /// Skip UMI-based grouping; group by position only. Forces identity strategy
@@ -1172,11 +985,11 @@ impl Command for GroupReadsByUmi {
                     return Ok(ProcessedPositionGroup {
                         templates: Vec::new(),
                         family_sizes: AHashMap::new(),
-                        filter_metrics: FilterMetrics::new(),
+                        filter_metrics: FilterMetrics::default(),
                         input_record_count,
                     });
                 }
-                let mut filter_metrics = FilterMetrics::new();
+                let mut filter_metrics = FilterMetrics::default();
 
                 // Track memory usage if debug mode is enabled (optimized for hot path)
                 #[cfg(feature = "memory-debug")]
@@ -1376,10 +1189,8 @@ impl Command for GroupReadsByUmi {
                     return Ok(count);
                 }
                 // Collect metrics for later aggregation
-                let position_group_size: u64 = processed.family_sizes.values().sum();
                 let metrics = CollectedMetrics {
                     family_sizes: processed.family_sizes,
-                    position_group_size: position_group_size as usize,
                     filter_metrics: processed.filter_metrics,
                 };
 
@@ -1511,15 +1322,11 @@ impl Command for GroupReadsByUmi {
         // Aggregate collected metrics from lock-free SegQueue
         // Drain all metrics and merge them
         let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut total_filter_metrics = FilterMetrics::new();
+        let mut total_filter_metrics = FilterMetrics::default();
 
         while let Some(m) = collected_metrics.pop() {
             for (size, count) in m.family_sizes {
                 *family_size_counter.entry(size).or_insert(0) += count;
-            }
-            if m.position_group_size > 0 {
-                *position_group_size_counter.entry(m.position_group_size).or_insert(0) += 1;
             }
             total_filter_metrics.merge(&m.filter_metrics);
         }
@@ -1527,11 +1334,27 @@ impl Command for GroupReadsByUmi {
         let metrics = build_grouping_metrics(&total_filter_metrics, &family_size_counter);
         log_umi_grouping_summary(&metrics);
 
-        // Write all metrics (individual flags and --metrics prefix)
-        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
+        // Write family size histogram
+        if let Some(path) = &self.family_size_histogram {
+            self.write_family_size_histogram(&family_size_counter).with_context(|| {
+                format!("Failed to write family size histogram: {}", path.display())
+            })?;
+            info!("Wrote family size histogram to {}", path.display());
+        }
+
+        // Save accepted_records before moving metrics
+        let accepted_records = metrics.accepted_records;
+
+        // Write grouping metrics using new metrics structure
+        if let Some(path) = &self.grouping_metrics {
+            DelimFile::default()
+                .write_tsv(path, [metrics])
+                .with_context(|| format!("Failed to write grouping metrics: {}", path.display()))?;
+            info!("Wrote grouping metrics to {}", path.display());
+        }
 
         // Log completion with timing
-        timer.log_completion(metrics.accepted_records);
+        timer.log_completion(accepted_records);
 
         info!("group completed successfully");
         info!("Records processed by pipeline: {records_processed}");
@@ -1579,9 +1402,8 @@ impl GroupReadsByUmi {
         let mut grouper = RecordPositionGrouper::new();
 
         // Metrics accumulators (no lock-free queue needed in single-threaded mode)
-        let mut total_filter_metrics = FilterMetrics::new();
+        let mut total_filter_metrics = FilterMetrics::default();
         let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
         let mut next_mi_base: u64 = 0;
 
         // Progress tracking
@@ -1611,7 +1433,6 @@ impl GroupReadsByUmi {
                     assign_tag_bytes,
                     &mut total_filter_metrics,
                     &mut family_size_counter,
-                    &mut position_group_size_counter,
                     &mut next_mi_base,
                     header,
                     &mut writer,
@@ -1634,7 +1455,6 @@ impl GroupReadsByUmi {
                 assign_tag_bytes,
                 &mut total_filter_metrics,
                 &mut family_size_counter,
-                &mut position_group_size_counter,
                 &mut next_mi_base,
                 header,
                 &mut writer,
@@ -1650,11 +1470,27 @@ impl GroupReadsByUmi {
         let metrics = build_grouping_metrics(&total_filter_metrics, &family_size_counter);
         log_umi_grouping_summary(&metrics);
 
-        // Write all metrics (individual flags and --metrics prefix)
-        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
+        // Write family size histogram
+        if let Some(path) = &self.family_size_histogram {
+            self.write_family_size_histogram(&family_size_counter).with_context(|| {
+                format!("Failed to write family size histogram: {}", path.display())
+            })?;
+            info!("Wrote family size histogram to {}", path.display());
+        }
+
+        // Save accepted_records before moving metrics
+        let accepted_records = metrics.accepted_records;
+
+        // Write grouping metrics
+        if let Some(path) = &self.grouping_metrics {
+            DelimFile::default()
+                .write_tsv(path, [metrics])
+                .with_context(|| format!("Failed to write grouping metrics: {}", path.display()))?;
+            info!("Wrote grouping metrics to {}", path.display());
+        }
 
         // Log completion with timing
-        timer.log_completion(metrics.accepted_records);
+        timer.log_completion(accepted_records);
 
         info!("group completed successfully");
         Ok(())
@@ -1674,7 +1510,6 @@ impl GroupReadsByUmi {
         assign_tag_bytes: [u8; 2],
         total_filter_metrics: &mut FilterMetrics,
         family_size_counter: &mut AHashMap<usize, u64>,
-        position_group_size_counter: &mut AHashMap<usize, u64>,
         next_mi_base: &mut u64,
         header: &Header,
         writer: &mut fgumi_lib::bam_io::BamWriter,
@@ -1682,7 +1517,7 @@ impl GroupReadsByUmi {
         // Build templates from raw records
         let all_templates = build_templates_from_records(group.records)?;
 
-        let mut filter_metrics = FilterMetrics::new();
+        let mut filter_metrics = FilterMetrics::default();
 
         // Filter templates
         let filtered_templates: Vec<Template> = all_templates
@@ -1734,11 +1569,10 @@ impl GroupReadsByUmi {
             a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
         });
 
-        // Count family sizes and position group size in one pass through sorted templates
+        // Count family sizes in one pass through sorted templates
         if !templates.is_empty() {
             let mut current_mi = templates[0].mi.to_vec_index();
             let mut current_count = 1usize;
-            let mut num_families = 0usize;
 
             for template in templates.iter().skip(1) {
                 let mi = template.mi.to_vec_index();
@@ -1748,7 +1582,6 @@ impl GroupReadsByUmi {
                     // Finish previous MI group
                     if current_mi.is_some() {
                         *family_size_counter.entry(current_count).or_insert(0) += 1;
-                        num_families += 1;
                     }
                     current_mi = mi;
                     current_count = 1;
@@ -1757,11 +1590,6 @@ impl GroupReadsByUmi {
             // Don't forget the last group
             if current_mi.is_some() {
                 *family_size_counter.entry(current_count).or_insert(0) += 1;
-                num_families += 1;
-            }
-
-            if num_families > 0 {
-                *position_group_size_counter.entry(num_families).or_insert(0) += 1;
             }
         }
 
@@ -1787,70 +1615,17 @@ impl GroupReadsByUmi {
         Ok(())
     }
 
-    /// Write all metrics files: individual flags and --metrics prefix outputs.
-    fn write_all_metrics(
-        &self,
-        grouping_metrics: &UmiGroupingMetrics,
-        family_sizes: &AHashMap<usize, u64>,
-        position_group_sizes: &AHashMap<usize, u64>,
-    ) -> Result<()> {
-        let family_size_metrics =
-            FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
-        let position_group_size_metrics = PositionGroupSizeMetrics::from_size_counts(
-            position_group_sizes.iter().map(|(&s, &c)| (s, c)),
-        );
-
-        // Write individual flag outputs (fgbio-compatible)
+    /// Write family size histogram
+    fn write_family_size_histogram(&self, family_sizes: &AHashMap<usize, u64>) -> Result<()> {
         if let Some(path) = &self.family_size_histogram {
-            write_metrics(path, &family_size_metrics, "family size histogram")?;
+            let metrics =
+                FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
+            DelimFile::default()
+                .write_tsv(path, metrics)
+                .with_context(|| format!("Failed to create file: {}", path.display()))?;
         }
-        if let Some(path) = &self.grouping_metrics {
-            write_metrics(path, std::slice::from_ref(grouping_metrics), "grouping metrics")?;
-        }
-
-        // Write --metrics prefix outputs (all three files)
-        if let Some(prefix) = &self.metrics {
-            let family_path = with_extension(prefix, "family_sizes.txt");
-            write_metrics(&family_path, &family_size_metrics, "family size histogram")?;
-
-            let grouping_path = with_extension(prefix, "grouping_metrics.txt");
-            write_metrics(
-                &grouping_path,
-                std::slice::from_ref(grouping_metrics),
-                "grouping metrics",
-            )?;
-
-            let position_path = with_extension(prefix, "position_group_sizes.txt");
-            write_metrics(
-                &position_path,
-                &position_group_size_metrics,
-                "position group size histogram",
-            )?;
-        }
-
         Ok(())
     }
-}
-
-/// Write metrics to a TSV file and log the output path.
-fn write_metrics<S: serde::Serialize>(
-    path: &Path,
-    data: impl IntoIterator<Item = S>,
-    label: &str,
-) -> Result<()> {
-    DelimFile::default()
-        .write_tsv(path, data)
-        .with_context(|| format!("Failed to write {label}: {}", path.display()))?;
-    info!("Wrote {label} to {}", path.display());
-    Ok(())
-}
-
-/// Build a path by appending `.{suffix}` to a prefix path.
-fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
-    let mut s = prefix.as_os_str().to_owned();
-    s.push(".");
-    s.push(suffix);
-    PathBuf::from(s)
 }
 
 #[cfg(test)]
@@ -1872,8 +1647,7 @@ mod tests {
         dir: TempDir,
         pub output: PathBuf,
         pub histogram: PathBuf,
-        pub grouping_metrics: PathBuf,
-        pub metrics_prefix: PathBuf,
+        pub metrics: PathBuf,
     }
 
     impl TestPaths {
@@ -1882,8 +1656,7 @@ mod tests {
             Ok(Self {
                 output: dir.path().join("output.bam"),
                 histogram: dir.path().join("histogram.txt"),
-                grouping_metrics: dir.path().join("grouping_metrics.txt"),
-                metrics_prefix: dir.path().join("metrics"),
+                metrics: dir.path().join("metrics.txt"),
                 dir,
             })
         }
@@ -1899,7 +1672,6 @@ mod tests {
             },
             family_size_histogram: None,
             grouping_metrics: None,
-            metrics: None,
             raw_tag: "RX".to_string(),
             assign_tag: "MI".to_string(),
             cell_tag: "CB".to_string(),
@@ -1950,21 +1722,17 @@ mod tests {
             .insert(go_tag, "query")
             .insert(ss_tag, "template-coordinate")
             .build()
-            .expect("valid header record");
+            .unwrap();
         builder = builder.set_header(map);
 
         // FIX: Use NonZeroUsize instead of Position
         builder = builder.add_reference_sequence(
             BString::from("chr1"),
-            Map::<ReferenceSequence>::new(
-                NonZeroUsize::new(248_956_422).expect("non-zero chr1 length"),
-            ),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(248_956_422).unwrap()),
         );
         builder = builder.add_reference_sequence(
             BString::from("chr2"),
-            Map::<ReferenceSequence>::new(
-                NonZeroUsize::new(242_193_529).expect("non-zero chr2 length"),
-            ),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(242_193_529).unwrap()),
         );
 
         builder.build()
@@ -2297,7 +2065,7 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            grouping_metrics: Some(paths.metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -2307,8 +2075,7 @@ mod tests {
         assert_eq!(output_records.len(), 4, "Should have 4 records (2 pairs, a02 filtered)");
 
         // Check metrics
-        let metrics: Vec<UmiGroupingMetrics> =
-            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].discarded_ns_in_umi, 2);
 
@@ -2453,264 +2220,6 @@ mod tests {
         Ok(())
     }
 
-    /// Helper to build the paths for `--metrics PREFIX` output files.
-    fn metrics_prefix_paths(prefix: &Path) -> (PathBuf, PathBuf, PathBuf) {
-        (
-            with_extension(prefix, "family_sizes.txt"),
-            with_extension(prefix, "grouping_metrics.txt"),
-            with_extension(prefix, "position_group_sizes.txt"),
-        )
-    }
-
-    #[test]
-    fn test_metrics_prefix_writes_all_files() -> Result<()> {
-        // Test setup:
-        //   Position group 1 (pos 100,300): UMI AAA (3 reads) + UMI CCC (1 read) = 2 families
-        //   Position group 2 (pos 200,400): UMI AAA (2 reads) = 1 family
-        //   Position group 3 (pos 300,500): UMI AAA (1 read) + UMI CCC (1 read) + UMI GGG (1 read) = 3 families
-        //
-        // Family sizes: {1: 4, 2: 1, 3: 1}  (four size-1, one size-2, one size-3)
-        // Position group sizes: {1: 1, 2: 1, 3: 1}  (one group with 1, 2, 3 families)
-        let mut records = Vec::new();
-
-        // Position group 1: 2 families (AAA x3, CCC x1)
-        for i in 1..=3 {
-            let (r1, r2) = build_test_pair(&format!("a{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
-            records.push(r1);
-            records.push(r2);
-        }
-        let (r1, r2) = build_test_pair("a04", 0, 100, 300, 60, 60, "CCCCCCCC");
-        records.push(r1);
-        records.push(r2);
-
-        // Position group 2: 1 family (AAA x2)
-        for i in 1..=2 {
-            let (r1, r2) = build_test_pair(&format!("b{i:02}"), 0, 200, 400, 60, 60, "AAAAAAAA");
-            records.push(r1);
-            records.push(r2);
-        }
-
-        // Position group 3: 3 families (AAA x1, CCC x1, GGG x1)
-        let (r1, r2) = build_test_pair("c01", 0, 300, 500, 60, 60, "AAAAAAAA");
-        records.push(r1);
-        records.push(r2);
-        let (r1, r2) = build_test_pair("c02", 0, 300, 500, 60, 60, "CCCCCCCC");
-        records.push(r1);
-        records.push(r2);
-        let (r1, r2) = build_test_pair("c03", 0, 300, 500, 60, 60, "GGGGGGGG");
-        records.push(r1);
-        records.push(r2);
-
-        let input = create_test_bam(records)?;
-        let paths = TestPaths::new()?;
-
-        let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            metrics: Some(paths.metrics_prefix.clone()),
-            ..test_group_cmd(Strategy::Identity, 0)
-        };
-
-        cmd.execute("test")?;
-
-        let (family_path, grouping_path, position_path) =
-            metrics_prefix_paths(&paths.metrics_prefix);
-
-        assert!(family_path.exists(), "Family sizes file should exist");
-        assert!(grouping_path.exists(), "Grouping metrics file should exist");
-        assert!(position_path.exists(), "Position group sizes file should exist");
-
-        // ---- Family size histogram ----
-        // 6 families total: four size-1, one size-2, one size-3
-        let family_metrics: Vec<FamilySizeMetrics> = DelimFile::default().read_tsv(&family_path)?;
-        assert_eq!(family_metrics.len(), 3);
-        assert_eq!(
-            family_metrics[0],
-            FamilySizeMetrics {
-                family_size: 1,
-                count: 4,
-                fraction: 4.0 / 6.0,
-                fraction_gt_or_eq_family_size: 1.0,
-            }
-        );
-        assert_eq!(
-            family_metrics[1],
-            FamilySizeMetrics {
-                family_size: 2,
-                count: 1,
-                fraction: 1.0 / 6.0,
-                fraction_gt_or_eq_family_size: 2.0 / 6.0,
-            }
-        );
-        assert_eq!(
-            family_metrics[2],
-            FamilySizeMetrics {
-                family_size: 3,
-                count: 1,
-                fraction: 1.0 / 6.0,
-                fraction_gt_or_eq_family_size: 1.0 / 6.0,
-            }
-        );
-
-        // ---- Grouping metrics ----
-        // 9 read pairs = 18 records accepted, 6 unique families
-        let grouping: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&grouping_path)?;
-        assert_eq!(grouping.len(), 1);
-        assert_eq!(grouping[0].total_records, 18);
-        assert_eq!(grouping[0].accepted_records, 18);
-        assert_eq!(grouping[0].total_families, 6);
-
-        // ---- Position group size histogram ----
-        // 3 position groups: one with 1 family, one with 2, one with 3
-        let position_metrics: Vec<PositionGroupSizeMetrics> =
-            DelimFile::default().read_tsv(&position_path)?;
-        assert_eq!(position_metrics.len(), 3);
-        assert_eq!(
-            position_metrics[0],
-            PositionGroupSizeMetrics {
-                position_group_size: 1,
-                count: 1,
-                fraction: 1.0 / 3.0,
-                fraction_gt_or_eq_position_group_size: 1.0,
-            }
-        );
-        assert_eq!(
-            position_metrics[1],
-            PositionGroupSizeMetrics {
-                position_group_size: 2,
-                count: 1,
-                fraction: 1.0 / 3.0,
-                fraction_gt_or_eq_position_group_size: 2.0 / 3.0,
-            }
-        );
-        assert_eq!(
-            position_metrics[2],
-            PositionGroupSizeMetrics {
-                position_group_size: 3,
-                count: 1,
-                fraction: 1.0 / 3.0,
-                fraction_gt_or_eq_position_group_size: 1.0 / 3.0,
-            }
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_metrics_prefix_and_individual_flags_write_same_content() -> Result<()> {
-        // Verify that --metrics PREFIX produces identical content to
-        // --family-size-histogram and --grouping-metrics individual flags.
-        let mut records = Vec::new();
-
-        // Two position groups with different family structures
-        for i in 1..=3 {
-            let (r1, r2) = build_test_pair(&format!("a{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
-            records.push(r1);
-            records.push(r2);
-        }
-        let (r1, r2) = build_test_pair("b01", 0, 200, 400, 60, 60, "CCCCCCCC");
-        records.push(r1);
-        records.push(r2);
-
-        let input = create_test_bam(records)?;
-        let paths = TestPaths::new()?;
-
-        let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            family_size_histogram: Some(paths.histogram.clone()),
-            grouping_metrics: Some(paths.grouping_metrics.clone()),
-            metrics: Some(paths.metrics_prefix.clone()),
-            ..test_group_cmd(Strategy::Identity, 0)
-        };
-
-        cmd.execute("test")?;
-
-        let (prefix_family, prefix_grouping, prefix_position) =
-            metrics_prefix_paths(&paths.metrics_prefix);
-
-        // Family size histogram: individual flag and prefix should match
-        let individual_family: Vec<FamilySizeMetrics> =
-            DelimFile::default().read_tsv(&paths.histogram)?;
-        let prefix_family: Vec<FamilySizeMetrics> =
-            DelimFile::default().read_tsv(&prefix_family)?;
-        assert_eq!(individual_family, prefix_family);
-
-        // Grouping metrics: individual flag and prefix should match
-        let individual_grouping: Vec<UmiGroupingMetrics> =
-            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
-        let prefix_grouping: Vec<UmiGroupingMetrics> =
-            DelimFile::default().read_tsv(&prefix_grouping)?;
-        assert_eq!(individual_grouping.len(), 1);
-        assert_eq!(prefix_grouping.len(), 1);
-        assert_eq!(individual_grouping[0].total_records, prefix_grouping[0].total_records);
-        assert_eq!(individual_grouping[0].accepted_records, prefix_grouping[0].accepted_records);
-        assert_eq!(individual_grouping[0].total_families, prefix_grouping[0].total_families);
-
-        // Position group sizes: only written via --metrics prefix
-        let position: Vec<PositionGroupSizeMetrics> =
-            DelimFile::default().read_tsv(&prefix_position)?;
-        assert_eq!(position.len(), 1);
-        // Both position groups have exactly 1 family each, so one entry: size=1, count=2
-        assert_eq!(position[0].position_group_size, 1);
-        assert_eq!(position[0].count, 2);
-        assert!((position[0].fraction - 1.0).abs() < f64::EPSILON);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_metrics_position_group_size_with_multi_read_families() -> Result<()> {
-        // Verify position group size counts families, not reads.
-        // Single position group with 2 families of different sizes:
-        //   UMI AAA: 5 reads  (family size 5)
-        //   UMI CCC: 2 reads  (family size 2)
-        // Position group size = 2 (two distinct families)
-        let mut records = Vec::new();
-
-        for i in 1..=5 {
-            let (r1, r2) = build_test_pair(&format!("r{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
-            records.push(r1);
-            records.push(r2);
-        }
-        for i in 6..=7 {
-            let (r1, r2) = build_test_pair(&format!("r{i:02}"), 0, 100, 300, 60, 60, "CCCCCCCC");
-            records.push(r1);
-            records.push(r2);
-        }
-
-        let input = create_test_bam(records)?;
-        let paths = TestPaths::new()?;
-
-        let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            metrics: Some(paths.metrics_prefix.clone()),
-            ..test_group_cmd(Strategy::Identity, 0)
-        };
-
-        cmd.execute("test")?;
-
-        let (family_path, _, position_path) = metrics_prefix_paths(&paths.metrics_prefix);
-
-        // Family sizes: one size-2 family, one size-5 family
-        let family_metrics: Vec<FamilySizeMetrics> = DelimFile::default().read_tsv(&family_path)?;
-        assert_eq!(family_metrics.len(), 2);
-        assert_eq!(family_metrics[0].family_size, 2);
-        assert_eq!(family_metrics[0].count, 1);
-        assert_eq!(family_metrics[1].family_size, 5);
-        assert_eq!(family_metrics[1].count, 1);
-
-        // Position group size: one group with 2 families
-        let position_metrics: Vec<PositionGroupSizeMetrics> =
-            DelimFile::default().read_tsv(&position_path)?;
-        assert_eq!(position_metrics.len(), 1);
-        assert_eq!(position_metrics[0].position_group_size, 2);
-        assert_eq!(position_metrics[0].count, 1);
-        assert!((position_metrics[0].fraction - 1.0).abs() < f64::EPSILON);
-        assert!(
-            (position_metrics[0].fraction_gt_or_eq_position_group_size - 1.0).abs() < f64::EPSILON
-        );
-
-        Ok(())
-    }
-
     #[test]
     fn test_outputs_grouping_metrics() -> Result<()> {
         let mut records = Vec::new();
@@ -2735,15 +2244,14 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            grouping_metrics: Some(paths.metrics.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
         cmd.execute("test")?;
 
-        let metrics: Vec<UmiGroupingMetrics> =
-            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].accepted_records, 2);
         assert_eq!(metrics[0].discarded_ns_in_umi, 2);
@@ -2773,7 +2281,7 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            grouping_metrics: Some(paths.metrics.clone()),
             min_umi_length: Some(6),
             ..test_group_cmd(Strategy::Edit, 0)
         };
@@ -2784,8 +2292,7 @@ mod tests {
         assert_eq!(output_records.len(), 2, "Should only have records with UMI length >= 6");
 
         // Check metrics
-        let metrics: Vec<UmiGroupingMetrics> =
-            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].accepted_records, 2);
         assert_eq!(metrics[0].discarded_ns_in_umi, 0);
@@ -2907,8 +2414,8 @@ mod tests {
         assert_eq!(b_mis.len(), 1, "Group B should have 1 unique MI");
 
         // The prefix (before '/') should be the same for both groups
-        let a_prefix = a_mis[0].split('/').next().expect("MI tag should contain '/' separator");
-        let b_prefix = b_mis[0].split('/').next().expect("MI tag should contain '/' separator");
+        let a_prefix = a_mis[0].split('/').next().unwrap();
+        let b_prefix = b_mis[0].split('/').next().unwrap();
         assert_eq!(a_prefix, b_prefix, "Both groups should have same MI prefix");
 
         // But the full MI (including suffix) should be different
@@ -3217,9 +2724,8 @@ mod tests {
         let mut groups: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
         for record in &output_records {
-            let mi = get_string_tag(record, "MI").expect("record should have MI tag");
-            let name = String::from_utf8_lossy(record.name().expect("record should have a name"))
-                .to_string();
+            let mi = get_string_tag(record, "MI").unwrap();
+            let name = String::from_utf8_lossy(record.name().unwrap()).to_string();
             groups.entry(mi).or_default().push(name);
         }
 
@@ -4202,14 +3708,14 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            grouping_metrics: Some(paths.metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
         cmd.execute("test")?;
 
         // Verify metrics file was created
-        assert!(&paths.grouping_metrics.exists());
+        assert!(&paths.metrics.exists());
 
         Ok(())
     }
@@ -4385,8 +3891,7 @@ mod tests {
 
         // Verify the output contains only reads from the "good" template
         for record in &output_records {
-            let name = String::from_utf8_lossy(record.name().expect("record should have a name"))
-                .to_string();
+            let name = String::from_utf8_lossy(record.name().unwrap()).to_string();
             assert_eq!(
                 name, "good",
                 "Only 'good' reads should remain, but found read with name: {name}"
@@ -4529,8 +4034,7 @@ mod tests {
         let mut mi_by_name: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         for record in &output_records {
-            let name = String::from_utf8_lossy(record.name().expect("record should have a name"))
-                .to_string();
+            let name = String::from_utf8_lossy(record.name().unwrap()).to_string();
             if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(mi)) =
                 record.data().get(&mi_tag)
             {
@@ -4586,8 +4090,7 @@ mod tests {
         let mut mi_by_name: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         for record in &output_records {
-            let name = String::from_utf8_lossy(record.name().expect("record should have a name"))
-                .to_string();
+            let name = String::from_utf8_lossy(record.name().unwrap()).to_string();
             if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(mi)) =
                 record.data().get(&mi_tag)
             {
@@ -4846,8 +4349,7 @@ mod tests {
             30,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 20,
@@ -4856,7 +4358,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
@@ -4871,8 +4373,7 @@ mod tests {
             10,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 20,
@@ -4881,7 +4382,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
@@ -4897,8 +4398,7 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -4907,7 +4407,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.discarded_non_pf, 1);
     }
@@ -4922,8 +4422,7 @@ mod tests {
             30,
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -4932,7 +4431,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.discarded_ns_in_umi, 1);
     }
@@ -4947,8 +4446,7 @@ mod tests {
             30,
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -4957,7 +4455,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.discarded_umi_too_short, 1);
     }
@@ -4971,8 +4469,7 @@ mod tests {
             0,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -4981,7 +4478,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         assert!(!filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
@@ -5020,8 +4517,7 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![supp])
-            .expect("Template::from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![supp]).unwrap();
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5030,7 +4526,7 @@ mod tests {
             no_umi: false,
             allow_unmapped: false,
         };
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         // Supplementary-only template has no primary R1/R2 → raw_r1() returns None
         assert!(!filter_template_raw(&template, &config, &mut metrics));
     }
@@ -5052,18 +4548,14 @@ mod tests {
         // Add header with queryname sort order
         let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
 
-        let map = HeaderRecordMap::<HeaderRecord>::builder()
-            .insert(so_tag, "queryname")
-            .build()
-            .expect("valid header record");
+        let map =
+            HeaderRecordMap::<HeaderRecord>::builder().insert(so_tag, "queryname").build().unwrap();
         builder = builder.set_header(map);
 
         // Add reference sequences (even though reads are unmapped, header needs refs)
         builder = builder.add_reference_sequence(
             BString::from("chr1"),
-            Map::<ReferenceSequence>::new(
-                NonZeroUsize::new(248_956_422).expect("non-zero chr1 length"),
-            ),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(248_956_422).unwrap()),
         );
 
         builder.build()
@@ -5111,7 +4603,7 @@ mod tests {
             allow_unmapped: true,
         };
 
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let should_keep = filter_template(&template, &config, &mut metrics);
 
         assert!(should_keep, "Unmapped template should be kept when allow_unmapped=true");
@@ -5135,7 +4627,7 @@ mod tests {
             allow_unmapped: false,
         };
 
-        let mut metrics = FilterMetrics::new();
+        let mut metrics = FilterMetrics::default();
         let should_keep = filter_template(&template, &config, &mut metrics);
 
         assert!(!should_keep, "Unmapped template should be rejected when allow_unmapped=false");

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_lib::bam_io::create_bam_reader;
+use fgumi_lib::defaults;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::sort::RawExternalSorter;
 use fgumi_lib::validation::validate_file_exists;
@@ -93,7 +94,7 @@ pub struct Merge {
     /// When merging in template-coordinate order, this tag is included in the
     /// sort key so that templates from different cells at the same locus are
     /// not interleaved. Only used for template-coordinate merge.
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: String,
 }
 

--- a/src/commands/simplex.rs
+++ b/src/commands/simplex.rs
@@ -14,6 +14,7 @@ use fgumi_lib::bam_io::{
 use fgumi_lib::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
 };
+use fgumi_lib::defaults;
 use fgumi_lib::logging::{OperationTimer, log_consensus_summary};
 use fgumi_lib::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
 use fgumi_lib::overlapping_consensus::{
@@ -190,7 +191,7 @@ pub struct Simplex {
     pub compression: CompressionOptions,
 
     /// The SAM tag containing the unique molecule identifier
-    #[arg(short = 't', long = "tag", default_value = "MI")]
+    #[arg(short = 't', long = "tag", default_value = defaults::MI_TAG)]
     pub tag: String,
 
     /// Minimum number of reads to produce a consensus (required, no default)
@@ -203,7 +204,7 @@ pub struct Simplex {
     pub max_reads: Option<usize>,
 
     /// SAM tag containing the cell barcode
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: Option<String>,
 
     /// Scheduler and pipeline statistics options.

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -23,6 +23,7 @@
 use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_lib::bam_io::create_bam_reader;
+use fgumi_lib::defaults;
 use fgumi_lib::logging::OperationTimer;
 use fgumi_lib::sort::{QuerynameComparator, RawExternalSorter, SortOrder};
 use fgumi_lib::validation::{string_to_tag, validate_file_exists};
@@ -189,14 +190,14 @@ pub struct Sort {
     ///
     /// With --memory-per-thread (default), this is multiplied by thread count
     /// (like samtools' -m option). With 8 threads and 768M, total = 6GB.
-    #[arg(short = 'm', long = "max-memory", default_value = "768M", value_parser = parse_memory)]
+    #[arg(short = 'm', long = "max-memory", default_value = defaults::SORT_MEMORY_LIMIT_DISPLAY, value_parser = parse_memory)]
     pub max_memory: usize,
 
     /// Scale memory limit by thread count (samtools behavior).
     ///
     /// When enabled (default), --max-memory specifies memory per thread.
     /// Total memory = `max_memory` × threads. Disable for fixed total memory.
-    #[arg(long = "memory-per-thread", default_value = "true", action = clap::ArgAction::Set)]
+    #[arg(long = "memory-per-thread", default_value_t = defaults::SORT_MEMORY_PER_THREAD, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub memory_per_thread: bool,
 
     /// Temporary directory for intermediate files.
@@ -222,7 +223,7 @@ pub struct Sort {
     /// Level 0 disables compression (fastest, uses most disk space).
     /// Level 1 (default) provides fast compression with reasonable space savings.
     /// Higher levels (up to 9) provide better compression but are slower.
-    #[arg(long = "temp-compression", default_value = "1", value_parser = clap::value_parser!(u32).range(0..=9))]
+    #[arg(long = "temp-compression", default_value_t = defaults::SORT_TEMP_COMPRESSION, value_parser = clap::value_parser!(u32).range(0..=9))]
     pub temp_compression: u32,
 
     /// Write BAM index (.bai) alongside output.
@@ -239,7 +240,7 @@ pub struct Sort {
     /// sort key so that templates from different cells at the same locus are
     /// not interleaved. Use the same value as `--cell-tag` in `fgumi group`
     /// and `fgumi dedup`. Only used for template-coordinate sort.
-    #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
+    #[arg(short = 'c', long = "cell-tag", default_value = defaults::CELL_TAG)]
     pub cell_tag: String,
 }
 
@@ -1006,5 +1007,18 @@ mod tests {
         assert!(total > 0);
         assert!(violations > 0, "unsorted file should fail coordinate verify");
         Ok(())
+    }
+
+    #[test]
+    fn sort_memory_default_matches_constant() {
+        let parsed = parse_memory(fgumi_lib::defaults::SORT_MEMORY_LIMIT_DISPLAY)
+            .expect("SORT_MEMORY_LIMIT_DISPLAY should be parseable");
+        assert_eq!(
+            parsed,
+            fgumi_lib::defaults::SORT_MEMORY_LIMIT,
+            "SORT_MEMORY_LIMIT_DISPLAY ({}) must parse to SORT_MEMORY_LIMIT ({})",
+            fgumi_lib::defaults::SORT_MEMORY_LIMIT_DISPLAY,
+            fgumi_lib::defaults::SORT_MEMORY_LIMIT,
+        );
     }
 }

--- a/src/commands/zipper.rs
+++ b/src/commands/zipper.rs
@@ -46,6 +46,8 @@
 //! - `TemplateIterator`: Lazily groups records by name from a BAM reader
 //! - `TagInfo`: Holds sets of tags to remove/reverse/revcomp
 //! - `merge()`: Core function that transfers metadata between templates
+use fgumi_lib::defaults;
+
 use crate::commands::command::Command;
 use crate::commands::common::CompressionOptions;
 use anyhow::{Context, Result};
@@ -160,7 +162,7 @@ pub struct Zipper {
     /// BWA -K parameter value (bases per batch). Used to optimize buffer sizing
     /// for stdin input. The buffer grows adaptively based on observed bytes per batch.
     /// Default matches common bwa mem usage.
-    #[arg(short = 'K', long = "bwa-chunk-size", default_value = "150000000")]
+    #[arg(short = 'K', long = "bwa-chunk-size", default_value_t = defaults::BWA_CHUNK_SIZE)]
     pub bwa_chunk_size: u64,
 
     /// Exclude reads from the unmapped BAM that are not present in the aligned BAM.


### PR DESCRIPTION
## Summary
- Move extraction, correction, sorting, and grouping shared logic from command implementations into fgumi-lib
- Add `defaults` module for centralizing default values used across commands
- Add `sort::sink` module with `SortedRecordSink` trait and `BamWriterSink` for pluggable sort output
- Add raw-record-based template filtering (`filter_template_raw`) and UMI extraction helpers to `grouper`
- Fix `total_templates` metric to count templates rather than primary reads
- Slim down command modules (`extract`, `correct`, `group`, `dedup`) by delegating to library functions

**Stack:** 3/6 — depends on #202

## Test plan
- [ ] `cargo ci-test` passes
- [ ] `cargo ci-fmt` passes
- [ ] `cargo ci-lint` passes
- [ ] Existing command behavior is unchanged (logic moved, not modified)