### PR TITLE
perf(sort): add memory probes and force mimalloc arena collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "libmimalloc-sys",
  "log",
  "lru",
+ "mach2",
  "memchr",
  "mimalloc",
  "murmur3",
@@ -1376,6 +1377,12 @@ checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matrixmultiply"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "2"
 noodles = { version = "0.106.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
 noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
 mimalloc = { version = "0.1.48", default-features = false }
-libmimalloc-sys = { version = "0.1.44", features = ["extended"], optional = true }
+libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
 env_logger = "0.11.8"
 enum_dispatch = "0.3.13"
 anyhow = "1.0.102"
@@ -87,6 +87,9 @@ fgumi-simd-fastq = { workspace = true }
 fgumi-umi = { workspace = true }
 fgumi-consensus = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.6"
+
 [features]
 default = ["simplex", "duplex", "codec"]
 simplex = ["fgumi-consensus/simplex"]
@@ -94,7 +97,7 @@ duplex = ["fgumi-consensus/duplex"]
 codec = ["fgumi-consensus/codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
-memory-debug = ["dep:libmimalloc-sys"]
+memory-debug = []
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
 # Enable simulate commands for generating synthetic test data

--- a/src/lib/reorder_buffer.rs
+++ b/src/lib/reorder_buffer.rs
@@ -224,6 +224,11 @@ impl<T> ReorderBuffer<T> {
         self.can_pop
     }
 
+    /// Iterate over all buffered items (skipping empty slots).
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.buffer.iter().filter_map(|opt| opt.as_ref().map(|(item, _)| item))
+    }
+
     /// Get the tracked heap memory in bytes.
     ///
     /// This returns the sum of sizes passed to `insert_with_size`.

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -17,6 +17,27 @@ use std::cmp::Ordering;
 use std::io::{Read, Write};
 
 // ============================================================================
+// Buffer Probe Trait
+// ============================================================================
+
+/// Common metrics shared by `RecordBuffer` and `TemplateRecordBuffer` for
+/// memory-probe instrumentation.
+pub trait ProbeableBuffer {
+    /// Logical bytes stored (data + refs).
+    fn memory_usage(&self) -> usize;
+    /// Total allocated capacity (segments + refs Vec).
+    fn allocated_capacity(&self) -> usize;
+    /// Number of records in the buffer.
+    fn len(&self) -> usize;
+    /// Whether the buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    /// Number of data segments.
+    fn num_segments(&self) -> usize;
+}
+
+// ============================================================================
 // Packed Sort Keys
 // ============================================================================
 
@@ -352,6 +373,24 @@ impl RecordBuffer {
     #[must_use]
     pub fn nref(&self) -> u32 {
         self.nref
+    }
+}
+
+impl ProbeableBuffer for RecordBuffer {
+    fn memory_usage(&self) -> usize {
+        self.memory_usage()
+    }
+
+    fn allocated_capacity(&self) -> usize {
+        self.allocated_capacity()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn num_segments(&self) -> usize {
+        self.num_segments()
     }
 }
 
@@ -881,6 +920,24 @@ impl TemplateRecordBuffer {
             radix_sort_template_refs,
             |r: &TemplateRecordRef| r.key
         )
+    }
+}
+
+impl ProbeableBuffer for TemplateRecordBuffer {
+    fn memory_usage(&self) -> usize {
+        self.memory_usage()
+    }
+
+    fn allocated_capacity(&self) -> usize {
+        self.allocated_capacity()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn num_segments(&self) -> usize {
+        self.num_segments()
     }
 }
 

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -318,6 +318,18 @@ impl RecordBuffer {
         self.data.len() + self.refs.len() * std::mem::size_of::<RecordRef>()
     }
 
+    /// Total allocated capacity in bytes (data segments + refs Vec).
+    #[must_use]
+    pub fn allocated_capacity(&self) -> usize {
+        self.data.allocated_capacity() + self.refs.capacity() * std::mem::size_of::<RecordRef>()
+    }
+
+    /// Number of data segments in the underlying buffer.
+    #[must_use]
+    pub fn num_segments(&self) -> usize {
+        self.data.num_segments()
+    }
+
     /// Number of records.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -808,6 +820,19 @@ impl TemplateRecordBuffer {
     #[must_use]
     pub fn memory_usage(&self) -> usize {
         self.data.len() + self.refs.len() * std::mem::size_of::<TemplateRecordRef>()
+    }
+
+    /// Total allocated capacity in bytes (data segments + refs Vec).
+    #[must_use]
+    pub fn allocated_capacity(&self) -> usize {
+        self.data.allocated_capacity()
+            + self.refs.capacity() * std::mem::size_of::<TemplateRecordRef>()
+    }
+
+    /// Number of data segments in the underlying buffer.
+    #[must_use]
+    pub fn num_segments(&self) -> usize {
+        self.data.num_segments()
     }
 
     /// Number of records.

--- a/src/lib/sort/memory_probe.rs
+++ b/src/lib/sort/memory_probe.rs
@@ -38,91 +38,97 @@
 //! log_snapshot("phase2.end", 0);
 //! ```
 
+use bytesize::ByteSize;
 use log::{Level, info, log_enabled};
 
-/// Force mimalloc to release retained arena segments back to the OS.
-///
-/// `mi_collect(true)` is a "force" collect that triggers cross-thread free
-/// list draining and arena purging. Used by the probe to distinguish
-/// "mimalloc is hoarding pages" from "real live allocations" — if
-/// `phys_footprint` drops sharply after a collect, the gap was retained
-/// arena memory.
-#[allow(unsafe_code)] // mimalloc FFI
-pub fn force_mi_collect() {
-    // SAFETY: mi_collect(true) is a thread-safe arena maintenance call.
-    unsafe {
-        libmimalloc_sys::mi_collect(true);
-    }
-}
+pub use platform_ffi::{force_mi_collect, process_rss_bytes};
 
 /// Log target for the memory probe. Enable with
 /// `RUST_LOG=fgumi_lib::sort::memory_probe=info`.
 const TARGET: &str = "fgumi_lib::sort::memory_probe";
 
-/// Read the current process resident-set size in bytes.
-///
-/// Returns `None` if the platform sampler is unavailable (e.g. `/proc` is not
-/// mounted on a non-Linux host and the `sysinfo` fallback fails).
-///
-/// # Implementation
-///
-/// - **Linux**: reads `VmRSS` from `/proc/self/status`. One short file read,
-///   no allocations on the hot path beyond the status string itself.
-/// - **macOS**: reads `phys_footprint` from `task_info(TASK_VM_INFO)`. This is
-///   what Activity Monitor reports as "Memory" and excludes purgeable
-///   `MADV_FREE` pages, unlike `task_basic_info::resident_size` (which sysinfo
-///   uses). For sort memory diagnosis we need this metric — Darwin keeps
-///   freed pages in `resident_size` until kernel pressure forces eviction,
-///   which produces a misleading ~30 GiB peak when mimalloc has actually
-///   already purged them.
-#[cfg(target_os = "macos")]
-#[allow(unsafe_code)] // mach task_info FFI; required for phys_footprint metric
-#[must_use]
-pub fn process_rss_bytes() -> Option<u64> {
-    use mach2::message::mach_msg_type_number_t;
-    use mach2::task::task_info;
-    use mach2::task_info::{TASK_VM_INFO, task_vm_info};
-    use mach2::traps::mach_task_self;
-    use mach2::vm_types::natural_t;
-
-    let mut info = task_vm_info::default();
-    let mut count: mach_msg_type_number_t = mach_msg_type_number_t::try_from(
-        std::mem::size_of::<task_vm_info>() / std::mem::size_of::<natural_t>(),
-    )
-    .ok()?;
-    // SAFETY: mach task_info FFI; passes a properly-sized output buffer and count.
-    let kr = unsafe {
-        task_info(
-            mach_task_self(),
-            TASK_VM_INFO,
-            std::ptr::addr_of_mut!(info).cast(),
-            std::ptr::addr_of_mut!(count),
-        )
-    };
-    if kr != 0 {
-        return None;
+/// Platform-specific FFI helpers isolated from the main module to contain the
+/// `#[allow(unsafe_code)]` surface to the smallest possible scope.
+#[allow(unsafe_code)]
+mod platform_ffi {
+    /// Force mimalloc to release retained arena segments back to the OS.
+    ///
+    /// `mi_collect(true)` is a "force" collect that triggers cross-thread free
+    /// list draining and arena purging. Used by the probe to distinguish
+    /// "mimalloc is hoarding pages" from "real live allocations" — if
+    /// `phys_footprint` drops sharply after a collect, the gap was retained
+    /// arena memory.
+    pub fn force_mi_collect() {
+        // SAFETY: mi_collect(true) is a thread-safe arena maintenance call.
+        unsafe {
+            libmimalloc_sys::mi_collect(true);
+        }
     }
-    Some(info.phys_footprint)
-}
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-#[must_use]
-pub fn process_rss_bytes() -> Option<u64> {
-    None
-}
+    /// Read the current process resident-set size in bytes.
+    ///
+    /// Returns `None` if the platform sampler is unavailable (e.g. `/proc` is not
+    /// mounted on a non-Linux host and the `sysinfo` fallback fails).
+    ///
+    /// # Implementation
+    ///
+    /// - **Linux**: reads `VmRSS` from `/proc/self/status`. One short file read,
+    ///   no allocations on the hot path beyond the status string itself.
+    /// - **macOS**: reads `phys_footprint` from `task_info(TASK_VM_INFO)`. This is
+    ///   what Activity Monitor reports as "Memory" and excludes purgeable
+    ///   `MADV_FREE` pages, unlike `task_basic_info::resident_size` (which sysinfo
+    ///   uses). For sort memory diagnosis we need this metric — Darwin keeps
+    ///   freed pages in `resident_size` until kernel pressure forces eviction,
+    ///   which produces a misleading ~30 GiB peak when mimalloc has actually
+    ///   already purged them.
+    #[cfg(target_os = "macos")]
+    #[must_use]
+    pub fn process_rss_bytes() -> Option<u64> {
+        use mach2::message::mach_msg_type_number_t;
+        use mach2::task::task_info;
+        use mach2::task_info::{TASK_VM_INFO, task_vm_info};
+        use mach2::traps::mach_task_self;
+        use mach2::vm_types::natural_t;
 
-#[cfg(target_os = "linux")]
-#[must_use]
-pub fn process_rss_bytes() -> Option<u64> {
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
-    status
-        .lines()
-        .find(|line| line.starts_with("VmRSS:"))?
-        .split_whitespace()
-        .nth(1)?
-        .parse::<u64>()
-        .ok()
-        .map(|kb| kb * 1024)
+        let mut info = task_vm_info::default();
+        let mut count: mach_msg_type_number_t = mach_msg_type_number_t::try_from(
+            std::mem::size_of::<task_vm_info>() / std::mem::size_of::<natural_t>(),
+        )
+        .ok()?;
+        // SAFETY: mach task_info FFI; passes a properly-sized output buffer and count.
+        let kr = unsafe {
+            task_info(
+                mach_task_self(),
+                TASK_VM_INFO,
+                std::ptr::addr_of_mut!(info).cast(),
+                std::ptr::addr_of_mut!(count),
+            )
+        };
+        if kr != 0 {
+            return None;
+        }
+        Some(info.phys_footprint)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[must_use]
+    pub fn process_rss_bytes() -> Option<u64> {
+        None
+    }
+
+    #[cfg(target_os = "linux")]
+    #[must_use]
+    pub fn process_rss_bytes() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        status
+            .lines()
+            .find(|line| line.starts_with("VmRSS:"))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<u64>()
+            .ok()
+            .map(|kb| kb * 1024)
+    }
 }
 
 /// Whether the probe is currently enabled. Callers can short-circuit their
@@ -133,22 +139,36 @@ pub fn enabled() -> bool {
     log_enabled!(target: TARGET, Level::Info)
 }
 
-/// Format a byte count as a human-readable value with two-decimal precision.
-#[allow(clippy::cast_precision_loss)]
-fn format_bytes(bytes: u64) -> String {
-    const KIB: f64 = 1024.0;
-    const MIB: f64 = 1024.0 * 1024.0;
-    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
-    let b = bytes as f64;
-    if b >= GIB {
-        format!("{:.2}G", b / GIB)
-    } else if b >= MIB {
-        format!("{:.2}M", b / MIB)
-    } else if b >= KIB {
-        format!("{:.2}K", b / KIB)
-    } else {
-        format!("{bytes}B")
-    }
+/// Format a byte count as a human-readable value using the `bytesize` crate.
+fn fmt_bytes(bytes: u64) -> String {
+    ByteSize(bytes).to_string()
+}
+
+/// RSS snapshot taken before and after a mimalloc arena collect.
+///
+/// Pre-formatted strings are stored so callers can splice them into log lines
+/// without repeating the sample → collect → re-sample sequence.
+struct RssSnapshot {
+    rss_str: String,
+    post_collect_str: String,
+    collected_str: String,
+    rss: Option<u64>,
+}
+
+/// Sample RSS, force-collect mimalloc arenas, re-sample, and return the
+/// pre-formatted snapshot. This is the single place the triple-sample
+/// pattern lives; every probe function delegates here.
+fn collect_rss_snapshot() -> RssSnapshot {
+    let rss = process_rss_bytes();
+    let rss_str = rss.map_or_else(|| "?".to_string(), fmt_bytes);
+    force_mi_collect();
+    let rss_after = process_rss_bytes();
+    let post_collect_str = rss_after.map_or_else(|| "?".to_string(), fmt_bytes);
+    let collected_str = match (rss, rss_after) {
+        (Some(a), Some(b)) => fmt_bytes(a.saturating_sub(b)),
+        _ => "?".to_string(),
+    };
+    RssSnapshot { rss_str, post_collect_str, collected_str, rss }
 }
 
 /// Sample process RSS and log a single memory snapshot under `label`.
@@ -156,7 +176,7 @@ fn format_bytes(bytes: u64) -> String {
 /// The log line has the form
 ///
 /// ```text
-/// MEM[label] rss=8.20G tracked=0.70G residual=7.50G residual_pct=91%
+/// MEM[label] rss=8.2 GiB tracked=716.8 MiB residual=7.5 GiB residual_pct=91%
 /// ```
 ///
 /// `tracked` is the caller's estimate of accounted-for bytes (typically
@@ -170,25 +190,17 @@ pub fn log_snapshot(label: &str, tracked_bytes: u64) {
     if !enabled() {
         return;
     }
-    let rss = process_rss_bytes();
-    let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
-    let tracked_str = format_bytes(tracked_bytes);
-    // Force mimalloc arena collection so we can compare retained vs live.
-    force_mi_collect();
-    let rss_after = process_rss_bytes();
-    let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
-    let collected = match (rss, rss_after) {
-        (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
-        _ => "?".to_string(),
-    };
-    match rss {
+    let snap = collect_rss_snapshot();
+    let tracked_str = fmt_bytes(tracked_bytes);
+    match snap.rss {
         Some(r) => {
             let residual = r.saturating_sub(tracked_bytes);
-            let residual_str = format_bytes(residual);
+            let residual_str = fmt_bytes(residual);
             let pct = if r == 0 { 0 } else { (residual * 100) / r };
             info!(
                 target: TARGET,
-                "MEM[{label}] rss={rss_str} post_collect={rss_after_str} collected={collected} tracked={tracked_str} residual={residual_str} residual_pct={pct}%"
+                "MEM[{label}] rss={} post_collect={} collected={} tracked={tracked_str} residual={residual_str} residual_pct={pct}%",
+                snap.rss_str, snap.post_collect_str, snap.collected_str,
             );
         }
         None => {
@@ -213,6 +225,15 @@ pub struct BufferProbeStats {
     pub segments: u64,
 }
 
+impl BufferProbeStats {
+    /// Construct stats for a simple (non-segmented) buffer where only usage
+    /// and record count are meaningful.
+    #[must_use]
+    pub fn simple(usage: u64, records: u64) -> Self {
+        Self { usage, capacity: 0, records, segments: 0 }
+    }
+}
+
 /// Log a Phase 1 snapshot with buffer stats and optional pool queue depths.
 ///
 /// Format: `MEM[label] rss=... buf_use=... buf_cap=... recs=... segs=... [raw_q=... decomp_q=... buf_q=...]`
@@ -224,20 +245,12 @@ fn log_phase1_snapshot(
     if !enabled() {
         return;
     }
-    let rss = process_rss_bytes();
-    let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
-    force_mi_collect();
-    let rss_after = process_rss_bytes();
-    let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
-    let collected = match (rss, rss_after) {
-        (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
-        _ => "?".to_string(),
-    };
+    let snap = collect_rss_snapshot();
     let buf_str = match buf_stats {
         Some(s) => format!(
             " buf_use={} buf_cap={} recs={} segs={}",
-            format_bytes(s.usage),
-            format_bytes(s.capacity),
+            fmt_bytes(s.usage),
+            fmt_bytes(s.capacity),
             s.records,
             s.segments,
         ),
@@ -250,17 +263,18 @@ fn log_phase1_snapshot(
         None => String::new(),
     };
     let tracked = buf_stats.map_or(0, |s| s.usage);
-    let residual_str = match rss {
+    let residual_str = match snap.rss {
         Some(r) => {
             let residual = r.saturating_sub(tracked);
             let pct = if r == 0 { 0 } else { (residual * 100) / r };
-            format!(" residual={} residual_pct={pct}%", format_bytes(residual))
+            format!(" residual={} residual_pct={pct}%", fmt_bytes(residual))
         }
         None => " residual=? residual_pct=?".to_string(),
     };
     info!(
         target: TARGET,
-        "MEM[{label}] rss={rss_str} post_collect={rss_after_str} collected={collected}{buf_str}{pool_str}{residual_str}"
+        "MEM[{label}] rss={} post_collect={} collected={}{buf_str}{pool_str}{residual_str}",
+        snap.rss_str, snap.post_collect_str, snap.collected_str,
     );
 }
 
@@ -360,8 +374,6 @@ impl SpillProbe {
         self.spill_idx += 1;
         // Reset mid-read counter for next fill cycle.
         self.read_sample_idx = 0;
-        self.next_read_threshold =
-            self.next_read_threshold.saturating_add(Self::READ_SAMPLE_INTERVAL);
     }
 
     /// Log a snapshot marking the end of phase 1 (before merge).
@@ -370,6 +382,7 @@ impl SpillProbe {
     }
 
     /// Number of spill cycles observed so far.
+    #[cfg(test)]
     #[must_use]
     pub fn spill_count(&self) -> usize {
         self.spill_idx
@@ -415,6 +428,7 @@ impl MergeProbe {
 
     /// Called once per merged record with the running total. Samples RSS
     /// when `records_merged` crosses the next threshold.
+    #[cfg(test)]
     #[inline]
     pub fn record(&mut self, records_merged: u64) {
         if records_merged < self.next_threshold {
@@ -428,6 +442,7 @@ impl MergeProbe {
     }
 
     /// Number of mid-merge samples logged so far.
+    #[cfg(test)]
     #[must_use]
     pub fn sample_count(&self) -> usize {
         self.sample_idx
@@ -442,7 +457,7 @@ impl MergeProbe {
     #[inline]
     #[must_use]
     pub fn should_sample(&self, records_merged: u64) -> bool {
-        records_merged >= self.next_threshold
+        enabled() && records_merged >= self.next_threshold
     }
 
     /// Log a mid-merge sample with per-component queue depths.
@@ -451,43 +466,31 @@ impl MergeProbe {
     /// `records_merged` count. Advances the sample counter and the next
     /// threshold.
     ///
-    /// The log line extends the standard `MEM[...]` format with additional
-    /// `raw_q=` `decomp_q=` `buf_q=` fields so a single snapshot captures
-    /// both the process RSS and the pool plumbing state at the same instant.
+    /// `pool_depths` is the `(raw_input, decompressed_input, buffer_pool)`
+    /// triple from [`SortWorkerPool::phase1_queue_depths`].
     pub fn log_mid_with_depths(
         &mut self,
-        raw_chunk_q: usize,
-        decompressed_chunk_q: usize,
-        buffer_pool_available: usize,
+        pool_depths: (usize, usize, usize),
         consumer_stats: Option<ConsumerProbeStats>,
     ) {
         if enabled() {
-            let rss = process_rss_bytes();
-            let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
-            // Force mimalloc arena collection and re-sample. The delta
-            // (rss - rss_after_collect) is the retained-arena footprint.
-            force_mi_collect();
-            let rss_after = process_rss_bytes();
-            let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
-            let collected = match (rss, rss_after) {
-                (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
-                _ => "?".to_string(),
-            };
+            let snap = collect_rss_snapshot();
+            let (raw_q, decomp_q, buf_q) = pool_depths;
             let consumer_str = match consumer_stats {
                 Some(s) => format!(
                     " cur_bytes={} cur_cap={} pend_blocks={} pend_bytes={} active_src={}",
-                    format_bytes(s.current_bytes),
-                    format_bytes(s.current_capacity),
+                    fmt_bytes(s.current_bytes),
+                    fmt_bytes(s.current_capacity),
                     s.pending_blocks,
-                    format_bytes(s.pending_bytes),
+                    fmt_bytes(s.pending_bytes),
                     s.active_sources,
                 ),
                 None => String::new(),
             };
             info!(
                 target: TARGET,
-                "MEM[phase2.mid_{}] rss={rss_str} post_collect={rss_after_str} collected={collected} raw_q={raw_chunk_q} decomp_q={decompressed_chunk_q} buf_q={buffer_pool_available}{consumer_str}",
-                self.sample_idx,
+                "MEM[phase2.mid_{}] rss={} post_collect={} collected={} raw_q={raw_q} decomp_q={decomp_q} buf_q={buf_q}{consumer_str}",
+                self.sample_idx, snap.rss_str, snap.post_collect_str, snap.collected_str,
             );
         }
         self.sample_idx += 1;
@@ -506,14 +509,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_bytes_units() {
-        assert_eq!(format_bytes(0), "0B");
-        assert_eq!(format_bytes(512), "512B");
-        assert_eq!(format_bytes(1024), "1.00K");
-        assert_eq!(format_bytes(1536), "1.50K");
-        assert_eq!(format_bytes(1024 * 1024), "1.00M");
-        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00G");
-        assert_eq!(format_bytes(2u64 * 1024 * 1024 * 1024 + 512 * 1024 * 1024), "2.50G");
+    fn test_fmt_bytes_units() {
+        assert_eq!(fmt_bytes(0), "0 B");
+        assert_eq!(fmt_bytes(512), "512 B");
+        assert_eq!(fmt_bytes(1024), "1.0 KiB");
+        assert_eq!(fmt_bytes(1536), "1.5 KiB");
+        assert_eq!(fmt_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(fmt_bytes(1024 * 1024 * 1024), "1.0 GiB");
+        assert_eq!(fmt_bytes(2u64 * 1024 * 1024 * 1024 + 512 * 1024 * 1024), "2.5 GiB");
     }
 
     #[test]

--- a/src/lib/sort/memory_probe.rs
+++ b/src/lib/sort/memory_probe.rs
@@ -1,0 +1,574 @@
+//! Per-checkpoint memory instrumentation for the sort pipeline.
+//!
+//! The probe answers a single question: how much of the process RSS is
+//! accounted for by the sort buffer (`RecordBuffer::memory_usage`) versus
+//! everything else (pool queues, reorder buffers, mimalloc arenas, noodles
+//! internals, etc.)?
+//!
+//! At each checkpoint it samples process RSS, the caller-supplied tracked
+//! byte count, and logs the difference as `residual`. A monotonically
+//! increasing residual across spill cycles is the fingerprint for untracked
+//! allocation growth (the dominant suspect for issue #238: peak memory usage
+//! versus samtools).
+//!
+//! # Overhead
+//!
+//! All sampling and formatting is gated on
+//! `log::log_enabled!(target: "fgumi_lib::sort::memory_probe", Info)`, so when
+//! probe logging is off the hooks are a single atomic load. Enable with
+//! `RUST_LOG=fgumi_lib::sort::memory_probe=info` (or at the crate level).
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use crate::sort::memory_probe::{BufferProbeStats, SpillProbe, log_snapshot};
+//!
+//! let mut probe = SpillProbe::new("phase1");
+//! // ... inside spill loop:
+//! probe.pre_spill(buf_stats, Some(pool.phase1_queue_depths()));
+//! // ... after drain_pending_spill:
+//! probe.post_drain(buf_stats, Some(pool.phase1_queue_depths()));
+//! // ... after buffer.clear():
+//! probe.post_spill(Some(pool.phase1_queue_depths()));
+//! // ... at end of phase 1:
+//! probe.phase1_end(buffer.memory_usage() as u64);
+//!
+//! // ... inside merge:
+//! log_snapshot("phase2.start", 0);
+//! log_snapshot("phase2.end", 0);
+//! ```
+
+use log::{Level, info, log_enabled};
+
+/// Force mimalloc to release retained arena segments back to the OS.
+///
+/// `mi_collect(true)` is a "force" collect that triggers cross-thread free
+/// list draining and arena purging. Used by the probe to distinguish
+/// "mimalloc is hoarding pages" from "real live allocations" — if
+/// `phys_footprint` drops sharply after a collect, the gap was retained
+/// arena memory.
+#[allow(unsafe_code)] // mimalloc FFI
+pub fn force_mi_collect() {
+    // SAFETY: mi_collect(true) is a thread-safe arena maintenance call.
+    unsafe {
+        libmimalloc_sys::mi_collect(true);
+    }
+}
+
+/// Log target for the memory probe. Enable with
+/// `RUST_LOG=fgumi_lib::sort::memory_probe=info`.
+const TARGET: &str = "fgumi_lib::sort::memory_probe";
+
+/// Read the current process resident-set size in bytes.
+///
+/// Returns `None` if the platform sampler is unavailable (e.g. `/proc` is not
+/// mounted on a non-Linux host and the `sysinfo` fallback fails).
+///
+/// # Implementation
+///
+/// - **Linux**: reads `VmRSS` from `/proc/self/status`. One short file read,
+///   no allocations on the hot path beyond the status string itself.
+/// - **macOS**: reads `phys_footprint` from `task_info(TASK_VM_INFO)`. This is
+///   what Activity Monitor reports as "Memory" and excludes purgeable
+///   `MADV_FREE` pages, unlike `task_basic_info::resident_size` (which sysinfo
+///   uses). For sort memory diagnosis we need this metric — Darwin keeps
+///   freed pages in `resident_size` until kernel pressure forces eviction,
+///   which produces a misleading ~30 GiB peak when mimalloc has actually
+///   already purged them.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)] // mach task_info FFI; required for phys_footprint metric
+#[must_use]
+pub fn process_rss_bytes() -> Option<u64> {
+    use mach2::message::mach_msg_type_number_t;
+    use mach2::task::task_info;
+    use mach2::task_info::{TASK_VM_INFO, task_vm_info};
+    use mach2::traps::mach_task_self;
+    use mach2::vm_types::natural_t;
+
+    let mut info = task_vm_info::default();
+    let mut count: mach_msg_type_number_t = mach_msg_type_number_t::try_from(
+        std::mem::size_of::<task_vm_info>() / std::mem::size_of::<natural_t>(),
+    )
+    .ok()?;
+    // SAFETY: mach task_info FFI; passes a properly-sized output buffer and count.
+    let kr = unsafe {
+        task_info(
+            mach_task_self(),
+            TASK_VM_INFO,
+            std::ptr::addr_of_mut!(info).cast(),
+            std::ptr::addr_of_mut!(count),
+        )
+    };
+    if kr != 0 {
+        return None;
+    }
+    Some(info.phys_footprint)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[must_use]
+pub fn process_rss_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn process_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status
+        .lines()
+        .find(|line| line.starts_with("VmRSS:"))?
+        .split_whitespace()
+        .nth(1)?
+        .parse::<u64>()
+        .ok()
+        .map(|kb| kb * 1024)
+}
+
+/// Whether the probe is currently enabled. Callers can short-circuit their
+/// own work with this when the tracked-bytes computation is non-trivial.
+#[must_use]
+#[inline]
+pub fn enabled() -> bool {
+    log_enabled!(target: TARGET, Level::Info)
+}
+
+/// Format a byte count as a human-readable value with two-decimal precision.
+#[allow(clippy::cast_precision_loss)]
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2}G", b / GIB)
+    } else if b >= MIB {
+        format!("{:.2}M", b / MIB)
+    } else if b >= KIB {
+        format!("{:.2}K", b / KIB)
+    } else {
+        format!("{bytes}B")
+    }
+}
+
+/// Sample process RSS and log a single memory snapshot under `label`.
+///
+/// The log line has the form
+///
+/// ```text
+/// MEM[label] rss=8.20G tracked=0.70G residual=7.50G residual_pct=91%
+/// ```
+///
+/// `tracked` is the caller's estimate of accounted-for bytes (typically
+/// `RecordBuffer::memory_usage()`). `residual = rss - tracked` is the signal
+/// we care about — when it grows monotonically across spill cycles, untracked
+/// allocations are piling up.
+///
+/// When probe logging is off this is a single atomic load via `log_enabled!`;
+/// no RSS sampling, no formatting, no allocation.
+pub fn log_snapshot(label: &str, tracked_bytes: u64) {
+    if !enabled() {
+        return;
+    }
+    let rss = process_rss_bytes();
+    let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
+    let tracked_str = format_bytes(tracked_bytes);
+    // Force mimalloc arena collection so we can compare retained vs live.
+    force_mi_collect();
+    let rss_after = process_rss_bytes();
+    let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
+    let collected = match (rss, rss_after) {
+        (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
+        _ => "?".to_string(),
+    };
+    match rss {
+        Some(r) => {
+            let residual = r.saturating_sub(tracked_bytes);
+            let residual_str = format_bytes(residual);
+            let pct = if r == 0 { 0 } else { (residual * 100) / r };
+            info!(
+                target: TARGET,
+                "MEM[{label}] rss={rss_str} post_collect={rss_after_str} collected={collected} tracked={tracked_str} residual={residual_str} residual_pct={pct}%"
+            );
+        }
+        None => {
+            info!(
+                target: TARGET,
+                "MEM[{label}] rss=? tracked={tracked_str} residual=? residual_pct=?"
+            );
+        }
+    }
+}
+
+/// Per-spill buffer stats for Phase 1 probes.
+#[derive(Copy, Clone, Debug)]
+pub struct BufferProbeStats {
+    /// Logical bytes stored (data + refs).
+    pub usage: u64,
+    /// Total allocated capacity (segments + refs Vec).
+    pub capacity: u64,
+    /// Number of records in the buffer.
+    pub records: u64,
+    /// Number of data segments.
+    pub segments: u64,
+}
+
+/// Log a Phase 1 snapshot with buffer stats and optional pool queue depths.
+///
+/// Format: `MEM[label] rss=... buf_use=... buf_cap=... recs=... segs=... [raw_q=... decomp_q=... buf_q=...]`
+fn log_phase1_snapshot(
+    label: &str,
+    buf_stats: Option<BufferProbeStats>,
+    pool_depths: Option<(usize, usize, usize)>,
+) {
+    if !enabled() {
+        return;
+    }
+    let rss = process_rss_bytes();
+    let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
+    force_mi_collect();
+    let rss_after = process_rss_bytes();
+    let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
+    let collected = match (rss, rss_after) {
+        (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
+        _ => "?".to_string(),
+    };
+    let buf_str = match buf_stats {
+        Some(s) => format!(
+            " buf_use={} buf_cap={} recs={} segs={}",
+            format_bytes(s.usage),
+            format_bytes(s.capacity),
+            s.records,
+            s.segments,
+        ),
+        None => String::new(),
+    };
+    let pool_str = match pool_depths {
+        Some((raw_q, decomp_q, buf_q)) => {
+            format!(" raw_q={raw_q} decomp_q={decomp_q} buf_q={buf_q}")
+        }
+        None => String::new(),
+    };
+    let tracked = buf_stats.map_or(0, |s| s.usage);
+    let residual_str = match rss {
+        Some(r) => {
+            let residual = r.saturating_sub(tracked);
+            let pct = if r == 0 { 0 } else { (residual * 100) / r };
+            format!(" residual={} residual_pct={pct}%", format_bytes(residual))
+        }
+        None => " residual=? residual_pct=?".to_string(),
+    };
+    info!(
+        target: TARGET,
+        "MEM[{label}] rss={rss_str} post_collect={rss_after_str} collected={collected}{buf_str}{pool_str}{residual_str}"
+    );
+}
+
+/// Spill-cycle probe helper.
+///
+/// Encapsulates the spill counter so call sites don't format strings at every
+/// iteration. Construct at the top of a sort phase, call `pre_spill`/`post_spill`
+/// across the spill trigger, and `phase1_end` once before the merge step.
+///
+/// Each boundary logs a snapshot with a label like `phase1.pre_spill_0`,
+/// `phase1.post_spill_0`, `phase1.pre_spill_1`, …
+///
+/// Also supports periodic mid-read sampling (every `READ_SAMPLE_INTERVAL`
+/// records) to track RSS growth between spills.
+pub struct SpillProbe {
+    phase: &'static str,
+    spill_idx: usize,
+    read_sample_idx: usize,
+    next_read_threshold: u64,
+}
+
+impl SpillProbe {
+    /// Sample RSS every this-many records during the Phase 1 read loop.
+    pub const READ_SAMPLE_INTERVAL: u64 = 1_000_000;
+
+    /// Create a probe for the named phase and log a `"<phase>.start"`
+    /// snapshot with tracked=0.
+    #[must_use]
+    pub fn new(phase: &'static str) -> Self {
+        log_snapshot(&format!("{phase}.start"), 0);
+        Self {
+            phase,
+            spill_idx: 0,
+            read_sample_idx: 0,
+            next_read_threshold: Self::READ_SAMPLE_INTERVAL,
+        }
+    }
+
+    /// Return true if a mid-read sample should be logged at the current record count.
+    #[inline]
+    #[must_use]
+    pub fn should_sample_read(&self, records_read: u64) -> bool {
+        enabled() && records_read >= self.next_read_threshold
+    }
+
+    /// Log a mid-read sample with buffer stats and optional pool queue depths.
+    ///
+    /// Only call this when `should_sample_read()` returned true.
+    pub fn log_mid_read(
+        &mut self,
+        buf_stats: BufferProbeStats,
+        pool_depths: Option<(usize, usize, usize)>,
+    ) {
+        log_phase1_snapshot(
+            &format!("{}.mid_read_{}", self.phase, self.read_sample_idx),
+            Some(buf_stats),
+            pool_depths,
+        );
+        self.read_sample_idx += 1;
+        self.next_read_threshold =
+            self.next_read_threshold.saturating_add(Self::READ_SAMPLE_INTERVAL);
+    }
+
+    /// Log a pre-spill snapshot with buffer stats and optional pool depths.
+    pub fn pre_spill(
+        &self,
+        buf_stats: BufferProbeStats,
+        pool_depths: Option<(usize, usize, usize)>,
+    ) {
+        log_phase1_snapshot(
+            &format!("{}.pre_spill_{}", self.phase, self.spill_idx),
+            Some(buf_stats),
+            pool_depths,
+        );
+    }
+
+    /// Log a post-drain snapshot (after previous spill is drained, buffer still full).
+    pub fn post_drain(
+        &self,
+        buf_stats: BufferProbeStats,
+        pool_depths: Option<(usize, usize, usize)>,
+    ) {
+        log_phase1_snapshot(
+            &format!("{}.post_drain_{}", self.phase, self.spill_idx),
+            Some(buf_stats),
+            pool_depths,
+        );
+    }
+
+    /// Log a post-spill snapshot (tracked=0) and advance the spill index.
+    pub fn post_spill(&mut self, pool_depths: Option<(usize, usize, usize)>) {
+        log_phase1_snapshot(
+            &format!("{}.post_spill_{}", self.phase, self.spill_idx),
+            None,
+            pool_depths,
+        );
+        self.spill_idx += 1;
+        // Reset mid-read counter for next fill cycle.
+        self.read_sample_idx = 0;
+        self.next_read_threshold =
+            self.next_read_threshold.saturating_add(Self::READ_SAMPLE_INTERVAL);
+    }
+
+    /// Log a snapshot marking the end of phase 1 (before merge).
+    pub fn phase1_end(&self, tracked: u64) {
+        log_snapshot(&format!("{}.end", self.phase), tracked);
+    }
+
+    /// Number of spill cycles observed so far.
+    #[must_use]
+    pub fn spill_count(&self) -> usize {
+        self.spill_idx
+    }
+}
+
+/// Merge-phase probe helper.
+///
+/// Encapsulates a periodic sampler that logs a snapshot every
+/// `SAMPLE_INTERVAL_RECORDS` merged records during phase 2. Like `SpillProbe`,
+/// the hot path is gated on `log_enabled!` so probes off = single atomic load.
+///
+/// Each sample is labelled `phase2.mid_N` where N is the sample index (0..).
+/// Optional consumer-side byte accounting sampled at mid-merge boundaries.
+#[derive(Copy, Clone, Debug)]
+pub struct ConsumerProbeStats {
+    pub current_bytes: u64,
+    pub current_capacity: u64,
+    pub pending_blocks: u64,
+    pub pending_bytes: u64,
+    pub active_sources: u64,
+}
+
+pub struct MergeProbe {
+    sample_idx: usize,
+    next_threshold: u64,
+}
+
+impl MergeProbe {
+    /// Sample the RSS every this-many merged records when probe logging is on.
+    /// Chosen to give ~20 samples on a 200M-record merge — fine-grained enough
+    /// to see the growth-curve shape, sparse enough that the sysinfo/proc
+    /// sampling overhead is negligible.
+    pub const SAMPLE_INTERVAL_RECORDS: u64 = 1_000_000;
+
+    /// Create a new merge probe. Logs a `"phase2.start"` snapshot with
+    /// tracked=0.
+    #[must_use]
+    pub fn new() -> Self {
+        log_snapshot("phase2.start", 0);
+        Self { sample_idx: 0, next_threshold: Self::SAMPLE_INTERVAL_RECORDS }
+    }
+
+    /// Called once per merged record with the running total. Samples RSS
+    /// when `records_merged` crosses the next threshold.
+    #[inline]
+    pub fn record(&mut self, records_merged: u64) {
+        if records_merged < self.next_threshold {
+            return;
+        }
+        if enabled() {
+            log_snapshot(&format!("phase2.mid_{}", self.sample_idx), 0);
+        }
+        self.sample_idx += 1;
+        self.next_threshold = self.next_threshold.saturating_add(Self::SAMPLE_INTERVAL_RECORDS);
+    }
+
+    /// Number of mid-merge samples logged so far.
+    #[must_use]
+    pub fn sample_count(&self) -> usize {
+        self.sample_idx
+    }
+
+    /// Return true if a mid-merge sample should be logged at the current
+    /// record count.
+    ///
+    /// Call sites use this to gate expensive context gathering (pool queue
+    /// depths, buffer pool counts) so those observations only happen on the
+    /// ~20-sample boundaries, not every record.
+    #[inline]
+    #[must_use]
+    pub fn should_sample(&self, records_merged: u64) -> bool {
+        records_merged >= self.next_threshold
+    }
+
+    /// Log a mid-merge sample with per-component queue depths.
+    ///
+    /// Only call this when `should_sample()` returned true for the same
+    /// `records_merged` count. Advances the sample counter and the next
+    /// threshold.
+    ///
+    /// The log line extends the standard `MEM[...]` format with additional
+    /// `raw_q=` `decomp_q=` `buf_q=` fields so a single snapshot captures
+    /// both the process RSS and the pool plumbing state at the same instant.
+    pub fn log_mid_with_depths(
+        &mut self,
+        raw_chunk_q: usize,
+        decompressed_chunk_q: usize,
+        buffer_pool_available: usize,
+        consumer_stats: Option<ConsumerProbeStats>,
+    ) {
+        if enabled() {
+            let rss = process_rss_bytes();
+            let rss_str = rss.map_or_else(|| "?".to_string(), format_bytes);
+            // Force mimalloc arena collection and re-sample. The delta
+            // (rss - rss_after_collect) is the retained-arena footprint.
+            force_mi_collect();
+            let rss_after = process_rss_bytes();
+            let rss_after_str = rss_after.map_or_else(|| "?".to_string(), format_bytes);
+            let collected = match (rss, rss_after) {
+                (Some(a), Some(b)) => format_bytes(a.saturating_sub(b)),
+                _ => "?".to_string(),
+            };
+            let consumer_str = match consumer_stats {
+                Some(s) => format!(
+                    " cur_bytes={} cur_cap={} pend_blocks={} pend_bytes={} active_src={}",
+                    format_bytes(s.current_bytes),
+                    format_bytes(s.current_capacity),
+                    s.pending_blocks,
+                    format_bytes(s.pending_bytes),
+                    s.active_sources,
+                ),
+                None => String::new(),
+            };
+            info!(
+                target: TARGET,
+                "MEM[phase2.mid_{}] rss={rss_str} post_collect={rss_after_str} collected={collected} raw_q={raw_chunk_q} decomp_q={decompressed_chunk_q} buf_q={buffer_pool_available}{consumer_str}",
+                self.sample_idx,
+            );
+        }
+        self.sample_idx += 1;
+        self.next_threshold = self.next_threshold.saturating_add(Self::SAMPLE_INTERVAL_RECORDS);
+    }
+}
+
+impl Default for MergeProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes_units() {
+        assert_eq!(format_bytes(0), "0B");
+        assert_eq!(format_bytes(512), "512B");
+        assert_eq!(format_bytes(1024), "1.00K");
+        assert_eq!(format_bytes(1536), "1.50K");
+        assert_eq!(format_bytes(1024 * 1024), "1.00M");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00G");
+        assert_eq!(format_bytes(2u64 * 1024 * 1024 * 1024 + 512 * 1024 * 1024), "2.50G");
+    }
+
+    #[test]
+    fn test_process_rss_bytes_returns_plausible_value() {
+        // Every host we target has either /proc/self/status or a working
+        // sysinfo fallback, so this should not return None in CI.
+        let rss = process_rss_bytes().expect("RSS sampling should work on supported platforms");
+        // 1 MiB is a safe lower bound for any running Rust process.
+        assert!(rss >= 1024 * 1024, "RSS {rss} is implausibly small");
+        // 1 TiB is a safe upper bound for a test process.
+        assert!(rss < 1024u64 * 1024 * 1024 * 1024, "RSS {rss} is implausibly large");
+    }
+
+    #[test]
+    fn test_log_snapshot_does_not_panic_without_logger() {
+        // With no logger configured, log_enabled! returns false and the
+        // entire function should short-circuit cleanly.
+        log_snapshot("test.label", 1024);
+        log_snapshot("test.label", 0);
+    }
+
+    #[test]
+    fn test_spill_probe_increments() {
+        let mut probe = SpillProbe::new("test_phase");
+        assert_eq!(probe.spill_count(), 0);
+        let stats = BufferProbeStats { usage: 1024, capacity: 2048, records: 10, segments: 1 };
+        probe.pre_spill(stats, None);
+        probe.post_spill(None);
+        assert_eq!(probe.spill_count(), 1);
+        let stats2 = BufferProbeStats { usage: 2048, capacity: 4096, records: 20, segments: 1 };
+        probe.pre_spill(stats2, None);
+        probe.post_spill(None);
+        assert_eq!(probe.spill_count(), 2);
+        probe.phase1_end(0);
+    }
+
+    #[test]
+    fn test_merge_probe_samples_at_interval() {
+        let mut probe = MergeProbe::new();
+        assert_eq!(probe.sample_count(), 0);
+
+        // Below threshold: no samples.
+        probe.record(MergeProbe::SAMPLE_INTERVAL_RECORDS - 1);
+        assert_eq!(probe.sample_count(), 0);
+
+        // At threshold: first sample.
+        probe.record(MergeProbe::SAMPLE_INTERVAL_RECORDS);
+        assert_eq!(probe.sample_count(), 1);
+
+        // Same interval doesn't re-fire.
+        probe.record(MergeProbe::SAMPLE_INTERVAL_RECORDS + 1);
+        assert_eq!(probe.sample_count(), 1);
+
+        // Second threshold fires.
+        probe.record(MergeProbe::SAMPLE_INTERVAL_RECORDS * 2);
+        assert_eq!(probe.sample_count(), 2);
+    }
+}

--- a/src/lib/sort/mod.rs
+++ b/src/lib/sort/mod.rs
@@ -38,6 +38,7 @@ pub mod bgzf_io;
 pub mod inline_buffer;
 pub mod keys;
 pub mod loser_tree;
+pub(crate) mod memory_probe;
 pub mod pipeline;
 pub mod pooled_bam_writer;
 pub mod pooled_chunk_writer;

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -21,7 +21,9 @@ use crate::bam_io::create_raw_bam_reader;
 use crate::progress::ProgressTracker;
 #[cfg(test)]
 use crate::sam::SamTag;
-use crate::sort::inline_buffer::{RecordBuffer, TemplateKey, TemplateRecordBuffer};
+use crate::sort::inline_buffer::{
+    ProbeableBuffer, RecordBuffer, TemplateKey, TemplateRecordBuffer,
+};
 use crate::sort::keys::{QuerynameComparator, RawSortKey, SortOrder};
 use crate::sort::memory_probe::{
     BufferProbeStats, ConsumerProbeStats, MergeProbe, SpillProbe, force_mi_collect, log_snapshot,
@@ -1018,27 +1020,16 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
     }
 
     /// Gather probe statistics from the per-file Phase 2 state.
-    ///
-    /// Iterates all files to sum up pending blocks, pending bytes (in
-    /// decompressed reorder buffers), active source count, and in-flight
-    /// decompression count.
     fn probe_consumer_stats(&self) -> ConsumerProbeStats {
         let mut pending_blocks: u64 = 0;
         let mut pending_bytes: u64 = 0;
         let mut active_sources: u64 = 0;
 
         for file in self.files.iter() {
-            let raw_len =
-                file.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned").len() as u64;
-            let decomp_guard =
-                file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
-            let decomp_len = decomp_guard.len() as u64;
-            let decomp_bytes: u64 = decomp_guard.iter().map(|buf| buf.len() as u64).sum();
-            drop(decomp_guard);
-
-            pending_blocks += raw_len + decomp_len;
-            pending_bytes += decomp_bytes;
-            if !file.reader_eof.load(std::sync::atomic::Ordering::Relaxed) {
+            let (blocks, bytes, active) = file.probe_stats();
+            pending_blocks += blocks;
+            pending_bytes += bytes;
+            if active {
                 active_sources += 1;
             }
         }
@@ -1125,20 +1116,9 @@ struct PendingSpill {
     chunk_path: PathBuf,
 }
 
-/// Build `BufferProbeStats` from a `RecordBuffer`.
+/// Build `BufferProbeStats` from any buffer implementing `ProbeableBuffer`.
 #[allow(clippy::cast_possible_truncation)]
-fn buf_probe_stats(buf: &RecordBuffer) -> BufferProbeStats {
-    BufferProbeStats {
-        usage: buf.memory_usage() as u64,
-        capacity: buf.allocated_capacity() as u64,
-        records: buf.len() as u64,
-        segments: buf.num_segments() as u64,
-    }
-}
-
-/// Build `BufferProbeStats` from a `TemplateRecordBuffer`.
-#[allow(clippy::cast_possible_truncation)]
-fn tmpl_buf_probe_stats(buf: &TemplateRecordBuffer) -> BufferProbeStats {
+fn probe_stats(buf: &impl ProbeableBuffer) -> BufferProbeStats {
     BufferProbeStats {
         usage: buf.memory_usage() as u64,
         capacity: buf.allocated_capacity() as u64,
@@ -1731,13 +1711,13 @@ impl RawExternalSorter {
             buffer.push_coordinate(record.as_ref())?;
 
             if probe.should_sample_read(stats.total_records) {
-                probe.log_mid_read(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.log_mid_read(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
             }
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
-                let bstats = buf_probe_stats(&buffer);
+                let bstats = probe_stats(&buffer);
                 let depths = Some(pool.phase1_queue_depths());
                 probe.pre_spill(bstats, depths);
 
@@ -1750,7 +1730,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
-                probe.post_drain(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -1911,12 +1891,12 @@ impl RawExternalSorter {
             buffer.push_coordinate(record.as_ref())?;
 
             if probe.should_sample_read(stats.total_records) {
-                probe.log_mid_read(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.log_mid_read(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
             }
 
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
-                let bstats = buf_probe_stats(&buffer);
+                let bstats = probe_stats(&buffer);
                 let depths = Some(pool.phase1_queue_depths());
                 probe.pre_spill(bstats, depths);
 
@@ -1929,7 +1909,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
-                probe.post_drain(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -1958,7 +1938,6 @@ impl RawExternalSorter {
         }
 
         timer.end_read_span();
-        probe.phase1_end(buffer.memory_usage() as u64);
         info!("Read {} records total", stats.total_records);
         if let Some(err) = record_source.take_error() {
             return Err(anyhow::Error::from(err));
@@ -1973,6 +1952,7 @@ impl RawExternalSorter {
             &mut namer,
             &pool,
         )?;
+        probe.phase1_end(buffer.memory_usage() as u64);
 
         let output_header = self.create_output_header(header);
 
@@ -2138,24 +2118,14 @@ impl RawExternalSorter {
             entries.push((key, bam_bytes.to_vec()));
 
             if probe.should_sample_read(stats.total_records) {
-                let bstats = BufferProbeStats {
-                    usage: memory_used as u64,
-                    capacity: 0,
-                    records: entries.len() as u64,
-                    segments: 0,
-                };
+                let bstats = BufferProbeStats::simple(memory_used as u64, entries.len() as u64);
                 probe.log_mid_read(bstats, Some(pool.phase1_queue_depths()));
             }
 
             // Check if we need to spill to disk
             if memory_used >= self.memory_limit {
                 timer.end_read_span();
-                let bstats = BufferProbeStats {
-                    usage: memory_used as u64,
-                    capacity: 0,
-                    records: entries.len() as u64,
-                    segments: 0,
-                };
+                let bstats = BufferProbeStats::simple(memory_used as u64, entries.len() as u64);
                 let depths = Some(pool.phase1_queue_depths());
                 probe.pre_spill(bstats, depths);
 
@@ -2361,13 +2331,13 @@ impl RawExternalSorter {
             buffer.push(bam_bytes, key)?;
 
             if probe.should_sample_read(stats.total_records) {
-                probe.log_mid_read(tmpl_buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.log_mid_read(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
             }
 
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
-                let bstats = tmpl_buf_probe_stats(&buffer);
+                let bstats = probe_stats(&buffer);
                 let depths = Some(pool.phase1_queue_depths());
                 probe.pre_spill(bstats, depths);
 
@@ -2380,7 +2350,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
-                probe.post_drain(tmpl_buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+                probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -2414,7 +2384,6 @@ impl RawExternalSorter {
         }
 
         // Drain any pending spill before merge
-        probe.phase1_end(buffer.memory_usage() as u64);
         self.drain_pending_spill::<TemplateKey>(
             &mut pending_spill,
             &mut chunk_files,
@@ -2423,6 +2392,7 @@ impl RawExternalSorter {
             &mut namer,
             &pool,
         )?;
+        probe.phase1_end(buffer.memory_usage() as u64);
 
         if chunk_files.is_empty() {
             // All records fit in memory
@@ -2676,9 +2646,9 @@ impl RawExternalSorter {
             merge_progress.log_if_needed(1);
 
             if merge_probe.should_sample(records_merged) {
-                let (raw_q, decomp_q, buf_q) = pool.phase1_queue_depths();
+                let depths = pool.phase1_queue_depths();
                 let consumer_stats = guard.consumer_mut().map(|c| c.probe_consumer_stats());
-                merge_probe.log_mid_with_depths(raw_q, decomp_q, buf_q, consumer_stats);
+                merge_probe.log_mid_with_depths(depths, consumer_stats);
             }
 
             let src_idx = source_map[winner];

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -23,6 +23,9 @@ use crate::progress::ProgressTracker;
 use crate::sam::SamTag;
 use crate::sort::inline_buffer::{RecordBuffer, TemplateKey, TemplateRecordBuffer};
 use crate::sort::keys::{QuerynameComparator, RawSortKey, SortOrder};
+use crate::sort::memory_probe::{
+    BufferProbeStats, ConsumerProbeStats, MergeProbe, SpillProbe, force_mi_collect, log_snapshot,
+};
 use crate::sort::pooled_chunk_writer::PooledChunkWriter;
 use crate::sort::read_ahead::{RawReadAheadReader, RecordSource};
 use crate::sort::worker_pool::SortWorkerPool;
@@ -1013,6 +1016,41 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             Err(e) => Err(anyhow::anyhow!("error reading key from source {source_id}: {e}")),
         }
     }
+
+    /// Gather probe statistics from the per-file Phase 2 state.
+    ///
+    /// Iterates all files to sum up pending blocks, pending bytes (in
+    /// decompressed reorder buffers), active source count, and in-flight
+    /// decompression count.
+    fn probe_consumer_stats(&self) -> ConsumerProbeStats {
+        let mut pending_blocks: u64 = 0;
+        let mut pending_bytes: u64 = 0;
+        let mut active_sources: u64 = 0;
+
+        for file in self.files.iter() {
+            let raw_len =
+                file.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned").len() as u64;
+            let decomp_guard =
+                file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+            let decomp_len = decomp_guard.len() as u64;
+            let decomp_bytes: u64 = decomp_guard.iter().map(|buf| buf.len() as u64).sum();
+            drop(decomp_guard);
+
+            pending_blocks += raw_len + decomp_len;
+            pending_bytes += decomp_bytes;
+            if !file.reader_eof.load(std::sync::atomic::Ordering::Relaxed) {
+                active_sources += 1;
+            }
+        }
+
+        ConsumerProbeStats {
+            current_bytes: 0,
+            current_capacity: 0,
+            pending_blocks,
+            pending_bytes,
+            active_sources,
+        }
+    }
 }
 
 /// Adapter that implements `std::io::Read` over a `MainThreadChunkConsumer` source.
@@ -1085,6 +1123,28 @@ impl<'a> ChunkNamer<'a> {
 struct PendingSpill {
     handle: crate::sort::pooled_chunk_writer::SpillWriteHandle,
     chunk_path: PathBuf,
+}
+
+/// Build `BufferProbeStats` from a `RecordBuffer`.
+#[allow(clippy::cast_possible_truncation)]
+fn buf_probe_stats(buf: &RecordBuffer) -> BufferProbeStats {
+    BufferProbeStats {
+        usage: buf.memory_usage() as u64,
+        capacity: buf.allocated_capacity() as u64,
+        records: buf.len() as u64,
+        segments: buf.num_segments() as u64,
+    }
+}
+
+/// Build `BufferProbeStats` from a `TemplateRecordBuffer`.
+#[allow(clippy::cast_possible_truncation)]
+fn tmpl_buf_probe_stats(buf: &TemplateRecordBuffer) -> BufferProbeStats {
+    BufferProbeStats {
+        usage: buf.memory_usage() as u64,
+        capacity: buf.allocated_capacity() as u64,
+        records: buf.len() as u64,
+        segments: buf.num_segments() as u64,
+    }
 }
 
 /// Raw-bytes external sorter for BAM files.
@@ -1661,6 +1721,7 @@ impl RawExternalSorter {
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
+        let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
             stats.total_records += 1;
@@ -1669,9 +1730,16 @@ impl RawExternalSorter {
             // Push directly to buffer - key extracted inline from raw bytes
             buffer.push_coordinate(record.as_ref())?;
 
+            if probe.should_sample_read(stats.total_records) {
+                probe.log_mid_read(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+            }
+
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
+                let bstats = buf_probe_stats(&buffer);
+                let depths = Some(pool.phase1_queue_depths());
+                probe.pre_spill(bstats, depths);
 
                 // Wait for any previous spill to complete before starting a new one
                 self.drain_pending_spill::<RawCoordinateKey>(
@@ -1682,6 +1750,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
+                probe.post_drain(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -1706,6 +1775,8 @@ impl RawExternalSorter {
                 pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                force_mi_collect();
+                probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
             }
         }
@@ -1725,6 +1796,7 @@ impl RawExternalSorter {
             &mut namer,
             &pool,
         )?;
+        probe.phase1_end(buffer.memory_usage() as u64);
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
@@ -1832,13 +1904,21 @@ impl RawExternalSorter {
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
+        let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
             stats.total_records += 1;
             buffer.push_coordinate(record.as_ref())?;
 
+            if probe.should_sample_read(stats.total_records) {
+                probe.log_mid_read(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+            }
+
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
+                let bstats = buf_probe_stats(&buffer);
+                let depths = Some(pool.phase1_queue_depths());
+                probe.pre_spill(bstats, depths);
 
                 // Wait for any previous spill to complete
                 self.drain_pending_spill::<RawCoordinateKey>(
@@ -1849,6 +1929,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
+                probe.post_drain(buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -1870,11 +1951,14 @@ impl RawExternalSorter {
                 pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                force_mi_collect();
+                probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
             }
         }
 
         timer.end_read_span();
+        probe.phase1_end(buffer.memory_usage() as u64);
         info!("Read {} records total", stats.total_records);
         if let Some(err) = record_source.take_error() {
             return Err(anyhow::Error::from(err));
@@ -2037,6 +2121,7 @@ impl RawExternalSorter {
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (keyed output)...");
+        let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
             stats.total_records += 1;
@@ -2052,9 +2137,27 @@ impl RawExternalSorter {
 
             entries.push((key, bam_bytes.to_vec()));
 
+            if probe.should_sample_read(stats.total_records) {
+                let bstats = BufferProbeStats {
+                    usage: memory_used as u64,
+                    capacity: 0,
+                    records: entries.len() as u64,
+                    segments: 0,
+                };
+                probe.log_mid_read(bstats, Some(pool.phase1_queue_depths()));
+            }
+
             // Check if we need to spill to disk
             if memory_used >= self.memory_limit {
                 timer.end_read_span();
+                let bstats = BufferProbeStats {
+                    usage: memory_used as u64,
+                    capacity: 0,
+                    records: entries.len() as u64,
+                    segments: 0,
+                };
+                let depths = Some(pool.phase1_queue_depths());
+                probe.pre_spill(bstats, depths);
 
                 // Wait for any previous spill to complete
                 self.drain_pending_spill::<K>(
@@ -2065,6 +2168,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
+                probe.post_drain(bstats, Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -2085,6 +2189,8 @@ impl RawExternalSorter {
                 pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 memory_used = 0;
+                force_mi_collect();
+                probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
             }
         }
@@ -2104,6 +2210,7 @@ impl RawExternalSorter {
             &mut namer,
             &pool,
         )?;
+        probe.phase1_end(memory_used as u64);
 
         if chunk_files.is_empty() {
             // All records fit in memory
@@ -2237,6 +2344,7 @@ impl RawExternalSorter {
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
         info!("Phase 1: Reading and sorting chunks (inline buffer)...");
+        let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
             stats.total_records += 1;
@@ -2252,9 +2360,16 @@ impl RawExternalSorter {
             );
             buffer.push(bam_bytes, key)?;
 
+            if probe.should_sample_read(stats.total_records) {
+                probe.log_mid_read(tmpl_buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
+            }
+
             // Check memory usage
             if buffer.memory_usage() >= self.memory_limit {
                 timer.end_read_span();
+                let bstats = tmpl_buf_probe_stats(&buffer);
+                let depths = Some(pool.phase1_queue_depths());
+                probe.pre_spill(bstats, depths);
 
                 // Wait for any previous spill to complete
                 self.drain_pending_spill::<TemplateKey>(
@@ -2265,6 +2380,7 @@ impl RawExternalSorter {
                     &mut namer,
                     &pool,
                 )?;
+                probe.post_drain(tmpl_buf_probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
                 let chunk_path = namer.next_chunk_path();
 
@@ -2285,6 +2401,8 @@ impl RawExternalSorter {
                 pending_spill = Some(PendingSpill { handle, chunk_path });
 
                 buffer.clear();
+                force_mi_collect();
+                probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
             }
         }
@@ -2296,6 +2414,7 @@ impl RawExternalSorter {
         }
 
         // Drain any pending spill before merge
+        probe.phase1_end(buffer.memory_usage() as u64);
         self.drain_pending_spill::<TemplateKey>(
             &mut pending_spill,
             &mut chunk_files,
@@ -2530,6 +2649,8 @@ impl RawExternalSorter {
             .with_interval(1_000_000)
             .with_total(total_records);
 
+        let mut merge_probe = MergeProbe::new();
+
         // Sub-phase timing: only paid when debug logging is enabled.
         let debug_timing = log::log_enabled!(log::Level::Debug);
         let merge_sample_interval: u64 = 1024;
@@ -2553,6 +2674,12 @@ impl RawExternalSorter {
 
             records_merged += 1;
             merge_progress.log_if_needed(1);
+
+            if merge_probe.should_sample(records_merged) {
+                let (raw_q, decomp_q, buf_q) = pool.phase1_queue_depths();
+                let consumer_stats = guard.consumer_mut().map(|c| c.probe_consumer_stats());
+                merge_probe.log_mid_with_depths(raw_q, decomp_q, buf_q, consumer_stats);
+            }
 
             let src_idx = source_map[winner];
 
@@ -2601,6 +2728,7 @@ impl RawExternalSorter {
 
         writer.finish()?;
         merge_progress.log_final();
+        log_snapshot("phase2.end", 0);
 
         Ok(records_merged)
     }

--- a/src/lib/sort/segmented_buf.rs
+++ b/src/lib/sort/segmented_buf.rs
@@ -178,6 +178,18 @@ impl SegmentedBuf {
         &seg[seg_offset..seg_offset + len]
     }
 
+    /// Total allocated capacity in bytes across all segments.
+    #[must_use]
+    pub fn allocated_capacity(&self) -> usize {
+        self.segments.iter().map(Vec::capacity).sum()
+    }
+
+    /// Number of allocated segments.
+    #[must_use]
+    pub fn num_segments(&self) -> usize {
+        self.segments.len()
+    }
+
     /// Clear all data, retaining the first segment's allocation.
     pub fn clear(&mut self) {
         self.segments.truncate(1);
@@ -210,12 +222,6 @@ impl SegmentedBuf {
     pub fn segment_size(&self) -> usize {
         self.segment_size
     }
-
-    /// Number of allocated segments.
-    #[must_use]
-    pub fn segment_count(&self) -> usize {
-        self.segments.len()
-    }
 }
 
 impl Default for SegmentedBuf {
@@ -233,7 +239,7 @@ mod tests {
         let buf = SegmentedBuf::new();
         assert!(buf.is_empty());
         assert_eq!(buf.len(), 0);
-        assert_eq!(buf.segment_count(), 1); // one pre-allocated segment
+        assert_eq!(buf.num_segments(), 1); // one pre-allocated segment
     }
 
     #[test]
@@ -268,12 +274,12 @@ mod tests {
 
         // Fill first segment exactly
         let o1 = buf.extend_from_slice(b"0123456789");
-        assert_eq!(buf.segment_count(), 1);
+        assert_eq!(buf.num_segments(), 1);
         assert_eq!(buf.len(), 10);
 
         // Next write starts a new segment
         let o2 = buf.extend_from_slice(b"abcde");
-        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.num_segments(), 2);
         assert_eq!(buf.len(), 15);
 
         // Data is retrievable across segments
@@ -287,13 +293,13 @@ mod tests {
 
         let o1 = buf.extend_from_slice(b"1234567"); // 7 bytes in seg 0
         assert_eq!(o1, 0);
-        assert_eq!(buf.segment_count(), 1);
+        assert_eq!(buf.num_segments(), 1);
 
         // 5 bytes won't fit in remaining 3 bytes, so spills to seg 1
         // total_len jumps from 7 → 10 (gap) → 15
         let o2 = buf.extend_from_slice(b"abcde");
         assert_eq!(o2, 10); // starts at segment boundary
-        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.num_segments(), 2);
         assert_eq!(buf.len(), 15); // 10 (seg 0 padded) + 5
 
         assert_eq!(buf.slice(o1, 7), b"1234567");
@@ -339,7 +345,7 @@ mod tests {
 
         assert!(buf.is_empty());
         assert_eq!(buf.len(), 0);
-        assert_eq!(buf.segment_count(), 1);
+        assert_eq!(buf.num_segments(), 1);
     }
 
     #[test]
@@ -356,7 +362,7 @@ mod tests {
         }
 
         // Each record in its own 100-byte segment
-        assert_eq!(buf.segment_count(), 50);
+        assert_eq!(buf.num_segments(), 50);
 
         // Verify all records readable
         #[allow(clippy::cast_possible_truncation)]
@@ -414,7 +420,7 @@ mod tests {
         buf.extend_in_place(&[0xCC; 16]);
         buf.extend_in_place(&[0xDD; 60]);
 
-        assert_eq!(buf.segment_count(), 2);
+        assert_eq!(buf.num_segments(), 2);
         assert_eq!(buf.slice(0, 16), &[0xAA; 16]);
         assert_eq!(buf.slice(16, 60), &[0xBB; 60]);
         assert_eq!(buf.slice(100, 16), &[0xCC; 16]);
@@ -433,7 +439,7 @@ mod tests {
         assert_eq!(o1, 0);
         assert_eq!(o2, 4);
         assert_eq!(o3, 8);
-        assert_eq!(buf.segment_count(), 1);
+        assert_eq!(buf.num_segments(), 1);
 
         // Can read the entire contiguous range
         assert_eq!(buf.slice(0, 12), b"aaaabbbbcccc");

--- a/src/lib/sort/worker_pool.rs
+++ b/src/lib/sort/worker_pool.rs
@@ -307,6 +307,18 @@ impl BufferPool {
         self.rx.try_recv().unwrap_or_default()
     }
 
+    /// Returns the number of buffers currently available in the pool.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rx.len()
+    }
+
+    /// Returns true if no buffers are currently available in the pool.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rx.is_empty()
+    }
+
     /// Return a buffer to the pool for reuse.
     /// If the pool is full, the buffer is dropped.
     pub fn checkin(&self, mut buf: Vec<u8>) {
@@ -1534,6 +1546,15 @@ impl SortWorkerPool {
     /// Number of worker threads in the pool.
     pub fn num_workers(&self) -> usize {
         self.num_workers
+    }
+
+    /// Phase 1 input pipeline queue depths: `(raw_input_blocks, decompressed_input, buffer_pool)`.
+    pub(crate) fn phase1_queue_depths(&self) -> (usize, usize, usize) {
+        (
+            self.shared.raw_input_blocks.len(),
+            self.shared.decompressed_input.len(),
+            self.buffer_pool.len(),
+        )
     }
 
     /// Get a clone of the decompressed input `ArrayQueue` for `PooledInputStream`.

--- a/src/lib/sort/worker_pool.rs
+++ b/src/lib/sort/worker_pool.rs
@@ -454,6 +454,30 @@ impl Phase2FileState {
         }
     }
 
+    /// Mark the disk reader as having reached EOF. Updates both the
+    /// reader-internal flag and the lock-free atomic copy. Must be called
+    /// while holding the reader `Mutex` (pass the guard to prove it).
+    pub(crate) fn mark_reader_eof(&self, reader_guard: &mut Phase2Reader) {
+        reader_guard.eof = true;
+        self.reader_eof.store(true, Ordering::Release);
+    }
+
+    /// Gather probe statistics for this file: `(pending_blocks, pending_bytes, active)`.
+    ///
+    /// `pending_blocks` counts raw + decompressed blocks in flight.
+    /// `pending_bytes` sums the byte length of decompressed blocks.
+    /// `active` is true if the disk reader has not yet reached EOF.
+    pub(crate) fn probe_stats(&self) -> (u64, u64, bool) {
+        let raw_len =
+            self.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned").len() as u64;
+        let decomp_guard = self.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+        let decomp_len = decomp_guard.len() as u64;
+        let decomp_bytes: u64 = decomp_guard.iter().map(|buf| buf.len() as u64).sum();
+        drop(decomp_guard);
+        let active = !self.reader_eof.load(Ordering::Relaxed);
+        (raw_len + decomp_len, decomp_bytes, active)
+    }
+
     /// Returns true when this file has produced all its data: disk reader at
     /// EOF, no raw blocks waiting, no decompressed blocks waiting, and no
     /// decompression in progress.
@@ -1421,8 +1445,7 @@ impl SortWorkerPool {
                 Err(e) => {
                     log::error!("I/O error reading chunk file (source {i}): {e}");
                     shared.chunk_read_error.store(true, Ordering::Release);
-                    reader_guard.eof = true;
-                    file.reader_eof.store(true, Ordering::Release);
+                    file.mark_reader_eof(&mut reader_guard);
                     drop(reader_guard);
                     shared.main_thread_handle.unpark();
                     Self::maybe_mark_all_eof(shared);
@@ -1432,8 +1455,7 @@ impl SortWorkerPool {
             };
 
             if blocks.is_empty() {
-                reader_guard.eof = true;
-                file.reader_eof.store(true, Ordering::Release);
+                file.mark_reader_eof(&mut reader_guard);
                 drop(reader_guard);
                 shared.main_thread_handle.unpark();
                 Self::maybe_mark_all_eof(shared);
@@ -2160,8 +2182,7 @@ mod tests {
     fn test_is_drained_respects_in_flight_counter() {
         let file = empty_phase2_file();
         // Mark reader as EOF and ensure both queues are empty.
-        file.reader.lock().expect("reader lock").eof = true;
-        file.reader_eof.store(true, Ordering::Release);
+        file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
         assert!(file.is_drained(), "reader_eof + empty queues + no in-flight should be drained");
 
         // Simulate a worker mid-decompression: in_flight > 0 must hide drain.
@@ -2176,8 +2197,7 @@ mod tests {
     #[test]
     fn test_is_drained_blocks_on_pending_raw() {
         let file = empty_phase2_file();
-        file.reader.lock().expect("reader lock").eof = true;
-        file.reader_eof.store(true, Ordering::Release);
+        file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
         file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
         assert!(!file.is_drained(), "raw blocks pending must keep is_drained=false");
     }
@@ -2185,8 +2205,7 @@ mod tests {
     #[test]
     fn test_is_drained_blocks_on_pending_decompressed() {
         let file = empty_phase2_file();
-        file.reader.lock().expect("reader lock").eof = true;
-        file.reader_eof.store(true, Ordering::Release);
+        file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
         file.decompressed.lock().expect("dec lock").insert(0, vec![1, 2, 3]);
         assert!(!file.is_drained(), "decompressed blocks pending must keep is_drained=false");
     }


### PR DESCRIPTION
## Summary

- Add Phase 1 and Phase 2 memory diagnostics gated by `RUST_LOG=fgumi_lib::sort::memory_probe=info`
- Call `mi_collect(true)` after each Phase 1 `buffer.clear()` to force mimalloc to return arena pages to the OS
- Add capacity introspection methods to `SegmentedBuf`, `RecordBuffer`, `TemplateRecordBuffer`, `ReorderBuffer`, and `BufferPool`

## Motivation

Addresses #238. On a 40 GiB WES BAM (`1kg-wes-HG00100.bam`) with `--max-memory 768M --threads 8`:

| Metric | Before (pre-#247) | After (this PR + #247) |
|---|---|---|
| Phase 1 peak RSS | 42 GiB (mimalloc retained arenas) | 5.8 GiB (buffer fill) → 788 MiB (post-spill) |
| Phase 2 peak RSS | 42 GiB (unbounded reorder buffers) | 1.52 GiB (flat, bounded by #247 backpressure) |
| Overall peak RSS | 42 GiB | 7.38 GiB |
| Wall clock | 217s | 85s |

Phase 2 memory is entirely solved by #247's per-file backpressure caps (`PHASE2_RAW_CAP=8`, `PHASE2_DECOMP_CAP=8`). This PR adds the `mi_collect(true)` fix for Phase 1 arena retention and diagnostics for ongoing memory work.

## New module: `sort::memory_probe`

- `SpillProbe` — Phase 1 probe with mid-read sampling (every 1M records), pre/post-spill, post-drain snapshots reporting buffer capacity, pool queue depths, and RSS
- `MergeProbe` — Phase 2 probe with periodic sampling reporting per-file pending blocks, decompressed bytes, active sources, and RSS
- `force_mi_collect()` — FFI call to `libmimalloc_sys::mi_collect(true)`
- `process_rss_bytes()` — Darwin `phys_footprint` via mach `task_info`, Linux via `/proc/self/status`

## Test plan

- [x] All 2346 tests pass (`cargo ci-test`)
- [x] `cargo ci-fmt` and `cargo ci-lint` clean
- [x] Verified on 40 GiB WES BAM: Phase 2 RSS flat at 1.52 GiB, Phase 1 spills release cleanly to ~788 MiB, 85s wall clock