### PR TITLE
perf(sort): implement N+2 worker-pool model for parallel sort I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Session.vim
 # Local notes (DEV.md, RD.md)
 /notes/
 /plans/
+
+# Benchmark data
+/tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "noodles",
  "noodles-bgzf",
  "noodles-csi",
+ "num_cpus",
  "parking_lot",
  "proptest",
  "rand 0.10.0",
@@ -975,6 +976,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -1609,6 +1616,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ murmur3 = "0.5"
 statrs = "0.18"
 bytesize = "2.3"
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }
+num_cpus = "1.16"
 rayon = "1.10"
 approx = "0.5.1"
 ahash = "0.8"

--- a/crates/fgumi-bgzf/src/lib.rs
+++ b/crates/fgumi-bgzf/src/lib.rs
@@ -14,4 +14,4 @@ pub use reader::{
     BGZF_EOF, BGZF_FOOTER_SIZE, BGZF_HEADER_SIZE, RawBgzfBlock, decompress_block,
     decompress_block_into, decompress_block_slice_into, read_raw_blocks,
 };
-pub use writer::{CompressedBlock, InlineBgzfCompressor};
+pub use writer::{BGZF_MAX_BLOCK_SIZE, CompressedBlock, InlineBgzfCompressor};

--- a/crates/fgumi-bgzf/src/writer.rs
+++ b/crates/fgumi-bgzf/src/writer.rs
@@ -14,7 +14,7 @@ use std::io;
 // ============================================================================
 
 /// Maximum uncompressed size for a BGZF block (64KB - header/footer overhead).
-const BGZF_MAX_BLOCK_SIZE: usize = bgzf::BGZF_BLOCK_SIZE;
+pub const BGZF_MAX_BLOCK_SIZE: usize = bgzf::BGZF_BLOCK_SIZE;
 
 // ============================================================================
 // Block types

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -567,11 +567,14 @@ impl QueueMemoryOptions {
 
     /// Warns if the requested memory exceeds reasonable system limits.
     fn validate_against_system_memory(requested_bytes: u64) {
-        use sysinfo::System;
-        let mut system = System::new();
+        let mut system = sysinfo::System::new();
         system.refresh_memory();
 
-        let total_memory_bytes = system.total_memory();
+        // Use cgroup-aware total so the warning is accurate inside containers.
+        let total_memory_bytes =
+            system.cgroup_limits().map(|c| c.total_memory).unwrap_or_else(|| system.total_memory());
+
+        // available_memory reflects free physical pages; no cgroup equivalent.
         let available_memory_bytes = system.available_memory();
 
         // Calculate 90% limit using integer arithmetic to avoid precision loss
@@ -632,6 +635,10 @@ pub(crate) fn parse_bool(s: &str) -> Result<bool, String> {
 
 // Re-export from the library crate for backward compatibility.
 pub use fgumi_lib::validation::parse_memory_size;
+
+// Re-export from the library crate so command code doesn't need to reach into
+// fgumi_lib::system directly.
+pub(crate) use fgumi_lib::system::detect_total_memory;
 
 /// Builds a [`BamPipelineConfig`] from the common CLI option structs.
 ///
@@ -1094,5 +1101,31 @@ mod tests {
     #[case(&["test", "--trim", "off"])]
     fn test_extended_bool_values_in_cli_invalid(#[case] args: &[&str]) {
         assert!(TestBoolFlags::try_parse_from(args).is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // cgroup-aware memory detection
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_detect_total_memory_returns_nonzero() {
+        let total = detect_total_memory();
+        assert!(total > 0, "detect_total_memory returned 0");
+        // Sanity: at least 64 MiB (even the smallest CI runner has more than this).
+        assert!(total >= 64 * 1024 * 1024, "detect_total_memory returned < 64 MiB: {total}");
+    }
+
+    #[test]
+    fn test_detect_total_memory_bounded_by_sysinfo() {
+        // cgroup_limits().total_memory is min(cgroup_max, physical_ram), so
+        // detect_total_memory() can never exceed what sysinfo reports.
+        let total = detect_total_memory();
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        let sysinfo_total = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+        assert!(
+            total <= sysinfo_total,
+            "cgroup-limited total {total} exceeded sysinfo total {sysinfo_total}"
+        );
     }
 }

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -31,7 +31,7 @@ use log::info;
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
-use crate::commands::common::{CompressionOptions, parse_bool};
+use crate::commands::common::{CompressionOptions, detect_total_memory, parse_bool};
 use fgumi_lib::validation::parse_memory_size;
 
 /// Sort order for BAM files.
@@ -408,10 +408,10 @@ fn resolve_reserve(reserve: MemoryReserve, total_memory: usize) -> usize {
 
 /// Resolves a [`MemoryLimit`] to a concrete byte count.
 ///
-/// For [`MemoryLimit::Auto`]: detects total system memory, subtracts the
-/// reserve (via [`MemoryReserve`]), and divides by thread count (when
-/// `memory_per_thread` is true). The result is clamped to a minimum of
-/// 256 MiB per thread.
+/// For [`MemoryLimit::Auto`]: detects total system memory (cgroup-aware via
+/// [`detect_total_memory`]), subtracts the reserve (via [`MemoryReserve`]),
+/// and divides by thread count (when `memory_per_thread` is true). The result
+/// is clamped to a minimum of 256 MiB per thread.
 ///
 /// For [`MemoryLimit::Fixed`]: applies the same `memory_per_thread`
 /// multiplication as before. The reserve is ignored.
@@ -436,9 +436,7 @@ fn resolve_memory_limit(
             }
         }
         MemoryLimit::Auto => {
-            let mut system = sysinfo::System::new();
-            system.refresh_memory();
-            let total = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+            let total = detect_total_memory();
 
             let margin = resolve_reserve(reserve, total);
             let available = total.saturating_sub(margin);
@@ -481,10 +479,8 @@ fn resolve_memory_limit(
         }
     };
 
-    // Post-resolution system memory check: warn if any mode exceeds host RAM
-    let mut system = sysinfo::System::new();
-    system.refresh_memory();
-    let total = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+    // Post-resolution sanity check: warn if budget exceeds the effective memory limit.
+    let total = detect_total_memory();
     if total_budget > total {
         log::warn!(
             "Memory budget {} exceeds total system memory {}; spill-to-disk is likely",
@@ -838,9 +834,7 @@ mod tests {
 
     #[test]
     fn test_resolve_memory_limit_auto() {
-        let mut system = sysinfo::System::new();
-        system.refresh_memory();
-        let total = system.total_memory() as usize;
+        let total = detect_total_memory();
 
         let resolved = resolve_memory_limit(MemoryLimit::Auto, MemoryReserve::Auto, 4, true)
             .expect("should succeed");
@@ -850,7 +844,7 @@ mod tests {
             resolved >= min_expected,
             "auto resolved to {resolved} bytes, expected at least {min_expected}"
         );
-        // And not more than total system memory
+        // And not more than effective total memory (cgroup-aware)
         assert!(resolved <= total);
     }
 

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -748,6 +748,103 @@ pub fn create_raw_bam_reader<P: AsRef<Path>>(
     Ok((raw_reader, header))
 }
 
+/// Create a raw BAM reader using the pool's Phase 1 integrated reading.
+///
+/// Workers in the pool do `ReadInputBlocks` + `DecompressInput`. The main thread
+/// consumes decompressed bytes via `PooledInputStream`. No extra threads are spawned.
+///
+/// # Flow
+///
+/// 1. Parse header with noodles (first pass, single-threaded)
+/// 2. Open file again, set as pool's input file
+/// 3. Set pool to PHASE1 — workers start reading/decompressing
+/// 4. Main thread skips header bytes from decompressed stream
+/// 5. Returns `RawBamReader<PooledInputStream>` for direct record iteration
+///
+/// # Errors
+///
+/// Returns an error if the BAM file cannot be opened, the header cannot be parsed,
+/// or header bytes cannot be skipped from the decompressed stream.
+pub fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
+    path: P,
+    pool: &std::sync::Arc<crate::sort::worker_pool::SortWorkerPool>,
+) -> Result<(RawBamReader<crate::sort::read_ahead::PooledInputStream>, Header)> {
+    use crate::sort::read_ahead::PooledInputStream;
+    use crate::sort::worker_pool::phase;
+
+    use std::io::{Seek, SeekFrom};
+
+    let path_ref = path.as_ref();
+
+    // Open once and reuse the same handle for both header reading and pool input.
+    // Re-opening would break non-replayable inputs (FIFOs, process substitution).
+    let mut file = File::open(path_ref)
+        .with_context(|| format!("Failed to open input BAM: {}", path_ref.display()))?;
+
+    let header = {
+        let bgzf = BgzfReader::new(&mut file);
+        let mut noodles_reader = noodles::bam::io::Reader::from(bgzf);
+        noodles_reader
+            .read_header()
+            .with_context(|| format!("Failed to read header from: {}", path_ref.display()))?
+    };
+
+    // Rewind to start so pool workers read from byte 0
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("Failed to rewind input BAM: {}", path_ref.display()))?;
+
+    let buf_reader = io::BufReader::with_capacity(2 * 1024 * 1024, file);
+
+    // Set the input file for pool workers and activate Phase 1
+    pool.set_input_file(Box::new(buf_reader));
+    pool.set_phase(phase::PHASE1);
+
+    // Create the decompressed input stream for the main thread.
+    // Uses the shared ArrayQueue and EOF flag from the pool's pipeline state.
+    let mut pooled_input = PooledInputStream::new(
+        pool.decompressed_input_queue(),
+        pool.decompressed_input_done_flag(),
+        pool.input_read_error_flag(),
+    );
+
+    // Skip BAM header from the decompressed stream
+    skip_bam_header(&mut pooled_input)
+        .with_context(|| format!("Failed to skip header from: {}", path_ref.display()))?;
+
+    let raw_reader = RawBamReader::new(pooled_input);
+    Ok((raw_reader, header))
+}
+
+/// Skip the BAM header from a reader positioned at the start of a BAM stream.
+///
+/// Reads and discards: magic (4 bytes), header text length + text, `n_ref` + reference entries.
+fn skip_bam_header<R: Read>(reader: &mut R) -> Result<()> {
+    let mut buf4 = [0u8; 4];
+
+    // Magic: "BAM\1"
+    reader.read_exact(&mut buf4)?;
+    anyhow::ensure!(&buf4 == b"BAM\x01", "Not a BAM file (bad magic)");
+
+    // Header text length + text
+    reader.read_exact(&mut buf4)?;
+    let l_text = u32::from_le_bytes(buf4) as usize;
+    io::copy(&mut reader.take(l_text as u64), &mut io::sink())?;
+
+    // Number of reference sequences
+    reader.read_exact(&mut buf4)?;
+    let n_ref = u32::from_le_bytes(buf4) as usize;
+
+    // Each reference: l_name (4 bytes) + name (l_name bytes) + l_ref (4 bytes)
+    for _ in 0..n_ref {
+        reader.read_exact(&mut buf4)?;
+        let l_name = u32::from_le_bytes(buf4) as usize;
+        io::copy(&mut reader.take(l_name as u64), &mut io::sink())?;
+        reader.read_exact(&mut buf4)?; // l_ref (discard)
+    }
+
+    Ok(())
+}
+
 /// Create a BAM writer and write the header in one operation
 ///
 /// # Arguments

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -149,6 +149,7 @@ pub use fgumi_metrics::rejection;
 pub mod reorder_buffer;
 pub mod sam;
 pub mod sort;
+pub mod system;
 pub mod tag_reversal;
 pub mod template;
 pub mod umi;

--- a/src/lib/sort/bgzf_io.rs
+++ b/src/lib/sort/bgzf_io.rs
@@ -1,0 +1,291 @@
+//! Shared BGZF I/O utilities for pooled writers.
+//!
+//! Provides the reorder-and-write loop used by both [`PooledBamWriter`](super::pooled_bam_writer)
+//! and [`PooledChunkWriter`](super::pooled_chunk_writer), and the staging buffer logic for
+//! accumulating data into ~64KB blocks before submitting compression jobs.
+
+use crate::sort::worker_pool::{BufferPool, CompressJob, CompressResult, SortWorkerPool};
+use anyhow::Result;
+use crossbeam_channel::{Receiver, Sender};
+use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
+use std::collections::BTreeMap;
+use std::io::{BufWriter, Write};
+use std::sync::Arc;
+
+/// Padding beyond `BGZF_MAX_BLOCK_SIZE` for the staging buffer capacity.
+const STAGING_PADDING: usize = 4096;
+
+/// Staging buffer that accumulates data and submits full blocks to the pool.
+pub(crate) struct StagingBuffer {
+    pool: Arc<SortWorkerPool>,
+    buf: Vec<u8>,
+    next_serial: u64,
+    result_tx: Sender<CompressResult>,
+}
+
+impl StagingBuffer {
+    /// Create a new staging buffer.
+    #[must_use]
+    pub(crate) fn new(pool: Arc<SortWorkerPool>, result_tx: Sender<CompressResult>) -> Self {
+        Self {
+            pool,
+            buf: Vec::with_capacity(BGZF_MAX_BLOCK_SIZE + STAGING_PADDING),
+            next_serial: 0,
+            result_tx,
+        }
+    }
+
+    /// The underlying byte buffer for direct writes.
+    ///
+    /// Callers must ensure writes followed by `flush_if_full()` keep each individual
+    /// append ≤ `BGZF_MAX_BLOCK_SIZE`. For potentially-large data use `write_chunked`.
+    pub(crate) fn buf(&mut self) -> &mut Vec<u8> {
+        &mut self.buf
+    }
+
+    /// Returns true if the staging buffer has reached the BGZF block size threshold.
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        self.buf.len() >= BGZF_MAX_BLOCK_SIZE
+    }
+
+    /// Flush the staging buffer: swap it with a recycled buffer and submit for compression.
+    ///
+    /// No-op when the buffer is empty (avoids submitting empty BGZF blocks).
+    pub(crate) fn flush(&mut self) {
+        if self.buf.is_empty() {
+            return;
+        }
+        let data = std::mem::replace(&mut self.buf, self.pool.buffer_pool.checkout());
+        if self.buf.capacity() < BGZF_MAX_BLOCK_SIZE + STAGING_PADDING {
+            self.buf.reserve(BGZF_MAX_BLOCK_SIZE + STAGING_PADDING - self.buf.capacity());
+        }
+
+        let serial = self.next_serial;
+        self.next_serial += 1;
+
+        self.pool.submit_compress(CompressJob { data, serial, result_tx: self.result_tx.clone() });
+    }
+
+    /// Flush if full, otherwise no-op.
+    #[inline]
+    pub(crate) fn flush_if_full(&mut self) {
+        if self.is_full() {
+            self.flush();
+        }
+    }
+
+    /// Write `data` to the staging buffer, flushing BGZF-sized chunks as they fill up.
+    ///
+    /// Unlike writing directly to `buf()`, this correctly handles data larger than
+    /// `BGZF_MAX_BLOCK_SIZE` (e.g. large BAM headers) by splitting into multiple jobs.
+    pub(crate) fn write_chunked(&mut self, data: &[u8]) {
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let space = BGZF_MAX_BLOCK_SIZE.saturating_sub(self.buf.len());
+            let n = remaining.len().min(space);
+            self.buf.extend_from_slice(&remaining[..n]);
+            remaining = &remaining[n..];
+            self.flush_if_full();
+        }
+    }
+}
+
+/// I/O writer loop: receives compressed blocks and writes them in serial order.
+///
+/// Uses a `BTreeMap` as a reorder buffer. When the next expected serial arrives,
+/// writes it immediately. Out-of-order blocks are buffered until their turn.
+/// Writes BGZF EOF marker and flushes when all blocks are received.
+///
+/// # Errors
+///
+/// Returns an error if any disk write fails.
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn io_writer_loop(
+    mut writer: BufWriter<std::fs::File>,
+    result_rx: Receiver<CompressResult>,
+    buffer_pool: BufferPool,
+) -> Result<()> {
+    let mut next_expected: u64 = 0;
+    let mut reorder_buf: BTreeMap<u64, Vec<u8>> = BTreeMap::new();
+
+    while let Ok(result) = result_rx.recv() {
+        buffer_pool.checkin(result.recycled_buf);
+
+        if result.serial == next_expected {
+            writer.write_all(&result.compressed)?;
+            next_expected += 1;
+
+            while let Some(data) = reorder_buf.remove(&next_expected) {
+                writer.write_all(&data)?;
+                next_expected += 1;
+            }
+        } else {
+            reorder_buf.insert(result.serial, result.compressed);
+        }
+    }
+
+    // Drain remaining buffered blocks — any gap means a worker dropped a result
+    while let Some((&serial, _)) = reorder_buf.first_key_value() {
+        if serial == next_expected {
+            let data = reorder_buf.remove(&serial).expect("key just checked");
+            writer.write_all(&data)?;
+            next_expected += 1;
+        } else {
+            return Err(anyhow::anyhow!(
+                "missing compressed block {next_expected}: next available is {serial}; \
+                 the output would be silently truncated"
+            ));
+        }
+    }
+
+    writer.write_all(&BGZF_EOF)?;
+    writer.flush()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Build a round-trip helper: write `data` via `StagingBuffer` → `io_writer_loop` → read back raw bytes.
+    fn roundtrip_data(data: &[u8]) -> Vec<u8> {
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+        let (result_tx, result_rx) = pool.compress_result_channel();
+        let buffer_pool = pool.buffer_pool.clone();
+
+        let dir = TempDir::new().unwrap();
+        let out_path = dir.path().join("out.bgzf");
+
+        let out_file = std::fs::File::create(&out_path).unwrap();
+        let writer = std::io::BufWriter::new(out_file);
+        let io_handle = std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool));
+
+        let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx);
+        staging.write_chunked(data);
+        staging.flush();
+        drop(staging); // closes result_tx senders → io_writer_loop exits
+
+        io_handle.join().unwrap().unwrap();
+
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+        std::fs::read(&out_path).unwrap()
+    }
+
+    #[test]
+    fn test_staging_buffer_flush_empty_is_noop() {
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6));
+        let (result_tx, _result_rx) = pool.compress_result_channel();
+
+        let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx);
+        // Flush with empty buffer: should not submit a compress job
+        staging.flush();
+
+        assert_eq!(pool.stats.compress_jobs.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_staging_buffer_is_full() {
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6));
+        let (result_tx, _result_rx) = pool.compress_result_channel();
+        let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx);
+
+        assert!(!staging.is_full(), "empty buffer should not be full");
+        staging.buf().extend(vec![0u8; BGZF_MAX_BLOCK_SIZE]);
+        assert!(staging.is_full(), "buffer at BGZF_MAX_BLOCK_SIZE should be full");
+
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_staging_buffer_write_chunked_large_data() {
+        // Data larger than BGZF_MAX_BLOCK_SIZE must be split into multiple compress jobs.
+        let large = vec![b'A'; BGZF_MAX_BLOCK_SIZE * 2 + 1000];
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+        let (result_tx, result_rx) = pool.compress_result_channel();
+        let buffer_pool = pool.buffer_pool.clone();
+
+        let dir = TempDir::new().unwrap();
+        let out_path = dir.path().join("large.bgzf");
+        let out_file = std::fs::File::create(&out_path).unwrap();
+        let writer = std::io::BufWriter::new(out_file);
+        let io_handle = std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool));
+
+        let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx);
+        staging.write_chunked(&large);
+        staging.flush();
+        drop(staging);
+
+        io_handle.join().unwrap().unwrap();
+
+        // ≥2 full blocks + 1 partial = at least 3 compress jobs
+        assert!(
+            pool.stats.compress_jobs.load(std::sync::atomic::Ordering::Relaxed) >= 2,
+            "expected multiple compress jobs for data > BGZF_MAX_BLOCK_SIZE"
+        );
+
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_io_writer_loop_reorders_out_of_order_blocks() {
+        // Write blocks out of order; io_writer_loop must reassemble them correctly.
+        let data1 = b"first block data".to_vec();
+        let data2 = b"second block data".to_vec();
+
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+        let (result_tx, result_rx) = pool.compress_result_channel();
+        let buffer_pool = pool.buffer_pool.clone();
+
+        let dir = TempDir::new().unwrap();
+        let out_path = dir.path().join("reorder.bgzf");
+        let out_file = std::fs::File::create(&out_path).unwrap();
+        let writer = std::io::BufWriter::new(out_file);
+        let io_handle = std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool));
+
+        // Submit block 1 first, then block 0 (out of order)
+        pool.submit_compress(CompressJob { data: data2, serial: 1, result_tx: result_tx.clone() });
+        pool.submit_compress(CompressJob { data: data1, serial: 0, result_tx });
+
+        // Wait for both compress results to be received by io_writer_loop
+        io_handle.join().unwrap().unwrap();
+
+        // Output file exists and contains the BGZF EOF marker
+        let bytes = std::fs::read(&out_path).unwrap();
+        assert!(bytes.ends_with(&BGZF_EOF), "output should end with BGZF EOF marker");
+
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_small_data() {
+        let data = b"hello world from bgzf_io";
+        let output = roundtrip_data(data);
+        // Output is a valid BGZF stream ending with the EOF marker
+        assert!(output.ends_with(&BGZF_EOF), "must end with BGZF EOF");
+        // Non-empty (has at least the compressed data block + EOF)
+        assert!(output.len() > BGZF_EOF.len());
+    }
+
+    #[test]
+    fn test_roundtrip_empty_data() {
+        // No data: flush() is a no-op, so io_writer_loop writes only the EOF marker
+        let output = roundtrip_data(b"");
+        assert_eq!(output, BGZF_EOF.to_vec(), "empty input → only BGZF EOF marker");
+    }
+}

--- a/src/lib/sort/mod.rs
+++ b/src/lib/sort/mod.rs
@@ -33,16 +33,20 @@ use noodles::sam::header::record::value::map::header::tag as header_tag;
 use tempfile::TempDir;
 
 pub use fgumi_raw_bam as bam_fields;
+pub mod bgzf_io;
 pub mod external;
 pub mod inline_buffer;
 pub mod keys;
 pub mod loser_tree;
 pub mod pipeline;
+pub mod pooled_bam_writer;
+pub mod pooled_chunk_writer;
 pub mod radix;
 pub mod raw;
 pub mod raw_bam_reader;
 pub mod read_ahead;
 pub(crate) mod segmented_buf;
+pub mod worker_pool;
 
 /// Buffer size for `BufReader` during merge phase.
 const MERGE_BUFFER_SIZE: usize = 64 * 1024;

--- a/src/lib/sort/pooled_bam_writer.rs
+++ b/src/lib/sort/pooled_bam_writer.rs
@@ -1,0 +1,350 @@
+//! Pool-based BAM writer using `SortWorkerPool` for parallel BGZF compression.
+//!
+//! `PooledBamWriter` replaces the noodles `MultithreadedWriter` during merge output,
+//! distributing BGZF block compression across the shared worker pool. This eliminates
+//! three inefficiencies in the noodles writer:
+//!
+//! 1. Per-block channel allocation (~100K `bounded(1)` channels for a 6GB file)
+//! 2. Per-block `Vec` clone (~2-4GB of unnecessary memcpy)
+//! 3. Separate deflater thread pool (wastes threads while `SortWorkerPool` sits idle)
+//!
+//! # Architecture
+//!
+//! ```text
+//! Main thread                   Worker pool            I/O thread
+//! ─────────────                 ───────────            ──────────
+//! write_raw_record() ──►        (compress)   ──►       write to disk
+//!   buffer ~64KB       submit    parallel      result   sequential
+//!   submit job         ──────►  workers        ──────► reorder buf
+//!                                              ──────► write ordered
+//! ```
+
+use crate::sort::bgzf_io::{StagingBuffer, io_writer_loop};
+use crate::sort::worker_pool::{CompressResult, SortWorkerPool};
+use anyhow::Result;
+use crossbeam_channel::bounded;
+use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use noodles::sam::Header;
+use std::io::BufWriter;
+use std::path::Path;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use super::pooled_chunk_writer::SpillWriteHandle;
+
+/// A BAM output writer that uses `SortWorkerPool` for parallel BGZF compression.
+///
+/// Records are buffered into ~64KB staging blocks, then submitted to the pool
+/// for compression. An I/O thread receives compressed blocks and writes them
+/// in serial order using a bounded reorder buffer.
+///
+/// This writer produces valid BAM output (header + length-prefixed records in BGZF blocks).
+pub struct PooledBamWriter {
+    staging: StagingBuffer,
+    io_handle: Option<JoinHandle<Result<()>>>,
+}
+
+impl PooledBamWriter {
+    /// Create a new pooled BAM writer.
+    ///
+    /// Opens the output file, writes the BAM header into the initial staging buffer,
+    /// and spawns an I/O writer thread that receives compressed blocks and writes
+    /// them in serial order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created or the header cannot
+    /// be serialized.
+    pub fn new(pool: Arc<SortWorkerPool>, path: &Path, header: &Header) -> Result<Self> {
+        let file = std::fs::File::create(path)?;
+        let writer = BufWriter::with_capacity(256 * 1024, file);
+
+        let reorder_capacity = pool.num_workers() * 4;
+        let (result_tx, result_rx) = bounded::<CompressResult>(reorder_capacity);
+        let buffer_pool = pool.buffer_pool.clone();
+
+        let io_handle = thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool));
+
+        let mut staging = StagingBuffer::new(pool, result_tx);
+
+        // Write BAM header into a temporary buffer then flush in BGZF-sized chunks.
+        // Headers can exceed BGZF_MAX_BLOCK_SIZE; write_chunked handles the splitting.
+        let mut header_buf = Vec::new();
+        crate::bam_io::write_bam_header(&mut header_buf, header)?;
+        staging.write_chunked(&header_buf);
+        staging.flush();
+
+        Ok(Self { staging, io_handle: Some(io_handle) })
+    }
+
+    /// Write a raw BAM record to the output.
+    ///
+    /// Writes a 4-byte little-endian length prefix followed by the raw record bytes.
+    /// When the staging buffer reaches ~64KB, it's submitted to the pool for compression.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails (currently infallible for staging buffer).
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn write_raw_record(&mut self, record_bytes: &[u8]) -> Result<()> {
+        let block_size = record_bytes.len() as u32;
+        // Pre-flush if this record won't fit in the current block to keep each
+        // CompressJob within BGZF_MAX_BLOCK_SIZE.
+        let needed = 4 + record_bytes.len();
+        if self.staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
+            self.staging.flush();
+        }
+        // Write the 4-byte length prefix (always fits: staging is empty after the pre-flush,
+        // and 4 bytes is well within BGZF_MAX_BLOCK_SIZE).
+        self.staging.buf().extend_from_slice(&block_size.to_le_bytes());
+        // If the record payload itself exceeds one BGZF block, split it across blocks.
+        // BAM records can legally span BGZF blocks; readers handle this transparently.
+        if record_bytes.len() > BGZF_MAX_BLOCK_SIZE.saturating_sub(4) {
+            self.staging.write_chunked(record_bytes);
+        } else {
+            self.staging.buf().extend_from_slice(record_bytes);
+            self.staging.flush_if_full();
+        }
+        Ok(())
+    }
+
+    /// Finish writing: flush remaining data, wait for I/O thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing or the I/O thread encountered an error.
+    pub fn finish(self) -> Result<()> {
+        self.start_finish()?.wait()
+    }
+
+    /// Flush remaining data and signal the I/O thread, but don't wait for it.
+    ///
+    /// Returns a [`SpillWriteHandle`] that can be waited on later.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing the staging buffer fails.
+    pub fn start_finish(mut self) -> Result<SpillWriteHandle> {
+        if !self.staging.buf().is_empty() {
+            self.staging.flush();
+        }
+        // Drop staging (and its result_tx clone) to signal I/O thread
+        drop(self.staging);
+        Ok(SpillWriteHandle::new(self.io_handle.take()))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::default_constructed_unit_structs)]
+mod tests {
+    use super::*;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::ReferenceSequence;
+
+    /// Build a minimal test header with a few reference sequences.
+    fn test_header() -> Header {
+        Header::builder()
+            .set_header(Map::<noodles::sam::header::record::value::map::Header>::new(
+                noodles::sam::header::record::value::map::header::Version::new(1, 6),
+            ))
+            .add_reference_sequence(
+                "chr1",
+                Map::<ReferenceSequence>::new(std::num::NonZero::new(100_000).expect("non-zero")),
+            )
+            .add_reference_sequence(
+                "chr2",
+                Map::<ReferenceSequence>::new(std::num::NonZero::new(200_000).expect("non-zero")),
+            )
+            .build()
+    }
+
+    /// Create a simple raw BAM record (unmapped, minimal fields).
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_test_record(name: &[u8], seq_len: usize) -> Vec<u8> {
+        let name_len = name.len() + 1;
+        let seq_bytes = seq_len.div_ceil(2);
+        let record_len = 32 + name_len + seq_bytes + seq_len;
+
+        let mut rec = Vec::with_capacity(record_len);
+
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // ref_id
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // pos
+        let bin_mq_nl: u32 = (name_len as u32) | (4680 << 16);
+        rec.extend_from_slice(&bin_mq_nl.to_le_bytes());
+        let flag_nc: u32 = 4 << 16; // unmapped
+        rec.extend_from_slice(&flag_nc.to_le_bytes());
+        rec.extend_from_slice(&(seq_len as u32).to_le_bytes());
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // mate_ref_id
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // mate_pos
+        rec.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        rec.extend_from_slice(name);
+        rec.push(0); // null terminator
+        rec.resize(rec.len() + seq_bytes, 0x11); // seq: all A's
+        rec.resize(rec.len() + seq_len, 0xFF); // qual
+
+        rec
+    }
+
+    #[test]
+    fn test_pooled_bam_writer_roundtrip() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("test.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        let num_records = 200;
+        let records: Vec<Vec<u8>> = (0..num_records)
+            .map(|i| make_test_record(format!("read_{i:04}").as_bytes(), 50))
+            .collect();
+
+        {
+            let mut writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            for rec in &records {
+                writer.write_raw_record(rec).expect("write record");
+            }
+            writer.finish().expect("finish writer");
+        }
+
+        let mut reader = noodles::bam::io::reader::Builder::default()
+            .build_from_path(&bam_path)
+            .expect("open reader");
+        let read_header = reader.read_header().expect("read header");
+        assert_eq!(read_header.reference_sequences().len(), 2);
+
+        let mut count = 0;
+        for result in reader.records() {
+            let _record = result.expect("read record");
+            count += 1;
+        }
+        assert_eq!(count, num_records, "record count mismatch");
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_pooled_bam_writer_empty() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("empty.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        {
+            let writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            writer.finish().expect("finish empty writer");
+        }
+
+        let mut reader = noodles::bam::io::reader::Builder::default()
+            .build_from_path(&bam_path)
+            .expect("open reader");
+        let read_header = reader.read_header().expect("read header");
+        assert_eq!(read_header.reference_sequences().len(), 2);
+        assert_eq!(reader.records().count(), 0);
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_pooled_bam_writer_many_records() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("many.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(4, 1, 6));
+
+        let num_records = 5000;
+        {
+            let mut writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            for i in 0..num_records {
+                let rec = make_test_record(format!("read_{i:06}").as_bytes(), 100);
+                writer.write_raw_record(&rec).expect("write record");
+            }
+            writer.finish().expect("finish writer");
+        }
+
+        let mut reader = noodles::bam::io::reader::Builder::default()
+            .build_from_path(&bam_path)
+            .expect("open reader");
+        let _header = reader.read_header().expect("read header");
+        assert_eq!(reader.records().count(), num_records);
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_pooled_bam_writer_raw_bytes_match() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("raw_match.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        let records: Vec<Vec<u8>> =
+            (0..50).map(|i| make_test_record(format!("r{i}").as_bytes(), 30)).collect();
+
+        {
+            let mut writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            for rec in &records {
+                writer.write_raw_record(rec).expect("write");
+            }
+            writer.finish().expect("finish");
+        }
+
+        let mut reader =
+            noodles::bam::io::reader::Builder::default().build_from_path(&bam_path).expect("open");
+        let _h = reader.read_header().expect("header");
+
+        let mut count = 0;
+        for result in reader.records() {
+            result.expect("read record");
+            count += 1;
+        }
+        assert_eq!(count, records.len());
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_pooled_bam_writer_oversized_record() {
+        // Verify that a record payload exceeding BGZF_MAX_BLOCK_SIZE is split across
+        // multiple BGZF blocks and can be read back correctly.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("oversized.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        // A sequence of BGZF_MAX_BLOCK_SIZE bytes exceeds the threshold.
+        let oversized_rec = make_test_record(b"oversized_read", BGZF_MAX_BLOCK_SIZE);
+
+        {
+            let mut writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            writer.write_raw_record(&oversized_rec).expect("write oversized record");
+            writer.finish().expect("finish writer");
+        }
+
+        let mut reader = noodles::bam::io::reader::Builder::default()
+            .build_from_path(&bam_path)
+            .expect("open reader");
+        let _header = reader.read_header().expect("read header");
+        assert_eq!(reader.records().count(), 1, "oversized record should round-trip");
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+}

--- a/src/lib/sort/pooled_chunk_writer.rs
+++ b/src/lib/sort/pooled_chunk_writer.rs
@@ -1,0 +1,387 @@
+//! Parallel chunk writer using `SortWorkerPool` for BGZF compression.
+//!
+//! `PooledChunkWriter` replaces single-threaded `GenericKeyedChunkWriter` during spill,
+//! distributing BGZF block compression across the shared worker pool. This targets the
+//! #1 bottleneck: spill write is 62-80% of total sort wall time.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Main thread                   Worker pool            I/O thread
+//! ─────────────                 ───────────            ──────────
+//! write_record() ──►            (compress)   ──►       write to disk
+//!   buffer ~64KB    submit job   parallel      result   sequential
+//!   submit job      ──────────► workers        ──────► reorder buf
+//!                                              ──────► write ordered
+//! ```
+//!
+//! The reorder buffer is bounded (capacity = `num_workers * 4`) with backpressure:
+//! if the I/O thread falls behind, the main thread blocks on submit, which is
+//! the correct behavior (don't produce faster than we can write).
+
+use crate::sort::bgzf_io::{StagingBuffer, io_writer_loop};
+use crate::sort::keys::RawSortKey;
+use crate::sort::worker_pool::{CompressResult, SortWorkerPool};
+use anyhow::Result;
+use crossbeam_channel::bounded;
+use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use std::io::BufWriter;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+/// A chunk writer that uses `SortWorkerPool` for parallel BGZF compression.
+///
+/// Records are buffered into ~64KB staging blocks, then submitted to the pool
+/// for compression. An I/O thread receives compressed blocks and writes them
+/// in serial order using a bounded reorder buffer.
+pub struct PooledChunkWriter<K: RawSortKey> {
+    staging: StagingBuffer,
+    io_handle: Option<JoinHandle<Result<()>>>,
+    _phantom: PhantomData<K>,
+}
+
+impl<K: RawSortKey> PooledChunkWriter<K> {
+    /// Create a new pooled chunk writer.
+    ///
+    /// Opens the output file and spawns an I/O writer thread that receives
+    /// compressed blocks and writes them in serial order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created.
+    pub fn new(pool: Arc<SortWorkerPool>, path: &Path) -> Result<Self> {
+        let file = std::fs::File::create(path)?;
+        let writer = BufWriter::with_capacity(256 * 1024, file);
+
+        let reorder_capacity = pool.num_workers() * 4;
+        let (result_tx, result_rx) = bounded::<CompressResult>(reorder_capacity);
+        let buffer_pool = pool.buffer_pool.clone();
+
+        let io_handle = thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool));
+
+        Ok(Self {
+            staging: StagingBuffer::new(pool, result_tx),
+            io_handle: Some(io_handle),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Write a keyed record to the chunk file.
+    ///
+    /// Buffers the record and its key into a staging area. When the staging
+    /// area reaches ~64KB, it's submitted to the pool for compression.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key serialization fails.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        if K::EMBEDDED_IN_RECORD {
+            // Fast path: key is part of the record bytes, no extra serialization.
+            // Budget: 4-byte length prefix + record bytes.
+            let needed = 4 + record.len();
+            if self.staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
+                self.staging.flush();
+            }
+            self.staging.buf().extend_from_slice(&(record.len() as u32).to_le_bytes());
+            if record.len() > BGZF_MAX_BLOCK_SIZE.saturating_sub(4) {
+                self.staging.write_chunked(record);
+            } else {
+                self.staging.buf().extend_from_slice(record);
+                self.staging.flush_if_full();
+            }
+        } else {
+            // Non-embedded key: serialize key to a temp buffer first so we know
+            // its exact size and can include it in the pre-flush size check.
+            let mut key_buf = Vec::new();
+            key.write_to(&mut key_buf)?;
+            let needed = key_buf.len() + 4 + record.len();
+            if self.staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
+                self.staging.flush();
+            }
+            self.staging.buf().extend_from_slice(&key_buf);
+            self.staging.buf().extend_from_slice(&(record.len() as u32).to_le_bytes());
+            self.staging.write_chunked(record);
+        }
+        Ok(())
+    }
+
+    /// Finish writing: flush remaining data, wait for I/O thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing or the I/O thread encountered an error.
+    pub fn finish(self) -> Result<()> {
+        self.start_finish()?.wait()
+    }
+
+    /// Flush remaining data and signal the I/O thread, but don't wait for it.
+    ///
+    /// Returns a [`SpillWriteHandle`] that can be waited on later. This allows
+    /// the caller to overlap the I/O thread's disk writes with other work
+    /// (e.g., reading the next batch of records).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing the staging buffer fails.
+    pub fn start_finish(mut self) -> Result<SpillWriteHandle> {
+        if !self.staging.buf().is_empty() {
+            self.staging.flush();
+        }
+        drop(self.staging);
+        Ok(SpillWriteHandle::new(self.io_handle.take()))
+    }
+}
+
+/// Handle for a spill write that is finishing in the background.
+///
+/// Created by [`PooledChunkWriter::start_finish`]. The I/O thread continues
+/// writing compressed blocks to disk. Call [`wait`](SpillWriteHandle::wait)
+/// to block until all data is written and the file is closed.
+///
+/// If dropped without calling `wait`, the `Drop` impl joins the thread and
+/// logs any error rather than silently detaching it.
+#[must_use = "call wait() to propagate write errors; dropping silently logs them"]
+pub struct SpillWriteHandle {
+    io_handle: Option<JoinHandle<Result<()>>>,
+}
+
+impl SpillWriteHandle {
+    /// Create a new handle wrapping an I/O thread join handle.
+    pub(crate) fn new(io_handle: Option<JoinHandle<Result<()>>>) -> Self {
+        Self { io_handle }
+    }
+
+    /// Wait for the background I/O thread to finish writing all blocks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O thread panicked or encountered a write error.
+    pub fn wait(mut self) -> Result<()> {
+        if let Some(handle) = self.io_handle.take() {
+            handle.join().map_err(|_| anyhow::anyhow!("I/O writer thread panicked"))??;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SpillWriteHandle {
+    fn drop(&mut self) {
+        if let Some(handle) = self.io_handle.take() {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => log::error!("SpillWriteHandle: I/O writer thread error: {e}"),
+                Err(_) => log::error!("SpillWriteHandle: I/O writer thread panicked"),
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sort::inline_buffer::TemplateKey;
+    use crate::sort::raw::GenericKeyedChunkReader;
+    use tempfile::TempDir;
+
+    /// Create a test `TemplateKey` with distinct values for roundtrip verification.
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_key(i: u64) -> TemplateKey {
+        TemplateKey::new(
+            i as i32,   // tid1
+            i as i32,   // pos1
+            false,      // neg1
+            i32::MAX,   // tid2
+            i32::MAX,   // pos2
+            false,      // neg2
+            0,          // cb_hash
+            0,          // library
+            (0, false), // mi
+            i,          // name_hash
+            false,      // is_upper
+        )
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn test_pooled_writer_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let chunk_path = dir.path().join("test_chunk.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        let records: Vec<(TemplateKey, Vec<u8>)> = (0..100)
+            .map(|i| {
+                let key = make_key(i);
+                let record = vec![(i % 256) as u8; 200 + (i as usize % 50)];
+                (key, record)
+            })
+            .collect();
+
+        {
+            let mut writer = PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)
+                .expect("create writer");
+
+            for (key, record) in &records {
+                writer.write_record(key, record).expect("write record");
+            }
+            writer.finish().expect("finish writer");
+        }
+
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(&chunk_path, None).expect("open reader");
+
+        let mut buf = Vec::new();
+        let mut read_records = Vec::new();
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            read_records.push((key, buf.clone()));
+        }
+
+        assert_eq!(records.len(), read_records.len(), "record count mismatch");
+        for (i, ((expected_key, expected_data), (actual_key, actual_data))) in
+            records.iter().zip(read_records.iter()).enumerate()
+        {
+            assert_eq!(*expected_key, *actual_key, "key mismatch at {i}");
+            assert_eq!(expected_data, actual_data, "data mismatch at {i}");
+        }
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_pooled_writer_empty() {
+        let dir = TempDir::new().unwrap();
+        let chunk_path = dir.path().join("empty_chunk.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        {
+            let writer = PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)
+                .expect("create writer");
+            writer.finish().expect("finish empty writer");
+        }
+
+        assert!(chunk_path.exists());
+        let metadata = std::fs::metadata(&chunk_path).expect("stat file");
+        assert!(metadata.len() > 0, "file should not be empty (has EOF marker)");
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn test_pooled_writer_large_records() {
+        let dir = TempDir::new().unwrap();
+        let chunk_path = dir.path().join("large_chunk.keyed");
+        let pool = Arc::new(SortWorkerPool::new(4, 1, 6));
+
+        let records: Vec<(TemplateKey, Vec<u8>)> = (0..500)
+            .map(|i| {
+                let key = make_key(i);
+                let record = vec![(i % 256) as u8; 1000];
+                (key, record)
+            })
+            .collect();
+
+        {
+            let mut writer = PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)
+                .expect("create writer");
+
+            for (key, record) in &records {
+                writer.write_record(key, record).expect("write record");
+            }
+            writer.finish().expect("finish writer");
+        }
+
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(&chunk_path, None).expect("open reader");
+
+        let mut buf = Vec::new();
+        let mut count = 0;
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            assert_eq!(key, records[count].0, "key mismatch at {count}");
+            assert_eq!(buf, records[count].1, "data mismatch at {count}");
+            count += 1;
+        }
+        assert_eq!(count, records.len());
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn test_start_finish_and_wait() {
+        // `start_finish()` returns a handle while the I/O thread runs in the background.
+        // `handle.wait()` must join it and surface any errors.
+        let dir = TempDir::new().unwrap();
+        let chunk_path = dir.path().join("pipelined_chunk.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        let records: Vec<(TemplateKey, Vec<u8>)> =
+            (0..50).map(|i| (make_key(i), vec![(i % 256) as u8; 100])).collect();
+
+        let handle = {
+            let mut writer = PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)
+                .expect("create writer");
+            for (key, record) in &records {
+                writer.write_record(key, record).expect("write record");
+            }
+            writer.start_finish().expect("start_finish")
+        };
+
+        // I/O is completing in background; wait for it
+        handle.wait().expect("wait should succeed");
+
+        // Verify all records are readable back
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(&chunk_path, None).expect("open reader");
+        let mut buf = Vec::new();
+        let mut count = 0;
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            assert_eq!(key, records[count].0, "key mismatch at {count}");
+            count += 1;
+        }
+        assert_eq!(count, records.len());
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    #[test]
+    fn test_spill_write_handle_drop_without_wait() {
+        // Dropping a `SpillWriteHandle` without calling `wait()` must not panic —
+        // the `Drop` impl joins the thread and logs any error.
+        let dir = TempDir::new().unwrap();
+        let chunk_path = dir.path().join("dropped_chunk.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6));
+
+        let handle = {
+            let mut writer = PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)
+                .expect("create writer");
+            writer.write_record(&make_key(0), &[1, 2, 3]).expect("write");
+            writer.start_finish().expect("start_finish")
+        };
+
+        // Drop handle without calling wait() — Drop impl joins thread silently
+        drop(handle);
+
+        // File must exist and be non-empty (the I/O thread completed via Drop)
+        assert!(chunk_path.exists());
+        assert!(std::fs::metadata(&chunk_path).unwrap().len() > 0);
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+}

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -20,11 +20,13 @@
 use crate::bam_io::create_raw_bam_reader;
 use crate::progress::ProgressTracker;
 use crate::sort::inline_buffer::{RecordBuffer, TemplateKey, TemplateRecordBuffer};
-use crate::sort::keys::{QuerynameComparator, SortOrder};
-use crate::sort::read_ahead::RawReadAheadReader;
+use crate::sort::keys::{QuerynameComparator, RawSortKey, SortOrder};
+use crate::sort::pooled_chunk_writer::PooledChunkWriter;
+use crate::sort::read_ahead::{RawReadAheadReader, RecordSource};
+use crate::sort::worker_pool::SortWorkerPool;
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, bounded};
-use log::info;
+use log::{debug, info};
 use noodles::sam::Header;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use noodles_bgzf::io::{
@@ -37,7 +39,160 @@ use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
+
+// ============================================================================
+// Per-Phase Timing for Sort Pipeline
+// ============================================================================
+
+/// Tracks wall-clock time spent in each phase of the sort pipeline.
+///
+/// Used to identify bottlenecks and validate thread architecture changes.
+/// All times are cumulative (multiple spill cycles accumulate).
+#[derive(Debug, Default)]
+struct SortPhaseTimer {
+    /// Time reading records from input BAM (includes BGZF decompression).
+    read_secs: f64,
+    /// Time sorting in-memory buffers (rayon parallel sort or single-threaded).
+    sort_secs: f64,
+    /// Time writing sorted chunks to temp files (BGZF compression).
+    spill_write_secs: f64,
+    /// Time consolidating temp files when limit exceeded.
+    consolidate_secs: f64,
+    /// Time in the final k-way merge phase (includes reader decompression + writer compression).
+    merge_secs: f64,
+    /// Time writing in-memory-only output (no merge needed).
+    write_output_secs: f64,
+    /// Number of spill cycles (sort + write).
+    spill_count: usize,
+    /// Number of consolidation merges.
+    consolidate_count: usize,
+    /// Total bytes written to spill files.
+    total_spill_bytes: u64,
+    /// Wall-clock start of the entire sort operation.
+    overall_start: Option<Instant>,
+    /// Tracks the start of the current read span (between spills).
+    read_span_start: Option<Instant>,
+}
+
+impl SortPhaseTimer {
+    fn new() -> Self {
+        Self {
+            overall_start: Some(Instant::now()),
+            read_span_start: Some(Instant::now()),
+            ..Default::default()
+        }
+    }
+
+    /// End a read span (call before sort/spill). Returns elapsed read time.
+    fn end_read_span(&mut self) -> Duration {
+        if let Some(start) = self.read_span_start.take() {
+            let elapsed = start.elapsed();
+            self.read_secs += elapsed.as_secs_f64();
+            elapsed
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    /// Start a new read span (call after spill write completes).
+    fn begin_read_span(&mut self) {
+        self.read_span_start = Some(Instant::now());
+    }
+
+    /// Time a sort operation.
+    fn time_sort(&mut self, f: impl FnOnce()) {
+        let start = Instant::now();
+        f();
+        self.sort_secs += start.elapsed().as_secs_f64();
+    }
+
+    /// Time a spill write operation.
+    fn time_spill_write<T>(&mut self, f: impl FnOnce() -> Result<T>) -> Result<T> {
+        let start = Instant::now();
+        let result = f();
+        self.spill_write_secs += start.elapsed().as_secs_f64();
+        self.spill_count += 1;
+        result
+    }
+
+    /// Record the size of a spill file.
+    fn record_spill_size(&mut self, path: &Path) {
+        if let Ok(meta) = std::fs::metadata(path) {
+            self.total_spill_bytes += meta.len();
+        }
+    }
+
+    /// Time a consolidation operation.
+    fn time_consolidate(&mut self, f: impl FnOnce() -> Result<()>) -> Result<()> {
+        let start = Instant::now();
+        let result = f();
+        let elapsed = start.elapsed().as_secs_f64();
+        if elapsed > 0.001 {
+            // Only count if consolidation actually happened
+            self.consolidate_secs += elapsed;
+            self.consolidate_count += 1;
+        }
+        result
+    }
+
+    /// Time the merge phase.
+    fn time_merge<T>(&mut self, f: impl FnOnce() -> Result<T>) -> Result<T> {
+        let start = Instant::now();
+        let result = f();
+        self.merge_secs += start.elapsed().as_secs_f64();
+        result
+    }
+
+    /// Time writing in-memory-only output (no merge needed).
+    fn time_write_output(&mut self, f: impl FnOnce() -> Result<()>) -> Result<()> {
+        let start = Instant::now();
+        let result = f();
+        self.write_output_secs += start.elapsed().as_secs_f64();
+        result
+    }
+
+    /// Log the final summary.
+    #[allow(clippy::cast_precision_loss)]
+    fn log_summary(&self, threads: usize) {
+        let overall = self.overall_start.map_or(0.0, |s| s.elapsed().as_secs_f64());
+        let read_pct = 100.0 * self.read_secs / overall;
+        let sort_pct = 100.0 * self.sort_secs / overall;
+        let spill_pct = 100.0 * self.spill_write_secs / overall;
+        let spill_count = self.spill_count;
+        let read_secs = self.read_secs;
+        let sort_secs = self.sort_secs;
+        let spill_secs = self.spill_write_secs;
+
+        info!("=== Sort Phase Timing ===");
+        info!("  Read + decompress: {read_secs:.1}s ({read_pct:.0}%)");
+        info!("  In-memory sort:    {sort_secs:.1}s ({sort_pct:.0}%) [{spill_count} spills]");
+        let spill_mb = self.total_spill_bytes as f64 / (1024.0 * 1024.0);
+        info!(
+            "  Spill write:       {spill_secs:.1}s ({spill_pct:.0}%) [{spill_count} writes, {spill_mb:.1} MB total]"
+        );
+        if self.consolidate_count > 0 {
+            let cons_secs = self.consolidate_secs;
+            let cons_pct = 100.0 * cons_secs / overall;
+            let cons_count = self.consolidate_count;
+            info!("  Consolidation:     {cons_secs:.1}s ({cons_pct:.0}%) [{cons_count} merges]");
+        }
+        if self.merge_secs > 0.0 {
+            let merge_secs = self.merge_secs;
+            let merge_pct = 100.0 * merge_secs / overall;
+            info!("  K-way merge:       {merge_secs:.1}s ({merge_pct:.0}%)");
+        }
+        if self.write_output_secs > 0.0 {
+            let write_secs = self.write_output_secs;
+            let write_pct = 100.0 * write_secs / overall;
+            info!("  Write output:      {write_secs:.1}s ({write_pct:.0}%)");
+        }
+        info!("  Total wall clock:  {overall:.1}s");
+        info!("  Threads: {threads}");
+        info!("=========================");
+    }
+}
 
 // ============================================================================
 // Library Lookup for Template-Coordinate Sort
@@ -177,7 +332,6 @@ pub(crate) fn make_reader_semaphore(threads: usize) -> Arc<ChunkReaderSemaphore>
 // Stores pre-computed sort keys alongside each record for O(1) merge comparisons.
 // Format: [key: serialized][len: 4 bytes][record: len bytes] per record
 
-use crate::sort::keys::RawSortKey;
 use std::marker::PhantomData;
 
 /// Wrapper for temp chunk writers supporting both raw and compressed output.
@@ -409,6 +563,10 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
         Ok(Self { receiver: rx, buf_return: buf_tx, _handle: handle })
     }
 
+    /// Open a keyed chunk file with pool-based BGZF decompression.
+    ///
+    /// Instead of decompressing BGZF blocks on the reader thread, raw blocks are
+    /// submitted to the shared `SortWorkerPool` for decompression. This matches
     /// Read records from a reader and send them through the channel.
     ///
     /// When a semaphore is provided, reads records in batches of 64: acquires
@@ -562,16 +720,25 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 
 /// Source for keyed chunks during merge (disk or in-memory).
 enum ChunkSource<K: RawSortKey + Default + 'static> {
-    /// Disk-based chunk with prefetching reader.
+    /// Disk-based chunk with prefetching reader (legacy path with per-source threads).
     Disk(GenericKeyedChunkReader<K>),
     /// In-memory sorted records.
     Memory { records: Vec<(K, Vec<u8>)>, idx: usize },
+    /// Pool-integrated disk source — workers read and decompress, main thread parses.
+    /// The `source_id` maps to the `MainThreadChunkConsumer`'s per-source buffer.
+    PoolDisk { source_id: usize },
 }
 
 impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     /// Fill `buf` with the next record's bytes and return the sort key,
     /// or `None` at EOF.
-    fn next_record(&mut self, buf: &mut Vec<u8>) -> Result<Option<K>> {
+    ///
+    /// For `PoolDisk` sources, `consumer` must be `Some`.
+    fn next_record(
+        &mut self,
+        buf: &mut Vec<u8>,
+        consumer: Option<&mut MainThreadChunkConsumer<K>>,
+    ) -> Result<Option<K>> {
         match self {
             ChunkSource::Disk(reader) => reader.next_record(buf),
             ChunkSource::Memory { records, idx } => {
@@ -585,6 +752,366 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
                     Ok(None)
                 }
             }
+            ChunkSource::PoolDisk { source_id } => consumer
+                .expect("PoolDisk source requires MainThreadChunkConsumer")
+                .next_record(*source_id, buf),
+        }
+    }
+}
+
+// ============================================================================
+// MainThreadChunkConsumer — pool-integrated merge reader (replaces GenericKeyedChunkReader)
+// ============================================================================
+
+/// Per-source buffer for reassembling decompressed blocks into a record stream.
+struct PerSourceBuffer {
+    /// Pending decompressed blocks waiting for consumption, keyed by serial.
+    pending: std::collections::BTreeMap<u64, Vec<u8>>,
+    /// Next serial number to consume from this source.
+    next_serial: u64,
+    /// Current byte buffer being consumed by the record parser.
+    current_buf: Vec<u8>,
+    /// Read position within `current_buf`.
+    current_pos: usize,
+    /// Whether this source has seen all its decompressed blocks.
+    eof: bool,
+}
+
+impl PerSourceBuffer {
+    fn new() -> Self {
+        Self {
+            pending: std::collections::BTreeMap::new(),
+            next_serial: 0,
+            current_buf: Vec::new(),
+            current_pos: 0,
+            eof: false,
+        }
+    }
+
+    /// Return how many bytes remain in the current buffer.
+    fn remaining(&self) -> usize {
+        self.current_buf.len() - self.current_pos
+    }
+
+    /// Advance to the next pending block if the current one is exhausted.
+    /// Returns true if data is now available.
+    fn advance_if_needed(&mut self) -> bool {
+        if self.remaining() > 0 {
+            return true;
+        }
+        if let Some(data) = self.pending.remove(&self.next_serial) {
+            self.current_buf = data;
+            self.current_pos = 0;
+            self.next_serial += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Reads from the pool's `decompressed_chunks` queue and presents records to the merge loop.
+///
+/// Replaces `GenericKeyedChunkReader` for the pool-integrated path. No threads are spawned —
+/// the main thread drives all consumption. Workers in the pool do all the reading and
+/// decompression.
+///
+/// # Type Parameter
+///
+/// `K` is the sort key type (`RawCoordinateKey`, `TemplateKey`, etc.).
+pub struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
+    /// Per-source reorder/parse buffers.
+    per_source: Vec<PerSourceBuffer>,
+    /// `ArrayQueue` to pop decompressed blocks from pool workers.
+    decompressed_chunks: std::sync::Arc<
+        crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedDecompressedBlock>,
+    >,
+    /// Raw (pre-decompression) chunk blocks in flight.
+    ///
+    /// `all_chunks_eof` is set when raw reads from disk finish, but blocks may still
+    /// be in this queue awaiting decompression. The EOF check in `poll_decompressed_blocks`
+    /// must wait for this queue to drain to avoid declaring EOF prematurely and losing data.
+    raw_chunk_blocks:
+        std::sync::Arc<crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedRawBlock>>,
+    /// Shared flag: set when all chunk files have been fully read from disk.
+    ///
+    /// Note: this is set when raw reads finish, not when decompression is done.
+    /// Always check `raw_chunk_blocks.is_empty()` alongside this before declaring EOF.
+    all_chunks_eof: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Maximum total pending blocks across all per-source buffers before we stop draining.
+    ///
+    /// Caps memory growth: without this, `poll_decompressed_blocks` could drain the entire
+    /// `decompressed_chunks` queue into unbounded per-source `pending` maps, bypassing the
+    /// backpressure the `ArrayQueue` was meant to provide.
+    max_pending_blocks: usize,
+    _phantom: std::marker::PhantomData<K>,
+}
+
+impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
+    /// Create a new consumer for the given number of sources.
+    #[must_use]
+    pub fn new(
+        num_sources: usize,
+        decompressed_chunks: std::sync::Arc<
+            crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedDecompressedBlock>,
+        >,
+        raw_chunk_blocks: std::sync::Arc<
+            crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedRawBlock>,
+        >,
+        all_chunks_eof: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        let per_source = (0..num_sources).map(|_| PerSourceBuffer::new()).collect();
+        // Default cap: queue capacity (num_workers * 8); keeps total pending ≤ 2× queue depth.
+        let max_pending_blocks = decompressed_chunks.capacity();
+        Self {
+            per_source,
+            decompressed_chunks,
+            raw_chunk_blocks,
+            all_chunks_eof,
+            max_pending_blocks,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Get the next record from a specific source.
+    ///
+    /// Polls the `decompressed_chunks` queue as needed, dispatching blocks to their
+    /// correct per-source buffer. Parses the next record from the source's byte stream.
+    ///
+    /// Returns `Ok(Some(key))` with record bytes swapped into `buf`, `Ok(None)` at EOF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a record is truncated or if reading from the source fails.
+    pub fn next_record(&mut self, source_id: usize, buf: &mut Vec<u8>) -> Result<Option<K>> {
+        loop {
+            let source = &mut self.per_source[source_id];
+
+            // Try to advance to next block if current is exhausted
+            source.advance_if_needed();
+
+            // Try to parse a record from the current data
+            if source.remaining() > 0 {
+                return self.parse_next_record(source_id, buf);
+            }
+
+            // If this source is at EOF and no pending blocks, it's done
+            if source.eof && source.pending.is_empty() {
+                return Ok(None);
+            }
+
+            // Need more data — poll the shared queue and dispatch
+            if !self.poll_decompressed_blocks(source_id)? {
+                // Queue closed and no more data for this source
+                self.per_source[source_id].eof = true;
+                if self.per_source[source_id].pending.is_empty()
+                    && self.per_source[source_id].remaining() == 0
+                {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    /// Poll the `decompressed_chunks` `ArrayQueue`, dispatching blocks to per-source buffers.
+    ///
+    /// Drains all available blocks into per-source buffers, then checks if the
+    /// target source has data. If not, parks the thread until a worker calls
+    /// `unpark()` after pushing new data.
+    ///
+    /// Returns `false` if all chunks are done (no more blocks coming).
+    fn poll_decompressed_blocks(&mut self, target_source: usize) -> Result<bool> {
+        loop {
+            // Drain available blocks into per-source buffers, respecting the pending cap.
+            // Without this cap, we could drain the entire decompressed_chunks ArrayQueue
+            // into unbounded per-source maps, bypassing the backpressure the queue provides.
+            let pending_total: usize = self.per_source.iter().map(|s| s.pending.len()).sum();
+            if pending_total < self.max_pending_blocks {
+                while let Some(block) = self.decompressed_chunks.pop() {
+                    let sid = block.source_id;
+                    let source = &mut self.per_source[sid];
+                    if block.serial == source.next_serial && source.remaining() == 0 {
+                        // Immediately consumable — install as current_buf (not pending)
+                        source.current_buf = block.data;
+                        source.current_pos = 0;
+                        source.next_serial += 1;
+                    } else {
+                        source.pending.insert(block.serial, block.data);
+                    }
+                    // Re-check cap after each block to avoid overshooting
+                    let new_total: usize = self.per_source.iter().map(|s| s.pending.len()).sum();
+                    if new_total >= self.max_pending_blocks {
+                        break;
+                    }
+                }
+            }
+
+            // Check if the target source now has data
+            let target = &self.per_source[target_source];
+            if target.remaining() > 0 || target.pending.contains_key(&target.next_serial) {
+                return Ok(true);
+            }
+
+            // Check EOF: all raw blocks must be read AND decompressed before declaring done.
+            // `all_chunks_eof` is set when raw disk reads finish, but blocks may still be
+            // in `raw_chunk_blocks` awaiting decompression. Checking only `decompressed_chunks`
+            // would race with the decompression workers and lose in-flight records.
+            if self.all_chunks_eof.load(std::sync::atomic::Ordering::Acquire)
+                && self.raw_chunk_blocks.is_empty()
+                && self.decompressed_chunks.is_empty()
+            {
+                for source in &mut self.per_source {
+                    source.eof = true;
+                }
+                return Ok(false);
+            }
+
+            // Park until a worker pushes a block and calls unpark()
+            std::thread::park();
+        }
+    }
+
+    /// Parse the next record from a source's byte stream.
+    ///
+    /// Handles the format: for `EMBEDDED_IN_RECORD` keys, reads [len(4)][record(len)].
+    /// For keyed format, reads [key][len(4)][record(len)].
+    fn parse_next_record(&mut self, source_id: usize, buf: &mut Vec<u8>) -> Result<Option<K>> {
+        let mut len_buf = [0u8; 4];
+
+        if K::EMBEDDED_IN_RECORD {
+            if !self.read_exact_from_source(source_id, &mut len_buf)? {
+                return Ok(None);
+            }
+            let len = u32::from_le_bytes(len_buf) as usize;
+
+            buf.clear();
+            buf.resize(len, 0);
+            if !self.read_exact_from_source(source_id, buf)? {
+                return Err(anyhow::anyhow!("truncated record in chunk source {source_id}"));
+            }
+            let key = K::extract_from_record(buf);
+            Ok(Some(key))
+        } else {
+            let Some(key) = self.read_key_from_source::<K>(source_id)? else {
+                return Ok(None);
+            };
+
+            if !self.read_exact_from_source(source_id, &mut len_buf)? {
+                return Err(anyhow::anyhow!("truncated record length in chunk source {source_id}"));
+            }
+            let len = u32::from_le_bytes(len_buf) as usize;
+
+            buf.clear();
+            buf.resize(len, 0);
+            if !self.read_exact_from_source(source_id, buf)? {
+                return Err(anyhow::anyhow!("truncated record in chunk source {source_id}"));
+            }
+            Ok(Some(key))
+        }
+    }
+
+    /// Read exactly `n` bytes from a source into `out`, pulling more blocks as needed.
+    ///
+    /// Returns `Ok(false)` at clean EOF (zero bytes available), `Ok(true)` on success.
+    fn read_exact_from_source(&mut self, source_id: usize, out: &mut [u8]) -> Result<bool> {
+        let n = out.len();
+        let mut filled = 0;
+
+        while filled < n {
+            let source = &mut self.per_source[source_id];
+            source.advance_if_needed();
+
+            if source.remaining() > 0 {
+                let take = (n - filled).min(source.remaining());
+                out[filled..filled + take].copy_from_slice(
+                    &source.current_buf[source.current_pos..source.current_pos + take],
+                );
+                source.current_pos += take;
+                filled += take;
+            } else if source.eof && source.pending.is_empty() {
+                if filled == 0 {
+                    return Ok(false);
+                }
+                return Err(anyhow::anyhow!(
+                    "truncated data in chunk source {source_id}: got {filled} of {n} bytes",
+                ));
+            } else if !self.poll_decompressed_blocks(source_id)? {
+                self.per_source[source_id].eof = true;
+                self.per_source[source_id].advance_if_needed();
+                if self.per_source[source_id].remaining() == 0 {
+                    if filled == 0 {
+                        return Ok(false);
+                    }
+                    return Err(anyhow::anyhow!(
+                        "truncated data in chunk source {source_id}: got {filled} of {n} bytes",
+                    ));
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Read a sort key from a source's byte stream.
+    ///
+    /// Returns `Ok(None)` at clean EOF.
+    fn read_key_from_source<KK: RawSortKey>(&mut self, source_id: usize) -> Result<Option<KK>> {
+        // Create a Read adapter over the source's buffer
+        let mut adapter = SourceReadAdapter { consumer: self, source_id };
+        match KK::read_from(&mut adapter) {
+            Ok(key) => Ok(Some(key)),
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("error reading key from source {source_id}: {e}")),
+        }
+    }
+}
+
+/// Adapter that implements `std::io::Read` over a `MainThreadChunkConsumer` source.
+///
+/// This allows `K::read_from(&mut reader)` to read from the pool-based byte stream.
+struct SourceReadAdapter<'a, K: RawSortKey + 'static> {
+    consumer: &'a mut MainThreadChunkConsumer<K>,
+    source_id: usize,
+}
+
+impl<K: RawSortKey + 'static> Read for SourceReadAdapter<'_, K> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let source = &mut self.consumer.per_source[self.source_id];
+
+        // Try current buffer first
+        source.advance_if_needed();
+        if source.remaining() > 0 {
+            let take = buf.len().min(source.remaining());
+            buf[..take].copy_from_slice(
+                &source.current_buf[source.current_pos..source.current_pos + take],
+            );
+            source.current_pos += take;
+            return Ok(take);
+        }
+
+        // Need more blocks
+        if source.eof && source.pending.is_empty() {
+            return Ok(0); // EOF
+        }
+
+        // Poll for more data (blocking)
+        match self.consumer.poll_decompressed_blocks(self.source_id) {
+            Ok(true) => {
+                let source = &mut self.consumer.per_source[self.source_id];
+                source.advance_if_needed();
+                if source.remaining() > 0 {
+                    let take = buf.len().min(source.remaining());
+                    buf[..take].copy_from_slice(
+                        &source.current_buf[source.current_pos..source.current_pos + take],
+                    );
+                    source.current_pos += take;
+                    Ok(take)
+                } else {
+                    Ok(0)
+                }
+            }
+            Ok(false) => Ok(0), // Channel closed
+            Err(e) => Err(std::io::Error::other(e.to_string())),
         }
     }
 }
@@ -618,6 +1145,16 @@ impl<'a> ChunkNamer<'a> {
         self.merge_count += 1;
         path
     }
+}
+
+/// A spill write that is finishing in the background.
+///
+/// Used for pipelining: the I/O thread continues writing while the main thread
+/// reads the next batch. The chunk path is stored alongside the handle so it
+/// can be pushed to `chunk_files` only after the write completes.
+struct PendingSpill {
+    handle: crate::sort::pooled_chunk_writer::SpillWriteHandle,
+    chunk_path: PathBuf,
 }
 
 /// Raw-bytes external sorter for BAM files.
@@ -778,6 +1315,7 @@ impl RawExternalSorter {
         &self,
         chunk_files: &mut Vec<PathBuf>,
         namer: &mut ChunkNamer<'_>,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<()> {
         use crate::sort::loser_tree::LoserTree;
 
@@ -803,19 +1341,15 @@ impl RawExternalSorter {
         // Create merged output file
         let merged_path = namer.next_merged_path();
 
-        // Open readers with semaphore to cap concurrent I/O
+        // Open readers with semaphore to cap concurrent I/O.
         let sem = make_reader_semaphore(self.threads);
         let mut readers: Vec<GenericKeyedChunkReader<K>> = files_to_merge
             .iter()
             .map(|p| GenericKeyedChunkReader::<K>::open(p, Some(Arc::clone(&sem))))
             .collect::<Result<Vec<_>>>()?;
 
-        // Create writer for merged output
-        let mut writer = GenericKeyedChunkWriter::<K>::create(
-            &merged_path,
-            self.temp_compression,
-            self.threads,
-        )?;
+        // Use pooled writer for parallel compression during consolidation.
+        let mut writer = PooledChunkWriter::<K>::new(Arc::clone(pool), &merged_path)?;
 
         // Initialize loser tree with first record from each reader
         let mut initial_keys: Vec<K> = Vec::with_capacity(readers.len());
@@ -882,8 +1416,22 @@ impl RawExternalSorter {
         info!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
         info!("Threads: {}", self.threads);
 
-        // Open input BAM with lazy record reading
-        let (reader, header) = create_raw_bam_reader(input, self.threads)?;
+        // Shared worker pool for parallel BGZF compress/decompress across all phases
+        let pool = Arc::new(SortWorkerPool::new(
+            self.threads.max(1),
+            self.temp_compression,
+            self.output_compression,
+        ));
+
+        // Open input BAM and create record source
+        // N+2 model: workers do ReadInputBlocks + DecompressInput,
+        // main thread reads records directly from PooledInputStream.
+        info!("Phase 1: Pool-integrated input reading ({} workers, N+2 model)", pool.num_workers());
+        let (record_source, header) = {
+            let (reader, header) =
+                crate::bam_io::create_raw_bam_reader_pool_integrated(input, &pool)?;
+            (RecordSource::direct(reader), header)
+        };
 
         // Add @PG record if pg_info was provided
         let header = if let Some((ref version, ref command_line)) = self.pg_info {
@@ -898,12 +1446,14 @@ impl RawExternalSorter {
 
         // Sort based on order
         match self.sort_order {
-            SortOrder::Coordinate => self.sort_coordinate(reader, &header, output, temp_path),
+            SortOrder::Coordinate => {
+                self.sort_coordinate(record_source, pool, &header, output, temp_path)
+            }
             SortOrder::Queryname(comparator) => {
-                self.sort_queryname(reader, &header, output, temp_path, comparator)
+                self.sort_queryname(record_source, pool, &header, output, temp_path, comparator)
             }
             SortOrder::TemplateCoordinate => {
-                self.sort_template_coordinate(reader, &header, output, temp_path)
+                self.sort_template_coordinate(record_source, pool, &header, output, temp_path)
             }
         }
     }
@@ -1051,15 +1601,16 @@ impl RawExternalSorter {
     /// Sort by coordinate order using optimized radix sort for large arrays.
     fn sort_coordinate(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
     ) -> Result<RawSortStats> {
         if self.write_index {
-            self.sort_coordinate_with_index(reader, header, output, temp_path)
+            self.sort_coordinate_with_index(record_source, pool, header, output, temp_path)
         } else {
-            self.sort_coordinate_optimized(reader, header, output, temp_path)
+            self.sort_coordinate_optimized(record_source, pool, header, output, temp_path)
         }
     }
 
@@ -1067,10 +1618,11 @@ impl RawExternalSorter {
     ///
     /// Uses `RecordBuffer` which stores records in a single contiguous allocation
     /// with pre-computed sort keys, eliminating per-record heap allocations.
-    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     fn sort_coordinate_optimized(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        mut record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
@@ -1078,6 +1630,7 @@ impl RawExternalSorter {
         use crate::sort::keys::RawCoordinateKey;
 
         let mut stats = RawSortStats::default();
+        let mut timer = SortPhaseTimer::new();
 
         // Get number of references (unmapped reads map to nref)
         let nref = header.reference_sequences().len() as u32;
@@ -1093,13 +1646,12 @@ impl RawExternalSorter {
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
-
-        let read_ahead = RawReadAheadReader::new(reader);
+        let mut pending_spill: Option<PendingSpill> = None;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
 
-        for record in read_ahead {
+        for record in record_source.by_ref() {
             stats.total_records += 1;
             progress.log_if_needed(1);
 
@@ -1108,72 +1660,98 @@ impl RawExternalSorter {
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
+                timer.end_read_span();
+
+                // Wait for any previous spill to complete before starting a new one
+                if let Some(prev) = pending_spill.take() {
+                    prev.handle.wait()?;
+                    timer.record_spill_size(&prev.chunk_path);
+                    chunk_files.push(prev.chunk_path);
+                    stats.chunks_written += 1;
+
+                    timer.time_consolidate(|| {
+                        self.maybe_consolidate_temp_files::<RawCoordinateKey>(
+                            &mut chunk_files,
+                            &mut namer,
+                            &pool,
+                        )
+                    })?;
+                }
+
                 let chunk_path = namer.next_chunk_path();
 
-                // Sort in place using parallel sort for large buffers
-                if self.threads > 1 {
-                    buffer.par_sort();
-                } else {
+                timer.time_sort(|| {
                     buffer.sort();
-                }
+                });
 
-                // Write keyed temp file (stores sort key with each record for O(1) merge)
-                let mut writer = GenericKeyedChunkWriter::<RawCoordinateKey>::create(
-                    &chunk_path,
-                    self.temp_compression,
-                    self.threads,
-                )?;
-                for r in buffer.refs() {
-                    let key = RawCoordinateKey { sort_key: r.sort_key };
-                    let record_bytes = buffer.get_record(r);
-                    writer.write_record(&key, record_bytes)?;
-                }
-                writer.finish()?;
+                // Write keyed temp file with parallel BGZF compression via worker pool.
+                // Use start_finish() for pipelining: I/O continues in background
+                // while we read the next batch.
+                let handle = timer.time_spill_write(|| {
+                    let mut writer =
+                        PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &chunk_path)?;
+                    for r in buffer.refs() {
+                        let key = RawCoordinateKey { sort_key: r.sort_key };
+                        let record_bytes = buffer.get_record(r);
+                        writer.write_record(&key, record_bytes)?;
+                    }
+                    writer.start_finish()
+                })?;
 
-                stats.chunks_written += 1;
-                chunk_files.push(chunk_path);
-
-                // Consolidate if we have too many temp files
-                self.maybe_consolidate_temp_files::<RawCoordinateKey>(
-                    &mut chunk_files,
-                    &mut namer,
-                )?;
+                pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                timer.begin_read_span();
             }
         }
 
+        timer.end_read_span();
         progress.log_final();
+        if let Some(err) = record_source.take_error() {
+            return Err(anyhow::Error::from(err));
+        }
+
+        // Drain any pending spill before merge
+        if let Some(prev) = pending_spill.take() {
+            prev.handle.wait()?;
+            timer.record_spill_size(&prev.chunk_path);
+            chunk_files.push(prev.chunk_path);
+            stats.chunks_written += 1;
+
+            timer.time_consolidate(|| {
+                self.maybe_consolidate_temp_files::<RawCoordinateKey>(
+                    &mut chunk_files,
+                    &mut namer,
+                    &pool,
+                )
+            })?;
+        }
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
             info!("All records fit in memory, performing in-memory sort");
 
-            if self.threads > 1 {
-                buffer.par_sort();
-            } else {
+            timer.time_sort(|| {
                 buffer.sort();
-            }
+            });
 
-            let output_header = self.create_output_header(header);
-            let mut writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
+            timer.time_write_output(|| {
+                use crate::sort::pooled_bam_writer::PooledBamWriter;
+                let output_header = self.create_output_header(header);
+                let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
-            for record_bytes in buffer.iter_sorted() {
-                writer.write_raw_record(record_bytes)?;
-            }
-            writer.finish()?;
+                for record_bytes in buffer.iter_sorted() {
+                    writer.write_raw_record(record_bytes)?;
+                }
+                writer.finish()?;
+                Ok(())
+            })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
+            let sort_start = Instant::now();
             let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
                 let chunk = buffer
@@ -1186,6 +1764,7 @@ impl RawExternalSorter {
                     .collect();
                 vec![chunk]
             };
+            timer.sort_secs += sort_start.elapsed().as_secs_f64();
 
             let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
@@ -1194,16 +1773,23 @@ impl RawExternalSorter {
             );
 
             // Merge disk chunks + in-memory chunks using O(1) key comparisons
-            self.merge_chunks_generic::<RawCoordinateKey>(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            timer.time_merge(|| {
+                self.merge_chunks_generic::<RawCoordinateKey>(
+                    &chunk_files,
+                    memory_chunks,
+                    header,
+                    output,
+                    stats.total_records,
+                    &pool,
+                )
+            })?;
         }
 
         stats.output_records = stats.total_records;
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+        timer.log_summary(self.threads);
         info!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -1217,7 +1803,8 @@ impl RawExternalSorter {
     #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     fn sort_coordinate_with_index(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        mut record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
@@ -1228,6 +1815,8 @@ impl RawExternalSorter {
         info!("Indexing enabled: will write BAM index alongside output");
 
         let mut stats = RawSortStats::default();
+        let mut timer = SortPhaseTimer::new();
+
         let nref = header.reference_sequences().len() as u32;
         let init_cap = self.effective_initial_capacity();
         // Per-record footprint: ~200 bytes BAM + 16 header + 24 ref = ~240 bytes
@@ -1237,49 +1826,78 @@ impl RawExternalSorter {
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
-        let read_ahead = RawReadAheadReader::new(reader);
+        let mut pending_spill: Option<PendingSpill> = None;
 
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
 
-        for record in read_ahead {
+        for record in record_source.by_ref() {
             stats.total_records += 1;
             buffer.push_coordinate(record.as_ref())?;
 
             if buffer.memory_usage() >= self.memory_limit {
+                timer.end_read_span();
+
+                // Wait for any previous spill to complete
+                if let Some(prev) = pending_spill.take() {
+                    prev.handle.wait()?;
+                    timer.record_spill_size(&prev.chunk_path);
+                    chunk_files.push(prev.chunk_path);
+                    stats.chunks_written += 1;
+
+                    timer.time_consolidate(|| {
+                        self.maybe_consolidate_temp_files::<RawCoordinateKey>(
+                            &mut chunk_files,
+                            &mut namer,
+                            &pool,
+                        )
+                    })?;
+                }
+
                 let chunk_path = namer.next_chunk_path();
 
-                if self.threads > 1 {
-                    buffer.par_sort();
-                } else {
+                timer.time_sort(|| {
                     buffer.sort();
-                }
+                });
 
-                let mut writer = GenericKeyedChunkWriter::<RawCoordinateKey>::create(
-                    &chunk_path,
-                    self.temp_compression,
-                    self.threads,
-                )?;
-                for r in buffer.refs() {
-                    let key = RawCoordinateKey { sort_key: r.sort_key };
-                    let record_bytes = buffer.get_record(r);
-                    writer.write_record(&key, record_bytes)?;
-                }
-                writer.finish()?;
+                let handle = timer.time_spill_write(|| {
+                    let mut writer =
+                        PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &chunk_path)?;
+                    for r in buffer.refs() {
+                        let key = RawCoordinateKey { sort_key: r.sort_key };
+                        let record_bytes = buffer.get_record(r);
+                        writer.write_record(&key, record_bytes)?;
+                    }
+                    writer.start_finish()
+                })?;
 
-                stats.chunks_written += 1;
-                chunk_files.push(chunk_path);
-
-                // Consolidate if we have too many temp files
-                self.maybe_consolidate_temp_files::<RawCoordinateKey>(
-                    &mut chunk_files,
-                    &mut namer,
-                )?;
+                pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                timer.begin_read_span();
             }
         }
 
+        timer.end_read_span();
         info!("Read {} records total", stats.total_records);
+        if let Some(err) = record_source.take_error() {
+            return Err(anyhow::Error::from(err));
+        }
+
+        // Drain any pending spill before merge
+        if let Some(prev) = pending_spill.take() {
+            prev.handle.wait()?;
+            timer.record_spill_size(&prev.chunk_path);
+            chunk_files.push(prev.chunk_path);
+            stats.chunks_written += 1;
+
+            timer.time_consolidate(|| {
+                self.maybe_consolidate_temp_files::<RawCoordinateKey>(
+                    &mut chunk_files,
+                    &mut namer,
+                    &pool,
+                )
+            })?;
+        }
 
         let output_header = self.create_output_header(header);
 
@@ -1287,37 +1905,34 @@ impl RawExternalSorter {
             // All records fit in memory - no merge needed
             info!("All records fit in memory, performing in-memory sort");
 
-            if self.threads > 1 {
-                buffer.par_sort();
-            } else {
+            timer.time_sort(|| {
                 buffer.sort();
-            }
+            });
 
-            // Use IndexingBamWriter for single-pass index generation
-            let mut writer = create_indexing_bam_writer(
-                output,
-                &output_header,
-                self.output_compression,
-                self.threads,
-            )?;
+            timer.time_write_output(|| {
+                let mut writer = create_indexing_bam_writer(
+                    output,
+                    &output_header,
+                    self.output_compression,
+                    self.threads,
+                )?;
 
-            for record_bytes in buffer.iter_sorted() {
-                writer.write_raw_record(record_bytes)?;
-            }
+                for record_bytes in buffer.iter_sorted() {
+                    writer.write_raw_record(record_bytes)?;
+                }
 
-            let index = writer.finish()?;
+                let index = writer.finish()?;
 
-            // Write the index file
-            let index_path = output.with_extension("bam.bai");
-            write_bai_index(&index_path, &index)?;
-            info!("Wrote BAM index: {}", index_path.display());
+                let index_path = output.with_extension("bam.bai");
+                write_bai_index(&index_path, &index)?;
+                info!("Wrote BAM index: {}", index_path.display());
+                Ok(())
+            })?;
         } else {
-            // Sort remaining records into separate sub-array chunks (avoids
-            // intermediate merge back into a single sorted buffer)
+            // Sort remaining records into separate sub-array chunks
+            let sort_start = Instant::now();
             let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
                 let chunk = buffer
@@ -1330,6 +1945,7 @@ impl RawExternalSorter {
                     .collect();
                 vec![chunk]
             };
+            timer.sort_secs += sort_start.elapsed().as_secs_f64();
 
             let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
@@ -1337,22 +1953,28 @@ impl RawExternalSorter {
                 chunk_files.len() + n_memory
             );
 
-            // Merge with index generation
-            let index = self.merge_chunks_with_index::<RawCoordinateKey>(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            timer.time_merge(|| {
+                let index = self.merge_chunks_with_index::<RawCoordinateKey>(
+                    &chunk_files,
+                    memory_chunks,
+                    header,
+                    output,
+                    stats.total_records,
+                    &pool,
+                )?;
 
-            // Write the index file
-            let index_path = output.with_extension("bam.bai");
-            write_bai_index(&index_path, &index)?;
-            info!("Wrote BAM index: {}", index_path.display());
+                let index_path = output.with_extension("bam.bai");
+                write_bai_index(&index_path, &index)?;
+                info!("Wrote BAM index: {}", index_path.display());
+                Ok(())
+            })?;
         }
 
         stats.output_records = stats.total_records;
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+        timer.log_summary(self.threads);
         info!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -1365,7 +1987,8 @@ impl RawExternalSorter {
     /// - `Natural`: uses `RawQuerynameKey` (natural numeric comparison)
     fn sort_queryname(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
@@ -1374,19 +1997,29 @@ impl RawExternalSorter {
         use crate::sort::keys::{RawQuerynameKey, RawQuerynameLexKey};
         info!("Using queryname sort with {comparator} comparator");
         match comparator {
-            QuerynameComparator::Lexicographic => {
-                self.sort_queryname_keyed::<RawQuerynameLexKey>(reader, header, output, temp_path)
-            }
-            QuerynameComparator::Natural => {
-                self.sort_queryname_keyed::<RawQuerynameKey>(reader, header, output, temp_path)
-            }
+            QuerynameComparator::Lexicographic => self.sort_queryname_keyed::<RawQuerynameLexKey>(
+                record_source,
+                pool,
+                header,
+                output,
+                temp_path,
+            ),
+            QuerynameComparator::Natural => self.sort_queryname_keyed::<RawQuerynameKey>(
+                record_source,
+                pool,
+                header,
+                output,
+                temp_path,
+            ),
         }
     }
 
     /// Generic queryname sort using a specific key type.
+    #[allow(clippy::too_many_lines)]
     fn sort_queryname_keyed<K: RawSortKey + Default + 'static>(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        mut record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
@@ -1394,6 +2027,8 @@ impl RawExternalSorter {
         use crate::sort::keys::SortContext;
 
         let mut stats = RawSortStats::default();
+        let mut timer = SortPhaseTimer::new();
+
         let ctx = SortContext::from_header(header);
 
         // Estimate capacity from initial_capacity to avoid huge upfront allocations.
@@ -1404,13 +2039,12 @@ impl RawExternalSorter {
         let mut entries: Vec<(K, Vec<u8>)> = Vec::with_capacity(estimated_records);
         let mut memory_used = 0usize;
         let mut namer = ChunkNamer::new(temp_path);
-
-        let read_ahead = RawReadAheadReader::new(reader);
+        let mut pending_spill: Option<PendingSpill> = None;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (keyed output)...");
 
-        for record in read_ahead {
+        for record in record_source.by_ref() {
             stats.total_records += 1;
             progress.log_if_needed(1);
 
@@ -1426,83 +2060,90 @@ impl RawExternalSorter {
 
             // Check if we need to spill to disk
             if memory_used >= self.memory_limit {
+                timer.end_read_span();
+
+                // Wait for any previous spill to complete
+                if let Some(prev) = pending_spill.take() {
+                    prev.handle.wait()?;
+                    timer.record_spill_size(&prev.chunk_path);
+                    chunk_files.push(prev.chunk_path);
+                    stats.chunks_written += 1;
+
+                    timer.time_consolidate(|| {
+                        self.maybe_consolidate_temp_files::<K>(&mut chunk_files, &mut namer, &pool)
+                    })?;
+                }
+
                 let chunk_path = namer.next_chunk_path();
 
-                // Sort the entries
-                if self.threads > 1 {
-                    use rayon::prelude::*;
-                    entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                } else {
+                timer.time_sort(|| {
                     entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                }
+                });
 
-                // Write keyed temp file
-                let mut writer = GenericKeyedChunkWriter::<K>::create(
-                    &chunk_path,
-                    self.temp_compression,
-                    self.threads,
-                )?;
-                for (key, record) in entries.drain(..) {
-                    writer.write_record(&key, &record)?;
-                }
-                writer.finish()?;
+                // Write keyed temp file with parallel BGZF compression via worker pool.
+                let handle = timer.time_spill_write(|| {
+                    let mut writer = PooledChunkWriter::<K>::new(Arc::clone(&pool), &chunk_path)?;
+                    for (key, record) in entries.drain(..) {
+                        writer.write_record(&key, &record)?;
+                    }
+                    writer.start_finish()
+                })?;
 
-                stats.chunks_written += 1;
-                chunk_files.push(chunk_path);
-
-                // Consolidate if we have too many temp files
-                self.maybe_consolidate_temp_files::<K>(&mut chunk_files, &mut namer)?;
+                pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 memory_used = 0;
+                timer.begin_read_span();
             }
         }
 
+        timer.end_read_span();
         progress.log_final();
+        if let Some(err) = record_source.take_error() {
+            return Err(anyhow::Error::from(err));
+        }
+
+        // Drain any pending spill before merge
+        if let Some(prev) = pending_spill.take() {
+            prev.handle.wait()?;
+            timer.record_spill_size(&prev.chunk_path);
+            chunk_files.push(prev.chunk_path);
+            stats.chunks_written += 1;
+
+            timer.time_consolidate(|| {
+                self.maybe_consolidate_temp_files::<K>(&mut chunk_files, &mut namer, &pool)
+            })?;
+        }
 
         if chunk_files.is_empty() {
             // All records fit in memory
             info!("All records fit in memory, performing in-memory sort");
 
-            if self.threads > 1 {
-                use rayon::prelude::*;
-                entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
-            } else {
+            timer.time_sort(|| {
                 entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-            }
+            });
 
-            let output_header = self.create_output_header(header);
-            let mut writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
+            timer.time_write_output(|| {
+                use crate::sort::pooled_bam_writer::PooledBamWriter;
+                let output_header = self.create_output_header(header);
+                let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
-            for (_key, record) in entries {
-                writer.write_raw_record(&record)?;
-            }
-            writer.finish()?;
+                for (_key, record) in entries {
+                    writer.write_raw_record(&record)?;
+                }
+                writer.finish()?;
+                Ok(())
+            })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
+            let sort_start = Instant::now();
             let memory_chunks: Vec<Vec<(K, Vec<u8>)>> = if entries.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                use rayon::prelude::*;
-                let chunk_size = entries.len().div_ceil(self.threads.max(1));
-                entries.par_chunks_mut(chunk_size).for_each(|chunk| {
-                    chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                });
-                let mut chunks = Vec::new();
-                while !entries.is_empty() {
-                    let take = chunk_size.min(entries.len());
-                    chunks.push(entries.drain(..take).collect());
-                }
-                chunks
             } else {
                 entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
                 vec![entries]
             };
+            timer.sort_secs += sort_start.elapsed().as_secs_f64();
 
             let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!(
@@ -1511,16 +2152,23 @@ impl RawExternalSorter {
             );
 
             // Merge disk chunks + in-memory records using keyed comparisons
-            self.merge_chunks_generic::<K>(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            timer.time_merge(|| {
+                self.merge_chunks_generic::<K>(
+                    &chunk_files,
+                    memory_chunks,
+                    header,
+                    output,
+                    stats.total_records,
+                    &pool,
+                )
+            })?;
         }
 
         stats.output_records = stats.total_records;
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+        timer.log_summary(self.threads);
         info!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -1533,14 +2181,17 @@ impl RawExternalSorter {
     ///
     /// Writes keyed temp chunks that preserve pre-computed sort keys, enabling O(1)
     /// comparisons during merge (instead of expensive CIGAR/aux parsing).
+    #[allow(clippy::too_many_lines)]
     fn sort_template_coordinate(
         &self,
-        reader: crate::bam_io::RawBamReaderAuto,
+        mut record_source: RecordSource,
+        pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
         temp_path: &Path,
     ) -> Result<RawSortStats> {
         let mut stats = RawSortStats::default();
+        let mut timer = SortPhaseTimer::new();
 
         // Build library lookup ONCE before sorting for O(1) ordinal lookups
         let lib_lookup = LibraryLookup::from_header(header);
@@ -1561,13 +2212,12 @@ impl RawExternalSorter {
         let mut buffer =
             TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
         let mut namer = ChunkNamer::new(temp_path);
-
-        let read_ahead = RawReadAheadReader::new(reader);
+        let mut pending_spill: Option<PendingSpill> = None;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer)...");
 
-        for record in read_ahead {
+        for record in record_source.by_ref() {
             stats.total_records += 1;
             progress.log_if_needed(1);
 
@@ -1583,109 +2233,166 @@ impl RawExternalSorter {
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
+                timer.end_read_span();
+
+                // Wait for any previous spill to complete
+                if let Some(prev) = pending_spill.take() {
+                    prev.handle.wait()?;
+                    timer.record_spill_size(&prev.chunk_path);
+                    chunk_files.push(prev.chunk_path);
+                    stats.chunks_written += 1;
+
+                    timer.time_consolidate(|| {
+                        self.maybe_consolidate_temp_files::<TemplateKey>(
+                            &mut chunk_files,
+                            &mut namer,
+                            &pool,
+                        )
+                    })?;
+                }
+
                 let chunk_path = namer.next_chunk_path();
 
-                // Sort in place using parallel sort for large buffers
-                if self.threads > 1 {
-                    buffer.par_sort();
-                } else {
+                timer.time_sort(|| {
                     buffer.sort();
-                }
+                });
 
-                // Write keyed chunk preserving sort keys for O(1) merge comparisons
-                let mut keyed_writer = GenericKeyedChunkWriter::<TemplateKey>::create(
-                    &chunk_path,
-                    self.temp_compression,
-                    self.threads,
-                )?;
-                for (key, record) in buffer.iter_sorted_keyed() {
-                    keyed_writer.write_record(&key, record)?;
-                }
-                keyed_writer.finish()?;
+                // Write keyed chunk with parallel BGZF compression via worker pool.
+                let handle = timer.time_spill_write(|| {
+                    let mut writer =
+                        PooledChunkWriter::<TemplateKey>::new(Arc::clone(&pool), &chunk_path)?;
+                    for (key, record) in buffer.iter_sorted_keyed() {
+                        writer.write_record(&key, record)?;
+                    }
+                    writer.start_finish()
+                })?;
 
-                stats.chunks_written += 1;
-                chunk_files.push(chunk_path);
-
-                // Consolidate if we have too many temp files
-                self.maybe_consolidate_temp_files::<TemplateKey>(&mut chunk_files, &mut namer)?;
+                pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                timer.begin_read_span();
             }
         }
 
+        timer.end_read_span();
         progress.log_final();
+        if let Some(err) = record_source.take_error() {
+            return Err(anyhow::Error::from(err));
+        }
+
+        // Drain any pending spill before merge
+        if let Some(prev) = pending_spill.take() {
+            prev.handle.wait()?;
+            timer.record_spill_size(&prev.chunk_path);
+            chunk_files.push(prev.chunk_path);
+            stats.chunks_written += 1;
+
+            timer.time_consolidate(|| {
+                self.maybe_consolidate_temp_files::<TemplateKey>(
+                    &mut chunk_files,
+                    &mut namer,
+                    &pool,
+                )
+            })?;
+        }
 
         if chunk_files.is_empty() {
             // All records fit in memory
             info!("All records fit in memory, performing in-memory sort");
 
-            if self.threads > 1 {
-                buffer.par_sort();
-            } else {
+            timer.time_sort(|| {
                 buffer.sort();
-            }
+            });
 
-            let output_header = self.create_output_header(header);
-            let mut writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
+            timer.time_write_output(|| {
+                use crate::sort::pooled_bam_writer::PooledBamWriter;
+                let output_header = self.create_output_header(header);
+                let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
-            for record_bytes in buffer.iter_sorted() {
-                writer.write_raw_record(record_bytes)?;
-            }
-            writer.finish()?;
+                for record_bytes in buffer.iter_sorted() {
+                    writer.write_raw_record(record_bytes)?;
+                }
+                writer.finish()?;
+                Ok(())
+            })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
+            let sort_start = Instant::now();
             let memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                buffer.par_sort_into_chunks(self.threads)
             } else {
                 buffer.sort();
                 let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
                 vec![chunk]
             };
+            timer.sort_secs += sort_start.elapsed().as_secs_f64();
 
             let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
             info!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
-            self.merge_chunks_keyed(
-                &chunk_files,
-                memory_chunks,
-                header,
-                output,
-                stats.total_records,
-            )?;
+            timer.time_merge(|| {
+                self.merge_chunks_keyed(
+                    &chunk_files,
+                    memory_chunks,
+                    header,
+                    output,
+                    stats.total_records,
+                    &pool,
+                )
+            })?;
         }
 
         stats.output_records = stats.total_records;
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+        timer.log_summary(self.threads);
         info!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
     }
 
     /// Build chunk sources from disk files and in-memory chunks.
+    ///
+    /// When `pool_decompress` is true, disk sources become `PoolDisk` variants —
+    /// workers read and decompress in the background, main thread parses records.
+    /// No per-source threads are spawned.
+    ///
+    /// When `pool_decompress` is false, disk sources use `GenericKeyedChunkReader`
+    /// with its own per-source background thread. Used by the indexing path, which
+    /// does not yet support pool-integrated decompression.
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
         memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
-        threads: usize,
+        reader_concurrency: usize,
+        pool_decompress: bool,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<Vec<ChunkSource<K>>> {
-        let sem = make_reader_semaphore(threads);
         let num_disk = chunk_files.len();
         let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
-
         let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
 
-        for path in chunk_files {
-            sources.push(ChunkSource::Disk(GenericKeyedChunkReader::<K>::open(
-                path,
-                Some(Arc::clone(&sem)),
-            )?));
+        if pool_decompress && !chunk_files.is_empty() {
+            // Pool-integrated path: distribute files to workers, create PoolDisk sources.
+            // Files are assigned: worker i gets files i, i+N, i+2N...
+            let files_with_ids: Vec<(PathBuf, usize)> =
+                chunk_files.iter().enumerate().map(|(idx, path)| (path.clone(), idx)).collect();
+            pool.distribute_chunk_files(files_with_ids)?;
+
+            for source_id in 0..num_disk {
+                sources.push(ChunkSource::PoolDisk { source_id });
+            }
+        } else {
+            // Legacy path: per-source reader threads (used by indexing path)
+            let sem = make_reader_semaphore(reader_concurrency);
+            for path in chunk_files {
+                sources.push(ChunkSource::Disk(GenericKeyedChunkReader::<K>::open(
+                    path,
+                    Some(Arc::clone(&sem)),
+                )?));
+            }
         }
 
         for chunk in memory_chunks {
@@ -1708,6 +2415,7 @@ impl RawExternalSorter {
         header: &Header,
         output: &Path,
         total_records: u64,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<u64> {
         self.merge_chunks_generic::<TemplateKey>(
             chunk_files,
@@ -1715,6 +2423,7 @@ impl RawExternalSorter {
             header,
             output,
             total_records,
+            pool,
         )
     }
 
@@ -1723,6 +2432,7 @@ impl RawExternalSorter {
     /// This is the unified merge function that works with any `RawSortKey` type.
     /// It provides `O(1)` comparisons during merge for fixed-size keys (coordinate, template)
     /// and `O(name_len)` for variable-size keys (queryname).
+    #[allow(clippy::too_many_lines)]
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
@@ -1730,13 +2440,47 @@ impl RawExternalSorter {
         header: &Header,
         output: &Path,
         total_records: u64,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<u64> {
         use crate::sort::loser_tree::LoserTree;
+        use crate::sort::pooled_bam_writer::PooledBamWriter;
+        use crate::sort::worker_pool::phase;
 
-        let mut sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, self.threads)?;
+        let reader_concurrency: usize = 1;
+        let num_disk = chunk_files.len();
+
+        if num_disk > 0 {
+            info!(
+                "Pool-integrated merge: {} disk sources, {} pool workers (N+2 model)",
+                num_disk,
+                pool.num_workers()
+            );
+        }
+
+        let mut sources = Self::build_chunk_sources::<K>(
+            chunk_files,
+            memory_chunks,
+            reader_concurrency,
+            true,
+            pool,
+        )?;
 
         let num_sources = sources.len();
         info!("Merging from {num_sources} sources...");
+
+        // Create pool consumer for PoolDisk sources and activate Phase 2
+        let mut consumer: Option<MainThreadChunkConsumer<K>> = if num_disk > 0 {
+            let consumer = MainThreadChunkConsumer::new(
+                num_disk,
+                pool.decompressed_chunks_queue(),
+                pool.raw_chunk_blocks_queue(),
+                pool.all_chunks_eof_flag(),
+            );
+            pool.set_phase(phase::PHASE2);
+            Some(consumer)
+        } else {
+            None
+        };
 
         let output_header = self.create_output_header(header);
 
@@ -1747,7 +2491,7 @@ impl RawExternalSorter {
 
         for (idx, source) in sources.iter_mut().enumerate() {
             let mut record = Vec::new();
-            if let Some(key) = source.next_record(&mut record)? {
+            if let Some(key) = source.next_record(&mut record, consumer.as_mut())? {
                 initial_keys.push(key);
                 records.push(record);
                 source_map.push(idx);
@@ -1756,42 +2500,89 @@ impl RawExternalSorter {
 
         if initial_keys.is_empty() {
             info!("Merge complete: 0 records merged");
-            let writer = crate::bam_io::create_raw_bam_writer(
-                output,
-                &output_header,
-                self.threads,
-                self.output_compression,
-            )?;
+            if consumer.is_some() {
+                pool.set_phase(phase::LEGACY);
+            }
+            let writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
             writer.finish()?;
             return Ok(0);
         }
 
         let mut tree = LoserTree::new(initial_keys);
 
-        let mut writer = crate::bam_io::create_raw_bam_writer(
-            output,
-            &output_header,
-            self.threads,
-            self.output_compression,
-        )?;
+        info!("Merge thread budget: {} pool workers + 1 I/O + 1 main (N+2)", pool.num_workers());
+        let mut writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
 
         let mut records_merged = 0u64;
         let merge_progress = ProgressTracker::new("Merged records")
             .with_interval(1_000_000)
             .with_total(total_records);
 
+        // Sub-phase timing: only paid when debug logging is enabled.
+        let debug_timing = log::log_enabled!(log::Level::Debug);
+        let merge_sample_interval: u64 = 1024;
+        let mut merge_write_secs = 0.0f64;
+        let mut merge_read_secs = 0.0f64;
+        let mut merge_tree_secs = 0.0f64;
+        let mut samples_taken: u64 = 0;
+        let loop_start = Instant::now();
+
         while tree.winner_is_active() {
             let winner = tree.winner();
-            writer.write_raw_record(&records[winner])?;
+            let sample_this = debug_timing && records_merged.is_multiple_of(merge_sample_interval);
+
+            if sample_this {
+                let t0 = Instant::now();
+                writer.write_raw_record(&records[winner])?;
+                merge_write_secs += t0.elapsed().as_secs_f64();
+            } else {
+                writer.write_raw_record(&records[winner])?;
+            }
+
             records_merged += 1;
             merge_progress.log_if_needed(1);
 
             let src_idx = source_map[winner];
-            if let Some(key) = sources[src_idx].next_record(&mut records[winner])? {
-                tree.replace_winner(key);
+
+            if sample_this {
+                let t0 = Instant::now();
+                let next = sources[src_idx].next_record(&mut records[winner], consumer.as_mut())?;
+                merge_read_secs += t0.elapsed().as_secs_f64();
+
+                let t0 = Instant::now();
+                if let Some(key) = next {
+                    tree.replace_winner(key);
+                } else {
+                    tree.remove_winner();
+                }
+                merge_tree_secs += t0.elapsed().as_secs_f64();
+                samples_taken += 1;
             } else {
-                tree.remove_winner();
+                let next = sources[src_idx].next_record(&mut records[winner], consumer.as_mut())?;
+                if let Some(key) = next {
+                    tree.replace_winner(key);
+                } else {
+                    tree.remove_winner();
+                }
             }
+        }
+
+        // Return to legacy mode before finishing writer (workers still need to compress)
+        if consumer.is_some() {
+            pool.set_phase(phase::LEGACY);
+        }
+
+        if debug_timing {
+            let loop_total = loop_start.elapsed().as_secs_f64();
+            #[allow(clippy::cast_precision_loss)]
+            let scale =
+                if samples_taken > 0 { records_merged as f64 / samples_taken as f64 } else { 1.0 };
+            let est_write = merge_write_secs * scale;
+            let est_read = merge_read_secs * scale;
+            let est_tree = merge_tree_secs * scale;
+            debug!(
+                "Merge sub-phases (sampled {samples_taken}/{records_merged}, scale={scale:.1}x): write={est_write:.2}s read={est_read:.2}s tree={est_tree:.2}s total={loop_total:.2}s records={records_merged}"
+            );
         }
 
         writer.finish()?;
@@ -1815,8 +2606,9 @@ impl RawExternalSorter {
         memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
         header: &Header,
         output: &Path,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<u64> {
-        self.merge_chunks_generic::<K>(chunk_files, memory_chunks, header, output, 0)
+        self.merge_chunks_generic::<K>(chunk_files, memory_chunks, header, output, 0, pool)
     }
 
     /// Merge keyed chunks with BAM index generation.
@@ -1830,14 +2622,35 @@ impl RawExternalSorter {
         header: &Header,
         output: &Path,
         total_records: u64,
+        pool: &Arc<SortWorkerPool>,
     ) -> Result<noodles::bam::bai::Index> {
         use crate::bam_io::create_indexing_bam_writer;
         use crate::sort::loser_tree::LoserTree;
 
-        let mut sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, self.threads)?;
+        // Thread budget: writer gets all threads (merge is output-compression-bound),
+        // readers use semaphore concurrency of 1. Same split as merge_chunks_generic.
+        // TODO: Replace create_indexing_bam_writer with PooledIndexingBamWriter (Step 4)
+        let writer_threads = self.threads;
+        let reader_concurrency: usize = 1;
+
+        // The indexing path uses a non-pooled writer and has no pool consumer set up,
+        // so use GenericKeyedChunkReader (pool_decompress=false).
+        // TODO: Replace create_indexing_bam_writer with PooledIndexingBamWriter to
+        // enable pool-integrated decompression for the indexing path.
+        let mut sources = Self::build_chunk_sources::<K>(
+            chunk_files,
+            memory_chunks,
+            reader_concurrency,
+            false,
+            pool,
+        )?;
 
         let num_sources = sources.len();
-        info!("Merging from {num_sources} sources...");
+        info!(
+            "Merge thread budget (indexing): {writer_threads} writer + {reader_concurrency} reader + 1 main = {} total",
+            writer_threads + reader_concurrency + 1
+        );
+        info!("Merging from {num_sources} sources (indexing)...");
 
         let output_header = self.create_output_header(header);
 
@@ -1848,7 +2661,7 @@ impl RawExternalSorter {
 
         for (idx, source) in sources.iter_mut().enumerate() {
             let mut record = Vec::new();
-            if let Some(key) = source.next_record(&mut record)? {
+            if let Some(key) = source.next_record(&mut record, None)? {
                 initial_keys.push(key);
                 records.push(record);
                 source_map.push(idx);
@@ -1860,7 +2673,7 @@ impl RawExternalSorter {
                 output,
                 &output_header,
                 self.output_compression,
-                self.threads,
+                writer_threads,
             )?;
             let index = writer.finish()?;
             info!("Merge complete: 0 records merged");
@@ -1873,7 +2686,7 @@ impl RawExternalSorter {
             output,
             &output_header,
             self.output_compression,
-            self.threads,
+            writer_threads,
         )?;
         let merge_progress = ProgressTracker::new("Merged records")
             .with_interval(1_000_000)
@@ -1885,7 +2698,7 @@ impl RawExternalSorter {
             merge_progress.log_if_needed(1);
 
             let src_idx = source_map[winner];
-            if let Some(key) = sources[src_idx].next_record(&mut records[winner])? {
+            if let Some(key) = sources[src_idx].next_record(&mut records[winner], None)? {
                 tree.replace_winner(key);
             } else {
                 tree.remove_winner();
@@ -2414,6 +3227,7 @@ mod tests {
     #[case::coordinate(SortOrder::Coordinate, false)]
     #[case::coordinate_with_index(SortOrder::Coordinate, true)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()), false)]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural), false)]
     #[case::template_coordinate(SortOrder::TemplateCoordinate, false)]
     fn test_sort_with_consolidation_preserves_all_records(
         #[case] sort_order: SortOrder,
@@ -2426,7 +3240,7 @@ mod tests {
         for i in 0..num_pairs {
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:04}"))
+                .name(&format!("read{i}"))
                 .start1(i * 200 + 1)
                 .start2(i * 200 + 101)
                 .build();
@@ -2459,11 +3273,12 @@ mod tests {
         assert_eq!(observed, expected, "chunk filename collision likely lost data");
     }
 
-    /// Verifies that sort with many chunks exercises the semaphore-capped
+    /// Verifies that sort with many chunks exercises the pool-integrated
     /// merge readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_many_chunks_with_semaphore(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2473,7 +3288,7 @@ mod tests {
         for i in 0..num_pairs {
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:04}"))
+                .name(&format!("read{i}"))
                 .start1(i * 200 + 1)
                 .start2(i * 200 + 101)
                 .build();
@@ -2485,9 +3300,12 @@ mod tests {
         builder.write_bam(&input).expect("failed to write BAM");
 
         // Small memory limit + many records = guaranteed spill to multiple chunks
-        // (no consolidation, so the semaphore must cap concurrent readers)
+        // (no consolidation, so the semaphore must cap concurrent readers).
+        // 32 KiB is small enough to force several spills across 400 records but
+        // large enough to avoid creating hundreds of tiny chunks that saturate
+        // OS threads on the CI runner and cause timeouts.
         let stats = RawExternalSorter::new(sort_order)
-            .memory_limit(4096)
+            .memory_limit(32 * 1024)
             .max_temp_files(0) // disable consolidation
             .threads(2) // semaphore allows 2 concurrent readers
             .temp_compression(0)
@@ -2511,10 +3329,11 @@ mod tests {
     // ========================================================================
 
     /// Verifies that multi-threaded sort produces the same output as single-threaded
-    /// sort for each sort order, exercising the parallel sub-array merge path.
+    /// sort for each sort order.
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_sub_arrays_match_single_thread(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2524,7 +3343,7 @@ mod tests {
         for i in 0..num_pairs {
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:04}"))
+                .name(&format!("read{i}"))
                 .start1(i * 200 + 1)
                 .start2(i * 200 + 101)
                 .build();
@@ -2538,16 +3357,16 @@ mod tests {
 
         // Sort single-threaded
         RawExternalSorter::new(sort_order)
-            .memory_limit(2048) // force spill so merge path is exercised
+            .memory_limit(16 * 1024) // force spill (50 pairs × ~300B ≈ 15KB) so merge path is exercised
             .threads(1)
             .temp_compression(0)
             .output_compression(0)
             .sort(&input, &output_st)
             .expect("sort should succeed");
 
-        // Sort multi-threaded (exercises par_sort_into_chunks / par_chunks_mut)
+        // Sort multi-threaded
         RawExternalSorter::new(sort_order)
-            .memory_limit(2048)
+            .memory_limit(16 * 1024)
             .threads(2)
             .temp_compression(0)
             .output_compression(0)
@@ -2565,11 +3384,11 @@ mod tests {
         assert_eq!(names_st, names_mt, "multi-thread sort order differs from single-thread");
     }
 
-    /// Verifies that the in-memory-only path (no spill to disk) also works
-    /// correctly with multi-threaded sub-array chunks.
+    /// Verifies that the in-memory-only path (no spill to disk) works correctly.
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
     fn test_sort_sub_arrays_in_memory_only(#[case] sort_order: SortOrder) {
         use crate::sam::builder::SamBuilder;
@@ -2579,7 +3398,7 @@ mod tests {
         for i in 0..num_pairs {
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:04}"))
+                .name(&format!("read{i}"))
                 .start1(i * 200 + 1)
                 .start2(i * 200 + 101)
                 .build();
@@ -2830,5 +3649,101 @@ mod tests {
         for w in positions.windows(2) {
             assert!(w[0] <= w[1], "coordinate sort violated with k={k}: {:?} > {:?}", w[0], w[1]);
         }
+    }
+
+    #[test]
+    fn test_merge_bams_queryname_natural_sort() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let nat = SortOrder::Queryname(QuerynameComparator::Natural);
+        let (bam_a, _) = create_sorted_bam(dir.path(), "a", 10, 0, nat);
+        let (bam_b, _) = create_sorted_bam(dir.path(), "b", 10, 10_000, nat);
+
+        let merged = dir.path().join("merged.bam");
+        let header = default_merge_header();
+        let count = RawExternalSorter::new(nat)
+            .output_compression(0)
+            .merge_bams(&[bam_a, bam_b], &header, &merged)
+            .expect("merge should succeed");
+
+        assert_eq!(count, 40);
+        assert_eq!(count_bam_records(&merged), 40);
+
+        // Verify natural queryname order: names are non-decreasing
+        let names = collect_read_names(&merged);
+        for w in names.windows(2) {
+            assert!(w[0] <= w[1], "natural queryname sort violated: {:?} > {:?}", w[0], w[1]);
+        }
+    }
+
+    // ========================================================================
+    // SortPhaseTimer tests
+    // ========================================================================
+
+    #[test]
+    fn test_sort_phase_timer_all_methods() {
+        let mut timer = SortPhaseTimer::new();
+        assert!(timer.overall_start.is_some());
+        assert!(timer.read_span_start.is_some());
+
+        // end_read_span accumulates and clears the span
+        let elapsed = timer.end_read_span();
+        assert!(timer.read_secs >= 0.0);
+        assert!(timer.read_span_start.is_none());
+        let _ = elapsed;
+
+        // end_read_span with no active span → zero, no panic
+        let elapsed2 = timer.end_read_span();
+        assert_eq!(elapsed2, std::time::Duration::ZERO);
+        assert!(timer.read_secs >= 0.0); // unchanged
+
+        // begin_read_span restores the span
+        timer.begin_read_span();
+        assert!(timer.read_span_start.is_some());
+
+        // time_sort measures elapsed
+        timer.time_sort(|| {});
+        assert!(timer.sort_secs >= 0.0);
+
+        // time_spill_write: counts spills and returns the closure result
+        let result = timer.time_spill_write(|| Ok::<u32, anyhow::Error>(42));
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(timer.spill_count, 1);
+        assert!(timer.spill_write_secs >= 0.0);
+
+        // record_spill_size: adds file size to total
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("spill.bin");
+        std::fs::write(&path, b"hello world").expect("write");
+        timer.record_spill_size(&path);
+        assert_eq!(timer.total_spill_bytes, 11);
+
+        // record_spill_size with nonexistent path: no-op, no panic
+        timer.record_spill_size(&dir.path().join("nonexistent.bin"));
+        assert_eq!(timer.total_spill_bytes, 11);
+
+        // time_consolidate: fast closure (<1ms) → consolidate_count stays 0
+        timer.time_consolidate(|| Ok(())).expect("consolidate ok");
+        assert_eq!(timer.consolidate_count, 0);
+
+        // time_consolidate: slow closure (>1ms) → counted
+        timer
+            .time_consolidate(|| {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                Ok(())
+            })
+            .expect("consolidate ok");
+        assert_eq!(timer.consolidate_count, 1);
+        assert!(timer.consolidate_secs > 0.0);
+
+        // time_merge
+        timer.time_merge(|| Ok::<(), anyhow::Error>(())).expect("merge ok");
+        assert!(timer.merge_secs >= 0.0);
+
+        // time_write_output
+        timer.time_write_output(|| Ok(())).expect("write ok");
+        assert!(timer.write_output_secs >= 0.0);
+
+        // log_summary must not panic (output goes to log sink)
+        timer.log_summary(4);
     }
 }

--- a/src/lib/sort/read_ahead.rs
+++ b/src/lib/sort/read_ahead.rs
@@ -28,7 +28,8 @@ use noodles::bam::Record;
 use std::thread::{self, JoinHandle};
 
 use crate::bam_io::{BamReaderAuto, RawBamReaderAuto};
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawBamReader, RawRecord};
+use std::io::Read as IoRead;
 
 /// Number of records per batch sent through the channel.
 /// This reduces channel synchronization overhead by sending multiple records per send.
@@ -209,28 +210,42 @@ impl RawReadAheadReader {
     /// Create a new raw read-ahead reader with default buffer size.
     #[must_use]
     pub fn new(reader: RawBamReaderAuto) -> Self {
-        Self::with_batch_size(reader, BATCH_SIZE, CHANNEL_BUFFER_SIZE)
+        Self::from_reader(reader)
     }
 
-    /// Create a new raw read-ahead reader with specified batch and buffer sizes.
+    /// Create a raw read-ahead reader from any `RawBamReader<R>`.
+    ///
+    /// This accepts any `RawBamReader<R>` and spawns a background thread that
+    /// reads records in batches.
     #[must_use]
-    pub fn with_batch_size(
-        mut reader: RawBamReaderAuto,
+    pub fn from_reader<R: IoRead + Send + 'static>(reader: RawBamReader<R>) -> Self {
+        Self::from_reader_with_batch_size(reader, BATCH_SIZE, CHANNEL_BUFFER_SIZE)
+    }
+
+    /// Create a raw read-ahead reader from any `RawBamReader<R>` with specified
+    /// batch and buffer sizes.
+    #[must_use]
+    pub fn from_reader_with_batch_size<R: IoRead + Send + 'static>(
+        mut reader: RawBamReader<R>,
         batch_size: usize,
         channel_buffer: usize,
     ) -> Self {
         let (tx, rx) = bounded(channel_buffer);
 
         let handle = thread::spawn(move || {
-            Self::reader_thread(&mut reader, tx, batch_size);
+            Self::reader_thread_generic(&mut reader, tx, batch_size);
         });
 
         Self { receiver: Some(rx), handle: Some(handle), current_batch: Vec::new(), batch_index: 0 }
     }
 
-    /// Reader thread function - reads raw records in batches.
+    /// Reader thread function - reads raw records in batches from any reader type.
     #[allow(clippy::needless_pass_by_value)]
-    fn reader_thread(reader: &mut RawBamReaderAuto, tx: Sender<Vec<RawRecord>>, batch_size: usize) {
+    fn reader_thread_generic<R: IoRead>(
+        reader: &mut RawBamReader<R>,
+        tx: Sender<Vec<RawRecord>>,
+        batch_size: usize,
+    ) {
         let mut record = RawRecord::new();
         let mut batch = Vec::with_capacity(batch_size);
 
@@ -315,6 +330,207 @@ impl Iterator for RawReadAheadReader {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_record()
+    }
+}
+
+// ============================================================================
+// PooledInputStream — pool-based decompressed input stream (no extra threads)
+// ============================================================================
+
+/// A `Read` implementation that consumes decompressed blocks from the pool's
+/// `decompressed_input` `ArrayQueue` and presents a contiguous byte stream.
+///
+/// Workers do `ReadInputBlocks` + `DecompressInput`; this struct reassembles
+/// the decompressed blocks in order for the main thread to parse records from.
+///
+/// Uses non-blocking `ArrayQueue::pop()` with `park()`/`unpark()` notification.
+/// Workers call `unpark()` on the main thread after pushing blocks, so the main
+/// thread sleeps at zero CPU when waiting and wakes instantly when data arrives.
+/// EOF is detected via the shared `decompressed_input_done` `AtomicBool` flag.
+pub struct PooledInputStream {
+    /// `ArrayQueue` to pop decompressed blocks from pool workers.
+    decompressed_input: std::sync::Arc<crossbeam_queue::ArrayQueue<(u64, Vec<u8>)>>,
+    /// Shared flag: set when all input blocks have been decompressed.
+    decompressed_input_done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Shared flag: set when a worker encountered an I/O error reading the input file.
+    input_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Pending blocks waiting to be consumed (keyed by serial).
+    reorder: std::collections::BTreeMap<u64, Vec<u8>>,
+    /// Next serial number to consume.
+    next_serial: u64,
+    /// Current buffer being read from.
+    current_buf: Vec<u8>,
+    /// Read position within `current_buf`.
+    current_pos: usize,
+}
+
+impl PooledInputStream {
+    /// Create a new pooled input stream from the pool's shared state.
+    #[must_use]
+    pub fn new(
+        decompressed_input: std::sync::Arc<crossbeam_queue::ArrayQueue<(u64, Vec<u8>)>>,
+        decompressed_input_done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        input_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        Self {
+            decompressed_input,
+            decompressed_input_done,
+            input_read_error,
+            reorder: std::collections::BTreeMap::new(),
+            next_serial: 0,
+            current_buf: Vec::new(),
+            current_pos: 0,
+        }
+    }
+
+    /// Check if all input has been decompressed and the queue is drained.
+    fn is_eof(&self) -> bool {
+        self.decompressed_input_done.load(std::sync::atomic::Ordering::Acquire)
+            && self.decompressed_input.is_empty()
+    }
+
+    /// Drain all available blocks from the `ArrayQueue` into the reorder buffer.
+    fn drain_queue(&mut self) {
+        while let Some((serial, data)) = self.decompressed_input.pop() {
+            self.reorder.insert(serial, data);
+        }
+    }
+
+    /// Get the next decompressed block in serial order.
+    ///
+    /// Drains the `ArrayQueue` into a reorder buffer, then checks if the next
+    /// expected serial is available. If not, parks the thread until a worker
+    /// calls `unpark()` after pushing new data.
+    fn next_block(&mut self) -> Option<Vec<u8>> {
+        loop {
+            // Drain everything available into the reorder buffer
+            self.drain_queue();
+
+            // Check if the block we need is ready
+            if let Some(data) = self.reorder.remove(&self.next_serial) {
+                self.next_serial += 1;
+                return Some(data);
+            }
+
+            // Nothing available — check EOF
+            if self.is_eof() {
+                // Re-drain one more time before declaring EOF: a block could have
+                // been pushed between the previous drain and the is_eof() check.
+                // `decompressed_input_done` is only set after the block is in the
+                // queue, so the risk is low, but a second drain makes this watertight.
+                self.drain_queue();
+                if let Some(data) = self.reorder.remove(&self.next_serial) {
+                    self.next_serial += 1;
+                    return Some(data);
+                }
+                return None;
+            }
+
+            // Park until a worker pushes a block and calls unpark()
+            std::thread::park();
+        }
+    }
+}
+
+impl IoRead for PooledInputStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Serve from current buffer first
+        if self.current_pos < self.current_buf.len() {
+            let available = &self.current_buf[self.current_pos..];
+            let n = available.len().min(buf.len());
+            buf[..n].copy_from_slice(&available[..n]);
+            self.current_pos += n;
+            return Ok(n);
+        }
+
+        // Check for I/O error before blocking on next_block()
+        if self.input_read_error.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(std::io::Error::other(
+                "I/O error reading input BAM blocks (see log for details)",
+            ));
+        }
+
+        // Get next block
+        if let Some(data) = self.next_block() {
+            let n = data.len().min(buf.len());
+            buf[..n].copy_from_slice(&data[..n]);
+            if n < data.len() {
+                self.current_buf = data;
+                self.current_pos = n;
+            } else {
+                self.current_buf.clear();
+                self.current_pos = 0;
+            }
+            Ok(n)
+        } else {
+            // Double-check error flag after draining (a read error may have caused early EOF)
+            if self.input_read_error.load(std::sync::atomic::Ordering::Acquire) {
+                return Err(std::io::Error::other(
+                    "I/O error reading input BAM blocks (see log for details)",
+                ));
+            }
+            Ok(0) // clean EOF
+        }
+    }
+}
+
+// ============================================================================
+// RecordSource — unified iterator for pool and non-pool paths
+// ============================================================================
+
+/// Unified record source for Phase 1 reading.
+///
+/// Wraps either a `RawReadAheadReader` (non-pool path, has background thread)
+/// or a direct `RawBamReader<PooledInputStream>` (pool path, no extra threads).
+pub enum RecordSource {
+    /// Legacy path: background thread prefetches records.
+    ReadAhead(RawReadAheadReader),
+    /// Pool path: main thread reads directly from pool's decompressed stream.
+    ///
+    /// The second field stores the first I/O error encountered during iteration,
+    /// if any. Callers should call `take_error()` after the iteration loop to
+    /// propagate errors rather than silently treating them as EOF.
+    Direct(RawBamReader<PooledInputStream>, Option<std::io::Error>),
+}
+
+impl RecordSource {
+    /// Wrap a pooled reader as the `Direct` variant.
+    #[must_use]
+    pub fn direct(reader: RawBamReader<PooledInputStream>) -> Self {
+        Self::Direct(reader, None)
+    }
+
+    /// Take any I/O error that occurred during iteration.
+    ///
+    /// Returns `Some(err)` if the iterator stopped due to a read error rather than
+    /// clean EOF. Call this after exhausting the iterator to detect truncated input.
+    pub fn take_error(&mut self) -> Option<std::io::Error> {
+        match self {
+            Self::Direct(_, err) => err.take(),
+            Self::ReadAhead(_) => None,
+        }
+    }
+}
+
+impl Iterator for RecordSource {
+    type Item = RawRecord;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::ReadAhead(r) => r.next(),
+            Self::Direct(reader, error_slot) => {
+                let mut record = RawRecord::default();
+                match reader.read_record(&mut record) {
+                    Ok(0) => None, // EOF
+                    Ok(_) => Some(record),
+                    Err(e) => {
+                        log::error!("Error reading raw BAM record: {e}");
+                        *error_slot = Some(e);
+                        None
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/lib/sort/worker_pool.rs
+++ b/src/lib/sort/worker_pool.rs
@@ -1,0 +1,1867 @@
+//! Shared worker pool for all sort pipeline work (N+2 thread model).
+//!
+//! This module provides `SortWorkerPool`, a fixed-size thread pool where each worker
+//! owns reusable compression and decompression state. Workers perform ALL CPU/IO work:
+//! block reading, decompression, and compression across all sort phases.
+//!
+//! # Thread Model (N+2)
+//!
+//! - **N pool workers**: Do ALL CPU/IO work (block reading, decompression, compression)
+//! - **+1 I/O writer thread**: `PooledBamWriter` / `PooledChunkWriter` (sequential disk write)
+//! - **+1 main thread**: Phase 1 orchestration + Phase 2 merge loop
+//!
+//! # Design
+//!
+//! - **Phase-aware scheduling**: Workers check the current phase to pick eligible steps.
+//!   Phase 1: `DecompressInput` > `ReadInputBlocks` > `CompressSpill`.
+//!   Phase 2: `DecompressChunks` > `ReadChunkBlocks` > `CompressOutput`.
+//! - **Per-worker state**: Each worker owns an `InlineBgzfCompressor` and a
+//!   `libdeflater::Decompressor`, avoiding cross-thread synchronization.
+//! - **Worker-owns-files**: In Phase 2, each worker exclusively owns a subset of spill
+//!   files (worker i owns files i, i+N, i+2N...). No locks needed for file access.
+//! - **Held-item pattern**: Workers never block on queue push. If output is full, they
+//!   hold the result locally and advance it first on the next iteration.
+//! - **Buffer recycling**: A shared buffer pool (`crossbeam` channel) recycles
+//!   `Vec<u8>` buffers to avoid per-job heap allocations.
+//! - **Bounded backpressure**: All channels are bounded to prevent unbounded memory
+//!   growth when producers outpace consumers.
+
+use crossbeam_channel::{Receiver, Sender, bounded};
+use crossbeam_queue::ArrayQueue;
+use fgumi_bgzf::reader::read_raw_blocks;
+use fgumi_bgzf::writer::InlineBgzfCompressor;
+use fgumi_bgzf::{RawBgzfBlock, decompress_block};
+use log::info;
+use std::fmt::Write as FmtWrite;
+use std::io::{BufReader, Read};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Instant;
+
+// ============================================================================
+// Job and Result Types
+// ============================================================================
+
+/// A compression job: compress uncompressed data into a BGZF block.
+pub struct CompressJob {
+    /// Uncompressed data to compress.
+    pub data: Vec<u8>,
+    /// Serial number for ordering output blocks.
+    pub serial: u64,
+    /// Channel to send the compressed result back.
+    pub result_tx: Sender<CompressResult>,
+}
+
+/// Result of a compression job.
+pub struct CompressResult {
+    /// Serial number matching the input job.
+    pub serial: u64,
+    /// Compressed BGZF block data.
+    pub compressed: Vec<u8>,
+    /// The original uncompressed buffer, cleared for reuse.
+    pub recycled_buf: Vec<u8>,
+}
+
+// ============================================================================
+// Pool Instrumentation
+// ============================================================================
+
+/// Tracks pool activity for diagnostics.
+#[derive(Debug, Default)]
+pub(crate) struct PoolStats {
+    pub(crate) compress_jobs: AtomicU64,
+}
+
+impl PoolStats {
+    pub fn log_summary(&self) {
+        let compress = self.compress_jobs.load(Ordering::Relaxed);
+        info!("  Pool stats: {compress} compress jobs");
+    }
+}
+
+// ============================================================================
+// Sort Pipeline Steps
+// ============================================================================
+
+/// Sort-specific work steps that pool workers can perform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SortStep {
+    /// Read raw BGZF blocks from input BAM during Phase 1.
+    ReadInputBlocks = 0,
+    /// Decompress input BGZF blocks during Phase 1.
+    DecompressInput = 1,
+    /// Compress data for spill files during Phase 1.
+    CompressSpill = 2,
+    /// Read raw BGZF blocks from spill files during Phase 2.
+    ReadChunkBlocks = 3,
+    /// Decompress spill file blocks during Phase 2.
+    DecompressChunks = 4,
+    /// Compress data for merge output during Phase 2.
+    CompressOutput = 5,
+}
+
+impl SortStep {
+    /// Number of distinct sort steps.
+    pub const COUNT: usize = 6;
+
+    /// Short label for display.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ReadInputBlocks => "RdInp",
+            Self::DecompressInput => "DecInp",
+            Self::CompressSpill => "CmpSpl",
+            Self::ReadChunkBlocks => "RdChk",
+            Self::DecompressChunks => "DecChk",
+            Self::CompressOutput => "CmpOut",
+        }
+    }
+}
+
+/// Maximum number of worker threads for per-thread stats arrays.
+const SORT_MAX_THREADS: usize = 32;
+
+// ============================================================================
+// Sort Pipeline Stats
+// ============================================================================
+
+/// Comprehensive instrumentation for sort pipeline worker pool.
+///
+/// Modeled on `PipelineStats` from the unified pipeline but tailored to sort's
+/// step set. All fields are `AtomicU64` for lock-free updates from workers.
+pub(crate) struct SortPipelineStats {
+    // Per-step timing (nanoseconds) — indexed by SortStep as usize
+    pub step_ns: [AtomicU64; SortStep::COUNT],
+    // Per-step success counts
+    pub step_count: [AtomicU64; SortStep::COUNT],
+
+    // Per-thread work distribution: [thread_id][step_index]
+    /// How many times each thread completed each step.
+    pub per_thread_step_counts: Box<[[AtomicU64; SortStep::COUNT]; SORT_MAX_THREADS]>,
+    /// Per-thread idle time in nanoseconds (time in backoff/yield).
+    pub per_thread_idle_ns: Box<[AtomicU64; SORT_MAX_THREADS]>,
+
+    /// Number of worker threads (for display bounds).
+    pub num_threads: usize,
+}
+
+impl SortPipelineStats {
+    /// Create a new stats collector for the given number of workers.
+    #[must_use]
+    pub fn new(num_threads: usize) -> Self {
+        Self {
+            step_ns: std::array::from_fn(|_| AtomicU64::new(0)),
+            step_count: std::array::from_fn(|_| AtomicU64::new(0)),
+            per_thread_step_counts: new_sort_2d_array(),
+            per_thread_idle_ns: new_sort_1d_array(),
+            num_threads,
+        }
+    }
+
+    /// Record a completed step with timing for a given worker thread.
+    pub fn record_step(&self, thread_id: usize, step: SortStep, elapsed_ns: u64) {
+        let step_idx = step as usize;
+        self.step_ns[step_idx].fetch_add(elapsed_ns, Ordering::Relaxed);
+        self.step_count[step_idx].fetch_add(1, Ordering::Relaxed);
+        if thread_id < SORT_MAX_THREADS {
+            self.per_thread_step_counts[thread_id][step_idx].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record idle/backoff time for a worker thread.
+    pub fn record_idle(&self, thread_id: usize, idle_ns: u64) {
+        if thread_id < SORT_MAX_THREADS {
+            self.per_thread_idle_ns[thread_id].fetch_add(idle_ns, Ordering::Relaxed);
+        }
+    }
+
+    /// Log a comprehensive summary of pipeline statistics.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn log_summary(&self) {
+        let mut s = String::with_capacity(1024);
+        writeln!(s, "=== Sort Pipeline Stats ===").expect("write to String");
+
+        // Per-step summary
+        let all_steps = [
+            SortStep::ReadInputBlocks,
+            SortStep::DecompressInput,
+            SortStep::CompressSpill,
+            SortStep::ReadChunkBlocks,
+            SortStep::DecompressChunks,
+            SortStep::CompressOutput,
+        ];
+
+        for &step in &all_steps {
+            let idx = step as usize;
+            let count = self.step_count[idx].load(Ordering::Relaxed);
+            if count > 0 {
+                let ns = self.step_ns[idx].load(Ordering::Relaxed);
+                let secs = ns as f64 / 1_000_000_000.0;
+                writeln!(s, "  {:<22} {count:>8} jobs, {secs:>6.1}s total", format!("{step:?}"))
+                    .expect("write");
+            }
+        }
+
+        // Per-thread work distribution
+        let nt = self.num_threads.min(SORT_MAX_THREADS);
+        if nt > 0 {
+            writeln!(s).expect("write");
+            writeln!(s, "  Per-Thread Work Distribution:").expect("write");
+
+            // Header
+            write!(s, "    Thread").expect("write");
+            for &step in &all_steps {
+                write!(s, " {:>8}", step.label()).expect("write");
+            }
+            writeln!(s, "   Idle ms").expect("write");
+
+            // Per-thread rows
+            for tid in 0..nt {
+                write!(s, "    T{tid:<5}").expect("write");
+                for step_idx in 0..SortStep::COUNT {
+                    let count = self.per_thread_step_counts[tid][step_idx].load(Ordering::Relaxed);
+                    write!(s, " {count:>8}").expect("write");
+                }
+                let idle_ns = self.per_thread_idle_ns[tid].load(Ordering::Relaxed);
+                writeln!(s, " {:>10.1}", idle_ns as f64 / 1_000_000.0).expect("write");
+            }
+
+            // Total row
+            write!(s, "    Total ").expect("write");
+            for step_idx in 0..SortStep::COUNT {
+                let mut total = 0u64;
+                for tid in 0..nt {
+                    total += self.per_thread_step_counts[tid][step_idx].load(Ordering::Relaxed);
+                }
+                write!(s, " {total:>8}").expect("write");
+            }
+            let total_idle: u64 =
+                (0..nt).map(|tid| self.per_thread_idle_ns[tid].load(Ordering::Relaxed)).sum();
+            writeln!(s, " {:>10.1}", total_idle as f64 / 1_000_000.0).expect("write");
+
+            // Utilization
+            let total_work_ns: u64 =
+                (0..SortStep::COUNT).map(|i| self.step_ns[i].load(Ordering::Relaxed)).sum();
+            let work_ms = total_work_ns as f64 / 1_000_000.0;
+            let idle_ms = total_idle as f64 / 1_000_000.0;
+            let total_ms = work_ms + idle_ms;
+            if total_ms > 0.0 {
+                let utilization = (work_ms / total_ms) * 100.0;
+                writeln!(s).expect("write");
+                writeln!(s, "  Thread Utilization: {utilization:.1}% (work={work_ms:.1}ms idle={idle_ms:.1}ms)")
+                    .expect("write");
+            }
+        }
+
+        // Log as a single multiline message
+        for line in s.trim_end().lines() {
+            info!("{line}");
+        }
+    }
+}
+
+/// Helper to create a boxed 2D array of `AtomicU64` for sort stats.
+#[allow(clippy::unnecessary_box_returns)]
+fn new_sort_2d_array() -> Box<[[AtomicU64; SortStep::COUNT]; SORT_MAX_THREADS]> {
+    let v: Vec<[AtomicU64; SortStep::COUNT]> =
+        (0..SORT_MAX_THREADS).map(|_| std::array::from_fn(|_| AtomicU64::new(0))).collect();
+    v.into_boxed_slice().try_into().expect("Vec length matches SORT_MAX_THREADS")
+}
+
+/// Helper to create a boxed 1D array of `AtomicU64` for sort stats.
+#[allow(clippy::unnecessary_box_returns)]
+fn new_sort_1d_array() -> Box<[AtomicU64; SORT_MAX_THREADS]> {
+    let v: Vec<AtomicU64> = (0..SORT_MAX_THREADS).map(|_| AtomicU64::new(0)).collect();
+    v.into_boxed_slice().try_into().expect("Vec length matches SORT_MAX_THREADS")
+}
+
+// ============================================================================
+// Buffer Pool
+// ============================================================================
+
+/// Recycling pool for `Vec<u8>` buffers.
+///
+/// Uses a bounded crossbeam channel: producers return used buffers,
+/// consumers check out buffers (falling back to new allocation if empty).
+pub struct BufferPool {
+    tx: Sender<Vec<u8>>,
+    rx: Receiver<Vec<u8>>,
+}
+
+impl BufferPool {
+    /// Create a buffer pool with the given capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let (tx, rx) = bounded(capacity);
+        Self { tx, rx }
+    }
+
+    /// Get a buffer from the pool, or allocate a new one if the pool is empty.
+    #[must_use]
+    pub fn checkout(&self) -> Vec<u8> {
+        self.rx.try_recv().unwrap_or_default()
+    }
+
+    /// Return a buffer to the pool for reuse.
+    /// If the pool is full, the buffer is dropped.
+    pub fn checkin(&self, mut buf: Vec<u8>) {
+        buf.clear();
+        let _ = self.tx.try_send(buf);
+    }
+}
+
+impl Clone for BufferPool {
+    fn clone(&self) -> Self {
+        Self { tx: self.tx.clone(), rx: self.rx.clone() }
+    }
+}
+
+// ============================================================================
+// Phase 2 Data Types (chunk reading)
+// ============================================================================
+
+/// Number of raw BGZF blocks to read in each I/O batch per file.
+const CHUNK_READ_BATCH_SIZE: usize = 16;
+
+/// Number of raw BGZF blocks to read in each I/O batch from input file.
+const INPUT_READ_BATCH_SIZE: usize = 16;
+
+/// A raw BGZF block tagged with its source (spill file) ID and serial number.
+pub struct TaggedRawBlock {
+    /// The raw compressed BGZF block.
+    pub block: RawBgzfBlock,
+    /// Which spill file this block came from.
+    pub source_id: usize,
+    /// Per-source serial number for reordering after decompression.
+    pub serial: u64,
+}
+
+/// A decompressed block tagged with its source ID and serial number.
+pub struct TaggedDecompressedBlock {
+    /// Decompressed data.
+    pub data: Vec<u8>,
+    /// Which spill file this block came from.
+    pub source_id: usize,
+    /// Per-source serial number for reordering.
+    pub serial: u64,
+}
+
+/// Per-spill-file state for the worker-owns-files pattern.
+///
+/// Each worker exclusively owns a set of `ChunkFileState` instances.
+/// Worker `i` owns files `i, i+N, i+2N, ...` where `N` is the number of workers.
+/// No locks needed — each worker has exclusive access to its files.
+pub struct ChunkFileState {
+    /// Buffered reader for this spill file.
+    reader: BufReader<std::fs::File>,
+    /// Source ID for tagging blocks.
+    source_id: usize,
+    /// Next serial number to assign to blocks from this file.
+    next_serial: u64,
+    /// Whether this file has reached EOF.
+    eof: bool,
+}
+
+impl ChunkFileState {
+    /// Create a new chunk file state.
+    fn new(reader: BufReader<std::fs::File>, source_id: usize) -> Self {
+        Self { reader, source_id, next_serial: 0, eof: false }
+    }
+}
+
+/// Phase constants for the sort pipeline.
+pub mod phase {
+    /// Pool is shut down.
+    pub const SHUTDOWN: u8 = 0;
+    /// Phase 1: Reading input, sorting, spilling.
+    pub const PHASE1: u8 = 1;
+    /// Phase 2: Merge reading from spill files + compressing output.
+    pub const PHASE2: u8 = 2;
+    /// Legacy mode: channel-based compress/decompress only (no phase-aware scheduling).
+    /// This is the default state when the pool is first created.
+    pub const LEGACY: u8 = 255;
+}
+
+// ============================================================================
+// SortWorkerPool
+// ============================================================================
+
+/// Shared pool of N worker threads for ALL sort pipeline work.
+///
+/// Workers perform all CPU/IO work: block reading, decompression, and compression.
+/// The pool is created once per sort invocation and reused across all phases.
+///
+/// # Thread Model (N+2)
+///
+/// - **N pool workers**: Do ALL CPU/IO work (block reading, decompression, compression)
+/// - **+1 I/O writer thread**: `PooledBamWriter` / `PooledChunkWriter` (sequential disk write)
+/// - **+1 main thread**: Phase 1 orchestration + Phase 2 merge loop
+///
+/// # Phase-Aware Scheduling
+///
+/// Workers check the current phase to determine eligible steps:
+/// - **Phase 1**: `DecompressInput` > `ReadInputBlocks` > `CompressSpill`
+/// - **Phase 2**: `DecompressChunks` > `ReadChunkBlocks` > `CompressOutput`
+pub struct SortWorkerPool {
+    // Shared pipeline state (visible to workers and main thread)
+    shared: Arc<SharedPipelineState>,
+
+    /// Worker thread handles. `None` after shutdown (taken by `Drop` or `shutdown`).
+    workers: Option<Vec<JoinHandle<()>>>,
+    pub(crate) stats: PoolStats,
+    pub(crate) pipeline_stats: Arc<SortPipelineStats>,
+    pub buffer_pool: BufferPool,
+    num_workers: usize,
+}
+
+/// Shared state visible to all workers and the main thread.
+///
+/// Uses `ArrayQueue` for all inter-step data queues (lock-free, non-blocking
+/// `push()`/`pop()` only). The compress result channel stays as `crossbeam_channel`
+/// because the I/O writer thread needs blocking `recv()`.
+pub(crate) struct SharedPipelineState {
+    /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
+    pub(crate) phase: AtomicU8,
+
+    // --- Phase 1 queues ---
+    /// Input BAM file (Mutex because only one worker reads at a time).
+    pub(crate) input_file: std::sync::Mutex<Option<Box<dyn Read + Send>>>,
+    /// Input EOF flag — set by the worker that reads the last block.
+    pub(crate) input_eof: AtomicBool,
+    /// Set when an I/O error occurs reading the input file.
+    ///
+    /// `PooledInputStream::read()` checks this and returns `io::Error` so the
+    /// error surfaces to the caller rather than appearing as a truncated stream.
+    pub(crate) input_read_error: Arc<AtomicBool>,
+    /// Next serial for input block reading (atomic increment for ordering).
+    input_read_serial: AtomicU64,
+    /// Raw input blocks: `ReadInputBlocks` → `DecompressInput`.
+    pub(crate) raw_input_blocks: Arc<ArrayQueue<(u64, RawBgzfBlock)>>,
+    /// Decompressed input blocks: `DecompressInput` → main thread.
+    pub(crate) decompressed_input: Arc<ArrayQueue<(u64, Vec<u8>)>>,
+    /// Set by the last worker to decompress the final input block.
+    pub(crate) decompressed_input_done: Arc<AtomicBool>,
+    /// Count of input blocks successfully pushed to `decompressed_input`.
+    ///
+    /// Unlike `input_blocks_decompressed` (which counted blocks entering decompression),
+    /// this only increments when a block reaches the queue. `decompressed_input_done`
+    /// is set only when this equals `input_read_serial`, preventing the race where a
+    /// worker with a held (not-yet-queued) block causes premature EOF signalling.
+    input_blocks_queued: AtomicU64,
+
+    // --- Phase 2 queues ---
+    /// Raw chunk blocks: `ReadChunkBlocks` → `DecompressChunks`.
+    pub(crate) raw_chunk_blocks: Arc<ArrayQueue<TaggedRawBlock>>,
+    /// Decompressed chunk blocks: `DecompressChunks` → main thread.
+    pub(crate) decompressed_chunks: Arc<ArrayQueue<TaggedDecompressedBlock>>,
+    /// All chunk files have reached EOF.
+    pub(crate) all_chunks_eof: Arc<AtomicBool>,
+    /// Number of sources that have reached EOF (when == `total_sources`, set `all_chunks_eof`).
+    sources_at_eof: AtomicU64,
+    /// Total number of chunk sources (set before Phase 2 starts).
+    pub(crate) total_sources: AtomicU64,
+
+    // --- Compress queue (shared Phase 1 + Phase 2) ---
+    /// Compress jobs: main thread → workers (`ArrayQueue`, non-blocking push).
+    pub(crate) compress_queue: Arc<ArrayQueue<CompressJob>>,
+
+    // --- Per-worker chunk file distribution (Phase 2) ---
+    /// One sender per worker; main thread sends `Vec<ChunkFileState>` before Phase 2.
+    chunk_file_senders: Vec<std::sync::Mutex<Option<Sender<Vec<ChunkFileState>>>>>,
+    /// One receiver per worker; worker receives its assigned files.
+    chunk_file_receivers: Vec<Receiver<Vec<ChunkFileState>>>,
+
+    /// Number of workers (for `low_water` threshold in backpressure).
+    num_workers: usize,
+
+    /// Main thread handle for `park()`/`unpark()` notification.
+    /// Workers call `unpark()` after pushing to `decompressed_input` or `decompressed_chunks`
+    /// so the main thread wakes immediately instead of spin-yielding.
+    main_thread_handle: std::thread::Thread,
+}
+
+impl SharedPipelineState {
+    fn new(num_workers: usize, main_thread_handle: std::thread::Thread) -> Self {
+        let data_queue_cap = num_workers * 8;
+        let compress_queue_cap = num_workers * 4;
+
+        // Per-worker channels for chunk file distribution (one-shot, keep as channel)
+        let mut senders = Vec::with_capacity(num_workers);
+        let mut receivers = Vec::with_capacity(num_workers);
+        for _ in 0..num_workers {
+            let (tx, rx) = bounded::<Vec<ChunkFileState>>(1);
+            senders.push(std::sync::Mutex::new(Some(tx)));
+            receivers.push(rx);
+        }
+
+        Self {
+            phase: AtomicU8::new(phase::LEGACY),
+
+            input_file: std::sync::Mutex::new(None),
+            input_eof: AtomicBool::new(false),
+            input_read_error: Arc::new(AtomicBool::new(false)),
+            input_read_serial: AtomicU64::new(0),
+            raw_input_blocks: Arc::new(ArrayQueue::new(data_queue_cap)),
+            decompressed_input: Arc::new(ArrayQueue::new(data_queue_cap)),
+            decompressed_input_done: Arc::new(AtomicBool::new(false)),
+            input_blocks_queued: AtomicU64::new(0),
+
+            raw_chunk_blocks: Arc::new(ArrayQueue::new(data_queue_cap)),
+            decompressed_chunks: Arc::new(ArrayQueue::new(data_queue_cap)),
+            all_chunks_eof: Arc::new(AtomicBool::new(false)),
+            sources_at_eof: AtomicU64::new(0),
+            total_sources: AtomicU64::new(0),
+
+            compress_queue: Arc::new(ArrayQueue::new(compress_queue_cap)),
+
+            chunk_file_senders: senders,
+            chunk_file_receivers: receivers,
+
+            num_workers,
+            main_thread_handle,
+        }
+    }
+
+    /// Snapshot current queue depths for backpressure-driven scheduling.
+    fn get_backpressure(&self) -> SortBackpressureState {
+        let current_phase = self.phase.load(Ordering::Acquire);
+        let low_water = self.num_workers;
+
+        SortBackpressureState {
+            decompressed_input_low: self.decompressed_input.len() < low_water,
+            input_eof: self.input_eof.load(Ordering::Acquire),
+            decompressed_input_done: self.decompressed_input_done.load(Ordering::Acquire),
+
+            decompressed_chunks_low: self.decompressed_chunks.len() < low_water,
+            all_chunks_eof: self.all_chunks_eof.load(Ordering::Acquire),
+
+            compress_has_items: !self.compress_queue.is_empty(),
+            phase: current_phase,
+        }
+    }
+}
+
+/// Per-worker mutable state — no sharing, no locks.
+///
+/// Every step output has a held-item slot. If an `ArrayQueue::push()` fails
+/// because the downstream queue is full, the item is stored here. On the next
+/// loop iteration, `try_advance_all_held` drains held items before any new work
+/// is attempted. This prevents deadlock: a worker holding an output item will
+/// try other steps (e.g., compress) instead of blocking.
+struct SortWorkerState {
+    worker_id: usize,
+    /// Compressor used for Phase 1 spill writes (temp compression level).
+    compressor: InlineBgzfCompressor,
+    /// Compressor used for Phase 2 merge output (output compression level).
+    output_compressor: InlineBgzfCompressor,
+    decompressor: libdeflater::Decompressor,
+    /// Worker's assigned chunk files for Phase 2 (worker i owns files i, i+N, i+2N...).
+    chunk_files: Vec<ChunkFileState>,
+
+    // Held items (one per step output) — see plan §Worker State
+    /// Held raw input blocks from `ReadInputBlocks` (couldn't push to `raw_input_blocks` queue).
+    held_raw_input_blocks: Vec<(u64, RawBgzfBlock)>,
+    /// Held decompressed input block from `DecompressInput`.
+    held_decompressed_input: Option<(u64, Vec<u8>)>,
+    /// Held raw chunk blocks from `ReadChunkBlocks` (couldn't push to `raw_chunk_blocks` queue).
+    held_raw_chunk_blocks: Vec<TaggedRawBlock>,
+    /// Held decompressed chunk block from `DecompressChunks`.
+    held_decompressed_chunk: Option<TaggedDecompressedBlock>,
+    // Compress output goes directly to result_tx channel (I/O thread) — no held item.
+    /// Backoff microseconds for idle spinning.
+    backoff_us: u64,
+}
+
+impl SortWorkerState {
+    /// Returns true if this worker is holding any items that need advancement.
+    /// CRITICAL: Workers must not exit while holding items — they would be lost.
+    fn has_any_held_items(&self) -> bool {
+        !self.held_raw_input_blocks.is_empty()
+            || self.held_decompressed_input.is_some()
+            || !self.held_raw_chunk_blocks.is_empty()
+            || self.held_decompressed_chunk.is_some()
+    }
+}
+
+// ============================================================================
+// Backpressure State and Priority Selection
+// ============================================================================
+
+/// Snapshot of queue depths for backpressure-driven scheduling.
+///
+/// Sampled once per worker loop iteration via `SharedPipelineState::get_backpressure()`.
+/// All checks use `ArrayQueue::len()` which is O(1) and lock-free.
+#[allow(clippy::struct_excessive_bools)]
+struct SortBackpressureState {
+    // Phase 1
+    decompressed_input_low: bool,
+    input_eof: bool,
+    decompressed_input_done: bool,
+
+    // Phase 2
+    decompressed_chunks_low: bool,
+    all_chunks_eof: bool,
+
+    // Shared
+    compress_has_items: bool,
+    phase: u8,
+}
+
+/// Backpressure-driven priority selection — the sort pipeline's equivalent
+/// of `BalancedChaseDrain.build_priorities()`.
+///
+/// Returns a static slice of steps ordered by priority. The scheduler naturally
+/// adapts to all 7 sub-phases without explicit phase tracking because:
+/// - During 1A (reading): compress queue empty, decompressed low → read/decompress
+/// - During 1C (sort): decompressed full → skip decompress, do compress if available
+/// - During 1D (spill): compress queue fills → prioritize compress
+/// - During 1E (overlap): both compress and decompress needed → split by queue depths
+/// - During Phase 2: both compress (output) and decompress (chunks) → split
+fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
+    match bp.phase {
+        phase::PHASE1 => {
+            if bp.input_eof && !bp.compress_has_items && bp.decompressed_input_done {
+                // Input fully decompressed and no compress work — nothing productive to do
+                &[]
+            } else if bp.compress_has_items && !bp.decompressed_input_low {
+                // Spill compression is the bottleneck (13.7s at t4). Drain compress
+                // while decompressed blocks are plentiful for the main thread.
+                &[SortStep::CompressSpill, SortStep::DecompressInput, SortStep::ReadInputBlocks]
+            } else {
+                // Default/starving: feed the main thread first, compress if available
+                &[SortStep::DecompressInput, SortStep::ReadInputBlocks, SortStep::CompressSpill]
+            }
+        }
+        phase::PHASE2 => {
+            if bp.all_chunks_eof && !bp.compress_has_items {
+                // All chunks at EOF and no compress work — nothing productive to do
+                &[]
+            } else if bp.compress_has_items && !bp.decompressed_chunks_low {
+                // Output compression backpressure (15.4s at t4). Drain it.
+                &[SortStep::CompressOutput, SortStep::DecompressChunks, SortStep::ReadChunkBlocks]
+            } else {
+                // Default: feed the merge loop, compress output when available
+                &[SortStep::DecompressChunks, SortStep::ReadChunkBlocks, SortStep::CompressOutput]
+            }
+        }
+        // Legacy/transition: compress only (drain any remaining jobs)
+        _ => &[SortStep::CompressSpill],
+    }
+}
+
+// ============================================================================
+// Backoff (ported from unified pipeline base.rs)
+// ============================================================================
+
+/// Minimum backoff duration in microseconds.
+const MIN_BACKOFF_US: u64 = 10;
+/// Maximum backoff duration in microseconds (1ms).
+const MAX_BACKOFF_US: u64 = 1000;
+
+/// Sleep for the given backoff duration with ±25% jitter.
+/// Uses `yield_now()` at minimum backoff to avoid sleep syscall overhead.
+fn sleep_with_jitter(backoff_us: u64) {
+    if backoff_us <= MIN_BACKOFF_US {
+        std::thread::yield_now();
+    } else {
+        let jitter_range = backoff_us / 4;
+        let jitter_seed = u64::from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0),
+        );
+        let jitter_offset = (jitter_seed % (jitter_range * 2)).saturating_sub(jitter_range);
+        let actual_us = backoff_us.saturating_add(jitter_offset).max(MIN_BACKOFF_US);
+        std::thread::sleep(std::time::Duration::from_micros(actual_us));
+    }
+}
+
+// ============================================================================
+// Held-Item Helpers (ported from unified pipeline)
+// ============================================================================
+
+/// Try to advance a held item to its output `ArrayQueue`.
+/// Returns true if the held slot is now empty (item pushed or was already None).
+fn try_advance_held<T>(queue: &ArrayQueue<T>, held: &mut Option<T>) -> bool {
+    if let Some(item) = held.take() {
+        match queue.push(item) {
+            Ok(()) => true,
+            Err(item) => {
+                *held = Some(item);
+                false
+            }
+        }
+    } else {
+        true // nothing held
+    }
+}
+
+/// Try to advance a batch of held items to an `ArrayQueue`.
+/// Returns true if all items were pushed (held vec is now empty).
+fn try_advance_held_batch<T>(queue: &ArrayQueue<T>, held: &mut Vec<T>) -> bool {
+    if held.is_empty() {
+        return true;
+    }
+    let batch = std::mem::take(held);
+    let mut iter = batch.into_iter();
+    for item in iter.by_ref() {
+        match queue.push(item) {
+            Ok(()) => {}
+            Err(item) => {
+                held.push(item);
+                break;
+            }
+        }
+    }
+    held.extend(iter); // keep remaining
+    held.is_empty()
+}
+
+/// Result of attempting a work step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StepResult {
+    /// Step completed successfully.
+    Success,
+    /// Step has input but output queue is full.
+    OutputFull,
+    /// Step has no input available.
+    InputEmpty,
+}
+
+impl SortWorkerPool {
+    /// Create a new worker pool with `num_workers` threads.
+    ///
+    /// Each worker owns its own compressor (×2: spill and output) and decompressor.
+    /// Workers are phase-aware and perform all CPU/IO work.
+    ///
+    /// - `temp_compression`: BGZF level for Phase 1 spill writes (typically 1 for speed).
+    /// - `output_compression`: BGZF level for Phase 2 merge output (typically 6 for size).
+    #[must_use]
+    pub fn new(num_workers: usize, temp_compression: u32, output_compression: u32) -> Self {
+        let buffer_pool = BufferPool::new(num_workers * 4);
+        let stats = PoolStats::default();
+        let pipeline_stats = Arc::new(SortPipelineStats::new(num_workers));
+        let main_thread_handle = std::thread::current();
+        let shared = Arc::new(SharedPipelineState::new(num_workers, main_thread_handle));
+
+        let workers: Vec<JoinHandle<()>> = (0..num_workers)
+            .map(|worker_id| {
+                let pstats = Arc::clone(&pipeline_stats);
+                let shared = Arc::clone(&shared);
+
+                thread::spawn(move || {
+                    let mut worker = SortWorkerState {
+                        worker_id,
+                        compressor: InlineBgzfCompressor::new(temp_compression),
+                        output_compressor: InlineBgzfCompressor::new(output_compression),
+                        decompressor: libdeflater::Decompressor::new(),
+                        chunk_files: Vec::new(),
+                        held_raw_input_blocks: Vec::new(),
+                        held_decompressed_input: None,
+                        held_raw_chunk_blocks: Vec::new(),
+                        held_decompressed_chunk: None,
+                        backoff_us: MIN_BACKOFF_US,
+                    };
+
+                    Self::worker_loop(&shared, &mut worker, &pstats);
+                })
+            })
+            .collect();
+
+        Self { shared, workers: Some(workers), stats, pipeline_stats, buffer_pool, num_workers }
+    }
+
+    // ========================================================================
+    // Worker Loop — modeled on generic_worker_loop (base.rs:4379)
+    // ========================================================================
+
+    /// The main worker loop — phase-aware, non-blocking, with held-item pattern.
+    ///
+    /// Follows the unified pipeline's `generic_worker_loop` pattern exactly:
+    /// 1. Check shutdown
+    /// 2. Check completion (safe exit requires no held items)
+    /// 3. Try to advance ALL held items first (deadlock prevention)
+    /// 4. Get priorities based on backpressure (queue depths)
+    /// 5. Try owned exclusive step first (prevents starvation)
+    /// 6. Try each priority step (break on first success)
+    /// 7. Backoff with jitter
+    fn worker_loop(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+        pstats: &SortPipelineStats,
+    ) {
+        loop {
+            // 1. Check shutdown
+            let current_phase = shared.phase.load(Ordering::Acquire);
+            if current_phase == phase::SHUTDOWN {
+                break;
+            }
+
+            // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
+            //    Workers must survive across Phase 1 → Phase 2 transitions.
+            if Self::is_phase_complete(shared, worker, current_phase)
+                && !worker.has_any_held_items()
+            {
+                sleep_with_jitter(worker.backoff_us);
+                worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
+                continue;
+            }
+
+            let mut did_work = false;
+
+            // 3. Try to advance ALL held items first (deadlock prevention)
+            did_work |= Self::try_advance_all_held(shared, worker);
+
+            // Phase 2: receive chunk files on first iteration
+            if current_phase == phase::PHASE2
+                && worker.chunk_files.is_empty()
+                && shared.total_sources.load(Ordering::Acquire) > 0
+            {
+                if let Ok(files) = shared.chunk_file_receivers[worker.worker_id].try_recv() {
+                    worker.chunk_files = files;
+                }
+            }
+
+            // 4. Get backpressure state and resolve priorities (done inline in step 6)
+            let owned_step = Self::exclusive_step_for(worker.worker_id, shared, current_phase);
+
+            // 5. Try owned exclusive step first (prevents starvation)
+            if !did_work {
+                if let Some(step) = owned_step {
+                    if Self::is_step_eligible(step, shared, worker, current_phase) {
+                        let t0 = Instant::now();
+                        let result = Self::execute_step(shared, worker, step);
+                        if result == StepResult::Success {
+                            pstats.record_step(
+                                worker.worker_id,
+                                step,
+                                Self::nanos_u64(t0.elapsed()),
+                            );
+                            did_work = true;
+                        }
+                    }
+                }
+            }
+
+            // 6. Try each priority step (break on first success or OutputFull)
+            //    Only compute backpressure/priorities when needed (skip if work already found)
+            if !did_work {
+                let bp = shared.get_backpressure();
+                let priorities = get_sort_priorities(&bp);
+
+                for &step in priorities {
+                    if !Self::is_step_eligible(step, shared, worker, current_phase) {
+                        continue;
+                    }
+                    // Skip exclusive steps this worker doesn't own
+                    if Self::is_exclusive_step(step)
+                        && !Self::can_attempt_exclusive(worker, step, shared, current_phase)
+                    {
+                        continue;
+                    }
+                    // Skip the owned step (already tried above)
+                    if owned_step == Some(step) {
+                        continue;
+                    }
+
+                    let t0 = Instant::now();
+                    match Self::execute_step(shared, worker, step) {
+                        StepResult::Success => {
+                            pstats.record_step(
+                                worker.worker_id,
+                                step,
+                                Self::nanos_u64(t0.elapsed()),
+                            );
+                            did_work = true;
+                            break; // Restart priority evaluation
+                        }
+                        StepResult::OutputFull => break, // Try downstream via held-item advancement
+                        StepResult::InputEmpty => {}     // Try next step
+                    }
+                }
+            }
+
+            // 7. Backoff with jitter (ported from unified pipeline)
+            if did_work {
+                worker.backoff_us = MIN_BACKOFF_US;
+            } else {
+                let idle_start = Instant::now();
+                sleep_with_jitter(worker.backoff_us);
+                worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
+                pstats.record_idle(worker.worker_id, Self::nanos_u64(idle_start.elapsed()));
+            }
+        }
+    }
+
+    /// Check if the current phase is "complete" (no more work to do).
+    ///
+    /// This does NOT mean the worker should exit — it must also have no held items.
+    fn is_phase_complete(
+        shared: &SharedPipelineState,
+        worker: &SortWorkerState,
+        current_phase: u8,
+    ) -> bool {
+        match current_phase {
+            phase::PHASE1 => {
+                shared.decompressed_input_done.load(Ordering::Acquire)
+                    && shared.compress_queue.is_empty()
+            }
+            phase::PHASE2 => {
+                shared.all_chunks_eof.load(Ordering::Acquire)
+                    && shared.raw_chunk_blocks.is_empty()
+                    && shared.decompressed_chunks.is_empty()
+                    && shared.compress_queue.is_empty()
+                    && worker.chunk_files.iter().all(|f| f.eof)
+            }
+            // Legacy mode never "completes" — it runs until phase changes
+            _ => false,
+        }
+    }
+
+    // ========================================================================
+    // Exclusive Step Ownership (plan §Exclusive Step Ownership)
+    // ========================================================================
+
+    /// Return the exclusive step this worker owns, if any.
+    ///
+    /// For `num_workers >= 2`: Worker 0 owns `ReadInputBlocks` (Phase 1) and
+    /// `ReadChunkBlocks` (Phase 2). For `num_workers == 1`: single worker does
+    /// everything (returns `None`, no ownership restrictions).
+    fn exclusive_step_for(
+        worker_id: usize,
+        shared: &SharedPipelineState,
+        current_phase: u8,
+    ) -> Option<SortStep> {
+        if shared.num_workers < 2 {
+            return None; // Single worker does everything
+        }
+        if worker_id != 0 {
+            return None; // Only worker 0 owns read steps
+        }
+        match current_phase {
+            phase::PHASE1 => Some(SortStep::ReadInputBlocks),
+            // Phase 2: each worker reads its own files, no exclusive ownership needed
+            _ => None,
+        }
+    }
+
+    /// Whether a step is exclusive (requires ownership).
+    ///
+    /// Only `ReadInputBlocks` is exclusive — it reads from a shared input file
+    /// protected by a Mutex. `ReadChunkBlocks` is NOT exclusive because each
+    /// worker reads from its own assigned chunk files (no contention).
+    fn is_exclusive_step(step: SortStep) -> bool {
+        matches!(step, SortStep::ReadInputBlocks)
+    }
+
+    /// Whether this worker can attempt an exclusive step it doesn't own.
+    ///
+    /// Non-owner workers can attempt exclusive steps only if `num_workers == 1`
+    /// (single worker mode).
+    fn can_attempt_exclusive(
+        worker: &SortWorkerState,
+        step: SortStep,
+        shared: &SharedPipelineState,
+        current_phase: u8,
+    ) -> bool {
+        // Owner can always attempt
+        if Self::exclusive_step_for(worker.worker_id, shared, current_phase) == Some(step) {
+            return true;
+        }
+        // Single worker mode: no restrictions
+        shared.num_workers < 2
+    }
+
+    // ========================================================================
+    // Step Eligibility and Dispatch
+    // ========================================================================
+
+    /// Check whether a step is eligible to run in the current state.
+    fn is_step_eligible(
+        step: SortStep,
+        shared: &SharedPipelineState,
+        worker: &SortWorkerState,
+        current_phase: u8,
+    ) -> bool {
+        match step {
+            SortStep::ReadInputBlocks => {
+                current_phase == phase::PHASE1
+                    && !shared.input_eof.load(Ordering::Acquire)
+                    && worker.held_raw_input_blocks.is_empty()
+            }
+            SortStep::DecompressInput => {
+                current_phase == phase::PHASE1
+                    && worker.held_decompressed_input.is_none()
+                    && (!shared.raw_input_blocks.is_empty()
+                        || (shared.input_eof.load(Ordering::Acquire)
+                            && !shared.decompressed_input_done.load(Ordering::Acquire)))
+            }
+            SortStep::CompressSpill | SortStep::CompressOutput => !shared.compress_queue.is_empty(),
+            SortStep::ReadChunkBlocks => {
+                current_phase == phase::PHASE2
+                    && worker.held_raw_chunk_blocks.is_empty()
+                    && !worker.chunk_files.is_empty()
+                    && !worker.chunk_files.iter().all(|f| f.eof)
+            }
+            SortStep::DecompressChunks => {
+                current_phase == phase::PHASE2
+                    && worker.held_decompressed_chunk.is_none()
+                    && !shared.raw_chunk_blocks.is_empty()
+            }
+        }
+    }
+
+    /// Dispatch to the appropriate step function.
+    fn execute_step(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+        step: SortStep,
+    ) -> StepResult {
+        match step {
+            SortStep::ReadInputBlocks => Self::try_read_input_blocks(shared, worker),
+            SortStep::DecompressInput => Self::try_decompress_input(shared, worker),
+            SortStep::CompressSpill | SortStep::CompressOutput => {
+                Self::try_compress(shared, worker)
+            }
+            SortStep::ReadChunkBlocks => Self::try_read_chunk_blocks(shared, worker),
+            SortStep::DecompressChunks => Self::try_decompress_chunks(shared, worker),
+        }
+    }
+
+    // ========================================================================
+    // Held-item advancement (deadlock prevention)
+    // ========================================================================
+
+    /// Try to push all held items to their output `ArrayQueue`s.
+    /// Returns true if any held item was successfully advanced.
+    fn try_advance_all_held(shared: &SharedPipelineState, worker: &mut SortWorkerState) -> bool {
+        let mut advanced = false;
+
+        // Raw input blocks (batch)
+        if !worker.held_raw_input_blocks.is_empty() {
+            let before = worker.held_raw_input_blocks.len();
+            try_advance_held_batch(&shared.raw_input_blocks, &mut worker.held_raw_input_blocks);
+            if worker.held_raw_input_blocks.len() < before {
+                advanced = true;
+            }
+        }
+
+        // Decompressed input (single) — always unpark main (drain full queue or deliver data)
+        if worker.held_decompressed_input.is_some() {
+            let pushed =
+                try_advance_held(&shared.decompressed_input, &mut worker.held_decompressed_input);
+            shared.main_thread_handle.unpark();
+            if pushed {
+                advanced = true;
+                // This may have been the last block. Increment `input_blocks_queued` now
+                // that the block is actually in the queue (not held), then re-check the
+                // done condition. This prevents premature EOF when multiple workers hold
+                // blocks simultaneously — decompressed_input_done is only set once all
+                // blocks have been queued, not just decompressed.
+                let queued = shared.input_blocks_queued.fetch_add(1, Ordering::AcqRel) + 1;
+                let total = shared.input_read_serial.load(Ordering::Acquire);
+                if shared.input_eof.load(Ordering::Acquire)
+                    && shared.raw_input_blocks.is_empty()
+                    && queued >= total
+                    && !shared.decompressed_input_done.load(Ordering::Acquire)
+                {
+                    shared.decompressed_input_done.store(true, Ordering::Release);
+                    shared.main_thread_handle.unpark();
+                }
+            }
+        }
+
+        // Raw chunk blocks (batch)
+        if !worker.held_raw_chunk_blocks.is_empty() {
+            let before = worker.held_raw_chunk_blocks.len();
+            try_advance_held_batch(&shared.raw_chunk_blocks, &mut worker.held_raw_chunk_blocks);
+            if worker.held_raw_chunk_blocks.len() < before {
+                advanced = true;
+            }
+        }
+
+        // Decompressed chunks (single) — always unpark main
+        if worker.held_decompressed_chunk.is_some() {
+            advanced |=
+                try_advance_held(&shared.decompressed_chunks, &mut worker.held_decompressed_chunk);
+            shared.main_thread_handle.unpark();
+        }
+
+        advanced
+    }
+
+    // ========================================================================
+    // Phase 1 Steps
+    // ========================================================================
+
+    /// `ReadInputBlocks`: read a batch of raw BGZF blocks from the input BAM file.
+    ///
+    /// Uses `try_lock` to avoid blocking — only one worker reads at a time.
+    /// Blocks that can't be pushed to the `ArrayQueue` are stored in `held_raw_input_blocks`.
+    fn try_read_input_blocks(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+    ) -> StepResult {
+        if shared.input_eof.load(Ordering::Acquire) {
+            return StepResult::InputEmpty;
+        }
+
+        // Try to acquire the input file lock (non-blocking)
+        let Ok(mut guard) = shared.input_file.try_lock() else {
+            return StepResult::InputEmpty; // Another worker is reading
+        };
+
+        let Some(reader) = guard.as_mut() else {
+            return StepResult::InputEmpty; // No input file set
+        };
+
+        // Read a batch of raw BGZF blocks
+        let blocks = match read_raw_blocks(reader.as_mut(), INPUT_READ_BATCH_SIZE) {
+            Ok(b) => b,
+            Err(e) => {
+                log::error!("I/O error reading input BAM: {e}");
+                shared.input_read_error.store(true, Ordering::Release);
+                shared.input_eof.store(true, Ordering::Release);
+                shared.main_thread_handle.unpark();
+                return StepResult::InputEmpty;
+            }
+        };
+
+        if blocks.is_empty() {
+            shared.input_eof.store(true, Ordering::Release);
+            return StepResult::InputEmpty;
+        }
+
+        // Drop the lock before pushing to queue
+        drop(guard);
+
+        // Assign serial numbers and push to raw_input_blocks ArrayQueue.
+        // Once the queue is full, hold this block and all remaining blocks.
+        let mut blocks_iter = blocks.into_iter();
+        for block in blocks_iter.by_ref() {
+            let serial = shared.input_read_serial.fetch_add(1, Ordering::Relaxed);
+            match shared.raw_input_blocks.push((serial, block)) {
+                Ok(()) => {}
+                Err((serial, block)) => {
+                    worker.held_raw_input_blocks.push((serial, block));
+                    break;
+                }
+            }
+        }
+        // Hold any remaining blocks we didn't attempt to push
+        for block in blocks_iter {
+            let serial = shared.input_read_serial.fetch_add(1, Ordering::Relaxed);
+            worker.held_raw_input_blocks.push((serial, block));
+        }
+
+        StepResult::Success
+    }
+
+    /// `DecompressInput`: decompress a raw input BGZF block.
+    fn try_decompress_input(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+    ) -> StepResult {
+        // Don't take new work if we're holding an item
+        if worker.held_decompressed_input.is_some() {
+            return StepResult::OutputFull;
+        }
+
+        let Some((serial, block)) = shared.raw_input_blocks.pop() else {
+            // No blocks to decompress. Check if all blocks are done — the EOF
+            // condition can only be detected here (not after a successful pop)
+            // when the last block was already queued before input_eof was set.
+            // Use `input_blocks_queued` (not `input_blocks_decompressed`) to avoid
+            // a race where workers with held blocks trigger premature EOF.
+            if shared.input_eof.load(Ordering::Acquire)
+                && !shared.decompressed_input_done.load(Ordering::Acquire)
+            {
+                let queued = shared.input_blocks_queued.load(Ordering::Acquire);
+                let total = shared.input_read_serial.load(Ordering::Acquire);
+                if queued >= total {
+                    shared.decompressed_input_done.store(true, Ordering::Release);
+                    shared.main_thread_handle.unpark();
+                }
+            }
+            return StepResult::InputEmpty;
+        };
+
+        let data = decompress_block(&block, &mut worker.decompressor)
+            .expect("BGZF decompression should not fail for valid input blocks");
+
+        let input_eof = shared.input_eof.load(Ordering::Acquire);
+        let raw_empty = shared.raw_input_blocks.is_empty();
+
+        // Try to push to decompressed_input ArrayQueue
+        let pushed = match shared.decompressed_input.push((serial, data)) {
+            Ok(()) => {
+                shared.main_thread_handle.unpark();
+                true
+            }
+            Err(item) => {
+                worker.held_decompressed_input = Some(item);
+                // Queue full — wake main thread to drain so we can push next time
+                shared.main_thread_handle.unpark();
+                false
+            }
+        };
+
+        // Only increment `input_blocks_queued` (and check done) when the block is
+        // actually in the queue. If held, the count stays low — preventing the race
+        // where another worker sees count==total and fires decompressed_input_done
+        // prematurely while this block is still in held_decompressed_input.
+        // The done check runs again in try_advance_all_held once the block is pushed.
+        if pushed {
+            let queued = shared.input_blocks_queued.fetch_add(1, Ordering::AcqRel) + 1;
+            let total = shared.input_read_serial.load(Ordering::Acquire);
+            if input_eof && raw_empty && queued >= total {
+                shared.decompressed_input_done.store(true, Ordering::Release);
+                shared.main_thread_handle.unpark();
+            }
+        }
+
+        StepResult::Success
+    }
+
+    // ========================================================================
+    // Phase 2 Steps
+    // ========================================================================
+
+    /// `ReadChunkBlocks`: read raw BGZF blocks from this worker's assigned chunk files.
+    ///
+    /// Worker-owns-files pattern: no locks needed. Worker i exclusively owns its files.
+    fn try_read_chunk_blocks(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+    ) -> StepResult {
+        if worker.chunk_files.is_empty() || shared.all_chunks_eof.load(Ordering::Acquire) {
+            return StepResult::InputEmpty;
+        }
+
+        let mut read_any = false;
+
+        // Round-robin through this worker's assigned files
+        for file_state in &mut worker.chunk_files {
+            if file_state.eof {
+                continue;
+            }
+
+            let blocks = match read_raw_blocks(&mut file_state.reader, CHUNK_READ_BATCH_SIZE) {
+                Ok(b) => b,
+                Err(e) => {
+                    log::error!(
+                        "I/O error reading chunk file (source {}): {e}",
+                        file_state.source_id
+                    );
+                    // Mark as EOF so the merge loop surfaces the truncation via
+                    // the missing-serial check in io_writer_loop rather than hanging.
+                    file_state.eof = true;
+                    Self::maybe_mark_all_eof(shared);
+                    continue;
+                }
+            };
+
+            if blocks.is_empty() {
+                file_state.eof = true;
+                Self::maybe_mark_all_eof(shared);
+                continue;
+            }
+
+            let mut blocks_iter = blocks.into_iter();
+            let source_id = file_state.source_id;
+            let mut backed_up = false;
+            for block in blocks_iter.by_ref() {
+                let serial = file_state.next_serial;
+                file_state.next_serial += 1;
+                let tagged = TaggedRawBlock { block, source_id, serial };
+                match shared.raw_chunk_blocks.push(tagged) {
+                    Ok(()) => {}
+                    Err(tagged) => {
+                        worker.held_raw_chunk_blocks.push(tagged);
+                        backed_up = true;
+                        break;
+                    }
+                }
+            }
+            // Hold any remaining blocks we didn't attempt to push
+            if backed_up {
+                for block in blocks_iter {
+                    let serial = file_state.next_serial;
+                    file_state.next_serial += 1;
+                    worker.held_raw_chunk_blocks.push(TaggedRawBlock { block, source_id, serial });
+                }
+            }
+            read_any = true;
+            break; // Read from one file per step to be fair
+        }
+
+        if read_any { StepResult::Success } else { StepResult::InputEmpty }
+    }
+
+    /// `DecompressChunks`: decompress a raw chunk block.
+    fn try_decompress_chunks(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+    ) -> StepResult {
+        // Don't take new work if we're holding an item
+        if worker.held_decompressed_chunk.is_some() {
+            return StepResult::OutputFull;
+        }
+
+        let Some(tagged) = shared.raw_chunk_blocks.pop() else {
+            return StepResult::InputEmpty;
+        };
+
+        let data = decompress_block(&tagged.block, &mut worker.decompressor)
+            .expect("BGZF decompression should not fail for valid chunk blocks");
+
+        let result =
+            TaggedDecompressedBlock { data, source_id: tagged.source_id, serial: tagged.serial };
+
+        match shared.decompressed_chunks.push(result) {
+            Ok(()) => {
+                shared.main_thread_handle.unpark();
+            }
+            Err(item) => {
+                worker.held_decompressed_chunk = Some(item);
+                // Queue full — wake main thread to drain so we can push next time
+                shared.main_thread_handle.unpark();
+            }
+        }
+
+        StepResult::Success
+    }
+
+    // ========================================================================
+    // Compress Step (shared by Phase 1 + Phase 2)
+    // ========================================================================
+
+    /// Try to pick up a compress job from the `ArrayQueue` (non-blocking).
+    fn try_compress(shared: &SharedPipelineState, worker: &mut SortWorkerState) -> StepResult {
+        let Some(job) = shared.compress_queue.pop() else {
+            return StepResult::InputEmpty;
+        };
+
+        // Use phase-appropriate compressor: Phase 1 spill uses temp compression level,
+        // Phase 2 merge output uses output compression level.
+        let compressor = if shared.phase.load(Ordering::Acquire) == phase::PHASE2 {
+            &mut worker.output_compressor
+        } else {
+            &mut worker.compressor
+        };
+        Self::handle_compress_job(job, compressor);
+        StepResult::Success
+    }
+
+    // ========================================================================
+    // Helper: EOF tracking for Phase 2
+    // ========================================================================
+
+    /// Check if all sources have reached EOF and set the global flag if so.
+    fn maybe_mark_all_eof(shared: &SharedPipelineState) {
+        let eof_count = shared.sources_at_eof.fetch_add(1, Ordering::AcqRel) + 1;
+        let total = shared.total_sources.load(Ordering::Acquire);
+        if total > 0 && eof_count >= total {
+            shared.all_chunks_eof.store(true, Ordering::Release);
+            shared.main_thread_handle.unpark();
+        }
+    }
+
+    // ========================================================================
+    // Public API
+    // ========================================================================
+
+    /// Number of worker threads in the pool.
+    pub fn num_workers(&self) -> usize {
+        self.num_workers
+    }
+
+    /// Get a clone of the decompressed input `ArrayQueue` for `PooledInputStream`.
+    pub(crate) fn decompressed_input_queue(
+        &self,
+    ) -> Arc<crossbeam_queue::ArrayQueue<(u64, Vec<u8>)>> {
+        Arc::clone(&self.shared.decompressed_input)
+    }
+
+    /// Get a clone of the decompressed input done flag for `PooledInputStream`.
+    pub(crate) fn decompressed_input_done_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shared.decompressed_input_done)
+    }
+
+    /// Get the input read error flag for `PooledInputStream` error surfacing.
+    pub(crate) fn input_read_error_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shared.input_read_error)
+    }
+
+    /// Get a clone of the decompressed chunks `ArrayQueue` for Phase 2 merge.
+    pub(crate) fn decompressed_chunks_queue(
+        &self,
+    ) -> Arc<crossbeam_queue::ArrayQueue<TaggedDecompressedBlock>> {
+        Arc::clone(&self.shared.decompressed_chunks)
+    }
+
+    /// Get a clone of the `all_chunks_eof` flag for Phase 2 merge.
+    pub(crate) fn all_chunks_eof_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shared.all_chunks_eof)
+    }
+
+    /// Get a clone of the raw (pre-decompression) chunk blocks queue for Phase 2 merge.
+    ///
+    /// Used by `MainThreadChunkConsumer` to verify all blocks have been decompressed
+    /// before declaring EOF — `all_chunks_eof` is set when raw reads finish, but blocks
+    /// may still be in this queue awaiting decompression.
+    pub(crate) fn raw_chunk_blocks_queue(&self) -> Arc<ArrayQueue<TaggedRawBlock>> {
+        Arc::clone(&self.shared.raw_chunk_blocks)
+    }
+
+    /// Set the current pipeline phase.
+    pub fn set_phase(&self, new_phase: u8) {
+        self.shared.phase.store(new_phase, Ordering::Release);
+    }
+
+    /// Set the input file for Phase 1 reading.
+    ///
+    /// Must be called before `set_phase(PHASE1)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input file mutex is poisoned.
+    pub fn set_input_file(&self, reader: Box<dyn Read + Send>) {
+        *self.shared.input_file.lock().expect("input_file mutex should not be poisoned") =
+            Some(reader);
+    }
+
+    /// Distribute chunk files to workers for Phase 2.
+    ///
+    /// Worker `i` gets files `i, i+N, i+2N, ...` where `N` is `num_workers`.
+    /// Must be called before `set_phase(PHASE2)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a chunk file cannot be opened.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a sender mutex is poisoned.
+    pub fn distribute_chunk_files(
+        &self,
+        files: Vec<(std::path::PathBuf, usize)>,
+    ) -> anyhow::Result<()> {
+        let n = self.num_workers;
+        let total_sources = files.len();
+        self.shared.total_sources.store(total_sources as u64, Ordering::Release);
+
+        // Reset EOF state
+        self.shared.all_chunks_eof.store(false, Ordering::Release);
+        self.shared.sources_at_eof.store(0, Ordering::Release);
+
+        // Assign files to workers: worker i gets files i, i+N, i+2N...
+        let mut per_worker: Vec<Vec<ChunkFileState>> = (0..n).map(|_| Vec::new()).collect();
+
+        for (idx, (path, source_id)) in files.into_iter().enumerate() {
+            let worker_idx = idx % n;
+            let file = std::fs::File::open(&path).map_err(|e| {
+                anyhow::anyhow!("Failed to open chunk file {}: {e}", path.display())
+            })?;
+            let reader = BufReader::with_capacity(2 * 1024 * 1024, file);
+            per_worker[worker_idx].push(ChunkFileState::new(reader, source_id));
+        }
+
+        // Send to each worker via their dedicated channel
+        for (worker_idx, files) in per_worker.into_iter().enumerate() {
+            let guard = self.shared.chunk_file_senders[worker_idx]
+                .lock()
+                .expect("chunk_file_sender mutex should not be poisoned");
+            if let Some(tx) = guard.as_ref() {
+                let _ = tx.send(files);
+            }
+        }
+        Ok(())
+    }
+
+    /// Submit a compression job to the pool (non-blocking, spin-yield on full).
+    ///
+    /// The main thread calls this during spill writes and merge output. If the
+    /// compress `ArrayQueue` is full, spins briefly with `yield_now()` — acceptable
+    /// because the main thread has no other productive work during spill writes.
+    pub fn submit_compress(&self, job: CompressJob) {
+        self.stats.compress_jobs.fetch_add(1, Ordering::Relaxed);
+        let mut job = job;
+        loop {
+            match self.shared.compress_queue.push(job) {
+                Ok(()) => return,
+                Err(returned) => {
+                    job = returned;
+                    std::thread::yield_now();
+                }
+            }
+        }
+    }
+
+    /// Create a new result channel pair for compress results.
+    ///
+    /// The result channel stays as `crossbeam_channel::bounded()` because the
+    /// I/O writer thread needs blocking `recv()`.
+    pub fn compress_result_channel(&self) -> (Sender<CompressResult>, Receiver<CompressResult>) {
+        bounded(self.num_workers * 2)
+    }
+
+    /// Shut down the pool, waiting for all workers to finish.
+    ///
+    /// Logs pipeline statistics before joining workers. After this call the pool is fully
+    /// stopped. It is also safe to simply drop the pool — `Drop` performs the same cleanup
+    /// (minus the debug logging) if `shutdown` was not called explicitly.
+    pub fn shutdown(mut self) {
+        if log::log_enabled!(log::Level::Debug) {
+            self.stats.log_summary();
+            self.pipeline_stats.log_summary();
+        }
+        self.do_shutdown();
+    }
+
+    /// Internal shutdown: signal workers and join them. Safe to call multiple times
+    /// (idempotent via `Option::take`). Called by both `shutdown` and `Drop`.
+    fn do_shutdown(&mut self) {
+        self.shared.phase.store(phase::SHUTDOWN, Ordering::Release);
+        // Drop chunk file senders so workers blocked on receiving them unblock.
+        for sender in &self.shared.chunk_file_senders {
+            if let Ok(mut guard) = sender.lock() {
+                *guard = None;
+            }
+        }
+        if let Some(workers) = self.workers.take() {
+            for w in workers {
+                let _ = w.join();
+            }
+        }
+    }
+
+    // ========================================================================
+    // Job handlers
+    // ========================================================================
+
+    /// Convert `Duration::as_nanos()` (u128) to u64 nanoseconds for stats.
+    #[allow(clippy::cast_possible_truncation)]
+    fn nanos_u64(d: std::time::Duration) -> u64 {
+        d.as_nanos() as u64
+    }
+
+    /// Handle a compress job on a worker thread.
+    fn handle_compress_job(job: CompressJob, compressor: &mut InlineBgzfCompressor) {
+        compressor
+            .write_all(&job.data)
+            .expect("BGZF compression write should not fail for valid data");
+        compressor.flush().expect("BGZF compression flush should not fail");
+
+        let blocks = compressor.take_blocks();
+        let total_len: usize = blocks.iter().map(|b| b.data.len()).sum();
+        let mut compressed = Vec::with_capacity(total_len);
+        for block in &blocks {
+            compressed.extend_from_slice(&block.data);
+        }
+
+        let mut recycled = job.data;
+        recycled.clear();
+
+        let serial = job.serial;
+        if job
+            .result_tx
+            .send(CompressResult { serial, compressed, recycled_buf: recycled })
+            .is_err()
+        {
+            log::warn!(
+                "compress result discarded (serial {serial}): I/O writer thread disconnected"
+            );
+        }
+    }
+}
+
+impl Drop for SortWorkerPool {
+    /// Ensures workers are joined even if `shutdown` was not called explicitly.
+    ///
+    /// This prevents thread leaks on early `?` exits in the sort pipeline. Statistics
+    /// are not logged here (only in `shutdown`).
+    fn drop(&mut self) {
+        self.do_shutdown();
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_pool_checkout_empty() {
+        let pool = BufferPool::new(4);
+        let buf = pool.checkout();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_buffer_pool_recycle() {
+        let pool = BufferPool::new(4);
+        let mut buf = Vec::with_capacity(1024);
+        buf.extend_from_slice(b"hello");
+        pool.checkin(buf);
+
+        let recycled = pool.checkout();
+        // Buffer should be cleared but retain capacity
+        assert!(recycled.is_empty());
+        assert!(recycled.capacity() >= 1024);
+    }
+
+    #[test]
+    fn test_pool_stats_log_summary() {
+        let stats = PoolStats::default();
+        stats.compress_jobs.fetch_add(42, Ordering::Relaxed);
+        // Verify log_summary executes without panicking (logging may be a no-op in tests).
+        stats.log_summary();
+        assert_eq!(stats.compress_jobs.load(Ordering::Relaxed), 42);
+    }
+
+    #[test]
+    fn test_pool_compress_roundtrip() {
+        let pool = SortWorkerPool::new(2, 1, 6);
+        let (result_tx, result_rx) = pool.compress_result_channel();
+
+        // Submit a compress job
+        let data = vec![b'A'; 1000];
+        pool.submit_compress(CompressJob { data, serial: 0, result_tx });
+
+        // Wait for result
+        let result = result_rx.recv().expect("should receive compress result");
+        assert_eq!(result.serial, 0);
+        assert!(!result.compressed.is_empty());
+        // Compressed data should start with BGZF magic
+        assert_eq!(&result.compressed[0..2], &[0x1f, 0x8b]);
+        // Recycled buffer should be empty
+        assert!(result.recycled_buf.is_empty());
+
+        pool.shutdown();
+    }
+
+    #[test]
+    fn test_pool_many_jobs() {
+        let pool = SortWorkerPool::new(4, 1, 6);
+        let (result_tx, result_rx) = pool.compress_result_channel();
+
+        let num_jobs = 100usize;
+
+        // Submit in a separate thread to avoid deadlock: the result channel
+        // is bounded, so workers block on send when it's full, which blocks
+        // the compress channel, which blocks submit.
+        let submit_tx = result_tx.clone();
+        let submit_handle = std::thread::spawn(move || {
+            for i in 0..num_jobs {
+                let data = vec![b'X'; 500 + i];
+                pool.submit_compress(CompressJob {
+                    data,
+                    serial: i as u64,
+                    result_tx: submit_tx.clone(),
+                });
+            }
+            drop(submit_tx);
+            pool
+        });
+        drop(result_tx);
+
+        let mut received = 0;
+        while let Ok(_result) = result_rx.recv() {
+            received += 1;
+        }
+        assert_eq!(received, num_jobs);
+
+        let pool = submit_handle.join().expect("submit thread should not panic");
+        pool.shutdown();
+    }
+
+    #[test]
+    fn test_pool_stats() {
+        let pool = SortWorkerPool::new(2, 1, 6);
+        let (c_tx, c_rx) = pool.compress_result_channel();
+
+        // Submit one compress job
+        pool.submit_compress(CompressJob { data: vec![b'A'; 100], serial: 0, result_tx: c_tx });
+        let _ = c_rx.recv();
+
+        assert_eq!(pool.stats.compress_jobs.load(Ordering::Relaxed), 1);
+
+        pool.shutdown();
+    }
+
+    #[test]
+    fn test_pipeline_stats_record_step_and_idle() {
+        let stats = SortPipelineStats::new(2);
+
+        stats.record_step(0, SortStep::ReadInputBlocks, 1_000_000);
+        stats.record_step(0, SortStep::ReadInputBlocks, 500_000);
+        stats.record_step(1, SortStep::DecompressInput, 2_000_000);
+        stats.record_step(0, SortStep::CompressSpill, 300_000);
+        stats.record_idle(0, 100_000);
+        stats.record_idle(1, 200_000);
+
+        let read_idx = SortStep::ReadInputBlocks as usize;
+        let decomp_idx = SortStep::DecompressInput as usize;
+        let compress_idx = SortStep::CompressSpill as usize;
+
+        assert_eq!(stats.step_count[read_idx].load(Ordering::Relaxed), 2);
+        assert_eq!(stats.step_ns[read_idx].load(Ordering::Relaxed), 1_500_000);
+        assert_eq!(stats.step_count[decomp_idx].load(Ordering::Relaxed), 1);
+        assert_eq!(stats.step_count[compress_idx].load(Ordering::Relaxed), 1);
+        assert_eq!(stats.per_thread_step_counts[0][read_idx].load(Ordering::Relaxed), 2);
+        assert_eq!(stats.per_thread_step_counts[1][decomp_idx].load(Ordering::Relaxed), 1);
+        assert_eq!(stats.per_thread_idle_ns[0].load(Ordering::Relaxed), 100_000);
+        assert_eq!(stats.per_thread_idle_ns[1].load(Ordering::Relaxed), 200_000);
+    }
+
+    #[test]
+    fn test_pipeline_stats_log_summary_does_not_panic() {
+        let stats = SortPipelineStats::new(4);
+        stats.record_step(0, SortStep::ReadInputBlocks, 1_000_000_000);
+        stats.record_step(1, SortStep::CompressSpill, 500_000_000);
+        stats.record_idle(0, 10_000_000);
+        // Verify log_summary doesn't panic (output goes to log, not captured in tests)
+        stats.log_summary();
+    }
+
+    #[test]
+    fn test_buffer_pool_full_drops_excess() {
+        let pool = BufferPool::new(2);
+
+        // Put 3 items in a capacity-2 pool; checkin clears len but preserves capacity.
+        pool.checkin(Vec::with_capacity(256));
+        pool.checkin(Vec::with_capacity(512));
+        pool.checkin(Vec::with_capacity(1024)); // silently dropped (pool full)
+
+        // Drain the 2 pooled items — both are len=0 but retain non-zero capacity.
+        let a = pool.checkout();
+        let b = pool.checkout();
+        assert!(
+            a.capacity() > 0 || b.capacity() > 0,
+            "at least one pooled buffer should retain allocated capacity"
+        );
+
+        // Third checkout: pool exhausted → fresh Vec::default() with zero capacity.
+        let fresh = pool.checkout();
+        assert_eq!(fresh.len(), 0);
+        assert_eq!(fresh.capacity(), 0, "fresh allocation has no pre-allocated capacity");
+    }
+
+    #[test]
+    fn test_sort_priorities_phase1_default_feeds_main_thread() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: true,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: false,
+            all_chunks_eof: false,
+            compress_has_items: false,
+            phase: phase::PHASE1,
+        };
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities[0], SortStep::DecompressInput);
+    }
+
+    #[test]
+    fn test_sort_priorities_phase1_compress_backpressure() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: false,
+            all_chunks_eof: false,
+            compress_has_items: true,
+            phase: phase::PHASE1,
+        };
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities[0], SortStep::CompressSpill);
+    }
+
+    #[test]
+    fn test_sort_priorities_phase1_all_done_returns_empty() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: true,
+            decompressed_input_done: true,
+            decompressed_chunks_low: false,
+            all_chunks_eof: false,
+            compress_has_items: false,
+            phase: phase::PHASE1,
+        };
+        assert!(get_sort_priorities(&bp).is_empty());
+    }
+
+    #[test]
+    fn test_sort_priorities_phase2_default_feeds_merge_loop() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: true,
+            all_chunks_eof: false,
+            compress_has_items: false,
+            phase: phase::PHASE2,
+        };
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities[0], SortStep::DecompressChunks);
+    }
+
+    #[test]
+    fn test_sort_priorities_phase2_compress_backpressure() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: false,
+            all_chunks_eof: false,
+            compress_has_items: true,
+            phase: phase::PHASE2,
+        };
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities[0], SortStep::CompressOutput);
+    }
+
+    #[test]
+    fn test_sort_priorities_phase2_all_done_returns_empty() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: false,
+            all_chunks_eof: true,
+            compress_has_items: false,
+            phase: phase::PHASE2,
+        };
+        assert!(get_sort_priorities(&bp).is_empty());
+    }
+
+    #[test]
+    fn test_sort_priorities_legacy_returns_compress_only() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            decompressed_chunks_low: false,
+            all_chunks_eof: false,
+            compress_has_items: true,
+            phase: phase::LEGACY,
+        };
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities.len(), 1);
+        assert_eq!(priorities[0], SortStep::CompressSpill);
+    }
+
+    #[test]
+    fn test_worker_pool_num_workers() {
+        let pool = SortWorkerPool::new(3, 1, 6);
+        assert_eq!(pool.num_workers(), 3);
+        pool.shutdown();
+    }
+}

--- a/src/lib/system.rs
+++ b/src/lib/system.rs
@@ -1,0 +1,77 @@
+//! Cgroup-aware system resource detection.
+//!
+//! Provides [`detect_total_memory`] and [`detect_cpu_count`] which correctly
+//! report resource limits when running inside Docker or Kubernetes containers.
+//! Both functions take the minimum of the cgroup limit and the host value so
+//! they behave correctly on bare-metal too.
+//!
+//! # Memory (`detect_total_memory`)
+//!
+//! Uses `sysinfo::System::cgroup_limits()` which reads:
+//! - cgroup v2: `/sys/fs/cgroup/memory.max`
+//! - cgroup v1: `/sys/fs/cgroup/memory/memory.limit_in_bytes`
+//!
+//! Falls back to `System::total_memory()` (physical RAM) on macOS and when
+//! no cgroup limit is configured.
+//!
+//! # CPU (`detect_cpu_count`)
+//!
+//! Uses the `num_cpus` crate which reads the CFS quota:
+//! - cgroup v2: `cpu.max`
+//! - cgroup v1: `cpu.cfs_quota_us` / `cpu.cfs_period_us`
+//!
+//! Falls back to `/proc/cpuinfo` on Linux and `sysctl` on macOS.
+//! Note: CFS quota is the *hard* limit set by `--cpus`; it is not the same as
+//! `cpu.shares` which is a soft scheduling weight.
+
+/// Returns the effective total memory available to this process in bytes.
+///
+/// Checks cgroup memory limits for container environments, falling back to
+/// physical RAM on bare-metal or macOS. Always returns `min(cgroup, physical)`.
+#[must_use]
+pub fn detect_total_memory() -> usize {
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let bytes = system.cgroup_limits().map_or_else(|| system.total_memory(), |c| c.total_memory);
+    usize::try_from(bytes).unwrap_or(usize::MAX)
+}
+
+/// Returns the number of logical CPUs available to this process.
+///
+/// Respects cgroup CPU quotas (set by `--cpus` in Docker or resource limits in
+/// Kubernetes), falling back to the physical core count. Returns at least 1.
+#[must_use]
+pub fn detect_cpu_count() -> usize {
+    num_cpus::get().max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_total_memory_nonzero() {
+        let total = detect_total_memory();
+        assert!(total >= 64 * 1024 * 1024, "expected at least 64 MiB, got {total}");
+    }
+
+    #[test]
+    fn test_detect_total_memory_bounded_by_physical() {
+        let total = detect_total_memory();
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        let physical = usize::try_from(system.total_memory()).unwrap_or(usize::MAX);
+        assert!(total <= physical, "cgroup-limited total {total} exceeded physical {physical}");
+    }
+
+    #[test]
+    fn test_detect_cpu_count_at_least_one() {
+        assert!(detect_cpu_count() >= 1);
+    }
+
+    #[test]
+    fn test_detect_cpu_count_reasonable() {
+        // No machine has more than 65536 logical CPUs (yet).
+        assert!(detect_cpu_count() <= 65536);
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -31,6 +31,7 @@ mod test_simplex_command;
 mod test_simplex_metrics_command;
 mod test_simplex_pipeline;
 mod test_simulate_sort;
+mod test_sort_correctness;
 mod test_sort_write_index;
 mod test_streaming_input;
 mod test_zipper_command;

--- a/tests/integration/test_sort_correctness.rs
+++ b/tests/integration/test_sort_correctness.rs
@@ -1,0 +1,401 @@
+//! Sort correctness tests for all sort orders and spill configurations.
+//!
+//! Validates that `fgumi sort` produces correctly sorted output across:
+//! - All 4 sort orders (coordinate, queryname-lex, queryname-natural, template-coordinate)
+//! - Multiple thread counts (1, 2, 4)
+//! - Various memory limits forcing 0, 1, and multiple spills
+//! - Record content is preserved (byte-identical records)
+
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn fgumi_binary() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_fgumi"))
+}
+
+fn fgumi(args: &[OsString]) -> Output {
+    Command::new(fgumi_binary()).args(args).output().expect("failed to execute fgumi")
+}
+
+fn samtools_available() -> bool {
+    Command::new("samtools").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Create a test BAM with many records at various positions using samtools.
+/// Returns the path to the unsorted BAM.
+fn create_test_bam(dir: &Path, num_reads: usize) -> std::path::PathBuf {
+    let bam_path = dir.join("unsorted.bam");
+
+    // Build SAM content with reads spread across multiple chromosomes
+    let mut sam = String::new();
+    sam.push_str("@HD\tVN:1.6\tSO:unsorted\n");
+    sam.push_str("@SQ\tSN:chr1\tLN:100000\n");
+    sam.push_str("@SQ\tSN:chr2\tLN:100000\n");
+    sam.push_str("@SQ\tSN:chr3\tLN:100000\n");
+    sam.push_str("@RG\tID:rg1\tSM:sample1\tLB:lib1\n");
+
+    let seq = "ACGTACGTAC";
+    let qual = "IIIIIIIIII";
+
+    // Generate reads in a deliberately unsorted order
+    for i in 0..num_reads {
+        let chrom = match i % 3 {
+            0 => "chr2",
+            1 => "chr1",
+            _ => "chr3",
+        };
+        // Positions go backwards within each chromosome to ensure unsorted input
+        let pos = 50000 - (i % 1000) * 50 + 1;
+        // Use non-zero-padded names so natural and lexicographic sort produce different
+        // orderings (e.g. read_2 < read_10 under natural but read_10 < read_2 under lex).
+        let name = format!("read_{i}");
+
+        // Paired-end reads
+        let mate_pos = pos + 200;
+        // Assign each template to one of 4 cells so template-coordinate tests
+        // exercise the cell-aware sort key path, not just the fallback.
+        let cell = format!("cell{}", i % 4);
+        // R1
+        writeln!(
+            sam,
+            "{name}\t99\t{chrom}\t{pos}\t60\t10M\t=\t{mate_pos}\t210\t{seq}\t{qual}\tRG:Z:rg1\tMI:Z:umi_{i}\tCB:Z:{cell}"
+        )
+        .expect("write SAM record");
+        // R2
+        writeln!(
+            sam,
+            "{name}\t147\t{chrom}\t{mate_pos}\t60\t10M\t=\t{pos}\t-210\t{seq}\t{qual}\tRG:Z:rg1\tMI:Z:umi_{i}\tCB:Z:{cell}"
+        )
+        .expect("write SAM record");
+    }
+
+    // Add some unmapped reads
+    for i in 0..10 {
+        let name = format!("unmapped_{i:04}");
+        writeln!(sam, "{name}\t77\t*\t0\t0\t*\t*\t0\t0\t{seq}\t{qual}\tRG:Z:rg1")
+            .expect("write SAM record");
+        writeln!(sam, "{name}\t141\t*\t0\t0\t*\t*\t0\t0\t{seq}\t{qual}\tRG:Z:rg1")
+            .expect("write SAM record");
+    }
+
+    let sam_path = dir.join("unsorted.sam");
+    std::fs::write(&sam_path, sam).expect("write SAM");
+
+    // Convert to BAM
+    let status = Command::new("samtools")
+        .args(["view", "-b", "-o", bam_path.to_str().unwrap(), sam_path.to_str().unwrap()])
+        .status()
+        .expect("samtools view");
+    assert!(status.success(), "samtools view failed");
+
+    bam_path
+}
+
+/// Run `fgumi sort --verify` and return whether the file is correctly sorted.
+fn verify_sorted(bam_path: &Path, order: &str) -> bool {
+    let mut cmd_args: Vec<OsString> = vec![
+        "sort".into(),
+        "--verify".into(),
+        "-i".into(),
+        bam_path.as_os_str().to_owned(),
+        "--order".into(),
+        order.into(),
+    ];
+    if order == "template-coordinate" {
+        cmd_args.push("--cell-tag".into());
+        cmd_args.push("CB".into());
+    }
+    let output = fgumi(&cmd_args);
+    output.status.success()
+}
+
+/// Count records in a BAM using samtools.
+fn count_records(bam_path: &Path) -> u64 {
+    let output = Command::new("samtools")
+        .args(["view", "-c", bam_path.to_str().unwrap()])
+        .output()
+        .expect("samtools view -c");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .expect("samtools view -c output should be a valid integer")
+}
+
+/// Sort a BAM file with fgumi and return the output path.
+fn sort_bam(input: &Path, output: &Path, order: &str, threads: usize, max_memory: &str) {
+    sort_bam_with_args(input, output, order, threads, max_memory, &[]);
+}
+
+fn sort_bam_with_args(
+    input: &Path,
+    output: &Path,
+    order: &str,
+    threads: usize,
+    max_memory: &str,
+    extra_args: &[&str],
+) {
+    let mut cmd_args: Vec<OsString> = vec![
+        "sort".into(),
+        "-i".into(),
+        input.as_os_str().to_owned(),
+        "-o".into(),
+        output.as_os_str().to_owned(),
+        "--order".into(),
+        order.into(),
+        "--threads".into(),
+        threads.to_string().into(),
+        "-m".into(),
+        max_memory.into(),
+        "--temp-compression".into(),
+        "1".into(),
+    ];
+    if order == "template-coordinate" {
+        cmd_args.push("--cell-tag".into());
+        cmd_args.push("CB".into());
+    }
+    for arg in extra_args {
+        cmd_args.push((*arg).into());
+    }
+    let output_result = fgumi(&cmd_args);
+    assert!(
+        output_result.status.success(),
+        "fgumi sort failed for order={order} threads={threads} memory={max_memory}:\nstderr: {}",
+        String::from_utf8_lossy(&output_result.stderr),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Coordinate Sort
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_in_memory() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 500);
+    let output = dir.path().join("sorted.bam");
+
+    // Large memory = no spills (in-memory sort)
+    sort_bam(&input, &output, "coordinate", 2, "100M");
+    assert!(verify_sorted(&output, "coordinate"), "coordinate sort verification failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_with_spills() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 2000);
+    let output = dir.path().join("sorted.bam");
+
+    // Small memory = forces spills to disk
+    sort_bam(&input, &output, "coordinate", 2, "50K");
+    assert!(verify_sorted(&output, "coordinate"), "coordinate sort with spills failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_many_spills_t4() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 3000);
+    let output = dir.path().join("sorted.bam");
+
+    // Very small memory with 4 threads = many spills
+    sort_bam(&input, &output, "coordinate", 4, "30K");
+    assert!(verify_sorted(&output, "coordinate"), "coordinate sort many spills failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_single_thread() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 1000);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "coordinate", 1, "50K");
+    assert!(verify_sorted(&output, "coordinate"), "coordinate sort t1 failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Queryname Lexicographic Sort
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_queryname_lex_in_memory() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 500);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "queryname", 2, "100M");
+    assert!(verify_sorted(&output, "queryname"), "queryname-lex sort failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_queryname_lex_with_spills() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 2000);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "queryname", 2, "50K");
+    assert!(verify_sorted(&output, "queryname"), "queryname-lex sort with spills failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Queryname Natural Sort
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_queryname_natural_in_memory() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 500);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "queryname::natural", 2, "100M");
+    assert!(verify_sorted(&output, "queryname::natural"), "queryname-natural sort failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_queryname_natural_with_spills() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 2000);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "queryname::natural", 2, "50K");
+    assert!(
+        verify_sorted(&output, "queryname::natural"),
+        "queryname-natural sort with spills failed"
+    );
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Template-Coordinate Sort
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_template_coordinate_in_memory() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 500);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "template-coordinate", 2, "100M");
+    assert!(verify_sorted(&output, "template-coordinate"), "template-coordinate sort failed");
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_template_coordinate_with_spills() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 2000);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "template-coordinate", 2, "50K");
+    assert!(
+        verify_sorted(&output, "template-coordinate"),
+        "template-coordinate sort with spills failed"
+    );
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_template_coordinate_many_spills_t4() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 3000);
+    let output = dir.path().join("sorted.bam");
+
+    sort_bam(&input, &output, "template-coordinate", 4, "30K");
+    assert!(
+        verify_sorted(&output, "template-coordinate"),
+        "template-coordinate many spills failed"
+    );
+    assert_eq!(count_records(&input), count_records(&output), "record count mismatch");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Consistency across thread counts
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_consistent_across_threads() {
+    if !samtools_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let input = create_test_bam(dir.path(), 1000);
+
+    // Sort with different thread counts using small memory to force spills
+    let outputs: Vec<_> = [1, 2, 4]
+        .iter()
+        .map(|t| {
+            let output = dir.path().join(format!("sorted_t{t}.bam"));
+            sort_bam(&input, &output, "coordinate", *t, "50K");
+            output
+        })
+        .collect();
+
+    // All should be correctly sorted
+    for output in &outputs {
+        assert!(verify_sorted(output, "coordinate"), "failed for {}", output.display());
+    }
+
+    // Record counts should all match
+    let input_count = count_records(&input);
+    for output in &outputs {
+        assert_eq!(input_count, count_records(output), "count mismatch for {}", output.display());
+    }
+}


### PR DESCRIPTION
## Summary

Replaces ad-hoc thread spawning in `fgumi sort` with a structured **N+2 model**: N pool workers + 1 I/O writer thread + 1 main thread. At `--threads 4`, this reduces the thread count from ~30 to exactly 6 and cuts wall time by 35–40% vs the previous implementation.

### Worker pool (`src/lib/sort/worker_pool.rs`)

- **`ArrayQueue` everywhere**: lock-free bounded queues replace crossbeam channels for all inter-step queues, eliminating blocking push/pop in the worker loop
- **`generic_worker_loop` pattern**: held-item advancement → backpressure priorities → exclusive step ownership → adaptive backoff (10 µs min, `yield_now` + jitter, up to 1 ms)
- **Phase 1**: Worker 0 owns `ReadInputBlocks` exclusively; all workers share `DecompressInput` and `Compress`
- **Phase 2**: each worker owns its own disjoint chunk files for `ReadChunkBlocks` (no exclusivity needed); workers share `DecompressChunks` and `Compress`
- **`park()`/`unpark()`**: workers call `unpark()` after pushing to main-thread-facing queues, eliminating polling delays between the main thread and the pool
- **Workers stay alive until SHUTDOWN** (not phase completion) to prevent premature-exit deadlocks during phase transitions

### Raw sorter (`src/lib/sort/raw.rs`)

- `pool_decompress` field and `use_sequential_sort()` helper gate worker-pool I/O; when enabled, rayon `par_sort` is replaced with single-threaded sort to preserve the N+2 budget
- **Bug fix**: `merge_chunks_with_index` (coordinate sort with `--write-index`) was passing `pool_decompress=true` to `build_chunk_sources` but then calling `next_record(…, None)`, which panics for `PoolDisk` sources. Fixed to always use `pool_decompress=false` in that path until the indexing path gets a pooled writer (see TODO comment)
- Removes dead `max_memory_total` field (superseded by `MemoryLimit::Auto` from #236); `--max-memory=auto` continues to work as intended

### Staging buffer (`src/lib/sort/bgzf_io.rs`)

- Removes dead `is_spill` field from `CompressJob` and `StagingBuffer`; the worker pool does not distinguish spill vs output jobs

## Performance (coordinate sort, 60 M records, MacBook Pro M-series)

| Threads | samtools | fgumi (this PR) | speedup |
|---------|----------|-----------------|---------|
| t1      | 69 s     | 74 s            | −7%     |
| t2      | 55 s     | 46 s            | +16%    |
| t4      | 37 s     | 26 s            | +30%    |
| t8      | 26 s     | 15 s            | +42%    |

fgumi is slower than samtools at t1 (pool overhead dominates; single-thread fast path is a follow-on). From t2 onward fgumi leads and the gap widens with thread count.

## Test plan

- [ ] All 2318 existing tests pass (`cargo ci-test`)
- [ ] Format and lint clean (`cargo ci-fmt && cargo ci-lint`)
- [ ] `fgumi sort --verify` passes for all four sort orders at t1/t2/t4/t8
- [ ] Coordinate sort with `--write-index` no longer panics (regression for the `merge_chunks_with_index` fix)
- [ ] Thread count at t4: confirm exactly 6 threads during sort (`ps -M`)

## Follow-on work

- Single-thread fast path: at `--threads 1`, skip the pool entirely (matches samtools t1 behavior; tracked as a separate issue)
- Memory overuse: `io_writer_loop` `BTreeMap` reorder buffer is unbounded and can hold many in-flight compressed blocks; mimalloc arena retention also inflates RSS. Will file a separate issue.
- Pooled indexing writer: `merge_chunks_with_index` currently falls back to non-pooled I/O; replacing with `PooledIndexingBamWriter` would extend the N+2 benefit to `--write-index` paths.