### PR TITLE
perf(sort): redesign phase 2 work stealing and bound rayon to --threads

### DIFF
--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -10,7 +10,7 @@
 //! - ~24 bytes overhead per record vs ~110 bytes
 
 use crate::sort::bam_fields;
-use crate::sort::keys::{RawSortKey, SortContext};
+use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::sort::radix::bytes_needed_u64;
 use crate::sort::segmented_buf::SegmentedBuf;
 use std::cmp::Ordering;
@@ -156,6 +156,37 @@ pub struct RecordBuffer {
 /// a single BAM record (≤128 MiB in practice) always fits within one segment.
 const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
+/// Shared implementation for `par_sort_into_chunks` on both buffer types.
+///
+/// Factors out the threshold check, chunk sizing, parallel radix sort, and
+/// materialization into a single macro so tuning and fixes stay in one place.
+macro_rules! par_sort_into_chunks_impl {
+    ($self:expr, $threads:expr, $sort_fn:ident, $key_fn:expr) => {{
+        use rayon::prelude::*;
+
+        let n = $self.refs.len();
+
+        if $threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
+            $sort_fn(&mut $self.refs);
+            let chunk =
+                $self.refs.iter().map(|r| ($key_fn(r), $self.get_record(r).to_vec())).collect();
+            return vec![chunk];
+        }
+
+        let chunk_size = n.div_ceil($threads);
+
+        $self.refs.par_chunks_mut(chunk_size).for_each(|chunk| {
+            $sort_fn(chunk);
+        });
+
+        $self
+            .refs
+            .chunks(chunk_size)
+            .map(|chunk| chunk.iter().map(|r| ($key_fn(r), $self.get_record(r).to_vec())).collect())
+            .collect()
+    }};
+}
+
 impl RecordBuffer {
     /// Create a new buffer with estimated capacity.
     ///
@@ -243,6 +274,23 @@ impl RecordBuffer {
         // Radix sort is already O(n×k), so parallelizing chunks provides
         // linear speedup without the merge overhead of comparison-based parallel sorts
         parallel_radix_sort_record_refs(&mut self.refs);
+    }
+
+    /// Sort in parallel and return each sub-array as a separate sorted chunk.
+    ///
+    /// Instead of merging the parallel sort sub-arrays back into one sorted
+    /// buffer (as `par_sort` does), this returns each sub-array as its own
+    /// `Vec<(RawCoordinateKey, Vec<u8>)>` so they can be passed as separate
+    /// merge sources to the k-way merge, avoiding the intermediate merge step.
+    ///
+    /// When `threads <= 1`, returns a single chunk.
+    pub fn par_sort_into_chunks(
+        &mut self,
+        threads: usize,
+    ) -> Vec<Vec<(RawCoordinateKey, Vec<u8>)>> {
+        par_sort_into_chunks_impl!(self, threads, radix_sort_record_refs, |r: &RecordRef| {
+            RawCoordinateKey { sort_key: r.sort_key }
+        })
     }
 
     /// Get record bytes by reference.
@@ -791,6 +839,23 @@ impl TemplateRecordBuffer {
     pub fn clear(&mut self) {
         self.data.clear();
         self.refs.clear();
+    }
+
+    /// Sort in parallel and return each sub-array as a separate sorted chunk.
+    ///
+    /// Instead of merging the parallel sort sub-arrays back into one sorted
+    /// buffer (as `par_sort` does), this returns each sub-array as its own
+    /// `Vec<(TemplateKey, Vec<u8>)>` so they can be passed as separate merge
+    /// sources to the k-way merge, avoiding the intermediate merge step.
+    ///
+    /// When `threads <= 1`, returns a single chunk.
+    pub fn par_sort_into_chunks(&mut self, threads: usize) -> Vec<Vec<(TemplateKey, Vec<u8>)>> {
+        par_sort_into_chunks_impl!(
+            self,
+            threads,
+            radix_sort_template_refs,
+            |r: &TemplateRecordRef| r.key
+        )
     }
 }
 
@@ -1685,6 +1750,217 @@ mod tests {
     fn test_template_key_default_has_zero_cb_hash() {
         let key = TemplateKey::default();
         assert_eq!(key.cb_hash, 0);
+    }
+
+    /// Helper: build a minimal raw BAM record byte array with a distinguishing index.
+    fn make_bam_record(index: u16) -> Vec<u8> {
+        let mut record = vec![
+            0, 0, 0, 0, // ref_id = 0
+            100, 0, 0, 0, // pos = 100
+            2, // name_len = 2 (including null)
+            0, // mapq = 0
+            0, 0, // bin
+            0, 0, // n_cigar_op = 0
+            99, 0, // flag = 99 (paired, proper, mate reverse, first)
+            1, 0, 0, 0, // seq_len = 1
+            0, 0, 0, 0, // mate_ref_id = 0
+            200, 0, 0, 0, // mate_pos = 200
+            0, 0, 0, 0, // tlen = 0
+            b'A', 0, // read name "A\0"
+        ];
+        // Encode the index into two bytes so each record is distinguishable
+        record.push((index & 0xFF) as u8);
+        record.push((index >> 8) as u8);
+        record.push(0xFF); // qual
+        // Pad to at least 40 bytes
+        while record.len() < 40 {
+            record.push(0);
+        }
+        record
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_single_threaded_fallback() {
+        // With 1 thread, par_sort_into_chunks should return exactly 1 chunk.
+        let n = 100;
+        let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
+
+        for i in 0..n {
+            let key = TemplateKey::new(
+                0,
+                (n - i) as i32,
+                false,
+                0,
+                200,
+                false,
+                0,
+                0,
+                (1, true),
+                0,
+                false,
+            );
+            buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
+        }
+
+        let chunks = buffer.par_sort_into_chunks(1);
+        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+
+        // Verify the chunk is sorted
+        for i in 1..chunks[0].len() {
+            assert!(
+                chunks[0][i - 1].0 <= chunks[0][i].0,
+                "single chunk should be sorted at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_parallel_path() {
+        // Use a dedicated rayon thread pool with multiple threads so that
+        // rayon::current_num_threads() > 1 inside par_sort_into_chunks.
+        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2 (512)
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("failed to build rayon thread pool");
+
+        let chunks = pool.install(|| {
+            let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
+
+            for i in 0..n {
+                // Vary the primary sort field so records are not all equal
+                let key = TemplateKey::new(
+                    0,
+                    (n - i) as i32,
+                    false,
+                    0,
+                    200,
+                    false,
+                    0,
+                    0,
+                    (1, true),
+                    0,
+                    false,
+                );
+                buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
+            }
+
+            buffer.par_sort_into_chunks(4)
+        });
+
+        // With 4 threads and > 10_000 records we should get multiple chunks
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks from parallel path, got {}",
+            chunks.len()
+        );
+
+        // Verify each chunk is individually sorted
+        for (ci, chunk) in chunks.iter().enumerate() {
+            for i in 1..chunk.len() {
+                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
+            }
+        }
+
+        // Verify total record count across all chunks matches input
+        let total: usize = chunks.iter().map(Vec::len).sum();
+        assert_eq!(total, n, "total records across chunks should equal input count");
+    }
+
+    /// Helper: build a minimal raw BAM record for coordinate sort with a specific position.
+    fn make_coordinate_bam_record(tid: i32, pos: i32) -> Vec<u8> {
+        let mut record = Vec::with_capacity(40);
+        record.extend_from_slice(&tid.to_le_bytes()); // ref_id
+        record.extend_from_slice(&pos.to_le_bytes()); // pos
+        record.push(2); // name_len = 2 (including null)
+        record.push(0); // mapq = 0
+        record.extend_from_slice(&0u16.to_le_bytes()); // bin
+        record.extend_from_slice(&0u16.to_le_bytes()); // n_cigar_op = 0
+        record.extend_from_slice(&0u16.to_le_bytes()); // flags = 0 (forward)
+        record.extend_from_slice(&1u32.to_le_bytes()); // seq_len = 1
+        record.extend_from_slice(&(-1i32).to_le_bytes()); // mate_ref_id
+        record.extend_from_slice(&(-1i32).to_le_bytes()); // mate_pos
+        record.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        record.push(b'A'); // read name
+        record.push(0); // null terminator
+        // Pad to at least 34 bytes (bam_fields::flags reads at offset 14-15)
+        while record.len() < 40 {
+            record.push(0);
+        }
+        record
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_coordinate_single_threaded() {
+        let nref = 10u32;
+        let n = 100;
+        let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
+
+        for i in 0..n {
+            // Reverse order so sorting is non-trivial
+            let pos = (n - i) as i32;
+            buffer
+                .push_coordinate(&make_coordinate_bam_record(0, pos))
+                .expect("push_coordinate should succeed in tests");
+        }
+
+        let chunks = buffer.par_sort_into_chunks(1);
+        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+
+        // Verify the chunk is sorted by key
+        for i in 1..chunks[0].len() {
+            assert!(
+                chunks[0][i - 1].0 <= chunks[0][i].0,
+                "single chunk should be sorted at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_coordinate_parallel() {
+        let nref = 10u32;
+        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("failed to build rayon thread pool");
+
+        let chunks = pool.install(|| {
+            let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
+
+            for i in 0..n {
+                let pos = (n - i) as i32;
+                buffer
+                    .push_coordinate(&make_coordinate_bam_record(0, pos))
+                    .expect("push_coordinate should succeed in tests");
+            }
+
+            buffer.par_sort_into_chunks(4)
+        });
+
+        // With 4 threads and > 10_000 records we should get multiple chunks
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks from parallel path, got {}",
+            chunks.len()
+        );
+
+        // Verify each chunk is individually sorted
+        for (ci, chunk) in chunks.iter().enumerate() {
+            for i in 1..chunk.len() {
+                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
+            }
+        }
+
+        // Verify total record count across all chunks matches input
+        let total: usize = chunks.iter().map(Vec::len).sum();
+        assert_eq!(total, n, "total records across chunks should equal input count");
     }
 
     mod proptest_msd {

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -112,8 +112,8 @@ impl SortPhaseTimer {
     }
 
     /// Time a sort operation.
-    fn time_sort(&mut self, f: impl FnOnce()) {
-        Self::time(&mut self.sort_secs, f);
+    fn time_sort<T>(&mut self, f: impl FnOnce() -> T) -> T {
+        Self::time(&mut self.sort_secs, f)
     }
 
     /// Time a spill write operation.
@@ -767,102 +767,59 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
 }
 
 // ============================================================================
-// MainThreadChunkConsumer — pool-integrated merge reader (replaces GenericKeyedChunkReader)
+// MainThreadChunkConsumer — pool-integrated merge reader
 // ============================================================================
+//
+// The pool's worker threads read raw BGZF blocks from disk, decompress them,
+// and insert the decompressed blocks into per-file `ReorderBuffer`s held in
+// each `Phase2FileState`. The main thread (the merge loop) holds a snapshot of
+// those file states and pulls one decompressed block at a time per source as
+// the loser tree advances. There is no global queue and no per-source
+// reorder/buffering layer in the consumer itself — the per-file
+// `Phase2FileState.decompressed` reorder buffer IS the per-source buffer.
+//
+// Backpressure is enforced inside the worker pool: when a per-file reorder
+// buffer reaches `PHASE2_DECOMP_CAP`, workers stop pulling new raw blocks for
+// that file (with a deadlock-free escape hatch for the gap-filling serial).
 
-/// Per-source buffer for reassembling decompressed blocks into a record stream.
-struct PerSourceBuffer {
-    /// Reorder buffer: holds out-of-order decompressed blocks until their serial is next.
-    ///
-    /// Uses `ReorderBuffer` instead of `BTreeMap` for O(1) insert and pop (sequential
-    /// blocks from the pool are common, giving `VecDeque` O(1) amortised behaviour vs
-    /// `BTreeMap`'s O(log n)).
-    pending: crate::reorder_buffer::ReorderBuffer<Vec<u8>>,
-    /// Current byte buffer being consumed by the record parser.
+/// Per-source byte-stream parser state owned by the main thread.
+///
+/// As blocks are pulled from `Phase2FileState.decompressed`, the bytes are
+/// stashed in `current_buf` and consumed left-to-right by the record parser.
+struct SourceParserState {
+    /// Current decompressed block being consumed.
     current_buf: Vec<u8>,
     /// Read position within `current_buf`.
     current_pos: usize,
-    /// Whether this source has seen all its decompressed blocks.
-    eof: bool,
 }
 
-impl PerSourceBuffer {
+impl SourceParserState {
     fn new() -> Self {
-        Self {
-            pending: crate::reorder_buffer::ReorderBuffer::new(),
-            current_buf: Vec::new(),
-            current_pos: 0,
-            eof: false,
-        }
+        Self { current_buf: Vec::new(), current_pos: 0 }
     }
 
-    /// Return how many bytes remain in the current buffer.
     fn remaining(&self) -> usize {
         self.current_buf.len() - self.current_pos
     }
-
-    /// Advance to the next pending block if the current one is exhausted.
-    ///
-    /// Returns `(data_available, consumed_pending)` where `consumed_pending` is `true`
-    /// when a block was moved from `pending` into `current_buf`.  The caller uses
-    /// `consumed_pending` to decrement the consumer's `pending_total` counter.
-    fn advance_if_needed(&mut self) -> (bool, bool) {
-        if self.remaining() > 0 {
-            return (true, false);
-        }
-        if let Some(data) = self.pending.try_pop_next() {
-            self.current_buf = data;
-            self.current_pos = 0;
-            (true, true)
-        } else {
-            (false, false)
-        }
-    }
 }
 
-/// Reads from the pool's `decompressed_chunks` queue and presents records to the merge loop.
+/// Reads from per-file decompressed-block reorder buffers and presents records
+/// to the merge loop.
 ///
-/// Replaces `GenericKeyedChunkReader` for the pool-integrated path. No threads are spawned —
-/// the main thread drives all consumption. Workers in the pool do all the reading and
-/// decompression.
+/// The main thread drives all record consumption; no threads are spawned here.
+/// Sort-pool workers do the disk reads and BGZF decompression in parallel and
+/// publish results into per-file `Phase2FileState.decompressed` reorder
+/// buffers, which this consumer drains in serial order.
 ///
 /// # Type Parameter
 ///
 /// `K` is the sort key type (`RawCoordinateKey`, `TemplateKey`, etc.).
-pub struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
-    /// Per-source reorder/parse buffers.
-    per_source: Vec<PerSourceBuffer>,
-    /// `ArrayQueue` to pop decompressed blocks from pool workers.
-    decompressed_chunks: std::sync::Arc<
-        crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedDecompressedBlock>,
-    >,
-    /// Raw (pre-decompression) chunk blocks in flight.
-    ///
-    /// `all_chunks_eof` is set when raw reads from disk finish, but blocks may still
-    /// be in this queue awaiting decompression. The EOF check in `poll_decompressed_blocks`
-    /// must wait for this queue to drain to avoid declaring EOF prematurely and losing data.
-    raw_chunk_blocks:
-        std::sync::Arc<crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedRawBlock>>,
-    /// Shared flag: set when all chunk files have been fully read from disk.
-    ///
-    /// Note: this is set when raw reads finish, not when decompression is done.
-    /// Always check `raw_chunk_blocks.is_empty()` alongside this before declaring EOF.
-    all_chunks_eof: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    /// Maximum total pending blocks across all per-source buffers before we stop draining.
-    ///
-    /// Caps memory growth: without this, `poll_decompressed_blocks` could drain the entire
-    /// `decompressed_chunks` queue into unbounded per-source `pending` maps, bypassing the
-    /// backpressure the `ArrayQueue` was meant to provide.
-    max_pending_blocks: usize,
-    /// Running total of blocks currently in all per-source `pending` maps.
-    ///
-    /// Maintained incrementally so the cap check in `poll_decompressed_blocks` is O(1)
-    /// instead of `O(num_sources)`.
-    pending_total: usize,
+pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
+    /// Snapshot of the pool's Phase 2 file vector. Indexed by `source_id`.
+    files: Arc<Vec<crate::sort::worker_pool::Phase2FileState>>,
+    /// Per-source parser state.
+    parser_state: Vec<SourceParserState>,
     /// Set by a pool worker when BGZF decompression of a chunk block fails.
-    ///
-    /// Checked in `poll_decompressed_blocks` so the main thread surfaces the error instead
-    /// of parking forever waiting for data that will never arrive.
     decompression_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Set by a pool worker when a chunk file I/O read fails.
     chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -872,31 +829,18 @@ pub struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
 }
 
 impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
-    /// Create a new consumer for the given number of sources.
+    /// Create a new consumer for the given pool file snapshot.
     #[must_use]
-    pub fn new(
-        num_sources: usize,
-        decompressed_chunks: std::sync::Arc<
-            crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedDecompressedBlock>,
-        >,
-        raw_chunk_blocks: std::sync::Arc<
-            crossbeam_queue::ArrayQueue<crate::sort::worker_pool::TaggedRawBlock>,
-        >,
-        all_chunks_eof: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    pub(crate) fn new(
+        files: Arc<Vec<crate::sort::worker_pool::Phase2FileState>>,
         decompression_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
-        let per_source = (0..num_sources).map(|_| PerSourceBuffer::new()).collect();
-        // Default cap: queue capacity (num_workers * 8); keeps total pending ≤ 2× queue depth.
-        let max_pending_blocks = decompressed_chunks.capacity();
+        let parser_state = (0..files.len()).map(|_| SourceParserState::new()).collect();
         Self {
-            per_source,
-            decompressed_chunks,
-            raw_chunk_blocks,
-            all_chunks_eof,
-            max_pending_blocks,
-            pending_total: 0,
+            files,
+            parser_state,
             decompression_error,
             chunk_read_error,
             worker_panicked,
@@ -906,84 +850,51 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
 
     /// Get the next record from a specific source.
     ///
-    /// Polls the `decompressed_chunks` queue as needed, dispatching blocks to their
-    /// correct per-source buffer. Parses the next record from the source's byte stream.
+    /// Pulls decompressed blocks from the source's per-file reorder buffer as
+    /// needed. Parses the next record from the source's byte stream.
     ///
     /// Returns `Ok(Some(key))` with record bytes swapped into `buf`, `Ok(None)` at EOF.
     ///
     /// # Errors
     ///
-    /// Returns an error if a record is truncated or if reading from the source fails.
+    /// Returns an error if a record is truncated or if a worker reported an error.
     pub fn next_record(&mut self, source_id: usize, buf: &mut Vec<u8>) -> Result<Option<K>> {
-        loop {
-            let (_, consumed) = self.per_source[source_id].advance_if_needed();
-            if consumed {
-                self.pending_total = self.pending_total.saturating_sub(1);
-            }
-
-            // Try to parse a record from the current data
-            if self.per_source[source_id].remaining() > 0 {
-                return self.parse_next_record(source_id, buf);
-            }
-
-            // If this source is at EOF and no pending blocks, it's done
-            if self.per_source[source_id].eof && self.per_source[source_id].pending.is_empty() {
-                return Ok(None);
-            }
-
-            // Need more data — poll the shared queue and dispatch
-            if !self.poll_decompressed_blocks(source_id)? {
-                // Queue closed and no more data for this source
-                self.per_source[source_id].eof = true;
-                if self.per_source[source_id].pending.is_empty()
-                    && self.per_source[source_id].remaining() == 0
-                {
-                    return Ok(None);
-                }
-            }
+        // Make sure we have data (or detect EOF) before parsing.
+        if self.parser_state[source_id].remaining() == 0
+            && !self.advance_to_next_block(source_id)?
+        {
+            return Ok(None);
         }
+        self.parse_next_record(source_id, buf)
     }
 
-    /// Poll the `decompressed_chunks` `ArrayQueue`, dispatching blocks to per-source buffers.
+    /// Pull the next decompressed block for `source_id` from the per-file
+    /// reorder buffer, blocking the main thread (`std::thread::park`) until
+    /// either a block becomes available, the source drains, or a worker error
+    /// is reported.
     ///
-    /// Drains all available blocks into per-source buffers, then checks if the
-    /// target source has data. If not, parks the thread until a worker calls
-    /// `unpark()` after pushing new data.
-    ///
-    /// Returns `false` if all chunks are done (no more blocks coming).
-    fn poll_decompressed_blocks(&mut self, target_source: usize) -> Result<bool> {
+    /// Returns `Ok(true)` if a new block was loaded into `current_buf`,
+    /// `Ok(false)` if the source has produced all its data, or an error if a
+    /// worker reported a fatal failure.
+    fn advance_to_next_block(&mut self, source_id: usize) -> Result<bool> {
+        let file = &self.files[source_id];
         loop {
-            // Drain available blocks into per-source buffers.
-            //
-            // We always drain until the target source has data, regardless of the pending cap.
-            // Once the target is satisfied we respect the cap to bound memory growth — without
-            // it we could drain the entire decompressed_chunks ArrayQueue into unbounded
-            // per-source maps, bypassing the backpressure the ArrayQueue was meant to provide.
-            // Skipping the drain entirely when at cap is a deadlock: if the target's next block
-            // is already in the queue but we refuse to pop it, we park forever.
-            while let Some(block) = self.decompressed_chunks.pop() {
-                let sid = block.source_id;
-                self.per_source[sid].pending.insert(block.serial, block.data);
-                self.pending_total += 1;
-                // Once the target has data, respect the pending cap to bound memory growth.
-                // `can_pop()` is O(1) — no map lookup needed.
-                let target = &self.per_source[target_source];
-                if (target.remaining() > 0 || target.pending.can_pop())
-                    && self.pending_total >= self.max_pending_blocks
-                {
-                    break;
+            // Try to pop the next-in-order decompressed block.
+            {
+                let mut guard =
+                    file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+                if let Some(data) = guard.try_pop_next() {
+                    drop(guard);
+                    let st = &mut self.parser_state[source_id];
+                    st.current_buf = data;
+                    st.current_pos = 0;
+                    return Ok(true);
                 }
             }
 
-            // Check if the target source now has data
-            let target = &self.per_source[target_source];
-            if target.remaining() > 0 || target.pending.can_pop() {
-                return Ok(true);
-            }
-
-            // Check for worker errors before EOF — if a worker failed, the EOF condition
-            // may also be set (e.g. single-source sort where all_chunks_eof fires on the
-            // same iteration). The error must win to avoid silently truncating output.
+            // No block ready. Check error flags first — they take precedence
+            // over EOF detection so a single-source sort that fails on its
+            // last block surfaces the error rather than silently truncating.
             if self.decompression_error.load(std::sync::atomic::Ordering::Acquire) {
                 return Err(anyhow::anyhow!(
                     "BGZF decompression error on chunk blocks (see log for details)"
@@ -998,21 +909,15 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 ));
             }
 
-            // Check EOF: all raw blocks must be read AND decompressed before declaring done.
-            // `all_chunks_eof` is set when raw disk reads finish, but blocks may still be
-            // in `raw_chunk_blocks` awaiting decompression. Checking only `decompressed_chunks`
-            // would race with the decompression workers and lose in-flight records.
-            if self.all_chunks_eof.load(std::sync::atomic::Ordering::Acquire)
-                && self.raw_chunk_blocks.is_empty()
-                && self.decompressed_chunks.is_empty()
-            {
-                for source in &mut self.per_source {
-                    source.eof = true;
-                }
+            // Source produced everything it ever will?
+            if file.is_drained() {
                 return Ok(false);
             }
 
-            // Park until a worker pushes a block and calls unpark()
+            // Park until a worker unparks us. Workers unpark after pushing a
+            // decompressed block, after setting reader.eof, and after error
+            // flags. The loop re-checks all conditions on wake-up so spurious
+            // wake-ups are harmless.
             std::thread::park();
         }
     }
@@ -1056,7 +961,8 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         }
     }
 
-    /// Read exactly `n` bytes from a source into `out`, pulling more blocks as needed.
+    /// Read exactly `out.len()` bytes from a source into `out`, pulling more
+    /// blocks from the per-file reorder buffer as needed.
     ///
     /// Returns `Ok(false)` at clean EOF (zero bytes available), `Ok(true)` on success.
     fn read_exact_from_source(&mut self, source_id: usize, out: &mut [u8]) -> Result<bool> {
@@ -1064,20 +970,8 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         let mut filled = 0;
 
         while filled < n {
-            let (_, consumed) = self.per_source[source_id].advance_if_needed();
-            if consumed {
-                self.pending_total = self.pending_total.saturating_sub(1);
-            }
-
-            if self.per_source[source_id].remaining() > 0 {
-                let src = &mut self.per_source[source_id];
-                let take = (n - filled).min(src.remaining());
-                out[filled..filled + take]
-                    .copy_from_slice(&src.current_buf[src.current_pos..src.current_pos + take]);
-                src.current_pos += take;
-                filled += take;
-            } else if self.per_source[source_id].eof
-                && self.per_source[source_id].pending.is_empty()
+            if self.parser_state[source_id].remaining() == 0
+                && !self.advance_to_next_block(source_id)?
             {
                 if filled == 0 {
                     return Ok(false);
@@ -1085,21 +979,14 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 return Err(anyhow::anyhow!(
                     "truncated data in chunk source {source_id}: got {filled} of {n} bytes",
                 ));
-            } else if !self.poll_decompressed_blocks(source_id)? {
-                self.per_source[source_id].eof = true;
-                let (_, consumed) = self.per_source[source_id].advance_if_needed();
-                if consumed {
-                    self.pending_total = self.pending_total.saturating_sub(1);
-                }
-                if self.per_source[source_id].remaining() == 0 {
-                    if filled == 0 {
-                        return Ok(false);
-                    }
-                    return Err(anyhow::anyhow!(
-                        "truncated data in chunk source {source_id}: got {filled} of {n} bytes",
-                    ));
-                }
             }
+
+            let st = &mut self.parser_state[source_id];
+            let take = (n - filled).min(st.remaining());
+            out[filled..filled + take]
+                .copy_from_slice(&st.current_buf[st.current_pos..st.current_pos + take]);
+            st.current_pos += take;
+            filled += take;
         }
 
         Ok(true)
@@ -1109,16 +996,13 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
     ///
     /// Returns `Ok(None)` at clean EOF.
     fn read_key_from_source<KK: RawSortKey>(&mut self, source_id: usize) -> Result<Option<KK>> {
-        // Create a Read adapter over the source's buffer
         let mut adapter = SourceReadAdapter { consumer: self, source_id, bytes_read: 0 };
         match KK::read_from(&mut adapter) {
             Ok(key) => Ok(Some(key)),
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 if adapter.bytes_read == 0 {
-                    // No bytes consumed — clean EOF between records
                     Ok(None)
                 } else {
-                    // Some bytes consumed before EOF — truncated key
                     Err(anyhow::anyhow!(
                         "truncated key in chunk source {source_id}: \
                          got {n} bytes then EOF",
@@ -1144,52 +1028,21 @@ struct SourceReadAdapter<'a, K: RawSortKey + 'static> {
 
 impl<K: RawSortKey + 'static> Read for SourceReadAdapter<'_, K> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        // Try current buffer first
-        let (_, consumed) = self.consumer.per_source[self.source_id].advance_if_needed();
-        if consumed {
-            self.consumer.pending_total = self.consumer.pending_total.saturating_sub(1);
-        }
-        if self.consumer.per_source[self.source_id].remaining() > 0 {
-            let src = &mut self.consumer.per_source[self.source_id];
-            let take = buf.len().min(src.remaining());
-            buf[..take].copy_from_slice(&src.current_buf[src.current_pos..src.current_pos + take]);
-            src.current_pos += take;
-            self.bytes_read += take;
-            return Ok(take);
-        }
-
-        // Need more blocks
-        let sid = self.source_id;
-        if self.consumer.per_source[sid].eof && self.consumer.per_source[sid].pending.is_empty() {
-            return Ok(0); // EOF
-        }
-
-        // Poll for more data (blocking)
-        match self.consumer.poll_decompressed_blocks(self.source_id) {
-            Ok(true) => {
-                let (_, consumed) = self.consumer.per_source[self.source_id].advance_if_needed();
-                if consumed {
-                    self.consumer.pending_total = self.consumer.pending_total.saturating_sub(1);
-                }
-                if self.consumer.per_source[self.source_id].remaining() > 0 {
-                    let sid = self.source_id;
-                    let source = &mut self.consumer.per_source[sid];
-                    let take = buf.len().min(source.remaining());
-                    buf[..take].copy_from_slice(
-                        &source.current_buf[source.current_pos..source.current_pos + take],
-                    );
-                    source.current_pos += take;
-                    self.bytes_read += take;
-                    Ok(take)
-                } else {
-                    // poll said data is ready but the source is still empty — retry rather
-                    // than returning Ok(0) which read_key_from_source treats as clean EOF.
-                    self.read(buf)
-                }
+        // Pull the next block if the current one is exhausted.
+        if self.consumer.parser_state[self.source_id].remaining() == 0 {
+            match self.consumer.advance_to_next_block(self.source_id) {
+                Ok(true) => {}
+                Ok(false) => return Ok(0), // clean EOF
+                Err(e) => return Err(std::io::Error::other(e.to_string())),
             }
-            Ok(false) => Ok(0), // All chunks done — clean EOF
-            Err(e) => Err(std::io::Error::other(e.to_string())),
         }
+
+        let st = &mut self.consumer.parser_state[self.source_id];
+        let take = buf.len().min(st.remaining());
+        buf[..take].copy_from_slice(&st.current_buf[st.current_pos..st.current_pos + take]);
+        st.current_pos += take;
+        self.bytes_read += take;
+        Ok(take)
     }
 }
 
@@ -1267,6 +1120,39 @@ pub struct RawExternalSorter {
     /// a modest allocation and let `Vec` grow on demand, while explicit limits
     /// pre-allocate the full budget upfront (preserving prior behavior).
     initial_capacity: Option<usize>,
+}
+
+/// RAII guard that ensures Phase 2 teardown runs on every exit path between
+/// `pool.set_phase(PHASE2)` and the explicit `deactivate()` in the merge loop.
+/// Without this, any `?` early-return would leave the pool stuck in PHASE2 with
+/// `phase2_files` still published. `deactivate()` drops the consumer (releasing
+/// the Arc snapshot of the per-file vector), resets the phase to `LEGACY`, and
+/// clears the pool's published file vector — in that order.
+struct Phase2Guard<'a, K: RawSortKey + 'static> {
+    pool: &'a Arc<SortWorkerPool>,
+    consumer: Option<MainThreadChunkConsumer<K>>,
+    active: bool,
+}
+
+impl<K: RawSortKey + 'static> Phase2Guard<'_, K> {
+    fn consumer_mut(&mut self) -> Option<&mut MainThreadChunkConsumer<K>> {
+        self.consumer.as_mut()
+    }
+
+    fn deactivate(&mut self) {
+        if self.active {
+            drop(self.consumer.take());
+            self.pool.set_phase(crate::sort::worker_pool::phase::LEGACY);
+            self.pool.clear_phase2_files();
+            self.active = false;
+        }
+    }
+}
+
+impl<K: RawSortKey + 'static> Drop for Phase2Guard<'_, K> {
+    fn drop(&mut self) {
+        self.deactivate();
+    }
 }
 
 impl RawExternalSorter {
@@ -1382,6 +1268,27 @@ impl RawExternalSorter {
     /// Uses `initial_capacity` if set, otherwise falls back to `memory_limit`.
     fn effective_initial_capacity(&self) -> usize {
         self.initial_capacity.unwrap_or(self.memory_limit).min(self.memory_limit)
+    }
+
+    /// Build a rayon thread pool sized to `self.threads`.
+    ///
+    /// The sort path uses `par_sort` and friends at several points. Rayon's
+    /// global pool defaults to `num_cpus::get()`, which silently violates the
+    /// user's `--threads` contract on machines where more physical cores are
+    /// available. Every rayon call site is wrapped with `pool.install(...)`
+    /// so that `rayon::current_num_threads()` returns `self.threads` and
+    /// fan-out is bounded to the requested thread count.
+    ///
+    /// Oversubscription with the `SortWorkerPool` is not a concern because
+    /// every call site is preceded by `drain_pending_spill`, which joins the
+    /// prior chunk's I/O thread and therefore guarantees all sort workers are
+    /// idle at the moment rayon fans out.
+    fn build_sort_rayon_pool(&self) -> Result<rayon::ThreadPool> {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(self.threads.max(1))
+            .thread_name(|i| format!("fgumi-sort-rayon-{i}"))
+            .build()
+            .map_err(|e| anyhow::anyhow!("failed to build rayon sort pool: {e}"))
     }
 
     /// Consolidate temp files if we've exceeded the limit.
@@ -1750,6 +1657,7 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
         let mut pending_spill: Option<PendingSpill> = None;
+        let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
@@ -1778,7 +1686,7 @@ impl RawExternalSorter {
                 let chunk_path = namer.next_chunk_path();
 
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
 
                 // Write keyed temp file with parallel BGZF compression via worker pool.
@@ -1823,7 +1731,7 @@ impl RawExternalSorter {
             info!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
-                buffer.sort();
+                rayon_pool.install(|| buffer.par_sort());
             });
 
             timer.time_write_output(|| {
@@ -1839,12 +1747,15 @@ impl RawExternalSorter {
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
-            // intermediate merge back into a single sorted buffer)
+            // intermediate merge back into a single sorted buffer); each
+            // chunk becomes its own in-memory merge source.
             let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
+            } else if self.threads > 1 {
+                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
             } else {
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
                 let chunk = buffer
                     .refs()
@@ -1918,6 +1829,7 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(temp_path);
         let mut pending_spill: Option<PendingSpill> = None;
+        let rayon_pool = self.build_sort_rayon_pool()?;
 
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
 
@@ -1941,7 +1853,7 @@ impl RawExternalSorter {
                 let chunk_path = namer.next_chunk_path();
 
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
 
                 let handle = timer.time_spill_write(|| {
@@ -1985,7 +1897,7 @@ impl RawExternalSorter {
             info!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
-                buffer.sort();
+                rayon_pool.install(|| buffer.par_sort());
             });
 
             timer.time_write_output(|| {
@@ -2011,9 +1923,11 @@ impl RawExternalSorter {
             // Sort remaining records into separate sub-array chunks
             let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
+            } else if self.threads > 1 {
+                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
             } else {
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
                 let chunk = buffer
                     .refs()
@@ -2119,6 +2033,7 @@ impl RawExternalSorter {
         let mut memory_used = 0usize;
         let mut namer = ChunkNamer::new(temp_path);
         let mut pending_spill: Option<PendingSpill> = None;
+        let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (keyed output)...");
@@ -2155,7 +2070,7 @@ impl RawExternalSorter {
 
                 timer.time_sort(|| {
                     use rayon::prelude::*;
-                    entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                    rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
                 });
 
                 // Write keyed temp file with parallel BGZF compression via worker pool.
@@ -2196,7 +2111,7 @@ impl RawExternalSorter {
 
             timer.time_sort(|| {
                 use rayon::prelude::*;
-                entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
             });
 
             timer.time_write_output(|| {
@@ -2215,10 +2130,37 @@ impl RawExternalSorter {
             // intermediate merge back into a single sorted buffer)
             let memory_chunks: Vec<Vec<(K, Vec<u8>)>> = if entries.is_empty() {
                 Vec::new()
-            } else {
+            } else if self.threads > 1 {
                 timer.time_sort(|| {
                     use rayon::prelude::*;
-                    entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                    let chunk_size = entries.len().div_ceil(self.threads.max(1));
+                    rayon_pool.install(|| {
+                        entries.par_chunks_mut(chunk_size).for_each(|chunk| {
+                            chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                        });
+                    });
+                    // Carve sub-chunks aligned with par_chunks_mut boundaries.
+                    // par_chunks_mut produces [0..cs), [cs..2cs), ..., [n-tail..n).
+                    // We peel the short tail first, then full chunks from the end,
+                    // and reverse. Each split_off is O(chunk_size) → O(n) total.
+                    let mut remaining = std::mem::take(&mut entries);
+                    let num_chunks = remaining.len().div_ceil(chunk_size);
+                    let mut chunks: Vec<Vec<(K, Vec<u8>)>> = Vec::with_capacity(num_chunks);
+                    let tail_len = remaining.len() % chunk_size;
+                    if tail_len != 0 {
+                        let split_at = remaining.len() - tail_len;
+                        chunks.push(remaining.split_off(split_at));
+                    }
+                    while !remaining.is_empty() {
+                        let split_at = remaining.len().saturating_sub(chunk_size);
+                        chunks.push(remaining.split_off(split_at));
+                    }
+                    chunks.reverse();
+                    chunks
+                })
+            } else {
+                timer.time_sort(|| {
+                    entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
                 });
                 vec![entries]
             };
@@ -2291,6 +2233,7 @@ impl RawExternalSorter {
             TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
         let mut namer = ChunkNamer::new(temp_path);
         let mut pending_spill: Option<PendingSpill> = None;
+        let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer)...");
@@ -2326,7 +2269,7 @@ impl RawExternalSorter {
                 let chunk_path = namer.next_chunk_path();
 
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
 
                 // Write keyed chunk with parallel BGZF compression via worker pool.
@@ -2367,7 +2310,7 @@ impl RawExternalSorter {
             info!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
-                buffer.sort();
+                rayon_pool.install(|| buffer.par_sort());
             });
 
             timer.time_write_output(|| {
@@ -2386,9 +2329,11 @@ impl RawExternalSorter {
             // intermediate merge back into a single sorted buffer)
             let memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>> = if buffer.is_empty() {
                 Vec::new()
+            } else if self.threads > 1 {
+                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
             } else {
                 timer.time_sort(|| {
-                    buffer.par_sort();
+                    rayon_pool.install(|| buffer.par_sort());
                 });
                 let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
                 vec![chunk]
@@ -2441,11 +2386,10 @@ impl RawExternalSorter {
         let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
 
         if pool_decompress && !chunk_files.is_empty() {
-            // Pool-integrated path: distribute files to workers, create PoolDisk sources.
-            // Files are assigned: worker i gets files i, i+N, i+2N...
-            let files_with_ids: Vec<(PathBuf, usize)> =
-                chunk_files.iter().enumerate().map(|(idx, path)| (path.clone(), idx)).collect();
-            pool.distribute_chunk_files(files_with_ids)?;
+            // Pool-integrated path: install per-file Phase 2 state on the
+            // pool, then create one PoolDisk source per file. Workers
+            // cooperatively read+decompress all files via work-stealing.
+            pool.set_phase2_files(chunk_files)?;
 
             for source_id in 0..num_disk {
                 sources.push(ChunkSource::PoolDisk { source_id });
@@ -2534,21 +2478,22 @@ impl RawExternalSorter {
         let num_sources = sources.len();
         info!("Merging from {num_sources} sources...");
 
-        // Create pool consumer for PoolDisk sources and activate Phase 2
-        let mut consumer: Option<MainThreadChunkConsumer<K>> = if num_disk > 0 {
+        // Create pool consumer for PoolDisk sources and activate Phase 2.
+        // The consumer holds an Arc snapshot of the pool's per-file Phase 2
+        // state — workers populate per-file reorder buffers, the consumer pops
+        // from them.
+        let mut guard: Phase2Guard<'_, K> = if num_disk > 0 {
+            let files = pool.phase2_files();
             let consumer = MainThreadChunkConsumer::new(
-                num_disk,
-                pool.decompressed_chunks_queue(),
-                pool.raw_chunk_blocks_queue(),
-                pool.all_chunks_eof_flag(),
+                files,
                 pool.decompress_error_flag(),
                 pool.chunk_read_error_flag(),
                 pool.worker_panicked_flag(),
             );
             pool.set_phase(phase::PHASE2);
-            Some(consumer)
+            Phase2Guard { pool, consumer: Some(consumer), active: true }
         } else {
-            None
+            Phase2Guard { pool, consumer: None, active: false }
         };
 
         let output_header = self.create_output_header(header);
@@ -2560,7 +2505,7 @@ impl RawExternalSorter {
 
         for (idx, source) in sources.iter_mut().enumerate() {
             let mut record = Vec::new();
-            if let Some(key) = source.next_record(&mut record, consumer.as_mut())? {
+            if let Some(key) = source.next_record(&mut record, guard.consumer_mut())? {
                 initial_keys.push(key);
                 records.push(record);
                 source_map.push(idx);
@@ -2569,9 +2514,7 @@ impl RawExternalSorter {
 
         if initial_keys.is_empty() {
             info!("Merge complete: 0 records merged");
-            if consumer.is_some() {
-                pool.set_phase(phase::LEGACY);
-            }
+            guard.deactivate();
             let writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
             writer.finish()?;
             return Ok(0);
@@ -2615,7 +2558,8 @@ impl RawExternalSorter {
 
             if sample_this {
                 let t0 = Instant::now();
-                let next = sources[src_idx].next_record(&mut records[winner], consumer.as_mut())?;
+                let next =
+                    sources[src_idx].next_record(&mut records[winner], guard.consumer_mut())?;
                 merge_read_secs += t0.elapsed().as_secs_f64();
 
                 let t0 = Instant::now();
@@ -2627,7 +2571,8 @@ impl RawExternalSorter {
                 merge_tree_secs += t0.elapsed().as_secs_f64();
                 samples_taken += 1;
             } else {
-                let next = sources[src_idx].next_record(&mut records[winner], consumer.as_mut())?;
+                let next =
+                    sources[src_idx].next_record(&mut records[winner], guard.consumer_mut())?;
                 if let Some(key) = next {
                     tree.replace_winner(key);
                 } else {
@@ -2636,10 +2581,10 @@ impl RawExternalSorter {
             }
         }
 
-        // Return to legacy mode before finishing writer (workers still need to compress)
-        if consumer.is_some() {
-            pool.set_phase(phase::LEGACY);
-        }
+        // Return to legacy mode before finishing writer (workers still need to compress).
+        // The guard's deactivate() drops the consumer, resets phase, and clears the
+        // pool's published file vector in the correct order.
+        guard.deactivate();
 
         if debug_timing {
             let loop_total = loop_start.elapsed().as_secs_f64();
@@ -3814,5 +3759,69 @@ mod tests {
 
         // log_summary must not panic (output goes to log sink)
         timer.log_summary(4);
+    }
+
+    // ========================================================================
+    // Chunk boundary alignment tests
+    // ========================================================================
+
+    /// Regression test: `split_off` from the tail must align with `par_chunks_mut`
+    /// boundaries so that every emitted chunk is individually sorted.
+    ///
+    /// The old code split fixed-size chunks from the tail, which crossed sorted
+    /// chunk boundaries when `n % chunk_size != 0`.
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn test_split_off_aligns_with_par_chunks_mut() {
+        use rayon::prelude::*;
+
+        let pool =
+            rayon::ThreadPoolBuilder::new().num_threads(4).build().expect("build rayon pool");
+
+        // Test a variety of (n, threads) combinations that exercise the tail case
+        for &(n, threads) in &[(10, 3), (11, 4), (17, 3), (100, 7), (1000, 8), (13, 5)] {
+            let mut entries: Vec<(u64, Vec<u8>)> =
+                (0..n).rev().map(|i| (i as u64, vec![i as u8])).collect();
+
+            let chunk_size = entries.len().div_ceil(threads);
+
+            pool.install(|| {
+                entries.par_chunks_mut(chunk_size).for_each(|chunk| {
+                    chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                });
+            });
+
+            // Apply the same split logic as production code
+            let mut remaining = std::mem::take(&mut entries);
+            let num_chunks = remaining.len().div_ceil(chunk_size);
+            let mut chunks: Vec<Vec<(u64, Vec<u8>)>> = Vec::with_capacity(num_chunks);
+            let tail_len = remaining.len() % chunk_size;
+            if tail_len != 0 {
+                let split_at = remaining.len() - tail_len;
+                chunks.push(remaining.split_off(split_at));
+            }
+            while !remaining.is_empty() {
+                let split_at = remaining.len().saturating_sub(chunk_size);
+                chunks.push(remaining.split_off(split_at));
+            }
+            chunks.reverse();
+
+            // Every chunk must be individually sorted
+            for (ci, chunk) in chunks.iter().enumerate() {
+                for i in 1..chunk.len() {
+                    assert!(
+                        chunk[i - 1].0 <= chunk[i].0,
+                        "n={n} threads={threads}: chunk {ci} not sorted at index {i} \
+                         ({} > {})",
+                        chunk[i - 1].0,
+                        chunk[i].0,
+                    );
+                }
+            }
+
+            // Total record count must match
+            let total: usize = chunks.iter().map(Vec::len).sum();
+            assert_eq!(total, n, "n={n} threads={threads}: total mismatch");
+        }
     }
 }

--- a/src/lib/sort/read_ahead.rs
+++ b/src/lib/sort/read_ahead.rs
@@ -438,13 +438,28 @@ impl PooledInputStream {
 
     /// Drain available blocks from the `ArrayQueue` into the reorder buffer.
     ///
-    /// Caps the drain at `queue.capacity()` iterations to bound the reorder
-    /// buffer size. In the normal case the reorder buffer stays small (only
-    /// the few blocks that arrive out of order are buffered); the cap prevents
-    /// a temporarily fast producer from building an unbounded backlog.
+    /// Applies a soft cap (`2 * queue.capacity()`) on the reorder buffer so
+    /// a temporarily fast producer cannot build an unbounded backlog, while
+    /// still draining unconditionally when the next expected sequence has not
+    /// yet landed (otherwise the pop that would unblock the main thread could
+    /// remain stuck in the `ArrayQueue` and deadlock the pipeline).
     fn drain_queue(&mut self) {
-        let limit = self.decompressed_input.capacity();
-        for _ in 0..limit {
+        // Deadlock-free soft cap on the reorder buffer to apply real
+        // backpressure upstream. Without a cap, drain_queue unconditionally
+        // empties the bounded ArrayQueue into the unbounded ReorderBuffer,
+        // allowing it to grow to tens of GB when the main thread consumes
+        // slower than workers produce.
+        //
+        // Invariant: if we *cannot* currently pop (next_seq is missing), we
+        // must keep draining unconditionally — otherwise next_seq, which may
+        // still be sitting in the ArrayQueue, can never be transferred, and
+        // we deadlock.
+        let reorder_cap = self.decompressed_input.capacity() * 2;
+        loop {
+            // Only enforce the cap when forward progress is possible.
+            if self.reorder.can_pop() && self.reorder.buffer_len() >= reorder_cap {
+                break;
+            }
             match self.decompressed_input.pop() {
                 Some((serial, data)) => self.reorder.insert(serial, data),
                 None => break,

--- a/src/lib/sort/worker_pool.rs
+++ b/src/lib/sort/worker_pool.rs
@@ -15,11 +15,14 @@
 //!
 //! - **Phase-aware scheduling**: Workers check the current phase to pick eligible steps.
 //!   Phase 1: `DecompressInput` > `ReadInputBlocks` > `CompressSpill`.
-//!   Phase 2: `DecompressChunks` > `ReadChunkBlocks` > `CompressOutput`.
+//!   Phase 2: `Phase2FileWork` (read+decompress the next block of any file that has
+//!   room in its reorder buffer) > `CompressOutput`.
 //! - **Per-worker state**: Each worker owns an `InlineBgzfCompressor` and a
 //!   `libdeflater::Decompressor`, avoiding cross-thread synchronization.
-//! - **Worker-owns-files**: In Phase 2, each worker exclusively owns a subset of spill
-//!   files (worker i owns files i, i+N, i+2N...). No locks needed for file access.
+//! - **Per-file work-stealing (Phase 2)**: Each spill file has its own `Phase2FileState`
+//!   with a `Mutex`-guarded reader, a raw-block FIFO, and a decompressed reorder buffer.
+//!   Workers scan the shared snapshot, pick a file with work to do, and advance it
+//!   one block at a time — any worker can make progress on any file.
 //! - **Held-item pattern**: Workers never block on queue push. If output is full, they
 //!   hold the result locally and advance it first on the next iteration.
 //! - **Buffer recycling**: A shared buffer pool (`crossbeam` channel) recycles
@@ -33,12 +36,15 @@ use fgumi_bgzf::reader::read_raw_blocks;
 use fgumi_bgzf::writer::InlineBgzfCompressor;
 use fgumi_bgzf::{RawBgzfBlock, decompress_block};
 use log::info;
+use std::collections::VecDeque;
 use std::fmt::Write as FmtWrite;
 use std::io::{BufReader, Read};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
+
+use crate::reorder_buffer::ReorderBuffer;
 
 // ============================================================================
 // Job and Result Types
@@ -95,17 +101,15 @@ pub enum SortStep {
     DecompressInput = 1,
     /// Compress data for spill files during Phase 1.
     CompressSpill = 2,
-    /// Read raw BGZF blocks from spill files during Phase 2.
-    ReadChunkBlocks = 3,
-    /// Decompress spill file blocks during Phase 2.
-    DecompressChunks = 4,
+    /// Read+decompress one unit of work for some Phase 2 spill file (work-stealing).
+    Phase2FileWork = 3,
     /// Compress data for merge output during Phase 2.
-    CompressOutput = 5,
+    CompressOutput = 4,
 }
 
 impl SortStep {
     /// Number of distinct sort steps.
-    pub const COUNT: usize = 6;
+    pub const COUNT: usize = 5;
 
     /// Short label for display.
     #[must_use]
@@ -114,8 +118,7 @@ impl SortStep {
             Self::ReadInputBlocks => "RdInp",
             Self::DecompressInput => "DecInp",
             Self::CompressSpill => "CmpSpl",
-            Self::ReadChunkBlocks => "RdChk",
-            Self::DecompressChunks => "DecChk",
+            Self::Phase2FileWork => "P2File",
             Self::CompressOutput => "CmpOut",
         }
     }
@@ -189,8 +192,7 @@ impl SortPipelineStats {
             SortStep::ReadInputBlocks,
             SortStep::DecompressInput,
             SortStep::CompressSpill,
-            SortStep::ReadChunkBlocks,
-            SortStep::DecompressChunks,
+            SortStep::Phase2FileWork,
             SortStep::CompressOutput,
         ];
 
@@ -373,56 +375,94 @@ impl PermitPool {
     }
 }
 
-// ============================================================================
-// Phase 2 Data Types (chunk reading)
-// ============================================================================
-
-/// Number of raw BGZF blocks to read in each I/O batch per file.
-const CHUNK_READ_BATCH_SIZE: usize = 16;
-
 /// Number of raw BGZF blocks to read in each I/O batch from input file.
 const INPUT_READ_BATCH_SIZE: usize = 16;
 
-/// A raw BGZF block tagged with its source (spill file) ID and serial number.
-pub struct TaggedRawBlock {
-    /// The raw compressed BGZF block.
-    pub block: RawBgzfBlock,
-    /// Which spill file this block came from.
-    pub source_id: usize,
-    /// Per-source serial number for reordering after decompression.
-    pub serial: u64,
-}
+// ============================================================================
+// Phase 2 per-file state (work-stealing across files)
+// ============================================================================
 
-/// A decompressed block tagged with its source ID and serial number.
-pub struct TaggedDecompressedBlock {
-    /// Decompressed data.
-    pub data: Vec<u8>,
-    /// Which spill file this block came from.
-    pub source_id: usize,
-    /// Per-source serial number for reordering.
-    pub serial: u64,
-}
-
-/// Per-spill-file state for the worker-owns-files pattern.
+/// Number of raw BGZF blocks to keep read-ahead per spill file.
 ///
-/// Each worker exclusively owns a set of `ChunkFileState` instances.
-/// Worker `i` owns files `i, i+N, i+2N, ...` where `N` is the number of workers.
-/// No locks needed — each worker has exclusive access to its files.
-pub struct ChunkFileState {
-    /// Buffered reader for this spill file.
-    reader: BufReader<std::fs::File>,
-    /// Source ID for tagging blocks.
-    source_id: usize,
-    /// Next serial number to assign to blocks from this file.
-    next_serial: u64,
-    /// Whether this file has reached EOF.
-    eof: bool,
+/// Bounds disk read-ahead memory: K files × `PHASE2_RAW_CAP` × ~64 KB.
+pub(crate) const PHASE2_RAW_CAP: usize = 8;
+
+/// Number of decompressed BGZF blocks the per-file reorder buffer may hold
+/// before workers stop decompressing more for that file.
+///
+/// Bounds in-flight decompressed memory: K files × `PHASE2_DECOMP_CAP` × ~256 KB.
+/// This is a soft cap — the "always accept the next-expected serial" rule lets
+/// it transiently exceed by up to ~`num_workers` blocks per file.
+pub(crate) const PHASE2_DECOMP_CAP: usize = 8;
+
+/// Number of raw blocks to read from disk per `ReadRawBlocks` call.
+pub(crate) const PHASE2_READ_BATCH: usize = 4;
+
+/// Reader state for a single spill file. Locked when reading from disk.
+pub(crate) struct Phase2Reader {
+    pub(crate) inner: BufReader<std::fs::File>,
+    pub(crate) next_serial: u64,
+    pub(crate) eof: bool,
 }
 
-impl ChunkFileState {
-    /// Create a new chunk file state.
-    fn new(reader: BufReader<std::fs::File>, source_id: usize) -> Self {
-        Self { reader, source_id, next_serial: 0, eof: false }
+/// Per-spill-file state shared between all pool workers and the main thread.
+///
+/// Phase 2 uses work stealing across files: any worker can grab work from any
+/// file. The locks here are deliberately fine-grained so different workers can
+/// be reading, decompressing, and the main thread can be popping records all
+/// concurrently as long as they touch different sub-states.
+pub(crate) struct Phase2FileState {
+    /// Disk reader. Held only while popping bytes from disk.
+    pub(crate) reader: Mutex<Phase2Reader>,
+    /// Lock-free copy of `reader.eof`. Set immediately after any code path
+    /// that sets `reader_guard.eof = true`, so `is_drained` can fast-path
+    /// without touching the reader mutex (called per decompressed block on
+    /// the hot Phase 2 path).
+    pub(crate) reader_eof: AtomicBool,
+    /// Raw BGZF blocks read from disk, in serial order. FIFO.
+    pub(crate) raw_blocks: Mutex<VecDeque<(u64, RawBgzfBlock)>>,
+    /// Decompressed blocks reordered by serial. Main thread pops the next-in-order
+    /// block here when its parser exhausts the current buffer.
+    pub(crate) decompressed: Mutex<ReorderBuffer<Vec<u8>>>,
+    /// Number of raw blocks currently being decompressed (popped from
+    /// `raw_blocks` but not yet inserted into `decompressed`). Used by
+    /// `is_drained` to avoid a race where the consumer exits while a worker
+    /// is mid-decompress.
+    pub(crate) decomp_in_flight: AtomicUsize,
+}
+
+impl Phase2FileState {
+    pub(crate) fn new(reader: BufReader<std::fs::File>) -> Self {
+        Self {
+            reader: Mutex::new(Phase2Reader { inner: reader, next_serial: 0, eof: false }),
+            reader_eof: AtomicBool::new(false),
+            raw_blocks: Mutex::new(VecDeque::with_capacity(PHASE2_RAW_CAP)),
+            decompressed: Mutex::new(ReorderBuffer::new()),
+            decomp_in_flight: AtomicUsize::new(0),
+        }
+    }
+
+    /// Returns true when this file has produced all its data: disk reader at
+    /// EOF, no raw blocks waiting, no decompressed blocks waiting, and no
+    /// decompression in progress.
+    ///
+    /// Fast path: if the disk reader has not yet reached EOF, returns `false`
+    /// without acquiring any mutex. This is the overwhelmingly common case on
+    /// the Phase 2 hot path — every successful decompression calls this to
+    /// decide whether to wake the consumer.
+    pub(crate) fn is_drained(&self) -> bool {
+        if !self.reader_eof.load(Ordering::Acquire) {
+            return false;
+        }
+        let raw_empty =
+            self.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned").is_empty();
+        if !raw_empty {
+            return false;
+        }
+        if self.decomp_in_flight.load(Ordering::Acquire) > 0 {
+            return false;
+        }
+        self.decompressed.lock().expect("phase2 decompressed mutex poisoned").is_empty()
     }
 }
 
@@ -458,7 +498,9 @@ pub mod phase {
 ///
 /// Workers check the current phase to determine eligible steps:
 /// - **Phase 1**: `DecompressInput` > `ReadInputBlocks` > `CompressSpill`
-/// - **Phase 2**: `DecompressChunks` > `ReadChunkBlocks` > `CompressOutput`
+/// - **Phase 2**: `Phase2FileWork` (per-file work stealing: read next raw block
+///   batch from any file with FIFO room, OR decompress the next queued raw
+///   block for any file whose reorder buffer has capacity) > `CompressOutput`
 pub struct SortWorkerPool {
     // Shared pipeline state (visible to workers and main thread)
     shared: Arc<SharedPipelineState>,
@@ -522,14 +564,18 @@ pub(crate) struct SharedPipelineState {
     /// worker with a held (not-yet-queued) block causes premature EOF signalling.
     input_blocks_queued: AtomicU64,
 
-    // --- Phase 2 queues ---
-    /// Raw chunk blocks: `ReadChunkBlocks` → `DecompressChunks`.
-    pub(crate) raw_chunk_blocks: Arc<ArrayQueue<TaggedRawBlock>>,
-    /// Decompressed chunk blocks: `DecompressChunks` → main thread.
-    pub(crate) decompressed_chunks: Arc<ArrayQueue<TaggedDecompressedBlock>>,
-    /// All chunk files have reached EOF.
+    // --- Phase 2 per-file state (work-stealing) ---
+    /// Per-spill-file state, indexed by merge source id (`0..K`). Built before
+    /// `set_phase(PHASE2)` and cleared when phase 2 ends.
+    ///
+    /// `RwLock` so the main thread can swap the vector across phase 2
+    /// invocations. Workers and the main thread only hold the read guard long
+    /// enough to `Arc::clone` the inner `Vec` (see `phase2_files_snapshot`),
+    /// so writers never block on a long-held reader.
+    pub(crate) phase2_files: std::sync::RwLock<Arc<Vec<Phase2FileState>>>,
+    /// All chunk files have reached disk EOF (raw queues may still hold blocks).
     pub(crate) all_chunks_eof: Arc<AtomicBool>,
-    /// Number of sources that have reached EOF (when == `total_sources`, set `all_chunks_eof`).
+    /// Number of files whose disk reader has hit EOF (when == K, set `all_chunks_eof`).
     sources_at_eof: AtomicU64,
     /// Total number of chunk sources (set before Phase 2 starts).
     pub(crate) total_sources: AtomicU64,
@@ -538,18 +584,14 @@ pub(crate) struct SharedPipelineState {
     /// Compress jobs: main thread → workers (`ArrayQueue`, non-blocking push).
     pub(crate) compress_queue: Arc<ArrayQueue<CompressJob>>,
 
-    // --- Per-worker chunk file distribution (Phase 2) ---
-    /// One sender per worker; main thread sends `Vec<ChunkFileState>` before Phase 2.
-    chunk_file_senders: Vec<std::sync::Mutex<Option<Sender<Vec<ChunkFileState>>>>>,
-    /// One receiver per worker; worker receives its assigned files.
-    chunk_file_receivers: Vec<Receiver<Vec<ChunkFileState>>>,
-
     /// Number of workers (for `low_water` threshold in backpressure).
     num_workers: usize,
 
     /// Main thread handle for `park()`/`unpark()` notification.
-    /// Workers call `unpark()` after pushing to `decompressed_input` or `decompressed_chunks`
-    /// so the main thread wakes immediately instead of spin-yielding.
+    /// Workers call `unpark()` after inserting into `decompressed_input`
+    /// (Phase 1) or into a per-file `Phase2FileState.decompressed` reorder
+    /// buffer (Phase 2) so the main thread wakes immediately instead of
+    /// spin-yielding.
     main_thread_handle: std::thread::Thread,
 }
 
@@ -557,15 +599,6 @@ impl SharedPipelineState {
     fn new(num_workers: usize, main_thread_handle: std::thread::Thread) -> Self {
         let data_queue_cap = num_workers * 8;
         let compress_queue_cap = num_workers * 4;
-
-        // Per-worker channels for chunk file distribution (one-shot, keep as channel)
-        let mut senders = Vec::with_capacity(num_workers);
-        let mut receivers = Vec::with_capacity(num_workers);
-        for _ in 0..num_workers {
-            let (tx, rx) = bounded::<Vec<ChunkFileState>>(1);
-            senders.push(std::sync::Mutex::new(Some(tx)));
-            receivers.push(rx);
-        }
 
         Self {
             phase: AtomicU8::new(phase::LEGACY),
@@ -582,20 +615,21 @@ impl SharedPipelineState {
             decompressed_input_done: Arc::new(AtomicBool::new(false)),
             input_blocks_queued: AtomicU64::new(0),
 
-            raw_chunk_blocks: Arc::new(ArrayQueue::new(data_queue_cap)),
-            decompressed_chunks: Arc::new(ArrayQueue::new(data_queue_cap)),
+            phase2_files: std::sync::RwLock::new(Arc::new(Vec::new())),
             all_chunks_eof: Arc::new(AtomicBool::new(false)),
             sources_at_eof: AtomicU64::new(0),
             total_sources: AtomicU64::new(0),
 
             compress_queue: Arc::new(ArrayQueue::new(compress_queue_cap)),
 
-            chunk_file_senders: senders,
-            chunk_file_receivers: receivers,
-
             num_workers,
             main_thread_handle,
         }
+    }
+
+    /// Snapshot the current Phase 2 file vector. Cheap (just clones the `Arc`).
+    pub(crate) fn phase2_files_snapshot(&self) -> Arc<Vec<Phase2FileState>> {
+        Arc::clone(&self.phase2_files.read().expect("phase2_files rwlock poisoned"))
     }
 
     /// Snapshot current queue depths for backpressure-driven scheduling.
@@ -607,9 +641,6 @@ impl SharedPipelineState {
             decompressed_input_low: self.decompressed_input.len() < low_water,
             input_eof: self.input_eof.load(Ordering::Acquire),
             decompressed_input_done: self.decompressed_input_done.load(Ordering::Acquire),
-
-            decompressed_chunks_low: self.decompressed_chunks.len() < low_water,
-            all_chunks_eof: self.all_chunks_eof.load(Ordering::Acquire),
 
             compress_has_items: !self.compress_queue.is_empty(),
             phase: current_phase,
@@ -631,18 +662,16 @@ struct SortWorkerState {
     /// Compressor used for Phase 2 merge output (output compression level).
     output_compressor: InlineBgzfCompressor,
     decompressor: libdeflater::Decompressor,
-    /// Worker's assigned chunk files for Phase 2 (worker i owns files i, i+N, i+2N...).
-    chunk_files: Vec<ChunkFileState>,
+    /// Phase 2 file scan cursor — starts at `worker_id` and advances on success
+    /// for cache locality and reduced lock contention. Workers no longer own a
+    /// fixed subset of files; any worker can do work on any file.
+    phase2_file_cursor: usize,
 
     // Held items (one per step output) — see plan §Worker State
     /// Held raw input blocks from `ReadInputBlocks` (couldn't push to `raw_input_blocks` queue).
     held_raw_input_blocks: Vec<(u64, RawBgzfBlock)>,
     /// Held decompressed input block from `DecompressInput`.
     held_decompressed_input: Option<(u64, Vec<u8>)>,
-    /// Held raw chunk blocks from `ReadChunkBlocks` (couldn't push to `raw_chunk_blocks` queue).
-    held_raw_chunk_blocks: Vec<TaggedRawBlock>,
-    /// Held decompressed chunk block from `DecompressChunks`.
-    held_decompressed_chunk: Option<TaggedDecompressedBlock>,
     // Compress output goes directly to result_tx channel (I/O thread) — no held item.
     /// Backoff microseconds for idle spinning.
     backoff_us: u64,
@@ -655,10 +684,7 @@ impl SortWorkerState {
     /// Returns true if this worker is holding any items that need advancement.
     /// CRITICAL: Workers must not exit while holding items — they would be lost.
     fn has_any_held_items(&self) -> bool {
-        !self.held_raw_input_blocks.is_empty()
-            || self.held_decompressed_input.is_some()
-            || !self.held_raw_chunk_blocks.is_empty()
-            || self.held_decompressed_chunk.is_some()
+        !self.held_raw_input_blocks.is_empty() || self.held_decompressed_input.is_some()
     }
 }
 
@@ -676,10 +702,6 @@ struct SortBackpressureState {
     decompressed_input_low: bool,
     input_eof: bool,
     decompressed_input_done: bool,
-
-    // Phase 2
-    decompressed_chunks_low: bool,
-    all_chunks_eof: bool,
 
     // Shared
     compress_has_items: bool,
@@ -712,15 +734,15 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
             }
         }
         phase::PHASE2 => {
-            if bp.all_chunks_eof && !bp.compress_has_items {
-                // All chunks at EOF and no compress work — nothing productive to do
-                &[]
-            } else if bp.compress_has_items && !bp.decompressed_chunks_low {
-                // Output compression backpressure (15.4s at t4). Drain it.
-                &[SortStep::CompressOutput, SortStep::DecompressChunks, SortStep::ReadChunkBlocks]
+            // Phase 2 file work and output compression are independent: each
+            // worker grabs whatever has work. We never gate on `all_chunks_eof`
+            // — even after disk reads finish, decompression and parser drain
+            // continue until all per-file reorder buffers empty.
+            if bp.compress_has_items {
+                // Drain output compression while we can; it's the writer-side bottleneck.
+                &[SortStep::CompressOutput, SortStep::Phase2FileWork]
             } else {
-                // Default: feed the merge loop, compress output when available
-                &[SortStep::DecompressChunks, SortStep::ReadChunkBlocks, SortStep::CompressOutput]
+                &[SortStep::Phase2FileWork, SortStep::CompressOutput]
             }
         }
         // Legacy/transition: compress only (drain any remaining jobs)
@@ -834,11 +856,9 @@ impl SortWorkerPool {
                         compressor: InlineBgzfCompressor::new(temp_compression),
                         output_compressor: InlineBgzfCompressor::new(output_compression),
                         decompressor: libdeflater::Decompressor::new(),
-                        chunk_files: Vec::new(),
+                        phase2_file_cursor: worker_id,
                         held_raw_input_blocks: Vec::new(),
                         held_decompressed_input: None,
-                        held_raw_chunk_blocks: Vec::new(),
-                        held_decompressed_chunk: None,
                         backoff_us: MIN_BACKOFF_US,
                         idle_iter: 0,
                     };
@@ -879,9 +899,7 @@ impl SortWorkerPool {
 
             // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
             //    Workers must survive across Phase 1 → Phase 2 transitions.
-            if Self::is_phase_complete(shared, worker, current_phase)
-                && !worker.has_any_held_items()
-            {
+            if Self::is_phase_complete(shared, current_phase) && !worker.has_any_held_items() {
                 sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
@@ -892,16 +910,6 @@ impl SortWorkerPool {
 
             // 3. Try to advance ALL held items first (deadlock prevention)
             did_work |= Self::try_advance_all_held(shared, worker);
-
-            // Phase 2: receive chunk files on first iteration
-            if current_phase == phase::PHASE2
-                && worker.chunk_files.is_empty()
-                && shared.total_sources.load(Ordering::Acquire) > 0
-            {
-                if let Ok(files) = shared.chunk_file_receivers[worker.worker_id].try_recv() {
-                    worker.chunk_files = files;
-                }
-            }
 
             // 4. Get backpressure state and resolve priorities (done inline in step 6)
             let owned_step = Self::exclusive_step_for(worker.worker_id, shared, current_phase);
@@ -978,22 +986,21 @@ impl SortWorkerPool {
     /// Check if the current phase is "complete" (no more work to do).
     ///
     /// This does NOT mean the worker should exit — it must also have no held items.
-    fn is_phase_complete(
-        shared: &SharedPipelineState,
-        worker: &SortWorkerState,
-        current_phase: u8,
-    ) -> bool {
+    fn is_phase_complete(shared: &SharedPipelineState, current_phase: u8) -> bool {
         match current_phase {
             phase::PHASE1 => {
                 shared.decompressed_input_done.load(Ordering::Acquire)
                     && shared.compress_queue.is_empty()
             }
             phase::PHASE2 => {
-                shared.all_chunks_eof.load(Ordering::Acquire)
-                    && shared.raw_chunk_blocks.is_empty()
-                    && shared.decompressed_chunks.is_empty()
-                    && shared.compress_queue.is_empty()
-                    && worker.chunk_files.iter().all(|f| f.eof)
+                if !shared.all_chunks_eof.load(Ordering::Acquire) {
+                    return false;
+                }
+                if !shared.compress_queue.is_empty() {
+                    return false;
+                }
+                let files = shared.phase2_files_snapshot();
+                files.iter().all(Phase2FileState::is_drained)
             }
             // Legacy mode never "completes" — it runs until phase changes
             _ => false,
@@ -1006,9 +1013,11 @@ impl SortWorkerPool {
 
     /// Return the exclusive step this worker owns, if any.
     ///
-    /// For `num_workers >= 2`: Worker 0 owns `ReadInputBlocks` (Phase 1) and
-    /// `ReadChunkBlocks` (Phase 2). For `num_workers == 1`: single worker does
-    /// everything (returns `None`, no ownership restrictions).
+    /// For `num_workers >= 2`: Worker 0 owns `ReadInputBlocks` (Phase 1) so
+    /// only one worker at a time can hold the input file lock. For
+    /// `num_workers == 1`: the single worker does everything (returns `None`,
+    /// no ownership restrictions). Phase 2 has no exclusive step — work
+    /// stealing across files handles contention via per-file mutexes.
     fn exclusive_step_for(
         worker_id: usize,
         shared: &SharedPipelineState,
@@ -1022,7 +1031,6 @@ impl SortWorkerPool {
         }
         match current_phase {
             phase::PHASE1 => Some(SortStep::ReadInputBlocks),
-            // Phase 2: each worker reads its own files, no exclusive ownership needed
             _ => None,
         }
     }
@@ -1030,8 +1038,7 @@ impl SortWorkerPool {
     /// Whether a step is exclusive (requires ownership).
     ///
     /// Only `ReadInputBlocks` is exclusive — it reads from a shared input file
-    /// protected by a Mutex. `ReadChunkBlocks` is NOT exclusive because each
-    /// worker reads from its own assigned chunk files (no contention).
+    /// protected by a Mutex.
     fn is_exclusive_step(step: SortStep) -> bool {
         matches!(step, SortStep::ReadInputBlocks)
     }
@@ -1079,17 +1086,7 @@ impl SortWorkerPool {
                             && !shared.decompressed_input_done.load(Ordering::Acquire)))
             }
             SortStep::CompressSpill | SortStep::CompressOutput => !shared.compress_queue.is_empty(),
-            SortStep::ReadChunkBlocks => {
-                current_phase == phase::PHASE2
-                    && worker.held_raw_chunk_blocks.is_empty()
-                    && !worker.chunk_files.is_empty()
-                    && !worker.chunk_files.iter().all(|f| f.eof)
-            }
-            SortStep::DecompressChunks => {
-                current_phase == phase::PHASE2
-                    && worker.held_decompressed_chunk.is_none()
-                    && !shared.raw_chunk_blocks.is_empty()
-            }
+            SortStep::Phase2FileWork => current_phase == phase::PHASE2,
         }
     }
 
@@ -1108,8 +1105,7 @@ impl SortWorkerPool {
             // at the output level.
             SortStep::CompressSpill => Self::try_compress(shared, &mut worker.compressor),
             SortStep::CompressOutput => Self::try_compress(shared, &mut worker.output_compressor),
-            SortStep::ReadChunkBlocks => Self::try_read_chunk_blocks(shared, worker),
-            SortStep::DecompressChunks => Self::try_decompress_chunks(shared, worker),
+            SortStep::Phase2FileWork => Self::try_phase2_file_work(shared, worker),
         }
     }
 
@@ -1154,25 +1150,6 @@ impl SortWorkerPool {
                     shared.decompressed_input_done.store(true, Ordering::Release);
                     shared.main_thread_handle.unpark();
                 }
-            }
-        }
-
-        // Raw chunk blocks (batch)
-        if !worker.held_raw_chunk_blocks.is_empty() {
-            let before = worker.held_raw_chunk_blocks.len();
-            try_advance_held_batch(&shared.raw_chunk_blocks, &mut worker.held_raw_chunk_blocks);
-            if worker.held_raw_chunk_blocks.len() < before {
-                advanced = true;
-            }
-        }
-
-        // Decompressed chunks (single) — unpark main only on successful push
-        if worker.held_decompressed_chunk.is_some() {
-            let pushed =
-                try_advance_held(&shared.decompressed_chunks, &mut worker.held_decompressed_chunk);
-            if pushed {
-                shared.main_thread_handle.unpark();
-                advanced = true;
             }
         }
 
@@ -1320,123 +1297,199 @@ impl SortWorkerPool {
     }
 
     // ========================================================================
-    // Phase 2 Steps
+    // Phase 2 Step: work-stealing across spill files
     // ========================================================================
 
-    /// `ReadChunkBlocks`: read raw BGZF blocks from this worker's assigned chunk files.
+    /// `Phase2FileWork`: do one unit of work for some Phase 2 spill file.
     ///
-    /// Worker-owns-files pattern: no locks needed. Worker i exclusively owns its files.
-    fn try_read_chunk_blocks(
+    /// This is the unified Phase 2 work step. Each call attempts to find a file
+    /// where we can productively make progress and does ONE unit of work for it
+    /// (either decompress one block or read a batch of raw blocks). On success,
+    /// the worker's per-file cursor advances so the next call rotates through
+    /// the file set fairly.
+    ///
+    /// # Per-file state
+    ///
+    /// Each [`Phase2FileState`] has three independently-locked sub-states:
+    /// - `reader`: the disk reader. Held while pulling raw bytes from disk.
+    /// - `raw_blocks`: FIFO of raw BGZF blocks waiting to be decompressed.
+    /// - `decompressed`: per-file [`ReorderBuffer`] of decompressed blocks the
+    ///   main thread will pop in serial order.
+    ///
+    /// Workers always prefer decompression to disk reads (decompressed blocks
+    /// directly feed the merge loop). They use `try_lock` everywhere so a
+    /// blocked file never starves the others.
+    ///
+    /// # Deadlock-free admission
+    ///
+    /// Workers refuse to pull a new raw block when the per-file decompressed
+    /// reorder buffer is at `PHASE2_DECOMP_CAP`, EXCEPT in the case where the
+    /// raw FIFO's head matches the buffer's `next_seq` and the buffer is stuck
+    /// (`!can_pop`). That is the gap-filler the main thread is waiting for, and
+    /// failing to admit it would deadlock the merge.
+    fn try_phase2_file_work(
         shared: &SharedPipelineState,
         worker: &mut SortWorkerState,
     ) -> StepResult {
-        if worker.chunk_files.is_empty() || shared.all_chunks_eof.load(Ordering::Acquire) {
+        let files = shared.phase2_files_snapshot();
+        let n = files.len();
+        if n == 0 {
             return StepResult::InputEmpty;
         }
 
-        let mut read_any = false;
+        for offset in 0..n {
+            let i = (worker.phase2_file_cursor + offset) % n;
+            let file = &files[i];
 
-        // Round-robin through this worker's assigned files
-        for file_state in &mut worker.chunk_files {
-            if file_state.eof {
+            // -- Try decompression first (highest-value work) ----------------
+            // `try_pop_raw_for_decompress` increments `decomp_in_flight` before
+            // returning, so the consumer's `is_drained` check sees this work as
+            // outstanding even after the raw FIFO becomes empty. We MUST
+            // decrement after inserting into the reorder buffer (or on the
+            // error path) to keep the counter balanced.
+            let popped = Self::try_pop_raw_for_decompress(file);
+            if let Some((serial, raw_block)) = popped {
+                let data = match decompress_block(&raw_block, &mut worker.decompressor) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        log::error!(
+                            "BGZF decompression error (chunk source {i} serial {serial}): {e}"
+                        );
+                        shared.decompression_error.store(true, Ordering::Release);
+                        // Balance the in-flight increment from try_pop_raw_for_decompress.
+                        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+                        shared.main_thread_handle.unpark();
+                        worker.phase2_file_cursor = (i + 1) % n;
+                        return StepResult::Success;
+                    }
+                };
+                let now_poppable = {
+                    let mut dec_guard =
+                        file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+                    dec_guard.insert(serial, data);
+                    dec_guard.can_pop()
+                };
+                // Decrement AFTER the insert is published. The unpark below
+                // wakes the consumer in case it has been parked waiting on
+                // this specific file (now_poppable=true) or is in the
+                // is_drained path waiting for in_flight to reach zero.
+                file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+                if now_poppable || file.is_drained() {
+                    // Wake the consumer either because new data is available
+                    // or because the last in-flight decompression for this
+                    // file just completed and the file is now fully drained.
+                    shared.main_thread_handle.unpark();
+                }
+                worker.phase2_file_cursor = (i + 1) % n;
+                return StepResult::Success;
+            }
+
+            // -- Try reading raw blocks from disk ----------------------------
+            // Skip if disk reader is contended OR already at EOF.
+            let Ok(mut reader_guard) = file.reader.try_lock() else {
+                continue; // another worker is reading this file
+            };
+            if reader_guard.eof {
                 continue;
             }
 
-            let blocks = match read_raw_blocks(&mut file_state.reader, CHUNK_READ_BATCH_SIZE) {
+            // Bound disk read-ahead per file: don't keep pulling if the raw
+            // FIFO is already full. Use try_lock so a momentarily contended
+            // raw FIFO doesn't block the reader.
+            let raw_full = match file.raw_blocks.try_lock() {
+                Ok(g) => g.len() >= PHASE2_RAW_CAP,
+                Err(_) => true,
+            };
+            if raw_full {
+                continue;
+            }
+
+            let blocks = match read_raw_blocks(&mut reader_guard.inner, PHASE2_READ_BATCH) {
                 Ok(b) => b,
                 Err(e) => {
-                    log::error!(
-                        "I/O error reading chunk file (source {}): {e}",
-                        file_state.source_id
-                    );
+                    log::error!("I/O error reading chunk file (source {i}): {e}");
                     shared.chunk_read_error.store(true, Ordering::Release);
-                    file_state.eof = true;
+                    reader_guard.eof = true;
+                    file.reader_eof.store(true, Ordering::Release);
+                    drop(reader_guard);
                     shared.main_thread_handle.unpark();
                     Self::maybe_mark_all_eof(shared);
-                    continue;
+                    worker.phase2_file_cursor = (i + 1) % n;
+                    return StepResult::Success;
                 }
             };
 
             if blocks.is_empty() {
-                file_state.eof = true;
+                reader_guard.eof = true;
+                file.reader_eof.store(true, Ordering::Release);
+                drop(reader_guard);
+                shared.main_thread_handle.unpark();
                 Self::maybe_mark_all_eof(shared);
-                continue;
+                worker.phase2_file_cursor = (i + 1) % n;
+                return StepResult::Success;
             }
 
-            let mut blocks_iter = blocks.into_iter();
-            let source_id = file_state.source_id;
-            let mut backed_up = false;
-            for block in blocks_iter.by_ref() {
-                let serial = file_state.next_serial;
-                file_state.next_serial += 1;
-                let tagged = TaggedRawBlock { block, source_id, serial };
-                match shared.raw_chunk_blocks.push(tagged) {
-                    Ok(()) => {}
-                    Err(tagged) => {
-                        worker.held_raw_chunk_blocks.push(tagged);
-                        backed_up = true;
-                        break;
-                    }
-                }
+            // Acquire the raw_blocks lock BEFORE releasing the reader lock and
+            // assigning serials. This is critical for FIFO order: if we dropped
+            // the reader lock before pushing, two workers could each read a
+            // batch and bump `next_serial`, then race on the raw_blocks push,
+            // landing higher serials in front of lower ones. The merge
+            // consumer's gap-filler admission rule cannot recover from that
+            // and would deadlock. Lock order `reader → raw_blocks` is the only
+            // nested-lock path in this function.
+            let mut raw_guard = file.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned");
+            let start_serial = reader_guard.next_serial;
+            reader_guard.next_serial += blocks.len() as u64;
+            for (idx, b) in blocks.into_iter().enumerate() {
+                raw_guard.push_back((start_serial + idx as u64, b));
             }
-            // Hold any remaining blocks we didn't attempt to push
-            if backed_up {
-                for block in blocks_iter {
-                    let serial = file_state.next_serial;
-                    file_state.next_serial += 1;
-                    worker.held_raw_chunk_blocks.push(TaggedRawBlock { block, source_id, serial });
-                }
-            }
-            read_any = true;
-            break; // Read from one file per step to be fair
+            drop(raw_guard);
+            drop(reader_guard);
+
+            worker.phase2_file_cursor = (i + 1) % n;
+            return StepResult::Success;
         }
 
-        if read_any { StepResult::Success } else { StepResult::InputEmpty }
+        StepResult::InputEmpty
     }
 
-    /// `DecompressChunks`: decompress a raw chunk block.
-    fn try_decompress_chunks(
-        shared: &SharedPipelineState,
-        worker: &mut SortWorkerState,
-    ) -> StepResult {
-        // Don't take new work if we're holding an item
-        if worker.held_decompressed_chunk.is_some() {
-            return StepResult::OutputFull;
+    /// Try to pop a raw block from `file` for decompression, applying
+    /// deadlock-free admission control against the file's reorder buffer.
+    ///
+    /// Returns `Some((serial, raw_block))` if a block was popped, `None` otherwise.
+    /// `None` is returned when:
+    /// - either lock is contended (`try_lock` failed),
+    /// - the raw FIFO is empty,
+    /// - or the reorder buffer is at cap and the head raw block isn't a gap-filler.
+    ///
+    /// On success, `decomp_in_flight` is incremented so the consumer's
+    /// `is_drained()` check correctly reflects the in-progress decompression.
+    /// The caller is responsible for the matching decrement after inserting
+    /// (or on the decompression-error path).
+    fn try_pop_raw_for_decompress(file: &Phase2FileState) -> Option<(u64, RawBgzfBlock)> {
+        let mut raw_guard = file.raw_blocks.try_lock().ok()?;
+        let head_serial = raw_guard.front().map(|(s, _)| *s)?;
+
+        // Cheap admission check using the per-file reorder buffer.
+        // Two cases admit: (1) under cap (normal), (2) reorder buffer is stuck
+        // and this serial is the gap-filler. Otherwise: backpressure.
+        let admit = {
+            let dec_guard = file.decompressed.try_lock().ok()?;
+            dec_guard.len() < PHASE2_DECOMP_CAP
+                || (!dec_guard.can_pop() && head_serial == dec_guard.next_seq())
+        };
+        if !admit {
+            return None;
         }
 
-        let Some(tagged) = shared.raw_chunk_blocks.pop() else {
-            return StepResult::InputEmpty;
-        };
-
-        let data = match decompress_block(&tagged.block, &mut worker.decompressor) {
-            Ok(d) => d,
-            Err(e) => {
-                log::error!(
-                    "BGZF decompression error (chunk block source {} serial {}): {e}",
-                    tagged.source_id,
-                    tagged.serial
-                );
-                shared.decompression_error.store(true, Ordering::Release);
-                shared.main_thread_handle.unpark();
-                return StepResult::InputEmpty;
-            }
-        };
-
-        let result =
-            TaggedDecompressedBlock { data, source_id: tagged.source_id, serial: tagged.serial };
-
-        match shared.decompressed_chunks.push(result) {
-            Ok(()) => {
-                shared.main_thread_handle.unpark();
-            }
-            Err(item) => {
-                worker.held_decompressed_chunk = Some(item);
-                // Queue full — wake main thread to drain so we can push next time
-                shared.main_thread_handle.unpark();
-            }
+        // Reserve the in-flight slot under the raw_blocks lock so the consumer
+        // can never observe (raw_empty && in_flight==0 && decompressed_empty)
+        // while a worker is still in the middle of decompressing this block.
+        let popped = raw_guard.pop_front();
+        if popped.is_some() {
+            file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
         }
-
-        StepResult::Success
+        popped
     }
 
     // ========================================================================
@@ -1515,25 +1568,12 @@ impl SortWorkerPool {
         Arc::clone(&self.shared.decompression_error)
     }
 
-    /// Get a clone of the decompressed chunks `ArrayQueue` for Phase 2 merge.
-    pub(crate) fn decompressed_chunks_queue(
-        &self,
-    ) -> Arc<crossbeam_queue::ArrayQueue<TaggedDecompressedBlock>> {
-        Arc::clone(&self.shared.decompressed_chunks)
-    }
-
-    /// Get a clone of the `all_chunks_eof` flag for Phase 2 merge.
-    pub(crate) fn all_chunks_eof_flag(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.shared.all_chunks_eof)
-    }
-
-    /// Get a clone of the raw (pre-decompression) chunk blocks queue for Phase 2 merge.
+    /// Snapshot the Phase 2 per-file state vector for the merge consumer.
     ///
-    /// Used by `MainThreadChunkConsumer` to verify all blocks have been decompressed
-    /// before declaring EOF — `all_chunks_eof` is set when raw reads finish, but blocks
-    /// may still be in this queue awaiting decompression.
-    pub(crate) fn raw_chunk_blocks_queue(&self) -> Arc<ArrayQueue<TaggedRawBlock>> {
-        Arc::clone(&self.shared.raw_chunk_blocks)
+    /// Returns the same `Arc` workers see — the consumer reads from per-file
+    /// reorder buffers via this snapshot.
+    pub(crate) fn phase2_files(&self) -> Arc<Vec<Phase2FileState>> {
+        self.shared.phase2_files_snapshot()
     }
 
     /// Set the current pipeline phase.
@@ -1553,10 +1593,10 @@ impl SortWorkerPool {
             Some(reader);
     }
 
-    /// Distribute chunk files to workers for Phase 2.
+    /// Build the Phase 2 per-file state vector and publish it to all workers.
     ///
-    /// Worker `i` gets files `i, i+N, i+2N, ...` where `N` is `num_workers`.
-    /// Must be called before `set_phase(PHASE2)`.
+    /// Workers do not own files — they cooperatively scan all files and steal
+    /// work via `try_lock`. Must be called before `set_phase(PHASE2)`.
     ///
     /// # Errors
     ///
@@ -1564,12 +1604,8 @@ impl SortWorkerPool {
     ///
     /// # Panics
     ///
-    /// Panics if a sender mutex is poisoned.
-    pub fn distribute_chunk_files(
-        &self,
-        files: Vec<(std::path::PathBuf, usize)>,
-    ) -> anyhow::Result<()> {
-        let n = self.num_workers;
+    /// Panics if the `phase2_files` rwlock is poisoned.
+    pub fn set_phase2_files(&self, files: &[std::path::PathBuf]) -> anyhow::Result<()> {
         let total_sources = files.len();
         self.shared.total_sources.store(total_sources as u64, Ordering::Release);
 
@@ -1577,28 +1613,29 @@ impl SortWorkerPool {
         self.shared.all_chunks_eof.store(false, Ordering::Release);
         self.shared.sources_at_eof.store(0, Ordering::Release);
 
-        // Assign files to workers: worker i gets files i, i+N, i+2N...
-        let mut per_worker: Vec<Vec<ChunkFileState>> = (0..n).map(|_| Vec::new()).collect();
-
-        for (idx, (path, source_id)) in files.into_iter().enumerate() {
-            let worker_idx = idx % n;
-            let file = std::fs::File::open(&path).map_err(|e| {
+        let mut states: Vec<Phase2FileState> = Vec::with_capacity(total_sources);
+        for path in files {
+            let file = std::fs::File::open(path).map_err(|e| {
                 anyhow::anyhow!("Failed to open chunk file {}: {e}", path.display())
             })?;
             let reader = BufReader::with_capacity(2 * 1024 * 1024, file);
-            per_worker[worker_idx].push(ChunkFileState::new(reader, source_id));
+            states.push(Phase2FileState::new(reader));
         }
 
-        // Send to each worker via their dedicated channel
-        for (worker_idx, files) in per_worker.into_iter().enumerate() {
-            let guard = self.shared.chunk_file_senders[worker_idx]
-                .lock()
-                .expect("chunk_file_sender mutex should not be poisoned");
-            if let Some(tx) = guard.as_ref() {
-                let _ = tx.send(files);
-            }
-        }
+        let mut guard = self.shared.phase2_files.write().expect("phase2_files rwlock poisoned");
+        *guard = Arc::new(states);
         Ok(())
+    }
+
+    /// Clear the Phase 2 file vector. Call this after Phase 2 finishes (and
+    /// before any subsequent Phase 1) so the file descriptors are released.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `phase2_files` rwlock is poisoned.
+    pub fn clear_phase2_files(&self) {
+        let mut guard = self.shared.phase2_files.write().expect("phase2_files rwlock poisoned");
+        *guard = Arc::new(Vec::new());
     }
 
     /// Submit a compression job to the pool (non-blocking, spin-yield on full).
@@ -1648,12 +1685,6 @@ impl SortWorkerPool {
     /// (idempotent via `Option::take`). Called by both `shutdown` and `Drop`.
     fn do_shutdown(&mut self) {
         self.shared.phase.store(phase::SHUTDOWN, Ordering::Release);
-        // Drop chunk file senders so workers blocked on receiving them unblock.
-        for sender in &self.shared.chunk_file_senders {
-            if let Ok(mut guard) = sender.lock() {
-                *guard = None;
-            }
-        }
         if let Some(workers) = self.workers.take() {
             for w in workers {
                 if w.join().is_err() {
@@ -1905,8 +1936,6 @@ mod tests {
             decompressed_input_low: true,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: false,
-            all_chunks_eof: false,
             compress_has_items: false,
             phase: phase::PHASE1,
         };
@@ -1920,8 +1949,6 @@ mod tests {
             decompressed_input_low: false,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: false,
-            all_chunks_eof: false,
             compress_has_items: true,
             phase: phase::PHASE1,
         };
@@ -1935,8 +1962,6 @@ mod tests {
             decompressed_input_low: false,
             input_eof: true,
             decompressed_input_done: true,
-            decompressed_chunks_low: false,
-            all_chunks_eof: false,
             compress_has_items: false,
             phase: phase::PHASE1,
         };
@@ -1949,13 +1974,11 @@ mod tests {
             decompressed_input_low: false,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: true,
-            all_chunks_eof: false,
             compress_has_items: false,
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::DecompressChunks);
+        assert_eq!(priorities[0], SortStep::Phase2FileWork);
     }
 
     #[test]
@@ -1964,8 +1987,6 @@ mod tests {
             decompressed_input_low: false,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: false,
-            all_chunks_eof: false,
             compress_has_items: true,
             phase: phase::PHASE2,
         };
@@ -1974,17 +1995,18 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_priorities_phase2_all_done_returns_empty() {
+    fn test_sort_priorities_phase2_after_eof_still_drains_files() {
+        // Even after all_chunks_eof, file work continues until per-file
+        // reorder buffers drain — `is_phase_complete` is the actual exit gate.
         let bp = SortBackpressureState {
             decompressed_input_low: false,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: false,
-            all_chunks_eof: true,
             compress_has_items: false,
             phase: phase::PHASE2,
         };
-        assert!(get_sort_priorities(&bp).is_empty());
+        let priorities = get_sort_priorities(&bp);
+        assert_eq!(priorities[0], SortStep::Phase2FileWork);
     }
 
     #[test]
@@ -1993,8 +2015,6 @@ mod tests {
             decompressed_input_low: false,
             input_eof: false,
             decompressed_input_done: false,
-            decompressed_chunks_low: false,
-            all_chunks_eof: false,
             compress_has_items: true,
             phase: phase::LEGACY,
         };
@@ -2008,5 +2028,145 @@ mod tests {
         let pool = SortWorkerPool::new(3, 1, 6);
         assert_eq!(pool.num_workers(), 3);
         pool.shutdown();
+    }
+
+    // ========================================================================
+    // Phase2FileState admission and drain tests
+    // ========================================================================
+
+    /// Build an empty `Phase2FileState` for unit-testing the admission rule.
+    /// The reader is backed by a temporary empty file — we don't exercise it
+    /// here; we only manipulate `raw_blocks` and `decompressed` directly.
+    fn empty_phase2_file() -> Phase2FileState {
+        let tmp = tempfile::tempfile().expect("failed to create tempfile");
+        let reader = BufReader::with_capacity(1024, tmp);
+        Phase2FileState::new(reader)
+    }
+
+    /// Build a tiny placeholder `RawBgzfBlock` whose contents we never decode.
+    fn dummy_raw_block(byte: u8) -> RawBgzfBlock {
+        RawBgzfBlock { data: vec![byte; 8] }
+    }
+
+    #[test]
+    fn test_admission_under_cap_admits() {
+        let file = empty_phase2_file();
+        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
+        assert!(popped.is_some(), "under cap with empty reorder buffer should admit");
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
+        assert!(file.raw_blocks.lock().expect("raw lock").is_empty());
+    }
+
+    #[test]
+    fn test_admission_at_cap_poppable_rejects() {
+        let file = empty_phase2_file();
+        // Fill the reorder buffer to PHASE2_DECOMP_CAP starting at serial 0,
+        // so the buffer is poppable (next_seq = 0 is present) AND at cap.
+        {
+            let mut dec = file.decompressed.lock().expect("dec lock");
+            for s in 0..PHASE2_DECOMP_CAP as u64 {
+                dec.insert(s, vec![0u8; 4]);
+            }
+            assert_eq!(dec.len(), PHASE2_DECOMP_CAP);
+            assert!(dec.can_pop());
+        }
+        // Head raw is the next serial after the buffer's contents — not the
+        // gap-filler, so admission should reject (consumer is supposed to
+        // drain the buffer first).
+        file.raw_blocks
+            .lock()
+            .expect("raw lock")
+            .push_back((PHASE2_DECOMP_CAP as u64, dummy_raw_block(1)));
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
+        assert!(popped.is_none(), "at cap and poppable should reject (apply backpressure)");
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
+        assert_eq!(file.raw_blocks.lock().expect("raw lock").len(), 1);
+    }
+
+    #[test]
+    fn test_admission_at_cap_stuck_admits_gap_filler() {
+        let file = empty_phase2_file();
+        // Fill the reorder buffer with serials 1..=PHASE2_DECOMP_CAP, leaving
+        // serial 0 as the gap. Buffer is at cap and !can_pop.
+        {
+            let mut dec = file.decompressed.lock().expect("dec lock");
+            for s in 1..=PHASE2_DECOMP_CAP as u64 {
+                dec.insert(s, vec![0u8; 4]);
+            }
+            assert_eq!(dec.len(), PHASE2_DECOMP_CAP);
+            assert!(!dec.can_pop(), "buffer should be stuck waiting for serial 0");
+        }
+        // The head raw is serial 0 — the gap-filler. Admission must take it
+        // even though we're at cap, otherwise the consumer deadlocks.
+        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
+        assert!(popped.is_some(), "at cap and stuck should admit gap-filler at next_seq");
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn test_admission_at_cap_stuck_wrong_head_rejects() {
+        let file = empty_phase2_file();
+        // Same setup as gap-filler test, but the head raw is NOT the
+        // gap-filler — admission must reject and the merge must rely on
+        // another file's progress to make this one drainable.
+        {
+            let mut dec = file.decompressed.lock().expect("dec lock");
+            for s in 1..=PHASE2_DECOMP_CAP as u64 {
+                dec.insert(s, vec![0u8; 4]);
+            }
+        }
+        file.raw_blocks
+            .lock()
+            .expect("raw lock")
+            .push_back((PHASE2_DECOMP_CAP as u64 + 1, dummy_raw_block(2)));
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
+        assert!(popped.is_none(), "at cap, stuck, but head != next_seq should reject");
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_admission_empty_raw_returns_none() {
+        let file = empty_phase2_file();
+        // Empty raw FIFO — try_pop must return None without touching in_flight.
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
+        assert!(popped.is_none());
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_is_drained_respects_in_flight_counter() {
+        let file = empty_phase2_file();
+        // Mark reader as EOF and ensure both queues are empty.
+        file.reader.lock().expect("reader lock").eof = true;
+        file.reader_eof.store(true, Ordering::Release);
+        assert!(file.is_drained(), "reader_eof + empty queues + no in-flight should be drained");
+
+        // Simulate a worker mid-decompression: in_flight > 0 must hide drain.
+        file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
+        assert!(!file.is_drained(), "in-flight decompression must keep is_drained=false");
+
+        // Decrementing brings us back to drained.
+        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+        assert!(file.is_drained());
+    }
+
+    #[test]
+    fn test_is_drained_blocks_on_pending_raw() {
+        let file = empty_phase2_file();
+        file.reader.lock().expect("reader lock").eof = true;
+        file.reader_eof.store(true, Ordering::Release);
+        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        assert!(!file.is_drained(), "raw blocks pending must keep is_drained=false");
+    }
+
+    #[test]
+    fn test_is_drained_blocks_on_pending_decompressed() {
+        let file = empty_phase2_file();
+        file.reader.lock().expect("reader lock").eof = true;
+        file.reader_eof.store(true, Ordering::Release);
+        file.decompressed.lock().expect("dec lock").insert(0, vec![1, 2, 3]);
+        assert!(!file.is_drained(), "decompressed blocks pending must keep is_drained=false");
     }
 }


### PR DESCRIPTION
## Summary

Fixes two independent problems hurting the N+2 sort worker-pool path on large inputs, plus a post-review cleanup sweep.

### Phase 2 redesign: per-file work-stealing state

Phase 2 regressed badly on WES (1kg-wes-HG00100.bam, 13 GB, 219M records): 450s+ wall and ~42 GB peak RSS under `--threads 8 --max-memory 768M`, driven by an over-coupled producer/consumer with global queues that deadlocked under backpressure and left workers idle while OOMing.

Replace it with per-file state:

```rust
struct Phase2FileState {
    reader: Mutex<Phase2Reader>,           // raw BGZF block reads
    reader_eof: AtomicBool,                // hot-path fast check
    raw_blocks: Mutex<VecDeque<...>>,      // bounded FIFO
    decompressed: Mutex<ReorderBuffer>,    // in-order decompressed
    decomp_in_flight: AtomicUsize,         // race-safe drain
}
```

Workers scan files with `try_lock` everywhere and steal work across spill files. Lock order is strict: `reader -> raw_blocks -> decompressed`.

- **Deadlock-free admission**: a popped raw block is always admitted when it is the gap-filler the reorder buffer is waiting for, even if the decompressed cap is full. Prevents head-of-line deadlock where every worker holds a stale raw block while the buffer waits on a missing serial.
- **Race fix**: `is_drained()` must observe `decomp_in_flight > 0` to avoid exiting Phase 2 between a worker popping a raw block and inserting the decompressed bytes.
- **FIFO bug fix**: serial assignment and the matching push into `raw_blocks` happen under both the reader and raw_blocks locks held simultaneously. Releasing the reader lock first allowed another worker to interleave a higher serial ahead of the lower one and break the gap-filler invariant.
- **Hot-path fast check**: `is_drained()` fast-paths on a lock-free `reader_eof` atomic; the common case (reader not at EOF) exits after a single atomic load, versus three mutex acquisitions per decompressed block.

### Rayon oversubscription

Rayon's global pool defaults to `num_cpus::get()`, which silently violated `--threads` on machines with more physical cores than the requested thread count. Every `par_sort` / `par_sort_into_chunks` / `par_sort_unstable_by` / `par_chunks_mut` call in the raw sort path now runs under a `rayon::ThreadPool` built with `num_threads = self.threads`, via `rayon_pool.install(|| ...)`. `rayon::current_num_threads()` inside `parallel_radix_sort_*` now returns the requested thread count, so chunk sizing is consistent with the worker-pool sizing.

Oversubscription with the `SortWorkerPool` is not introduced: every call site is preceded by `drain_pending_spill`, which joins the prior chunk's I/O thread, so the sort worker pool is provably idle when rayon fans out.

### Additional fixes

- Use `par_sort` in the three in-memory sort fallbacks (coordinate, coordinate-index, template-coordinate). The single-threaded `buffer.sort()` serialized the sort step onto one core even with `--threads` set high when the entire input fit in memory.
- In-memory split path replaces the O(n²) `drain(..chunk_size)` loop with O(n) `split_off` from the tail. The old loop memmoved the tail on every drain and became a measurable cost once `entries` grew into the millions under tight `--max-memory` budgets.
- Drop `Phase2FileState::source_id` (always equal to the file's index in the shared vector), `SourceParserState::eof`, and the unused `_worker` parameter on `is_phase_complete` — all written or threaded through but never read.
- Refresh stale module, struct, and function docs to describe the per-file work-stealing Phase 2 model.

### Result

WES (`1kg-wes-HG00100.bam`, `--threads 8 --max-memory 4g`):

| | wall | peak RSS | sort violations |
|---|---|---|---|
| before (5df7e17) | 450s+ | ~42 GB | OOM-prone |
| this branch     | 139 s | 37.6 GB | 0 |

## Test plan
- [x] \`cargo ci-fmt\`
- [x] \`cargo ci-lint\`
- [x] \`cargo ci-test\` (2351 tests pass)
- [x] WES end-to-end sort with coordinate order, verified sorted output
- [ ] Reviewer spot-check of Phase 2 lock order and admission rule