### PR TITLE
feat: add fgumi-pipeline streaming pipeline engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -86,15 +86,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -281,9 +281,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -382,15 +382,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -575,19 +575,25 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.11.9"
+name = "env_home"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -614,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "fgoxide"
@@ -661,6 +667,7 @@ dependencies = [
  "fgumi-dna",
  "fgumi-lib",
  "fgumi-metrics",
+ "fgumi-pipeline",
  "fgumi-raw-bam",
  "fgumi-sam",
  "fgumi-simd-fastq",
@@ -690,7 +697,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
- "wide 1.1.1",
+ "wide 1.2.0",
 ]
 
 [[package]]
@@ -717,7 +724,7 @@ dependencies = [
  "log",
  "noodles",
  "rand 0.10.0",
- "wide 1.1.1",
+ "wide 1.2.0",
 ]
 
 [[package]]
@@ -793,6 +800,30 @@ dependencies = [
  "noodles",
  "serde",
  "tempfile",
+]
+
+[[package]]
+name = "fgumi-pipeline"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "fgumi-bgzf",
+ "fgumi-consensus",
+ "fgumi-derive",
+ "fgumi-lib",
+ "fgumi-raw-bam",
+ "fgumi-sam",
+ "fgumi-umi",
+ "log",
+ "lru",
+ "noodles",
+ "rayon",
+ "rstest",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1060,12 +1091,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1073,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1086,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1100,15 +1132,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1120,15 +1152,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1168,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1210,9 +1242,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1250,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1329,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdeflate-sys"
@@ -1382,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -1400,9 +1432,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1477,9 +1509,9 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "nalgebra"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -1671,18 +1703,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -1699,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1817,18 +1849,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1872,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -2237,9 +2269,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq_io"
@@ -2313,7 +2345,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "itoa 1.0.17",
+ "itoa 1.0.18",
  "memchr",
  "serde",
  "serde_core",
@@ -2341,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2435,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -2449,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -2508,9 +2540,9 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2528,18 +2560,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2549,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -2661,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2674,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2684,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2697,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2740,12 +2772,24 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -2760,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
+checksum = "198f6abc41fab83526d10880fa5c17e2b4ee44e763949b4bb34e2fd1e8ca48e4"
 dependencies = [
  "bytemuck",
  "safe_arch 1.0.0",
@@ -2920,12 +2964,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -3017,15 +3067,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3034,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3046,18 +3096,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3066,18 +3116,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3087,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3098,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3109,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/fgumi-derive", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-simd-fastq", "crates/fgumi-umi", "crates/fgumi-consensus", "crates/fgumi-lib"]
+members = [".", "crates/fgumi-derive", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-simd-fastq", "crates/fgumi-umi", "crates/fgumi-consensus", "crates/fgumi-lib", "crates/fgumi-pipeline"]
 resolver = "2"
 
 [workspace.package]
@@ -16,6 +16,7 @@ fgumi-derive = { version = "0.1.2", path = "crates/fgumi-derive" }
 fgumi-consensus = { version = "0.1.2", path = "crates/fgumi-consensus", default-features = false }
 fgumi-dna = { version = "0.1.2", path = "crates/fgumi-dna" }
 fgumi-lib = { version = "0.1.2", path = "crates/fgumi-lib", default-features = false }
+fgumi-pipeline = { version = "0.1.2", path = "crates/fgumi-pipeline" }
 fgumi-metrics = { version = "0.1.2", path = "crates/fgumi-metrics" }
 fgumi-raw-bam = { version = "0.1.2", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.1.2", path = "crates/fgumi-sam" }
@@ -123,6 +124,7 @@ thiserror = { workspace = true }
 wide = { workspace = true }
 fgumi-derive = { workspace = true }
 fgumi-lib = { workspace = true }
+fgumi-pipeline = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-dna = { workspace = true }
 fgumi-bgzf = { workspace = true }

--- a/crates/fgumi-pipeline/Cargo.toml
+++ b/crates/fgumi-pipeline/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fgumi-pipeline"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Pipeline for fgumi: extract, sort, group, consensus, and filter in one pass"
+
+[dependencies]
+fgumi-lib = { workspace = true }
+fgumi-consensus = { workspace = true }
+fgumi-bgzf = { workspace = true }
+fgumi-sam = { workspace = true }
+fgumi-raw-bam = { workspace = true, features = ["noodles"] }
+fgumi-umi = { workspace = true }
+fgumi-derive = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["string"] }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+log = { workspace = true }
+lru = { workspace = true }
+noodles = { workspace = true, features = ["bam", "sam", "bgzf", "core"] }
+rayon = { workspace = true }
+which = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+tempfile = { workspace = true }
+fgumi-raw-bam = { workspace = true, features = ["test-utils"] }

--- a/crates/fgumi-pipeline/src/lib.rs
+++ b/crates/fgumi-pipeline/src/lib.rs
@@ -1,0 +1,9 @@
+//! Pipeline crate: parallel Zone 3 stages, work-stealing scheduler, and pipeline builder.
+
+#![deny(unsafe_code)]
+
+pub mod pipeline;
+pub mod stage;
+pub mod stages;
+
+pub use stage::{PipelineStage, SequencedItem};

--- a/crates/fgumi-pipeline/src/pipeline/aligner_io.rs
+++ b/crates/fgumi-pipeline/src/pipeline/aligner_io.rs
@@ -1,0 +1,90 @@
+//! Aligner I/O mode selection and dedicated I/O thread management.
+//!
+//! Two modes:
+//! - [`BatchCoordinated`](AlignerIoMode::BatchCoordinated): uses
+//!   [`AlignerBatchState`](super::batch_state::AlignerBatchState) for `-K` flow control.
+//!   Two lightweight I/O threads (stdin-writer, stdout-reader) handle blocking pipe I/O.
+//! - [`DedicatedThreads`](AlignerIoMode::DedicatedThreads): no batch coordination.
+//!   Two I/O threads handle all pipe I/O.
+//!
+//! In both modes, I/O threads do NOT count against `--threads`.
+
+/// How the pipeline communicates with the aligner subprocess.
+#[derive(Debug, Clone)]
+pub enum AlignerIoMode {
+    /// Batch-coordinated with bwa `-K` flow control.
+    BatchCoordinated {
+        /// bwa's `-K` value in bases.
+        k_bases: u64,
+    },
+    /// Dedicated I/O threads without batch coordination.
+    /// Used for non-bwa aligners or when `-K` is not specified.
+    DedicatedThreads,
+}
+
+impl AlignerIoMode {
+    /// Default `-K` value matching bwa mem's common usage.
+    pub const DEFAULT_K_BASES: u64 = 150_000_000;
+
+    /// Create a batch-coordinated mode with the given `-K` value.
+    #[must_use]
+    pub fn batch_coordinated(k_bases: u64) -> Self {
+        Self::BatchCoordinated { k_bases }
+    }
+
+    /// Create a dedicated-threads mode (no batch coordination).
+    #[must_use]
+    pub fn dedicated() -> Self {
+        Self::DedicatedThreads
+    }
+
+    /// Whether this mode uses batch coordination.
+    #[must_use]
+    pub fn is_batch_coordinated(&self) -> bool {
+        matches!(self, Self::BatchCoordinated { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_batch_coordinated_mode() {
+        let mode = AlignerIoMode::batch_coordinated(100_000);
+        assert!(mode.is_batch_coordinated());
+        match mode {
+            AlignerIoMode::BatchCoordinated { k_bases } => assert_eq!(k_bases, 100_000),
+            AlignerIoMode::DedicatedThreads => panic!("expected BatchCoordinated"),
+        }
+    }
+
+    #[test]
+    fn test_dedicated_mode() {
+        let mode = AlignerIoMode::dedicated();
+        assert!(!mode.is_batch_coordinated());
+        assert!(matches!(mode, AlignerIoMode::DedicatedThreads));
+    }
+
+    #[test]
+    fn test_default_k_bases() {
+        assert_eq!(AlignerIoMode::DEFAULT_K_BASES, 150_000_000);
+        let mode = AlignerIoMode::batch_coordinated(AlignerIoMode::DEFAULT_K_BASES);
+        match mode {
+            AlignerIoMode::BatchCoordinated { k_bases } => {
+                assert_eq!(k_bases, 150_000_000);
+            }
+            AlignerIoMode::DedicatedThreads => panic!("expected BatchCoordinated"),
+        }
+    }
+
+    #[test]
+    fn test_clone_and_debug() {
+        let mode = AlignerIoMode::batch_coordinated(1000);
+        let cloned = mode.clone();
+        assert!(cloned.is_batch_coordinated());
+        // Ensure Debug is implemented (compile-time check, runtime smoke test).
+        let debug_str = format!("{mode:?}");
+        assert!(debug_str.contains("BatchCoordinated"));
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/batch_state.rs
+++ b/crates/fgumi-pipeline/src/pipeline/batch_state.rs
@@ -1,0 +1,241 @@
+//! Batch flow control for aligner subprocess coordination.
+//!
+//! When bwa mem is run with `-K <bases>`, it processes reads in chunks of approximately
+//! K bases. `ToFastq` and `ReadSam` coordinate through [`AlignerBatchState`] to prevent pipe
+//! deadlocks: `ToFastq` sends one batch, waits for `ReadSam` to consume the SAM output,
+//! then sends the next batch.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// Shared state for coordinating FASTQ send / SAM receive batch boundaries.
+///
+/// `ToFastq` writes FASTQ records to the aligner's stdin, tracking bases and record
+/// counts. When a batch boundary is reached (enough bases with an even record count
+/// to keep read pairs together), it marks the batch as sent and waits. `ReadSam` reads
+/// SAM records from the aligner's stdout, and once all records for the batch have been
+/// received, it calls [`advance_batch`](Self::advance_batch) to reset counters and
+/// unblock the next batch.
+pub struct AlignerBatchState {
+    /// bwa's -K value in bases.
+    k_chunk_bases: u64,
+    /// Bases written to stdin in the current batch.
+    bases_sent: AtomicU64,
+    /// Records sent in the current batch.
+    records_sent: AtomicU64,
+    /// True when the current batch has been fully sent to stdin.
+    batch_sent: AtomicBool,
+    /// Records received from stdout for the current batch.
+    records_received: AtomicU64,
+    /// Batch sequence counter for debugging/logging.
+    batch_number: AtomicU64,
+}
+
+impl AlignerBatchState {
+    /// Create a new batch state with the given `-K` value.
+    #[must_use]
+    pub fn new(k_chunk_bases: u64) -> Self {
+        Self {
+            k_chunk_bases,
+            bases_sent: AtomicU64::new(0),
+            records_sent: AtomicU64::new(0),
+            batch_sent: AtomicBool::new(false),
+            records_received: AtomicU64::new(0),
+            batch_number: AtomicU64::new(0),
+        }
+    }
+
+    /// Called by `ToFastq`: can we send more FASTQ data?
+    ///
+    /// Returns `true` if the current batch has not yet been fully sent, meaning
+    /// `ToFastq` can continue writing records to the aligner's stdin.
+    #[must_use]
+    pub fn can_send(&self) -> bool {
+        !self.batch_sent.load(Ordering::Acquire)
+    }
+
+    /// Called by `ToFastq`: record that `bases` bases and `records` records were written
+    /// to stdin.
+    ///
+    /// When the accumulated bases reach `k_chunk_bases` AND the record count is even
+    /// (to keep read pairs together, matching bwa's behavior), marks the batch as sent.
+    pub fn record_send(&self, bases: u64, records: u64) {
+        let total_bases = self.bases_sent.fetch_add(bases, Ordering::AcqRel) + bases;
+        let total_records = self.records_sent.fetch_add(records, Ordering::AcqRel) + records;
+        // Batch boundary: enough bases AND even record count (read pairs stay together)
+        if total_bases >= self.k_chunk_bases && total_records.is_multiple_of(2) {
+            self.batch_sent.store(true, Ordering::Release);
+        }
+    }
+
+    /// Called by `ReadSam`: record that `records` records were received from stdout.
+    pub fn record_receive(&self, records: u64) {
+        self.records_received.fetch_add(records, Ordering::AcqRel);
+    }
+
+    /// Called by `ReadSam`: check if the current batch is complete.
+    ///
+    /// A batch is complete when:
+    /// 1. `batch_sent` is true (`ToFastq` finished sending)
+    /// 2. `records_received >= records_sent` (all SAM output consumed)
+    #[must_use]
+    pub fn is_batch_complete(&self) -> bool {
+        if !self.batch_sent.load(Ordering::Acquire) {
+            return false;
+        }
+        let sent = self.records_sent.load(Ordering::Acquire);
+        let received = self.records_received.load(Ordering::Acquire);
+        received >= sent
+    }
+
+    /// Called by `ReadSam`: signal that the current batch's SAM output is fully consumed.
+    /// Resets counters for the next batch.
+    ///
+    /// # Safety invariant (not `unsafe`, but protocol-critical)
+    ///
+    /// This method resets four atomics individually. Correctness depends on the
+    /// protocol guarantee that `ToFastq` will not call `record_sent()` until it
+    /// observes `can_send() == true`, which requires `batch_sent == false` (the
+    /// last store in this method). The `Release` ordering on `batch_sent` ensures
+    /// the preceding resets are visible to `ToFastq` before it resumes sending.
+    pub fn advance_batch(&self) {
+        self.bases_sent.store(0, Ordering::Release);
+        self.records_sent.store(0, Ordering::Release);
+        self.records_received.store(0, Ordering::Release);
+        self.batch_sent.store(false, Ordering::Release);
+        self.batch_number.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Current batch number (for logging/debugging).
+    #[must_use]
+    pub fn batch_number(&self) -> u64 {
+        self.batch_number.load(Ordering::Relaxed)
+    }
+
+    /// The `-K` value in bases.
+    #[must_use]
+    pub fn k_chunk_bases(&self) -> u64 {
+        self.k_chunk_bases
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_send_initially() {
+        let state = AlignerBatchState::new(1000);
+        assert!(state.can_send(), "should be able to send initially");
+        assert_eq!(state.batch_number(), 0);
+    }
+
+    #[test]
+    fn test_batch_boundary() {
+        let state = AlignerBatchState::new(100);
+
+        // Send 100 bases in 2 records (even) — should trigger batch boundary.
+        state.record_send(100, 2);
+
+        assert!(!state.can_send(), "batch_sent should be true after reaching k_chunk_bases");
+        assert!(
+            !state.is_batch_complete(),
+            "batch should not be complete until records are received"
+        );
+    }
+
+    #[test]
+    fn test_odd_records_delay_boundary() {
+        let state = AlignerBatchState::new(100);
+
+        // Send 150 bases but only 1 record (odd) — should NOT trigger batch boundary.
+        state.record_send(150, 1);
+        assert!(state.can_send(), "odd record count should delay batch boundary");
+
+        // Send 1 more record with 0 bases — now 2 records (even), boundary should trigger.
+        state.record_send(0, 1);
+        assert!(!state.can_send(), "even record count should trigger batch boundary");
+    }
+
+    #[test]
+    fn test_batch_complete_detection() {
+        let state = AlignerBatchState::new(100);
+
+        // Not complete when nothing has been sent.
+        assert!(!state.is_batch_complete());
+
+        // Send a full batch: 100 bases, 4 records.
+        state.record_send(100, 4);
+        assert!(!state.is_batch_complete(), "not complete until records received");
+
+        // Receive 3 of 4 records.
+        state.record_receive(3);
+        assert!(!state.is_batch_complete(), "not complete with fewer records than sent");
+
+        // Receive the 4th record.
+        state.record_receive(1);
+        assert!(state.is_batch_complete(), "complete when records_received >= records_sent");
+    }
+
+    #[test]
+    fn test_batch_complete_with_extra_receives() {
+        let state = AlignerBatchState::new(50);
+
+        state.record_send(50, 2);
+        // Receive more records than sent (e.g. supplementary alignments).
+        state.record_receive(4);
+        assert!(state.is_batch_complete(), "complete when records_received > records_sent");
+    }
+
+    #[test]
+    fn test_advance_batch_resets() {
+        let state = AlignerBatchState::new(100);
+
+        // Complete a batch.
+        state.record_send(100, 2);
+        state.record_receive(2);
+        assert!(state.is_batch_complete());
+        assert_eq!(state.batch_number(), 0);
+
+        // Advance to next batch.
+        state.advance_batch();
+        assert!(state.can_send(), "should be able to send after advance");
+        assert!(!state.is_batch_complete(), "new batch should not be complete");
+        assert_eq!(state.batch_number(), 1);
+    }
+
+    #[test]
+    fn test_batch_number_increments() {
+        let state = AlignerBatchState::new(10);
+
+        for i in 0..5 {
+            assert_eq!(state.batch_number(), i);
+            state.record_send(10, 2);
+            state.record_receive(2);
+            state.advance_batch();
+        }
+        assert_eq!(state.batch_number(), 5);
+    }
+
+    #[test]
+    fn test_k_chunk_bases_accessor() {
+        let state = AlignerBatchState::new(150_000_000);
+        assert_eq!(state.k_chunk_bases(), 150_000_000);
+    }
+
+    #[test]
+    fn test_incremental_sends_accumulate() {
+        let state = AlignerBatchState::new(100);
+
+        // Send in small increments — should not trigger boundary until total >= k.
+        state.record_send(30, 2);
+        assert!(state.can_send());
+        state.record_send(30, 2);
+        assert!(state.can_send());
+        // Now at 80 bases, 6 records (even) — still under k.
+        state.record_send(20, 2);
+        assert!(state.can_send()); // 80 < 100, no trigger yet
+        // Now send enough to exceed k: 80 + 30 = 110 bases, 8 records (even).
+        state.record_send(30, 2);
+        assert!(!state.can_send());
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/builder.rs
+++ b/crates/fgumi-pipeline/src/pipeline/builder.rs
@@ -1,0 +1,935 @@
+//! Pipeline builder: composes Zone 3 stages, wires queues, and runs the scheduler.
+//!
+//! Supports three entry points:
+//! - `Stage::Group` — reads a template-coordinate-sorted BAM and feeds Zone 3 directly.
+//! - `Stage::Sort` — reads an unsorted BAM, sorts by template-coordinate, then feeds Zone 3.
+//! - `run_two_phase` — runs Phase A (extract → align → zipper → sort) then Phase B (Zone 3).
+//!
+//! All threads (including the calling thread during completion) participate in work-stealing.
+//! There is no dedicated writer thread; writing is a stage runner with the highest priority.
+//! This unified model works with any thread count, including `--threads 1`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use anyhow::{Context, Result};
+use log::info;
+
+use fgumi_bgzf::reader::BGZF_EOF;
+use fgumi_consensus::filter::FilterConfig;
+use fgumi_lib::bam_io::create_raw_bam_reader;
+use fgumi_lib::extract::{ExtractParams, QualityEncoding};
+use fgumi_lib::grouper::GroupFilterConfig;
+use fgumi_lib::sort::{
+    LibraryLookup, RawExternalSorter, SortOrder, SortedRecordSink, cb_hasher,
+    extract_template_key_inline, merge_sorted_chunks_to_sink,
+};
+use fgumi_lib::template::TemplateIterator;
+use fgumi_lib::unified_pipeline::MemoryEstimate;
+use fgumi_umi::{TagInfo, UmiAssigner};
+
+use crate::pipeline::batch_state::AlignerBatchState;
+use crate::pipeline::phase_a::PhaseAStep;
+use crate::pipeline::phase_a_graph::{ExtractSource, MergeFn, PhaseAGraph};
+use crate::pipeline::phase_a_steps;
+use crate::pipeline::phase_a_worker::{start_phase_a_pool, wait_phase_a_pool};
+use crate::stages::aligner::AlignerProcess;
+
+use crate::pipeline::queue::WorkQueue;
+use crate::pipeline::reorder::ReorderBuffer;
+use crate::pipeline::scheduler::{
+    BackpressureState, PipelineStep, Scheduler, StageGraph, StepResult, WorkerState,
+    WorkerStateSlot, WriteState,
+};
+use crate::pipeline::stats::StageStats;
+use crate::stage::SequencedItem;
+use crate::stages::compress::{CompressStage, CompressedBatch};
+use crate::stages::consensus::{CallerFactory, ConsensusStage};
+use crate::stages::filter::FilterStage;
+use crate::stages::group_assign::{GroupAndAssignStage, MiGroup, PositionGroupBatch};
+use crate::stages::position_batch::PositionBatcher;
+
+// ============================================================================
+// Configuration types
+// ============================================================================
+
+/// Callback type that builds the final output header from the mapped SAM header.
+///
+/// The stdout-reader thread calls this after reading the SAM header from the aligner.
+/// The closure typically merges the unmapped header, mapped header, and reference dict,
+/// then adds a PG record.
+pub type BuildOutputHeaderFn =
+    Box<dyn FnOnce(&noodles::sam::Header) -> anyhow::Result<noodles::sam::Header> + Send>;
+
+/// Pipeline entry point: which stage to start from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    /// Start from sorting: read unsorted BAM → template-coordinate sort → Zone 3.
+    Sort,
+    /// Start from grouping: read already-sorted BAM → Zone 3.
+    Group,
+}
+
+/// Configuration for the runall pipeline.
+pub struct PipelineConfig {
+    /// Input BAM file path.
+    pub input: PathBuf,
+    /// Output BAM file path.
+    pub output: PathBuf,
+    /// Reference FASTA path (for consensus calling).
+    pub reference: PathBuf,
+    /// Total threads available to the pipeline.
+    pub threads: usize,
+    /// Which stage to begin from.
+    pub start_from: Stage,
+
+    // -- Stage configs --
+    /// UMI assigner for grouping.
+    pub assigner: Arc<dyn UmiAssigner>,
+    /// Two-byte BAM tag containing the UMI (e.g., `b"RX"`).
+    pub umi_tag: [u8; 2],
+    /// Two-byte BAM tag for the assigned molecule ID (e.g., `b"MI"`).
+    pub assign_tag: [u8; 2],
+    /// Template filter config for pre-UMI-assignment filtering (MAPQ, unmapped, etc.).
+    pub group_filter_config: GroupFilterConfig,
+    /// Factory that creates per-thread consensus callers.
+    pub caller_factory: CallerFactory,
+    /// Filter configuration for consensus-read filtering.
+    pub filter_config: FilterConfig,
+    /// Require single-strand agreement for duplex base masking.
+    pub require_ss_agreement: bool,
+    /// Minimum base quality for masking.
+    pub min_base_quality: u8,
+    /// BGZF compression level for output (1–12).
+    pub compression_level: u32,
+
+    // -- Sort config (used when start_from == Sort) --
+    /// Memory limit for external sort (bytes).
+    pub sort_memory_limit: usize,
+    /// Temporary directory for sort spill files.
+    pub sort_temp_dir: Option<PathBuf>,
+}
+
+/// Configuration for the full two-phase pipeline: Phase A (extract → align → zipper → sort)
+/// followed by Phase B (Zone 3: group → consensus → filter → compress → write).
+///
+/// Phase A uses a work-stealing pool for Extract, `ToFastq`, and Zipper, with dedicated
+/// I/O threads for the aligner stdout reader and sort-accumulate. Phase B reuses the
+/// existing [`PipelineBuilder::run_from_sorted_chunks`] infrastructure.
+///
+/// The caller is responsible for:
+/// 1. Spawning the aligner process and taking its stdin.
+/// 2. Reading the SAM header from aligner stdout (to resolve the output header).
+/// 3. Passing the already-header-consumed SAM reader and the mapped header to this config.
+pub struct TwoPhaseConfig {
+    // -- Phase A inputs --
+    /// FASTQ source iterator for Extract.
+    pub extract_source: ExtractSource,
+    /// Extract parameters (tags, read group, read structures).
+    pub extract_params: ExtractParams,
+    /// Detected quality encoding for FASTQ input.
+    pub quality_encoding: QualityEncoding,
+    /// Aligner subprocess handle (stdin already taken; stdout already taken).
+    /// Caller must pass this so `run_two_phase` can `wait()` on it.
+    pub aligner_process: AlignerProcess,
+    /// Aligner stdin pipe (taken from the aligner process before constructing this config).
+    pub aligner_stdin: std::process::ChildStdin,
+    /// Aligner stdout pipe (taken from the aligner process). The stdout-reader thread will
+    /// read the SAM header and then records from this pipe.
+    pub aligner_stdout: std::process::ChildStdout,
+    /// Callback that builds the final output header from the mapped header read by the
+    /// stdout-reader thread. This lets the binary crate inject its header-building logic
+    /// (e.g. `build_output_header` + `add_pg_record`) without the library crate depending
+    /// on it.
+    pub build_output_header_fn: BuildOutputHeaderFn,
+    /// Tag manipulation info for zipper merge.
+    pub tag_info: Arc<TagInfo>,
+    /// Whether to skip PA (primary alignment) tag generation in zipper.
+    pub skip_pa_tags: bool,
+    /// Zipper merge function: transfers tags from unmapped to mapped template.
+    pub merge_fn: MergeFn,
+    /// Batch coordination state for bwa `-K` flow control (optional).
+    pub batch_state: Option<Arc<AlignerBatchState>>,
+
+    // -- Correction config (optional) --
+    /// UMI correction configuration. When `Some`, the Correct pool step is active
+    /// between Extract and `ToFastq`, using per-worker LRU caches.
+    pub correction_config: Option<crate::pipeline::phase_a_graph::CorrectionConfig>,
+
+    // -- Sort config --
+    /// Memory limit for external sort (bytes).
+    pub sort_memory_limit: usize,
+    /// Temporary directory for sort spill files.
+    pub sort_temp_dir: Option<PathBuf>,
+    /// Number of threads for the external sorter.
+    pub sort_threads: usize,
+
+    // -- Phase B config --
+    /// Pipeline configuration for Zone 3 stages.
+    pub pipeline_config: PipelineConfig,
+
+    // -- Thread control --
+    /// Total threads for the Phase A worker pool.
+    pub threads: usize,
+    /// Shared cancellation flag.
+    pub cancel: Arc<AtomicBool>,
+}
+
+// ============================================================================
+// Queue capacity defaults
+// ============================================================================
+
+/// Default channel capacity for inter-stage queues.
+///
+/// Sized large enough (4096) to absorb producer bursts without triggering the
+/// spin-loop in [`WorkQueue::push_blocking`].  The real backpressure mechanism is the
+/// per-queue memory limit, not the slot count.  At 5 queues the pre-allocated
+/// overhead is ~5 * 4096 * 8 bytes ≈ 160 KB — negligible.
+const QUEUE_CAPACITY: usize = 4096;
+
+/// Default memory limit per queue (256 MB).
+const QUEUE_MEMORY_LIMIT: usize = 256 * 1024 * 1024;
+
+// ============================================================================
+// PipelineBuilder
+// ============================================================================
+
+/// Builds and executes the runall pipeline from a [`PipelineConfig`].
+///
+/// The pipeline wires Zone 3 stages (group-assign → consensus → filter → compress → write)
+/// with bounded work queues and runs them under a work-stealing scheduler. All threads,
+/// including the calling thread during completion, participate in the same work-stealing
+/// loop. Writing is the highest-priority stage runner, protected by a mutex.
+pub struct PipelineBuilder;
+
+impl PipelineBuilder {
+    /// Build and run the pipeline according to `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any stage fails, I/O fails, or the scheduler encounters an error.
+    pub fn run(config: &PipelineConfig) -> Result<()> {
+        match config.start_from {
+            Stage::Group => Self::run_from_group(config),
+            Stage::Sort => Self::run_from_sort(config),
+        }
+    }
+
+    /// Run the pipeline starting from an already template-coordinate-sorted BAM.
+    ///
+    /// Reads records from the input BAM, batches them by position into
+    /// [`PositionGroupBatch`] items, and feeds them through Zone 3 stages.
+    fn run_from_group(config: &PipelineConfig) -> Result<()> {
+        info!("Pipeline: starting from grouped/sorted BAM input");
+
+        // 1. Open input BAM and read header.
+        // Single I/O thread for BAM reading; parallelism is in the worker pool.
+        let io_threads = 1;
+        let (reader, header) =
+            create_raw_bam_reader(&config.input, io_threads).context("opening input BAM")?;
+        let lib_lookup = LibraryLookup::from_header(&header);
+
+        // 2. Build Zone 3 queues and stages, start scheduler (including write stage).
+        let zone3 = Zone3::start(config, &header)?;
+
+        // 3. Feed input records to the position batcher.
+        let mut batcher = PositionBatcher::new(zone3.q_position_batch.clone());
+        let read_ahead = fgumi_lib::sort::read_ahead::RawReadAheadReader::new(reader);
+        let hasher = cb_hasher();
+
+        for record in read_ahead {
+            let bam_bytes = record.as_ref();
+            let key = extract_template_key_inline(bam_bytes, &lib_lookup, None, &hasher);
+            batcher.emit(&key, bam_bytes.to_vec())?;
+        }
+        batcher.finish()?;
+        let total_batches = batcher.batches_pushed();
+        info!("Pipeline: fed {total_batches} position batches to Zone 3");
+
+        // 4. Signal that no more position batches will arrive, then wait for completion.
+        zone3.q_position_batch.close();
+        zone3.wait_for_completion(total_batches)?;
+
+        info!("Pipeline: done");
+        Ok(())
+    }
+
+    /// Run the pipeline starting from an unsorted BAM (sort → Zone 3).
+    ///
+    /// Uses a two-phase approach:
+    /// 1. **Sort-accumulate** (blocking on calling thread): reads the input BAM, sorts chunks
+    ///    to disk/memory.
+    /// 2. **Merge** (spawned on a feeder thread): K-way merges the sorted chunks through a
+    ///    [`PositionBatcher`] into Zone 3.
+    ///
+    /// While the feeder thread drives the merge, the calling thread immediately joins the
+    /// Zone 3 worker pool to help with consensus and other stages. This eliminates the
+    /// blocking merge-on-calling-thread pattern where the calling thread was stuck on
+    /// merge I/O instead of contributing to downstream work.
+    fn run_from_sort(config: &PipelineConfig) -> Result<()> {
+        info!("Pipeline: starting from unsorted BAM (sort first)");
+
+        // 1. Open input to read the header for queue/stage setup.
+        let (_, header) =
+            create_raw_bam_reader(&config.input, 1).context("opening input BAM for header")?;
+
+        // 2. Sort-accumulate phase (blocking on calling thread).
+        let sort_threads = 2.max(config.threads.saturating_sub(2));
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(config.sort_memory_limit)
+            .threads(sort_threads);
+        if let Some(ref temp_dir) = config.sort_temp_dir {
+            sorter = sorter.temp_dir(temp_dir.clone());
+        }
+
+        let sorted_chunks = sorter
+            .sort_accumulate_template(&config.input, &header)
+            .context("sort-accumulate phase")?;
+        info!(
+            "Pipeline: sort-accumulate complete ({} records, {} disk chunks)",
+            sorted_chunks.stats.total_records, sorted_chunks.stats.chunks_written
+        );
+
+        // 3. Merge sorted chunks into Zone 3.
+        Self::run_from_sorted_chunks(config, &header, sorted_chunks)
+    }
+
+    /// Run Zone 3 from pre-sorted chunks (sort-accumulate already done).
+    ///
+    /// Spawns the K-way merge on a feeder thread and immediately joins the calling thread
+    /// to the Zone 3 worker pool. This is the shared tail of both `run_from_sort` (which
+    /// reads from a BAM file) and direct callers that sort-accumulate from an iterator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any stage fails, I/O fails, or the scheduler encounters an error.
+    pub fn run_from_sorted_chunks(
+        config: &PipelineConfig,
+        header: &noodles::sam::Header,
+        sorted_chunks: fgumi_lib::sort::SortedChunks,
+    ) -> Result<()> {
+        // 1. Build Zone 3 queues and stages, start scheduler (including write stage).
+        let zone3 = Zone3::start(config, header)?;
+
+        // 2. Spawn merge on a dedicated feeder thread so the calling thread can join
+        //    the Zone 3 worker pool immediately.
+        let q_position_batch = zone3.q_position_batch.clone();
+        let merge_handle = thread::spawn(move || -> Result<u64> {
+            // Guard: close the queue when this scope exits (success, error, or panic)
+            // to ensure the close cascade always fires and wait_for_completion won't hang.
+            let close_guard = CloseOnDrop(q_position_batch.clone());
+            let mut batcher = PositionBatcher::new(q_position_batch);
+            let records_merged =
+                merge_sorted_chunks_to_sink(sorted_chunks, &mut batcher).context("merge phase")?;
+            batcher.finish().context("flushing final position batch")?;
+            let total_batches = batcher.batches_pushed();
+            info!("Pipeline: merge complete, fed {total_batches} position batches to Zone 3");
+            drop(close_guard); // explicit close for clarity
+            Ok(records_merged)
+        });
+
+        // 3. Calling thread immediately joins the pool as a worker.
+        //    The merge thread will close q_position_batch (via batcher drop / close cascade)
+        //    when done, which cascades through all queues to signal completion.
+        zone3.wait_for_completion(0)?;
+
+        // 4. Wait for merge thread and propagate any errors.
+        let _records_merged =
+            merge_handle.join().map_err(|e| anyhow::anyhow!("merge thread panicked: {e:?}"))??;
+
+        info!("Pipeline: done");
+        Ok(())
+    }
+
+    /// Run the full two-phase pipeline: Phase A (extract → align → zipper → sort)
+    /// followed by Phase B (Zone 3: group → consensus → filter → compress → write).
+    ///
+    /// Phase A uses a work-stealing pool for Extract, `ToFastq`, and Zipper stages.
+    /// Two dedicated I/O threads handle the aligner stdout (SAM parsing) and sort
+    /// accumulation (draining `q_zippered`). These I/O threads do not count against
+    /// `--threads`.
+    ///
+    /// The close cascade propagates through the queues:
+    /// - Extract done → close `q_extracted`
+    /// - `q_extracted` drained by `ToFastq` → close aligner stdin + close `q_unmapped`
+    /// - Aligner finishes → stdout EOF → stdout-reader closes `q_mapped`
+    /// - Zipper thread drains `q_unmapped` + `q_mapped` → pushes to `q_zippered`
+    /// - After Zipper thread exits → close `q_zippered`
+    /// - `q_zippered` drained → sort-accumulate produces `SortedChunks`
+    /// - `SortedChunks` merged into Zone 3
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any phase, stage, or I/O thread fails.
+    #[expect(clippy::too_many_lines, reason = "orchestration method wires multiple phases")]
+    pub fn run_two_phase(config: TwoPhaseConfig) -> Result<()> {
+        info!("Pipeline: starting two-phase pipeline (Phase A + Phase B)");
+
+        // 1. Build Phase A graph (output_header is not yet available — it will be set
+        //    by the stdout-reader thread after reading the SAM header from the aligner).
+        let graph = Arc::new(PhaseAGraph::new(
+            config.extract_source,
+            config.extract_params,
+            config.quality_encoding,
+            Arc::clone(&config.tag_info),
+            config.skip_pa_tags,
+            config.merge_fn,
+            config.batch_state,
+            config.aligner_stdin,
+            Arc::clone(&config.cancel),
+            config.correction_config,
+        ));
+
+        // 2. Spawn stdout-reader thread (dedicated, not counted in --threads).
+        //    Reads the SAM header from aligner stdout, builds the output header,
+        //    sets it on the graph, sends it to the main thread, then reads records.
+        let (header_tx, header_rx) = std::sync::mpsc::sync_channel::<Arc<noodles::sam::Header>>(1);
+        let q_mapped = graph.q_mapped.clone();
+        let graph_for_stdout = Arc::clone(&graph);
+        let build_output_header_fn = config.build_output_header_fn;
+        let aligner_stdout = config.aligner_stdout;
+        let stdout_cancel = Arc::clone(&config.cancel);
+        let stdout_reader = thread::Builder::new()
+            .name("stdout-reader".into())
+            .spawn(move || -> Result<u64> {
+                // Read the SAM header from aligner stdout.
+                let buf_reader = std::io::BufReader::with_capacity(256 * 1024, aligner_stdout);
+                let mut sam_reader = noodles::sam::io::Reader::new(buf_reader);
+                let mapped_header = sam_reader.read_header()?;
+                info!("stdout-reader: read SAM header from aligner");
+
+                // Build the final output header and publish it.
+                let output_header = build_output_header_fn(&mapped_header)?;
+                let output_header = Arc::new(output_header);
+                let _ = graph_for_stdout.output_header.set(Arc::clone(&output_header));
+                let _ = header_tx.send(Arc::clone(&output_header));
+
+                // Read records from aligner stdout.
+                let iter = TemplateIterator::new(
+                    sam_reader.record_bufs(&mapped_header).map(|r| r.map_err(anyhow::Error::from)),
+                );
+                let mut count = 0u64;
+                for template_result in iter {
+                    if stdout_cancel.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let template = template_result?;
+                    let mem = template.estimate_heap_size();
+                    q_mapped.push_blocking(template, mem)?;
+                    count += 1;
+                }
+                q_mapped.close();
+                info!("stdout-reader: finished, pushed {count} templates to q_mapped");
+                Ok(count)
+            })
+            .context("failed to spawn stdout-reader thread")?;
+
+        // 3. Spawn dedicated Zipper thread.
+        //    Sequentially matches q_unmapped + q_mapped templates by queryname
+        //    (guaranteed to be in the same order), merges, encodes to BAM bytes,
+        //    and pushes to q_zippered. No HashMap needed — ordering is guaranteed
+        //    because ToFastq is exclusive and bwa preserves input order.
+        let graph_for_zipper = Arc::clone(&graph);
+        let zipper_handle = thread::Builder::new()
+            .name("zipper".into())
+            .spawn(move || -> Result<u64> { phase_a_steps::zipper_thread_loop(&graph_for_zipper) })
+            .context("failed to spawn zipper thread")?;
+
+        // 4. Spawn sort-accumulate thread (dedicated, not counted in --threads).
+        //    Drains q_zippered and accumulates records into SortedChunks.
+        let q_zippered = graph.q_zippered.clone();
+        let sort_memory_limit = config.sort_memory_limit;
+        let sort_temp_dir = config.sort_temp_dir.clone();
+        let sort_threads = config.sort_threads;
+        let graph_for_sort = Arc::clone(&graph);
+        let sort_cancel = Arc::clone(&config.cancel);
+        let sort_handle = thread::Builder::new()
+            .name("sort-accumulate".into())
+            .spawn(move || -> Result<fgumi_lib::sort::SortedChunks> {
+                // Wait for the output header to become available (set by stdout-reader).
+                let sort_header = loop {
+                    if let Some(h) = graph_for_sort.output_header.get() {
+                        break h.as_ref().clone();
+                    }
+                    if sort_cancel.load(Ordering::Acquire) {
+                        anyhow::bail!("sort-accumulate cancelled while waiting for header");
+                    }
+                    thread::sleep(std::time::Duration::from_millis(1));
+                };
+
+                // Build an iterator that drains q_zippered via blocking pop.
+                let iter = std::iter::from_fn(|| {
+                    if sort_cancel.load(Ordering::Acquire) {
+                        return None;
+                    }
+                    let item = q_zippered.pop()?;
+                    let mem = item.len();
+                    q_zippered.complete_in_flight();
+                    q_zippered.release_memory(mem);
+                    Some(item)
+                });
+
+                let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                    .memory_limit(sort_memory_limit)
+                    .threads(sort_threads)
+                    .temp_compression(1);
+                if let Some(ref temp_dir) = sort_temp_dir {
+                    sorter = sorter.temp_dir(temp_dir.clone());
+                }
+                let sorted_chunks = sorter
+                    .sort_accumulate_from_iter(iter, &sort_header)
+                    .context("sort-accumulate from q_zippered")?;
+                info!(
+                    "sort-accumulate: complete ({} records, {} disk chunks)",
+                    sorted_chunks.stats.total_records, sorted_chunks.stats.chunks_written
+                );
+                Ok(sorted_chunks)
+            })
+            .context("failed to spawn sort-accumulate thread")?;
+
+        // 5. Run Phase A worker pool (Extract + optional Correct + ToFastq).
+        //    Zipper and SortAccumulate are dedicated threads.
+        let mut active_steps = [false; PhaseAStep::NUM_STEPS];
+        active_steps[PhaseAStep::Extract as usize] = true;
+        active_steps[PhaseAStep::Correct as usize] = graph.correction_config.is_some();
+        active_steps[PhaseAStep::ToFastq as usize] = true;
+
+        let num_workers = config.threads.max(1);
+        let umi_cache_size = graph.correction_config.as_ref().map_or(0, |c| c.cache_size);
+        let (handles, worker_slots, error_rx) =
+            start_phase_a_pool(&graph, num_workers, active_steps, &config.cancel, umi_cache_size);
+        info!("Pipeline Phase A: started {num_workers} worker threads");
+
+        // Wait for all Phase A workers to finish.
+        wait_phase_a_pool(handles, &worker_slots, &error_rx)
+            .context("Phase A worker pool error")?;
+        info!("Pipeline Phase A: all workers finished");
+
+        // Close q_unmapped and aligner stdin. The pool may have exited before
+        // ToFastq got a chance to close these (the last ToFastq step processes
+        // an item and returns Success; the pool then exits via is_pool_done()
+        // before ToFastq runs again to see the empty/closed q_extracted).
+        graph.close_aligner_stdin();
+        graph.q_unmapped.close();
+        if let Some(ref q) = graph.q_corrected {
+            q.close();
+        }
+
+        // 6. Wait for aligner process to complete.
+        config.aligner_process.wait().context("aligner subprocess failed")?;
+        info!("Pipeline Phase A: aligner process exited successfully");
+
+        // 7. Wait for stdout-reader thread.
+        let mapped_count = stdout_reader
+            .join()
+            .map_err(|e| anyhow::anyhow!("stdout-reader thread panicked: {e:?}"))??;
+        info!("Pipeline Phase A: stdout-reader pushed {mapped_count} templates");
+
+        // 8. Wait for Zipper thread (closes q_zippered when done).
+        let zipper_count = zipper_handle
+            .join()
+            .map_err(|e| anyhow::anyhow!("zipper thread panicked: {e:?}"))??;
+        info!("Pipeline Phase A: zipper merged {zipper_count} records");
+
+        // Close q_zippered to signal sort-accumulate to finish.
+        graph.q_zippered.close();
+
+        // 9. Wait for sort-accumulate thread.
+        let sorted_chunks = sort_handle
+            .join()
+            .map_err(|e| anyhow::anyhow!("sort-accumulate thread panicked: {e:?}"))??;
+        info!(
+            "Pipeline Phase A: sort-accumulate produced {} records in {} chunks",
+            sorted_chunks.stats.total_records, sorted_chunks.stats.chunks_written
+        );
+
+        // 10. Phase B: merge sorted chunks through Zone 3.
+        info!("Pipeline Phase B: starting Zone 3 from sorted chunks");
+        let output_header = header_rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("failed to receive output header from stdout-reader"))?;
+        let phase_b_header = output_header.as_ref().clone();
+        Self::run_from_sorted_chunks(&config.pipeline_config, &phase_b_header, sorted_chunks)?;
+
+        info!("Pipeline: two-phase pipeline complete");
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Zone3 — internal orchestration of the Zone 3 stages
+// ============================================================================
+
+/// Holds the running Zone 3 pipeline: queues, scheduler, and shared state.
+///
+/// All threads participate in work-stealing, including the write stage. There is no
+/// dedicated writer thread; writing is the highest-priority stage for the write-preferred
+/// worker.
+struct Zone3 {
+    /// Queue where position batches enter Zone 3.
+    q_position_batch: WorkQueue<SequencedItem<PositionGroupBatch>>,
+    /// Final queue — closed+empty signals all work has cascaded through the pipeline.
+    q_compressed: WorkQueue<SequencedItem<CompressedBatch>>,
+    /// The scheduler managing worker threads.
+    scheduler: Scheduler,
+    /// Worker thread handles.
+    worker_handles: Vec<thread::JoinHandle<()>>,
+    /// Per-worker state (for stats collection after join).
+    worker_states: Vec<WorkerStateSlot>,
+    /// Number of workers (for creating the calling thread's `WorkerState`).
+    num_workers: usize,
+    /// Shared write state (file handle, reorder buffer, batch counter).
+    write_state: Arc<Mutex<WriteState>>,
+    /// Per-stage timing stats.
+    stage_stats: Vec<Arc<StageStats>>,
+}
+
+impl Zone3 {
+    /// Create queues, stages, and start the scheduler with the typed `StageGraph`.
+    ///
+    /// The output file is created and the BAM header is written before workers start,
+    /// so that the write runner only needs to append pre-compressed BGZF blocks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created or the header cannot be written.
+    fn start(config: &PipelineConfig, header: &noodles::sam::Header) -> Result<Self> {
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        // -- Queues --
+        let q_position_batch: WorkQueue<SequencedItem<PositionGroupBatch>> =
+            WorkQueue::new(QUEUE_CAPACITY, QUEUE_MEMORY_LIMIT, "position_batch");
+        let q_mi_batch: WorkQueue<SequencedItem<Vec<MiGroup>>> =
+            WorkQueue::new(QUEUE_CAPACITY, QUEUE_MEMORY_LIMIT, "mi_batch");
+        let q_consensus: WorkQueue<SequencedItem<fgumi_consensus::caller::ConsensusOutput>> =
+            WorkQueue::new(QUEUE_CAPACITY, QUEUE_MEMORY_LIMIT, "consensus");
+        let q_filtered: WorkQueue<SequencedItem<Vec<u8>>> =
+            WorkQueue::new(QUEUE_CAPACITY, QUEUE_MEMORY_LIMIT, "filtered");
+        let q_compressed: WorkQueue<SequencedItem<CompressedBatch>> =
+            WorkQueue::new(QUEUE_CAPACITY, QUEUE_MEMORY_LIMIT, "compressed");
+
+        // -- Open output file and write BAM header before starting workers --
+        let mut file = std::fs::File::create(&config.output)
+            .with_context(|| format!("creating output BAM: {}", config.output.display()))?;
+        write_bam_header_to_file(&mut file, header, config.compression_level)?;
+
+        let write_state = Arc::new(Mutex::new(WriteState {
+            file,
+            reorder_buf: ReorderBuffer::new(),
+            batches_written: 0,
+        }));
+
+        // -- Stages --
+        let group_assign_stage = Arc::new(GroupAndAssignStage::new(
+            Arc::clone(&config.assigner),
+            config.umi_tag,
+            config.assign_tag,
+            config.group_filter_config.clone(),
+        ));
+        let consensus_stage = Arc::new(ConsensusStage::new(Arc::clone(&config.caller_factory)));
+        let filter_stage =
+            Arc::new(FilterStage::new(config.filter_config.clone(), config.require_ss_agreement));
+        let compress_stage = Arc::new(CompressStage::new(config.compression_level));
+
+        // -- Per-stage stats --
+        let group_assign_stats = Arc::new(StageStats::new("group_assign"));
+        let consensus_stats = Arc::new(StageStats::new("consensus"));
+        let filter_stats = Arc::new(StageStats::new("filter"));
+        let compress_stats = Arc::new(StageStats::new("compress"));
+        let writer_stats = Arc::new(StageStats::new("write"));
+        let stage_stats: Vec<Arc<StageStats>> = vec![
+            Arc::clone(&group_assign_stats),
+            Arc::clone(&consensus_stats),
+            Arc::clone(&filter_stats),
+            Arc::clone(&compress_stats),
+            Arc::clone(&writer_stats),
+        ];
+
+        // -- Build StageGraph --
+        let graph = StageGraph {
+            group_assign: group_assign_stage,
+            consensus: consensus_stage,
+            filter: filter_stage,
+            compress: compress_stage,
+            q_position_batch: q_position_batch.clone(),
+            q_mi_batch,
+            q_consensus,
+            q_filtered,
+            q_compressed: q_compressed.clone(),
+            write_state: Arc::clone(&write_state),
+            stats: [
+                group_assign_stats,
+                consensus_stats,
+                filter_stats,
+                compress_stats,
+                writer_stats,
+            ],
+            cancel,
+        };
+
+        // -- Scheduler --
+        let num_workers = config.threads.max(1);
+        let scheduler = Scheduler::new(graph);
+        let (worker_handles, worker_states) = scheduler.start(num_workers);
+        info!("Pipeline: started {num_workers} worker threads (unified model)");
+
+        Ok(Self {
+            q_position_batch,
+            q_compressed,
+            scheduler,
+            worker_handles,
+            worker_states,
+            num_workers,
+            write_state,
+            stage_stats,
+        })
+    }
+
+    /// Wait for all input to be fully processed through the pipeline.
+    ///
+    /// The calling thread participates as a worker, running the same priority
+    /// loop as spawned workers. This avoids idle spinning and ensures progress even
+    /// with `--threads 1`.
+    ///
+    /// **Important:** The caller must ensure that `q_position_batch` will be closed
+    /// (either before calling this method, or from a feeder thread) so that the
+    /// close cascade can propagate through all queues and signal completion.
+    fn wait_for_completion(self, _expected_position_batches: u64) -> Result<()> {
+        // The calling thread participates as an additional worker.
+        let graph = Arc::clone(self.scheduler.graph());
+        let _cancel_flag = self.scheduler.cancel_flag();
+        let (_caller_error_tx, _caller_error_rx) = crossbeam_channel::unbounded::<anyhow::Error>();
+        let caller_worker_id = self.num_workers; // one past the last spawned worker
+        let total_workers = self.num_workers + 1;
+        let mut caller_worker = WorkerState::new(caller_worker_id, total_workers);
+
+        loop {
+            if self.scheduler.is_cancelled() {
+                break;
+            }
+            if let Some(err) = self.scheduler.check_error() {
+                self.scheduler.cancel();
+                return Err(err).context("scheduler error during pipeline execution");
+            }
+
+            // Run one iteration of the worker loop inline.
+            let mut did_work = false;
+
+            // 1. Try to push held items.
+            did_work |=
+                crate::pipeline::scheduler::try_push_held_compress(&graph, &mut caller_worker);
+            did_work |=
+                crate::pipeline::scheduler::try_push_held_filter(&graph, &mut caller_worker);
+            did_work |=
+                crate::pipeline::scheduler::try_push_held_consensus(&graph, &mut caller_worker);
+            did_work |=
+                crate::pipeline::scheduler::try_push_held_group_assign(&graph, &mut caller_worker);
+
+            // 2. Sample backpressure and get priorities.
+            let bp = BackpressureState::sample(&graph);
+            let priorities = *caller_worker.scheduler.get_priorities(&bp);
+
+            // 3. Execute one stage in priority order.
+            for &stage in &priorities {
+                if self.scheduler.is_cancelled() {
+                    break;
+                }
+
+                let result = match stage {
+                    PipelineStep::Write => {
+                        crate::pipeline::scheduler::try_step_write(&graph, &mut caller_worker)
+                    }
+                    PipelineStep::Compress => {
+                        crate::pipeline::scheduler::try_step_compress(&graph, &mut caller_worker)
+                    }
+                    PipelineStep::Filter => {
+                        crate::pipeline::scheduler::try_step_filter(&graph, &mut caller_worker)
+                    }
+                    PipelineStep::Consensus => {
+                        crate::pipeline::scheduler::try_step_consensus(&graph, &mut caller_worker)
+                    }
+                    PipelineStep::GroupAssign => crate::pipeline::scheduler::try_step_group_assign(
+                        &graph,
+                        &mut caller_worker,
+                    ),
+                };
+
+                match result {
+                    StepResult::Success => {
+                        caller_worker.scheduler.record_outcome(stage, true);
+                        did_work = true;
+                        break;
+                    }
+                    StepResult::OutputFull => {
+                        caller_worker.scheduler.record_outcome(stage, false);
+                    }
+                    StepResult::InputEmpty => {}
+                    StepResult::Error(e) => {
+                        self.scheduler.cancel();
+                        return Err(e).context("error in calling thread worker loop");
+                    }
+                }
+            }
+
+            if did_work {
+                caller_worker.reset_backoff();
+            } else {
+                // Check completion.
+                let done = self.q_compressed.is_closed_and_empty()
+                    && self.write_state.lock().expect("lock").reorder_buf.is_empty();
+
+                if done {
+                    break;
+                }
+
+                caller_worker.sleep_backoff();
+                caller_worker.increase_backoff();
+            }
+        }
+
+        // Signal scheduler to stop and wait for workers.
+        self.scheduler.cancel();
+        self.scheduler.wait(self.worker_handles, &self.worker_states)?;
+
+        // Log caller worker stats.
+        log::info!("  Caller thread:");
+        caller_worker.log_stats();
+
+        // Write BGZF EOF marker and flush.
+        let mut state = self.write_state.lock().expect("write state lock poisoned");
+        state.file.write_all(&BGZF_EOF).context("writing BGZF EOF")?;
+        state.file.flush().context("flushing output BAM")?;
+
+        info!("Pipeline writer: finished, wrote {} batches", state.batches_written);
+
+        // Log per-stage timing stats.
+        info!("Pipeline stage stats:");
+        #[expect(clippy::cast_precision_loss, reason = "item counts are approximate for display")]
+        for stats in &self.stage_stats {
+            let secs = stats.total_secs();
+            let items = stats.items();
+            let rate = if secs > 0.0 { items as f64 / secs } else { 0.0 };
+            info!(
+                "  {:<14} {:.2}s  {:>10} items  {:>10.0} items/sec",
+                stats.name(),
+                secs,
+                items,
+                rate
+            );
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// CloseOnDrop — ensures a WorkQueue is closed even on panic/error
+// ============================================================================
+
+/// RAII guard that closes a [`WorkQueue`] when dropped.
+///
+/// Used by the merge feeder thread to guarantee the close cascade fires,
+/// even if the merge errors or the thread panics.
+struct CloseOnDrop<T>(WorkQueue<SequencedItem<T>>);
+
+impl<T> Drop for CloseOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.close();
+    }
+}
+
+// ============================================================================
+// BAM header writing
+// ============================================================================
+
+/// Write the BAM header to a file using BGZF compression.
+///
+/// Uses a temporary in-memory BGZF compressor to produce BGZF-compressed header
+/// blocks, then writes those blocks directly to the file.
+fn write_bam_header_to_file(
+    file: &mut std::fs::File,
+    header: &noodles::sam::Header,
+    compression_level: u32,
+) -> Result<()> {
+    use fgumi_bgzf::writer::InlineBgzfCompressor;
+
+    let mut compressor = InlineBgzfCompressor::new(compression_level);
+
+    // Serialize the BAM header into the compressor.
+    // BAM magic
+    compressor.write_all(fgumi_raw_bam::BAM_MAGIC)?;
+
+    // Header text
+    let mut sam_writer = noodles::sam::io::Writer::new(Vec::new());
+    sam_writer.write_header(header)?;
+    let header_bytes = sam_writer.into_inner();
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "BAM header text is always < 2 GB"
+    )]
+    let l_text = header_bytes.len() as i32;
+    compressor.write_all(&l_text.to_le_bytes())?;
+    compressor.write_all(&header_bytes)?;
+
+    // Reference sequences
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "number of reference sequences always fits in i32"
+    )]
+    let n_ref = header.reference_sequences().len() as i32;
+    compressor.write_all(&n_ref.to_le_bytes())?;
+
+    for (name, map) in header.reference_sequences() {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "reference name length always fits in u32"
+        )]
+        let l_name = (name.len() + 1) as u32;
+        compressor.write_all(&l_name.to_le_bytes())?;
+        compressor.write_all(name.as_ref())?;
+        compressor.write_all(&[0u8])?; // NUL terminator
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            reason = "reference length always fits in i32"
+        )]
+        let l_ref = map.length().get() as i32;
+        compressor.write_all(&l_ref.to_le_bytes())?;
+    }
+
+    compressor.flush()?;
+    let blocks = compressor.take_blocks();
+    for block in &blocks {
+        file.write_all(&block.data).context("writing header BGZF block")?;
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stage_enum_variants() {
+        assert_eq!(Stage::Sort, Stage::Sort);
+        assert_eq!(Stage::Group, Stage::Group);
+        assert_ne!(Stage::Sort, Stage::Group);
+    }
+
+    #[test]
+    fn test_queue_defaults_are_reasonable() {
+        const { assert!(QUEUE_CAPACITY > 0) };
+        const { assert!(QUEUE_MEMORY_LIMIT > 0) };
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/health.rs
+++ b/crates/fgumi-pipeline/src/pipeline/health.rs
@@ -1,0 +1,220 @@
+//! Health monitor for the aligner subprocess.
+//!
+//! [`HealthMonitor`] runs in a background thread and watches activity timestamps
+//! on the aligner's stdin and stdout pipes. If stdout goes silent for longer than
+//! the configured timeout the monitor logs a warning; at twice the timeout it
+//! sets the shared cancellation flag so the rest of the pipeline can shut down
+//! cleanly.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Interval between health checks.
+const CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Return the current time as milliseconds since the Unix epoch.
+///
+/// Returns `0` on the (extremely unlikely) event that the system clock is
+/// before the epoch.
+#[must_use]
+pub fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+// ============================================================================
+// HealthMonitor
+// ============================================================================
+
+/// Monitors aligner subprocess liveness by watching stdin/stdout activity timestamps.
+///
+/// Activity is reported by the I/O threads that read SAM from the aligner stdout
+/// and write FASTQ to the aligner stdin. Each I/O thread updates the corresponding
+/// [`AtomicU64`] with [`now_millis`] after every successful read/write.
+///
+/// The monitor wakes every 5 seconds and checks:
+/// - stdout inactive for > `timeout` → log a warning.
+/// - stdout inactive for > `2 × timeout` → set `cancel`, log an error.
+/// - stdin inactive for > `timeout` → log a warning.
+pub struct HealthMonitor {
+    /// PID of the aligner child process (used in log messages).
+    child_pid: u32,
+    /// Epoch-millisecond timestamp of the last successful stdout read.
+    last_stdout_activity: Arc<AtomicU64>,
+    /// Epoch-millisecond timestamp of the last successful stdin write.
+    last_stdin_activity: Arc<AtomicU64>,
+    /// Duration after which inactivity is considered a warning condition.
+    timeout: Duration,
+    /// Shared cancellation flag; set to `true` by this monitor on fatal timeout.
+    cancel: Arc<AtomicBool>,
+}
+
+impl HealthMonitor {
+    /// Create a new `HealthMonitor`.
+    ///
+    /// # Arguments
+    ///
+    /// * `child_pid`             - PID of the aligner process (for log messages).
+    /// * `last_stdout_activity`  - Shared timestamp updated by the stdout reader thread.
+    /// * `last_stdin_activity`   - Shared timestamp updated by the stdin writer thread.
+    /// * `timeout`               - Inactivity threshold for warning (error at `2 × timeout`).
+    /// * `cancel`                - Shared flag set to `true` when a fatal timeout occurs.
+    #[must_use]
+    pub fn new(
+        child_pid: u32,
+        last_stdout_activity: Arc<AtomicU64>,
+        last_stdin_activity: Arc<AtomicU64>,
+        timeout: Duration,
+        cancel: Arc<AtomicBool>,
+    ) -> Self {
+        Self { child_pid, last_stdout_activity, last_stdin_activity, timeout, cancel }
+    }
+
+    /// Start the health monitor in a background thread.
+    ///
+    /// The thread runs until the `cancel` flag is set (either by the monitor itself
+    /// or by another component of the pipeline). Returns the thread join handle.
+    #[must_use]
+    pub fn start(self) -> JoinHandle<()> {
+        thread::spawn(move || self.run())
+    }
+
+    /// Main monitor loop.
+    fn run(self) {
+        loop {
+            thread::sleep(CHECK_INTERVAL);
+
+            if self.cancel.load(Ordering::Acquire) {
+                break;
+            }
+
+            let now = now_millis();
+            let timeout_ms = u64::try_from(self.timeout.as_millis()).unwrap_or(u64::MAX);
+
+            // ---- stdout checks ----
+            let last_out = self.last_stdout_activity.load(Ordering::Acquire);
+            if last_out > 0 {
+                let elapsed_ms = now.saturating_sub(last_out);
+                if elapsed_ms > timeout_ms * 2 {
+                    log::error!(
+                        "aligner pid={} stdout has been silent for {}ms (threshold {}ms); \
+                         cancelling pipeline",
+                        self.child_pid,
+                        elapsed_ms,
+                        timeout_ms * 2,
+                    );
+                    self.cancel.store(true, Ordering::Release);
+                    break;
+                } else if elapsed_ms > timeout_ms {
+                    log::warn!(
+                        "aligner pid={} stdout has been silent for {}ms (threshold {}ms)",
+                        self.child_pid,
+                        elapsed_ms,
+                        timeout_ms,
+                    );
+                }
+            }
+
+            // ---- stdin checks ----
+            let last_in = self.last_stdin_activity.load(Ordering::Acquire);
+            if last_in > 0 {
+                let elapsed_ms = now.saturating_sub(last_in);
+                if elapsed_ms > timeout_ms {
+                    log::warn!(
+                        "aligner pid={} stdin has been silent for {}ms (threshold {}ms)",
+                        self.child_pid,
+                        elapsed_ms,
+                        timeout_ms,
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that the monitor does not set the cancel flag when activity timestamps
+    /// are recent (i.e. within the timeout window).
+    #[test]
+    fn test_health_monitor_no_alert() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let recent = now_millis();
+
+        let last_stdout = Arc::new(AtomicU64::new(recent));
+        let last_stdin = Arc::new(AtomicU64::new(recent));
+
+        let monitor = HealthMonitor::new(
+            1234,
+            Arc::clone(&last_stdout),
+            Arc::clone(&last_stdin),
+            Duration::from_secs(30), // generous timeout
+            Arc::clone(&cancel),
+        );
+
+        let handle = monitor.start();
+
+        // Let the monitor run for a couple of check cycles (CHECK_INTERVAL = 5 s would
+        // be too slow for a unit test; we just verify the cancel flag stays clear for
+        // a brief period).
+        thread::sleep(Duration::from_millis(50));
+        assert!(!cancel.load(Ordering::Acquire), "cancel should not be set with recent activity");
+
+        // Signal the monitor to stop.
+        cancel.store(true, Ordering::Release);
+        handle.join().expect("monitor thread should finish cleanly");
+    }
+
+    /// Verify that the monitor sets the cancel flag when stdout has been inactive
+    /// for longer than 2 × timeout.
+    #[test]
+    fn test_health_monitor_timeout() {
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        // Simulate a stdout timestamp that is 10 seconds in the past.
+        let stale = now_millis().saturating_sub(10_000);
+        let last_stdout = Arc::new(AtomicU64::new(stale));
+        // stdin is also stale but that only triggers a warning, not cancellation.
+        let last_stdin = Arc::new(AtomicU64::new(stale));
+
+        let timeout = Duration::from_secs(1); // very short for testing
+
+        // Run the monitor loop inline (synchronously) so we don't have to wait
+        // 5 seconds for the background thread to wake.
+        let cancel_clone = Arc::clone(&cancel);
+        let last_stdout_clone = Arc::clone(&last_stdout);
+        let last_stdin_clone = Arc::clone(&last_stdin);
+
+        let monitor =
+            HealthMonitor::new(5678, last_stdout_clone, last_stdin_clone, timeout, cancel_clone);
+
+        // Drive one check cycle directly by calling the internal logic.
+        let now = now_millis();
+        let timeout_ms = u64::try_from(monitor.timeout.as_millis()).unwrap_or(u64::MAX);
+        let last_out = monitor.last_stdout_activity.load(Ordering::Acquire);
+        let elapsed_ms = now.saturating_sub(last_out);
+
+        if elapsed_ms > timeout_ms * 2 {
+            monitor.cancel.store(true, Ordering::Release);
+        }
+
+        assert!(
+            cancel.load(Ordering::Acquire),
+            "cancel should be set when stdout is silent for > 2x timeout"
+        );
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/mod.rs
+++ b/crates/fgumi-pipeline/src/pipeline/mod.rs
@@ -1,0 +1,28 @@
+//! Pipeline orchestration: builder, scheduler, and progress tracking.
+
+/// Queue fill-ratio threshold for backpressure decisions.
+///
+/// When a queue's fill ratio exceeds this value, the pipeline considers it "high" and
+/// adjusts scheduling priorities to favor downstream stages that drain those queues.
+pub(crate) const BACKPRESSURE_HIGH_WATERMARK: f32 = 0.75;
+
+pub mod aligner_io;
+pub mod batch_state;
+pub mod builder;
+pub mod health;
+pub mod phase;
+pub mod phase_a;
+pub mod phase_a_graph;
+pub mod phase_a_steps;
+pub mod phase_a_worker;
+pub mod queue;
+pub mod reorder;
+pub mod scheduler;
+pub mod stats;
+pub mod worker_util;
+pub use builder::{PipelineBuilder, PipelineConfig, Stage, TwoPhaseConfig};
+pub use health::HealthMonitor;
+pub use queue::WorkQueue;
+pub use reorder::ReorderBuffer;
+pub use scheduler::{Scheduler, StageGraph, WorkerState, WriteState};
+pub use stats::StageStats;

--- a/crates/fgumi-pipeline/src/pipeline/phase.rs
+++ b/crates/fgumi-pipeline/src/pipeline/phase.rs
@@ -1,0 +1,108 @@
+//! Pipeline phase state for the two-phase architecture.
+//!
+//! The pipeline runs in two phases:
+//! - **Phase A (Alignment):** Extract through `SortAccumulate`, with an external aligner.
+//! - **Phase B (Processing):** `SortMerge` through Write (group, consensus, filter, compress).
+//!
+//! [`PhaseState`] provides an atomic flag that all workers read to determine which phase is active.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Pipeline phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PipelinePhase {
+    /// Phase A: alignment pipeline (Extract through `SortAccumulate`).
+    Alignment = 0,
+    /// Phase B: processing pipeline (`SortMerge` through Write).
+    Processing = 1,
+    /// Both phases complete.
+    Done = 2,
+}
+
+/// Atomic phase flag read by all workers.
+pub struct PhaseState {
+    phase: AtomicU8,
+}
+
+impl PhaseState {
+    /// Create a new phase state starting at the given phase.
+    #[must_use]
+    pub fn new(initial: PipelinePhase) -> Self {
+        Self { phase: AtomicU8::new(initial as u8) }
+    }
+
+    /// Get the current phase.
+    #[must_use]
+    pub fn current(&self) -> PipelinePhase {
+        match self.phase.load(Ordering::Acquire) {
+            0 => PipelinePhase::Alignment,
+            1 => PipelinePhase::Processing,
+            _ => PipelinePhase::Done,
+        }
+    }
+
+    /// Atomically transition from Alignment to Processing.
+    /// Returns true if this call performed the transition.
+    pub fn transition_to_processing(&self) -> bool {
+        self.phase
+            .compare_exchange(
+                PipelinePhase::Alignment as u8,
+                PipelinePhase::Processing as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Transition to Done.
+    pub fn transition_to_done(&self) {
+        self.phase.store(PipelinePhase::Done as u8, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initial_phase() {
+        let state = PhaseState::new(PipelinePhase::Alignment);
+        assert_eq!(state.current(), PipelinePhase::Alignment);
+
+        let state = PhaseState::new(PipelinePhase::Processing);
+        assert_eq!(state.current(), PipelinePhase::Processing);
+
+        let state = PhaseState::new(PipelinePhase::Done);
+        assert_eq!(state.current(), PipelinePhase::Done);
+    }
+
+    #[test]
+    fn test_transition_to_processing() {
+        let state = PhaseState::new(PipelinePhase::Alignment);
+        assert!(state.transition_to_processing());
+        assert_eq!(state.current(), PipelinePhase::Processing);
+    }
+
+    #[test]
+    fn test_transition_idempotent() {
+        let state = PhaseState::new(PipelinePhase::Alignment);
+        assert!(state.transition_to_processing());
+        assert!(!state.transition_to_processing());
+        assert_eq!(state.current(), PipelinePhase::Processing);
+    }
+
+    #[test]
+    fn test_transition_from_wrong_phase() {
+        let state = PhaseState::new(PipelinePhase::Processing);
+        assert!(!state.transition_to_processing());
+        assert_eq!(state.current(), PipelinePhase::Processing);
+    }
+
+    #[test]
+    fn test_transition_to_done() {
+        let state = PhaseState::new(PipelinePhase::Processing);
+        state.transition_to_done();
+        assert_eq!(state.current(), PipelinePhase::Done);
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/phase_a.rs
+++ b/crates/fgumi-pipeline/src/pipeline/phase_a.rs
@@ -1,0 +1,238 @@
+//! Phase A types and step definitions for the alignment pipeline.
+//!
+//! Phase A covers Extract through `SortAccumulate`, with an external aligner in the middle.
+//! [`PhaseAStep`] enumerates the work-stealing pool stages. Zipper and `SortAccumulate` are
+//! dedicated threads (not pool stages). [`PhaseAScheduler`] implements drain-first priority
+//! with sticky behavior for work-stealing scheduling.
+
+/// Phase A pool stages (work-stealing).
+///
+/// Only Extract and `ToFastq` run in the pool. Zipper, stdout-reader, and
+/// sort-accumulate are dedicated threads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PhaseAStep {
+    Extract = 0,
+    Correct = 1,
+    ToFastq = 2,
+}
+
+impl PhaseAStep {
+    /// Number of Phase A pool steps.
+    pub const NUM_STEPS: usize = 3;
+
+    /// All steps in priority order (downstream-first for drain).
+    pub const ALL: [PhaseAStep; 3] = [
+        PhaseAStep::ToFastq, // drain q_extracted first
+        PhaseAStep::Correct,
+        PhaseAStep::Extract, // producer last
+    ];
+
+    /// Step name for logging.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Extract => "extract",
+            Self::Correct => "correct",
+            Self::ToFastq => "to_fastq",
+        }
+    }
+}
+
+/// Backpressure state for Phase A scheduling.
+pub struct PhaseABackpressure {
+    /// `q_extracted` is getting full — deprioritize Extract.
+    pub extracted_high: bool,
+    /// `ToFastq` input queue (`q_corrected` or `q_extracted`) is getting full — deprioritize Correct.
+    pub tofastq_input_high: bool,
+    /// Aligner batch gate — can `ToFastq` send?
+    pub can_send_fastq: bool,
+}
+
+impl Default for PhaseABackpressure {
+    fn default() -> Self {
+        Self { extracted_high: false, tofastq_input_high: false, can_send_fastq: true }
+    }
+}
+
+/// Phase A scheduler: drain-first priority with sticky behavior.
+pub struct PhaseAScheduler {
+    /// Current preferred step.
+    current_step: PhaseAStep,
+    /// Priority buffer.
+    priority_buffer: [PhaseAStep; PhaseAStep::NUM_STEPS],
+    /// Which steps are active (some may be skipped via `--start-from`).
+    active_steps: [bool; PhaseAStep::NUM_STEPS],
+}
+
+impl PhaseAScheduler {
+    /// Create a new scheduler with the given active steps.
+    #[must_use]
+    pub fn new(active_steps: [bool; PhaseAStep::NUM_STEPS]) -> Self {
+        // Start on the highest-priority active step.
+        let initial = PhaseAStep::ALL
+            .iter()
+            .find(|s| active_steps[**s as usize])
+            .copied()
+            .unwrap_or(PhaseAStep::ToFastq);
+
+        Self {
+            current_step: initial,
+            priority_buffer: [PhaseAStep::Extract; PhaseAStep::NUM_STEPS],
+            active_steps,
+        }
+    }
+
+    /// Get priorities for this iteration.
+    ///
+    /// Returns a slice of steps in priority order. The current (sticky) step comes first,
+    /// followed by remaining active steps in drain-first order. Steps gated by backpressure
+    /// (`ToFastq` when batch gate is closed, Extract when extracted queue is high) are pushed
+    /// to the end.
+    pub fn get_priorities(&mut self, bp: &PhaseABackpressure) -> &[PhaseAStep] {
+        let mut count = 0;
+
+        // 1. Current step first (sticky on success).
+        if self.active_steps[self.current_step as usize] {
+            self.priority_buffer[count] = self.current_step;
+            count += 1;
+        }
+
+        // 2. Drain-first order: ToFastq > Correct > Extract.
+        //    Skip ToFastq if batch gate is closed; skip Extract if q_extracted is high.
+        for &step in &PhaseAStep::ALL {
+            if step == self.current_step {
+                continue;
+            }
+            if !self.active_steps[step as usize] {
+                continue;
+            }
+            if step == PhaseAStep::ToFastq && !bp.can_send_fastq {
+                continue;
+            }
+            if step == PhaseAStep::Correct && bp.tofastq_input_high {
+                continue;
+            }
+            if step == PhaseAStep::Extract && bp.extracted_high {
+                continue;
+            }
+
+            self.priority_buffer[count] = step;
+            count += 1;
+        }
+
+        // 3. Add backpressure-gated steps at the end (still available, just deprioritized).
+        if self.active_steps[PhaseAStep::ToFastq as usize]
+            && !bp.can_send_fastq
+            && self.current_step != PhaseAStep::ToFastq
+        {
+            self.priority_buffer[count] = PhaseAStep::ToFastq;
+            count += 1;
+        }
+        if self.active_steps[PhaseAStep::Correct as usize]
+            && bp.tofastq_input_high
+            && self.current_step != PhaseAStep::Correct
+        {
+            self.priority_buffer[count] = PhaseAStep::Correct;
+            count += 1;
+        }
+        if self.active_steps[PhaseAStep::Extract as usize]
+            && bp.extracted_high
+            && self.current_step != PhaseAStep::Extract
+        {
+            self.priority_buffer[count] = PhaseAStep::Extract;
+            count += 1;
+        }
+
+        &self.priority_buffer[..count]
+    }
+
+    /// Record the outcome of attempting a step.
+    ///
+    /// On success, the step becomes the new sticky step. On failure, the current sticky step
+    /// is unchanged and the priority list will naturally move to the next option.
+    pub fn record_outcome(&mut self, step: PhaseAStep, success: bool) {
+        if success {
+            self.current_step = step;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: all steps active.
+    fn all_active() -> [bool; PhaseAStep::NUM_STEPS] {
+        [true; PhaseAStep::NUM_STEPS]
+    }
+
+    #[test]
+    fn test_default_priority_order() {
+        let mut scheduler = PhaseAScheduler::new(all_active());
+        let bp = PhaseABackpressure::default();
+        let priorities = scheduler.get_priorities(&bp);
+
+        // First should be ToFastq (highest priority, also initial sticky step).
+        assert_eq!(priorities[0], PhaseAStep::ToFastq);
+        // Should contain all 3 steps.
+        assert_eq!(priorities.len(), PhaseAStep::NUM_STEPS);
+        // Remaining should be in drain-first order.
+        assert_eq!(priorities[1], PhaseAStep::Correct);
+        assert_eq!(priorities[2], PhaseAStep::Extract);
+    }
+
+    #[test]
+    fn test_sticky_on_success() {
+        let mut scheduler = PhaseAScheduler::new(all_active());
+        let bp = PhaseABackpressure::default();
+
+        // Record success on Extract — it becomes the sticky step.
+        scheduler.record_outcome(PhaseAStep::Extract, true);
+        let priorities = scheduler.get_priorities(&bp);
+        assert_eq!(priorities[0], PhaseAStep::Extract);
+    }
+
+    #[test]
+    fn test_batch_gate_skips_to_fastq() {
+        let mut scheduler = PhaseAScheduler::new(all_active());
+        // Make Extract the sticky step so ToFastq is handled by the drain-first loop.
+        scheduler.record_outcome(PhaseAStep::Extract, true);
+        let bp = PhaseABackpressure {
+            tofastq_input_high: false,
+            can_send_fastq: false,
+            ..Default::default()
+        };
+        let priorities = scheduler.get_priorities(&bp);
+
+        // ToFastq should be last (deprioritized, not removed).
+        assert_eq!(*priorities.last().unwrap(), PhaseAStep::ToFastq);
+
+        // ToFastq should not appear in the middle.
+        let middle = &priorities[1..priorities.len() - 1];
+        assert!(!middle.contains(&PhaseAStep::ToFastq));
+    }
+
+    #[test]
+    fn test_correct_backpressure_deprioritizes() {
+        let mut scheduler = PhaseAScheduler::new(all_active());
+        scheduler.record_outcome(PhaseAStep::Extract, true);
+        let bp = PhaseABackpressure { tofastq_input_high: true, ..Default::default() };
+        let priorities = scheduler.get_priorities(&bp);
+
+        // Correct should be last (deprioritized because q_corrected is full).
+        assert_eq!(*priorities.last().unwrap(), PhaseAStep::Correct);
+    }
+
+    #[test]
+    fn test_inactive_steps_skipped() {
+        let mut active = all_active();
+        active[PhaseAStep::Correct as usize] = false;
+
+        let mut scheduler = PhaseAScheduler::new(active);
+        let bp = PhaseABackpressure::default();
+        let priorities = scheduler.get_priorities(&bp);
+
+        assert_eq!(priorities.len(), PhaseAStep::NUM_STEPS - 1);
+        assert!(!priorities.contains(&PhaseAStep::Correct));
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/phase_a_graph.rs
+++ b/crates/fgumi-pipeline/src/pipeline/phase_a_graph.rs
@@ -1,0 +1,376 @@
+//! Phase A graph: queues and shared state for the alignment pipeline stages.
+//!
+//! The graph holds all inter-stage queues, shared configuration, and the mutex-protected
+//! FASTQ source for Extract. Pool workers reference this graph immutably; mutable per-worker
+//! state lives in [`PhaseAWorkerState`](super::phase_a_worker::PhaseAWorkerState).
+//!
+//! **Pool stages (work-stealing):** Extract, `ToFastq`.
+//! **Dedicated threads (not in pool):** stdout-reader (SAM → `q_mapped`),
+//! zipper (merge `q_unmapped` + `q_mapped` → `q_zippered`),
+//! sort-accumulate (`q_zippered` → `SortedChunks`).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use fgumi_lib::correct::EncodedUmiSet;
+use fgumi_lib::extract::{ExtractParams, QualityEncoding};
+use fgumi_lib::fastq::FastqSet;
+use fgumi_lib::template::Template;
+use fgumi_umi::TagInfo;
+use noodles::sam::Header;
+
+use crate::pipeline::batch_state::AlignerBatchState;
+use crate::pipeline::queue::WorkQueue;
+use crate::pipeline::reorder::ReorderBuffer;
+
+/// Type alias for the zipper merge function.
+///
+/// The merge function transfers tags from the unmapped template to the mapped template.
+/// This is a function pointer (not a closure) because the merge logic lives in the binary
+/// crate (`commands::zipper::merge`) and is injected into the graph at construction time.
+pub type MergeFn = fn(&Template, &mut Template, &TagInfo, bool) -> anyhow::Result<()>;
+
+/// Type alias for an ordinal-tagged `(Template, FASTQ bytes)` pair.
+///
+/// The ordinal (`u64`) is assigned by [`ExtractSource`] at FASTQ read time and tracks the
+/// original read order. This enables parallel Extract compute — workers can push to
+/// `q_extracted` in any order, and the [`ToFastqState`] reorder buffer restores ordinal
+/// order before writing to the aligner stdin.
+pub type OrdinalPair = (u64, Template, Vec<u8>);
+
+// ============================================================================
+// ToFastqState
+// ============================================================================
+
+/// Shared state for the `ToFastq` stage: reorder buffer and aligner stdin pipe.
+///
+/// Protected by a single mutex in [`PhaseAGraph`]. Workers pop items from the input
+/// queue *without* holding this lock, then acquire it to insert into the reorder buffer,
+/// drain consecutive items, and write them to the aligner stdin in ordinal order.
+///
+/// This replaces the previous exclusive `tofastq_lock` approach: multiple workers can
+/// pop from the input queue concurrently, and the reorder buffer restores the correct
+/// FASTQ read order for the aligner.
+pub struct ToFastqState {
+    /// Reorder buffer that reassembles items in ordinal order.
+    pub(super) reorder: ReorderBuffer<(Template, Vec<u8>)>,
+    /// Aligner stdin writer. Set to `None` when the stdin pipe is closed (extract done).
+    pub(super) stdin: Option<std::process::ChildStdin>,
+}
+
+// ============================================================================
+// Queue capacity and memory defaults
+// ============================================================================
+
+/// Default slot capacity for Template queues (unmapped, corrected, mapped).
+const TEMPLATE_QUEUE_CAPACITY: usize = 4096;
+
+/// Default slot capacity for FASTQ bytes and zippered raw BAM bytes queues.
+const BYTES_QUEUE_CAPACITY: usize = 4096;
+
+/// Default memory limit per queue (256 MiB).
+const DEFAULT_QUEUE_MEMORY_LIMIT: usize = 256 * 1024 * 1024;
+
+// ============================================================================
+// ExtractSource
+// ============================================================================
+
+/// Mutex-protected iterator over combined FASTQ read sets.
+///
+/// Extract is inherently serial for gzipped input, so only one worker runs it at a time
+/// via `try_lock()`. Other workers that fail to acquire the lock move on to other stages.
+pub struct ExtractSource {
+    /// The FASTQ read-set iterator producing one [`FastqSet`] per template.
+    /// `None` once the source is exhausted.
+    inner: Option<Box<dyn Iterator<Item = FastqSet> + Send>>,
+    /// Monotonic ordinal counter, incremented on each successful read.
+    /// Ordinals track the original FASTQ read order so that downstream stages
+    /// (via the reorder buffer) can restore this order after parallel compute.
+    next_ordinal: u64,
+}
+
+impl ExtractSource {
+    /// Create a new extract source from the given iterator.
+    #[must_use]
+    pub fn new(iter: Box<dyn Iterator<Item = FastqSet> + Send>) -> Self {
+        Self { inner: Some(iter), next_ordinal: 0 }
+    }
+
+    /// Try to read the next FASTQ read set with its ordinal.
+    ///
+    /// Returns `Some((ordinal, read_set))` on success, `None` when exhausted.
+    /// The ordinal is a monotonically increasing counter starting at 0, assigned
+    /// in the order items are read from the FASTQ source.
+    pub fn next_read_set(&mut self) -> Option<(u64, FastqSet)> {
+        let iter = self.inner.as_mut()?;
+        let item = iter.next();
+        if let Some(read_set) = item {
+            let ordinal = self.next_ordinal;
+            self.next_ordinal += 1;
+            Some((ordinal, read_set))
+        } else {
+            self.inner = None;
+            None
+        }
+    }
+
+    /// Returns `true` if the source has been exhausted.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        self.inner.is_none()
+    }
+}
+
+// ============================================================================
+// CorrectionConfig
+// ============================================================================
+
+/// Configuration for in-pipeline UMI correction.
+///
+/// When present in the graph, the Correct stage is active and uses `q_corrected`
+/// as an intermediate queue between Extract and `ToFastq`.
+pub struct CorrectionConfig {
+    /// Pre-encoded set of known UMI sequences for matching.
+    pub encoded_umi_set: Arc<EncodedUmiSet>,
+    /// UMI length (all segments must match this length).
+    pub umi_length: usize,
+    /// Maximum mismatches per UMI segment.
+    pub max_mismatches: usize,
+    /// Minimum distance difference between best and second-best match.
+    pub min_distance_diff: usize,
+    /// UMI tag name as 2-byte array (e.g. `*b"RX"`).
+    pub umi_tag: [u8; 2],
+    /// LRU cache capacity per worker thread (0 = no cache).
+    pub cache_size: usize,
+}
+
+// ============================================================================
+// PhaseAGraph
+// ============================================================================
+
+/// Phase A graph: queues and shared state for alignment pipeline stages.
+///
+/// Shared immutably across all pool workers. The graph connects two pool stages:
+///
+/// - **Extract**: reads FASTQ, produces `(Template, Vec<u8>)` pairs (template + FASTQ bytes)
+/// - **`ToFastq`**: pops pairs from `q_extracted`, writes FASTQ bytes to aligner stdin,
+///   pushes Templates to `q_unmapped` (maintaining insertion order = stdin order)
+///
+/// Dedicated threads handle the rest:
+/// - **stdout-reader**: SAM from aligner → `q_mapped`
+/// - **zipper**: joins `q_unmapped` + `q_mapped` → merge → encode → `q_zippered`
+/// - **sort-accumulate**: `q_zippered` → `SortedChunks`
+///
+/// ## Ordering guarantee
+///
+/// Each FASTQ read set is assigned a monotonic ordinal by [`ExtractSource`] at read
+/// time. After parallel Extract compute, items may arrive in `q_extracted` out of
+/// ordinal order. The `ToFastq` stage uses a [`ReorderBuffer`] (inside
+/// [`tofastq_state`](Self::tofastq_state)) to reassemble items in ordinal order
+/// before writing to the aligner stdin and pushing to `q_unmapped`. Since bwa
+/// preserves input order within `-K` batches, `q_unmapped` and `q_mapped` arrive
+/// in the same queryname order, enabling simple sequential matching in the Zipper.
+pub struct PhaseAGraph {
+    // ---- Queues ----
+    /// Ordinal-tagged `(ordinal, Template, FASTQ bytes)` triples from Extract.
+    ///
+    /// Items may arrive out of FASTQ-read order because Extract compute runs in parallel
+    /// after the source mutex is released. The ordinal tracks the original read order so
+    /// that the [`ToFastqState`] reorder buffer can restore it before writing to stdin.
+    pub q_extracted: WorkQueue<OrdinalPair>,
+    /// Corrected ordinal-tagged triples (feeds `ToFastq`).
+    /// Only present when UMI correction is enabled.
+    pub q_corrected: Option<WorkQueue<OrdinalPair>>,
+    /// Unmapped Templates, populated by `ToFastq` after writing FASTQ to stdin.
+    /// Order matches aligner stdin order (feeds the dedicated Zipper thread).
+    pub q_unmapped: WorkQueue<Template>,
+    /// Mapped templates from the aligner stdout reader thread (feeds Zipper).
+    pub q_mapped: WorkQueue<Template>,
+    /// Raw BAM bytes from Zipper merge (feeds the sort-accumulate thread).
+    pub q_zippered: WorkQueue<Vec<u8>>,
+
+    // ---- Extract state ----
+    /// Shared FASTQ source, protected by mutex (Extract is serial for gzipped input).
+    pub extract_source: Mutex<ExtractSource>,
+    /// Extract configuration (tags, read group, read structures, etc.).
+    pub extract_params: ExtractParams,
+    /// Detected quality encoding for FASTQ input.
+    pub quality_encoding: QualityEncoding,
+    /// Set to `true` when the FASTQ source is exhausted.
+    pub extract_done: AtomicBool,
+
+    // ---- ToFastq reorder state ----
+    /// Shared state for the `ToFastq` stage: reorder buffer + aligner stdin pipe.
+    ///
+    /// Workers pop ordinal-tagged items from the input queue without holding this lock,
+    /// then acquire it to insert into the reorder buffer, drain consecutive items in
+    /// ordinal order, write FASTQ bytes to stdin, and push Templates to `q_unmapped`.
+    /// This replaces the previous exclusive `tofastq_lock` approach.
+    pub tofastq_state: Mutex<ToFastqState>,
+
+    // ---- Correction config ----
+    /// UMI correction configuration. When `Some`, the Correct pool step is active.
+    pub correction_config: Option<CorrectionConfig>,
+
+    // ---- Zipper / output header ----
+    /// Output SAM header used to encode merged records to BAM bytes.
+    /// Set by the stdout-reader thread once the SAM header has been read from the aligner.
+    pub output_header: OnceLock<Arc<Header>>,
+    /// Tag manipulation info for the zipper merge (remove/reverse/revcomp).
+    pub tag_info: Arc<TagInfo>,
+    /// Whether to skip PA (primary alignment) tag generation in zipper.
+    pub skip_pa_tags: bool,
+    /// Zipper merge function: transfers tags from unmapped to mapped template.
+    pub merge_fn: MergeFn,
+
+    // ---- Aligner batch state (optional, when bwa -K is used) ----
+    /// Batch coordination state for bwa `-K` flow control.
+    pub batch_state: Option<Arc<AlignerBatchState>>,
+
+    // ---- Cancellation ----
+    /// Shared cancellation flag.
+    pub cancel: Arc<AtomicBool>,
+}
+
+impl PhaseAGraph {
+    /// Create a new Phase A graph with the given configuration.
+    ///
+    /// Queues are created with default capacities and memory limits.
+    // The graph struct needs all its dependencies passed in at construction.
+    #[expect(clippy::too_many_arguments, reason = "graph requires all dependencies")]
+    #[must_use]
+    pub fn new(
+        extract_source: ExtractSource,
+        extract_params: ExtractParams,
+        quality_encoding: QualityEncoding,
+        tag_info: Arc<TagInfo>,
+        skip_pa_tags: bool,
+        merge_fn: MergeFn,
+        batch_state: Option<Arc<AlignerBatchState>>,
+        aligner_stdin: std::process::ChildStdin,
+        cancel: Arc<AtomicBool>,
+        correction_config: Option<CorrectionConfig>,
+    ) -> Self {
+        let q_corrected = correction_config.as_ref().map(|_| {
+            WorkQueue::new(TEMPLATE_QUEUE_CAPACITY, DEFAULT_QUEUE_MEMORY_LIMIT, "q_corrected")
+        });
+
+        Self {
+            q_extracted: WorkQueue::new(
+                TEMPLATE_QUEUE_CAPACITY,
+                DEFAULT_QUEUE_MEMORY_LIMIT,
+                "q_extracted",
+            ),
+            q_corrected,
+            q_unmapped: WorkQueue::new(
+                TEMPLATE_QUEUE_CAPACITY,
+                DEFAULT_QUEUE_MEMORY_LIMIT,
+                "q_unmapped",
+            ),
+            q_mapped: WorkQueue::new(
+                TEMPLATE_QUEUE_CAPACITY,
+                DEFAULT_QUEUE_MEMORY_LIMIT,
+                "q_mapped",
+            ),
+            q_zippered: WorkQueue::new(
+                BYTES_QUEUE_CAPACITY,
+                DEFAULT_QUEUE_MEMORY_LIMIT,
+                "q_zippered",
+            ),
+            extract_source: Mutex::new(extract_source),
+            extract_params,
+            quality_encoding,
+            extract_done: AtomicBool::new(false),
+            tofastq_state: Mutex::new(ToFastqState {
+                reorder: ReorderBuffer::new(),
+                stdin: Some(aligner_stdin),
+            }),
+            correction_config,
+            output_header: OnceLock::new(),
+            tag_info,
+            skip_pa_tags,
+            merge_fn,
+            batch_state,
+            cancel,
+        }
+    }
+
+    /// Returns the input queue for the `ToFastq` stage.
+    ///
+    /// When correction is enabled, this is `q_corrected` (Correct pops from `q_extracted`
+    /// and pushes to `q_corrected`). When correction is disabled, this is `q_extracted`
+    /// directly (Extract → `ToFastq` with no intermediate queue).
+    #[must_use]
+    pub fn tofastq_input_queue(&self) -> &WorkQueue<OrdinalPair> {
+        self.q_corrected.as_ref().unwrap_or(&self.q_extracted)
+    }
+
+    /// Sample backpressure signals from queue state.
+    #[must_use]
+    pub fn sample_backpressure(&self) -> super::phase_a::PhaseABackpressure {
+        super::phase_a::PhaseABackpressure {
+            extracted_high: self.q_extracted.fill_ratio() > super::BACKPRESSURE_HIGH_WATERMARK,
+            tofastq_input_high: self.tofastq_input_queue().fill_ratio()
+                > super::BACKPRESSURE_HIGH_WATERMARK,
+            can_send_fastq: self.batch_state.as_ref().is_none_or(|bs| bs.can_send()),
+        }
+    }
+
+    /// Returns `true` if all pool work is complete.
+    ///
+    /// The pool handles Extract, Correct (when enabled), and `ToFastq`. Work is complete
+    /// when the `ToFastq` input queue is closed and empty (all pairs have been split
+    /// by `ToFastq` and their Templates pushed to `q_unmapped`).
+    #[must_use]
+    pub fn is_pool_done(&self) -> bool {
+        self.tofastq_input_queue().is_closed_and_empty()
+    }
+
+    /// Mark extract as done and close `q_extracted`.
+    pub fn mark_extract_done(&self) {
+        self.extract_done.store(true, Ordering::Release);
+        self.q_extracted.close();
+    }
+
+    /// Close `q_corrected` after all extracted pairs have been corrected.
+    ///
+    /// Called by the Correct step when `q_extracted` is closed and empty.
+    /// Only meaningful when correction is enabled.
+    pub fn mark_correct_done(&self) {
+        if let Some(ref q) = self.q_corrected {
+            q.close();
+        }
+    }
+
+    /// Close the aligner stdin pipe (signals EOF to the aligner).
+    ///
+    /// Called by `ToFastq` when the input queue is drained. Dropping the stdin handle
+    /// closes the pipe and signals EOF to the aligner subprocess.
+    pub fn close_aligner_stdin(&self) {
+        if let Ok(mut guard) = self.tofastq_state.lock() {
+            guard.stdin = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_source_exhaustion() {
+        // We can't easily construct a real FastqSet, so test the wrapper logic
+        // with a None-initialized source.
+        let mut source = ExtractSource { inner: None, next_ordinal: 0 };
+        assert!(source.is_exhausted());
+        assert!(source.next_read_set().is_none());
+    }
+
+    #[test]
+    fn test_backpressure_default() {
+        let bp = super::super::phase_a::PhaseABackpressure::default();
+        assert!(!bp.extracted_high);
+        assert!(!bp.tofastq_input_high);
+        assert!(bp.can_send_fastq);
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/phase_a_steps.rs
+++ b/crates/fgumi-pipeline/src/pipeline/phase_a_steps.rs
@@ -1,0 +1,474 @@
+//! Phase A `try_step` functions for work-stealing pool stages.
+//!
+//! Each function attempts one unit of work for its stage. Returns a [`StepResult`] to
+//! indicate success, output-full (item held in worker state), input-empty, or error.
+//! The worker loop calls these in priority order determined by the scheduler.
+//!
+//! **Pool stages:**
+//! - [`try_step_extract`]: Read one FASTQ template, produce an ordinal-tagged
+//!   `(ordinal, Template, Vec<u8>)` triple. Multiple workers can compute in parallel
+//!   after the FASTQ source mutex is released.
+//! - [`try_step_correct`]: Pop an ordinal-tagged triple, correct the UMI, push the
+//!   corrected triple to `q_corrected` (parallelizable, per-worker LRU caches).
+//! - [`try_step_to_fastq`]: Pop an ordinal-tagged triple, insert into the reorder buffer,
+//!   drain consecutive items in ordinal order to aligner stdin + `q_unmapped`.
+
+use std::io::Write;
+use std::sync::atomic::Ordering;
+
+use anyhow::anyhow;
+use fgumi_lib::correct;
+use fgumi_lib::extract::extract_template_and_fastq;
+use fgumi_lib::unified_pipeline::MemoryEstimate;
+use noodles::sam;
+
+use crate::pipeline::phase_a_graph::{OrdinalPair, PhaseAGraph, ToFastqState};
+use crate::pipeline::phase_a_worker::PhaseAWorkerState;
+use crate::pipeline::queue::WorkQueue;
+use crate::pipeline::scheduler::StepResult;
+
+// ============================================================================
+// Extract
+// ============================================================================
+
+/// Attempt one Extract step: read one FASTQ template, produce an ordinal-tagged
+/// `(ordinal, Template, Vec<u8>)` triple.
+///
+/// The FASTQ source mutex is held only during the read (serial for gzipped input).
+/// After reading, the mutex is released and the compute-intensive
+/// `extract_template_and_fastq` runs in parallel. The ordinal assigned at read time
+/// tracks the original FASTQ order; the `ToFastq` reorder buffer restores this order
+/// before writing to the aligner stdin.
+///
+/// On success, pushes the ordinal-tagged triple to `q_extracted`.
+/// If the output queue is full, the triple is held in worker state for retry.
+pub fn try_step_extract(graph: &PhaseAGraph, worker: &mut PhaseAWorkerState) -> StepResult {
+    // 1. Try to push any held pair from a previous iteration.
+    if let Some(pair) = worker.held_extract_pair.take() {
+        let mem = worker.held_extract_pair_mem;
+        if let Some(returned) = graph.q_extracted.push(pair, mem) {
+            worker.held_extract_pair = Some(returned);
+            return StepResult::OutputFull;
+        }
+        worker.held_extract_pair_mem = 0;
+    }
+
+    // 2. Check if extract is already done.
+    if graph.extract_done.load(Ordering::Acquire) {
+        return StepResult::InputEmpty;
+    }
+
+    // 3. Try to acquire the FASTQ source lock (non-blocking).
+    let mut source_guard = match graph.extract_source.try_lock() {
+        Ok(guard) => guard,
+        Err(std::sync::TryLockError::WouldBlock) => return StepResult::InputEmpty,
+        Err(std::sync::TryLockError::Poisoned(e)) => {
+            return StepResult::Error(anyhow!("extract source lock poisoned: {e}"));
+        }
+    };
+
+    // 4. Read one FASTQ read set (assigns a monotonic ordinal).
+    let Some((ordinal, read_set)) = source_guard.next_read_set() else {
+        // Source exhausted. Mark extract done (closes q_extracted).
+        drop(source_guard);
+        graph.mark_extract_done();
+        return StepResult::InputEmpty;
+    };
+    // Release the lock before doing compute work — other workers can read the next
+    // item while this worker runs extract_template_and_fastq in parallel.
+    drop(source_guard);
+
+    // 5. Extract template + FASTQ bytes (CPU-intensive, runs without any lock).
+    let extracted = match extract_template_and_fastq(
+        &read_set,
+        graph.quality_encoding,
+        &graph.extract_params,
+    ) {
+        Ok(e) => e,
+        Err(e) => return StepResult::Error(e),
+    };
+
+    let template = extracted.template;
+    let fastq_bytes = extracted.fastq_bytes;
+
+    // 6. Push the ordinal-tagged triple to q_extracted.
+    //    Items may arrive out of ordinal order due to parallel compute; the
+    //    ToFastq reorder buffer will restore ordinal order downstream.
+    let pair_mem = template.estimate_heap_size() + fastq_bytes.len();
+    if let Some(returned) = graph.q_extracted.push((ordinal, template, fastq_bytes), pair_mem) {
+        // Queue full — hold the triple for retry.
+        worker.held_extract_pair = Some(returned);
+        worker.held_extract_pair_mem = pair_mem;
+        return StepResult::OutputFull;
+    }
+
+    StepResult::Success
+}
+
+// ============================================================================
+// Correct
+// ============================================================================
+
+/// Attempt one Correct step: pop an ordinal-tagged `(ordinal, Template, Vec<u8>)` triple
+/// from `q_extracted`, correct the UMI on the Template, and push the corrected triple
+/// to `q_corrected`.
+///
+/// Correct is parallelizable — multiple workers can run it concurrently, each with
+/// their own LRU cache. The ordinal and FASTQ bytes pass through unchanged.
+///
+/// When `q_extracted` is closed and empty, closes `q_corrected` to propagate the
+/// close cascade to `ToFastq`.
+pub fn try_step_correct(graph: &PhaseAGraph, worker: &mut PhaseAWorkerState) -> StepResult {
+    let Some(ref correction_config) = graph.correction_config else {
+        return StepResult::InputEmpty;
+    };
+    let Some(ref q_corrected) = graph.q_corrected else {
+        return StepResult::InputEmpty;
+    };
+
+    // 1. Try to push any held pair from a previous iteration.
+    if let Some(pair) = worker.held_correct_pair.take() {
+        let mem = worker.held_correct_pair_mem;
+        if let Some(returned) = q_corrected.push(pair, mem) {
+            worker.held_correct_pair = Some(returned);
+            return StepResult::OutputFull;
+        }
+        worker.held_correct_pair_mem = 0;
+        graph.q_extracted.complete_in_flight();
+        graph.q_extracted.release_memory(mem);
+    }
+
+    // 2. Pop from q_extracted.
+    let Some((ordinal, mut template, fastq_bytes)) = graph.q_extracted.try_pop() else {
+        if graph.q_extracted.is_closed_and_empty() {
+            graph.mark_correct_done();
+        }
+        return StepResult::InputEmpty;
+    };
+
+    // 3. Extract UMI from the first record and correct it.
+    let umi_tag = sam::alignment::record::data::field::Tag::new(
+        correction_config.umi_tag[0],
+        correction_config.umi_tag[1],
+    );
+
+    let umi_opt = template.records.first().and_then(|rec| {
+        rec.data().get(&umi_tag).and_then(|v| {
+            if let sam::alignment::record_buf::data::field::Value::String(s) = v {
+                Some(String::from_utf8_lossy(s).to_string())
+            } else {
+                None
+            }
+        })
+    });
+
+    if let Some(umi) = umi_opt {
+        let correction = correct::compute_template_correction(
+            &umi,
+            correction_config.umi_length,
+            false, // revcomp not exposed in pipeline
+            correction_config.max_mismatches,
+            correction_config.min_distance_diff,
+            &correction_config.encoded_umi_set,
+            &mut worker.umi_cache,
+        );
+
+        if correction.matched {
+            // Apply correction to all records in the template.
+            if correction.needs_correction {
+                for record in &mut template.records {
+                    if correction.has_mismatches {
+                        record.data_mut().insert(
+                            sam::alignment::record::data::field::Tag::ORIGINAL_UMI_BARCODE_SEQUENCE,
+                            sam::alignment::record_buf::data::field::Value::String(
+                                correction.original_umi.clone().into(),
+                            ),
+                        );
+                    }
+                    if let Some(ref corrected) = correction.corrected_umi {
+                        record.data_mut().insert(
+                            umi_tag,
+                            sam::alignment::record_buf::data::field::Value::String(
+                                corrected.clone().into(),
+                            ),
+                        );
+                    }
+                }
+            }
+        } else {
+            // Unmatched — drop the template (pipeline doesn't write rejects).
+            graph.q_extracted.complete_in_flight();
+            let mem = template.estimate_heap_size() + fastq_bytes.len();
+            graph.q_extracted.release_memory(mem);
+            return StepResult::Success;
+        }
+    }
+    // If no UMI tag, pass template through unchanged.
+
+    // 4. Push corrected triple (with ordinal) to q_corrected.
+    let pair_mem = template.estimate_heap_size() + fastq_bytes.len();
+    if let Some(returned) = q_corrected.push((ordinal, template, fastq_bytes), pair_mem) {
+        worker.held_correct_pair = Some(returned);
+        worker.held_correct_pair_mem = pair_mem;
+        return StepResult::OutputFull;
+    }
+
+    // 5. Complete in-flight tracking on q_extracted.
+    graph.q_extracted.complete_in_flight();
+    graph.q_extracted.release_memory(pair_mem);
+
+    StepResult::Success
+}
+
+// ============================================================================
+// ToFastq
+// ============================================================================
+
+/// Attempt one `ToFastq` step: pop an ordinal-tagged triple from the input queue,
+/// insert it into the reorder buffer, drain consecutive items in ordinal order,
+/// and write them to the aligner stdin + push to `q_unmapped`.
+///
+/// Workers pop from the input queue *without* holding the `tofastq_state` lock. This
+/// allows multiple workers to pop concurrently. The lock is then acquired to insert
+/// into the reorder buffer, drain ready items, and perform the serial I/O (stdin write
+/// and `q_unmapped` push) in ordinal order.
+pub fn try_step_to_fastq(graph: &PhaseAGraph, _worker: &mut PhaseAWorkerState) -> StepResult {
+    let input_q = graph.tofastq_input_queue();
+
+    let Some((ordinal, template, fastq_bytes)) = input_q.try_pop() else {
+        if input_q.is_closed_and_empty() {
+            // A worker may have popped the last item and inserted it into the reorder
+            // buffer but not yet drained it. Drain any stragglers before closing.
+            if let Ok(mut state) = graph.tofastq_state.lock() {
+                if let Err(e) = drain_reorder_buffer(graph, &mut state, input_q) {
+                    return StepResult::Error(e);
+                }
+            }
+            graph.close_aligner_stdin();
+            graph.q_unmapped.close();
+        }
+        return StepResult::InputEmpty;
+    };
+
+    let mut state = match graph.tofastq_state.lock() {
+        Ok(guard) => guard,
+        Err(e) => {
+            return StepResult::Error(anyhow!("tofastq_state lock poisoned: {e}"));
+        }
+    };
+
+    state.reorder.insert(ordinal, (template, fastq_bytes));
+
+    if let Err(e) = drain_reorder_buffer(graph, &mut state, input_q) {
+        return StepResult::Error(e);
+    }
+
+    StepResult::Success
+}
+
+/// Drain consecutive items from the reorder buffer, writing FASTQ to stdin and
+/// pushing Templates to `q_unmapped` in ordinal order.
+///
+/// Called while holding the `tofastq_state` lock.
+fn drain_reorder_buffer(
+    graph: &PhaseAGraph,
+    state: &mut ToFastqState,
+    input_q: &WorkQueue<OrdinalPair>,
+) -> anyhow::Result<()> {
+    while let Some((template, fastq_bytes)) = state.reorder.try_next() {
+        let template_mem = template.estimate_heap_size();
+        let pair_mem = template_mem + fastq_bytes.len();
+
+        match write_fastq_to_stdin(state, &fastq_bytes) {
+            Ok(()) | Err(WriteResult::StdinClosed) => {}
+            Err(WriteResult::Error(e)) => {
+                input_q.complete_in_flight();
+                input_q.release_memory(pair_mem);
+                return Err(e);
+            }
+        }
+
+        if let Some(ref bs) = graph.batch_state {
+            let num_bytes = fastq_bytes.len() as u64;
+            #[expect(
+                clippy::naive_bytecount,
+                reason = "small buffer; adding bytecount dep not worthwhile"
+            )]
+            let newline_count = fastq_bytes.iter().filter(|&&b| b == b'\n').count() as u64;
+            let num_records = newline_count / 4;
+            // bwa -K counts bases, not bytes; paired-end FASTQ has ~2x bytes per base.
+            bs.record_send(num_bytes / 2, num_records);
+        }
+
+        // Spin-push to q_unmapped — must complete before draining the next item
+        // so that q_unmapped order matches stdin write order.
+        let mut current_template = template;
+        loop {
+            match graph.q_unmapped.push(current_template, template_mem) {
+                None => break,
+                Some(returned) => {
+                    if graph.cancel.load(Ordering::Acquire) {
+                        input_q.complete_in_flight();
+                        input_q.release_memory(pair_mem);
+                        return Err(anyhow!("cancelled while pushing to q_unmapped"));
+                    }
+                    current_template = returned;
+                    std::thread::yield_now();
+                }
+            }
+        }
+
+        input_q.complete_in_flight();
+        input_q.release_memory(pair_mem);
+    }
+
+    Ok(())
+}
+
+/// Result of attempting to write FASTQ bytes to aligner stdin.
+enum WriteResult {
+    /// Aligner stdin has been closed (normal during shutdown).
+    StdinClosed,
+    /// I/O error writing to aligner stdin.
+    Error(anyhow::Error),
+}
+
+/// Write FASTQ bytes to the aligner's stdin pipe via the `ToFastqState`.
+fn write_fastq_to_stdin(state: &mut ToFastqState, data: &[u8]) -> Result<(), WriteResult> {
+    let Some(stdin) = state.stdin.as_mut() else {
+        return Err(WriteResult::StdinClosed);
+    };
+
+    stdin.write_all(data).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::BrokenPipe {
+            WriteResult::StdinClosed
+        } else {
+            WriteResult::Error(anyhow!("failed to write FASTQ to aligner stdin: {e}"))
+        }
+    })
+}
+
+// ============================================================================
+// Zipper (dedicated thread — not a pool stage)
+// ============================================================================
+
+/// Run the Zipper merge as a dedicated thread.
+///
+/// Sequentially pops one Template from `q_unmapped` and one from `q_mapped`, verifies
+/// their querynames match (guaranteed by the ordering invariant), merges tags from the
+/// unmapped into the mapped template, encodes the result to raw BAM bytes, and pushes
+/// them to `q_zippered`.
+///
+/// Returns the total number of raw BAM records pushed.
+///
+/// # Errors
+///
+/// Returns an error if merge fails, encoding fails, names don't match (ordering
+/// violation), or the mapped stream ends before the unmapped stream.
+///
+/// ## Ordering guarantee
+///
+/// `q_unmapped` is populated by the exclusive `ToFastq` stage in stdin write order.
+/// `q_mapped` is populated by the stdout-reader in aligner output order. Since bwa
+/// preserves input order within `-K` batches, these two queues arrive in the same
+/// queryname order, enabling simple sequential matching without a `HashMap`.
+pub fn zipper_thread_loop(graph: &PhaseAGraph) -> anyhow::Result<u64> {
+    use fgumi_lib::progress::ProgressTracker;
+    use fgumi_lib::vendored::encode_record_buf;
+
+    let progress = ProgressTracker::new("Zipper merged records").with_interval(1_000_000);
+
+    // Wait for the output header (set by stdout-reader after reading SAM header).
+    let output_header = loop {
+        if let Some(h) = graph.output_header.get() {
+            break h;
+        }
+        if graph.cancel.load(Ordering::Acquire) {
+            anyhow::bail!("zipper cancelled while waiting for output header");
+        }
+        // Also check if q_unmapped is already done (no templates to merge).
+        if graph.q_unmapped.is_closed_and_empty() {
+            log::info!(
+                "zipper: q_unmapped closed before output header available, nothing to merge"
+            );
+            return Ok(0);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    };
+
+    let mut record_count: u64 = 0;
+
+    loop {
+        // Pop unmapped (blocking).
+        let Some(unmapped) = graph.q_unmapped.pop() else {
+            break; // q_unmapped closed+empty → done
+        };
+        graph.q_unmapped.complete_in_flight();
+
+        // Pop mapped (blocking).
+        let Some(mut mapped) = graph.q_mapped.pop() else {
+            anyhow::bail!(
+                "Zipper: mapped stream ended before unmapped. \
+                 Unmapped template '{}' has no corresponding mapped template.",
+                String::from_utf8_lossy(&unmapped.name)
+            );
+        };
+        graph.q_mapped.complete_in_flight();
+
+        // Verify names match — ordering guarantee from combined q_extracted queue.
+        if unmapped.name != mapped.name {
+            anyhow::bail!(
+                "Zipper ordering violation: unmapped='{}' vs mapped='{}'. \
+                 This indicates a bug in the pipeline ordering logic.",
+                String::from_utf8_lossy(&unmapped.name),
+                String::from_utf8_lossy(&mapped.name),
+            );
+        }
+
+        // Merge unmapped metadata into the mapped template.
+        (graph.merge_fn)(&unmapped, &mut mapped, &graph.tag_info, graph.skip_pa_tags)?;
+
+        // Encode all records from the merged template to raw BAM bytes.
+        let header = output_header.as_ref();
+        for rec in mapped.all_reads() {
+            let mut buf = Vec::new();
+            encode_record_buf(&mut buf, header, rec)
+                .map_err(|e| anyhow!("failed to encode merged record to BAM: {e}"))?;
+            let mem = buf.len();
+            graph.q_zippered.push_blocking(buf, mem)?;
+            record_count += 1;
+            progress.log_if_needed(1);
+        }
+
+        // Release memory for the unmapped template.
+        let unmapped_mem = unmapped.estimate_heap_size();
+        graph.q_unmapped.release_memory(unmapped_mem);
+        let mapped_mem = mapped.estimate_heap_size();
+        graph.q_mapped.release_memory(mapped_mem);
+    }
+
+    // Check for leftover mapped reads.
+    if let Some(remaining) = graph.q_mapped.pop() {
+        graph.q_mapped.complete_in_flight();
+        anyhow::bail!(
+            "Zipper: processed all unmapped reads but mapped reads remain. \
+             Found template '{}'. Ensure unmapped and mapped inputs have matching read names.",
+            String::from_utf8_lossy(&remaining.name)
+        );
+    }
+
+    progress.log_final();
+    Ok(record_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_result_variants() {
+        // Ensure the enum compiles and can be matched.
+        let _closed = WriteResult::StdinClosed;
+        let _err = WriteResult::Error(anyhow!("test"));
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/phase_a_worker.rs
+++ b/crates/fgumi-pipeline/src/pipeline/phase_a_worker.rs
@@ -1,0 +1,399 @@
+//! Phase A worker state and pool execution loop.
+//!
+//! Each pool worker owns a [`PhaseAWorkerState`] with held-item slots and scheduler state.
+//! The [`start_phase_a_pool`] function spawns worker threads that execute the Phase A loop
+//! until all queues are drained or cancellation is signaled.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use anyhow::anyhow;
+use crossbeam_channel::{Receiver, Sender};
+use lru::LruCache;
+
+use fgumi_lib::correct::UmiMatch;
+
+use crate::pipeline::phase_a::{PhaseAScheduler, PhaseAStep};
+use crate::pipeline::phase_a_graph::{OrdinalPair, PhaseAGraph};
+use crate::pipeline::phase_a_steps;
+use crate::pipeline::scheduler::StepResult;
+use crate::pipeline::worker_util::{WorkerBackoff, panic_message};
+
+// ============================================================================
+// Worker stats
+// ============================================================================
+
+/// Per-worker statistics for Phase A diagnostics.
+pub struct PhaseAWorkerStats {
+    /// Per-stage attempt count.
+    pub stage_attempts: [AtomicU64; PhaseAStep::NUM_STEPS],
+    /// Per-stage success count.
+    pub stage_successes: [AtomicU64; PhaseAStep::NUM_STEPS],
+    /// Number of idle cycles (no work found in any stage).
+    pub idle_cycles: AtomicU64,
+    /// Cumulative nanoseconds spent in backoff sleep.
+    pub idle_nanos: AtomicU64,
+}
+
+impl PhaseAWorkerStats {
+    /// Create a new zeroed stats instance.
+    fn new() -> Self {
+        Self {
+            stage_attempts: std::array::from_fn(|_| AtomicU64::new(0)),
+            stage_successes: std::array::from_fn(|_| AtomicU64::new(0)),
+            idle_cycles: AtomicU64::new(0),
+            idle_nanos: AtomicU64::new(0),
+        }
+    }
+}
+
+// ============================================================================
+// PhaseAWorkerState
+// ============================================================================
+
+/// Per-worker mutable state for Phase A pool stages.
+///
+/// Each worker thread owns one instance. Held items are stored here when output queues
+/// are full, enabling non-blocking push semantics.
+pub struct PhaseAWorkerState {
+    /// Worker ID (0-indexed).
+    pub worker_id: usize,
+
+    // ---- Extract held item ----
+    /// Held ordinal-tagged `(ordinal, Template, fastq_bytes)` triple from Extract
+    /// (`q_extracted` was full).
+    pub held_extract_pair: Option<OrdinalPair>,
+    /// Memory estimate for the held extract pair.
+    pub held_extract_pair_mem: usize,
+
+    // ---- Correct held item ----
+    /// Held corrected ordinal-tagged `(ordinal, Template, fastq_bytes)` triple
+    /// (`q_corrected` was full).
+    pub held_correct_pair: Option<OrdinalPair>,
+    /// Memory estimate for the held correct pair.
+    pub held_correct_pair_mem: usize,
+    /// Per-worker LRU cache for UMI segment matching.
+    /// `None` when correction is disabled or `cache_size` is 0.
+    pub umi_cache: Option<LruCache<Vec<u8>, UmiMatch>>,
+
+    // ---- Scheduler and backoff ----
+    /// Phase A scheduler for priority determination.
+    pub scheduler: PhaseAScheduler,
+    /// Per-worker statistics.
+    pub stats: PhaseAWorkerStats,
+    /// Adaptive backoff with jitter.
+    backoff: WorkerBackoff,
+}
+
+impl PhaseAWorkerState {
+    /// Create a new worker state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `umi_cache_size` is non-zero but cannot be converted to a `NonZero<usize>`.
+    #[must_use]
+    pub fn new(
+        worker_id: usize,
+        active_steps: [bool; PhaseAStep::NUM_STEPS],
+        umi_cache_size: usize,
+    ) -> Self {
+        let umi_cache = if umi_cache_size > 0 {
+            Some(LruCache::new(std::num::NonZero::new(umi_cache_size).unwrap()))
+        } else {
+            None
+        };
+        Self {
+            worker_id,
+            held_extract_pair: None,
+            held_extract_pair_mem: 0,
+            held_correct_pair: None,
+            held_correct_pair_mem: 0,
+            umi_cache,
+            scheduler: PhaseAScheduler::new(active_steps),
+            stats: PhaseAWorkerStats::new(),
+            backoff: WorkerBackoff::new(worker_id),
+        }
+    }
+
+    /// Returns `true` if this worker is holding any items.
+    pub fn has_any_held_items(&self) -> bool {
+        self.held_extract_pair.is_some() || self.held_correct_pair.is_some()
+    }
+
+    /// Reset backoff to zero on successful work.
+    pub fn reset_backoff(&mut self) {
+        self.backoff.reset();
+    }
+
+    /// Sleep for the current backoff duration with per-worker jitter.
+    pub fn sleep_backoff(&mut self) {
+        self.backoff.sleep();
+    }
+
+    /// Increase backoff exponentially.
+    pub fn increase_backoff(&mut self) {
+        self.backoff.increase();
+    }
+
+    /// Log stats for this worker.
+    #[expect(clippy::cast_precision_loss, reason = "nanos fits in f64 for display")]
+    pub fn log_stats(&self) {
+        log::info!("  Phase A Worker {}:", self.worker_id);
+        for &step in &PhaseAStep::ALL {
+            let idx = step as usize;
+            let attempts = self.stats.stage_attempts[idx].load(Ordering::Relaxed);
+            let successes = self.stats.stage_successes[idx].load(Ordering::Relaxed);
+            if attempts > 0 {
+                log::info!(
+                    "    {:<14} {attempts:>8} attempts, {successes:>8} success",
+                    step.name()
+                );
+            }
+        }
+        let idle_cycles = self.stats.idle_cycles.load(Ordering::Relaxed);
+        let idle_nanos = self.stats.idle_nanos.load(Ordering::Relaxed);
+        let idle_secs = idle_nanos as f64 / 1_000_000_000.0;
+        log::info!("    idle: {idle_cycles} cycles, {idle_secs:.3}s");
+    }
+}
+
+// ============================================================================
+// Worker loop
+// ============================================================================
+
+/// The main loop executed by each Phase A worker thread.
+///
+/// Each iteration: (1) sample backpressure and get priorities, (2) try one step in
+/// priority order, (3) backoff if idle.
+fn phase_a_worker_loop(
+    graph: &PhaseAGraph,
+    worker: &mut PhaseAWorkerState,
+    cancel: &AtomicBool,
+    error_tx: &Sender<anyhow::Error>,
+) {
+    loop {
+        // Exit when cancelled AND no held items remain.
+        if cancel.load(Ordering::Acquire) && !worker.has_any_held_items() {
+            break;
+        }
+
+        // Check if all pool work is done.
+        if graph.is_pool_done() && !worker.has_any_held_items() {
+            break;
+        }
+
+        let mut did_work = false;
+
+        // 1. Sample backpressure and get priority order.
+        let bp = graph.sample_backpressure();
+        let priorities = worker.scheduler.get_priorities(&bp);
+        // Copy to avoid borrow conflict with worker mutation in the loop.
+        let priorities_copy: Vec<PhaseAStep> = priorities.to_vec();
+
+        // 2. Execute one stage in priority order.
+        for &step in &priorities_copy {
+            if cancel.load(Ordering::Acquire) {
+                break;
+            }
+
+            let idx = step as usize;
+            worker.stats.stage_attempts[idx].fetch_add(1, Ordering::Relaxed);
+
+            let result = match step {
+                PhaseAStep::Extract => phase_a_steps::try_step_extract(graph, worker),
+                PhaseAStep::Correct => phase_a_steps::try_step_correct(graph, worker),
+                PhaseAStep::ToFastq => phase_a_steps::try_step_to_fastq(graph, worker),
+            };
+
+            match result {
+                StepResult::Success => {
+                    worker.stats.stage_successes[idx].fetch_add(1, Ordering::Relaxed);
+                    worker.scheduler.record_outcome(step, true);
+                    did_work = true;
+                    break;
+                }
+                StepResult::OutputFull => {
+                    worker.scheduler.record_outcome(step, false);
+                }
+                StepResult::InputEmpty => {}
+                StepResult::Error(e) => {
+                    let _ = error_tx.send(e);
+                    cancel.store(true, Ordering::Release);
+                    return;
+                }
+            }
+        }
+
+        // 3. Adaptive backoff if no work done.
+        if did_work {
+            worker.reset_backoff();
+        } else {
+            worker.stats.idle_cycles.fetch_add(1, Ordering::Relaxed);
+            let start = Instant::now();
+            worker.sleep_backoff();
+            #[expect(clippy::cast_possible_truncation, reason = "sleep nanos won't exceed u64")]
+            let idle_nanos = start.elapsed().as_nanos() as u64;
+            worker.stats.idle_nanos.fetch_add(idle_nanos, Ordering::Relaxed);
+            worker.increase_backoff();
+        }
+    }
+}
+
+// ============================================================================
+// Pool execution
+// ============================================================================
+
+/// Shared slot for returning worker state after thread completion.
+pub type PhaseAWorkerSlot = Arc<Mutex<Option<PhaseAWorkerState>>>;
+
+/// Run the Phase A worker pool.
+///
+/// Spawns `num_workers` threads that execute the Phase A work-stealing loop. Returns
+/// the join handles and worker state slots for stats collection.
+///
+/// The active steps determine which stages are enabled. For the initial implementation
+/// (no Correct), the active steps are: Extract, `ToFastq`.
+///
+/// # Panics
+///
+/// Panics if a worker-state mutex is poisoned or thread spawning fails.
+#[must_use]
+pub fn start_phase_a_pool(
+    graph: &Arc<PhaseAGraph>,
+    num_workers: usize,
+    active_steps: [bool; PhaseAStep::NUM_STEPS],
+    cancel: &Arc<AtomicBool>,
+    umi_cache_size: usize,
+) -> (Vec<thread::JoinHandle<()>>, Vec<PhaseAWorkerSlot>, Receiver<anyhow::Error>) {
+    let (error_tx, error_rx) = crossbeam_channel::unbounded();
+    let mut handles = Vec::with_capacity(num_workers);
+    let mut worker_slots = Vec::with_capacity(num_workers);
+
+    for worker_id in 0..num_workers {
+        let graph = Arc::clone(graph);
+        let cancel = Arc::clone(cancel);
+        let error_tx = error_tx.clone();
+
+        let ws = Arc::new(Mutex::new(Some(PhaseAWorkerState::new(
+            worker_id,
+            active_steps,
+            umi_cache_size,
+        ))));
+        let ws_clone = Arc::clone(&ws);
+        worker_slots.push(ws);
+
+        handles.push(
+            thread::Builder::new()
+                .name(format!("phase-a-{worker_id}"))
+                .spawn(move || {
+                    let mut state = ws_clone.lock().expect("worker state lock").take().unwrap();
+
+                    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        phase_a_worker_loop(&graph, &mut state, &cancel, &error_tx);
+                    }));
+
+                    if let Err(payload) = result {
+                        let msg = panic_message(&payload);
+                        let _ = error_tx.send(anyhow!("Phase A worker thread panicked: {msg}"));
+                        cancel.store(true, Ordering::Release);
+                    }
+
+                    // Put the state back for stats collection.
+                    *ws_clone.lock().expect("worker state lock") = Some(state);
+                })
+                .expect("failed to spawn Phase A worker thread"),
+        );
+    }
+
+    (handles, worker_slots, error_rx)
+}
+
+/// Wait for all Phase A worker threads to finish and return the first error if any.
+///
+/// # Errors
+///
+/// Returns an error if any worker thread panicked or sent an error.
+///
+/// # Panics
+///
+/// Panics if a worker-state mutex is poisoned.
+pub fn wait_phase_a_pool(
+    handles: Vec<thread::JoinHandle<()>>,
+    worker_slots: &[PhaseAWorkerSlot],
+    error_rx: &Receiver<anyhow::Error>,
+) -> anyhow::Result<()> {
+    for handle in handles {
+        if let Err(payload) = handle.join() {
+            let msg = panic_message(&payload);
+            return Err(anyhow!("Phase A worker thread panicked: {msg}"));
+        }
+    }
+
+    // Log worker stats.
+    log::info!("Phase A worker stats:");
+    for slot in worker_slots {
+        if let Some(ref state) = *slot.lock().expect("worker state lock") {
+            state.log_stats();
+        }
+    }
+
+    // Check for errors.
+    if let Ok(e) = error_rx.try_recv() {
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_worker_state_initial() {
+        let active = [true; PhaseAStep::NUM_STEPS];
+        let worker = PhaseAWorkerState::new(0, active, 0);
+        assert_eq!(worker.worker_id, 0);
+        assert!(!worker.has_any_held_items());
+    }
+
+    #[test]
+    fn test_worker_state_held_items() {
+        use fgumi_lib::template::Template;
+        let active = [true; PhaseAStep::NUM_STEPS];
+        let mut worker = PhaseAWorkerState::new(0, active, 0);
+        assert!(!worker.has_any_held_items());
+
+        worker.held_extract_pair = Some((0, Template::new(b"test".to_vec()), vec![1, 2, 3]));
+        assert!(worker.has_any_held_items());
+    }
+
+    #[test]
+    fn test_worker_state_with_cache() {
+        let active = [true; PhaseAStep::NUM_STEPS];
+        let worker = PhaseAWorkerState::new(0, active, 100);
+        assert!(worker.umi_cache.is_some());
+        assert!(!worker.has_any_held_items());
+    }
+
+    #[test]
+    fn test_worker_state_no_cache() {
+        let active = [true; PhaseAStep::NUM_STEPS];
+        let worker = PhaseAWorkerState::new(0, active, 0);
+        assert!(worker.umi_cache.is_none());
+    }
+
+    #[test]
+    fn test_worker_state_held_correct_pair() {
+        use fgumi_lib::template::Template;
+        let active = [true; PhaseAStep::NUM_STEPS];
+        let mut worker = PhaseAWorkerState::new(0, active, 0);
+        assert!(!worker.has_any_held_items());
+
+        worker.held_correct_pair = Some((0, Template::new(b"test".to_vec()), vec![1, 2, 3]));
+        assert!(worker.has_any_held_items());
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/queue.rs
+++ b/crates/fgumi-pipeline/src/pipeline/queue.rs
@@ -1,0 +1,428 @@
+//! Bounded, memory-aware work queues for connecting Zone 3 pipeline stages.
+//!
+//! Uses `crossbeam_queue::ArrayQueue` for lock-free, non-blocking push/pop.
+//! Workers that find a queue full or empty simply try another stage (work-stealing).
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use crossbeam_queue::ArrayQueue;
+
+/// A lock-free bounded queue with memory tracking for backpressure.
+///
+/// Uses `crossbeam_queue::ArrayQueue` — never blocks. `push` returns the item
+/// on failure (full), `try_pop` returns `None` on empty. Workers that find a
+/// queue full/empty simply try another stage (work-stealing).
+///
+/// Multiple clones of a `WorkQueue` share the same underlying queue, memory counter,
+/// and completion flag, allowing work-stealing schedulers to have many producers and
+/// consumers on the same queue.
+///
+/// The queue does not automatically decrement memory when items are popped; callers must
+/// invoke [`WorkQueue::release_memory`] after consuming and processing each item.
+pub struct WorkQueue<T> {
+    inner: Arc<ArrayQueue<T>>,
+    memory_bytes: Arc<AtomicUsize>,
+    memory_limit: usize,
+    name: &'static str,
+    /// Explicit "input exhausted" flag — set by the producer when no more items will arrive.
+    closed: Arc<AtomicBool>,
+    /// Number of items that have been popped but whose results have not yet been pushed
+    /// to the downstream queue. This prevents premature close cascades: a queue is only
+    /// truly done when `closed && is_empty() && in_flight == 0`.
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl<T> WorkQueue<T> {
+    /// Create a new work queue with the given capacity and memory limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` — maximum number of items that may be buffered in the queue.
+    /// * `memory_limit` — soft memory ceiling in bytes; checked by [`WorkQueue::memory_available`].
+    /// * `name` — a static label used for logging and diagnostics.
+    #[must_use]
+    pub fn new(capacity: usize, memory_limit: usize, name: &'static str) -> Self {
+        Self {
+            inner: Arc::new(ArrayQueue::new(capacity)),
+            memory_bytes: Arc::new(AtomicUsize::new(0)),
+            memory_limit,
+            name,
+            closed: Arc::new(AtomicBool::new(false)),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Attempt a non-blocking push.
+    ///
+    /// Returns `None` if the item was queued successfully, or `Some(item)` if the
+    /// queue was full (the item is returned to the caller for holding).
+    /// Memory is only incremented on success.
+    pub fn push(&self, item: T, size_bytes: usize) -> Option<T> {
+        match self.inner.push(item) {
+            Ok(()) => {
+                self.memory_bytes.fetch_add(size_bytes, Ordering::Relaxed);
+                None
+            }
+            Err(returned) => Some(returned),
+        }
+    }
+
+    /// Push an item onto the queue, spinning with backoff if full.
+    ///
+    /// `size_bytes` is added to the shared memory counter on success so that
+    /// any concurrent reader of [`WorkQueue::memory_bytes`] sees the item's footprint
+    /// as soon as it enters the queue.
+    ///
+    /// This spins with exponential backoff when the queue is full: the first few
+    /// attempts yield the thread, then subsequent attempts sleep for 1 µs … 128 µs.
+    /// The output queues are sized large enough (4096 slots) that persistent fullness
+    /// is rare — this naturally applies backpressure as downstream stages drain.
+    ///
+    /// Use this for producer threads that must block when the queue is full (e.g. the
+    /// position batcher feeding the pipeline entry point).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the queue has been closed (no more items should be pushed).
+    pub fn push_blocking(&self, item: T, size_bytes: usize) -> anyhow::Result<()> {
+        let mut current = item;
+        let mut attempts: u32 = 0;
+        loop {
+            // Check for closure/cancellation before attempting to push, not just after failure.
+            if self.closed.load(Ordering::Acquire) {
+                anyhow::bail!("queue '{}' is closed", self.name);
+            }
+            match self.inner.push(current) {
+                Ok(()) => {
+                    self.memory_bytes.fetch_add(size_bytes, Ordering::Relaxed);
+                    return Ok(());
+                }
+                Err(returned) => {
+                    current = returned;
+                    attempts += 1;
+                    if attempts < 4 {
+                        std::thread::yield_now();
+                    } else {
+                        // Exponential backoff: 1, 2, 4, 8, … up to 128 µs.
+                        let shift = (attempts - 4).min(7);
+                        std::thread::sleep(std::time::Duration::from_micros(1 << shift));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Blocking pop. Spins with `thread::yield_now()` until an item is available
+    /// or the queue is closed, empty, and no items are in flight.
+    ///
+    /// Returns `None` when the queue is fully done (no more items will arrive).
+    ///
+    /// On success, increments the in-flight counter. The caller **must** call
+    /// [`WorkQueue::complete_in_flight`] after the popped item's result has been
+    /// pushed to the downstream queue (or otherwise fully handled).
+    #[must_use]
+    pub fn pop(&self) -> Option<T> {
+        let mut attempts: u32 = 0;
+        loop {
+            if let Some(item) = self.inner.pop() {
+                self.in_flight.fetch_add(1, Ordering::AcqRel);
+                return Some(item);
+            }
+            if self.is_closed_and_empty() {
+                return None;
+            }
+            attempts += 1;
+            if attempts < 4 {
+                std::thread::yield_now();
+            } else {
+                let shift = (attempts - 4).min(7);
+                std::thread::sleep(std::time::Duration::from_micros(1 << shift));
+            }
+        }
+    }
+
+    /// Non-blocking pop. Returns `None` if the queue is currently empty.
+    ///
+    /// On success, increments the in-flight counter. The caller **must** call
+    /// [`WorkQueue::complete_in_flight`] after the popped item's result has been
+    /// pushed to the downstream queue (or otherwise fully handled).
+    #[must_use]
+    pub fn try_pop(&self) -> Option<T> {
+        let item = self.inner.pop()?;
+        self.in_flight.fetch_add(1, Ordering::AcqRel);
+        Some(item)
+    }
+
+    /// Decrement the memory counter by `size_bytes`.
+    ///
+    /// Callers must invoke this after fully processing each popped item so that the
+    /// memory accounting stays accurate and [`WorkQueue::memory_available`] remains
+    /// meaningful for backpressure decisions.
+    pub fn release_memory(&self, size_bytes: usize) {
+        self.memory_bytes.fetch_sub(size_bytes, Ordering::Relaxed);
+    }
+
+    /// Return the current approximate memory usage tracked by this queue, in bytes.
+    #[must_use]
+    pub fn memory_bytes(&self) -> usize {
+        self.memory_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Return `true` if the tracked memory usage is below the configured limit.
+    ///
+    /// This is a soft check; the queue does not enforce the limit — callers should
+    /// consult this before deciding whether to push additional work.
+    #[must_use]
+    pub fn memory_available(&self) -> bool {
+        self.memory_bytes() < self.memory_limit
+    }
+
+    /// Return the queue's slot capacity.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// Return the fill ratio (0.0 to 1.0) for backpressure decisions.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "queue lengths are small enough that f32 precision is sufficient"
+    )]
+    #[must_use]
+    pub fn fill_ratio(&self) -> f32 {
+        self.len() as f32 / self.capacity() as f32
+    }
+
+    /// Return the ratio of current memory usage to the configured memory limit.
+    ///
+    /// A value >= 1.0 means memory usage meets or exceeds the limit.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "memory values are approximate for backpressure decisions"
+    )]
+    #[must_use]
+    pub fn memory_ratio(&self) -> f32 {
+        debug_assert!(self.memory_limit > 0, "memory_limit must be positive");
+        self.memory_bytes() as f32 / self.memory_limit as f32
+    }
+
+    /// Return `true` if the underlying queue currently holds no items.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Return the number of items currently buffered in the queue.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Return the static name assigned to this queue.
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Signal that one in-flight item has been fully processed and its result
+    /// pushed to the downstream queue.
+    ///
+    /// Must be called exactly once per successful [`try_pop`](WorkQueue::try_pop) or
+    /// [`pop`](WorkQueue::pop) call, after the downstream push is complete.
+    pub fn complete_in_flight(&self) {
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    /// Mark the queue as closed. No more items should be pushed after this call.
+    ///
+    /// Existing items can still be popped. This is used to signal that the upstream
+    /// producer has finished and no further work will arrive.
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    /// Returns `true` if the queue has been closed, is currently empty, **and** no
+    /// items are in flight (being processed by workers between pop and downstream push).
+    ///
+    /// This three-way check prevents premature close cascades: a queue is only truly
+    /// done when all popped items have been fully processed and their results pushed
+    /// downstream.
+    #[must_use]
+    pub fn is_closed_and_empty(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+            && self.inner.is_empty()
+            && self.in_flight.load(Ordering::Acquire) == 0
+    }
+}
+
+impl<T> Clone for WorkQueue<T> {
+    /// Clone the queue, sharing the same underlying queue and memory counter.
+    ///
+    /// All clones participate in the same queue; a push on any clone is
+    /// visible to a pop on any other clone.
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            memory_bytes: Arc::clone(&self.memory_bytes),
+            memory_limit: self.memory_limit,
+            name: self.name,
+            closed: Arc::clone(&self.closed),
+            in_flight: Arc::clone(&self.in_flight),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_pop() {
+        let q: WorkQueue<u32> = WorkQueue::new(4, 1024, "test");
+        q.push_blocking(42, 4).unwrap();
+        let item = q.pop().unwrap();
+        assert_eq!(item, 42);
+    }
+
+    #[test]
+    fn test_memory_tracking() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "mem-test");
+
+        q.push_blocking(1, 100).unwrap();
+        q.push_blocking(2, 200).unwrap();
+        assert_eq!(q.memory_bytes(), 300);
+
+        // Pop and release the first item.
+        let _ = q.pop().unwrap();
+        q.release_memory(100);
+        assert_eq!(q.memory_bytes(), 200);
+
+        // Pop and release the second item.
+        let _ = q.pop().unwrap();
+        q.release_memory(200);
+        assert_eq!(q.memory_bytes(), 0);
+    }
+
+    #[test]
+    fn test_try_pop_empty() {
+        let q: WorkQueue<u32> = WorkQueue::new(4, 1024, "empty-test");
+        assert!(q.try_pop().is_none());
+    }
+
+    #[test]
+    fn test_bounded_capacity() {
+        let q: WorkQueue<u32> = WorkQueue::new(2, usize::MAX, "bounded-test");
+
+        // Fill to capacity.
+        assert!(q.push(1, 0).is_none());
+        assert!(q.push(2, 0).is_none());
+
+        // Queue is full — push should return Some(item).
+        let result = q.push(3, 0);
+        assert_eq!(result, Some(3), "expected Some(3) when queue is full");
+
+        // Drain and confirm items arrive in order.
+        assert_eq!(q.pop().unwrap(), 1);
+        assert_eq!(q.pop().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_memory_available() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, 500, "avail-test");
+        assert!(q.memory_available());
+
+        q.push_blocking(1, 400).unwrap();
+        assert!(q.memory_available()); // 400 < 500
+
+        q.push_blocking(2, 101).unwrap();
+        assert!(!q.memory_available()); // 501 >= 500
+
+        let _ = q.pop().unwrap();
+        q.release_memory(400);
+        assert!(q.memory_available()); // back to 101 < 500
+    }
+
+    #[test]
+    fn test_clone_shares_channel() {
+        let q1: WorkQueue<u32> = WorkQueue::new(4, 1024, "clone-test");
+        let q2 = q1.clone();
+
+        q1.push_blocking(99, 8).unwrap();
+        assert_eq!(q2.memory_bytes(), 8);
+
+        let item = q2.pop().unwrap();
+        assert_eq!(item, 99);
+
+        q2.release_memory(8);
+        assert_eq!(q1.memory_bytes(), 0);
+    }
+
+    #[test]
+    fn test_close_and_is_closed_and_empty() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "close-test");
+
+        // Not closed initially.
+        assert!(!q.is_closed_and_empty());
+
+        // Closed but not empty.
+        q.push_blocking(1, 4).unwrap();
+        q.close();
+        assert!(!q.is_closed_and_empty());
+
+        // Closed and empty after draining, but still in-flight.
+        let _ = q.pop().unwrap();
+        assert!(!q.is_closed_and_empty()); // in_flight == 1
+
+        // Truly done after completing in-flight.
+        q.complete_in_flight();
+        assert!(q.is_closed_and_empty());
+    }
+
+    #[test]
+    fn test_close_shared_across_clones() {
+        let q1: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "clone-close-test");
+        let q2 = q1.clone();
+
+        q1.close();
+        assert!(q2.is_closed_and_empty());
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "len-test");
+        assert!(q.is_empty());
+        assert_eq!(q.len(), 0);
+
+        q.push_blocking(1, 0).unwrap();
+        q.push_blocking(2, 0).unwrap();
+        assert!(!q.is_empty());
+        assert_eq!(q.len(), 2);
+
+        let _ = q.pop();
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn test_pop_returns_none_when_closed_and_empty() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "pop-close-test");
+        q.close();
+        assert!(q.pop().is_none());
+    }
+
+    #[test]
+    fn test_pop_drains_before_returning_none() {
+        let q: WorkQueue<u32> = WorkQueue::new(8, usize::MAX, "pop-drain-test");
+        q.push_blocking(1, 0).unwrap();
+        q.push_blocking(2, 0).unwrap();
+        q.close();
+
+        assert_eq!(q.pop().unwrap(), 1);
+        q.complete_in_flight();
+        assert_eq!(q.pop().unwrap(), 2);
+        q.complete_in_flight();
+        assert!(q.pop().is_none());
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/reorder.rs
+++ b/crates/fgumi-pipeline/src/pipeline/reorder.rs
@@ -1,0 +1,151 @@
+//! Reorder buffer for reassembling out-of-order items into sequence order.
+
+use std::collections::VecDeque;
+
+/// A buffer that reassembles out-of-order items into sequence order.
+///
+/// Items are inserted with sequence numbers. [`try_next`](ReorderBuffer::try_next) returns items
+/// in sequence order as they become available.
+///
+/// Internally uses a `VecDeque<Option<T>>` indexed by offset from `next_expected`,
+/// giving O(1) insert and O(1) pop with better cache locality than a `HashMap`.
+pub struct ReorderBuffer<T> {
+    pending: VecDeque<Option<T>>,
+    next_expected: u64,
+}
+
+impl<T> ReorderBuffer<T> {
+    /// Create a new empty reorder buffer starting at sequence number 0.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { pending: VecDeque::new(), next_expected: 0 }
+    }
+
+    /// Insert an item at the given sequence number. Items may be inserted in any order.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "reorder buffer offset from next_expected always fits in usize in practice"
+    )]
+    pub fn insert(&mut self, seq: u64, item: T) {
+        debug_assert!(
+            seq >= self.next_expected,
+            "ReorderBuffer::insert: seq {seq} < next_expected {}",
+            self.next_expected
+        );
+        let idx = (seq - self.next_expected) as usize;
+        // Extend with None slots if the sequence number is beyond the current length.
+        if idx >= self.pending.len() {
+            self.pending.resize_with(idx + 1, || None);
+        }
+        self.pending[idx] = Some(item);
+    }
+
+    /// Get the next item in sequence order, if available.
+    ///
+    /// Returns `Some(item)` if the item with sequence number `next_expected` is present,
+    /// advancing `next_expected` by one. Returns `None` otherwise.
+    pub fn try_next(&mut self) -> Option<T> {
+        if self.pending.front().is_some_and(Option::is_some) {
+            self.next_expected += 1;
+            self.pending.pop_front().flatten()
+        } else {
+            None
+        }
+    }
+
+    /// Drain all consecutive available items starting from `next_expected`.
+    ///
+    /// Returns a `Vec` of items in sequence order. Stops as soon as there is a gap.
+    pub fn drain_ready(&mut self) -> Vec<T> {
+        let mut result = Vec::new();
+        while let Some(item) = self.try_next() {
+            result.push(item);
+        }
+        result
+    }
+
+    /// Number of items buffered but not yet emitted.
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.pending.iter().filter(|slot| slot.is_some()).count()
+    }
+
+    /// The next expected sequence number.
+    #[must_use]
+    pub fn next_expected(&self) -> u64 {
+        self.next_expected
+    }
+
+    /// Returns `true` if no items are buffered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pending.iter().all(Option::is_none)
+    }
+}
+
+impl<T> Default for ReorderBuffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_in_order_passthrough() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new();
+        buf.insert(0, 10);
+        buf.insert(1, 20);
+        buf.insert(2, 30);
+
+        assert_eq!(buf.try_next(), Some(10));
+        assert_eq!(buf.try_next(), Some(20));
+        assert_eq!(buf.try_next(), Some(30));
+        assert_eq!(buf.try_next(), None);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_out_of_order() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new();
+
+        // Insert out of order: 2, then 0, then 1
+        buf.insert(2, 30);
+        assert_eq!(buf.try_next(), None); // seq 0 not yet available
+
+        buf.insert(0, 10);
+        assert_eq!(buf.try_next(), Some(10)); // seq 0 now available
+
+        // seq 1 not yet available
+        assert_eq!(buf.try_next(), None);
+
+        buf.insert(1, 20);
+        let ready = buf.drain_ready();
+        assert_eq!(ready, vec![20, 30]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_drain_ready() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new();
+        buf.insert(0, 10);
+        buf.insert(1, 20);
+        buf.insert(2, 30);
+        buf.insert(5, 60); // gap at 3 and 4
+
+        let ready = buf.drain_ready();
+        assert_eq!(ready, vec![10, 20, 30]);
+        assert_eq!(buf.pending_count(), 1);
+        assert_eq!(buf.next_expected(), 3);
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new();
+        assert_eq!(buf.try_next(), None);
+        assert!(buf.is_empty());
+        assert_eq!(buf.pending_count(), 0);
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/scheduler.rs
+++ b/crates/fgumi-pipeline/src/pipeline/scheduler.rs
@@ -1,0 +1,1523 @@
+//! Sticky-consensus scheduler for Zone 3 pipeline stages.
+//!
+//! Most workers stay on Consensus (the CPU bottleneck). One dedicated writer prevents Write
+//! contention. When a worker's current step has no work, it chases downstream to drain the
+//! pipeline.
+//!
+//! Each worker owns a [`WorkerState`] with held-item slots, enabling non-blocking push:
+//! when an output queue is full, the item is stored in the worker's state and retried on the
+//! next iteration. This eliminates the per-item spin-wait of the old blocking push.
+
+use std::io::Write;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use anyhow::{Result, anyhow};
+use crossbeam_channel::{Receiver, Sender};
+
+use crate::pipeline::WorkQueue;
+use crate::pipeline::reorder::ReorderBuffer;
+use crate::pipeline::stats::StageStats;
+use crate::pipeline::worker_util::{WorkerBackoff, panic_message};
+use crate::stage::{PipelineStage, SequencedItem};
+use crate::stages::compress::CompressedBatch;
+use crate::stages::group_assign::{MiGroup, PositionGroupBatch};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Number of pipeline stages.
+const NUM_STAGES: usize = 5;
+/// Number of stages that can hold items (all except Write).
+const NUM_HOLDABLE: usize = 4;
+
+/// Stage indices.
+const GROUP_ASSIGN: usize = 0;
+const CONSENSUS: usize = 1;
+const FILTER: usize = 2;
+const COMPRESS: usize = 3;
+const WRITE: usize = 4;
+
+// ============================================================================
+// StepResult
+// ============================================================================
+
+/// Result of attempting a pipeline step.
+#[derive(Debug)]
+pub enum StepResult {
+    /// Successfully processed and pushed an item.
+    Success,
+    /// Output queue is full. Item is held in worker state.
+    OutputFull,
+    /// Input queue is empty or closed.
+    InputEmpty,
+    /// Processing error. The caller should propagate this and cancel.
+    Error(anyhow::Error),
+}
+
+// ============================================================================
+// PipelineStep / BackpressureState
+// ============================================================================
+
+/// The five pipeline stages in the runall pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipelineStep {
+    GroupAssign = 0,
+    Consensus = 1,
+    Filter = 2,
+    Compress = 3,
+    Write = 4,
+}
+
+impl PipelineStep {
+    /// Convert an index (0..5) to a `PipelineStep`.
+    #[cfg(test)]
+    fn from_index(idx: usize) -> Self {
+        match idx {
+            0 => Self::GroupAssign,
+            1 => Self::Consensus,
+            2 => Self::Filter,
+            3 => Self::Compress,
+            4 => Self::Write,
+            _ => panic!("invalid PipelineStep index: {idx}"),
+        }
+    }
+}
+
+/// Backpressure signals sampled from queue state each iteration.
+pub struct BackpressureState {
+    /// True when `q_compressed` (Compress output) exceeds high-water mark.
+    pub output_high: bool,
+    /// True when `q_mi_batch` memory tracker is at or above limit.
+    pub memory_high: bool,
+}
+
+impl BackpressureState {
+    /// Sample current backpressure state from the `StageGraph`'s queues.
+    #[must_use]
+    pub fn sample(graph: &StageGraph) -> Self {
+        Self {
+            output_high: graph.q_compressed.fill_ratio() > super::BACKPRESSURE_HIGH_WATERMARK,
+            memory_high: graph.q_mi_batch.memory_ratio() >= 1.0,
+        }
+    }
+}
+
+// ============================================================================
+// PipelineScheduler — sticky-consensus strategy
+// ============================================================================
+
+/// Thread role within the runall pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerRole {
+    /// Worker N-1: tries Write first, then Consensus.
+    WritePreferred,
+    /// Worker 1: tries `GroupAssign` first, then Consensus (only when >= 4 workers).
+    GroupAssignPreferred,
+    /// Workers 2..N-2: sticky on Consensus, chase downstream on idle.
+    ConsensusWorker,
+}
+
+/// Per-worker scheduler for the runall pipeline.
+///
+/// Uses a sticky-consensus strategy: most workers stay on Consensus (the CPU bottleneck,
+/// 49% of time). One dedicated writer prevents Write contention. When a worker's current
+/// step has no work, it chases downstream to drain the pipeline.
+pub struct PipelineScheduler {
+    /// Current preferred step — stays on last successful step.
+    current_step: PipelineStep,
+    /// Priority output buffer.
+    priority_buffer: [PipelineStep; NUM_STAGES],
+    /// Thread role.
+    pub role: WorkerRole,
+}
+
+impl PipelineScheduler {
+    /// Create a new scheduler for the given worker.
+    #[must_use]
+    pub fn new(worker_id: usize, num_workers: usize) -> Self {
+        let role = if worker_id == num_workers.saturating_sub(1) {
+            WorkerRole::WritePreferred
+        } else if worker_id == 1 && num_workers >= 4 {
+            WorkerRole::GroupAssignPreferred
+        } else {
+            WorkerRole::ConsensusWorker
+        };
+
+        let current_step = match role {
+            WorkerRole::WritePreferred => PipelineStep::Compress,
+            WorkerRole::GroupAssignPreferred => PipelineStep::GroupAssign,
+            WorkerRole::ConsensusWorker => PipelineStep::Consensus,
+        };
+
+        Self { current_step, priority_buffer: [PipelineStep::GroupAssign; NUM_STAGES], role }
+    }
+
+    /// Build priority list based on current state and backpressure signals.
+    ///
+    /// Priority logic:
+    /// 1. Exclusive role step first (if any)
+    /// 2. Current step (sticky on last success)
+    /// 3. Chase downstream: Filter -> Compress -> Write
+    /// 4. Chase upstream: `GroupAssign`
+    /// 5. Remaining steps
+    ///
+    /// Backpressure override: if `output_high`, move Compress to front (after exclusive role).
+    pub fn get_priorities(&mut self, bp: &BackpressureState) -> &[PipelineStep; NUM_STAGES] {
+        let mut buf: [PipelineStep; NUM_STAGES] = [PipelineStep::GroupAssign; NUM_STAGES];
+        let mut len = 0;
+
+        let mut push = |step: PipelineStep| {
+            if !buf[..len].contains(&step) {
+                buf[len] = step;
+                len += 1;
+            }
+        };
+
+        // 1. Exclusive role step first.
+        match self.role {
+            WorkerRole::WritePreferred => push(PipelineStep::Write),
+            WorkerRole::GroupAssignPreferred => push(PipelineStep::GroupAssign),
+            WorkerRole::ConsensusWorker => {}
+        }
+
+        // Backpressure override: if output_high, Compress goes right after exclusive role.
+        if bp.output_high {
+            push(PipelineStep::Compress);
+        }
+
+        // 2. Current step (sticky).
+        push(self.current_step);
+
+        // 3. Chase downstream: Filter -> Compress -> Write.
+        push(PipelineStep::Filter);
+        push(PipelineStep::Compress);
+        push(PipelineStep::Write);
+
+        // 4. Chase upstream: Consensus -> GroupAssign.
+        push(PipelineStep::Consensus);
+        push(PipelineStep::GroupAssign);
+
+        self.priority_buffer = buf;
+        &self.priority_buffer
+    }
+
+    /// Record outcome of attempting a step.
+    ///
+    /// On success, the current step becomes sticky on the successful step.
+    /// Special pivots: `WritePreferred` pivots to Compress after Write,
+    /// `GroupAssignPreferred` pivots to Consensus after `GroupAssign`.
+    pub fn record_outcome(&mut self, step: PipelineStep, success: bool) {
+        if success {
+            self.current_step = match self.role {
+                WorkerRole::WritePreferred if step == PipelineStep::Write => PipelineStep::Compress,
+                WorkerRole::GroupAssignPreferred if step == PipelineStep::GroupAssign => {
+                    PipelineStep::Consensus
+                }
+                _ => step,
+            };
+        }
+        // On failure: leave current_step unchanged; the priority list naturally tries
+        // the next step.
+    }
+}
+
+// ============================================================================
+// WorkerStats — per-worker comprehensive statistics
+// ============================================================================
+
+/// Per-worker statistics for pipeline diagnostics.
+///
+/// Each worker owns its own `WorkerStats` instance — no cross-thread
+/// contention on stat counters.
+pub struct WorkerStats {
+    /// Per-stage: number of times `try_step_*` was called.
+    pub stage_attempts: [AtomicU64; NUM_STAGES],
+    /// Per-stage: number of successful `try_step_*` calls.
+    pub stage_successes: [AtomicU64; NUM_STAGES],
+    /// Per-stage: cumulative nanoseconds spent in `process()` calls.
+    pub stage_nanos: [AtomicU64; NUM_STAGES],
+    /// Per-stage: cumulative items processed.
+    pub stage_items: [AtomicU64; NUM_STAGES],
+
+    /// Number of failed `try_lock` attempts on the write mutex.
+    pub write_lock_contention: AtomicU64,
+    /// Per-stage: number of times `push()` returned full.
+    pub push_full_count: [AtomicU64; NUM_STAGES],
+    /// Per-stage: number of times `try_pop()` returned None.
+    pub pop_empty_count: [AtomicU64; NUM_STAGES],
+
+    /// Per-holdable-stage: number of times an item was held.
+    pub held_count: [AtomicU64; NUM_HOLDABLE],
+
+    /// Number of full iterations where no work was found.
+    pub idle_cycles: AtomicU64,
+    /// Cumulative nanoseconds spent in backoff sleep.
+    pub idle_nanos: AtomicU64,
+}
+
+impl WorkerStats {
+    /// Create a new zeroed stats instance.
+    fn new() -> Self {
+        Self {
+            stage_attempts: std::array::from_fn(|_| AtomicU64::new(0)),
+            stage_successes: std::array::from_fn(|_| AtomicU64::new(0)),
+            stage_nanos: std::array::from_fn(|_| AtomicU64::new(0)),
+            stage_items: std::array::from_fn(|_| AtomicU64::new(0)),
+            write_lock_contention: AtomicU64::new(0),
+            push_full_count: std::array::from_fn(|_| AtomicU64::new(0)),
+            pop_empty_count: std::array::from_fn(|_| AtomicU64::new(0)),
+            held_count: std::array::from_fn(|_| AtomicU64::new(0)),
+            idle_cycles: AtomicU64::new(0),
+            idle_nanos: AtomicU64::new(0),
+        }
+    }
+}
+
+// ============================================================================
+// WorkerState — per-worker mutable state
+// ============================================================================
+
+/// Per-worker mutable state for all stages.
+///
+/// Each worker thread owns one `WorkerState`. Held items are stored here
+/// when an output queue is full, enabling non-blocking push semantics.
+pub struct WorkerState {
+    /// Worker ID (0-indexed).
+    pub worker_id: usize,
+
+    // Held output items for each inter-stage queue. Each held item is paired with
+    // the input memory estimate needed to call `release_memory()` on the input queue
+    // when the held item is finally pushed.
+    held_group_assign: Option<(SequencedItem<Vec<MiGroup>>, usize)>,
+    held_consensus: Option<(SequencedItem<fgumi_consensus::caller::ConsensusOutput>, usize)>,
+    held_filter: Option<(SequencedItem<Vec<u8>>, usize)>,
+    held_compress: Option<(SequencedItem<CompressedBatch>, usize)>,
+
+    /// Adaptive backoff with jitter.
+    backoff: WorkerBackoff,
+
+    /// Sticky-consensus scheduler — determines priority order each iteration.
+    pub scheduler: PipelineScheduler,
+    /// Per-worker stats.
+    pub stats: WorkerStats,
+}
+
+impl WorkerState {
+    /// Create a new `WorkerState` for the given worker.
+    #[must_use]
+    pub fn new(worker_id: usize, num_workers: usize) -> Self {
+        Self {
+            worker_id,
+            held_group_assign: None,
+            held_consensus: None,
+            held_filter: None,
+            held_compress: None,
+            backoff: WorkerBackoff::new(worker_id),
+            scheduler: PipelineScheduler::new(worker_id, num_workers),
+            stats: WorkerStats::new(),
+        }
+    }
+
+    /// Returns `true` if this worker is holding any items.
+    pub fn has_any_held_items(&self) -> bool {
+        self.held_group_assign.is_some()
+            || self.held_consensus.is_some()
+            || self.held_filter.is_some()
+            || self.held_compress.is_some()
+    }
+
+    /// Reset backoff to zero on successful work.
+    pub fn reset_backoff(&mut self) {
+        self.backoff.reset();
+    }
+
+    /// Sleep for the current backoff duration with per-worker jitter.
+    pub fn sleep_backoff(&mut self) {
+        self.backoff.sleep();
+    }
+
+    /// Increase backoff exponentially.
+    pub fn increase_backoff(&mut self) {
+        self.backoff.increase();
+    }
+
+    /// Log comprehensive stats for this worker.
+    #[expect(clippy::cast_precision_loss, reason = "nanos fits in f64 for display")]
+    pub fn log_stats(&self) {
+        let role = match self.scheduler.role {
+            WorkerRole::WritePreferred => " (write-preferred)",
+            WorkerRole::GroupAssignPreferred => " (group-assign-preferred)",
+            WorkerRole::ConsensusWorker => " (consensus-worker)",
+        };
+        log::info!("  Worker {}{role}:", self.worker_id);
+
+        let stage_names = ["group_assign", "consensus", "filter", "compress", "write"];
+        for (idx, name) in stage_names.iter().enumerate() {
+            let attempts = self.stats.stage_attempts[idx].load(Ordering::Relaxed);
+            let successes = self.stats.stage_successes[idx].load(Ordering::Relaxed);
+            let nanos = self.stats.stage_nanos[idx].load(Ordering::Relaxed);
+            let items = self.stats.stage_items[idx].load(Ordering::Relaxed);
+            let empty = self.stats.pop_empty_count[idx].load(Ordering::Relaxed);
+            let full = self.stats.push_full_count[idx].load(Ordering::Relaxed);
+            let secs = nanos as f64 / 1_000_000_000.0;
+            log::info!(
+                "    {name:<14} {attempts:>8} attempts, {successes:>8} success, \
+                 {items:>8} items, {empty:>6} empty, {full:>6} full, {secs:.2}s"
+            );
+        }
+
+        let contention = self.stats.write_lock_contention.load(Ordering::Relaxed);
+        if contention > 0 {
+            log::info!("    write_contention: {contention}");
+        }
+
+        let held_names = ["group_assign", "consensus", "filter", "compress"];
+        for (idx, name) in held_names.iter().enumerate() {
+            let held = self.stats.held_count[idx].load(Ordering::Relaxed);
+            if held > 0 {
+                log::info!("    {name:<14} {held:>8} held");
+            }
+        }
+
+        let idle_cycles = self.stats.idle_cycles.load(Ordering::Relaxed);
+        let idle_nanos = self.stats.idle_nanos.load(Ordering::Relaxed);
+        let idle_secs = idle_nanos as f64 / 1_000_000_000.0;
+        log::info!("    idle: {idle_cycles} cycles, {idle_secs:.3}s");
+    }
+}
+
+// ============================================================================
+// WriteState — shared mutable state for the write stage
+// ============================================================================
+
+/// Shared mutable state for the write stage, protected by a [`Mutex`].
+///
+/// Any worker thread (or the calling thread) can acquire the lock and perform writes.
+pub struct WriteState {
+    /// Output file handle.
+    pub(crate) file: std::fs::File,
+    /// Reorder buffer ensuring compressed batches are written in sequence order.
+    pub(crate) reorder_buf: ReorderBuffer<CompressedBatch>,
+    /// Counter tracking how many compressed batches have been written.
+    pub(crate) batches_written: u64,
+}
+
+// ============================================================================
+// StageGraph — typed stage graph replacing opaque closures
+// ============================================================================
+
+/// The typed stage graph for the runall pipeline.
+///
+/// Holds `Arc` references to all stages and queues. Shared (immutable) across
+/// all worker threads. Workers iterate stages via the `try_step_*` functions,
+/// using their own [`WorkerState`] for held items.
+pub struct StageGraph {
+    // Stages.
+    pub(crate) group_assign:
+        Arc<dyn PipelineStage<Input = PositionGroupBatch, Output = Vec<MiGroup>>>,
+    pub(crate) consensus: Arc<
+        dyn PipelineStage<Input = Vec<MiGroup>, Output = fgumi_consensus::caller::ConsensusOutput>,
+    >,
+    pub(crate) filter:
+        Arc<dyn PipelineStage<Input = fgumi_consensus::caller::ConsensusOutput, Output = Vec<u8>>>,
+    pub(crate) compress: Arc<dyn PipelineStage<Input = Vec<u8>, Output = CompressedBatch>>,
+
+    // Queues (ordered upstream to downstream).
+    pub(crate) q_position_batch: WorkQueue<SequencedItem<PositionGroupBatch>>,
+    pub(crate) q_mi_batch: WorkQueue<SequencedItem<Vec<MiGroup>>>,
+    pub(crate) q_consensus: WorkQueue<SequencedItem<fgumi_consensus::caller::ConsensusOutput>>,
+    pub(crate) q_filtered: WorkQueue<SequencedItem<Vec<u8>>>,
+    pub(crate) q_compressed: WorkQueue<SequencedItem<CompressedBatch>>,
+
+    // Write state (mutex-protected, highest priority).
+    pub(crate) write_state: Arc<Mutex<WriteState>>,
+
+    // Per-stage stats.
+    pub(crate) stats: [Arc<StageStats>; NUM_STAGES],
+
+    // Cancellation.
+    pub(crate) cancel: Arc<AtomicBool>,
+}
+
+// ============================================================================
+// try_push_held_* — advance held items from previous iteration
+// ============================================================================
+
+/// Try to push a held `group_assign` output. Returns true if pushed.
+pub(crate) fn try_push_held_group_assign(graph: &StageGraph, worker: &mut WorkerState) -> bool {
+    let Some((held, input_mem)) = worker.held_group_assign.take() else {
+        return false;
+    };
+    let output_mem = held.memory_estimate;
+    if let Some(returned) = graph.q_mi_batch.push(held, output_mem) {
+        // Still full — put it back.
+        worker.held_group_assign = Some((returned, input_mem));
+        false
+    } else {
+        // Successfully pushed.
+        graph.q_position_batch.complete_in_flight();
+        graph.q_position_batch.release_memory(input_mem);
+        true
+    }
+}
+
+/// Try to push a held consensus output. Returns true if pushed.
+pub(crate) fn try_push_held_consensus(graph: &StageGraph, worker: &mut WorkerState) -> bool {
+    let Some((held, input_mem)) = worker.held_consensus.take() else {
+        return false;
+    };
+    let output_mem = held.memory_estimate;
+    if let Some(returned) = graph.q_consensus.push(held, output_mem) {
+        worker.held_consensus = Some((returned, input_mem));
+        false
+    } else {
+        graph.q_mi_batch.complete_in_flight();
+        graph.q_mi_batch.release_memory(input_mem);
+        true
+    }
+}
+
+/// Try to push a held filter output. Returns true if pushed.
+pub(crate) fn try_push_held_filter(graph: &StageGraph, worker: &mut WorkerState) -> bool {
+    let Some((held, input_mem)) = worker.held_filter.take() else {
+        return false;
+    };
+    let output_mem = held.memory_estimate;
+    if let Some(returned) = graph.q_filtered.push(held, output_mem) {
+        worker.held_filter = Some((returned, input_mem));
+        false
+    } else {
+        graph.q_consensus.complete_in_flight();
+        graph.q_consensus.release_memory(input_mem);
+        true
+    }
+}
+
+/// Try to push a held compress output. Returns true if pushed.
+pub(crate) fn try_push_held_compress(graph: &StageGraph, worker: &mut WorkerState) -> bool {
+    let Some((held, input_mem)) = worker.held_compress.take() else {
+        return false;
+    };
+    let output_mem = held.memory_estimate;
+    if let Some(returned) = graph.q_compressed.push(held, output_mem) {
+        worker.held_compress = Some((returned, input_mem));
+        false
+    } else {
+        graph.q_filtered.complete_in_flight();
+        graph.q_filtered.release_memory(input_mem);
+        true
+    }
+}
+
+// ============================================================================
+// try_step_* — one per pipeline stage
+// ============================================================================
+
+/// Attempt one unit of group-assign work.
+pub(crate) fn try_step_group_assign(graph: &StageGraph, worker: &mut WorkerState) -> StepResult {
+    worker.stats.stage_attempts[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+
+    // 1. If holding an item from a previous iteration, try to push it first.
+    if let Some((held, input_mem)) = worker.held_group_assign.take() {
+        let output_mem = held.memory_estimate;
+        if let Some(returned) = graph.q_mi_batch.push(held, output_mem) {
+            worker.held_group_assign = Some((returned, input_mem));
+            worker.stats.push_full_count[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+            return StepResult::OutputFull;
+        }
+        graph.q_position_batch.complete_in_flight();
+        graph.q_position_batch.release_memory(input_mem);
+        // Held item pushed — fall through to try new input.
+    }
+
+    // 2. Pop input.
+    let Some(input) = graph.q_position_batch.try_pop() else {
+        worker.stats.pop_empty_count[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+        if graph.q_position_batch.is_closed_and_empty() {
+            graph.q_mi_batch.close();
+        }
+        return StepResult::InputEmpty;
+    };
+    let input_mem = input.memory_estimate;
+
+    // 3. Process.
+    let start = Instant::now();
+    let result = match graph.group_assign.process(input.item) {
+        Ok(r) => r,
+        Err(e) => {
+            graph.q_position_batch.complete_in_flight();
+            graph.q_position_batch.release_memory(input_mem);
+            return StepResult::Error(e);
+        }
+    };
+    #[expect(clippy::cast_possible_truncation, reason = "elapsed nanos won't exceed u64")]
+    let elapsed_nanos = start.elapsed().as_nanos() as u64;
+    worker.stats.stage_nanos[GROUP_ASSIGN].fetch_add(elapsed_nanos, Ordering::Relaxed);
+    graph.stats[GROUP_ASSIGN].record(elapsed_nanos, 1);
+
+    let output_mem = graph.group_assign.output_memory_estimate(&result);
+    let output = SequencedItem::new(input.seq, result, output_mem);
+
+    // 4. Push or hold.
+    if let Some(returned) = graph.q_mi_batch.push(output, output_mem) {
+        worker.held_group_assign = Some((returned, input_mem));
+        worker.stats.push_full_count[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+        worker.stats.held_count[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+        StepResult::OutputFull
+    } else {
+        graph.q_position_batch.complete_in_flight();
+        graph.q_position_batch.release_memory(input_mem);
+        worker.stats.stage_successes[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+        worker.stats.stage_items[GROUP_ASSIGN].fetch_add(1, Ordering::Relaxed);
+        StepResult::Success
+    }
+}
+
+/// Attempt one unit of consensus work.
+pub(crate) fn try_step_consensus(graph: &StageGraph, worker: &mut WorkerState) -> StepResult {
+    worker.stats.stage_attempts[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+
+    if let Some((held, input_mem)) = worker.held_consensus.take() {
+        let output_mem = held.memory_estimate;
+        if let Some(returned) = graph.q_consensus.push(held, output_mem) {
+            worker.held_consensus = Some((returned, input_mem));
+            worker.stats.push_full_count[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+            return StepResult::OutputFull;
+        }
+        graph.q_mi_batch.complete_in_flight();
+        graph.q_mi_batch.release_memory(input_mem);
+    }
+
+    let Some(input) = graph.q_mi_batch.try_pop() else {
+        worker.stats.pop_empty_count[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+        if graph.q_mi_batch.is_closed_and_empty() {
+            graph.q_consensus.close();
+        }
+        return StepResult::InputEmpty;
+    };
+    let input_mem = input.memory_estimate;
+
+    let start = Instant::now();
+    let result = match graph.consensus.process(input.item) {
+        Ok(r) => r,
+        Err(e) => {
+            graph.q_mi_batch.complete_in_flight();
+            graph.q_mi_batch.release_memory(input_mem);
+            return StepResult::Error(e);
+        }
+    };
+    #[expect(clippy::cast_possible_truncation, reason = "elapsed nanos won't exceed u64")]
+    let elapsed_nanos = start.elapsed().as_nanos() as u64;
+    worker.stats.stage_nanos[CONSENSUS].fetch_add(elapsed_nanos, Ordering::Relaxed);
+    graph.stats[CONSENSUS].record(elapsed_nanos, 1);
+
+    let output_mem = graph.consensus.output_memory_estimate(&result);
+    let output = SequencedItem::new(input.seq, result, output_mem);
+
+    if let Some(returned) = graph.q_consensus.push(output, output_mem) {
+        worker.held_consensus = Some((returned, input_mem));
+        worker.stats.push_full_count[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+        worker.stats.held_count[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+        StepResult::OutputFull
+    } else {
+        graph.q_mi_batch.complete_in_flight();
+        graph.q_mi_batch.release_memory(input_mem);
+        worker.stats.stage_successes[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+        worker.stats.stage_items[CONSENSUS].fetch_add(1, Ordering::Relaxed);
+        StepResult::Success
+    }
+}
+
+/// Attempt one unit of filter work.
+pub(crate) fn try_step_filter(graph: &StageGraph, worker: &mut WorkerState) -> StepResult {
+    worker.stats.stage_attempts[FILTER].fetch_add(1, Ordering::Relaxed);
+
+    if let Some((held, input_mem)) = worker.held_filter.take() {
+        let output_mem = held.memory_estimate;
+        if let Some(returned) = graph.q_filtered.push(held, output_mem) {
+            worker.held_filter = Some((returned, input_mem));
+            worker.stats.push_full_count[FILTER].fetch_add(1, Ordering::Relaxed);
+            return StepResult::OutputFull;
+        }
+        graph.q_consensus.complete_in_flight();
+        graph.q_consensus.release_memory(input_mem);
+    }
+
+    let Some(input) = graph.q_consensus.try_pop() else {
+        worker.stats.pop_empty_count[FILTER].fetch_add(1, Ordering::Relaxed);
+        if graph.q_consensus.is_closed_and_empty() {
+            graph.q_filtered.close();
+        }
+        return StepResult::InputEmpty;
+    };
+    let input_mem = input.memory_estimate;
+
+    let start = Instant::now();
+    let result = match graph.filter.process(input.item) {
+        Ok(r) => r,
+        Err(e) => {
+            graph.q_consensus.complete_in_flight();
+            graph.q_consensus.release_memory(input_mem);
+            return StepResult::Error(e);
+        }
+    };
+    #[expect(clippy::cast_possible_truncation, reason = "elapsed nanos won't exceed u64")]
+    let elapsed_nanos = start.elapsed().as_nanos() as u64;
+    worker.stats.stage_nanos[FILTER].fetch_add(elapsed_nanos, Ordering::Relaxed);
+    graph.stats[FILTER].record(elapsed_nanos, 1);
+
+    let output_mem = graph.filter.output_memory_estimate(&result);
+    let output = SequencedItem::new(input.seq, result, output_mem);
+
+    if let Some(returned) = graph.q_filtered.push(output, output_mem) {
+        worker.held_filter = Some((returned, input_mem));
+        worker.stats.push_full_count[FILTER].fetch_add(1, Ordering::Relaxed);
+        worker.stats.held_count[FILTER].fetch_add(1, Ordering::Relaxed);
+        StepResult::OutputFull
+    } else {
+        graph.q_consensus.complete_in_flight();
+        graph.q_consensus.release_memory(input_mem);
+        worker.stats.stage_successes[FILTER].fetch_add(1, Ordering::Relaxed);
+        worker.stats.stage_items[FILTER].fetch_add(1, Ordering::Relaxed);
+        StepResult::Success
+    }
+}
+
+/// Attempt one unit of compress work.
+pub(crate) fn try_step_compress(graph: &StageGraph, worker: &mut WorkerState) -> StepResult {
+    worker.stats.stage_attempts[COMPRESS].fetch_add(1, Ordering::Relaxed);
+
+    if let Some((held, input_mem)) = worker.held_compress.take() {
+        let output_mem = held.memory_estimate;
+        if let Some(returned) = graph.q_compressed.push(held, output_mem) {
+            worker.held_compress = Some((returned, input_mem));
+            worker.stats.push_full_count[COMPRESS].fetch_add(1, Ordering::Relaxed);
+            return StepResult::OutputFull;
+        }
+        graph.q_filtered.complete_in_flight();
+        graph.q_filtered.release_memory(input_mem);
+    }
+
+    let Some(input) = graph.q_filtered.try_pop() else {
+        worker.stats.pop_empty_count[COMPRESS].fetch_add(1, Ordering::Relaxed);
+        if graph.q_filtered.is_closed_and_empty() {
+            graph.q_compressed.close();
+        }
+        return StepResult::InputEmpty;
+    };
+    let input_mem = input.memory_estimate;
+
+    let start = Instant::now();
+    let result = match graph.compress.process(input.item) {
+        Ok(r) => r,
+        Err(e) => {
+            graph.q_filtered.complete_in_flight();
+            graph.q_filtered.release_memory(input_mem);
+            return StepResult::Error(e);
+        }
+    };
+    #[expect(clippy::cast_possible_truncation, reason = "elapsed nanos won't exceed u64")]
+    let elapsed_nanos = start.elapsed().as_nanos() as u64;
+    worker.stats.stage_nanos[COMPRESS].fetch_add(elapsed_nanos, Ordering::Relaxed);
+    graph.stats[COMPRESS].record(elapsed_nanos, 1);
+
+    let output_mem = graph.compress.output_memory_estimate(&result);
+    let output = SequencedItem::new(input.seq, result, output_mem);
+
+    if let Some(returned) = graph.q_compressed.push(output, output_mem) {
+        worker.held_compress = Some((returned, input_mem));
+        worker.stats.push_full_count[COMPRESS].fetch_add(1, Ordering::Relaxed);
+        worker.stats.held_count[COMPRESS].fetch_add(1, Ordering::Relaxed);
+        StepResult::OutputFull
+    } else {
+        graph.q_filtered.complete_in_flight();
+        graph.q_filtered.release_memory(input_mem);
+        worker.stats.stage_successes[COMPRESS].fetch_add(1, Ordering::Relaxed);
+        worker.stats.stage_items[COMPRESS].fetch_add(1, Ordering::Relaxed);
+        StepResult::Success
+    }
+}
+
+/// Attempt one unit of write work.
+///
+/// The write stage pops ALL available items from `q_compressed` in a single lock
+/// acquisition, inserts them into the reorder buffer, and drains consecutive ready
+/// batches to the output file. This batch-drain pattern reduces lock contention.
+pub(crate) fn try_step_write(graph: &StageGraph, worker: &mut WorkerState) -> StepResult {
+    worker.stats.stage_attempts[WRITE].fetch_add(1, Ordering::Relaxed);
+
+    // Try to acquire write lock non-blocking.
+    let mut state = match graph.write_state.try_lock() {
+        Ok(guard) => guard,
+        Err(std::sync::TryLockError::WouldBlock) => {
+            worker.stats.write_lock_contention.fetch_add(1, Ordering::Relaxed);
+            return StepResult::InputEmpty;
+        }
+        Err(std::sync::TryLockError::Poisoned(e)) => {
+            return StepResult::Error(anyhow!("write state lock poisoned: {e}"));
+        }
+    };
+
+    // Drain ALL available items from the compressed queue.
+    let mut popped_any = false;
+    while let Some(sequenced) = graph.q_compressed.try_pop() {
+        if graph.cancel.load(Ordering::Acquire) {
+            graph.q_compressed.complete_in_flight();
+            return StepResult::InputEmpty;
+        }
+        let mem: usize = sequenced.item.blocks.iter().map(|b| b.data.len()).sum();
+        state.reorder_buf.insert(sequenced.seq, sequenced.item);
+        graph.q_compressed.release_memory(mem);
+        graph.q_compressed.complete_in_flight();
+        popped_any = true;
+    }
+
+    if !popped_any && state.reorder_buf.is_empty() {
+        worker.stats.pop_empty_count[WRITE].fetch_add(1, Ordering::Relaxed);
+        return StepResult::InputEmpty;
+    }
+
+    let start = Instant::now();
+
+    // Drain consecutive ready batches and write them.
+    let mut batches_written: u64 = 0;
+    for batch in state.reorder_buf.drain_ready() {
+        for block in &batch.blocks {
+            if let Err(e) = state.file.write_all(&block.data) {
+                return StepResult::Error(
+                    anyhow::Error::new(e).context("writing compressed BGZF block"),
+                );
+            }
+        }
+        state.batches_written += 1;
+        batches_written += 1;
+    }
+
+    #[expect(clippy::cast_possible_truncation, reason = "elapsed nanos won't exceed u64")]
+    let elapsed_nanos = start.elapsed().as_nanos() as u64;
+    worker.stats.stage_nanos[WRITE].fetch_add(elapsed_nanos, Ordering::Relaxed);
+    graph.stats[WRITE].record(elapsed_nanos, batches_written);
+
+    if popped_any || batches_written > 0 {
+        worker.stats.stage_successes[WRITE].fetch_add(1, Ordering::Relaxed);
+        worker.stats.stage_items[WRITE].fetch_add(batches_written, Ordering::Relaxed);
+        StepResult::Success
+    } else {
+        StepResult::InputEmpty
+    }
+}
+
+// ============================================================================
+// Worker loop
+// ============================================================================
+
+/// The main loop executed by each worker thread.
+///
+/// Each iteration: (1) try to push held items, (2) sample backpressure and get
+/// priority order, (3) execute one stage in priority order, (4) backoff if idle.
+fn worker_loop(
+    graph: &StageGraph,
+    worker: &mut WorkerState,
+    cancel: &AtomicBool,
+    error_tx: &Sender<anyhow::Error>,
+) {
+    loop {
+        // Only exit when cancelled AND no held items remain.
+        if cancel.load(Ordering::Acquire) && !worker.has_any_held_items() {
+            break;
+        }
+
+        let mut did_work = false;
+
+        // 1. Try to advance any held items first (most downstream first).
+        did_work |= try_push_held_compress(graph, worker);
+        did_work |= try_push_held_filter(graph, worker);
+        did_work |= try_push_held_consensus(graph, worker);
+        did_work |= try_push_held_group_assign(graph, worker);
+
+        // 2. Sample backpressure and get priority order.
+        let bp = BackpressureState::sample(graph);
+        let priorities = *worker.scheduler.get_priorities(&bp);
+
+        // 3. Execute one stage in priority order.
+        for &stage in &priorities {
+            if cancel.load(Ordering::Acquire) {
+                break;
+            }
+
+            let result = match stage {
+                PipelineStep::Write => try_step_write(graph, worker),
+                PipelineStep::Compress => try_step_compress(graph, worker),
+                PipelineStep::Filter => try_step_filter(graph, worker),
+                PipelineStep::Consensus => try_step_consensus(graph, worker),
+                PipelineStep::GroupAssign => try_step_group_assign(graph, worker),
+            };
+
+            match result {
+                StepResult::Success => {
+                    worker.scheduler.record_outcome(stage, true);
+                    did_work = true;
+                    break;
+                }
+                StepResult::OutputFull => {
+                    worker.scheduler.record_outcome(stage, false);
+                }
+                StepResult::InputEmpty => {}
+                StepResult::Error(e) => {
+                    let _ = error_tx.send(e);
+                    cancel.store(true, Ordering::Release);
+                    return;
+                }
+            }
+        }
+
+        // 4. Adaptive backoff if no work done.
+        if did_work {
+            worker.reset_backoff();
+        } else {
+            worker.stats.idle_cycles.fetch_add(1, Ordering::Relaxed);
+            let start = Instant::now();
+            worker.sleep_backoff();
+            #[expect(clippy::cast_possible_truncation, reason = "sleep nanos won't exceed u64")]
+            let idle_nanos = start.elapsed().as_nanos() as u64;
+            worker.stats.idle_nanos.fetch_add(idle_nanos, Ordering::Relaxed);
+            worker.increase_backoff();
+        }
+    }
+}
+
+// ============================================================================
+// Scheduler
+// ============================================================================
+
+/// Shared worker state slot used to return stats from a worker thread after it completes.
+pub type WorkerStateSlot = Arc<Mutex<Option<WorkerState>>>;
+
+/// A work-stealing scheduler that runs Zone 3 pipeline stages across a pool of worker
+/// threads using a typed [`StageGraph`] and per-worker [`WorkerState`] with held-item slots.
+pub struct Scheduler {
+    graph: Arc<StageGraph>,
+    cancel: Arc<AtomicBool>,
+    error_tx: Sender<anyhow::Error>,
+    error_rx: Receiver<anyhow::Error>,
+}
+
+impl Scheduler {
+    /// Create a new scheduler from a [`StageGraph`].
+    #[must_use]
+    pub fn new(graph: StageGraph) -> Self {
+        let cancel = Arc::clone(&graph.cancel);
+        let (error_tx, error_rx) = crossbeam_channel::unbounded();
+        Self { graph: Arc::new(graph), cancel, error_tx, error_rx }
+    }
+
+    /// Start `num_workers` worker threads. Returns their join handles and
+    /// the per-worker `WorkerState` instances (for stats collection after join).
+    ///
+    /// Each worker runs the held-item priority loop until cancelled and all held items
+    /// are flushed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal worker-state mutex is poisoned.
+    #[must_use]
+    pub fn start(&self, num_workers: usize) -> (Vec<thread::JoinHandle<()>>, Vec<WorkerStateSlot>) {
+        let mut handles = Vec::with_capacity(num_workers);
+        let mut worker_states = Vec::with_capacity(num_workers);
+
+        for worker_id in 0..num_workers {
+            let graph = Arc::clone(&self.graph);
+            let cancel = Arc::clone(&self.cancel);
+            let error_tx = self.error_tx.clone();
+
+            // Create worker state and wrap it so the main thread can retrieve stats.
+            let ws = Arc::new(Mutex::new(Some(WorkerState::new(worker_id, num_workers))));
+            let ws_clone = Arc::clone(&ws);
+            worker_states.push(ws);
+
+            handles.push(thread::spawn(move || {
+                // Take the WorkerState out — the worker owns it for its lifetime.
+                let mut state = ws_clone.lock().expect("worker state lock").take().unwrap();
+
+                // Outer catch_unwind so panics in any stage are caught.
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    worker_loop(&graph, &mut state, &cancel, &error_tx);
+                }));
+
+                if let Err(payload) = result {
+                    let msg = panic_message(&payload);
+                    let _ = error_tx.send(anyhow!("worker thread panicked: {msg}"));
+                    cancel.store(true, Ordering::Release);
+                }
+
+                // Put the state back for stats collection.
+                *ws_clone.lock().expect("worker state lock") = Some(state);
+            }));
+        }
+
+        (handles, worker_states)
+    }
+
+    /// Check for errors. Returns the first error if any worker has failed.
+    #[must_use]
+    pub fn check_error(&self) -> Option<anyhow::Error> {
+        self.error_rx.try_recv().ok()
+    }
+
+    /// Signal all workers to stop.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Release);
+    }
+
+    /// Returns `true` if the scheduler has been cancelled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::Acquire)
+    }
+
+    /// Return a clone of the cancellation flag.
+    #[must_use]
+    pub fn cancel_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+
+    /// Return a reference to the stage graph for the calling thread to participate.
+    #[must_use]
+    pub fn graph(&self) -> &Arc<StageGraph> {
+        &self.graph
+    }
+
+    /// Wait for all worker threads to finish, log stats, and return the first error if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any worker thread panicked or sent an error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a worker-state mutex is poisoned.
+    pub fn wait(
+        self,
+        handles: Vec<thread::JoinHandle<()>>,
+        worker_states: &[WorkerStateSlot],
+    ) -> Result<()> {
+        for handle in handles {
+            if let Err(panic_payload) = handle.join() {
+                let msg = panic_message(&panic_payload);
+                return Err(anyhow!("worker thread panicked: {msg}"));
+            }
+        }
+
+        // Log per-worker stats.
+        let num_workers = worker_states.len();
+        log::info!("Pipeline worker stats ({num_workers} workers):");
+        for ws in worker_states {
+            if let Some(state) = ws.lock().expect("worker state lock").as_ref() {
+                state.log_stats();
+            }
+        }
+
+        // Drain all errors; return the first, log the rest.
+        let mut first_error = None;
+        while let Ok(err) = self.error_rx.try_recv() {
+            if first_error.is_none() {
+                first_error = Some(err);
+            } else {
+                log::warn!("Additional pipeline error (suppressed): {err:#}");
+            }
+        }
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    reason = "test indices are small enough that truncation/wrap/sign-loss cannot occur"
+)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A mock stage that doubles its input.
+    struct DoubleStage;
+
+    impl PipelineStage for DoubleStage {
+        type Input = i32;
+        type Output = i32;
+
+        fn process(&self, input: i32) -> Result<i32> {
+            Ok(input * 2)
+        }
+
+        fn output_memory_estimate(&self, _output: &i32) -> usize {
+            std::mem::size_of::<i32>()
+        }
+    }
+
+    /// A mock stage that converts i32 to String.
+    struct ToStringStage;
+
+    impl PipelineStage for ToStringStage {
+        type Input = i32;
+        type Output = String;
+
+        fn process(&self, input: i32) -> Result<String> {
+            Ok(input.to_string())
+        }
+
+        fn output_memory_estimate(&self, output: &String) -> usize {
+            output.len()
+        }
+    }
+
+    /// A mock stage that returns an error on a specific input value.
+    struct FailOnStage {
+        fail_value: i32,
+    }
+
+    impl PipelineStage for FailOnStage {
+        type Input = i32;
+        type Output = i32;
+
+        fn process(&self, input: i32) -> Result<i32> {
+            if input == self.fail_value {
+                Err(anyhow!("intentional failure on value {input}"))
+            } else {
+                Ok(input)
+            }
+        }
+
+        fn output_memory_estimate(&self, _output: &i32) -> usize {
+            std::mem::size_of::<i32>()
+        }
+    }
+
+    /// A fast identity stage for testing priority ordering.
+    struct IdentityStage;
+
+    impl PipelineStage for IdentityStage {
+        type Input = i32;
+        type Output = i32;
+
+        fn process(&self, input: i32) -> Result<i32> {
+            Ok(input)
+        }
+
+        fn output_memory_estimate(&self, _output: &i32) -> usize {
+            std::mem::size_of::<i32>()
+        }
+    }
+
+    /// A slow stage that sleeps briefly to simulate expensive work.
+    struct SlowStage {
+        delay: Duration,
+        call_count: AtomicUsize,
+    }
+
+    impl SlowStage {
+        fn new(delay: Duration) -> Self {
+            Self { delay, call_count: AtomicUsize::new(0) }
+        }
+    }
+
+    impl PipelineStage for SlowStage {
+        type Input = i32;
+        type Output = i32;
+
+        fn process(&self, input: i32) -> Result<i32> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            thread::sleep(self.delay);
+            Ok(input)
+        }
+
+        fn output_memory_estimate(&self, _output: &i32) -> usize {
+            std::mem::size_of::<i32>()
+        }
+    }
+
+    /// Helper: spawn 2 worker threads running a drain-first i32->i32->O two-stage pipeline.
+    fn spawn_two_stage_workers<O: Send + 'static>(
+        stage1: &Arc<dyn PipelineStage<Input = i32, Output = i32>>,
+        stage2: &Arc<dyn PipelineStage<Input = i32, Output = O>>,
+        q_input: &WorkQueue<SequencedItem<i32>>,
+        q_middle: &WorkQueue<SequencedItem<i32>>,
+        q_output: &WorkQueue<SequencedItem<O>>,
+        cancel: &Arc<AtomicBool>,
+    ) -> Vec<thread::JoinHandle<()>> {
+        let (error_tx, _error_rx) = crossbeam_channel::unbounded::<anyhow::Error>();
+
+        (0..2)
+            .map(|_| {
+                let s1 = Arc::clone(stage1);
+                let s2 = Arc::clone(stage2);
+                let qi = q_input.clone();
+                let qm = q_middle.clone();
+                let qo = q_output.clone();
+                let c = Arc::clone(cancel);
+                let etx = error_tx.clone();
+
+                thread::spawn(move || {
+                    loop {
+                        if c.load(Ordering::Acquire) {
+                            break;
+                        }
+                        let mut did_work = false;
+
+                        // Drain-first: try downstream (s2) first.
+                        if let Some(input) = qm.try_pop() {
+                            let input_mem = input.memory_estimate;
+                            match s2.process(input.item) {
+                                Ok(result) => {
+                                    let output_mem = s2.output_memory_estimate(&result);
+                                    let out = SequencedItem::new(input.seq, result, output_mem);
+                                    qo.push_blocking(out, output_mem).unwrap();
+                                    qm.complete_in_flight();
+                                    qm.release_memory(input_mem);
+                                    did_work = true;
+                                }
+                                Err(e) => {
+                                    qm.complete_in_flight();
+                                    let _ = etx.send(e);
+                                    c.store(true, Ordering::Release);
+                                    return;
+                                }
+                            }
+                        } else if qm.is_closed_and_empty() {
+                            qo.close();
+                        }
+
+                        if !did_work {
+                            if let Some(input) = qi.try_pop() {
+                                let input_mem = input.memory_estimate;
+                                match s1.process(input.item) {
+                                    Ok(result) => {
+                                        let output_mem = s1.output_memory_estimate(&result);
+                                        let out = SequencedItem::new(input.seq, result, output_mem);
+                                        qm.push_blocking(out, output_mem).unwrap();
+                                        qi.complete_in_flight();
+                                        qi.release_memory(input_mem);
+                                        did_work = true;
+                                    }
+                                    Err(e) => {
+                                        qi.complete_in_flight();
+                                        let _ = etx.send(e);
+                                        c.store(true, Ordering::Release);
+                                        return;
+                                    }
+                                }
+                            } else if qi.is_closed_and_empty() {
+                                qm.close();
+                            }
+                        }
+
+                        if !did_work {
+                            thread::sleep(Duration::from_millis(1));
+                        }
+                    }
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_scheduler_basic() {
+        let q_input: WorkQueue<SequencedItem<i32>> = WorkQueue::new(64, usize::MAX, "input");
+        let q_middle: WorkQueue<SequencedItem<i32>> = WorkQueue::new(64, usize::MAX, "middle");
+        let q_output: WorkQueue<SequencedItem<String>> = WorkQueue::new(64, usize::MAX, "output");
+
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let num_items = 20_usize;
+        for i in 0..num_items {
+            let val = i as i32;
+            q_input
+                .push_blocking(
+                    SequencedItem::new(i as u64, val, std::mem::size_of::<i32>()),
+                    std::mem::size_of::<i32>(),
+                )
+                .unwrap();
+        }
+        q_input.close();
+
+        let stage1: Arc<dyn PipelineStage<Input = i32, Output = i32>> = Arc::new(DoubleStage);
+        let stage2: Arc<dyn PipelineStage<Input = i32, Output = String>> = Arc::new(ToStringStage);
+        let handles =
+            spawn_two_stage_workers(&stage1, &stage2, &q_input, &q_middle, &q_output, &cancel);
+
+        let mut results: Vec<(u64, String)> = Vec::new();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while results.len() < num_items {
+            assert!(std::time::Instant::now() < deadline, "timed out waiting for results");
+            if let Some(item) = q_output.try_pop() {
+                results.push((item.seq, item.item));
+            } else {
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+
+        cancel.store(true, Ordering::Release);
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        results.sort_by_key(|(seq, _)| *seq);
+        for (i, (_seq, value)) in results.iter().enumerate() {
+            let expected = (i as i32 * 2).to_string();
+            assert_eq!(value, &expected, "seq={i}");
+        }
+    }
+
+    #[test]
+    fn test_scheduler_error_propagation() {
+        let q_input: WorkQueue<SequencedItem<i32>> = WorkQueue::new(64, usize::MAX, "input");
+        let q_output: WorkQueue<SequencedItem<i32>> = WorkQueue::new(64, usize::MAX, "output");
+
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        for i in 0..10_i32 {
+            q_input
+                .push_blocking(
+                    SequencedItem::new(i as u64, i, std::mem::size_of::<i32>()),
+                    std::mem::size_of::<i32>(),
+                )
+                .unwrap();
+        }
+        q_input.close();
+
+        let fail_stage = Arc::new(FailOnStage { fail_value: 5 });
+
+        let (error_tx, error_rx) = crossbeam_channel::unbounded();
+        let c = Arc::clone(&cancel);
+        let qi = q_input.clone();
+        let qo = q_output.clone();
+        let stage = Arc::clone(&fail_stage);
+        let etx = error_tx.clone();
+
+        let handle = thread::spawn(move || {
+            loop {
+                if c.load(Ordering::Acquire) {
+                    break;
+                }
+                if let Some(input) = qi.try_pop() {
+                    let input_mem = input.memory_estimate;
+                    match stage.process(input.item) {
+                        Ok(result) => {
+                            let output_mem = stage.output_memory_estimate(&result);
+                            let out = SequencedItem::new(input.seq, result, output_mem);
+                            qo.push_blocking(out, output_mem).unwrap();
+                            qi.complete_in_flight();
+                            qi.release_memory(input_mem);
+                        }
+                        Err(e) => {
+                            qi.complete_in_flight();
+                            let _ = etx.send(e);
+                            c.store(true, Ordering::Release);
+                            return;
+                        }
+                    }
+                } else if qi.is_closed_and_empty() {
+                    break;
+                } else {
+                    thread::sleep(Duration::from_millis(1));
+                }
+            }
+        });
+
+        handle.join().unwrap();
+
+        let err = error_rx.try_recv().expect("should have received an error");
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("intentional failure"), "unexpected error message: {err_msg}");
+    }
+
+    #[test]
+    fn test_scheduler_drain_first() {
+        let q_input: WorkQueue<SequencedItem<i32>> = WorkQueue::new(128, usize::MAX, "input");
+        let q_middle: WorkQueue<SequencedItem<i32>> = WorkQueue::new(128, usize::MAX, "middle");
+        let q_output: WorkQueue<SequencedItem<i32>> = WorkQueue::new(128, usize::MAX, "output");
+
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let slow = Arc::new(SlowStage::new(Duration::from_millis(5)));
+        let fast = Arc::new(IdentityStage);
+
+        let num_items = 40_usize;
+        for i in 0..num_items {
+            q_input
+                .push_blocking(
+                    SequencedItem::new(i as u64, i as i32, std::mem::size_of::<i32>()),
+                    std::mem::size_of::<i32>(),
+                )
+                .unwrap();
+        }
+        q_input.close();
+
+        let fast_stage: Arc<dyn PipelineStage<Input = i32, Output = i32>> = fast;
+        let slow_stage: Arc<dyn PipelineStage<Input = i32, Output = i32>> = slow;
+        let handles = spawn_two_stage_workers(
+            &fast_stage,
+            &slow_stage,
+            &q_input,
+            &q_middle,
+            &q_output,
+            &cancel,
+        );
+
+        let mut max_middle_len: usize = 0;
+        let mut collected: usize = 0;
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+
+        while collected < num_items {
+            assert!(std::time::Instant::now() < deadline, "timed out waiting for results");
+            let middle_len = q_middle.len();
+            if middle_len > max_middle_len {
+                max_middle_len = middle_len;
+            }
+            if q_output.try_pop().is_some() {
+                collected += 1;
+            } else {
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+
+        cancel.store(true, Ordering::Release);
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert!(
+            max_middle_len < num_items,
+            "middle queue grew to {max_middle_len} (total items: {num_items}); \
+             drain-first priority should prevent this"
+        );
+    }
+
+    #[test]
+    fn test_write_preferred_starts_on_compress() {
+        // WritePreferred starts with current_step = Compress.
+        let mut sched = PipelineScheduler::new(3, 4);
+        assert_eq!(sched.role, WorkerRole::WritePreferred);
+        let bp = BackpressureState { output_high: false, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        // Write is the exclusive role step, so it goes first.
+        assert_eq!(priorities[0], PipelineStep::Write);
+        // Compress is the current_step (sticky start), so it goes second.
+        assert_eq!(priorities[1], PipelineStep::Compress);
+    }
+
+    #[test]
+    fn test_consensus_worker_starts_on_consensus() {
+        let mut sched = PipelineScheduler::new(0, 4);
+        assert_eq!(sched.role, WorkerRole::ConsensusWorker);
+        let bp = BackpressureState { output_high: false, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        // ConsensusWorker has no exclusive role, current_step = Consensus.
+        assert_eq!(priorities[0], PipelineStep::Consensus);
+    }
+
+    #[test]
+    fn test_sticky_on_success() {
+        let mut sched = PipelineScheduler::new(0, 4);
+        // Record success on Filter — current_step should become Filter.
+        sched.record_outcome(PipelineStep::Filter, true);
+        let bp = BackpressureState { output_high: false, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        // Filter is now the current step (sticky), so it goes first.
+        assert_eq!(priorities[0], PipelineStep::Filter);
+    }
+
+    #[test]
+    fn test_write_preferred_pivots_after_write() {
+        let mut sched = PipelineScheduler::new(3, 4);
+        assert_eq!(sched.role, WorkerRole::WritePreferred);
+        // After successful Write, WritePreferred pivots to Compress.
+        sched.record_outcome(PipelineStep::Write, true);
+        let bp = BackpressureState { output_high: false, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        assert_eq!(priorities[0], PipelineStep::Write); // exclusive role
+        assert_eq!(priorities[1], PipelineStep::Compress); // pivoted current_step
+    }
+
+    #[test]
+    fn test_group_preferred_pivots_after_group() {
+        let mut sched = PipelineScheduler::new(1, 4);
+        assert_eq!(sched.role, WorkerRole::GroupAssignPreferred);
+        // After successful GroupAssign, GroupAssignPreferred pivots to Consensus.
+        sched.record_outcome(PipelineStep::GroupAssign, true);
+        let bp = BackpressureState { output_high: false, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        assert_eq!(priorities[0], PipelineStep::GroupAssign); // exclusive role
+        assert_eq!(priorities[1], PipelineStep::Consensus); // pivoted current_step
+    }
+
+    #[test]
+    fn test_backpressure_moves_compress_up() {
+        let mut sched = PipelineScheduler::new(0, 4);
+        assert_eq!(sched.role, WorkerRole::ConsensusWorker);
+        let bp = BackpressureState { output_high: true, memory_high: false };
+        let priorities = sched.get_priorities(&bp);
+        // With output_high, Compress should be early (before GroupAssign).
+        let compress_pos = priorities.iter().position(|s| *s == PipelineStep::Compress).unwrap();
+        let group_pos = priorities.iter().position(|s| *s == PipelineStep::GroupAssign).unwrap();
+        assert!(
+            compress_pos < group_pos,
+            "Compress should have higher priority than GroupAssign under backpressure"
+        );
+    }
+
+    #[test]
+    fn test_role_assignment() {
+        // 4 workers: 0=ConsensusWorker, 1=GroupAssignPreferred, 2=ConsensusWorker, 3=WritePreferred
+        assert_eq!(PipelineScheduler::new(0, 4).role, WorkerRole::ConsensusWorker);
+        assert_eq!(PipelineScheduler::new(1, 4).role, WorkerRole::GroupAssignPreferred);
+        assert_eq!(PipelineScheduler::new(2, 4).role, WorkerRole::ConsensusWorker);
+        assert_eq!(PipelineScheduler::new(3, 4).role, WorkerRole::WritePreferred);
+
+        // 3 workers: 0=ConsensusWorker, 1=ConsensusWorker (not enough for GroupAssign), 2=WritePreferred
+        assert_eq!(PipelineScheduler::new(0, 3).role, WorkerRole::ConsensusWorker);
+        assert_eq!(PipelineScheduler::new(1, 3).role, WorkerRole::ConsensusWorker);
+        assert_eq!(PipelineScheduler::new(2, 3).role, WorkerRole::WritePreferred);
+
+        // 2 workers: 0=ConsensusWorker, 1=WritePreferred
+        assert_eq!(PipelineScheduler::new(0, 2).role, WorkerRole::ConsensusWorker);
+        assert_eq!(PipelineScheduler::new(1, 2).role, WorkerRole::WritePreferred);
+
+        // 1 worker: 0=WritePreferred (it's the last worker)
+        assert_eq!(PipelineScheduler::new(0, 1).role, WorkerRole::WritePreferred);
+    }
+
+    #[test]
+    fn test_worker_state_held_items() {
+        let mut ws = WorkerState::new(0, 1);
+        assert!(!ws.has_any_held_items());
+
+        ws.held_compress = Some((SequencedItem::new(0, CompressedBatch { blocks: vec![] }, 0), 0));
+        assert!(ws.has_any_held_items());
+    }
+
+    #[test]
+    fn test_pipeline_step_from_index() {
+        assert_eq!(PipelineStep::from_index(0), PipelineStep::GroupAssign);
+        assert_eq!(PipelineStep::from_index(1), PipelineStep::Consensus);
+        assert_eq!(PipelineStep::from_index(2), PipelineStep::Filter);
+        assert_eq!(PipelineStep::from_index(3), PipelineStep::Compress);
+        assert_eq!(PipelineStep::from_index(4), PipelineStep::Write);
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/stats.rs
+++ b/crates/fgumi-pipeline/src/pipeline/stats.rs
@@ -1,0 +1,71 @@
+//! Per-stage performance counters for the parallel pipeline.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Per-stage performance counters for the parallel pipeline.
+///
+/// Thread-safe via atomic operations. Use [`StageStats::record`] from any worker thread
+/// to accumulate timing and item counts, then read totals after the pipeline completes.
+pub struct StageStats {
+    /// Total nanoseconds spent processing items in this stage.
+    total_nanos: AtomicU64,
+    /// Number of items processed.
+    items_processed: AtomicU64,
+    /// Stage name for logging.
+    name: &'static str,
+}
+
+impl StageStats {
+    /// Create a new stats tracker for the named stage.
+    #[must_use]
+    pub fn new(name: &'static str) -> Self {
+        Self { total_nanos: AtomicU64::new(0), items_processed: AtomicU64::new(0), name }
+    }
+
+    /// Record the elapsed time and item count for one `process()` call.
+    pub fn record(&self, nanos: u64, items: u64) {
+        self.total_nanos.fetch_add(nanos, Ordering::Relaxed);
+        self.items_processed.fetch_add(items, Ordering::Relaxed);
+    }
+
+    /// Total wall-clock seconds accumulated across all worker threads.
+    #[must_use]
+    #[expect(clippy::cast_precision_loss, reason = "nanosecond precision loss is acceptable")]
+    pub fn total_secs(&self) -> f64 {
+        self.total_nanos.load(Ordering::Relaxed) as f64 / 1_000_000_000.0
+    }
+
+    /// Total number of items processed.
+    #[must_use]
+    pub fn items(&self) -> u64 {
+        self.items_processed.load(Ordering::Relaxed)
+    }
+
+    /// Stage name.
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[expect(clippy::float_cmp, reason = "exact float comparison is fine for test values")]
+    fn test_record_and_read() {
+        let stats = StageStats::new("test_stage");
+        assert_eq!(stats.items(), 0);
+        assert_eq!(stats.total_secs(), 0.0);
+        assert_eq!(stats.name(), "test_stage");
+
+        stats.record(1_000_000_000, 10);
+        assert_eq!(stats.items(), 10);
+        assert!((stats.total_secs() - 1.0).abs() < f64::EPSILON);
+
+        stats.record(500_000_000, 5);
+        assert_eq!(stats.items(), 15);
+        assert!((stats.total_secs() - 1.5).abs() < f64::EPSILON);
+    }
+}

--- a/crates/fgumi-pipeline/src/pipeline/worker_util.rs
+++ b/crates/fgumi-pipeline/src/pipeline/worker_util.rs
@@ -1,0 +1,119 @@
+//! Shared utilities for worker threads: adaptive backoff and panic message extraction.
+
+use std::time::Duration;
+
+// ============================================================================
+// WorkerBackoff
+// ============================================================================
+
+/// Adaptive backoff with per-worker jitter for work-stealing loops.
+///
+/// Progression: yield → 1µs → 2µs → 4µs → … → 100µs max.
+/// Jitter is ±25% of the current backoff to reduce thundering-herd effects.
+pub struct WorkerBackoff {
+    backoff_us: u64,
+    rng_state: u64,
+}
+
+impl WorkerBackoff {
+    /// Create a new backoff seeded from the worker ID.
+    #[must_use]
+    pub fn new(worker_id: usize) -> Self {
+        Self {
+            backoff_us: 0,
+            rng_state: (worker_id as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1,
+        }
+    }
+
+    /// Reset backoff to zero on successful work.
+    pub fn reset(&mut self) {
+        self.backoff_us = 0;
+    }
+
+    /// Sleep for the current backoff duration with per-worker jitter.
+    pub fn sleep(&mut self) {
+        if self.backoff_us == 0 {
+            std::thread::yield_now();
+        } else {
+            let jitter_range = self.backoff_us / 4;
+            let jitter =
+                if jitter_range > 0 { self.next_rng() % (jitter_range * 2 + 1) } else { 0 };
+            let sleep_us = self.backoff_us.saturating_sub(jitter_range) + jitter;
+            std::thread::sleep(Duration::from_micros(sleep_us));
+        }
+    }
+
+    /// Increase backoff: yield → 1µs → 2µs → 4µs → … → 100µs max.
+    pub fn increase(&mut self) {
+        if self.backoff_us == 0 {
+            self.backoff_us = 1;
+        } else {
+            self.backoff_us = (self.backoff_us * 2).min(100);
+        }
+    }
+
+    /// Simple xorshift64 RNG.
+    fn next_rng(&mut self) -> u64 {
+        let mut x = self.rng_state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.rng_state = x;
+        x
+    }
+}
+
+// ============================================================================
+// panic_message
+// ============================================================================
+
+/// Extract a human-readable message from a panic payload.
+pub fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backoff_progression() {
+        let mut b = WorkerBackoff::new(0);
+        assert_eq!(b.backoff_us, 0);
+
+        b.increase();
+        assert_eq!(b.backoff_us, 1);
+
+        b.increase();
+        assert_eq!(b.backoff_us, 2);
+
+        b.increase();
+        assert_eq!(b.backoff_us, 4);
+
+        for _ in 0..20 {
+            b.increase();
+        }
+        assert_eq!(b.backoff_us, 100);
+
+        b.reset();
+        assert_eq!(b.backoff_us, 0);
+    }
+
+    #[test]
+    fn test_panic_message() {
+        let str_payload: Box<dyn std::any::Any + Send> = Box::new("test panic");
+        assert_eq!(panic_message(&str_payload), "test panic");
+
+        let string_payload: Box<dyn std::any::Any + Send> = Box::new(String::from("string panic"));
+        assert_eq!(panic_message(&string_payload), "string panic");
+
+        let other_payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        assert_eq!(panic_message(&other_payload), "unknown panic");
+    }
+}

--- a/crates/fgumi-pipeline/src/stage.rs
+++ b/crates/fgumi-pipeline/src/stage.rs
@@ -1,0 +1,68 @@
+//! Core traits and types for the pipeline's work-stealing scheduler.
+
+use anyhow::Result;
+
+/// Trait for Zone 3 pipeline stages that process work items.
+///
+/// The scheduler pulls items from input queues, calls `process()`, and pushes
+/// results to output queues. Any worker thread can execute any stage.
+pub trait PipelineStage: Send + Sync {
+    /// The input type consumed by this stage.
+    type Input: Send;
+    /// The output type produced by this stage.
+    type Output: Send;
+
+    /// Process a single work item. Called by worker threads.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if processing fails.
+    fn process(&self, input: Self::Input) -> Result<Self::Output>;
+
+    /// Estimate memory usage of one output item (bytes).
+    /// Used by the scheduler for queue backpressure.
+    fn output_memory_estimate(&self, output: &Self::Output) -> usize;
+}
+
+/// Execute a closure with a thread-local value, initializing it on first use.
+///
+/// This is a helper for the common pattern of lazily initializing a per-worker-thread
+/// resource stored in `thread_local! { RefCell<Option<T>> }`. On the first call in
+/// each thread, `init` creates the value; subsequent calls reuse the stored instance.
+///
+/// # Panics
+///
+/// Cannot panic in practice: the `unwrap()` on the inner `Option` is reached only
+/// after the `is_none()` check has ensured the value is initialized.
+pub fn with_thread_local<T, R>(
+    local: &'static std::thread::LocalKey<std::cell::RefCell<Option<T>>>,
+    init: impl FnOnce() -> T,
+    f: impl FnOnce(&mut T) -> R,
+) -> R {
+    local.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        if borrow.is_none() {
+            *borrow = Some(init());
+        }
+        f(borrow.as_mut().unwrap())
+    })
+}
+
+/// A work item tagged with a sequence number for ordered reassembly.
+#[derive(Debug)]
+pub struct SequencedItem<T> {
+    /// Sequence number for ordering.
+    pub seq: u64,
+    /// The wrapped item.
+    pub item: T,
+    /// Estimated heap memory in bytes for the item, computed at push time.
+    /// Used by the scheduler to release the correct amount from the input queue.
+    pub memory_estimate: usize,
+}
+
+impl<T> SequencedItem<T> {
+    /// Create a new sequenced item with a memory estimate.
+    pub fn new(seq: u64, item: T, memory_estimate: usize) -> Self {
+        Self { seq, item, memory_estimate }
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/aligner.rs
+++ b/crates/fgumi-pipeline/src/stages/aligner.rs
@@ -1,0 +1,356 @@
+//! Aligner subprocess management for the runall pipeline.
+//!
+//! This module provides [`AlignerProcess`] for spawning an aligner as a child process
+//! and communicating with it via stdin/stdout pipes, and [`AlignerPreset`] for building
+//! well-formed aligner command strings for common aligners.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+
+// ============================================================================
+// AlignerProcess
+// ============================================================================
+
+/// A running aligner subprocess with managed stdin, stdout, and stderr.
+///
+/// The aligner is spawned via `/bin/bash -c`, allowing the command string to contain
+/// pipes, redirects, and other shell constructs.
+///
+/// Stderr from the child process is relayed to fgumi's own stderr in real time,
+/// and the last `ring_size` lines are retained for inclusion in error messages.
+pub struct AlignerProcess {
+    child: Child,
+    /// The child's stdin pipe, available until [`take_stdin`] is called.
+    stdin: Option<ChildStdin>,
+    /// The child's stdout pipe, available until [`take_stdout`] is called.
+    stdout: Option<ChildStdout>,
+    /// Background thread that relays child stderr; returns the captured ring buffer.
+    stderr_thread: Option<JoinHandle<Vec<String>>>,
+}
+
+impl AlignerProcess {
+    /// Spawn an aligner subprocess with the given shell command.
+    ///
+    /// The command is run via `/bin/bash -c`, so it supports pipes and redirects.
+    /// A background thread is started immediately to relay the child's stderr to
+    /// fgumi's stderr in real time; the last `ring_size` lines are captured for
+    /// failure diagnostics.
+    ///
+    /// # Arguments
+    ///
+    /// * `command`   - Shell command to run (passed to `/bin/bash -c`).
+    /// * `ring_size` - Number of stderr lines to retain for error reporting.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the subprocess cannot be spawned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the OS does not provide the stderr pipe after configuring `Stdio::piped()`,
+    /// which should never happen in practice.
+    pub fn spawn(command: &str, ring_size: usize) -> Result<Self> {
+        let mut child = Command::new("/bin/bash")
+            .args(["-c", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn aligner command: {command}"))?;
+
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let child_stderr = child.stderr.take().expect("stderr was configured as piped");
+
+        let stderr_thread = thread::spawn(move || relay_stderr(child_stderr, ring_size));
+
+        Ok(Self { child, stdin, stdout, stderr_thread: Some(stderr_thread) })
+    }
+
+    /// Take the stdin pipe for writing FASTQ data.
+    ///
+    /// Returns `None` if stdin has already been taken.
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.stdin.take()
+    }
+
+    /// Take the stdout pipe for reading SAM data.
+    ///
+    /// Returns `None` if stdout has already been taken.
+    pub fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.stdout.take()
+    }
+
+    /// Wait for the aligner process to finish.
+    ///
+    /// Collects the stderr relay thread and includes the last captured stderr lines
+    /// in the error message if the process exits with a non-zero status.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the process exits with a non-zero status code or if
+    /// waiting on the process fails.
+    pub fn wait(mut self) -> Result<()> {
+        let status = self.child.wait().context("failed to wait for aligner process")?;
+
+        // Always join the stderr relay thread so its resources are cleaned up.
+        let last_lines = self.stderr_thread.take().and_then(|t| t.join().ok()).unwrap_or_default();
+
+        if !status.success() {
+            let code = status.code().map_or_else(|| "signal".to_string(), |c| c.to_string());
+            let tail = if last_lines.is_empty() {
+                "(no stderr captured)".to_string()
+            } else {
+                last_lines.join("\n")
+            };
+            bail!("aligner process exited with status {code}. Last stderr lines:\n{tail}");
+        }
+
+        Ok(())
+    }
+
+    /// Kill the aligner process.
+    ///
+    /// Sends SIGKILL immediately (`Child::kill()` always sends SIGKILL on Unix).
+    /// Waits up to 1 second for the process to exit.
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+
+        // Wait for the process to actually exit so its resources are cleaned up.
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while let Ok(None) = self.child.try_wait() {
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Return the process ID of the aligner child process.
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+}
+
+impl Drop for AlignerProcess {
+    fn drop(&mut self) {
+        // If the child process is still running when the struct is dropped (e.g. due to
+        // a panic or early return), kill it to prevent orphaned processes.
+        if let Ok(None) = self.child.try_wait() {
+            self.kill();
+        }
+        // Always join the stderr relay thread to avoid resource leaks.
+        if let Some(handle) = self.stderr_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Read lines from `stderr`, print each to fgumi's stderr, and retain the last
+/// `ring_size` lines in a [`VecDeque`] ring buffer.
+///
+/// Returns the captured lines when the child closes its stderr fd.
+fn relay_stderr(stderr: impl std::io::Read, ring_size: usize) -> Vec<String> {
+    let reader = BufReader::new(stderr);
+    let mut ring: VecDeque<String> = VecDeque::with_capacity(ring_size);
+
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        eprintln!("{line}");
+        if ring_size > 0 {
+            if ring.len() == ring_size {
+                ring.pop_front();
+            }
+            ring.push_back(line);
+        }
+    }
+
+    ring.into_iter().collect()
+}
+
+// ============================================================================
+// AlignerPreset
+// ============================================================================
+
+/// Preset aligner configurations with command-building and index validation.
+pub enum AlignerPreset {
+    /// BWA-MEM aligner (`bwa mem`).
+    BwaMem,
+    /// BWA-MEM2 aligner (`bwa-mem2 mem`).
+    BwaMem2,
+}
+
+impl AlignerPreset {
+    /// Build the aligner shell command for this preset.
+    ///
+    /// The command reads FASTQ from `/dev/stdin` and writes SAM to stdout, allowing it
+    /// to be connected to fgumi's pipeline via stdin/stdout pipes.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference`  - Path to the reference FASTA (index must already exist).
+    /// * `threads`    - Number of threads to pass to the aligner (`-t`).
+    /// * `chunk_size` - Chunk size in bases to pass to the aligner (`-K`).
+    /// * `extra_args` - Additional arguments inserted verbatim before the reference path.
+    #[must_use]
+    pub fn build_command(
+        &self,
+        reference: &Path,
+        threads: usize,
+        chunk_size: u64,
+        extra_args: &str,
+    ) -> String {
+        let binary = match self {
+            AlignerPreset::BwaMem => "bwa",
+            AlignerPreset::BwaMem2 => "bwa-mem2",
+        };
+        let ref_str = reference.display();
+        let extra = extra_args.trim();
+        if extra.is_empty() {
+            format!("{binary} mem -p -K {chunk_size} -t {threads} {ref_str} /dev/stdin")
+        } else {
+            format!("{binary} mem -p -K {chunk_size} -t {threads} {extra} {ref_str} /dev/stdin")
+        }
+    }
+
+    /// Validate that the aligner binary and required index files are present.
+    ///
+    /// Checks that:
+    /// - The aligner binary is on `PATH` (via `which`).
+    /// - The expected index file(s) exist alongside the reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the binary is not found or any required index file is missing.
+    pub fn validate(&self, reference: &Path) -> Result<()> {
+        let (binary, index_extensions) = match self {
+            AlignerPreset::BwaMem => ("bwa", vec![".bwt"]),
+            AlignerPreset::BwaMem2 => ("bwa-mem2", vec![".bwt.2bit.64"]),
+        };
+
+        // Check binary is on PATH.
+        which::which(binary)
+            .with_context(|| format!("aligner binary `{binary}` not found on PATH"))?;
+
+        // Check required index files.
+        for ext in index_extensions {
+            let index_path = append_extension(reference, ext);
+            if !index_path.exists() {
+                bail!(
+                    "required index file not found: {} (run `{binary} index {}`)",
+                    index_path.display(),
+                    reference.display()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Append a suffix to a path without replacing the existing extension.
+///
+/// For example, `append_extension("/ref/genome.fa", ".bwt")` → `/ref/genome.fa.bwt`.
+fn append_extension(path: &Path, suffix: &str) -> std::path::PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(suffix);
+    std::path::PathBuf::from(s)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use super::*;
+
+    /// Spawn a simple `echo` command and verify that stdout can be read.
+    #[test]
+    fn test_spawn_echo() {
+        let mut proc = AlignerProcess::spawn("echo hello", 10).expect("spawn should succeed");
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+
+        let mut output = String::new();
+        stdout.read_to_string(&mut output).expect("should read stdout");
+        assert_eq!(output.trim(), "hello");
+
+        proc.wait().expect("process should exit successfully");
+    }
+
+    /// Spawn a command that writes to both stdout and stderr; verify both are captured.
+    #[test]
+    fn test_stderr_capture() {
+        let mut proc = AlignerProcess::spawn("bash -c 'echo err >&2; echo out'", 10)
+            .expect("spawn should succeed");
+
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+        let mut stdout_buf = String::new();
+        stdout.read_to_string(&mut stdout_buf).expect("should read stdout");
+        assert_eq!(stdout_buf.trim(), "out");
+
+        proc.wait().expect("process should exit successfully");
+    }
+
+    /// Spawn a command that exits with a non-zero status and verify that `wait` returns
+    /// an error.
+    #[test]
+    fn test_nonzero_exit() {
+        let proc = AlignerProcess::spawn("bash -c 'exit 1'", 10).expect("spawn should succeed");
+        let result = proc.wait();
+        assert!(result.is_err(), "wait() should return Err for non-zero exit");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("status"), "error message should mention status: {msg}");
+    }
+
+    /// Verify that `build_command` produces the correct command string for bwa mem.
+    #[test]
+    fn test_bwa_mem_command() {
+        let reference = Path::new("/ref/genome.fa");
+        let cmd = AlignerPreset::BwaMem.build_command(reference, 8, 10_000_000, "");
+        assert_eq!(cmd, "bwa mem -p -K 10000000 -t 8 /ref/genome.fa /dev/stdin");
+    }
+
+    /// Verify that `build_command` produces the correct command string for bwa-mem2.
+    #[test]
+    fn test_bwa_mem2_command() {
+        let reference = Path::new("/ref/genome.fa");
+        let cmd = AlignerPreset::BwaMem2.build_command(reference, 4, 5_000_000, "-Y");
+        assert_eq!(cmd, "bwa-mem2 mem -p -K 5000000 -t 4 -Y /ref/genome.fa /dev/stdin");
+    }
+
+    /// Verify that `extra_args` is omitted when empty and included when non-empty for bwa mem.
+    #[test]
+    fn test_bwa_mem_command_with_extra_args() {
+        let reference = Path::new("/data/hg38.fa");
+        let cmd = AlignerPreset::BwaMem.build_command(reference, 16, 100_000, "-R '@RG\\tID:1'");
+        assert!(cmd.contains("-R '@RG\\tID:1'"), "extra args should appear in command: {cmd}");
+        assert!(cmd.contains("/data/hg38.fa"), "reference should appear in command: {cmd}");
+    }
+
+    /// Verify that stdin can be written to and the subprocess reads it.
+    #[test]
+    fn test_stdin_write() {
+        let mut proc = AlignerProcess::spawn("bash -c 'cat'", 10).expect("spawn should succeed");
+        let mut stdin = proc.take_stdin().expect("stdin should be available");
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+
+        stdin.write_all(b"hello pipe\n").expect("should write to stdin");
+        drop(stdin); // close stdin so the child process can exit
+
+        let mut output = String::new();
+        stdout.read_to_string(&mut output).expect("should read stdout");
+        assert_eq!(output.trim(), "hello pipe");
+
+        proc.wait().expect("process should exit successfully");
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/compress.rs
+++ b/crates/fgumi-pipeline/src/stages/compress.rs
@@ -1,0 +1,171 @@
+//! BGZF compression pipeline stage.
+//!
+//! This stage consumes a flat `Vec<u8>` of raw BAM record bytes (without `block_size`
+//! prefixes) produced by [`FilterStage`] and compresses them into one or more BGZF blocks
+//! using [`InlineBgzfCompressor`].
+//!
+//! Each call to `process` produces a [`CompressedBatch`] containing all BGZF blocks
+//! generated for the input batch. The blocks are ordered by their internal serial counter
+//! (see [`InlineBgzfCompressor`]) and may be written directly to the output file once
+//! the `ReorderBuffer` has reassembled pipeline batches in sequence.
+//!
+//! ## Thread safety
+//!
+//! `CompressStage` is shared across worker threads (`Send + Sync`). Each worker thread
+//! maintains its own [`InlineBgzfCompressor`] in thread-local storage so that compression
+//! state — including buffer allocations — is not shared or synchronised.
+
+use std::cell::RefCell;
+use std::io;
+
+use anyhow::Result;
+use fgumi_bgzf::writer::{CompressedBlock, InlineBgzfCompressor};
+
+use crate::stage::{PipelineStage, with_thread_local};
+
+// ============================================================================
+// Output type
+// ============================================================================
+
+/// One or more BGZF blocks produced by compressing a single pipeline batch.
+///
+/// Blocks are in the order they were produced and should be written sequentially
+/// to the output file.
+pub struct CompressedBatch {
+    /// BGZF-compressed blocks ready for writing to the output BAM file.
+    pub blocks: Vec<CompressedBlock>,
+}
+
+// ============================================================================
+// Thread-local compressor storage
+// ============================================================================
+
+thread_local! {
+    /// Per-worker [`InlineBgzfCompressor`].  Initialised on first use.
+    static THREAD_COMPRESSOR: RefCell<Option<InlineBgzfCompressor>> = const { RefCell::new(None) };
+}
+
+// ============================================================================
+// CompressStage
+// ============================================================================
+
+/// Pipeline stage that BGZF-compresses filtered raw BAM bytes into [`CompressedBatch`]es.
+///
+/// Each worker thread owns an [`InlineBgzfCompressor`] stored in thread-local storage.
+/// The compressor accumulates data until its internal 64 KB BGZF block fills, then
+/// flushes the remaining bytes when `process` completes.
+pub struct CompressStage {
+    /// BGZF compression level (1 = fastest, 12 = smallest).
+    compression_level: u32,
+}
+
+impl CompressStage {
+    /// Create a new `CompressStage`.
+    ///
+    /// # Arguments
+    ///
+    /// * `compression_level` - BGZF compression level in the range `[1, 12]`.
+    ///   Values outside this range are clamped by [`InlineBgzfCompressor`].
+    ///   A value of 1 is fastest; 6 is a good balance of speed and size.
+    #[must_use]
+    pub fn new(compression_level: u32) -> Self {
+        Self { compression_level }
+    }
+}
+
+impl PipelineStage for CompressStage {
+    /// Input: flat raw BAM bytes (no `block_size` prefixes) from [`FilterStage`].
+    type Input = Vec<u8>;
+    /// Output: one or more BGZF-compressed blocks.
+    type Output = CompressedBatch;
+
+    /// Compress `input` bytes into BGZF blocks using the calling thread's compressor.
+    ///
+    /// A new [`InlineBgzfCompressor`] is created on the first call within each worker
+    /// thread and reused for subsequent calls. The compressor is flushed at the end of
+    /// each call so that all bytes for this batch are contained in the returned blocks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if BGZF compression fails (e.g., libdeflate returns an error).
+    fn process(&self, input: Self::Input) -> Result<Self::Output> {
+        let compression_level = self.compression_level;
+        with_thread_local(
+            &THREAD_COMPRESSOR,
+            || InlineBgzfCompressor::new(compression_level),
+            |compressor| {
+                compressor
+                    .write_all(&input)
+                    .map_err(|e| anyhow::anyhow!("BGZF write_all failed: {e}"))?;
+                compressor
+                    .flush()
+                    .map_err(|e: io::Error| anyhow::anyhow!("BGZF flush failed: {e}"))?;
+
+                let blocks = compressor.take_blocks();
+                Ok(CompressedBatch { blocks })
+            },
+        )
+    }
+
+    /// Estimate memory usage as the sum of all compressed block sizes.
+    fn output_memory_estimate(&self, output: &Self::Output) -> usize {
+        output.blocks.iter().map(|b| b.data.len()).sum()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that compressing a small non-empty input produces at least one BGZF block
+    /// with the correct magic bytes.
+    #[test]
+    fn test_compress_stage_small_input_produces_bgzf_block() {
+        let stage = CompressStage::new(6);
+        let input: Vec<u8> = b"Hello, BGZF pipeline!".to_vec();
+
+        let output = stage.process(input).expect("compression should succeed");
+        assert!(!output.blocks.is_empty(), "should produce at least one block");
+
+        let first_block = &output.blocks[0];
+        assert!(!first_block.data.is_empty(), "block data should be non-empty");
+        // BGZF magic: gzip magic 0x1f 0x8b
+        assert_eq!(&first_block.data[0..2], &[0x1f, 0x8b], "should start with gzip magic");
+    }
+
+    /// Verify that compressing an empty input produces no blocks.
+    #[test]
+    fn test_compress_stage_empty_input_no_blocks() {
+        let stage = CompressStage::new(6);
+        let input: Vec<u8> = Vec::new();
+
+        let output = stage.process(input).expect("empty input should succeed");
+        assert!(output.blocks.is_empty(), "empty input should produce no blocks");
+    }
+
+    /// Verify that `output_memory_estimate` returns the sum of block data lengths.
+    #[test]
+    fn test_compress_stage_memory_estimate() {
+        let stage = CompressStage::new(6);
+        let input: Vec<u8> = b"test data for memory estimate".to_vec();
+
+        let output = stage.process(input).expect("should succeed");
+        let expected: usize = output.blocks.iter().map(|b| b.data.len()).sum();
+        assert_eq!(stage.output_memory_estimate(&output), expected);
+    }
+
+    /// Verify that compressing more than 64 KB of data produces multiple blocks.
+    #[test]
+    fn test_compress_stage_large_input_multiple_blocks() {
+        let stage = CompressStage::new(1); // fastest compression for speed
+        // 65280 is the BGZF_MAX_BLOCK_SIZE; write slightly more to force 2 blocks.
+        let input: Vec<u8> = vec![b'X'; 65_380];
+
+        let output = stage.process(input).expect("large input should succeed");
+        assert!(output.blocks.len() >= 2, "large input should produce multiple blocks");
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/consensus.rs
+++ b/crates/fgumi-pipeline/src/stages/consensus.rs
@@ -1,0 +1,193 @@
+//! Consensus calling pipeline stage.
+//!
+//! This module wraps `ConsensusCaller` implementations behind a `PipelineStage` interface.
+//! Because `consensus_reads` takes `&mut self`, a single shared caller would serialize all
+//! consensus work across worker threads. Instead, a **caller factory** is used: each worker
+//! thread lazily creates its own `ConsensusCaller` instance the first time it processes an
+//! item, stored in a `thread_local!` slot for the lifetime of the pipeline.
+//!
+//! This approach is sound because the scheduler uses dedicated `std::thread` workers (not
+//! rayon tasks), so each thread's local storage is stable and one-to-one with workers.
+
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use anyhow::Result;
+use fgumi_consensus::caller::{ConsensusCaller, ConsensusOutput};
+
+use crate::stage::{PipelineStage, with_thread_local};
+use crate::stages::group_assign::MiGroup;
+
+// ============================================================================
+// CallerFactory
+// ============================================================================
+
+/// A factory that produces a new, independent `ConsensusCaller` for each worker thread.
+///
+/// The factory is called at most once per worker thread. The resulting caller is stored
+/// in thread-local storage and reused for all subsequent work items on that thread.
+pub type CallerFactory = Arc<dyn Fn() -> Box<dyn ConsensusCaller> + Send + Sync>;
+
+// ============================================================================
+// Thread-local caller storage
+// ============================================================================
+
+thread_local! {
+    /// Per-worker `ConsensusCaller` instance. Initialized on first use by `ConsensusStage`.
+    static THREAD_CALLER: RefCell<Option<Box<dyn ConsensusCaller>>> = const { RefCell::new(None) };
+}
+
+// ============================================================================
+// ConsensusStage
+// ============================================================================
+
+/// Pipeline stage that runs consensus calling on each [`MiGroup`].
+///
+/// Worker threads share a single `ConsensusStage` instance, but each thread maintains its
+/// own `ConsensusCaller` in thread-local storage, created on demand by `caller_factory`.
+/// This gives full parallelism without lock contention.
+pub struct ConsensusStage {
+    /// Factory invoked once per worker thread to create a per-thread caller.
+    caller_factory: CallerFactory,
+}
+
+impl ConsensusStage {
+    /// Create a new `ConsensusStage` with the given caller factory.
+    ///
+    /// # Arguments
+    ///
+    /// * `caller_factory` - A factory function that returns a fresh `ConsensusCaller`.
+    ///   It will be called at most once per worker thread.
+    pub fn new(caller_factory: CallerFactory) -> Self {
+        Self { caller_factory }
+    }
+}
+
+impl PipelineStage for ConsensusStage {
+    type Input = Vec<MiGroup>;
+    type Output = ConsensusOutput;
+
+    /// Call consensus on all MI groups in the batch and merge their outputs.
+    ///
+    /// Lazily initializes a thread-local `ConsensusCaller` on first invocation within
+    /// each worker thread, then processes each [`MiGroup`] in the batch, merging all
+    /// [`ConsensusOutput`]s into a single buffer via [`ConsensusOutput::merge`].
+    ///
+    /// # Errors
+    ///
+    /// Returns any error propagated from the underlying `ConsensusCaller`.
+    fn process(&self, input: Self::Input) -> Result<Self::Output> {
+        let factory = &self.caller_factory;
+        with_thread_local(
+            &THREAD_CALLER,
+            || factory(),
+            |caller| {
+                let mut merged = ConsensusOutput::new();
+                for group in input {
+                    let output = caller.consensus_reads(group.records)?;
+                    merged.merge(output);
+                }
+                Ok(merged)
+            },
+        )
+    }
+
+    /// Estimate memory usage as the number of bytes in the serialized consensus output.
+    fn output_memory_estimate(&self, output: &Self::Output) -> usize {
+        output.data.len()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_consensus::caller::ConsensusCallingStats;
+
+    /// A no-op `ConsensusCaller` that always returns an empty `ConsensusOutput`.
+    struct MockCaller {
+        stats: ConsensusCallingStats,
+    }
+
+    impl MockCaller {
+        fn new() -> Self {
+            Self { stats: ConsensusCallingStats::new() }
+        }
+    }
+
+    impl ConsensusCaller for MockCaller {
+        fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
+            self.stats.record_input(records.len());
+            Ok(ConsensusOutput::new())
+        }
+
+        fn total_reads(&self) -> usize {
+            self.stats.total_reads
+        }
+
+        fn total_filtered(&self) -> usize {
+            self.stats.filtered_reads
+        }
+
+        fn consensus_reads_constructed(&self) -> usize {
+            self.stats.consensus_reads
+        }
+
+        fn statistics(&self) -> ConsensusCallingStats {
+            self.stats.clone()
+        }
+
+        fn log_statistics(&self) {}
+    }
+
+    #[test]
+    fn test_consensus_stage_process_returns_empty_output_from_mock() {
+        let factory: CallerFactory = Arc::new(|| Box::new(MockCaller::new()));
+        let stage = ConsensusStage::new(factory);
+
+        let group = MiGroup { records: vec![vec![0u8; 50], vec![0u8; 50]], mi: 1, byte_size: 100 };
+
+        let output = stage.process(vec![group]).expect("process should succeed");
+        assert_eq!(output.count, 0, "mock returns empty output");
+        assert!(output.data.is_empty(), "mock returns no data bytes");
+    }
+
+    #[test]
+    fn test_consensus_stage_output_memory_estimate() {
+        let factory: CallerFactory = Arc::new(|| Box::new(MockCaller::new()));
+        let stage = ConsensusStage::new(factory);
+
+        let output = ConsensusOutput { data: vec![0u8; 128], count: 1 };
+        assert_eq!(stage.output_memory_estimate(&output), 128);
+    }
+
+    #[test]
+    fn test_consensus_stage_empty_batch() {
+        let factory: CallerFactory = Arc::new(|| Box::new(MockCaller::new()));
+        let stage = ConsensusStage::new(factory);
+
+        let output = stage.process(vec![]).expect("empty batch should succeed");
+        assert_eq!(output.count, 0);
+        assert!(output.data.is_empty());
+    }
+
+    #[test]
+    fn test_consensus_stage_multiple_mi_groups_merged() {
+        let factory: CallerFactory = Arc::new(|| Box::new(MockCaller::new()));
+        let stage = ConsensusStage::new(factory);
+
+        let groups = vec![
+            MiGroup { records: vec![vec![0u8; 50]], mi: 0, byte_size: 50 },
+            MiGroup { records: vec![vec![0u8; 30], vec![0u8; 30]], mi: 1, byte_size: 60 },
+            MiGroup { records: vec![], mi: 2, byte_size: 0 },
+        ];
+
+        let output = stage.process(groups).expect("batch should succeed");
+        // MockCaller returns empty ConsensusOutput for each group, so merged is also empty.
+        assert_eq!(output.count, 0);
+        assert!(output.data.is_empty());
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/filter.rs
+++ b/crates/fgumi-pipeline/src/stages/filter.rs
@@ -1,0 +1,329 @@
+//! Consensus-read filtering pipeline stage.
+//!
+//! This stage consumes the serialized output of [`ConsensusStage`] — a buffer of
+//! concatenated BAM records with 4-byte little-endian `block_size` prefixes — and
+//! applies quality-based masking and per-read filtering to produce a flat `Vec<u8>` of
+//! framed BAM record bytes (with `block_size` prefixes) ready for BGZF compression.
+//!
+//! For each record the stage:
+//! 1. Optionally masks low-quality or low-depth bases in place.
+//! 2. Checks per-read quality metrics against `FilterConfig` thresholds.
+//! 3. Checks global `max_no_call_fraction` and optional `min_mean_base_quality`.
+//! 4. Passes or discards the record.
+//!
+//! Duplex consensus records (detected by the presence of `aD`/`bD` aux tags) are
+//! dispatched to the duplex-aware raw filter. Single-strand records use the simpler
+//! per-read filter.
+
+use anyhow::{Result, anyhow};
+use fgumi_consensus::filter::{
+    FilterConfig, FilterResult, compute_read_stats_raw, filter_duplex_read_raw, filter_read_raw,
+    is_duplex_consensus_raw, mask_bases_raw, mask_duplex_bases_raw,
+};
+use fgumi_raw_bam::fields::aux_data_slice;
+
+use crate::stage::PipelineStage;
+use fgumi_consensus::caller::ConsensusOutput;
+
+// ============================================================================
+// FilterStage
+// ============================================================================
+
+/// Pipeline stage that applies consensus-read filters to `ConsensusOutput`.
+///
+/// The stage iterates over the framed BAM records embedded in a `ConsensusOutput`
+/// buffer, applies base masking and per-read quality filters according to `config`,
+/// and returns raw bytes for records that pass.
+pub struct FilterStage {
+    /// Filter thresholds and per-base masking configuration.
+    config: FilterConfig,
+    /// Require single-strand agreement for duplex base masking.
+    require_ss_agreement: bool,
+}
+
+impl FilterStage {
+    /// Create a new `FilterStage` with the given filter configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Filter configuration controlling masking thresholds and filter thresholds.
+    /// * `require_ss_agreement` - Whether duplex base masking requires single-strand agreement.
+    #[must_use]
+    pub fn new(config: FilterConfig, require_ss_agreement: bool) -> Self {
+        Self { config, require_ss_agreement }
+    }
+
+    /// Apply masking and filtering to a single raw BAM record.
+    ///
+    /// Returns `Ok(true)` if the record passes all filters and `Ok(false)` if it should
+    /// be discarded. The record bytes may be modified in place (base masking).
+    fn process_record(&self, record: &mut [u8]) -> Result<bool> {
+        // Determine whether this is a duplex consensus record (presence of aD/bD tags).
+        let aux = aux_data_slice(record);
+        let is_duplex = is_duplex_consensus_raw(aux);
+
+        // Pre-compute thresholds once to avoid redundant method calls.
+        let duplex_t = self.config.duplex_thresholds();
+        let ss_t = self.config.effective_single_strand_thresholds();
+
+        // --- Base masking + per-read filter (combined to avoid duplicate dispatch) ---
+        let filter_result = if is_duplex {
+            if let Some((cc, ab, ba)) = duplex_t {
+                mask_duplex_bases_raw(
+                    record,
+                    cc,
+                    ab,
+                    ba,
+                    self.config.min_base_quality,
+                    self.require_ss_agreement,
+                )?;
+                let aux = aux_data_slice(record);
+                filter_duplex_read_raw(aux, cc, ab, ba)?
+            } else {
+                FilterResult::Pass
+            }
+        } else if let Some(thresholds) = ss_t {
+            mask_bases_raw(record, thresholds, self.config.min_base_quality)?;
+            let aux = aux_data_slice(record);
+            filter_read_raw(aux, thresholds)?
+        } else {
+            FilterResult::Pass
+        };
+
+        if filter_result != FilterResult::Pass {
+            return Ok(false);
+        }
+
+        // --- Global per-read checks (no-call fraction, mean base quality) ---
+        let (no_call_count, mean_base_qual) = compute_read_stats_raw(record);
+
+        let seq_len = fgumi_raw_bam::fields::l_seq(record) as usize;
+        if seq_len > 0 {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "precision loss is acceptable for no-call fraction comparison"
+            )]
+            let no_call_fraction = no_call_count as f64 / seq_len as f64;
+            if no_call_fraction > self.config.max_no_call_fraction {
+                return Ok(false);
+            }
+        }
+
+        if let Some(min_mean_qual) = self.config.min_mean_base_quality {
+            if mean_base_qual < min_mean_qual {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+impl PipelineStage for FilterStage {
+    /// Input: framed BAM records from consensus calling (each record prefixed with 4-byte
+    /// little-endian `block_size`).
+    type Input = ConsensusOutput;
+    /// Output: framed BAM record bytes (with `block_size` prefixes), ready for
+    /// BGZF compression.
+    type Output = Vec<u8>;
+
+    /// Iterate over framed records in `input.data`, apply masking and filtering, and collect
+    /// the framed bytes (with `block_size` prefix) of passing records into the output buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a record is too short or aux data cannot be parsed.
+    fn process(&self, input: Self::Input) -> Result<Self::Output> {
+        let mut result: Vec<u8> = Vec::with_capacity(input.data.len());
+        let mut data = input.data;
+        let mut offset = 0usize;
+
+        while offset < data.len() {
+            // Read 4-byte little-endian block_size prefix.
+            if offset + 4 > data.len() {
+                return Err(anyhow!(
+                    "truncated ConsensusOutput: expected 4-byte block_size at offset {offset}"
+                ));
+            }
+            let block_size = u32::from_le_bytes(
+                data[offset..offset + 4].try_into().expect("slice is exactly 4 bytes"),
+            ) as usize;
+            let frame_start = offset;
+            offset += 4;
+
+            if offset + block_size > data.len() {
+                return Err(anyhow!(
+                    "truncated ConsensusOutput: block_size {block_size} extends past buffer end"
+                ));
+            }
+
+            // Process the record in-place within the data buffer to avoid an extra copy.
+            let record = &mut data[offset..offset + block_size];
+            if self.process_record(record)? {
+                // Write the 4-byte block_size prefix followed by the record bytes.
+                // BAM requires each record to be preceded by its block_size.
+                result.extend_from_slice(&data[frame_start..offset + block_size]);
+            }
+            offset += block_size;
+        }
+
+        Ok(result)
+    }
+
+    /// Estimate memory usage as the number of raw bytes in the output.
+    fn output_memory_estimate(&self, output: &Self::Output) -> usize {
+        output.len()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_consensus::filter::{FilterConfig, FilterThresholds};
+
+    // ---- helpers -----------------------------------------------------------
+
+    /// Build a minimal framed raw BAM record (4-byte `block_size` prefix followed by the
+    /// record body). The record has a 4-base sequence with qualities all set to 40, no
+    /// aux tags, so it should survive the default lenient filter config.
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_framed_record(name: &[u8], seq: &[u8], qual: &[u8]) -> Vec<u8> {
+        assert_eq!(seq.len(), qual.len());
+        let seq_len = seq.len();
+        let l_read_name = (name.len() + 1) as u8;
+        let n_cigar_op: u16 = 1;
+        let seq_bytes = seq_len.div_ceil(2);
+
+        // BAM fixed header (32) + read name + 1 cigar op (4 bytes) + seq + qual
+        let body_len = 32 + l_read_name as usize + n_cigar_op as usize * 4 + seq_bytes + seq_len;
+        let mut body = vec![0u8; body_len];
+
+        // ref_id = 0, pos = 100
+        body[0..4].copy_from_slice(&0i32.to_le_bytes());
+        body[4..8].copy_from_slice(&100i32.to_le_bytes());
+        body[8] = l_read_name;
+        body[9] = 60; // mapq
+        body[10..12].copy_from_slice(&0u16.to_le_bytes()); // bin
+        body[12..14].copy_from_slice(&n_cigar_op.to_le_bytes());
+        body[14..16].copy_from_slice(&0u16.to_le_bytes()); // flags (unmapped=0 is fine for filter)
+        body[16..20].copy_from_slice(&(seq_len as u32).to_le_bytes());
+        body[20..24].copy_from_slice(&0i32.to_le_bytes()); // mate_ref_id
+        body[24..28].copy_from_slice(&200i32.to_le_bytes()); // mate_pos
+        body[28..32].copy_from_slice(&150i32.to_le_bytes()); // tlen
+
+        // Read name (NUL-terminated)
+        let name_start = 32;
+        body[name_start..name_start + name.len()].copy_from_slice(name);
+        body[name_start + name.len()] = 0;
+
+        // CIGAR: one op encoding seq_len * M (op type 0)
+        let cigar_start = name_start + l_read_name as usize;
+        let cigar_op = (seq_len as u32) << 4; // M (op kind 0, encoding = len << 4)
+        body[cigar_start..cigar_start + 4].copy_from_slice(&cigar_op.to_le_bytes());
+
+        // Sequence (4-bit packed, 2 bases per byte)
+        // Base encoding: A=1, C=2, G=4, T=8, N=15
+        let base_enc = |b: u8| -> u8 {
+            match b {
+                b'A' => 1,
+                b'C' => 2,
+                b'G' => 4,
+                b'T' => 8,
+                _ => 15,
+            }
+        };
+        let seq_start = cigar_start + n_cigar_op as usize * 4;
+        for (i, &b) in seq.iter().enumerate() {
+            let byte_idx = seq_start + i / 2;
+            if i % 2 == 0 {
+                body[byte_idx] = base_enc(b) << 4;
+            } else {
+                body[byte_idx] |= base_enc(b);
+            }
+        }
+
+        // Quality scores (Phred, not +33 encoded in BAM)
+        let qual_start = seq_start + seq_bytes;
+        body[qual_start..qual_start + seq_len].copy_from_slice(qual);
+
+        // Prepend 4-byte block_size prefix
+        let mut framed = Vec::with_capacity(4 + body_len);
+        framed.extend_from_slice(&(body_len as u32).to_le_bytes());
+        framed.extend_from_slice(&body);
+        framed
+    }
+
+    /// Build a `ConsensusOutput` from a slice of already-framed record buffers.
+    fn make_consensus_output(framed_records: &[Vec<u8>]) -> ConsensusOutput {
+        let mut data = Vec::new();
+        let mut count = 0usize;
+        for rec in framed_records {
+            data.extend_from_slice(rec);
+            count += 1;
+        }
+        ConsensusOutput { data, count }
+    }
+
+    /// A permissive `FilterConfig` with `min_reads` = 1, error rates = 1.0, no masking.
+    fn permissive_config() -> FilterConfig {
+        FilterConfig::for_single_strand(
+            FilterThresholds { min_reads: 1, max_read_error_rate: 1.0, max_base_error_rate: 1.0 },
+            None,
+            None,
+            1.0,
+        )
+    }
+
+    // ---- tests -------------------------------------------------------------
+
+    #[test]
+    fn test_filter_stage_passes_valid_record() {
+        let stage = FilterStage::new(permissive_config(), false);
+
+        let rec = make_framed_record(b"read1", b"ACGT", &[40, 40, 40, 40]);
+        let input = make_consensus_output(&[rec]);
+
+        let output = stage.process(input).expect("should succeed");
+        // The record should pass; output should be non-empty.
+        assert!(!output.is_empty(), "passing record should produce output bytes");
+    }
+
+    #[test]
+    fn test_filter_stage_empty_input() {
+        let stage = FilterStage::new(permissive_config(), false);
+        let input = ConsensusOutput { data: vec![], count: 0 };
+        let output = stage.process(input).expect("empty input should succeed");
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_filter_stage_multiple_records_all_pass() {
+        let stage = FilterStage::new(permissive_config(), false);
+
+        let rec1 = make_framed_record(b"read1", b"ACGT", &[40, 40, 40, 40]);
+        let rec2 = make_framed_record(b"read2", b"TTTT", &[35, 35, 35, 35]);
+        let input = make_consensus_output(&[rec1, rec2]);
+
+        let output = stage.process(input).expect("should succeed");
+        assert!(!output.is_empty(), "both records should pass");
+    }
+
+    #[test]
+    fn test_filter_stage_output_memory_estimate() {
+        let stage = FilterStage::new(permissive_config(), false);
+        let output: Vec<u8> = vec![0u8; 256];
+        assert_eq!(stage.output_memory_estimate(&output), 256);
+    }
+
+    #[test]
+    fn test_filter_stage_truncated_input_returns_error() {
+        let stage = FilterStage::new(permissive_config(), false);
+        // Only 2 bytes — not enough for a 4-byte block_size prefix.
+        let input = ConsensusOutput { data: vec![0u8, 1u8], count: 1 };
+        assert!(stage.process(input).is_err(), "truncated input should error");
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/group_assign.rs
+++ b/crates/fgumi-pipeline/src/stages/group_assign.rs
@@ -1,0 +1,381 @@
+//! `GroupAndAssign` pipeline stage: template build, UMI assign, and MI regroup.
+//!
+//! This stage takes a batch of raw BAM records sharing the same genomic position,
+//! groups them by queryname into [`Template`]s, runs UMI assignment to assign
+//! molecule IDs, then regroups records by molecule ID into [`MiGroup`]s ready
+//! for consensus calling.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use fgumi_lib::grouper::{
+    FilterMetrics, GroupFilterConfig, extract_umi_from_template, filter_template_raw,
+    get_pair_orientation_raw, group_by_queryname,
+};
+use fgumi_lib::template::Template;
+use fgumi_raw_bam::update_string_tag;
+use fgumi_umi::{Umi, UmiAssigner};
+
+use crate::stage::PipelineStage;
+
+/// A batch of raw BAM records sharing the same genomic position.
+///
+/// Records within the batch are sorted by template-coordinate key, which includes
+/// a name hash. Records with the same queryname are adjacent but name-hash
+/// collisions are possible, so actual queryname comparison is required.
+pub struct PositionGroupBatch {
+    /// Raw BAM record bytes (without `block_size` prefix).
+    pub records: Vec<Vec<u8>>,
+    /// Position key `(primary, secondary)` from the template-coordinate sort key.
+    ///
+    /// Note: `cb_hash` (cellular barcode hash) is intentionally excluded from this key.
+    /// `cb_hash` is used only for batch boundary detection in [`PositionBatcher`] — records
+    /// with different `cb_hash` values are split into separate batches upstream, so within
+    /// a single `PositionGroupBatch` all records share the same `cb_hash`.
+    pub position_key: (u64, u64),
+}
+
+/// A group of raw BAM records sharing the same molecule ID, ready for consensus.
+pub struct MiGroup {
+    /// Raw BAM record bytes for all templates assigned to this molecule.
+    pub records: Vec<Vec<u8>>,
+    /// The assigned molecule ID.
+    pub mi: u64,
+    /// Precomputed sum of record byte lengths, avoiding redundant recomputation.
+    pub byte_size: usize,
+}
+
+/// Pipeline stage that groups raw BAM records by queryname, assigns UMIs,
+/// and regroups by molecule ID.
+pub struct GroupAndAssignStage {
+    assigner: Arc<dyn UmiAssigner>,
+    umi_tag: [u8; 2],
+    /// The two-byte BAM tag for the assigned molecule ID (e.g., `b"MI"`).
+    assign_tag: [u8; 2],
+    /// Template filter config (MAPQ, unmapped, non-PF, UMI validation).
+    group_filter_config: GroupFilterConfig,
+    /// Global base offset for molecule IDs, incremented atomically across
+    /// position groups so that MI values are globally unique.
+    next_mi: AtomicU64,
+}
+
+impl GroupAndAssignStage {
+    /// Create a new `GroupAndAssignStage`.
+    ///
+    /// # Arguments
+    ///
+    /// * `assigner` - The UMI assignment strategy to use.
+    /// * `umi_tag` - The two-byte BAM tag containing the UMI (e.g., `b"RX"`).
+    /// * `assign_tag` - The two-byte BAM tag for the assigned molecule ID (e.g., `b"MI"`).
+    /// * `group_filter_config` - Template filter config (MAPQ, unmapped, etc.).
+    pub fn new(
+        assigner: Arc<dyn UmiAssigner>,
+        umi_tag: [u8; 2],
+        assign_tag: [u8; 2],
+        group_filter_config: GroupFilterConfig,
+    ) -> Self {
+        Self { assigner, umi_tag, assign_tag, group_filter_config, next_mi: AtomicU64::new(0) }
+    }
+
+    /// Extract the UMI string from a template, delegating to the shared helper.
+    fn extract_umi(&self, template: &Template) -> Result<Umi> {
+        extract_umi_from_template(template, self.umi_tag)
+    }
+}
+
+impl PipelineStage for GroupAndAssignStage {
+    type Input = PositionGroupBatch;
+    type Output = Vec<MiGroup>;
+
+    fn process(&self, input: Self::Input) -> Result<Self::Output> {
+        // 1. Group records by queryname (consecutive runs with same name).
+        let record_groups = group_by_queryname(input.records);
+
+        if record_groups.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 2. Build Templates from each name group.
+        let mut templates: Vec<Template> = Vec::with_capacity(record_groups.len());
+        for group in record_groups {
+            templates.push(Template::from_raw_records(group)?);
+        }
+
+        // 2b. Filter templates (same criteria as standalone group command:
+        //     both-unmapped, MAPQ < min_mapq, non-PF, UMI validation).
+        let mut filter_metrics = FilterMetrics::default();
+        templates
+            .retain(|t| filter_template_raw(t, &self.group_filter_config, &mut filter_metrics));
+
+        if templates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 3. Extract UMIs and run UMI assignment, optionally splitting by pair orientation.
+        //    Templates with empty or missing UMIs are skipped (retain MoleculeId::None)
+        //    to match the standalone group command's filtering behavior.
+        if self.assigner.split_templates_by_pair_orientation() {
+            let mut subgroups: HashMap<(bool, bool), Vec<usize>> = HashMap::new();
+            for (idx, template) in templates.iter().enumerate() {
+                let orientation = get_pair_orientation_raw(template);
+                subgroups.entry(orientation).or_default().push(idx);
+            }
+
+            for indices in subgroups.values() {
+                // Filter to templates with non-empty UMIs
+                let (valid_indices, umis): (Vec<usize>, Vec<Umi>) = indices
+                    .iter()
+                    .filter_map(|&i| {
+                        let umi = self.extract_umi(&templates[i]).ok()?;
+                        if umi.is_empty() { None } else { Some((i, umi)) }
+                    })
+                    .unzip();
+                if umis.is_empty() {
+                    continue;
+                }
+                let molecule_ids = self.assigner.assign(&umis);
+                for (idx, mi) in valid_indices.into_iter().zip(molecule_ids) {
+                    templates[idx].mi = mi;
+                }
+            }
+        } else {
+            // Filter to templates with non-empty UMIs
+            let (valid_indices, umis): (Vec<usize>, Vec<Umi>) = templates
+                .iter()
+                .enumerate()
+                .filter_map(|(i, t)| {
+                    let umi = self.extract_umi(t).ok()?;
+                    if umi.is_empty() { None } else { Some((i, umi)) }
+                })
+                .unzip();
+            if !umis.is_empty() {
+                let molecule_ids = self.assigner.assign(&umis);
+                for (idx, mi) in valid_indices.into_iter().zip(molecule_ids) {
+                    templates[idx].mi = mi;
+                }
+            }
+        }
+
+        // 5. Compute the max local MI id so we can reserve a contiguous range of
+        //    global IDs for this position group.
+        let max_local_id = templates.iter().filter_map(|t| t.mi.id()).max().map_or(0, |id| id + 1);
+        let base_mi = self.next_mi.fetch_add(max_local_id, Ordering::Relaxed);
+
+        // 6. Inject MI tags into raw records and regroup by molecule ID.
+        let mut mi_map: HashMap<u64, Vec<Vec<u8>>> = HashMap::new();
+        let mut mi_buf = String::new();
+
+        for template in templates {
+            let mi = template.mi;
+            if !mi.is_assigned() {
+                // Templates with MoleculeId::None are dropped (unassigned).
+                continue;
+            }
+            let mi_value = mi.write_with_offset(base_mi, &mut mi_buf);
+            let global_id = base_mi + mi.id().unwrap_or(0);
+            let mut raw_records = template.into_raw_records().unwrap_or_default();
+            for record in &mut raw_records {
+                update_string_tag(record, &self.assign_tag, mi_value);
+            }
+            mi_map.entry(global_id).or_default().extend(raw_records);
+        }
+
+        let mi_groups: Vec<MiGroup> = mi_map
+            .into_iter()
+            .map(|(mi, records)| {
+                let byte_size = records.iter().map(Vec::len).sum();
+                MiGroup { records, mi, byte_size }
+            })
+            .collect();
+
+        Ok(mi_groups)
+    }
+
+    fn output_memory_estimate(&self, output: &Self::Output) -> usize {
+        output.iter().map(|g| g.byte_size).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::fields::read_name;
+    use fgumi_umi::IdentityUmiAssigner;
+
+    /// Build a minimal raw BAM record with the specified name, flags, and UMI.
+    ///
+    /// Creates a mapped paired-end record with a 4-base sequence and a single
+    /// `RX:Z:<umi>` auxiliary tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_raw_record(name: &[u8], flag: u16, umi: &[u8]) -> Vec<u8> {
+        let seq_len: usize = 4;
+        let l_read_name = (name.len() + 1) as u8; // +1 for NUL
+        // Single CIGAR op: 4M
+        let cigar_ops: &[u32] = &[(seq_len as u32) << 4];
+        let n_cigar_op = cigar_ops.len() as u16;
+        let seq_bytes = seq_len.div_ceil(2);
+        let total = 32 + l_read_name as usize + cigar_ops.len() * 4 + seq_bytes + seq_len;
+        let mut buf = vec![0u8; total];
+
+        // ref_id = 0
+        buf[0..4].copy_from_slice(&0i32.to_le_bytes());
+        // pos = 100
+        buf[4..8].copy_from_slice(&100i32.to_le_bytes());
+        // l_read_name
+        buf[8] = l_read_name;
+        // mapq = 60
+        buf[9] = 60;
+        // n_cigar_op
+        buf[12..14].copy_from_slice(&n_cigar_op.to_le_bytes());
+        // flags
+        buf[14..16].copy_from_slice(&flag.to_le_bytes());
+        // l_seq
+        buf[16..20].copy_from_slice(&(seq_len as u32).to_le_bytes());
+        // mate_ref_id = 0
+        buf[20..24].copy_from_slice(&0i32.to_le_bytes());
+        // mate_pos = 200
+        buf[24..28].copy_from_slice(&200i32.to_le_bytes());
+        // tlen = 150
+        buf[28..32].copy_from_slice(&150i32.to_le_bytes());
+
+        // Read name (NUL-terminated)
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+
+        // CIGAR
+        let cigar_start = name_start + l_read_name as usize;
+        for (i, &op) in cigar_ops.iter().enumerate() {
+            let off = cigar_start + i * 4;
+            buf[off..off + 4].copy_from_slice(&op.to_le_bytes());
+        }
+
+        // Append RX:Z:<umi>\0 tag
+        if !umi.is_empty() {
+            buf.extend_from_slice(b"RXZ");
+            buf.extend_from_slice(umi);
+            buf.push(0);
+        }
+
+        buf
+    }
+
+    /// SAM flags for paired, first segment (R1)
+    const PAIRED_R1: u16 = 0x1 | 0x40; // paired + first_segment
+    /// SAM flags for paired, second segment (R2)
+    const PAIRED_R2: u16 = 0x1 | 0x80; // paired + last_segment
+
+    #[test]
+    fn test_group_by_queryname_groups_consecutive_records() {
+        let r1 = make_raw_record(b"read1", PAIRED_R1, b"ACGT");
+        let r2 = make_raw_record(b"read1", PAIRED_R2, b"ACGT");
+        let r3 = make_raw_record(b"read2", PAIRED_R1, b"TTTT");
+        let r4 = make_raw_record(b"read2", PAIRED_R2, b"TTTT");
+
+        let groups = group_by_queryname(vec![r1, r2, r3, r4]);
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(read_name(&groups[0][0]), b"read1");
+        assert_eq!(groups[0].len(), 2);
+        assert_eq!(read_name(&groups[1][0]), b"read2");
+        assert_eq!(groups[1].len(), 2);
+    }
+
+    #[test]
+    fn test_group_by_queryname_empty_input() {
+        let groups = group_by_queryname(vec![]);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_group_by_queryname_single_record() {
+        let r = make_raw_record(b"read1", PAIRED_R1, b"ACGT");
+        let groups = group_by_queryname(vec![r]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 1);
+    }
+
+    #[test]
+    fn test_process_two_templates_same_umi() {
+        // Two templates with the same UMI should get the same molecule ID
+        let assigner = Arc::new(IdentityUmiAssigner::new());
+        let stage = GroupAndAssignStage::new(
+            assigner,
+            *b"RX",
+            *b"MI",
+            GroupFilterConfig::with_defaults(*b"RX"),
+        );
+
+        let r1a = make_raw_record(b"readA", PAIRED_R1, b"ACGT");
+        let r2a = make_raw_record(b"readA", PAIRED_R2, b"ACGT");
+        let r1b = make_raw_record(b"readB", PAIRED_R1, b"ACGT");
+        let r2b = make_raw_record(b"readB", PAIRED_R2, b"ACGT");
+
+        let batch = PositionGroupBatch { records: vec![r1a, r2a, r1b, r2b], position_key: (0, 0) };
+
+        let result = stage.process(batch).unwrap();
+        // IdentityUmiAssigner groups identical UMIs together
+        assert_eq!(result.len(), 1, "Same UMI should yield one MI group");
+        assert_eq!(result[0].records.len(), 4, "All 4 records in single group");
+    }
+
+    #[test]
+    fn test_process_two_templates_different_umis() {
+        let assigner = Arc::new(IdentityUmiAssigner::new());
+        let stage = GroupAndAssignStage::new(
+            assigner,
+            *b"RX",
+            *b"MI",
+            GroupFilterConfig::with_defaults(*b"RX"),
+        );
+
+        let r1a = make_raw_record(b"readA", PAIRED_R1, b"AAAA");
+        let r2a = make_raw_record(b"readA", PAIRED_R2, b"AAAA");
+        let r1b = make_raw_record(b"readB", PAIRED_R1, b"CCCC");
+        let r2b = make_raw_record(b"readB", PAIRED_R2, b"CCCC");
+
+        let batch = PositionGroupBatch { records: vec![r1a, r2a, r1b, r2b], position_key: (0, 0) };
+
+        let result = stage.process(batch).unwrap();
+        assert_eq!(result.len(), 2, "Different UMIs should yield two MI groups");
+        for group in &result {
+            assert_eq!(group.records.len(), 2, "Each group should have 2 records (R1+R2)");
+        }
+    }
+
+    #[test]
+    fn test_process_empty_batch() {
+        let assigner = Arc::new(IdentityUmiAssigner::new());
+        let stage = GroupAndAssignStage::new(
+            assigner,
+            *b"RX",
+            *b"MI",
+            GroupFilterConfig::with_defaults(*b"RX"),
+        );
+
+        let batch = PositionGroupBatch { records: vec![], position_key: (0, 0) };
+
+        let result = stage.process(batch).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_output_memory_estimate() {
+        let assigner = Arc::new(IdentityUmiAssigner::new());
+        let stage = GroupAndAssignStage::new(
+            assigner,
+            *b"RX",
+            *b"MI",
+            GroupFilterConfig::with_defaults(*b"RX"),
+        );
+
+        let groups = vec![
+            MiGroup { records: vec![vec![0u8; 100], vec![0u8; 50]], mi: 0, byte_size: 150 },
+            MiGroup { records: vec![vec![0u8; 200]], mi: 1, byte_size: 200 },
+        ];
+
+        assert_eq!(stage.output_memory_estimate(&groups), 350);
+    }
+}

--- a/crates/fgumi-pipeline/src/stages/mod.rs
+++ b/crates/fgumi-pipeline/src/stages/mod.rs
@@ -1,0 +1,15 @@
+//! Stage implementations for the runall pipeline.
+
+pub mod aligner;
+pub mod compress;
+pub mod consensus;
+pub mod filter;
+pub mod group_assign;
+pub mod position_batch;
+
+pub use aligner::{AlignerPreset, AlignerProcess};
+pub use compress::{CompressStage, CompressedBatch};
+pub use consensus::{CallerFactory, ConsensusStage};
+pub use filter::FilterStage;
+pub use group_assign::{GroupAndAssignStage, MiGroup, PositionGroupBatch};
+pub use position_batch::PositionBatcher;

--- a/crates/fgumi-pipeline/src/stages/position_batch.rs
+++ b/crates/fgumi-pipeline/src/stages/position_batch.rs
@@ -1,0 +1,241 @@
+//! `PositionBatcher` — bridges the sort/merge phase into Zone 3 processing.
+//!
+//! Implements [`SortedRecordSink`] to consume sorted BAM records one at a time,
+//! detects position-group boundaries from [`TemplateKey`] changes, and pushes
+//! completed [`PositionGroupBatch`] items into a downstream [`WorkQueue`].
+
+use anyhow::Result;
+use fgumi_lib::sort::inline_buffer::TemplateKey;
+use fgumi_lib::sort::sink::SortedRecordSink;
+
+use super::group_assign::PositionGroupBatch;
+use crate::pipeline::queue::WorkQueue;
+use crate::stage::SequencedItem;
+
+/// Buffers sorted BAM records by position group and forwards completed batches
+/// to a Zone 3 work queue.
+///
+/// Two records belong to the same position group when their `(primary, secondary,
+/// cb_hash)` triple is identical. When any of those fields change, the current
+/// batch is flushed as a [`PositionGroupBatch`] and a new batch begins.
+///
+/// Call [`finish`](PositionBatcher::finish) after the last record to flush any
+/// in-progress batch before dropping the batcher.
+pub struct PositionBatcher {
+    output_queue: WorkQueue<SequencedItem<PositionGroupBatch>>,
+    current_batch: Vec<Vec<u8>>,
+    /// `(primary, secondary, cb_hash)` of the batch currently being accumulated.
+    current_pos_key: Option<(u64, u64, u64)>,
+    /// Monotonically increasing sequence number assigned to each flushed batch.
+    seq_counter: u64,
+}
+
+impl PositionBatcher {
+    /// Create a new `PositionBatcher` that pushes completed batches to `output_queue`.
+    #[must_use]
+    pub fn new(output_queue: WorkQueue<SequencedItem<PositionGroupBatch>>) -> Self {
+        Self { output_queue, current_batch: Vec::new(), current_pos_key: None, seq_counter: 0 }
+    }
+
+    /// Return the number of batches pushed to the output queue so far.
+    ///
+    /// Each batch corresponds to one position group; the counter increments on
+    /// every successful flush.
+    #[must_use]
+    pub fn batches_pushed(&self) -> u64 {
+        self.seq_counter
+    }
+
+    /// Flush the current batch to the output queue if it is non-empty.
+    ///
+    /// The batch is tagged with the next sequence number and the accumulated
+    /// `current_batch` buffer is replaced with an empty `Vec`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output queue channel is disconnected.
+    fn flush_batch(&mut self) -> Result<()> {
+        if self.current_batch.is_empty() {
+            return Ok(());
+        }
+
+        let pos_key =
+            self.current_pos_key.expect("current_pos_key must be set when batch is non-empty");
+        // The batch's `position_key` carries only `(primary, secondary)` — `cb_hash` (pos_key.2)
+        // is used solely for boundary detection here (different `cb_hash` values split batches)
+        // and is not needed downstream since all records in a batch share the same `cb_hash`.
+        let batch = PositionGroupBatch {
+            records: std::mem::take(&mut self.current_batch),
+            position_key: (pos_key.0, pos_key.1),
+        };
+        let size_bytes = batch.records.iter().map(Vec::len).sum::<usize>();
+        self.output_queue
+            .push_blocking(SequencedItem::new(self.seq_counter, batch, size_bytes), size_bytes)?;
+        self.seq_counter += 1;
+        Ok(())
+    }
+}
+
+impl SortedRecordSink for PositionBatcher {
+    /// Append `record_bytes` to the current position-group batch.
+    ///
+    /// If `key`'s `(primary, secondary, cb_hash)` differs from the previous record,
+    /// the accumulated batch is flushed first and a new batch is started.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing the previous batch fails (channel disconnected).
+    fn emit(&mut self, key: &TemplateKey, record_bytes: Vec<u8>) -> Result<()> {
+        let pos_key = (key.primary, key.secondary, key.cb_hash);
+
+        if self.current_pos_key != Some(pos_key) {
+            self.flush_batch()?;
+            self.current_pos_key = Some(pos_key);
+        }
+
+        self.current_batch.push(record_bytes);
+        Ok(())
+    }
+
+    /// Flush any in-progress batch and finalize the sink.
+    ///
+    /// Must be called once after all records have been emitted to ensure the
+    /// last position group is delivered to the output queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the final flush fails (channel disconnected).
+    fn finish(&mut self) -> Result<()> {
+        self.flush_batch()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_key(primary: u64, secondary: u64, cb_hash: u64) -> TemplateKey {
+        TemplateKey { primary, secondary, cb_hash, tertiary: 0, name_hash_upper: 0 }
+    }
+
+    #[test]
+    fn test_single_position_group() {
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+
+        let key = make_key(1, 2, 0);
+        batcher.emit(&key, vec![1, 2, 3]).unwrap();
+        batcher.emit(&key, vec![4, 5, 6]).unwrap();
+        batcher.finish().unwrap();
+
+        let item = queue.pop().unwrap();
+        assert_eq!(item.seq, 0);
+        assert_eq!(item.item.records.len(), 2);
+        assert_eq!(item.item.records[0], vec![1, 2, 3]);
+        assert_eq!(item.item.records[1], vec![4, 5, 6]);
+        assert!(queue.try_pop().is_none());
+        assert_eq!(batcher.batches_pushed(), 1);
+    }
+
+    #[test]
+    fn test_multiple_position_groups() {
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+
+        let key1 = make_key(1, 2, 0);
+        let key2 = make_key(3, 4, 0);
+
+        batcher.emit(&key1, vec![1]).unwrap();
+        batcher.emit(&key1, vec![2]).unwrap();
+        batcher.emit(&key2, vec![3]).unwrap();
+        batcher.finish().unwrap();
+
+        let batch1 = queue.pop().unwrap();
+        assert_eq!(batch1.seq, 0);
+        assert_eq!(batch1.item.records.len(), 2);
+        assert_eq!(batch1.item.position_key, (1, 2));
+
+        let batch2 = queue.pop().unwrap();
+        assert_eq!(batch2.seq, 1);
+        assert_eq!(batch2.item.records.len(), 1);
+        assert_eq!(batch2.item.position_key, (3, 4));
+
+        assert!(queue.try_pop().is_none());
+        assert_eq!(batcher.batches_pushed(), 2);
+    }
+
+    #[test]
+    fn test_position_key_uses_cb_hash() {
+        // Two records that differ only in cb_hash must land in separate batches.
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+
+        let key_a = make_key(1, 1, 0xaaa);
+        let key_b = make_key(1, 1, 0xbbb);
+
+        batcher.emit(&key_a, vec![10]).unwrap();
+        batcher.emit(&key_b, vec![20]).unwrap();
+        batcher.finish().unwrap();
+
+        let batch_a = queue.pop().unwrap();
+        assert_eq!(batch_a.item.records.len(), 1);
+        assert_eq!(batch_a.item.records[0], vec![10]);
+
+        let batch_b = queue.pop().unwrap();
+        assert_eq!(batch_b.item.records.len(), 1);
+        assert_eq!(batch_b.item.records[0], vec![20]);
+    }
+
+    #[test]
+    fn test_tertiary_ignored_for_boundary() {
+        // Records with the same (primary, secondary, cb_hash) but different tertiary
+        // (i.e. different MI) must be batched together — MI grouping happens downstream.
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+
+        let key1 =
+            TemplateKey { primary: 5, secondary: 6, cb_hash: 0, tertiary: 1, name_hash_upper: 0 };
+        let key2 =
+            TemplateKey { primary: 5, secondary: 6, cb_hash: 0, tertiary: 2, name_hash_upper: 100 };
+
+        batcher.emit(&key1, vec![1]).unwrap();
+        batcher.emit(&key2, vec![2]).unwrap();
+        batcher.finish().unwrap();
+
+        let batch = queue.pop().unwrap();
+        assert_eq!(
+            batch.item.records.len(),
+            2,
+            "different tertiary/name_hash should not split the batch"
+        );
+        assert!(queue.try_pop().is_none());
+    }
+
+    #[test]
+    fn test_empty_no_batches_pushed() {
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+        batcher.finish().unwrap();
+        assert!(queue.try_pop().is_none());
+        assert_eq!(batcher.batches_pushed(), 0);
+    }
+
+    #[test]
+    fn test_sequence_numbers_are_monotonic() {
+        let queue = WorkQueue::new(100, 1_000_000, "test");
+        let mut batcher = PositionBatcher::new(queue.clone());
+
+        for i in 0u64..5 {
+            let key = make_key(i, 0, 0);
+            #[allow(clippy::cast_possible_truncation)]
+            batcher.emit(&key, vec![i as u8]).unwrap();
+        }
+        batcher.finish().unwrap();
+
+        for expected_seq in 0u64..5 {
+            let item = queue.pop().unwrap();
+            assert_eq!(item.seq, expected_seq);
+        }
+        assert!(queue.try_pop().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `fgumi-pipeline` workspace crate implementing a work-stealing pipeline engine
- Bounded memory-aware queues with backpressure scheduling
- Two-phase execution: Phase A handles alignment I/O, Phase B handles sort/group/consensus/filter
- Pipeline stages: aligner, position batching, group/assign, consensus, filter, compress
- Reorder buffer ensures deterministic output ordering
- \`AlignerProcess\` with Drop impl to prevent orphaned subprocesses
- Scheduler with adaptive thread allocation based on queue pressure

**Stack:** 5/6 — depends on #204

## Test plan
- [ ] `cargo ci-test` passes (includes fgumi-pipeline unit tests)
- [ ] `cargo ci-fmt` passes
- [ ] `cargo ci-lint` passes