### PR TITLE
feat(sort): add --max-memory=auto with system memory detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ memchr = "2"
 murmur3 = "0.5"
 statrs = "0.18"
 bytesize = "2.3"
-sysinfo = { version = "0.38", default-features = false, features = ["system"], optional = true }
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 rayon = "1.10"
 approx = "0.5.1"
 ahash = "0.8"
@@ -93,7 +93,7 @@ duplex = ["fgumi-consensus/duplex"]
 codec = ["fgumi-consensus/codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
-memory-debug = ["dep:libmimalloc-sys", "dep:sysinfo"]
+memory-debug = ["dep:libmimalloc-sys"]
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
 # Enable simulate commands for generating synthetic test data

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -5,7 +5,6 @@
 
 use std::path::PathBuf;
 
-use anyhow::Context;
 use bytesize::ByteSize;
 use clap::Args;
 use fgumi_lib::bam_io::is_stdin_path;
@@ -487,7 +486,6 @@ impl QueueMemoryOptions {
     /// or the memory calculation would overflow.
     pub fn calculate_memory_limit(&self, num_threads: usize) -> anyhow::Result<u64> {
         let total_memory = self.compute_memory_limit(num_threads)?;
-        #[cfg(feature = "memory-debug")]
         Self::validate_against_system_memory(total_memory);
         Ok(total_memory)
     }
@@ -522,8 +520,8 @@ impl QueueMemoryOptions {
             )
         } else {
             (
-                parse_memory_size(&self.queue_memory).with_context(|| {
-                    format!("Failed to parse queue memory size: {}", self.queue_memory)
+                parse_memory_size(&self.queue_memory).map_err(|e| {
+                    anyhow::anyhow!("Failed to parse queue memory size: {}: {e}", self.queue_memory)
                 })?,
                 false,
             )
@@ -568,7 +566,6 @@ impl QueueMemoryOptions {
     }
 
     /// Warns if the requested memory exceeds reasonable system limits.
-    #[cfg(feature = "memory-debug")]
     fn validate_against_system_memory(requested_bytes: u64) {
         use sysinfo::System;
         let mut system = System::new();
@@ -633,95 +630,8 @@ pub(crate) fn parse_bool(s: &str) -> Result<bool, String> {
     }
 }
 
-/// Parses a memory size string into bytes.
-///
-/// Accepts both plain numbers (interpreted as MB) and human-readable formats like:
-/// - "2GB", "2G" -> 2 gigabytes
-/// - "1.5GB" -> 1.5 gigabytes
-/// - "1024MB", "1024M" -> 1024 megabytes
-/// - "512MiB" -> 512 mebibytes
-/// - "768" -> 768 megabytes (backward compatibility)
-///
-/// # Examples
-///
-/// ```
-/// # use anyhow::Result;
-/// # use fgumi::commands::common::parse_memory_size;
-/// assert_eq!(parse_memory_size("768")?, 768 * 1024 * 1024);
-/// assert_eq!(parse_memory_size("2GB")?, 2 * 1000 * 1000 * 1000);
-/// assert_eq!(parse_memory_size("1024MiB")?, 1024 * 1024 * 1024);
-/// ```
-///
-/// # Errors
-///
-/// Returns an error if the string cannot be parsed as a valid size.
-pub fn parse_memory_size(size_str: &str) -> anyhow::Result<u64> {
-    // Validate input string
-    let trimmed = size_str.trim();
-    if trimmed.is_empty() {
-        anyhow::bail!("Memory size cannot be empty");
-    }
-
-    // Handle negative values early
-    if trimmed.starts_with('-') {
-        anyhow::bail!("Memory size cannot be negative: '{trimmed}'");
-    }
-
-    // First try parsing as a plain integer in MB (backward compatibility)
-    // Only accept simple integers, not floats or scientific notation
-    if let Ok(mb_value) = trimmed.parse::<u64>() {
-        // Validate reasonable range for plain numbers
-        if mb_value == 0 {
-            anyhow::bail!("Memory size cannot be zero");
-        }
-        if mb_value > 1_000_000 {
-            // Sanity guard: >1TB as a plain number likely means the user forgot a unit suffix.
-            // Values above this should use human-readable format (e.g. "2TB") which bypasses
-            // this check and goes through ByteSize parsing instead.
-            anyhow::bail!(
-                "Plain number memory size too large: {} MB. Use human-readable format like '{}GB' instead.",
-                mb_value,
-                mb_value / 1000
-            );
-        }
-
-        return mb_value
-            .checked_mul(1024 * 1024)
-            .ok_or_else(|| anyhow::anyhow!("Memory size calculation overflow for {mb_value} MB"));
-    }
-
-    // Reject scientific notation (e.g. "1e3") but allow decimals in human-readable sizes (e.g. "1.5GB")
-    if trimmed.contains('e') || trimmed.contains('E') {
-        anyhow::bail!(
-            "Scientific notation not supported: '{trimmed}'. Use integer values or human-readable formats like '2GB'."
-        );
-    }
-
-    // Reject bare decimal numbers without a unit suffix (e.g. "1.5") since plain numbers are MB
-    if trimmed.contains('.') && trimmed.chars().all(|c| c.is_ascii_digit() || c == '.') {
-        anyhow::bail!(
-            "Plain decimal numbers not supported: '{trimmed}'. Use an integer for MB (e.g. '768') or a human-readable format (e.g. '1.5GB')."
-        );
-    }
-
-    // Fall back to parsing as a human-readable size (like "2GB", "1024MiB")
-    match trimmed.parse::<ByteSize>() {
-        Ok(size) => {
-            if size.0 == 0 {
-                anyhow::bail!("Memory size cannot be zero: '{trimmed}'");
-            }
-            Ok(size.0)
-        }
-        Err(_) => {
-            anyhow::bail!(
-                "Invalid memory size '{trimmed}'. Valid formats:\n\
-                 - Plain numbers (interpreted as MB): '768', '4096'\n\
-                 - Human-readable (decimal): '2GB', '1024MB'\n\
-                 - Human-readable (binary): '1GiB', '512MiB'"
-            )
-        }
-    }
-}
+// Re-export from the library crate for backward compatibility.
+pub use fgumi_lib::validation::parse_memory_size;
 
 /// Builds a [`BamPipelineConfig`] from the common CLI option structs.
 ///
@@ -918,111 +828,6 @@ mod tests {
             deadlock_recover: true,
         };
         assert!(opts.deadlock_recover_enabled());
-    }
-
-    // ========== Tests for memory size parsing ==========
-
-    #[test]
-    fn test_parse_memory_size_plain_numbers() {
-        assert_eq!(
-            parse_memory_size("768").expect("parse '768' should succeed"),
-            768 * 1024 * 1024
-        );
-        assert_eq!(parse_memory_size("1").expect("parse '1' should succeed"), 1024 * 1024);
-        assert_eq!(
-            parse_memory_size("4096").expect("parse '4096' should succeed"),
-            4096 * 1024 * 1024
-        );
-    }
-
-    #[test]
-    fn test_parse_memory_size_human_readable() {
-        assert_eq!(
-            parse_memory_size("2GB").expect("parse '2GB' should succeed"),
-            2 * 1000 * 1000 * 1000
-        );
-        assert_eq!(
-            parse_memory_size("2G").expect("parse '2G' should succeed"),
-            2 * 1000 * 1000 * 1000
-        );
-        assert_eq!(
-            parse_memory_size("1024MB").expect("parse '1024MB' should succeed"),
-            1024 * 1000 * 1000
-        );
-        assert_eq!(
-            parse_memory_size("1024M").expect("parse '1024M' should succeed"),
-            1024 * 1000 * 1000
-        );
-        assert_eq!(
-            parse_memory_size("1GiB").expect("parse '1GiB' should succeed"),
-            1024 * 1024 * 1024
-        );
-        assert_eq!(
-            parse_memory_size("512MiB").expect("parse '512MiB' should succeed"),
-            512 * 1024 * 1024
-        );
-    }
-
-    #[test]
-    fn test_parse_memory_size_invalid() {
-        assert!(parse_memory_size("invalid").is_err());
-        assert!(parse_memory_size("").is_err());
-        assert!(parse_memory_size("GB2").is_err());
-    }
-
-    #[test]
-    fn test_parse_memory_size_zero() {
-        // Zero values should be rejected
-        assert!(parse_memory_size("0").is_err());
-        assert!(parse_memory_size("0MB").is_err());
-        assert!(parse_memory_size("0GB").is_err());
-    }
-
-    // ========== Tests for new edge cases and validation ==========
-
-    #[test]
-    fn test_parse_memory_size_edge_cases() {
-        // Empty and whitespace
-        assert!(parse_memory_size("").is_err());
-        assert!(parse_memory_size("   ").is_err());
-
-        // Negative values
-        assert!(parse_memory_size("-100").is_err());
-        assert!(parse_memory_size("-1GB").is_err());
-
-        // Bare floating point without unit suffix (should be rejected)
-        assert!(parse_memory_size("1.5").is_err());
-
-        // Floating point with unit suffix (should be accepted via ByteSize)
-        assert!(parse_memory_size("1.5GB").is_ok());
-        assert!(parse_memory_size("2.5GB").is_ok());
-
-        // Scientific notation (should be rejected for plain numbers)
-        assert!(parse_memory_size("1e3").is_err());
-        assert!(parse_memory_size("1E6").is_err());
-
-        // Very large plain numbers (should be rejected)
-        assert!(parse_memory_size("9999999").is_err());
-    }
-
-    #[test]
-    fn test_parse_memory_size_whitespace_handling() {
-        // Trimmed input should work
-        assert_eq!(
-            parse_memory_size("  768  ").expect("parse trimmed '768' should succeed"),
-            768 * 1024 * 1024
-        );
-        assert_eq!(
-            parse_memory_size("\t1GB\n").expect("parse trimmed '1GB' should succeed"),
-            1000 * 1000 * 1000
-        );
-    }
-
-    #[test]
-    fn test_parse_memory_size_overflow() {
-        // Very large MB values should be caught
-        let very_large = format!("{}", u64::MAX / 1024); // Would overflow when * 1024 * 1024
-        assert!(parse_memory_size(&very_large).is_err());
     }
 
     // ========== Tests for QueueMemoryOptions ==========

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -21,6 +21,7 @@
 //! Use `--verify` to check if a BAM file is correctly sorted without writing output.
 
 use anyhow::{Result, bail};
+use bytesize::ByteSize;
 use clap::Parser;
 use fgumi_lib::bam_io::create_bam_reader;
 use fgumi_lib::logging::OperationTimer;
@@ -31,6 +32,7 @@ use std::path::PathBuf;
 
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
+use fgumi_lib::validation::parse_memory_size;
 
 /// Sort order for BAM files.
 ///
@@ -133,7 +135,7 @@ PERFORMANCE:
   - Handles BAM files larger than available RAM via spill-to-disk
   - Uses parallel sorting (--threads) for in-memory chunks
   - Configurable temp file compression (--temp-compression)
-  - Memory scales with threads by default (768MB/thread, like samtools)
+  - Auto memory detection with configurable reserve for co-running processes
 
 EXAMPLES:
 
@@ -146,9 +148,14 @@ EXAMPLES:
   # Sort by queryname for zipper
   fgumi sort -i input.bam -o sorted.bam --order queryname
 
-  # High-performance sort with more memory and threads
-  fgumi sort -i input.bam -o sorted.bam --order template-coordinate \
-    --max-memory 8G --threads 8
+  # Multi-threaded sort (auto-detects available memory)
+  fgumi sort -i input.bam -o sorted.bam --order template-coordinate --threads 8
+
+  # Override auto memory with an explicit per-thread limit
+  fgumi sort -i input.bam -o sorted.bam -m 2GiB --threads 8
+
+  # Reserve extra memory for bwa mem running in a pipeline
+  fgumi sort -i input.bam -o sorted.bam --memory-reserve 12GiB --threads 4
 
   # Verify a BAM file is correctly sorted
   fgumi sort -i sorted.bam --verify --order template-coordinate
@@ -181,16 +188,27 @@ pub struct Sort {
     #[arg(long = "order", default_value = "template-coordinate", value_parser = SortOrderArg::parse)]
     pub order: SortOrderArg,
 
-    /// Maximum memory to use for in-memory sorting (per thread when --memory-per-thread).
+    /// Maximum memory for in-memory sorting.
     ///
-    /// Accepts values like "512M", "1G", "2G". When the memory limit
-    /// is reached, sorted chunks are written to temporary files and
-    /// merged at the end.
+    /// "auto" (default) detects system memory and subtracts --memory-reserve
+    /// to leave room for the OS and co-running processes (e.g. an aligner).
+    /// Explicit values like "512M", "1G", "4GiB" are per-thread when
+    /// --memory-per-thread is enabled (default).
     ///
-    /// With --memory-per-thread (default), this is multiplied by thread count
-    /// (like samtools' -m option). With 8 threads and 768M, total = 6GB.
-    #[arg(short = 'm', long = "max-memory", default_value = "768M", value_parser = parse_memory)]
-    pub max_memory: usize,
+    /// When the limit is reached, sorted chunks spill to temporary files.
+    #[arg(short = 'm', long = "max-memory", default_value = "auto", value_parser = parse_memory)]
+    pub max_memory: MemoryLimit,
+
+    /// Memory to reserve for other processes when --max-memory=auto.
+    ///
+    /// "auto" (default) reserves min(10 GiB, 50% of system memory). Explicit
+    /// values like "10G", "8GiB" set a fixed reservation. Set higher when
+    /// running alongside a memory-intensive aligner (e.g. `bwa mem` with a
+    /// human genome index uses ~8 GiB).
+    ///
+    /// Ignored when --max-memory is set to an explicit value.
+    #[arg(long = "memory-reserve", default_value = "auto", value_parser = parse_memory_reserve)]
+    pub memory_reserve: MemoryReserve,
 
     /// Scale memory limit by thread count (samtools behavior).
     ///
@@ -243,32 +261,57 @@ pub struct Sort {
     pub cell_tag: String,
 }
 
-/// Parse memory size string (e.g., "512M", "1G", "2G").
-pub(crate) fn parse_memory(s: &str) -> Result<usize, String> {
-    let s = s.trim().to_uppercase();
+/// Represents the memory limit configuration for sorting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLimit {
+    /// Automatically detect system memory and compute an optimal limit.
+    Auto,
+    /// Use a fixed memory limit in bytes.
+    Fixed(usize),
+}
 
-    if s.is_empty() {
-        return Err("Empty memory specification".to_string());
+/// Represents how much memory to reserve for other processes (OS, aligners, etc.)
+/// when `--max-memory=auto`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryReserve {
+    /// Automatic: `min(10 GiB, 50% of system memory)`.
+    Auto,
+    /// Reserve a fixed number of bytes.
+    Fixed(usize),
+}
+
+/// Parse a memory size string into `usize` bytes, suitable for use in clap
+/// value parsers.
+///
+/// Delegates to [`parse_memory_size`] for numeric parsing. Plain numbers are
+/// interpreted as MiB (e.g. "768" = 768 MiB). Supports human-readable formats
+/// like "2GB", "1GiB", "512MiB". See [`parse_memory_size`] for full details.
+fn parse_memory_bytes(s: &str, label: &str) -> Result<usize, String> {
+    let bytes = parse_memory_size(s).map_err(|e| e.to_string())?;
+    usize::try_from(bytes).map_err(|_| format!("{label} too large: {bytes}"))
+}
+
+/// Parse memory size string (e.g., "512M", "1G", "2G", "auto").
+pub(crate) fn parse_memory(s: &str) -> Result<MemoryLimit, String> {
+    let s = s.trim();
+
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(MemoryLimit::Auto);
     }
 
-    let (num_str, multiplier) = if s.ends_with('G') {
-        (&s[..s.len() - 1], 1024 * 1024 * 1024)
-    } else if s.ends_with('M') {
-        (&s[..s.len() - 1], 1024 * 1024)
-    } else if s.ends_with('K') {
-        (&s[..s.len() - 1], 1024)
-    } else {
-        // Assume bytes
-        (s.as_str(), 1)
-    };
+    Ok(MemoryLimit::Fixed(parse_memory_bytes(s, "Memory size")?))
+}
 
-    let num: f64 = num_str.parse().map_err(|_| format!("Invalid number: {num_str}"))?;
+/// Parse memory reserve string (e.g., "10G", "auto").
+pub(crate) fn parse_memory_reserve(s: &str) -> Result<MemoryReserve, String> {
+    let s = s.trim();
 
-    if num < 0.0 {
-        return Err("Memory size must be positive".to_string());
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(MemoryReserve::Auto);
     }
 
-    Ok((num * multiplier as f64) as usize)
+    let bytes = parse_memory_bytes(s, "Memory reserve")?;
+    Ok(MemoryReserve::Fixed(bytes))
 }
 
 /// Parse the cell tag for template-coordinate sort/verify, returning `None`
@@ -346,6 +389,113 @@ impl Command for Sort {
     }
 }
 
+/// The minimum per-thread memory budget (256 MiB).
+const MIN_MEMORY_PER_THREAD: usize = 256 * 1024 * 1024;
+
+/// Default auto-reserve cap: 10 GiB.
+const AUTO_RESERVE_CAP: usize = 10 * 1024 * 1024 * 1024;
+
+/// Resolve a [`MemoryReserve`] to a concrete byte count given total system memory.
+fn resolve_reserve(reserve: MemoryReserve, total_memory: usize) -> usize {
+    match reserve {
+        MemoryReserve::Fixed(bytes) => bytes,
+        MemoryReserve::Auto => {
+            // min(10 GiB, 50% of system memory)
+            AUTO_RESERVE_CAP.min(total_memory / 2)
+        }
+    }
+}
+
+/// Resolves a [`MemoryLimit`] to a concrete byte count.
+///
+/// For [`MemoryLimit::Auto`]: detects total system memory, subtracts the
+/// reserve (via [`MemoryReserve`]), and divides by thread count (when
+/// `memory_per_thread` is true). The result is clamped to a minimum of
+/// 256 MiB per thread.
+///
+/// For [`MemoryLimit::Fixed`]: applies the same `memory_per_thread`
+/// multiplication as before. The reserve is ignored.
+fn resolve_memory_limit(
+    limit: MemoryLimit,
+    reserve: MemoryReserve,
+    threads: usize,
+    memory_per_thread: bool,
+) -> Result<usize> {
+    if threads == 0 {
+        bail!("--threads must be at least 1");
+    }
+
+    let total_budget = match limit {
+        MemoryLimit::Fixed(bytes) => {
+            if memory_per_thread {
+                bytes
+                    .checked_mul(threads)
+                    .ok_or_else(|| anyhow::anyhow!("--max-memory × --threads overflowed"))?
+            } else {
+                bytes
+            }
+        }
+        MemoryLimit::Auto => {
+            let mut system = sysinfo::System::new();
+            system.refresh_memory();
+            let total = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+
+            let margin = resolve_reserve(reserve, total);
+            let available = total.saturating_sub(margin);
+
+            if memory_per_thread {
+                let per_thread = (available / threads).max(MIN_MEMORY_PER_THREAD);
+                let budget = per_thread
+                    .checked_mul(threads)
+                    .ok_or_else(|| anyhow::anyhow!("auto memory budget overflowed"))?;
+                if budget > available {
+                    log::warn!(
+                        "Auto memory: total budget {} exceeds available {} \
+                         ({}/thread x {} threads, reserve {}); may spill to disk earlier than expected",
+                        ByteSize(budget as u64),
+                        ByteSize(available as u64),
+                        ByteSize(per_thread as u64),
+                        threads,
+                        ByteSize(margin as u64),
+                    );
+                }
+                info!(
+                    "Auto memory: using {} of {} ({}/thread x {} threads, reserve {})",
+                    ByteSize(budget as u64),
+                    ByteSize(total as u64),
+                    ByteSize(per_thread as u64),
+                    threads,
+                    ByteSize(margin as u64),
+                );
+                budget
+            } else {
+                let budget = available.max(MIN_MEMORY_PER_THREAD);
+                info!(
+                    "Auto memory: using {} of {} (fixed total, reserve {})",
+                    ByteSize(budget as u64),
+                    ByteSize(total as u64),
+                    ByteSize(margin as u64),
+                );
+                budget
+            }
+        }
+    };
+
+    // Post-resolution system memory check: warn if any mode exceeds host RAM
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let total = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+    if total_budget > total {
+        log::warn!(
+            "Memory budget {} exceeds total system memory {}; spill-to-disk is likely",
+            ByteSize(total_budget as u64),
+            ByteSize(total as u64),
+        );
+    }
+
+    Ok(total_budget)
+}
+
 impl Sort {
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
     /// for other sort orders.
@@ -357,10 +507,6 @@ impl Sort {
     fn execute_sort(&self, command_line: &str) -> Result<()> {
         let output = self.output.as_ref().expect("output required for sort mode");
 
-        if self.max_memory == 0 {
-            bail!("--max-memory must be greater than 0");
-        }
-
         // --write-index only valid for coordinate sort
         if self.write_index && !matches!(self.order, SortOrderArg::Coordinate) {
             bail!("--write-index is only valid for coordinate sort");
@@ -368,12 +514,13 @@ impl Sort {
 
         let timer = OperationTimer::new("Sorting BAM");
 
-        // Calculate effective memory: per-thread or fixed total
-        let effective_memory = if self.memory_per_thread {
-            self.max_memory.saturating_mul(self.threads.max(1))
-        } else {
-            self.max_memory
-        };
+        // Resolve memory limit (auto-detect or fixed)
+        let effective_memory = resolve_memory_limit(
+            self.max_memory,
+            self.memory_reserve,
+            self.threads,
+            self.memory_per_thread,
+        )?;
 
         let cell_tag = self.parse_cell_tag()?;
 
@@ -384,15 +531,17 @@ impl Sort {
         if let Some(ct) = cell_tag {
             info!("Cell tag: {}{}", ct[0] as char, ct[1] as char);
         }
-        if self.memory_per_thread {
-            info!(
-                "Max memory: {} MB ({} MB/thread × {} threads)",
-                effective_memory / (1024 * 1024),
-                self.max_memory / (1024 * 1024),
-                self.threads
-            );
-        } else {
-            info!("Max memory: {} MB (fixed)", effective_memory / (1024 * 1024));
+        if let MemoryLimit::Fixed(per_thread) = self.max_memory {
+            if self.memory_per_thread {
+                info!(
+                    "Max memory: {} ({}/thread x {} threads)",
+                    ByteSize(effective_memory as u64),
+                    ByteSize(per_thread as u64),
+                    self.threads
+                );
+            } else {
+                info!("Max memory: {} (fixed)", ByteSize(effective_memory as u64));
+            }
         }
         info!("Threads: {}", self.threads);
         info!("Temp compression level: {}", self.temp_compression);
@@ -411,6 +560,17 @@ impl Sort {
             .temp_compression(self.temp_compression)
             .write_index(self.write_index)
             .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
+
+        // For auto mode, cap initial buffer pre-allocation at 768 MiB/thread
+        // (matching samtools default) to avoid huge upfront allocations.
+        // The buffer will grow on demand up to memory_limit.
+        if matches!(self.max_memory, MemoryLimit::Auto) {
+            let init = 768_usize
+                .checked_mul(1024 * 1024)
+                .and_then(|b| b.checked_mul(self.threads))
+                .ok_or_else(|| anyhow::anyhow!("initial auto buffer size overflowed"))?;
+            sorter = sorter.initial_capacity(effective_memory.min(init));
+        }
 
         if let Some(ct) = cell_tag {
             sorter = sorter.cell_tag(ct);
@@ -537,7 +697,8 @@ mod tests {
             output: None,
             verify: false,
             order,
-            max_memory: 512 * 1024 * 1024,
+            max_memory: MemoryLimit::Fixed(512 * 1024 * 1024),
+            memory_reserve: MemoryReserve::Auto,
             memory_per_thread: true,
             tmp_dir: None,
             threads: 1,
@@ -575,62 +736,77 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_memory_megabytes() {
+    fn test_parse_memory_auto() {
         assert_eq!(
-            parse_memory("512M").expect("parse_memory should succeed for 512M"),
-            512 * 1024 * 1024
+            parse_memory("auto").expect("parse_memory should succeed for 'auto'"),
+            MemoryLimit::Auto
         );
         assert_eq!(
-            parse_memory("1024M").expect("parse_memory should succeed for 1024M"),
-            1024 * 1024 * 1024
+            parse_memory("AUTO").expect("parse_memory should succeed for 'AUTO'"),
+            MemoryLimit::Auto
+        );
+        assert_eq!(
+            parse_memory("Auto").expect("parse_memory should succeed for 'Auto'"),
+            MemoryLimit::Auto
         );
     }
 
     #[test]
-    fn test_parse_memory_gigabytes() {
+    fn test_parse_memory_plain_numbers_as_mb() {
+        // Plain numbers are interpreted as MB (via parse_memory_size)
+        assert_eq!(
+            parse_memory("768").expect("parse_memory should succeed for 768"),
+            MemoryLimit::Fixed(768 * 1024 * 1024)
+        );
+        assert_eq!(
+            parse_memory("1").expect("parse_memory should succeed for 1"),
+            MemoryLimit::Fixed(1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn test_parse_memory_human_readable() {
+        // Suffixed values use ByteSize (decimal: G=1000^3, M=1000^2)
+        assert_eq!(
+            parse_memory("512MB").expect("parse_memory should succeed for 512MB"),
+            MemoryLimit::Fixed(512 * 1000 * 1000)
+        );
         assert_eq!(
             parse_memory("1G").expect("parse_memory should succeed for 1G"),
-            1024 * 1024 * 1024
+            MemoryLimit::Fixed(1_000_000_000)
         );
         assert_eq!(
-            parse_memory("2G").expect("parse_memory should succeed for 2G"),
-            2 * 1024 * 1024 * 1024
+            parse_memory("2GB").expect("parse_memory should succeed for 2GB"),
+            MemoryLimit::Fixed(2_000_000_000)
         );
-    }
-
-    #[test]
-    fn test_parse_memory_kilobytes() {
+        // Binary suffixes (GiB, MiB)
         assert_eq!(
-            parse_memory("1024K").expect("parse_memory should succeed for 1024K"),
-            1024 * 1024
+            parse_memory("1GiB").expect("parse_memory should succeed for 1GiB"),
+            MemoryLimit::Fixed(1024 * 1024 * 1024)
         );
-    }
-
-    #[test]
-    fn test_parse_memory_bytes() {
         assert_eq!(
-            parse_memory("1048576").expect("parse_memory should succeed for bare bytes"),
-            1_048_576
+            parse_memory("512MiB").expect("parse_memory should succeed for 512MiB"),
+            MemoryLimit::Fixed(512 * 1024 * 1024)
         );
     }
 
     #[test]
-    fn test_parse_memory_lowercase() {
+    fn test_parse_memory_case_insensitive() {
         assert_eq!(
-            parse_memory("512m").expect("parse_memory should succeed for lowercase 512m"),
-            512 * 1024 * 1024
+            parse_memory("512mb").expect("parse_memory should succeed for lowercase 512mb"),
+            MemoryLimit::Fixed(512 * 1000 * 1000)
         );
         assert_eq!(
-            parse_memory("1g").expect("parse_memory should succeed for lowercase 1g"),
-            1024 * 1024 * 1024
+            parse_memory("1gb").expect("parse_memory should succeed for lowercase 1gb"),
+            MemoryLimit::Fixed(1_000_000_000)
         );
     }
 
     #[test]
-    fn test_parse_memory_decimal() {
+    fn test_parse_memory_decimal_with_suffix() {
         assert_eq!(
-            parse_memory("1.5G").expect("parse_memory should succeed for 1.5G"),
-            (1.5 * 1024.0 * 1024.0 * 1024.0) as usize
+            parse_memory("1.5GB").expect("parse_memory should succeed for 1.5GB"),
+            MemoryLimit::Fixed(1_500_000_000)
         );
     }
 
@@ -639,6 +815,104 @@ mod tests {
         assert!(parse_memory("").is_err());
         assert!(parse_memory("abc").is_err());
         assert!(parse_memory("-1G").is_err());
+    }
+
+    #[test]
+    fn test_resolve_memory_limit_fixed() {
+        let fixed = MemoryLimit::Fixed(1024 * 1024 * 1024); // 1 GiB
+        // Reserve is ignored for fixed limits
+        let resolved =
+            resolve_memory_limit(fixed, MemoryReserve::Auto, 4, true).expect("should succeed");
+        // Fixed + memory_per_thread: total = 1 GiB * 4 = 4 GiB
+        assert_eq!(resolved, 4 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_resolve_memory_limit_fixed_no_per_thread() {
+        let fixed = MemoryLimit::Fixed(4 * 1024 * 1024 * 1024); // 4 GiB
+        let resolved =
+            resolve_memory_limit(fixed, MemoryReserve::Auto, 4, false).expect("should succeed");
+        // Fixed + no per-thread: total = 4 GiB
+        assert_eq!(resolved, 4 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_resolve_memory_limit_auto() {
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        let total = system.total_memory() as usize;
+
+        let resolved = resolve_memory_limit(MemoryLimit::Auto, MemoryReserve::Auto, 4, true)
+            .expect("should succeed");
+        // Must be at least the per-thread minimum floor (256 MiB * 4 threads)
+        let min_expected = MIN_MEMORY_PER_THREAD.saturating_mul(4).min(total);
+        assert!(
+            resolved >= min_expected,
+            "auto resolved to {resolved} bytes, expected at least {min_expected}"
+        );
+        // And not more than total system memory
+        assert!(resolved <= total);
+    }
+
+    #[test]
+    fn test_resolve_memory_limit_auto_no_per_thread() {
+        let resolved = resolve_memory_limit(MemoryLimit::Auto, MemoryReserve::Auto, 8, false)
+            .expect("should succeed");
+        // Auto + no per-thread: should be total budget, not divided by threads
+        // Must be at least the minimum floor (256 MB)
+        assert!(resolved >= 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_resolve_reserve_auto() {
+        let gib = 1024 * 1024 * 1024;
+        // 32 GiB system: min(10 GiB, 16 GiB) = 10 GiB
+        assert_eq!(resolve_reserve(MemoryReserve::Auto, 32 * gib), 10 * gib);
+        // 16 GiB system: min(10 GiB, 8 GiB) = 8 GiB
+        assert_eq!(resolve_reserve(MemoryReserve::Auto, 16 * gib), 8 * gib);
+        // 8 GiB system: min(10 GiB, 4 GiB) = 4 GiB
+        assert_eq!(resolve_reserve(MemoryReserve::Auto, 8 * gib), 4 * gib);
+        // 128 GiB system: min(10 GiB, 64 GiB) = 10 GiB
+        assert_eq!(resolve_reserve(MemoryReserve::Auto, 128 * gib), 10 * gib);
+    }
+
+    #[test]
+    fn test_resolve_reserve_fixed() {
+        let gib = 1024 * 1024 * 1024;
+        assert_eq!(resolve_reserve(MemoryReserve::Fixed(12 * gib), 64 * gib), 12 * gib);
+    }
+
+    #[test]
+    fn test_parse_memory_reserve() {
+        assert_eq!(parse_memory_reserve("auto").expect("should parse 'auto'"), MemoryReserve::Auto,);
+        assert_eq!(
+            parse_memory_reserve("10GiB").expect("should parse '10GiB'"),
+            MemoryReserve::Fixed(10 * 1024 * 1024 * 1024),
+        );
+        assert_eq!(
+            parse_memory_reserve("8G").expect("should parse '8G'"),
+            MemoryReserve::Fixed(8_000_000_000),
+        );
+    }
+
+    #[test]
+    fn test_resolve_memory_limit_auto_with_fixed_reserve() {
+        // With a large fixed reserve, auto should return less memory
+        let large_reserve = resolve_memory_limit(
+            MemoryLimit::Auto,
+            MemoryReserve::Fixed(10 * 1024 * 1024 * 1024),
+            4,
+            true,
+        )
+        .expect("should succeed");
+        let small_reserve = resolve_memory_limit(
+            MemoryLimit::Auto,
+            MemoryReserve::Fixed(2 * 1024 * 1024 * 1024),
+            4,
+            true,
+        )
+        .expect("should succeed");
+        assert!(large_reserve < small_reserve);
     }
 
     #[test]

--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -54,6 +54,13 @@ pub enum FgumiError {
         /// The reference sequence name
         ref_name: String,
     },
+
+    /// Invalid memory size string
+    #[error("Invalid memory size: {reason}")]
+    InvalidMemorySize {
+        /// Explanation of why the value is invalid
+        reason: String,
+    },
 }
 
 #[cfg(test)]
@@ -89,6 +96,15 @@ mod tests {
         let msg = format!("{error}");
         assert!(msg.contains("Invalid BAM file"));
         assert!(msg.contains("truncated file"));
+    }
+
+    #[test]
+    fn test_invalid_memory_size() {
+        let error =
+            FgumiError::InvalidMemorySize { reason: "Memory size cannot be empty".to_string() };
+        let msg = format!("{error}");
+        assert!(msg.contains("Invalid memory size"));
+        assert!(msg.contains("cannot be empty"));
     }
 
     #[test]

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -12,6 +12,7 @@
 use crate::sort::bam_fields;
 use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::sort::radix::bytes_needed_u64;
+use crate::sort::segmented_buf::SegmentedBuf;
 use std::cmp::Ordering;
 use std::io::{Read, Write};
 
@@ -141,13 +142,16 @@ const HEADER_SIZE: usize = std::mem::size_of::<InlineHeader>(); // 16 bytes
 /// An index array of `RecordRef` is maintained for sorting.
 /// Sorting only reorders the index; records stay in place.
 pub struct RecordBuffer {
-    /// Raw byte storage for all records (headers + BAM data).
-    data: Vec<u8>,
+    /// Segmented byte storage for all records (headers + BAM data).
+    data: SegmentedBuf,
     /// Index of record references for sorting.
     refs: Vec<RecordRef>,
     /// Number of reference sequences (for unmapped handling).
     nref: u32,
 }
+
+/// Segment size for `RecordBuffer`'s `SegmentedBuf`: 256 MiB.
+const RECORD_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
 impl RecordBuffer {
     /// Create a new buffer with estimated capacity.
@@ -159,7 +163,10 @@ impl RecordBuffer {
     #[must_use]
     pub fn with_capacity(estimated_records: usize, estimated_bytes: usize, nref: u32) -> Self {
         Self {
-            data: Vec::with_capacity(estimated_bytes + estimated_records * HEADER_SIZE),
+            data: SegmentedBuf::with_capacity(
+                estimated_bytes + estimated_records * HEADER_SIZE,
+                RECORD_SEGMENT_SIZE,
+            ),
             refs: Vec::with_capacity(estimated_records),
             nref,
         }
@@ -169,30 +176,52 @@ impl RecordBuffer {
     ///
     /// Extracts the sort key inline from raw BAM bytes (zero-copy).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the record length exceeds `u32::MAX`.
+    /// Returns an error if the record (plus header) exceeds the segment size
+    /// (256 MiB) or if the record length exceeds `u32::MAX`.
     #[inline]
-    pub fn push_coordinate(&mut self, record: &[u8]) {
-        let offset = self.data.len() as u64;
-        let len = u32::try_from(record.len()).expect("record length exceeds u32::MAX");
+    pub fn push_coordinate(&mut self, record: &[u8]) -> anyhow::Result<()> {
+        // BAM fixed-length block is 32 bytes; coordinate fields end at offset 15.
+        const MIN_BAM_RECORD_LEN: usize = 16;
+        anyhow::ensure!(
+            record.len() >= MIN_BAM_RECORD_LEN,
+            "BAM record is truncated: need at least {} bytes to extract coordinate fields, got {}",
+            MIN_BAM_RECORD_LEN,
+            record.len(),
+        );
+
+        let total_bytes = HEADER_SIZE + record.len();
+        anyhow::ensure!(
+            total_bytes <= RECORD_SEGMENT_SIZE,
+            "BAM record of {} bytes (+ {} byte header) exceeds segment size of {} bytes; \
+             this is likely a malformed BAM file",
+            record.len(),
+            HEADER_SIZE,
+            RECORD_SEGMENT_SIZE,
+        );
+        let len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("record length {} exceeds u32::MAX", record.len()))?;
 
         // Extract sort key from raw BAM bytes
         let sort_key = extract_coordinate_key_inline(record, self.nref);
 
+        // Reserve contiguous space for header + record
+        let total_bytes = HEADER_SIZE + record.len();
+        let offset = self.data.reserve_contiguous(total_bytes) as u64;
+
         // Write inline header (16 bytes)
         let header = InlineHeader { sort_key, record_len: len, padding: 0 };
-
-        // Extend data with header bytes
-        self.data.extend_from_slice(&header.sort_key.to_le_bytes());
-        self.data.extend_from_slice(&header.record_len.to_le_bytes());
-        self.data.extend_from_slice(&header.padding.to_le_bytes());
+        self.data.extend_in_place(&header.sort_key.to_le_bytes());
+        self.data.extend_in_place(&header.record_len.to_le_bytes());
+        self.data.extend_in_place(&header.padding.to_le_bytes());
 
         // Write raw BAM data
-        self.data.extend_from_slice(record);
+        self.data.extend_in_place(record);
 
         // Add to index
         self.refs.push(RecordRef { sort_key, offset, len, padding: 0 });
+        Ok(())
     }
 
     /// Sort the index by key (records stay in place).
@@ -267,9 +296,7 @@ impl RecordBuffer {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn get_record(&self, r: &RecordRef) -> &[u8] {
-        let start = r.offset as usize + HEADER_SIZE;
-        let end = start + r.len as usize;
-        &self.data[start..end]
+        self.data.slice(r.offset as usize + HEADER_SIZE, r.len as usize)
     }
 
     /// Iterate over sorted records.
@@ -587,16 +614,19 @@ const _: () = assert!(
 );
 
 impl TemplateInlineHeader {
-    /// Write header to a byte buffer.
+    /// Serialize header to a byte array.
     #[inline]
-    pub fn write_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.key.primary.to_le_bytes());
-        buf.extend_from_slice(&self.key.secondary.to_le_bytes());
-        buf.extend_from_slice(&self.key.cb_hash.to_le_bytes());
-        buf.extend_from_slice(&self.key.tertiary.to_le_bytes());
-        buf.extend_from_slice(&self.key.name_hash_upper.to_le_bytes());
-        buf.extend_from_slice(&self.record_len.to_le_bytes());
-        buf.extend_from_slice(&self.padding.to_le_bytes());
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; TEMPLATE_HEADER_SIZE] {
+        let mut buf = [0u8; TEMPLATE_HEADER_SIZE];
+        buf[0..8].copy_from_slice(&self.key.primary.to_le_bytes());
+        buf[8..16].copy_from_slice(&self.key.secondary.to_le_bytes());
+        buf[16..24].copy_from_slice(&self.key.cb_hash.to_le_bytes());
+        buf[24..32].copy_from_slice(&self.key.tertiary.to_le_bytes());
+        buf[32..40].copy_from_slice(&self.key.name_hash_upper.to_le_bytes());
+        buf[40..44].copy_from_slice(&self.record_len.to_le_bytes());
+        buf[44..48].copy_from_slice(&self.padding.to_le_bytes());
+        buf
     }
 
     /// Read header from a byte slice.
@@ -683,43 +713,63 @@ impl Ord for TemplateRecordRef {
 /// 1. Compares primary keys from refs (fast, O(1))
 /// 2. On ties, fetches full keys from inline headers
 pub struct TemplateRecordBuffer {
-    /// Raw byte storage: inline headers + record data.
-    data: Vec<u8>,
+    /// Segmented byte storage: inline headers + record data.
+    data: SegmentedBuf,
     /// Minimal index for sorting.
     refs: Vec<TemplateRecordRef>,
 }
+
+/// Segment size for `TemplateRecordBuffer`'s `SegmentedBuf`: 256 MiB.
+const TEMPLATE_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
 impl TemplateRecordBuffer {
     /// Create a new buffer with estimated capacity.
     #[must_use]
     pub fn with_capacity(estimated_records: usize, estimated_bytes: usize) -> Self {
-        // Account for inline headers in data capacity
         let header_bytes = estimated_records * TEMPLATE_HEADER_SIZE;
         Self {
-            data: Vec::with_capacity(estimated_bytes + header_bytes),
+            data: SegmentedBuf::with_capacity(
+                estimated_bytes + header_bytes,
+                TEMPLATE_SEGMENT_SIZE,
+            ),
             refs: Vec::with_capacity(estimated_records),
         }
     }
 
     /// Push a record with a pre-computed template key.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the record length exceeds `u32::MAX`.
+    /// Returns an error if the record (plus header) exceeds the segment size
+    /// (256 MiB) or if the record length exceeds `u32::MAX`.
     #[inline]
-    pub fn push(&mut self, record: &[u8], key: TemplateKey) {
-        let offset = self.data.len() as u64;
-        let record_len = u32::try_from(record.len()).expect("record length exceeds u32::MAX");
+    pub fn push(&mut self, record: &[u8], key: TemplateKey) -> anyhow::Result<()> {
+        let total_bytes = TEMPLATE_HEADER_SIZE + record.len();
+        anyhow::ensure!(
+            total_bytes <= TEMPLATE_SEGMENT_SIZE,
+            "BAM record of {} bytes (+ {} byte header) exceeds segment size of {} bytes; \
+             this is likely a malformed BAM file",
+            record.len(),
+            TEMPLATE_HEADER_SIZE,
+            TEMPLATE_SEGMENT_SIZE,
+        );
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("record length {} exceeds u32::MAX", record.len()))?;
 
-        // Write inline header using manual byte operations (avoids alignment issues)
+        // Reserve contiguous space for header + record
+        let total_bytes = TEMPLATE_HEADER_SIZE + record.len();
+        let offset = self.data.reserve_contiguous(total_bytes) as u64;
+
+        // Write inline header
         let header = TemplateInlineHeader { key, record_len, padding: 0 };
-        header.write_to(&mut self.data);
+        self.data.extend_in_place(&header.to_bytes());
 
         // Write raw BAM data
-        self.data.extend_from_slice(record);
+        self.data.extend_in_place(record);
 
         // Add ref with cached key for O(1) sort comparisons
         self.refs.push(TemplateRecordRef { key, offset, len: record_len, padding: 0 });
+        Ok(())
     }
 
     /// Sort the index by cached key using stable LSD radix sort.
@@ -744,9 +794,7 @@ impl TemplateRecordBuffer {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn get_record(&self, r: &TemplateRecordRef) -> &[u8] {
-        let start = r.offset as usize + TEMPLATE_HEADER_SIZE;
-        let end = start + r.len as usize;
-        &self.data[start..end]
+        self.data.slice(r.offset as usize + TEMPLATE_HEADER_SIZE, r.len as usize)
     }
 
     /// Iterate over sorted records.
@@ -795,12 +843,6 @@ impl TemplateRecordBuffer {
     pub fn clear(&mut self) {
         self.data.clear();
         self.refs.clear();
-    }
-
-    /// Get underlying data buffer (for direct access to raw bytes).
-    #[must_use]
-    pub fn data(&self) -> &[u8] {
-        &self.data
     }
 
     /// Sort in parallel and return each sub-array as a separate sorted chunk.
@@ -1637,7 +1679,7 @@ mod tests {
             while record.len() < 40 {
                 record.push(0);
             }
-            buffer.push(&record, key);
+            buffer.push(&record, key).expect("push should succeed in tests");
         }
 
         buffer.sort();
@@ -1779,7 +1821,7 @@ mod tests {
                 0,
                 false,
             );
-            buffer.push(&make_bam_record(i as u16), key);
+            buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
         }
 
         let chunks = buffer.par_sort_into_chunks(1);
@@ -1824,7 +1866,7 @@ mod tests {
                     0,
                     false,
                 );
-                buffer.push(&make_bam_record(i as u16), key);
+                buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
             }
 
             buffer.par_sort_into_chunks(4)
@@ -1882,7 +1924,9 @@ mod tests {
         for i in 0..n {
             // Reverse order so sorting is non-trivial
             let pos = (n - i) as i32;
-            buffer.push_coordinate(&make_coordinate_bam_record(0, pos));
+            buffer
+                .push_coordinate(&make_coordinate_bam_record(0, pos))
+                .expect("push_coordinate should succeed in tests");
         }
 
         let chunks = buffer.par_sort_into_chunks(1);
@@ -1913,7 +1957,9 @@ mod tests {
 
             for i in 0..n {
                 let pos = (n - i) as i32;
-                buffer.push_coordinate(&make_coordinate_bam_record(0, pos));
+                buffer
+                    .push_coordinate(&make_coordinate_bam_record(0, pos))
+                    .expect("push_coordinate should succeed in tests");
             }
 
             buffer.par_sort_into_chunks(4)

--- a/src/lib/sort/mod.rs
+++ b/src/lib/sort/mod.rs
@@ -42,6 +42,7 @@ pub mod radix;
 pub mod raw;
 pub mod raw_bam_reader;
 pub mod read_ahead;
+pub(crate) mod segmented_buf;
 
 /// Buffer size for `BufReader` during merge phase.
 const MERGE_BUFFER_SIZE: usize = 64 * 1024;

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -647,6 +647,12 @@ pub struct RawExternalSorter {
     /// Cell barcode tag for template-coordinate sort (e.g., `[b'C', b'B']`).
     /// When `Some`, CB hash is included in sort key for single-cell data.
     cell_tag: Option<[u8; 2]>,
+    /// Initial buffer capacity hint (bytes) for pre-allocation.
+    ///
+    /// Decoupled from `memory_limit` so that auto-detected limits can start with
+    /// a modest allocation and let `Vec` grow on demand, while explicit limits
+    /// pre-allocate the full budget upfront (preserving prior behavior).
+    initial_capacity: Option<usize>,
 }
 
 impl RawExternalSorter {
@@ -664,6 +670,7 @@ impl RawExternalSorter {
             pg_info: None,
             max_temp_files: DEFAULT_MAX_TEMP_FILES,
             cell_tag: None,
+            initial_capacity: None,
         }
     }
 
@@ -743,6 +750,24 @@ impl RawExternalSorter {
     pub fn cell_tag(mut self, tag: [u8; 2]) -> Self {
         self.cell_tag = Some(tag);
         self
+    }
+
+    /// Set the initial buffer capacity hint (bytes).
+    ///
+    /// When set, buffer pre-allocation uses this value instead of `memory_limit`.
+    /// This avoids huge upfront allocations when auto-detecting memory, while
+    /// still allowing the buffer to grow up to `memory_limit` before spilling.
+    #[must_use]
+    pub fn initial_capacity(mut self, bytes: usize) -> Self {
+        self.initial_capacity = Some(bytes);
+        self
+    }
+
+    /// Returns the effective initial capacity for buffer pre-allocation.
+    ///
+    /// Uses `initial_capacity` if set, otherwise falls back to `memory_limit`.
+    fn effective_initial_capacity(&self) -> usize {
+        self.initial_capacity.unwrap_or(self.memory_limit).min(self.memory_limit)
     }
 
     /// Consolidate temp files if we've exceeded the limit.
@@ -1057,11 +1082,16 @@ impl RawExternalSorter {
         // Get number of references (unmapped reads map to nref)
         let nref = header.reference_sequences().len() as u32;
 
-        // Estimate capacity: ~200 bytes per record average
-        let estimated_records = self.memory_limit / 200;
+        // Estimate capacity from initial_capacity (not memory_limit) to avoid
+        // huge upfront allocations when auto-detecting memory.
+        let init_cap = self.effective_initial_capacity();
+        // Per-record footprint: ~200 bytes BAM + 16 header + 24 ref = ~240 bytes
+        let estimated_records = init_cap / 240;
+        // Data bytes = init_cap minus ref overhead (24 bytes/record)
+        let estimated_data_bytes = init_cap.saturating_sub(estimated_records * 24);
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
-        let mut buffer = RecordBuffer::with_capacity(estimated_records, self.memory_limit, nref);
+        let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
 
         let read_ahead = RawReadAheadReader::new(reader);
@@ -1074,7 +1104,7 @@ impl RawExternalSorter {
             progress.log_if_needed(1);
 
             // Push directly to buffer - key extracted inline from raw bytes
-            buffer.push_coordinate(record.as_ref());
+            buffer.push_coordinate(record.as_ref())?;
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
@@ -1199,10 +1229,13 @@ impl RawExternalSorter {
 
         let mut stats = RawSortStats::default();
         let nref = header.reference_sequences().len() as u32;
-        let estimated_records = self.memory_limit / 200;
+        let init_cap = self.effective_initial_capacity();
+        // Per-record footprint: ~200 bytes BAM + 16 header + 24 ref = ~240 bytes
+        let estimated_records = init_cap / 240;
+        let estimated_data_bytes = init_cap.saturating_sub(estimated_records * 24);
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
-        let mut buffer = RecordBuffer::with_capacity(estimated_records, self.memory_limit, nref);
+        let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
         let read_ahead = RawReadAheadReader::new(reader);
 
@@ -1210,7 +1243,7 @@ impl RawExternalSorter {
 
         for record in read_ahead {
             stats.total_records += 1;
-            buffer.push_coordinate(record.as_ref());
+            buffer.push_coordinate(record.as_ref())?;
 
             if buffer.memory_usage() >= self.memory_limit {
                 let chunk_path = namer.next_chunk_path();
@@ -1363,8 +1396,9 @@ impl RawExternalSorter {
         let mut stats = RawSortStats::default();
         let ctx = SortContext::from_header(header);
 
-        // Estimate capacity: ~250 bytes per record + ~50 bytes for name + flags
-        let estimated_records = self.memory_limit / 300;
+        // Estimate capacity from initial_capacity to avoid huge upfront allocations.
+        let init_cap = self.effective_initial_capacity();
+        let estimated_records = init_cap / 300;
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut entries: Vec<(K, Vec<u8>)> = Vec::with_capacity(estimated_records);
@@ -1512,16 +1546,16 @@ impl RawExternalSorter {
         let lib_lookup = LibraryLookup::from_header(header);
         let cb_hasher = cb_hasher();
 
-        // Estimate capacity accounting for inline headers and cached-key refs
+        // Estimate capacity from initial_capacity to avoid huge upfront allocations.
         // Memory layout per record:
         //   - data: 48 bytes (inline header) + ~250 bytes (BAM record) = 298 bytes
         //   - refs: 56 bytes (TemplateKey + u64 offset + u32 len + u32 pad)
         //   - Total: ~354 bytes per record
-        // The larger refs trade memory for cache locality during sort
+        let init_cap = self.effective_initial_capacity();
         let bytes_per_record = 354;
-        let estimated_records = self.memory_limit / bytes_per_record;
+        let estimated_records = init_cap / bytes_per_record;
         // Allocate ~86% for data, ~14% for refs (48/338 ≈ 14%)
-        let estimated_data_bytes = self.memory_limit * 86 / 100;
+        let estimated_data_bytes = init_cap * 86 / 100;
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer =
@@ -1545,7 +1579,7 @@ impl RawExternalSorter {
                 self.cell_tag.as_ref(),
                 &cb_hasher,
             );
-            buffer.push(bam_bytes, key);
+            buffer.push(bam_bytes, key)?;
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {

--- a/src/lib/sort/segmented_buf.rs
+++ b/src/lib/sort/segmented_buf.rs
@@ -1,0 +1,430 @@
+#![deny(unsafe_code)]
+//! Segmented byte buffer that grows without copying existing data.
+//!
+//! Unlike `Vec<u8>`, which must reallocate and copy all existing data when it
+//! outgrows its capacity, `SegmentedBuf` appends new fixed-size segments.
+//! This avoids the O(n) memcpy cost on each doubling and the transient peak
+//! memory of holding both old and new buffers simultaneously.
+//!
+//! Designed as a drop-in replacement for `Vec<u8>` in the sort buffer, where
+//! records are appended sequentially and later accessed by `(offset, len)`.
+
+/// Default segment size: 256 MiB.
+const DEFAULT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
+
+/// A growable byte buffer backed by fixed-size segments.
+///
+/// Each segment is an independent heap allocation. Appending data never moves
+/// existing bytes — when the current segment is full, a new one is allocated.
+///
+/// Records written via [`extend_from_slice`](Self::extend_from_slice) are
+/// guaranteed not to span segment boundaries: if the current segment lacks
+/// room, a new segment is started first.
+pub struct SegmentedBuf {
+    /// The fixed capacity of each segment.
+    segment_size: usize,
+    /// Backing storage: one `Vec<u8>` per segment, each with capacity `segment_size`.
+    segments: Vec<Vec<u8>>,
+    /// Total bytes stored across all segments.
+    total_len: usize,
+}
+
+#[allow(dead_code)] // Some methods are only exercised from tests for now.
+impl SegmentedBuf {
+    /// Create a new buffer with the given initial capacity hint and segment size.
+    ///
+    /// The first segment is pre-allocated immediately.  Additional segments are
+    /// allocated on demand.
+    #[must_use]
+    pub fn with_capacity(capacity: usize, segment_size: usize) -> Self {
+        let segment_size = segment_size.max(1);
+        // Pre-allocate the first segment up to segment_size.  The capacity hint
+        // tells the outer `segments` Vec how many segments to expect, avoiding
+        // re-allocations as the buffer grows.
+        let first_cap = capacity.min(segment_size);
+        let estimated_segments = (capacity / segment_size).max(1);
+        let mut segments = Vec::with_capacity(estimated_segments);
+        segments.push(Vec::with_capacity(first_cap));
+        Self { segment_size, segments, total_len: 0 }
+    }
+
+    /// Create a new buffer with a default segment size of 256 MiB.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(0, DEFAULT_SEGMENT_SIZE)
+    }
+
+    /// Append bytes to the buffer, returning the global offset of the write.
+    ///
+    /// If the current segment does not have enough remaining capacity for the
+    /// entire slice, a new segment is allocated first.  This guarantees the
+    /// written bytes are contiguous within a single segment, so callers can
+    /// later retrieve them with a single `(offset, len)` reference.
+    ///
+    /// **Important:** always use the returned offset — do not use [`len`](Self::len)
+    /// as a pre-write offset, because gap padding may shift it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() > segment_size` — a single write must fit in one
+    /// segment.
+    pub fn extend_from_slice(&mut self, data: &[u8]) -> usize {
+        assert!(
+            data.len() <= self.segment_size,
+            "write of {} bytes exceeds segment size {}",
+            data.len(),
+            self.segment_size,
+        );
+
+        let seg = self.segments.last().expect("segments is never empty");
+        if seg.len() + data.len() > self.segment_size {
+            // Pad total_len to the next segment boundary so locate() works.
+            let remainder = self.total_len % self.segment_size;
+            if remainder > 0 {
+                self.total_len += self.segment_size - remainder;
+            }
+            self.segments.push(Vec::with_capacity(self.segment_size));
+        }
+
+        let offset = self.total_len;
+        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.total_len += data.len();
+        offset
+    }
+
+    /// Ensure at least `additional` bytes fit in the current segment.
+    ///
+    /// If the remaining capacity in the current segment is less than
+    /// `additional`, a new segment is started (with gap padding).
+    /// Returns the global offset where the next write will land.
+    ///
+    /// Use this before a sequence of `extend_from_slice` calls that must
+    /// stay contiguous (e.g. header + record body).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `additional > segment_size`.
+    pub fn reserve_contiguous(&mut self, additional: usize) -> usize {
+        assert!(
+            additional <= self.segment_size,
+            "reserve of {} bytes exceeds segment size {}",
+            additional,
+            self.segment_size,
+        );
+
+        let seg = self.segments.last().expect("segments is never empty");
+        if seg.len() + additional > self.segment_size {
+            let remainder = self.total_len % self.segment_size;
+            if remainder > 0 {
+                self.total_len += self.segment_size - remainder;
+            }
+            self.segments.push(Vec::with_capacity(self.segment_size));
+        }
+        self.total_len
+    }
+
+    /// Append bytes to the current segment without checking capacity.
+    ///
+    /// Caller must ensure room via [`reserve_contiguous`](Self::reserve_contiguous)
+    /// first. This is the fast path for multi-part writes (header + body).
+    ///
+    /// # Panics
+    ///
+    /// Panics (in debug builds) if the segments vec is empty.
+    #[inline]
+    pub fn extend_in_place(&mut self, data: &[u8]) {
+        debug_assert!(
+            self.segments.last().is_some_and(|s| s.len() + data.len() <= self.segment_size),
+            "extend_in_place exceeds segment capacity; use reserve_contiguous first"
+        );
+        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.total_len += data.len();
+    }
+
+    /// Total bytes stored (including gap padding at segment boundaries).
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.total_len
+    }
+
+    /// Whether the buffer is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total_len == 0
+    }
+
+    /// Retrieve a contiguous slice by global `(offset, len)`.
+    ///
+    /// Because [`extend_from_slice`](Self::extend_from_slice) never splits a
+    /// write across segments, any range that was written in a single call is
+    /// guaranteed to be within one segment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range is out of bounds or spans a segment boundary.
+    #[inline]
+    #[must_use]
+    pub fn slice(&self, offset: usize, len: usize) -> &[u8] {
+        let (seg_idx, seg_offset) = self.locate(offset);
+        let seg = &self.segments[seg_idx];
+        assert!(
+            seg_offset + len <= seg.len(),
+            "slice ({offset}..{}) spans segment boundary (seg {seg_idx}, seg_offset {seg_offset}, seg_len {})",
+            offset + len,
+            seg.len(),
+        );
+        &seg[seg_offset..seg_offset + len]
+    }
+
+    /// Clear all data, retaining the first segment's allocation.
+    pub fn clear(&mut self) {
+        self.segments.truncate(1);
+        self.segments[0].clear();
+        self.total_len = 0;
+    }
+
+    /// Translate a global byte offset to `(segment_index, offset_within_segment)`.
+    #[inline]
+    fn locate(&self, offset: usize) -> (usize, usize) {
+        // Fast path for fixed-size segments (all but the last are full)
+        let seg_idx = offset / self.segment_size;
+        let seg_offset = offset % self.segment_size;
+        (seg_idx, seg_offset)
+    }
+
+    /// The segment size.
+    #[must_use]
+    pub fn segment_size(&self) -> usize {
+        self.segment_size
+    }
+
+    /// Number of allocated segments.
+    #[must_use]
+    pub fn segment_count(&self) -> usize {
+        self.segments.len()
+    }
+}
+
+impl Default for SegmentedBuf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_is_empty() {
+        let buf = SegmentedBuf::new();
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.segment_count(), 1); // one pre-allocated segment
+    }
+
+    #[test]
+    fn test_extend_and_len() {
+        let mut buf = SegmentedBuf::with_capacity(0, 1024);
+        let o1 = buf.extend_from_slice(b"hello");
+        assert_eq!(o1, 0);
+        assert_eq!(buf.len(), 5);
+        assert!(!buf.is_empty());
+
+        let o2 = buf.extend_from_slice(b" world");
+        assert_eq!(o2, 5);
+        assert_eq!(buf.len(), 11);
+    }
+
+    #[test]
+    fn test_slice_retrieval() {
+        let mut buf = SegmentedBuf::with_capacity(0, 1024);
+        let o1 = buf.extend_from_slice(b"hello");
+        let o2 = buf.extend_from_slice(b" world");
+
+        assert_eq!(buf.slice(o1, 5), b"hello");
+        assert_eq!(buf.slice(o2, 6), b" world");
+        // Both in same segment, so contiguous range works
+        assert_eq!(buf.slice(o1, 11), b"hello world");
+    }
+
+    #[test]
+    fn test_segment_boundary() {
+        // Segment size of 10 bytes
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+
+        // Fill first segment exactly
+        let o1 = buf.extend_from_slice(b"0123456789");
+        assert_eq!(buf.segment_count(), 1);
+        assert_eq!(buf.len(), 10);
+
+        // Next write starts a new segment
+        let o2 = buf.extend_from_slice(b"abcde");
+        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.len(), 15);
+
+        // Data is retrievable across segments
+        assert_eq!(buf.slice(o1, 10), b"0123456789");
+        assert_eq!(buf.slice(o2, 5), b"abcde");
+    }
+
+    #[test]
+    fn test_spill_to_new_segment_when_not_enough_room() {
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+
+        let o1 = buf.extend_from_slice(b"1234567"); // 7 bytes in seg 0
+        assert_eq!(o1, 0);
+        assert_eq!(buf.segment_count(), 1);
+
+        // 5 bytes won't fit in remaining 3 bytes, so spills to seg 1
+        // total_len jumps from 7 → 10 (gap) → 15
+        let o2 = buf.extend_from_slice(b"abcde");
+        assert_eq!(o2, 10); // starts at segment boundary
+        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.len(), 15); // 10 (seg 0 padded) + 5
+
+        assert_eq!(buf.slice(o1, 7), b"1234567");
+        assert_eq!(buf.slice(o2, 5), b"abcde");
+    }
+
+    #[test]
+    fn test_offset_accounting_with_gaps() {
+        // When a write spills to a new segment, total_len must include the
+        // gap at the end of the previous segment so that locate() works.
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+
+        let o0 = buf.extend_from_slice(b"aaa"); // seg 0
+        assert_eq!(o0, 0);
+
+        let o1 = buf.extend_from_slice(b"bbb"); // seg 0
+        assert_eq!(o1, 3);
+
+        // 6 bytes used in seg 0, 5-byte write won't fit → spills to seg 1
+        let o2 = buf.extend_from_slice(b"ccccc");
+        assert_eq!(o2, 10); // gap of 4 bytes at end of seg 0
+
+        assert_eq!(buf.len(), 15); // 10 (seg 0 padded) + 5
+
+        // All three slices are retrievable
+        assert_eq!(buf.slice(o0, 3), b"aaa");
+        assert_eq!(buf.slice(o1, 3), b"bbb");
+        assert_eq!(buf.slice(o2, 5), b"ccccc");
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds segment size")]
+    fn test_write_exceeding_segment_panics() {
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        buf.extend_from_slice(b"12345678901"); // 11 bytes > 10
+    }
+
+    #[test]
+    fn test_clear_resets() {
+        let mut buf = SegmentedBuf::with_capacity(0, 1024);
+        buf.extend_from_slice(b"some data");
+        buf.clear();
+
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.segment_count(), 1);
+    }
+
+    #[test]
+    fn test_many_segments() {
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+
+        // Write 50 records of 80 bytes each. First record fits in seg 0 (80 bytes),
+        // second doesn't fit (80+80=160 > 100), so each record gets its own segment.
+        let mut offsets = Vec::new();
+        for i in 0u8..50 {
+            let record = vec![i; 80];
+            let offset = buf.extend_from_slice(&record);
+            offsets.push(offset);
+        }
+
+        // Each record in its own 100-byte segment
+        assert_eq!(buf.segment_count(), 50);
+
+        // Verify all records readable
+        #[allow(clippy::cast_possible_truncation)]
+        for (i, &offset) in offsets.iter().enumerate() {
+            let data = buf.slice(offset, 80);
+            assert_eq!(data[0], i as u8);
+        }
+    }
+
+    #[test]
+    fn test_realistic_record_pattern() {
+        // Simulate RecordBuffer usage: header (16 bytes) + record (~200-400 bytes)
+        // written as two separate extend_from_slice calls at the same logical offset.
+        let mut buf = SegmentedBuf::with_capacity(0, 1024);
+
+        let header = [0u8; 16];
+        let record = [42u8; 300];
+
+        let offset = buf.extend_from_slice(&header);
+        let record_offset = buf.extend_from_slice(&record);
+
+        // Both in same segment, so header starts at offset, record right after
+        assert_eq!(record_offset, offset + 16);
+        assert_eq!(buf.slice(offset, 16), &header);
+        assert_eq!(buf.slice(record_offset, 300), &record);
+    }
+
+    #[test]
+    fn test_memory_usage_includes_gaps() {
+        // memory_usage should reflect the virtual address space used (including gaps),
+        // not just the bytes of actual data written.
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+
+        buf.extend_from_slice(&[0u8; 60]); // seg 0: 60 bytes used
+        buf.extend_from_slice(&[0u8; 60]); // spills to seg 1: gap of 40 at end of seg 0
+
+        // len() includes the gap: 100 + 60 = 160
+        assert_eq!(buf.len(), 160);
+    }
+
+    #[test]
+    fn test_reserve_contiguous_then_multi_part_write() {
+        // Simulate RecordBuffer: reserve space for header+record, then write parts.
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+
+        // First record: 16-byte header + 60-byte record = 76 bytes
+        let offset = buf.reserve_contiguous(76);
+        assert_eq!(offset, 0);
+        buf.extend_in_place(&[0xAA; 16]); // header
+        buf.extend_in_place(&[0xBB; 60]); // record
+
+        // Second record: 16+60 = 76 bytes, only 24 left in seg 0 → spill
+        let offset2 = buf.reserve_contiguous(76);
+        assert_eq!(offset2, 100); // new segment
+        buf.extend_in_place(&[0xCC; 16]);
+        buf.extend_in_place(&[0xDD; 60]);
+
+        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.slice(0, 16), &[0xAA; 16]);
+        assert_eq!(buf.slice(16, 60), &[0xBB; 60]);
+        assert_eq!(buf.slice(100, 16), &[0xCC; 16]);
+        assert_eq!(buf.slice(116, 60), &[0xDD; 60]);
+    }
+
+    #[test]
+    fn test_consecutive_writes_same_segment() {
+        // Multiple small writes that all fit in one segment should be contiguous.
+        let mut buf = SegmentedBuf::with_capacity(0, 1024);
+
+        let o1 = buf.extend_from_slice(b"aaaa");
+        let o2 = buf.extend_from_slice(b"bbbb");
+        let o3 = buf.extend_from_slice(b"cccc");
+
+        assert_eq!(o1, 0);
+        assert_eq!(o2, 4);
+        assert_eq!(o3, 8);
+        assert_eq!(buf.segment_count(), 1);
+
+        // Can read the entire contiguous range
+        assert_eq!(buf.slice(0, 12), b"aaaabbbbcccc");
+    }
+}

--- a/src/lib/unified_pipeline/rebalancer.rs
+++ b/src/lib/unified_pipeline/rebalancer.rs
@@ -304,38 +304,20 @@ pub fn initial_allocation_for_command(
 /// # Errors
 ///
 /// Returns an error if:
-/// - The value cannot be parsed as a number
-/// - The value is below the minimum (256MB)
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+/// - The value cannot be parsed by [`crate::validation::parse_memory_size`]
+/// - The value is below the minimum (256 MiB)
+///
+/// Plain numeric values are interpreted as MB (e.g. "768" = 768 MB).
+/// See [`crate::validation::parse_memory_size`] for the full set of accepted formats.
 pub fn parse_memory_limit(s: &str) -> Result<u64, String> {
-    const MIN_BYTES: u64 = 256 * 1024 * 1024; // 256MB
+    const MIN_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
 
-    let s = s.trim().to_uppercase();
+    let bytes = crate::validation::parse_memory_size(s).map_err(|e| e.to_string())?;
 
-    let (num_str, multiplier) = if s.ends_with("GB") {
-        (s.trim_end_matches("GB"), 1024 * 1024 * 1024)
-    } else if s.ends_with('G') {
-        (s.trim_end_matches('G'), 1024 * 1024 * 1024)
-    } else if s.ends_with("MB") {
-        (s.trim_end_matches("MB"), 1024 * 1024)
-    } else if s.ends_with('M') {
-        (s.trim_end_matches('M'), 1024 * 1024)
-    } else if s.ends_with("KB") {
-        (s.trim_end_matches("KB"), 1024)
-    } else if s.ends_with('K') {
-        (s.trim_end_matches('K'), 1024)
-    } else {
-        // Assume bytes
-        (s.as_str(), 1)
-    };
-
-    let num: f64 = num_str.trim().parse().map_err(|_| format!("Invalid memory value: {s}"))?;
-
-    let bytes = (num * f64::from(multiplier)) as u64;
     if bytes < MIN_BYTES {
         return Err(format!(
-            "Queue memory limit {}MB is too low (minimum: 256MB)",
-            bytes / (1024 * 1024)
+            "Queue memory limit {} is too low (minimum: 256 MiB)",
+            bytesize::ByteSize(bytes)
         ));
     }
 
@@ -347,42 +329,47 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn test_parse_memory_limit() {
+        // Suffixed values use ByteSize (decimal: GB=1000^3, MB=1000^2)
         assert_eq!(
             parse_memory_limit("4GB").expect("parsing \"4GB\" should succeed"),
-            4 * 1024 * 1024 * 1024
+            4_000_000_000
         );
-        assert_eq!(
-            parse_memory_limit("4G").expect("parsing \"4G\" should succeed"),
-            4 * 1024 * 1024 * 1024
-        );
+        assert_eq!(parse_memory_limit("4G").expect("parsing \"4G\" should succeed"), 4_000_000_000);
         assert_eq!(
             parse_memory_limit("512MB").expect("parsing \"512MB\" should succeed"),
-            512 * 1024 * 1024
+            512_000_000
         );
         assert_eq!(
             parse_memory_limit("512M").expect("parsing \"512M\" should succeed"),
-            512 * 1024 * 1024
+            512_000_000
         );
         assert_eq!(
             parse_memory_limit("1gb").expect("parsing \"1gb\" should succeed"),
-            1024 * 1024 * 1024
+            1_000_000_000
         );
         assert_eq!(
             parse_memory_limit("  2GB  ").expect("parsing \"  2GB  \" should succeed"),
-            2 * 1024 * 1024 * 1024
+            2_000_000_000
         );
         assert_eq!(
             parse_memory_limit("1.5GB").expect("parsing \"1.5GB\" should succeed"),
-            (1.5 * 1024.0 * 1024.0 * 1024.0) as u64
+            1_500_000_000
+        );
+        // Binary suffix for exact 1 GiB
+        assert_eq!(
+            parse_memory_limit("1GiB").expect("parsing \"1GiB\" should succeed"),
+            1024 * 1024 * 1024
         );
     }
 
     #[test]
     fn test_parse_memory_limit_minimum() {
         assert!(parse_memory_limit("100MB").is_err());
-        assert!(parse_memory_limit("256MB").is_ok());
+        // 256 MiB exceeds the 256 MiB minimum
+        assert!(parse_memory_limit("256MiB").is_ok());
+        // 256 MB (decimal) = 256,000,000 < 268,435,456 (256 MiB minimum)
+        assert!(parse_memory_limit("256MB").is_err());
     }
 
     #[test]

--- a/src/lib/validation.rs
+++ b/src/lib/validation.rs
@@ -7,6 +7,7 @@
 //! rich contextual information when validation fails.
 
 use crate::errors::{FgumiError, Result};
+use bytesize::ByteSize;
 use noodles::sam::alignment::record::data::field::Tag;
 use std::fmt::Display;
 use std::path::Path;
@@ -281,6 +282,105 @@ pub fn validate_positive<T: Ord + Display + Default>(value: T, name: &str) -> Re
     Ok(())
 }
 
+/// Parses a memory size string into bytes.
+///
+/// Accepts both plain numbers (interpreted as MiB) and human-readable formats like:
+/// - "2GB", "2G" -> 2 gigabytes (decimal: 2,000,000,000)
+/// - "1.5GB" -> 1.5 gigabytes
+/// - "1024MB", "1024M" -> 1024 megabytes (decimal)
+/// - "512MiB" -> 512 mebibytes (binary: 536,870,912)
+/// - "768" -> 768 MiB (plain numbers are interpreted as mebibytes, i.e. `n * 1024 * 1024`)
+///
+/// # Examples
+///
+/// ```
+/// # use fgumi_lib::validation::parse_memory_size;
+/// assert_eq!(parse_memory_size("768").unwrap(), 768 * 1024 * 1024);
+/// assert_eq!(parse_memory_size("2GB").unwrap(), 2 * 1000 * 1000 * 1000);
+/// assert_eq!(parse_memory_size("1024MiB").unwrap(), 1024 * 1024 * 1024);
+/// ```
+///
+/// # Errors
+///
+/// Returns [`FgumiError::InvalidMemorySize`] if the string cannot be parsed as a valid size.
+pub fn parse_memory_size(size_str: &str) -> Result<u64> {
+    let trimmed = size_str.trim();
+    if trimmed.is_empty() {
+        return Err(FgumiError::InvalidMemorySize {
+            reason: "Memory size cannot be empty".to_string(),
+        });
+    }
+
+    // Handle negative values early
+    if trimmed.starts_with('-') {
+        return Err(FgumiError::InvalidMemorySize {
+            reason: format!("Memory size cannot be negative: '{trimmed}'"),
+        });
+    }
+
+    // First try parsing as a plain integer in MiB (backward compatibility)
+    // Only accept simple integers, not floats or scientific notation
+    if let Ok(mb_value) = trimmed.parse::<u64>() {
+        if mb_value == 0 {
+            return Err(FgumiError::InvalidMemorySize {
+                reason: "Memory size cannot be zero".to_string(),
+            });
+        }
+        if mb_value > 1_000_000 {
+            // Sanity guard: >1TB as a plain number likely means the user forgot a unit suffix.
+            return Err(FgumiError::InvalidMemorySize {
+                reason: format!(
+                    "Plain number memory size too large: {} MiB. Use human-readable format like '{}GB' instead.",
+                    mb_value,
+                    mb_value / 1000
+                ),
+            });
+        }
+
+        return mb_value.checked_mul(1024 * 1024).ok_or_else(|| FgumiError::InvalidMemorySize {
+            reason: format!("Memory size calculation overflow for {mb_value} MiB"),
+        });
+    }
+
+    // Reject scientific notation (e.g. "1e3") but allow decimals in human-readable sizes (e.g. "1.5GB")
+    if trimmed.contains('e') || trimmed.contains('E') {
+        return Err(FgumiError::InvalidMemorySize {
+            reason: format!(
+                "Scientific notation not supported: '{trimmed}'. Use integer values or human-readable formats like '2GB'."
+            ),
+        });
+    }
+
+    // Reject bare decimal numbers without a unit suffix (e.g. "1.5") since plain numbers are MiB
+    if trimmed.contains('.') && trimmed.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return Err(FgumiError::InvalidMemorySize {
+            reason: format!(
+                "Plain decimal numbers not supported: '{trimmed}'. Use an integer for MiB (e.g. '768') or a human-readable format (e.g. '1.5GB')."
+            ),
+        });
+    }
+
+    // Fall back to parsing as a human-readable size (like "2GB", "1024MiB")
+    match trimmed.parse::<ByteSize>() {
+        Ok(size) => {
+            if size.0 == 0 {
+                return Err(FgumiError::InvalidMemorySize {
+                    reason: format!("Memory size cannot be zero: '{trimmed}'"),
+                });
+            }
+            Ok(size.0)
+        }
+        Err(_) => Err(FgumiError::InvalidMemorySize {
+            reason: format!(
+                "Invalid memory size '{trimmed}'. Valid formats:\n\
+                 - Plain numbers (interpreted as MB): '768', '4096'\n\
+                 - Human-readable (decimal): '2GB', '1024MB'\n\
+                 - Human-readable (binary): '1GiB', '512MiB'"
+            ),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -500,5 +600,94 @@ mod tests {
         assert!(err_msg.contains("Invalid parameter 'threshold'"));
         assert!(err_msg.contains("Must be positive"));
         assert!(err_msg.contains("got: -5"));
+    }
+
+    // ========== Tests for memory size parsing ==========
+
+    #[test]
+    fn test_parse_memory_size_plain_numbers() {
+        assert_eq!(
+            parse_memory_size("768").expect("parse '768' should succeed"),
+            768 * 1024 * 1024
+        );
+        assert_eq!(parse_memory_size("1").expect("parse '1' should succeed"), 1024 * 1024);
+        assert_eq!(
+            parse_memory_size("4096").expect("parse '4096' should succeed"),
+            4096 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_parse_memory_size_human_readable() {
+        assert_eq!(
+            parse_memory_size("2GB").expect("parse '2GB' should succeed"),
+            2 * 1000 * 1000 * 1000
+        );
+        assert_eq!(
+            parse_memory_size("2G").expect("parse '2G' should succeed"),
+            2 * 1000 * 1000 * 1000
+        );
+        assert_eq!(
+            parse_memory_size("1024MB").expect("parse '1024MB' should succeed"),
+            1024 * 1000 * 1000
+        );
+        assert_eq!(
+            parse_memory_size("1024M").expect("parse '1024M' should succeed"),
+            1024 * 1000 * 1000
+        );
+        assert_eq!(
+            parse_memory_size("1GiB").expect("parse '1GiB' should succeed"),
+            1024 * 1024 * 1024
+        );
+        assert_eq!(
+            parse_memory_size("512MiB").expect("parse '512MiB' should succeed"),
+            512 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_parse_memory_size_invalid() {
+        assert!(parse_memory_size("invalid").is_err());
+        assert!(parse_memory_size("").is_err());
+        assert!(parse_memory_size("GB2").is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_size_zero() {
+        assert!(parse_memory_size("0").is_err());
+        assert!(parse_memory_size("0MB").is_err());
+        assert!(parse_memory_size("0GB").is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_size_edge_cases() {
+        assert!(parse_memory_size("").is_err());
+        assert!(parse_memory_size("   ").is_err());
+        assert!(parse_memory_size("-100").is_err());
+        assert!(parse_memory_size("-1GB").is_err());
+        assert!(parse_memory_size("1.5").is_err());
+        assert!(parse_memory_size("1.5GB").is_ok());
+        assert!(parse_memory_size("2.5GB").is_ok());
+        assert!(parse_memory_size("1e3").is_err());
+        assert!(parse_memory_size("1E6").is_err());
+        assert!(parse_memory_size("9999999").is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_size_whitespace_handling() {
+        assert_eq!(
+            parse_memory_size("  768  ").expect("parse trimmed '768' should succeed"),
+            768 * 1024 * 1024
+        );
+        assert_eq!(
+            parse_memory_size("\t1GB\n").expect("parse trimmed '1GB' should succeed"),
+            1000 * 1000 * 1000
+        );
+    }
+
+    #[test]
+    fn test_parse_memory_size_overflow() {
+        let very_large = format!("{}", u64::MAX / 1024);
+        assert!(parse_memory_size(&very_large).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Add `--max-memory=auto` (now the default) that detects system memory and subtracts a configurable reserve to leave room for co-running processes
- Add `--memory-reserve` option: `auto` (default) reserves `min(10 GiB, 50% of RAM)`, or an explicit value like `12GiB` for pipelines alongside `bwa mem`
- Add `SegmentedBuf` (fixed-size 256 MiB segments) to replace `Vec<u8>` in sort buffers, eliminating the O(n) memcpy and transient 2x peak memory from Vec doubling at multi-GiB scale
- Add `initial_capacity` to `RawExternalSorter` to decouple buffer pre-allocation (768 MiB/thread) from the spill-to-disk threshold
- Consolidate three separate memory parsers into a single canonical `parse_memory_size` in `fgumi_lib::validation`
- Make `sysinfo` a non-optional dependency; always validate memory against system limits

### Auto reserve defaults

| Machine | Reserve (auto) | Sort gets |
|---|---|---|
| 8 GiB | 4 GiB (50%) | 4 GiB |
| 16 GiB | 8 GiB (50%) | 8 GiB |
| 32 GiB | 10 GiB (cap) | 22 GiB |
| 64 GiB | 10 GiB (cap) | 54 GiB |
| 128 GiB | 10 GiB (cap) | 118 GiB |

### Benchmarks (6 GiB BAM, 60M records, template-coordinate, 4 threads)

| Tool | Mode | Time | Peak RSS | Spills |
|---|---|---|---|---|
| fgumi auto | segmented buf, 768 MiB/thd init | **27s** | 29.4 GiB | 0 |
| fgumi explicit 14.4G/thd | full pre-alloc | 26s | 26.9 GiB | 0 |
| fgumi explicit 4G/thd | full pre-alloc | 47s | 23.0 GiB | 5 |
| samtools 14.4G/thd | — | 67s | 26.7 GiB | 0 |
| samtools 4G/thd | — | 87s | 22.1 GiB | 1 |

## Test plan

- [x] `cargo ci-test` — all tests pass (includes new `SegmentedBuf`, `resolve_reserve`, and `parse_memory_reserve` tests)
- [x] `cargo ci-fmt && cargo ci-lint` — clean
- [x] Verify `fgumi sort -i large.bam -o out.bam --order template-coordinate -@ 4` works with auto (default)
- [x] Verify `fgumi sort -m 4GiB` still works as explicit override
- [x] Verify `fgumi sort --memory-reserve 12GiB` reserves extra for pipeline use
- [x] Verify `fgumi sort -m 256MiB` correctly spills to disk