### PR TITLE
feat(group): add position group size metrics and --metrics prefix output

### DIFF
--- a/crates/fgumi-metrics/src/group.rs
+++ b/crates/fgumi-metrics/src/group.rs
@@ -7,6 +7,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::Metric;
 
+/// Build a size distribution from (size, count) pairs.
+///
+/// Sorts by ascending size, computes per-entry fractions and reverse cumulative
+/// fractions (fraction of entries with size >= this value), then returns a `Vec`
+/// in ascending size order. The `ctor` closure maps `(size, count, fraction,
+/// cumulative_fraction)` into the caller's metric type.
+#[allow(clippy::cast_precision_loss)]
+fn build_size_distribution<T>(
+    counts: impl IntoIterator<Item = (usize, u64)>,
+    ctor: impl Fn(usize, u64, f64, f64) -> T,
+) -> Vec<T> {
+    let mut sorted: Vec<_> = counts.into_iter().collect();
+    sorted.sort_by_key(|(size, _)| *size);
+
+    let total: f64 = sorted.iter().map(|(_, count)| *count as f64).sum();
+    if total == 0.0 {
+        return Vec::new();
+    }
+
+    let mut metrics = Vec::with_capacity(sorted.len());
+    let mut cumulative = 0.0;
+    for &(size, count) in sorted.iter().rev() {
+        let fraction = count as f64 / total;
+        cumulative += fraction;
+        metrics.push(ctor(size, count, fraction, cumulative));
+    }
+    metrics.reverse();
+    metrics
+}
+
 /// Metrics for UMI grouping operations.
 ///
 /// These metrics track how reads are grouped by UMI and provide insight into
@@ -110,31 +140,14 @@ impl FamilySizeMetrics {
     ///
     /// Returns a `Vec` sorted by ascending family size, with cumulative
     /// fractions computed from largest to smallest.
-    #[allow(clippy::cast_precision_loss)]
     #[must_use]
     pub fn from_size_counts(counts: impl IntoIterator<Item = (usize, u64)>) -> Vec<Self> {
-        let mut sorted: Vec<_> = counts.into_iter().collect();
-        sorted.sort_by_key(|(size, _)| *size);
-
-        let total: f64 = sorted.iter().map(|(_, count)| *count as f64).sum();
-        if total == 0.0 {
-            return Vec::new();
-        }
-
-        let mut metrics = Vec::with_capacity(sorted.len());
-        let mut cumulative = 0.0;
-        for &(family_size, count) in sorted.iter().rev() {
-            let fraction = count as f64 / total;
-            cumulative += fraction;
-            metrics.push(Self {
-                family_size,
-                count,
-                fraction,
-                fraction_gt_or_eq_family_size: cumulative,
-            });
-        }
-        metrics.reverse();
-        metrics
+        build_size_distribution(counts, |size, count, fraction, cumulative| Self {
+            family_size: size,
+            count,
+            fraction,
+            fraction_gt_or_eq_family_size: cumulative,
+        })
     }
 }
 
@@ -147,6 +160,64 @@ impl Default for FamilySizeMetrics {
 impl Metric for FamilySizeMetrics {
     fn metric_name() -> &'static str {
         "family size"
+    }
+}
+
+/// Position group size distribution metrics.
+///
+/// Describes the distribution of position group sizes (the number of unique UMI
+/// families sharing the same start/end coordinates) in the dataset.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PositionGroupSizeMetrics {
+    /// Position group size (number of unique UMI families at the same genomic position)
+    pub position_group_size: usize,
+
+    /// Number of position groups with this size
+    pub count: u64,
+
+    /// Fraction of all position groups with this size
+    pub fraction: f64,
+
+    /// Cumulative fraction (position groups with size >= this value)
+    pub fraction_gt_or_eq_position_group_size: f64,
+}
+
+impl PositionGroupSizeMetrics {
+    /// Creates a new position group size metric.
+    #[must_use]
+    pub fn new(position_group_size: usize) -> Self {
+        Self {
+            position_group_size,
+            count: 0,
+            fraction: 0.0,
+            fraction_gt_or_eq_position_group_size: 0.0,
+        }
+    }
+
+    /// Build position group size metrics from (`position_group_size`, count) pairs.
+    ///
+    /// Returns a `Vec` sorted by ascending position group size, with cumulative
+    /// fractions computed from largest to smallest.
+    #[must_use]
+    pub fn from_size_counts(counts: impl IntoIterator<Item = (usize, u64)>) -> Vec<Self> {
+        build_size_distribution(counts, |size, count, fraction, cumulative| Self {
+            position_group_size: size,
+            count,
+            fraction,
+            fraction_gt_or_eq_position_group_size: cumulative,
+        })
+    }
+}
+
+impl Default for PositionGroupSizeMetrics {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl Metric for PositionGroupSizeMetrics {
+    fn metric_name() -> &'static str {
+        "position group size"
     }
 }
 
@@ -201,6 +272,38 @@ mod tests {
     #[test]
     fn test_from_size_counts_empty() {
         let metrics = FamilySizeMetrics::from_size_counts(std::iter::empty());
+        assert!(metrics.is_empty());
+    }
+
+    #[test]
+    fn test_position_group_size_metrics_new() {
+        let metrics = PositionGroupSizeMetrics::new(5);
+        assert_eq!(metrics.position_group_size, 5);
+        assert_eq!(metrics.count, 0);
+        assert!(metrics.fraction.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_position_group_size_metric_name() {
+        assert_eq!(PositionGroupSizeMetrics::metric_name(), "position group size");
+    }
+
+    #[test]
+    fn test_position_group_size_from_size_counts() {
+        let counts = vec![(3, 1u64), (1, 1), (2, 1)];
+        let metrics = PositionGroupSizeMetrics::from_size_counts(counts);
+        assert_eq!(metrics.len(), 3);
+        assert_eq!(metrics[0].position_group_size, 1);
+        assert_eq!(metrics[1].position_group_size, 2);
+        assert_eq!(metrics[2].position_group_size, 3);
+        assert!((metrics[0].fraction - 1.0 / 3.0).abs() < 1e-10);
+        assert!((metrics[0].fraction_gt_or_eq_position_group_size - 1.0).abs() < 1e-10);
+        assert!((metrics[2].fraction_gt_or_eq_position_group_size - 1.0 / 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_position_group_size_from_size_counts_empty() {
+        let metrics = PositionGroupSizeMetrics::from_size_counts(std::iter::empty());
         assert!(metrics.is_empty());
     }
 }

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -94,7 +94,7 @@ pub use duplex::{
     DuplexFamilySizeMetric, DuplexMetricsCollector, DuplexUmiMetric, DuplexYieldMetric,
     FamilySizeMetric,
 };
-pub use group::{FamilySizeMetrics, UmiGroupingMetrics};
+pub use group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 pub use rejection::{RejectionReason, format_count};
 pub use shared::UmiMetric;
 pub use simplex::{SimplexFamilySizeMetric, SimplexMetricsCollector, SimplexYieldMetric};

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -18,7 +18,7 @@ use fgumi_lib::grouper::{
     build_templates_from_records,
 };
 use fgumi_lib::logging::{OperationTimer, log_umi_grouping_summary};
-use fgumi_lib::metrics::group::{FamilySizeMetrics, UmiGroupingMetrics};
+use fgumi_lib::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 use fgumi_lib::progress::ProgressTracker;
 use fgumi_lib::read_info::{LibraryIndex, compute_group_key};
 use fgumi_lib::sam::{is_sorted, is_template_coordinate_sorted, unclipped_five_prime_position};
@@ -42,7 +42,7 @@ use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Estimate total heap size of a template slice using sampling for large batches.
@@ -68,6 +68,8 @@ fn estimate_templates_heap_size(templates: &[Template]) -> usize {
 #[derive(Default, Debug)]
 struct CollectedMetrics {
     family_sizes: AHashMap<usize, u64>,
+    /// Number of UMI families in this position group.
+    position_group_size: usize,
     filter_metrics: FilterMetrics,
 }
 
@@ -741,6 +743,14 @@ pub struct GroupReadsByUmi {
     #[arg(short = 'g', long = "grouping-metrics")]
     pub grouping_metrics: Option<PathBuf>,
 
+    /// Output prefix for all group metrics files.
+    ///
+    /// Writes `PREFIX.family_sizes.txt`, `PREFIX.grouping_metrics.txt`,
+    /// and `PREFIX.position_group_sizes.txt`. Can be used alongside
+    /// `--family-size-histogram` and `--grouping-metrics`.
+    #[arg(short = 'M', long = "metrics")]
+    pub metrics: Option<PathBuf>,
+
     /// The tag containing the raw UMI
     #[arg(short = 't', long = "raw-tag", default_value = "RX")]
     pub raw_tag: String,
@@ -1366,8 +1376,10 @@ impl Command for GroupReadsByUmi {
                     return Ok(count);
                 }
                 // Collect metrics for later aggregation
+                let position_group_size: u64 = processed.family_sizes.values().sum();
                 let metrics = CollectedMetrics {
                     family_sizes: processed.family_sizes,
+                    position_group_size: position_group_size as usize,
                     filter_metrics: processed.filter_metrics,
                 };
 
@@ -1499,11 +1511,15 @@ impl Command for GroupReadsByUmi {
         // Aggregate collected metrics from lock-free SegQueue
         // Drain all metrics and merge them
         let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
+        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
         let mut total_filter_metrics = FilterMetrics::new();
 
         while let Some(m) = collected_metrics.pop() {
             for (size, count) in m.family_sizes {
                 *family_size_counter.entry(size).or_insert(0) += count;
+            }
+            if m.position_group_size > 0 {
+                *position_group_size_counter.entry(m.position_group_size).or_insert(0) += 1;
             }
             total_filter_metrics.merge(&m.filter_metrics);
         }
@@ -1511,27 +1527,11 @@ impl Command for GroupReadsByUmi {
         let metrics = build_grouping_metrics(&total_filter_metrics, &family_size_counter);
         log_umi_grouping_summary(&metrics);
 
-        // Write family size histogram
-        if let Some(path) = &self.family_size_histogram {
-            self.write_family_size_histogram(&family_size_counter).with_context(|| {
-                format!("Failed to write family size histogram: {}", path.display())
-            })?;
-            info!("Wrote family size histogram to {}", path.display());
-        }
-
-        // Save accepted_records before moving metrics
-        let accepted_records = metrics.accepted_records;
-
-        // Write grouping metrics using new metrics structure
-        if let Some(path) = &self.grouping_metrics {
-            DelimFile::default()
-                .write_tsv(path, [metrics])
-                .with_context(|| format!("Failed to write grouping metrics: {}", path.display()))?;
-            info!("Wrote grouping metrics to {}", path.display());
-        }
+        // Write all metrics (individual flags and --metrics prefix)
+        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
 
         // Log completion with timing
-        timer.log_completion(accepted_records);
+        timer.log_completion(metrics.accepted_records);
 
         info!("group completed successfully");
         info!("Records processed by pipeline: {records_processed}");
@@ -1581,6 +1581,7 @@ impl GroupReadsByUmi {
         // Metrics accumulators (no lock-free queue needed in single-threaded mode)
         let mut total_filter_metrics = FilterMetrics::new();
         let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
+        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
         let mut next_mi_base: u64 = 0;
 
         // Progress tracking
@@ -1610,6 +1611,7 @@ impl GroupReadsByUmi {
                     assign_tag_bytes,
                     &mut total_filter_metrics,
                     &mut family_size_counter,
+                    &mut position_group_size_counter,
                     &mut next_mi_base,
                     header,
                     &mut writer,
@@ -1632,6 +1634,7 @@ impl GroupReadsByUmi {
                 assign_tag_bytes,
                 &mut total_filter_metrics,
                 &mut family_size_counter,
+                &mut position_group_size_counter,
                 &mut next_mi_base,
                 header,
                 &mut writer,
@@ -1647,27 +1650,11 @@ impl GroupReadsByUmi {
         let metrics = build_grouping_metrics(&total_filter_metrics, &family_size_counter);
         log_umi_grouping_summary(&metrics);
 
-        // Write family size histogram
-        if let Some(path) = &self.family_size_histogram {
-            self.write_family_size_histogram(&family_size_counter).with_context(|| {
-                format!("Failed to write family size histogram: {}", path.display())
-            })?;
-            info!("Wrote family size histogram to {}", path.display());
-        }
-
-        // Save accepted_records before moving metrics
-        let accepted_records = metrics.accepted_records;
-
-        // Write grouping metrics
-        if let Some(path) = &self.grouping_metrics {
-            DelimFile::default()
-                .write_tsv(path, [metrics])
-                .with_context(|| format!("Failed to write grouping metrics: {}", path.display()))?;
-            info!("Wrote grouping metrics to {}", path.display());
-        }
+        // Write all metrics (individual flags and --metrics prefix)
+        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
 
         // Log completion with timing
-        timer.log_completion(accepted_records);
+        timer.log_completion(metrics.accepted_records);
 
         info!("group completed successfully");
         Ok(())
@@ -1687,6 +1674,7 @@ impl GroupReadsByUmi {
         assign_tag_bytes: [u8; 2],
         total_filter_metrics: &mut FilterMetrics,
         family_size_counter: &mut AHashMap<usize, u64>,
+        position_group_size_counter: &mut AHashMap<usize, u64>,
         next_mi_base: &mut u64,
         header: &Header,
         writer: &mut fgumi_lib::bam_io::BamWriter,
@@ -1746,10 +1734,11 @@ impl GroupReadsByUmi {
             a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
         });
 
-        // Count family sizes in one pass through sorted templates
+        // Count family sizes and position group size in one pass through sorted templates
         if !templates.is_empty() {
             let mut current_mi = templates[0].mi.to_vec_index();
             let mut current_count = 1usize;
+            let mut num_families = 0usize;
 
             for template in templates.iter().skip(1) {
                 let mi = template.mi.to_vec_index();
@@ -1759,6 +1748,7 @@ impl GroupReadsByUmi {
                     // Finish previous MI group
                     if current_mi.is_some() {
                         *family_size_counter.entry(current_count).or_insert(0) += 1;
+                        num_families += 1;
                     }
                     current_mi = mi;
                     current_count = 1;
@@ -1767,6 +1757,11 @@ impl GroupReadsByUmi {
             // Don't forget the last group
             if current_mi.is_some() {
                 *family_size_counter.entry(current_count).or_insert(0) += 1;
+                num_families += 1;
+            }
+
+            if num_families > 0 {
+                *position_group_size_counter.entry(num_families).or_insert(0) += 1;
             }
         }
 
@@ -1792,17 +1787,70 @@ impl GroupReadsByUmi {
         Ok(())
     }
 
-    /// Write family size histogram
-    fn write_family_size_histogram(&self, family_sizes: &AHashMap<usize, u64>) -> Result<()> {
+    /// Write all metrics files: individual flags and --metrics prefix outputs.
+    fn write_all_metrics(
+        &self,
+        grouping_metrics: &UmiGroupingMetrics,
+        family_sizes: &AHashMap<usize, u64>,
+        position_group_sizes: &AHashMap<usize, u64>,
+    ) -> Result<()> {
+        let family_size_metrics =
+            FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
+        let position_group_size_metrics = PositionGroupSizeMetrics::from_size_counts(
+            position_group_sizes.iter().map(|(&s, &c)| (s, c)),
+        );
+
+        // Write individual flag outputs (fgbio-compatible)
         if let Some(path) = &self.family_size_histogram {
-            let metrics =
-                FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
-            DelimFile::default()
-                .write_tsv(path, metrics)
-                .with_context(|| format!("Failed to create file: {}", path.display()))?;
+            write_metrics(path, &family_size_metrics, "family size histogram")?;
         }
+        if let Some(path) = &self.grouping_metrics {
+            write_metrics(path, std::slice::from_ref(grouping_metrics), "grouping metrics")?;
+        }
+
+        // Write --metrics prefix outputs (all three files)
+        if let Some(prefix) = &self.metrics {
+            let family_path = with_extension(prefix, "family_sizes.txt");
+            write_metrics(&family_path, &family_size_metrics, "family size histogram")?;
+
+            let grouping_path = with_extension(prefix, "grouping_metrics.txt");
+            write_metrics(
+                &grouping_path,
+                std::slice::from_ref(grouping_metrics),
+                "grouping metrics",
+            )?;
+
+            let position_path = with_extension(prefix, "position_group_sizes.txt");
+            write_metrics(
+                &position_path,
+                &position_group_size_metrics,
+                "position group size histogram",
+            )?;
+        }
+
         Ok(())
     }
+}
+
+/// Write metrics to a TSV file and log the output path.
+fn write_metrics<S: serde::Serialize>(
+    path: &Path,
+    data: impl IntoIterator<Item = S>,
+    label: &str,
+) -> Result<()> {
+    DelimFile::default()
+        .write_tsv(path, data)
+        .with_context(|| format!("Failed to write {label}: {}", path.display()))?;
+    info!("Wrote {label} to {}", path.display());
+    Ok(())
+}
+
+/// Build a path by appending `.{suffix}` to a prefix path.
+fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_owned();
+    s.push(".");
+    s.push(suffix);
+    PathBuf::from(s)
 }
 
 #[cfg(test)]
@@ -1824,7 +1872,8 @@ mod tests {
         dir: TempDir,
         pub output: PathBuf,
         pub histogram: PathBuf,
-        pub metrics: PathBuf,
+        pub grouping_metrics: PathBuf,
+        pub metrics_prefix: PathBuf,
     }
 
     impl TestPaths {
@@ -1833,7 +1882,8 @@ mod tests {
             Ok(Self {
                 output: dir.path().join("output.bam"),
                 histogram: dir.path().join("histogram.txt"),
-                metrics: dir.path().join("metrics.txt"),
+                grouping_metrics: dir.path().join("grouping_metrics.txt"),
+                metrics_prefix: dir.path().join("metrics"),
                 dir,
             })
         }
@@ -1849,6 +1899,7 @@ mod tests {
             },
             family_size_histogram: None,
             grouping_metrics: None,
+            metrics: None,
             raw_tag: "RX".to_string(),
             assign_tag: "MI".to_string(),
             cell_tag: "CB".to_string(),
@@ -2242,7 +2293,7 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.metrics.clone()),
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -2252,7 +2303,8 @@ mod tests {
         assert_eq!(output_records.len(), 4, "Should have 4 records (2 pairs, a02 filtered)");
 
         // Check metrics
-        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].discarded_ns_in_umi, 2);
 
@@ -2397,6 +2449,264 @@ mod tests {
         Ok(())
     }
 
+    /// Helper to build the paths for `--metrics PREFIX` output files.
+    fn metrics_prefix_paths(prefix: &Path) -> (PathBuf, PathBuf, PathBuf) {
+        (
+            with_extension(prefix, "family_sizes.txt"),
+            with_extension(prefix, "grouping_metrics.txt"),
+            with_extension(prefix, "position_group_sizes.txt"),
+        )
+    }
+
+    #[test]
+    fn test_metrics_prefix_writes_all_files() -> Result<()> {
+        // Test setup:
+        //   Position group 1 (pos 100,300): UMI AAA (3 reads) + UMI CCC (1 read) = 2 families
+        //   Position group 2 (pos 200,400): UMI AAA (2 reads) = 1 family
+        //   Position group 3 (pos 300,500): UMI AAA (1 read) + UMI CCC (1 read) + UMI GGG (1 read) = 3 families
+        //
+        // Family sizes: {1: 4, 2: 1, 3: 1}  (four size-1, one size-2, one size-3)
+        // Position group sizes: {1: 1, 2: 1, 3: 1}  (one group with 1, 2, 3 families)
+        let mut records = Vec::new();
+
+        // Position group 1: 2 families (AAA x3, CCC x1)
+        for i in 1..=3 {
+            let (r1, r2) = build_test_pair(&format!("a{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
+            records.push(r1);
+            records.push(r2);
+        }
+        let (r1, r2) = build_test_pair("a04", 0, 100, 300, 60, 60, "CCCCCCCC");
+        records.push(r1);
+        records.push(r2);
+
+        // Position group 2: 1 family (AAA x2)
+        for i in 1..=2 {
+            let (r1, r2) = build_test_pair(&format!("b{i:02}"), 0, 200, 400, 60, 60, "AAAAAAAA");
+            records.push(r1);
+            records.push(r2);
+        }
+
+        // Position group 3: 3 families (AAA x1, CCC x1, GGG x1)
+        let (r1, r2) = build_test_pair("c01", 0, 300, 500, 60, 60, "AAAAAAAA");
+        records.push(r1);
+        records.push(r2);
+        let (r1, r2) = build_test_pair("c02", 0, 300, 500, 60, 60, "CCCCCCCC");
+        records.push(r1);
+        records.push(r2);
+        let (r1, r2) = build_test_pair("c03", 0, 300, 500, 60, 60, "GGGGGGGG");
+        records.push(r1);
+        records.push(r2);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            metrics: Some(paths.metrics_prefix.clone()),
+            ..test_group_cmd(Strategy::Identity, 0)
+        };
+
+        cmd.execute("test")?;
+
+        let (family_path, grouping_path, position_path) =
+            metrics_prefix_paths(&paths.metrics_prefix);
+
+        assert!(family_path.exists(), "Family sizes file should exist");
+        assert!(grouping_path.exists(), "Grouping metrics file should exist");
+        assert!(position_path.exists(), "Position group sizes file should exist");
+
+        // ---- Family size histogram ----
+        // 6 families total: four size-1, one size-2, one size-3
+        let family_metrics: Vec<FamilySizeMetrics> = DelimFile::default().read_tsv(&family_path)?;
+        assert_eq!(family_metrics.len(), 3);
+        assert_eq!(
+            family_metrics[0],
+            FamilySizeMetrics {
+                family_size: 1,
+                count: 4,
+                fraction: 4.0 / 6.0,
+                fraction_gt_or_eq_family_size: 1.0,
+            }
+        );
+        assert_eq!(
+            family_metrics[1],
+            FamilySizeMetrics {
+                family_size: 2,
+                count: 1,
+                fraction: 1.0 / 6.0,
+                fraction_gt_or_eq_family_size: 2.0 / 6.0,
+            }
+        );
+        assert_eq!(
+            family_metrics[2],
+            FamilySizeMetrics {
+                family_size: 3,
+                count: 1,
+                fraction: 1.0 / 6.0,
+                fraction_gt_or_eq_family_size: 1.0 / 6.0,
+            }
+        );
+
+        // ---- Grouping metrics ----
+        // 9 read pairs = 18 records accepted, 6 unique families
+        let grouping: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&grouping_path)?;
+        assert_eq!(grouping.len(), 1);
+        assert_eq!(grouping[0].total_records, 18);
+        assert_eq!(grouping[0].accepted_records, 18);
+        assert_eq!(grouping[0].total_families, 6);
+
+        // ---- Position group size histogram ----
+        // 3 position groups: one with 1 family, one with 2, one with 3
+        let position_metrics: Vec<PositionGroupSizeMetrics> =
+            DelimFile::default().read_tsv(&position_path)?;
+        assert_eq!(position_metrics.len(), 3);
+        assert_eq!(
+            position_metrics[0],
+            PositionGroupSizeMetrics {
+                position_group_size: 1,
+                count: 1,
+                fraction: 1.0 / 3.0,
+                fraction_gt_or_eq_position_group_size: 1.0,
+            }
+        );
+        assert_eq!(
+            position_metrics[1],
+            PositionGroupSizeMetrics {
+                position_group_size: 2,
+                count: 1,
+                fraction: 1.0 / 3.0,
+                fraction_gt_or_eq_position_group_size: 2.0 / 3.0,
+            }
+        );
+        assert_eq!(
+            position_metrics[2],
+            PositionGroupSizeMetrics {
+                position_group_size: 3,
+                count: 1,
+                fraction: 1.0 / 3.0,
+                fraction_gt_or_eq_position_group_size: 1.0 / 3.0,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_metrics_prefix_and_individual_flags_write_same_content() -> Result<()> {
+        // Verify that --metrics PREFIX produces identical content to
+        // --family-size-histogram and --grouping-metrics individual flags.
+        let mut records = Vec::new();
+
+        // Two position groups with different family structures
+        for i in 1..=3 {
+            let (r1, r2) = build_test_pair(&format!("a{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
+            records.push(r1);
+            records.push(r2);
+        }
+        let (r1, r2) = build_test_pair("b01", 0, 200, 400, 60, 60, "CCCCCCCC");
+        records.push(r1);
+        records.push(r2);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            family_size_histogram: Some(paths.histogram.clone()),
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            metrics: Some(paths.metrics_prefix.clone()),
+            ..test_group_cmd(Strategy::Identity, 0)
+        };
+
+        cmd.execute("test")?;
+
+        let (prefix_family, prefix_grouping, prefix_position) =
+            metrics_prefix_paths(&paths.metrics_prefix);
+
+        // Family size histogram: individual flag and prefix should match
+        let individual_family: Vec<FamilySizeMetrics> =
+            DelimFile::default().read_tsv(&paths.histogram)?;
+        let prefix_family: Vec<FamilySizeMetrics> =
+            DelimFile::default().read_tsv(&prefix_family)?;
+        assert_eq!(individual_family, prefix_family);
+
+        // Grouping metrics: individual flag and prefix should match
+        let individual_grouping: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
+        let prefix_grouping: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&prefix_grouping)?;
+        assert_eq!(individual_grouping.len(), 1);
+        assert_eq!(prefix_grouping.len(), 1);
+        assert_eq!(individual_grouping[0].total_records, prefix_grouping[0].total_records);
+        assert_eq!(individual_grouping[0].accepted_records, prefix_grouping[0].accepted_records);
+        assert_eq!(individual_grouping[0].total_families, prefix_grouping[0].total_families);
+
+        // Position group sizes: only written via --metrics prefix
+        let position: Vec<PositionGroupSizeMetrics> =
+            DelimFile::default().read_tsv(&prefix_position)?;
+        assert_eq!(position.len(), 1);
+        // Both position groups have exactly 1 family each, so one entry: size=1, count=2
+        assert_eq!(position[0].position_group_size, 1);
+        assert_eq!(position[0].count, 2);
+        assert!((position[0].fraction - 1.0).abs() < f64::EPSILON);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_metrics_position_group_size_with_multi_read_families() -> Result<()> {
+        // Verify position group size counts families, not reads.
+        // Single position group with 2 families of different sizes:
+        //   UMI AAA: 5 reads  (family size 5)
+        //   UMI CCC: 2 reads  (family size 2)
+        // Position group size = 2 (two distinct families)
+        let mut records = Vec::new();
+
+        for i in 1..=5 {
+            let (r1, r2) = build_test_pair(&format!("r{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
+            records.push(r1);
+            records.push(r2);
+        }
+        for i in 6..=7 {
+            let (r1, r2) = build_test_pair(&format!("r{i:02}"), 0, 100, 300, 60, 60, "CCCCCCCC");
+            records.push(r1);
+            records.push(r2);
+        }
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            metrics: Some(paths.metrics_prefix.clone()),
+            ..test_group_cmd(Strategy::Identity, 0)
+        };
+
+        cmd.execute("test")?;
+
+        let (family_path, _, position_path) = metrics_prefix_paths(&paths.metrics_prefix);
+
+        // Family sizes: one size-2 family, one size-5 family
+        let family_metrics: Vec<FamilySizeMetrics> = DelimFile::default().read_tsv(&family_path)?;
+        assert_eq!(family_metrics.len(), 2);
+        assert_eq!(family_metrics[0].family_size, 2);
+        assert_eq!(family_metrics[0].count, 1);
+        assert_eq!(family_metrics[1].family_size, 5);
+        assert_eq!(family_metrics[1].count, 1);
+
+        // Position group size: one group with 2 families
+        let position_metrics: Vec<PositionGroupSizeMetrics> =
+            DelimFile::default().read_tsv(&position_path)?;
+        assert_eq!(position_metrics.len(), 1);
+        assert_eq!(position_metrics[0].position_group_size, 2);
+        assert_eq!(position_metrics[0].count, 1);
+        assert!((position_metrics[0].fraction - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (position_metrics[0].fraction_gt_or_eq_position_group_size - 1.0).abs() < f64::EPSILON
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_outputs_grouping_metrics() -> Result<()> {
         let mut records = Vec::new();
@@ -2421,14 +2731,15 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.metrics.clone()),
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
         cmd.execute("test")?;
 
-        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].accepted_records, 2);
         assert_eq!(metrics[0].discarded_ns_in_umi, 2);
@@ -2458,7 +2769,7 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.metrics.clone()),
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_umi_length: Some(6),
             ..test_group_cmd(Strategy::Edit, 0)
         };
@@ -2469,7 +2780,8 @@ mod tests {
         assert_eq!(output_records.len(), 2, "Should only have records with UMI length >= 6");
 
         // Check metrics
-        let metrics: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&paths.metrics)?;
+        let metrics: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].accepted_records, 2);
         assert_eq!(metrics[0].discarded_ns_in_umi, 0);
@@ -3885,14 +4197,14 @@ mod tests {
 
         let cmd = GroupReadsByUmi {
             io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
-            grouping_metrics: Some(paths.metrics.clone()),
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
         cmd.execute("test")?;
 
         // Verify metrics file was created
-        assert!(&paths.metrics.exists());
+        assert!(&paths.grouping_metrics.exists());
 
         Ok(())
     }

--- a/src/lib/metrics/mod.rs
+++ b/src/lib/metrics/mod.rs
@@ -34,6 +34,6 @@ pub use duplex::{
     DuplexFamilySizeMetric, DuplexMetricsCollector, DuplexUmiMetric, DuplexYieldMetric,
     FamilySizeMetric,
 };
-pub use group::{FamilySizeMetrics, UmiGroupingMetrics};
+pub use group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 pub use shared::UmiMetric;
 pub use writer::{read_metrics, write_metrics};


### PR DESCRIPTION
## Summary

Adds position group size metrics to the `group` command, tracking how many unique UMI families share the same start/end coordinates. This complements the existing family size histogram (reads per family) with a distinct measurement of UMI diversity at each genomic position.

Adds a new `--metrics/-M PREFIX` flag that writes all group metrics files:
- `PREFIX.family_sizes.txt` — family size histogram (same format as `--family-size-histogram`)
- `PREFIX.grouping_metrics.txt` — UMI grouping summary (same format as `--grouping-metrics`)
- `PREFIX.position_group_sizes.txt` — **new** position group size histogram

The `--metrics` prefix is extensible for future metric types (e.g. half-match metrics from #57). The existing `--family-size-histogram` and `--grouping-metrics` flags are retained for fgbio compatibility and can be used alongside `--metrics`.

### Position group size histogram format

| Column | Description |
|--------|-------------|
| `position_group_size` | Number of unique UMI families at the same genomic position |
| `count` | Number of position groups with this size |
| `fraction` | Fraction of all position groups with this size |
| `fraction_gt_or_eq_position_group_size` | Cumulative fraction (groups with size >= this value) |

### Validated on real data

Ran on the idt-cfdna benchmark sample (adjacency strategy):
- 327,538 total position groups, 367,269 total families
- 87.9% of position groups have 1 family, 12.1% have 2, tiny tail to 4
- Total families derived from position group sizes matches `total_families` in grouping metrics exactly
- Fractions and cumulative fractions verified correct
- Individual flag outputs (`-f`, `-g`) are byte-identical to `--metrics` prefix outputs

Closes #230

## Test plan

- [x] Unit tests for `PositionGroupSizeMetrics` (construction, `from_size_counts`, empty input)
- [x] Integration test: `--metrics` prefix writes all three files with correct content (multi-family, multi-position-group scenario)
- [x] Integration test: `--metrics` and individual flags (`-f`, `-g`) produce identical content
- [x] Integration test: position group size counts families not reads (multi-read families)
- [x] Existing family size histogram and grouping metrics tests still pass
- [x] Full test suite: 2216 tests pass
- [x] `cargo ci-fmt && cargo ci-lint` clean
- [x] Manual validation on idt-cfdna benchmark sample