### PR TITLE
Remove unused --sort-order flag from codec and simplex

### DIFF
--- a/src/commands/codec.rs
+++ b/src/commands/codec.rs
@@ -224,10 +224,6 @@ pub struct Codec {
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: Option<String>,
 
-    /// Output sort order (Unsorted, Queryname, Coordinate, Unknown)
-    #[arg(short = 'S', long = "sort-order")]
-    pub sort_order: Option<String>,
-
     /// Scheduler and pipeline statistics options.
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
@@ -721,7 +717,6 @@ mod tests {
             max_duplex_disagreement_rate: 1.0,
             max_duplex_disagreements: None,
             cell_tag: None,
-            sort_order: None,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         }

--- a/src/commands/simplex.rs
+++ b/src/commands/simplex.rs
@@ -202,10 +202,6 @@ pub struct Simplex {
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
 
-    /// Sort order for output BAM
-    #[arg(short = 'S', long = "sort-order")]
-    pub sort_order: Option<String>,
-
     /// SAM tag containing the cell barcode
     #[arg(short = 'c', long = "cell-tag", default_value = "CB")]
     pub cell_tag: Option<String>,
@@ -747,7 +743,6 @@ mod tests {
             tag: "MI".to_string(),
             min_reads: 1,
             max_reads: None,
-            sort_order: None,
             cell_tag: None,
             scheduler_opts: SchedulerOptions::default(),
         }


### PR DESCRIPTION
## Summary

- Removes the `--sort-order` / `-S` CLI argument from `codec` and `simplex` consensus callers
- The flag was defined but never wired through — the output header is hardcoded to `SO:unknown` in `create_unmapped_consensus_header()`, so passing `--sort-order Queryname` silently did nothing
- `duplex` never had this flag; `clip`'s `--sort-order` is functional and unaffected

## Test plan

- [x] `cargo ci-test` — 1998 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Verified `fgumi codec --help` and `fgumi simplex --help` no longer show `--sort-order`