### PR TITLE
fix: abort pipeline on deadlock detection when recovery is disabled

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -35,7 +35,9 @@ use super::base::{
     generic_worker_loop, handle_worker_panic, join_monitor_thread, join_worker_threads,
     shared_try_step_compress,
 };
-use super::deadlock::{DeadlockConfig, DeadlockState, QueueSnapshot, check_deadlock_and_restore};
+use super::deadlock::{
+    DeadlockAction, DeadlockConfig, DeadlockState, QueueSnapshot, check_deadlock_and_restore,
+};
 use super::scheduler::{BackpressureState, SchedulerStrategy};
 use crate::read_info::{LibraryIndex, compute_group_key};
 use crate::sort::bam_fields;
@@ -3479,7 +3481,16 @@ where
                     if deadlock_check_counter >= 10 {
                         deadlock_check_counter = 0;
                         let snapshot = state_clone.build_queue_snapshot();
-                        check_deadlock_and_restore(&state_clone.deadlock_state, &snapshot);
+                        if let DeadlockAction::Detected =
+                            check_deadlock_and_restore(&state_clone.deadlock_state, &snapshot)
+                        {
+                            state_clone.set_error(io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                "pipeline deadlock detected with recovery disabled; \
+                                 use --deadlock-recover to enable automatic recovery",
+                            ));
+                            break;
+                        }
                     }
                 }
             }

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -86,7 +86,7 @@ use std::time::{Duration, Instant};
 
 use crate::progress::ProgressTracker;
 
-use super::deadlock::{DeadlockState, QueueSnapshot, check_deadlock_and_restore};
+use super::deadlock::{DeadlockAction, DeadlockState, QueueSnapshot, check_deadlock_and_restore};
 
 use crate::bgzf_reader::{RawBgzfBlock, decompress_block_into, read_raw_blocks};
 use crate::read_info::LibraryIndex;
@@ -2260,7 +2260,16 @@ pub fn run_monitor_loop<S, F>(
             if deadlock_counter >= deadlock_check_samples {
                 deadlock_counter = 0;
                 let snapshot = state.build_queue_snapshot();
-                check_deadlock_and_restore(state.deadlock_state(), &snapshot);
+                if let DeadlockAction::Detected =
+                    check_deadlock_and_restore(state.deadlock_state(), &snapshot)
+                {
+                    state.set_error(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "pipeline deadlock detected with recovery disabled; \
+                         use --deadlock-recover to enable automatic recovery",
+                    ));
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- When deadlock detection fires and `--deadlock-recover` is not enabled, the pipeline now aborts with a clear error instead of logging a warning and hanging indefinitely
- Workers observe `has_error()` on their next iteration and exit gracefully — no panics, proper output cleanup
- Error uses `TimedOut` kind with an actionable message suggesting `--deadlock-recover`
- Both monitor paths fixed: `run_monitor_loop` (FASTQ pipeline) and the inline BAM monitor thread

### Before

Deadlock detected → warning logged → progress timer reset → pipeline continues hanging → repeated warnings every 10s → user must Ctrl-C

### After

Deadlock detected → warning logged with diagnostics → `set_error()` called → all workers exit on next `has_error()` check → pipeline exits with non-zero status and clear message

## Test plan

- [x] All 2347 existing tests pass
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [ ] Manual verification: run with `--deadlock-timeout 5` (no `--deadlock-recover`) on a workload that deadlocks — should exit with error after 5s instead of hanging