### PR TITLE
fix: prevent OOM and group flush timeout in unified pipeline

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -1153,6 +1153,10 @@ impl<G: Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipelineState
         self.output.write_reorder_state.can_proceed(serial)
     }
 
+    fn write_reorder_is_memory_high(&self) -> bool {
+        self.output.write_reorder_state.is_memory_high()
+    }
+
     fn stats(&self) -> Option<&PipelineStats> {
         self.output.stats.as_deref()
     }
@@ -1779,17 +1783,10 @@ fn try_step_read<G: Send, P: Send + MemoryEstimate>(
 /// # Non-Blocking Design
 ///
 /// Uses the held-item pattern to prevent deadlock. If the output queue is full,
-/// the batch is stored in `worker.held_decompressed` and the function returns immediately.
-///
-/// # Memory-Based Backpressure
-///
-/// Before pushing to `q2_decompressed`, checks if the Q2 reorder buffer would accept
-/// this serial number. This prevents unbounded memory growth in the reorder buffer
-/// while avoiding deadlock by always accepting the serial that `FindBoundaries` needs.
-///
-/// When a held item is blocked by backpressure, the function continues to
-/// Priority 3 so the next-in-sequence batch can still be popped and processed,
-/// breaking potential deadlocks where every thread holds an out-of-order batch.
+/// the batch is stored in `worker.held_decompressed` and the function returns
+/// immediately. Held batches push unconditionally at Priority 1 (physical
+/// capacity only — no memory check). Memory backpressure is applied between
+/// P1 and P3 to gate new work when the reorder buffer is large.
 fn try_step_decompress<G: Send, P: Send + MemoryEstimate>(
     state: &BamPipelineState<G, P>,
     worker: &mut WorkerState<P>,
@@ -1797,46 +1794,39 @@ fn try_step_decompress<G: Send, P: Send + MemoryEstimate>(
     // =========================================================================
     // Priority 1: Try to advance any held decompressed batch first
     // =========================================================================
-    // Held items had their heap_size released when held. Re-reserve before checking.
-    let held_blocked = if let Some((serial, held, heap_size)) = worker.held_decompressed.take() {
-        // Re-reserve memory for this held batch
+    // Push unconditionally — only physical queue capacity can block.
+    // Memory backpressure is NOT checked here: the held batch is already in
+    // memory (just untracked while held), so pushing it doesn't increase actual
+    // usage. Checking can_proceed here caused deadlocks when all workers held
+    // non-next_seq batches and nobody could produce next_seq.
+    let mut advanced_held = false;
+    if let Some((serial, held, heap_size)) = worker.held_decompressed.take() {
         state.q2_reorder_state.add_heap_bytes(heap_size as u64);
-
-        // Check memory-based backpressure before trying to push
-        if state.can_decompress_proceed(serial) {
-            match state.q2_decompressed.push((serial, held)) {
-                Ok(()) => {
-                    // Successfully pushed - keep reservation (released by FindBoundaries when popping)
-                    state.batches_decompressed.fetch_add(1, Ordering::Release);
-                    state.deadlock_state.record_q2_push();
-                    false
-                }
-                Err((serial, held)) => {
-                    // Q2 physically full - release reservation and hold
-                    state.q2_reorder_state.sub_heap_bytes(heap_size as u64);
-                    worker.held_decompressed = Some((serial, held, heap_size));
-                    return false;
-                }
+        match state.q2_decompressed.push((serial, held)) {
+            Ok(()) => {
+                state.batches_decompressed.fetch_add(1, Ordering::Release);
+                state.deadlock_state.record_q2_push();
+                advanced_held = true;
             }
-        } else {
-            // Reorder buffer is over limit - release reservation and hold again,
-            // but do NOT return early. Continue to Priority 3 so the next-seq
-            // batch in Q1 can still be popped and decompressed.
-            state.q2_reorder_state.sub_heap_bytes(heap_size as u64);
-            worker.held_decompressed = Some((serial, held, heap_size));
-            true
+            Err((serial, held)) => {
+                state.q2_reorder_state.sub_heap_bytes(heap_size as u64);
+                worker.held_decompressed = Some((serial, held, heap_size));
+                return false;
+            }
         }
-    } else {
-        false
-    };
+    }
 
     // =========================================================================
-    // Priority 2: Check if output queue has space (soft check)
+    // Priority 2: Check backpressure (physical capacity AND memory)
     // =========================================================================
-    // When holding a blocked item, skip this check — we must still try to
-    // decompress the next-seq batch to break the deadlock.
-    if !held_blocked && state.q2_decompressed.is_full() {
-        return false;
+    // Memory check gates new work when the Q2 reorder buffer is large.
+    // This is safe from deadlock: Q1 is FIFO, so `next_seq` for q2_reorder
+    // has already been decompressed (it's in q2_decompressed, q2_reorder,
+    // or a held slot pushed at P1). FindBoundaries continues draining →
+    // memory drops → workers resume. Same pattern as Process step's
+    // `should_apply_process_backpressure()`.
+    if state.q2_decompressed.is_full() || state.q2_reorder_state.is_memory_high() {
+        return advanced_held;
     }
 
     // =========================================================================
@@ -1846,7 +1836,7 @@ fn try_step_decompress<G: Send, P: Send + MemoryEstimate>(
         if let Some(stats) = state.stats() {
             stats.record_queue_empty(1);
         }
-        return false;
+        return advanced_held;
     };
     // Track Q1 memory on pop
     #[cfg(feature = "memory-debug")]
@@ -1886,40 +1876,20 @@ fn try_step_decompress<G: Send, P: Send + MemoryEstimate>(
     }
 
     // =========================================================================
-    // Priority 4: Calculate and reserve memory BEFORE checking backpressure
+    // Priority 4: Calculate and reserve memory for tracking
     // =========================================================================
     let batch = DecompressedBatch { data: decompressed };
     let heap_size = batch.estimate_heap_size();
     state.q2_reorder_state.add_heap_bytes(heap_size as u64);
 
     // =========================================================================
-    // Priority 5: Check memory backpressure and try to push result
+    // Priority 5: Try to push result
     // =========================================================================
-    // When held_blocked is true, bypass the can_proceed check — we must push
-    // this batch to Q2 to avoid deadlock. The held item already occupies the
-    // worker's slot, so the only way to make progress is to push directly.
-    if !held_blocked && !state.can_decompress_proceed(serial) {
-        // Over limit - release reservation and hold
-        state.q2_reorder_state.sub_heap_bytes(heap_size as u64);
-        worker.held_decompressed = Some((serial, batch, heap_size));
-        return false;
-    }
-
     match state.q2_decompressed.push((serial, batch)) {
         Ok(()) => {
-            // Successfully pushed - keep reservation (released by FindBoundaries when popping)
             state.batches_decompressed.fetch_add(1, Ordering::Release);
             state.deadlock_state.record_q2_push();
             true
-        }
-        Err((_serial, _batch)) if held_blocked => {
-            // Already holding a blocked batch — cannot store two batches.
-            // Release the memory reservation for the new batch and set an error.
-            state.q2_reorder_state.sub_heap_bytes(heap_size as u64);
-            state.set_error(std::io::Error::other(
-                "decompress: output queue full while holding a blocked batch",
-            ));
-            false
         }
         Err((serial, batch)) => {
             // Output full - release reservation and hold
@@ -2127,17 +2097,10 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
 /// # Non-Blocking Design
 ///
 /// Uses the held-item pattern to prevent deadlock. If the output queue is full,
-/// the batch is stored in `worker.held_decoded` and the function returns immediately.
-///
-/// # Memory-Based Backpressure
-///
-/// Before pushing to `q3_decoded`, checks if the Q3 reorder buffer would accept
-/// this serial number. This prevents unbounded memory growth in the reorder buffer
-/// while avoiding deadlock by always accepting the serial that Group is waiting for.
-///
-/// When a held item is blocked by backpressure, the function continues to
-/// Priority 3 so the next-in-sequence batch can still be popped and decoded,
-/// breaking potential deadlocks where every thread holds an out-of-order batch.
+/// the batch is stored in `worker.held_decoded` and the function returns
+/// immediately. Held batches push unconditionally at Priority 1 (physical
+/// capacity only — no memory check). Memory backpressure is applied between
+/// P1 and P3 to gate new work when the reorder buffer is large.
 fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
     state: &BamPipelineState<G, P>,
     worker: &mut WorkerState<P>,
@@ -2145,46 +2108,32 @@ fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
     // =========================================================================
     // Priority 1: Try to advance any held decoded batch first
     // =========================================================================
-    // Held items had their heap_size released when held. Re-reserve before checking.
-    let held_blocked = if let Some((serial, held, heap_size)) = worker.held_decoded.take() {
-        // Re-reserve memory for this held batch
+    // Push unconditionally — only physical queue capacity can block.
+    // See Decompress Priority 1 for rationale.
+    let mut advanced_held = false;
+    if let Some((serial, held, heap_size)) = worker.held_decoded.take() {
         state.q3_reorder_state.add_heap_bytes(heap_size as u64);
-
-        // Check memory-based backpressure before trying to push
-        if state.can_decode_proceed(serial) {
-            match state.q3_decoded.push((serial, held)) {
-                Ok(()) => {
-                    // Successfully pushed - keep reservation (released by Group when popping)
-                    state.batches_decoded.fetch_add(1, Ordering::Release);
-                    state.deadlock_state.record_q3_push();
-                    false
-                }
-                Err((serial, held)) => {
-                    // Q3 physically full - release reservation and hold
-                    state.q3_reorder_state.sub_heap_bytes(heap_size as u64);
-                    worker.held_decoded = Some((serial, held, heap_size));
-                    return false;
-                }
+        match state.q3_decoded.push((serial, held)) {
+            Ok(()) => {
+                state.batches_decoded.fetch_add(1, Ordering::Release);
+                state.deadlock_state.record_q3_push();
+                advanced_held = true;
             }
-        } else {
-            // Reorder buffer is over limit - release reservation and hold again,
-            // but do NOT return early. Continue to Priority 3 so the next-seq
-            // batch in Q2b can still be popped and decoded.
-            state.q3_reorder_state.sub_heap_bytes(heap_size as u64);
-            worker.held_decoded = Some((serial, held, heap_size));
-            true
+            Err((serial, held)) => {
+                state.q3_reorder_state.sub_heap_bytes(heap_size as u64);
+                worker.held_decoded = Some((serial, held, heap_size));
+                return false;
+            }
         }
-    } else {
-        false
-    };
+    }
 
     // =========================================================================
-    // Priority 2: Check if output queue has space
+    // Priority 2: Check backpressure (physical capacity AND memory)
     // =========================================================================
-    // When holding a blocked item, skip this check — we must still try to
-    // decode the next-seq batch to break the deadlock.
-    if !held_blocked && state.q3_decoded.is_full() {
-        return false;
+    // Memory check gates new work when the Q3 reorder buffer is large.
+    // Same deadlock-safe pattern as Decompress P2 — see comment there.
+    if state.q3_decoded.is_full() || state.q3_reorder_state.is_memory_high() {
+        return advanced_held;
     }
 
     // =========================================================================
@@ -2201,7 +2150,7 @@ fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
             // Q2b is extension of Q2
             stats.record_queue_empty(2);
         }
-        return false;
+        return advanced_held;
     };
     state.deadlock_state.record_q2b_pop();
 
@@ -2215,38 +2164,18 @@ fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
                 stats.records_decoded.fetch_add(records.len() as u64, Ordering::Relaxed);
             }
 
-            // Calculate and reserve memory BEFORE checking backpressure
+            // Calculate and reserve memory for tracking
             let heap_size = records.estimate_heap_size();
             state.q3_reorder_state.add_heap_bytes(heap_size as u64);
 
             // =========================================================================
-            // Priority 5: Check memory backpressure and try to push result
+            // Priority 5: Try to push result
             // =========================================================================
-            // When held_blocked is true, bypass the can_proceed check — we must push
-            // this batch to Q3 to avoid deadlock. The held item already occupies the
-            // worker's slot, so the only way to make progress is to push directly.
-            if !held_blocked && !state.can_decode_proceed(serial) {
-                // Over limit - release reservation and hold
-                state.q3_reorder_state.sub_heap_bytes(heap_size as u64);
-                worker.held_decoded = Some((serial, records, heap_size));
-                return false;
-            }
-
             match state.q3_decoded.push((serial, records)) {
                 Ok(()) => {
-                    // Successfully pushed - keep reservation (released by Group when popping)
                     state.batches_decoded.fetch_add(1, Ordering::Release);
                     state.deadlock_state.record_q3_push();
                     true
-                }
-                Err((_serial, _records)) if held_blocked => {
-                    // Already holding a blocked batch — cannot store two batches.
-                    // Release the memory reservation for the new batch and set an error.
-                    state.q3_reorder_state.sub_heap_bytes(heap_size as u64);
-                    state.set_error(std::io::Error::other(
-                        "decode: output queue full while holding a blocked batch",
-                    ));
-                    false
                 }
                 Err((serial, records)) => {
                     // Output full - release reservation and hold
@@ -2276,7 +2205,6 @@ fn try_step_group<G: Send + BatchWeight + MemoryEstimate + 'static, P: Send + Me
     state: &BamPipelineState<G, P>,
     group_state: &Mutex<GroupState<G>>,
 ) -> (bool, bool) {
-    const MAX_RETRIES: u32 = 10_000;
     const MAX_BATCHES_PER_LOCK: usize = 8;
     const MAX_PENDING_DRAIN: usize = 16;
 
@@ -2384,22 +2312,14 @@ fn try_step_group<G: Send + BatchWeight + MemoryEstimate + 'static, P: Send + Me
 
     // If finish() was called and all pending groups have been drained
     if guard.is_finished() && !state.group_done.load(Ordering::SeqCst) {
-        // CRITICAL: Must retry until flush succeeds to avoid data loss
-        let mut retries = 0;
-        loop {
-            if flush_all(&mut guard, state).is_some() {
-                state.group_done.store(true, Ordering::SeqCst);
-                return (true, false); // Success
-            }
-            retries += 1;
-            if retries > MAX_RETRIES {
-                state.set_error(std::io::Error::other(format!(
-                    "Failed to flush final groups after {MAX_RETRIES} retries"
-                )));
-                return (false, false);
-            }
-            std::thread::yield_now();
+        // Try to flush remaining groups non-blocking. If Q4 is full, return
+        // and let the scheduler retry — the thread can do useful Process work
+        // in between to drain Q4. The deadlock detector handles true deadlocks.
+        if flush_all(&mut guard, state).is_some() {
+            state.group_done.store(true, Ordering::SeqCst);
+            return (true, false);
         }
+        return (false, false); // Q4 full, scheduler will retry
     }
 
     // Process multiple record batches per lock acquisition to reduce contention
@@ -2560,43 +2480,18 @@ fn try_step_group<G: Send + BatchWeight + MemoryEstimate + 'static, P: Send + Me
                     }
                 }
 
-                // Flush any remaining
-                // CRITICAL: Must retry until flush succeeds to avoid data loss
-                {
-                    let mut retries = 0;
-                    loop {
-                        if flush_all(&mut guard, state).is_some() {
-                            state.group_done.store(true, Ordering::SeqCst);
-                            break;
-                        }
-                        retries += 1;
-                        if retries > MAX_RETRIES {
-                            state.set_error(std::io::Error::other(format!(
-                                "Failed to flush final groups after {MAX_RETRIES} retries"
-                            )));
-                            return (false, false);
-                        }
-                        std::thread::yield_now();
-                    }
+                // Flush any remaining groups non-blocking. If Q4 is full,
+                // return and let the scheduler retry via is_finished() check.
+                if flush_all(&mut guard, state).is_some() {
+                    state.group_done.store(true, Ordering::SeqCst);
                 }
-                (true, false) // Success
+                (true, false) // Did work (finished grouper)
             }
             Ok(None) => {
-                // CRITICAL: Must retry until flush succeeds to avoid data loss
-                let mut retries = 0;
-                loop {
-                    if flush_all(&mut guard, state).is_some() {
-                        state.group_done.store(true, Ordering::SeqCst);
-                        break;
-                    }
-                    retries += 1;
-                    if retries > MAX_RETRIES {
-                        state.set_error(std::io::Error::other(format!(
-                            "Failed to flush final groups after {MAX_RETRIES} retries"
-                        )));
-                        return (false, false);
-                    }
-                    std::thread::yield_now();
+                // No final group — flush any pending. If Q4 is full, return
+                // and let the scheduler retry via is_finished() check.
+                if flush_all(&mut guard, state).is_some() {
+                    state.group_done.store(true, Ordering::SeqCst);
                 }
                 (false, false) // Finished, no new work
             }
@@ -2921,7 +2816,9 @@ fn try_step_write<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
                 }
             }
 
-            // Update admission-control state so write_reorder_can_proceed stays accurate.
+            // Update admission-control state so the scheduler-level
+            // write_reorder_is_memory_high signal stays accurate. (Compress
+            // does not consume this gate — see WritePipelineState docs.)
             state.output.write_reorder_state.sub_heap_bytes(heap_size as u64);
             state.output.write_reorder_state.update_next_seq(reorder.next_seq());
 
@@ -4525,6 +4422,133 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.non_empty_queues.iter().any(|s| s.contains("write_reorder")));
+    }
+
+    /// Create a worker for testing decompress/decode steps
+    /// (`compression_level=6`, `thread_id=0`, `num_threads=2`).
+    fn create_test_worker() -> WorkerState<()> {
+        WorkerState::new(6, 0, 2, SchedulerStrategy::default())
+    }
+
+    /// Seed a reorder buffer state with a held-item stress scenario: a
+    /// non-next_seq serial is waiting to land while the reorder heap is
+    /// under partial memory pressure. `next_seq = 0` (so any held serial
+    /// other than 0 is "out of order"), and `heap_bytes = 800` — above the
+    /// 50% mark of the `memory_limit = 1024` used by these tests but below
+    /// the full `is_memory_high` threshold, so the P2 memory gate does NOT
+    /// fire. This lets the held-item P1 unconditional-push path be exercised
+    /// in isolation: Priority 1 must admit the out-of-order held batch, and
+    /// Priority 2 must still allow Q1/Q2b to drain (because memory is not
+    /// high).
+    fn setup_memory_backpressure(reorder_state: &ReorderBufferState) {
+        reorder_state.heap_bytes.store(800, Ordering::SeqCst);
+        reorder_state.next_seq.store(0, Ordering::SeqCst);
+    }
+
+    /// Held batch pushes unconditionally at Priority 1 when Q2 has physical
+    /// capacity, regardless of memory backpressure. This prevents the deadlock
+    /// where all workers hold non-next_seq batches and nobody can produce
+    /// `next_seq`.
+    #[test]
+    fn test_decompress_held_pushes_unconditionally_when_q2_has_room() {
+        let state = create_test_state(1024);
+        setup_memory_backpressure(&state.q2_reorder_state);
+
+        let raw = RawBlockBatch::new();
+        assert!(state.q1_raw_blocks.push((0, raw)).is_ok());
+
+        // Worker holds serial 50 — would be blocked by can_proceed (50 != next_seq 0),
+        // but Priority 1 now pushes unconditionally.
+        let mut worker = create_test_worker();
+        worker.held_decompressed = Some((50, DecompressedBatch { data: vec![0u8; 16] }, 16));
+
+        let result = try_step_decompress(&state, &mut worker);
+        assert!(result, "should succeed — held batch pushed, then new batch processed");
+        assert!(!state.has_error(), "should not error");
+        assert!(state.q1_raw_blocks.is_empty(), "Q1 should have been popped");
+        // Both the held batch (serial 50) and the new batch were pushed to Q2
+        assert_eq!(state.q2_decompressed.len(), 2, "Q2 should have both batches");
+        assert!(worker.held_decompressed.is_none(), "held slot should be empty");
+    }
+
+    /// When Q2 is physically full, the held batch cannot push at Priority 1.
+    /// The function returns false without error and without popping Q1.
+    #[test]
+    fn test_decompress_held_blocked_by_full_q2() {
+        let state = create_test_state(1024);
+
+        let cap = state.q2_decompressed.capacity();
+        for i in 0..cap {
+            assert!(
+                state
+                    .q2_decompressed
+                    .push((i as u64, DecompressedBatch { data: vec![0u8; 8] }))
+                    .is_ok(),
+                "failed to fill q2 at serial {i}"
+            );
+        }
+        assert!(state.q2_decompressed.is_full());
+
+        assert!(state.q1_raw_blocks.push((100, RawBlockBatch::new())).is_ok());
+
+        let mut worker = create_test_worker();
+        worker.held_decompressed = Some((50, DecompressedBatch { data: vec![0u8; 16] }, 16));
+
+        let result = try_step_decompress(&state, &mut worker);
+        assert!(!result, "should return false when Q2 is full");
+        assert!(!state.has_error(), "should NOT set error; got: {:?}", state.take_error());
+        assert!(worker.held_decompressed.is_some(), "held batch should be preserved");
+        assert!(!state.q1_raw_blocks.is_empty(), "Q1 should not have been popped");
+    }
+
+    /// Held batch pushes unconditionally at Priority 1 when Q3 has physical
+    /// capacity (symmetric to the decompress test).
+    #[test]
+    fn test_decode_held_pushes_unconditionally_when_q3_has_room() {
+        let state = create_test_state(1024);
+        setup_memory_backpressure(&state.q3_reorder_state);
+
+        let boundary = BoundaryBatch { buffer: Vec::new(), offsets: vec![0] };
+        assert!(state.q2b_boundaries.push((0, boundary)).is_ok());
+
+        let mut worker = create_test_worker();
+        worker.held_decoded = Some((50, vec![], 16));
+
+        let result = try_step_decode(&state, &mut worker);
+        assert!(result, "should succeed — held batch pushed, then new batch processed");
+        assert!(!state.has_error(), "should not error");
+        assert!(state.q2b_boundaries.is_empty(), "Q2b should have been popped");
+        // Both the held batch and the new batch were pushed to Q3
+        assert_eq!(state.q3_decoded.len(), 2, "Q3 should have both batches");
+        assert!(worker.held_decoded.is_none(), "held slot should be empty");
+    }
+
+    /// When Q3 is physically full, the held batch cannot push at Priority 1.
+    /// The function returns false without error.
+    #[test]
+    fn test_decode_held_blocked_by_full_q3() {
+        let state = create_test_state(1024);
+
+        let cap = state.q3_decoded.capacity();
+        for i in 0..cap {
+            assert!(
+                state.q3_decoded.push((i as u64, vec![])).is_ok(),
+                "failed to fill q3 at serial {i}"
+            );
+        }
+        assert!(state.q3_decoded.is_full());
+
+        let boundary = BoundaryBatch { buffer: Vec::new(), offsets: vec![0] };
+        assert!(state.q2b_boundaries.push((100, boundary)).is_ok());
+
+        let mut worker = create_test_worker();
+        worker.held_decoded = Some((50, vec![], 16));
+
+        let result = try_step_decode(&state, &mut worker);
+        assert!(!result, "should return false when Q3 is full");
+        assert!(!state.has_error(), "should NOT set error; got: {:?}", state.take_error());
+        assert!(worker.held_decoded.is_some(), "held batch should be preserved");
+        assert!(!state.q2b_boundaries.is_empty(), "Q2b should not have been popped");
     }
 
     #[test]

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -2568,6 +2568,10 @@ impl<G: Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipelineState
         // Deadlock tracking handled by caller if needed
     }
 
+    fn write_reorder_is_memory_high(&self) -> bool {
+        self.write_reorder_state.is_memory_high()
+    }
+
     fn stats(&self) -> Option<&PipelineStats> {
         self.stats.as_deref()
     }
@@ -4210,16 +4214,39 @@ pub trait OutputPipelineState: Send + Sync {
     /// Record progress when pushing to compressed queue (Q7).
     fn record_q7_push_progress(&self) {}
 
-    /// Check whether the compress step can push a batch with the given serial to Q6.
+    /// Serial-aware admission check for the write reorder buffer.
     ///
-    /// Delegates to the write reorder buffer's admission control state. Returns
-    /// `false` when the write reorder buffer is over its memory threshold and the
-    /// serial is not the one the write step is currently waiting for. Workers that
-    /// receive `false` should hold the batch and retry (same pattern as Q2/Q3).
+    /// Returns `false` when the write reorder buffer is over its memory
+    /// threshold and the given `serial` is not the one Write is currently
+    /// waiting for.
+    ///
+    /// **Scheduler-only signal — NOT a per-step gate on Compress/Serialize.**
+    /// Q5 is fed by parallel Serialize workers and is not serial-ordered, so
+    /// blocking Compress on this check can trap the missing `next_seq` in Q5
+    /// and deadlock Write: the batch Write needs may still be sitting in Q5
+    /// awaiting compression. Compress is gated only on physical Q6 capacity;
+    /// see also [`write_reorder_is_memory_high`](Self::write_reorder_is_memory_high),
+    /// which is consulted at the scheduler level to redirect threads toward
+    /// draining Compress/Write under memory pressure.
     ///
     /// Default implementation always returns `true` (no backpressure).
     fn write_reorder_can_proceed(&self, _serial: u64) -> bool {
         true
+    }
+
+    /// Check if the write reorder buffer memory is at the backpressure threshold.
+    ///
+    /// Used by the scheduler (not the Compress step) to signal that it should
+    /// redirect threads toward draining Compress/Write. This is NOT safe to use
+    /// as a per-step gate on Compress because Q5 is fed by parallel Serialize
+    /// workers and is not serial-ordered: blocking Q5 pops on memory-high alone
+    /// can trap the missing `next_seq` in Q5 and deadlock Write. See also
+    /// [`write_reorder_can_proceed`](Self::write_reorder_can_proceed), which
+    /// carries the same scheduler-only caveat.
+    ///
+    /// Default implementation returns `false` (no backpressure).
+    fn write_reorder_is_memory_high(&self) -> bool {
+        false
     }
 
     // Stats access (optional, with default no-op implementation)
@@ -4619,17 +4646,10 @@ pub trait HasHeldBoundaries<B> {
 /// It takes data from Q5, compresses it using the worker's compressor,
 /// and pushes the resulting blocks to Q6.
 ///
-/// # Non-Blocking Behavior
+/// # Non-Blocking Design
 ///
-/// Instead of blocking when Q6 is full, this function:
-/// 1. First tries to advance any held compressed batch from a previous attempt
-/// 2. If held batch can't be advanced, **continues** to process new work
-///    (the next-seq batch may be in Q5 and must be compressed to unblock Write)
-/// 3. Pushes the result or holds it for the next attempt
-///
-/// This prevents deadlock by ensuring workers can always compress the
-/// next-in-sequence batch even when holding an out-of-order batch that
-/// is blocked by write reorder buffer backpressure.
+/// Uses the held-item pattern to prevent deadlock. If the output queue is full,
+/// the batch is stored in the worker's held slot and the function returns immediately.
 pub fn shared_try_step_compress<S, W>(state: &S, worker: &mut W) -> StepResult
 where
     S: OutputPipelineState,
@@ -4638,40 +4658,38 @@ where
     // =========================================================================
     // Priority 1: Try to advance any held compressed batch
     // =========================================================================
-    let held_blocked = if let Some((serial, held, heap_size)) = worker.held_compressed_mut().take()
-    {
-        if state.write_reorder_can_proceed(serial) {
-            match state.q6_push((serial, held)) {
-                Ok(()) => {
-                    // Successfully advanced held item, continue to process more
-                    state.record_q7_push_progress();
-                    false
-                }
-                Err((serial, held)) => {
-                    // Q6 physically full — hold and return, nothing more we can do
-                    let heap_size = held.estimate_heap_size();
-                    *worker.held_compressed_mut() = Some((serial, held, heap_size));
-                    return StepResult::OutputFull;
-                }
+    // Push unconditionally — only physical queue capacity can block.
+    // See Decompress Priority 1 in bam.rs for rationale.
+    let mut advanced_held = false;
+    if let Some((serial, held, _heap_size)) = worker.held_compressed_mut().take() {
+        match state.q6_push((serial, held)) {
+            Ok(()) => {
+                state.record_q7_push_progress();
+                advanced_held = true;
             }
-        } else {
-            // Can't advance — put it back but do NOT return early.
-            // We must continue to Priority 3 so the next-seq batch in Q5
-            // can still be popped and compressed, breaking the deadlock.
-            *worker.held_compressed_mut() = Some((serial, held, heap_size));
-            true
+            Err((serial, held)) => {
+                let heap_size = held.estimate_heap_size();
+                *worker.held_compressed_mut() = Some((serial, held, heap_size));
+                return StepResult::OutputFull;
+            }
         }
-    } else {
-        false
-    };
+    }
 
     // =========================================================================
-    // Priority 2: Check if output queue has space (soft check)
+    // Priority 2: Check physical capacity
     // =========================================================================
-    // When we're holding a blocked item, skip this check — we must still
-    // try to compress the next-seq batch to break the deadlock.
-    if !held_blocked && state.q6_is_full() {
-        return StepResult::OutputFull;
+    // Only gate on Q6's physical capacity. We intentionally do NOT gate on
+    // `write_reorder_is_memory_high()` here: unlike Decompress/Decode (which
+    // consume the FIFO Q1), Q5 is fed by parallel Serialize workers and is
+    // NOT serial-ordered. If the write reorder buffer is memory-high because
+    // later serials are buffered waiting for a missing `next_seq`, that
+    // missing serial may still be sitting in Q5 awaiting compression — and
+    // blocking Q5 pops would trap it there, deadlocking Write. Memory
+    // backpressure on the write side is applied at the scheduler level
+    // (`BackpressureState::memory_high`), which redirects threads to drain
+    // Compress/Write rather than stopping them.
+    if state.q6_is_full() {
+        return if advanced_held { StepResult::Success } else { StepResult::OutputFull };
     }
 
     // =========================================================================
@@ -4681,7 +4699,7 @@ where
         if let Some(stats) = state.stats() {
             stats.record_queue_empty(6);
         }
-        return if held_blocked { StepResult::OutputFull } else { StepResult::InputEmpty };
+        return if advanced_held { StepResult::Success } else { StepResult::InputEmpty };
     };
     state.record_q6_pop_progress();
 
@@ -4723,34 +4741,20 @@ where
     // =========================================================================
     // Priority 5: Try to push result
     // =========================================================================
-    if !held_blocked && !state.write_reorder_can_proceed(serial) {
-        let heap_size = batch.estimate_heap_size();
-        *worker.held_compressed_mut() = Some((serial, batch, heap_size));
-        return StepResult::OutputFull;
-    }
-    // When held_blocked is true, we bypass the can_proceed check for the new
-    // batch — we must push it to Q6 to avoid deadlock. The held item already
-    // occupies the worker's slot, so the only way to make progress is to push
-    // this freshly compressed batch directly to Q6.
     match state.q6_push((serial, batch)) {
         Ok(()) => {
             state.record_q7_push_progress();
             StepResult::Success
         }
         Err((serial, batch)) => {
-            if held_blocked {
-                // Already holding a blocked batch — cannot store two batches.
-                // This means Q6 is physically full despite bypassing the soft
-                // check, which shouldn't happen with adequate queue sizing.
-                state.set_error(io::Error::other(
-                    "compress: output queue full while holding a blocked batch",
-                ));
-                return StepResult::OutputFull;
-            }
-            // Output full - hold the result for next attempt
+            // Output full - hold the result for next attempt. If Priority 1
+            // already pushed a held batch earlier in this iteration, report
+            // Success so the scheduler credits the forward progress; the
+            // fresh batch lost a TOCTOU race against Q6 but the held-batch
+            // drain did happen.
             let heap_size = batch.estimate_heap_size();
             *worker.held_compressed_mut() = Some((serial, batch, heap_size));
-            StepResult::OutputFull
+            if advanced_held { StepResult::Success } else { StepResult::OutputFull }
         }
     }
 }
@@ -5135,7 +5139,9 @@ pub trait WritePipelineState: Send + Sync {
     /// Get reference to the write reorder buffer admission-control state.
     ///
     /// Used by `shared_try_step_write_new` to track heap bytes and `next_seq`
-    /// so that `write_reorder_can_proceed` in the compress step stays accurate.
+    /// so that the scheduler-level `write_reorder_is_memory_high` signal (and
+    /// the `write_reorder_can_proceed` helper — both scheduler-only, not
+    /// consumed by Compress/Serialize) stay accurate.
     fn write_reorder_state(&self) -> &ReorderBufferState;
 
     /// Check if an error has occurred.
@@ -6140,6 +6146,9 @@ mod tests {
         fn write_reorder_can_proceed(&self, serial: u64) -> bool {
             self.reorder.can_proceed(serial)
         }
+        fn write_reorder_is_memory_high(&self) -> bool {
+            self.reorder.is_memory_high()
+        }
     }
 
     /// Mock worker for testing `shared_try_step_compress`.
@@ -6184,50 +6193,47 @@ mod tests {
 
     /// Regression test: held out-of-order batch must not prevent compressing
     /// the next-in-sequence batch from Q5.
+    /// Held batch pushes unconditionally at Priority 1, then the worker
+    /// processes new input. Both batches end up in Q6.
     ///
     /// Scenario:
-    /// 1. Write reorder buffer expects serial 0 (`next_seq`=0)
-    /// 2. Worker holds serial 5 (blocked by backpressure — `heap_bytes` over 50%)
-    /// 3. Q5 contains serial 0 (the one Write needs)
+    /// 1. Worker holds serial 5 (would have been blocked by memory backpressure)
+    /// 2. Q5 contains serial 0
+    /// 3. Q6 has room for both
     ///
-    /// Before fix: returns `OutputFull` immediately at Priority 1 — serial 0
-    /// sits in Q5 forever, causing deadlock.
-    ///
-    /// After fix: continues past Priority 1, pops serial 0, compresses it,
-    /// and pushes it to Q6 (since `write_reorder_can_proceed(0)` == true).
+    /// Result: serial 5 pushed at Priority 1, serial 0 compressed and pushed
+    /// at Priority 5. Worker's held slot is empty.
     #[test]
-    fn test_compress_held_item_does_not_block_next_seq() {
-        // memory_limit=1000 → backpressure at 500
+    fn test_compress_held_pushes_unconditionally() {
         let state = MockCompressState::new(8, 1000);
 
-        // Push heap_bytes over 50% threshold so non-next-seq serials are blocked
+        // Push heap_bytes over 50% threshold (would have blocked non-next-seq)
         state.reorder.add_heap_bytes(600);
 
-        // Put the next-seq batch (serial 0) in Q5
+        // Put serial 0 in Q5
         let batch_0 =
             SerializedBatch { data: vec![0u8; 10], record_count: 1, secondary_data: None };
         assert!(state.q5.push((0, batch_0)).is_ok());
 
         let mut worker = MockCompressWorker::new();
-
-        // Worker holds serial 5 — blocked because 5 != next_seq(0) and heap > 500
         let held_batch = CompressedBlockBatch::new();
         worker.held_compressed = Some((5, held_batch, 100));
 
-        // Call compress — this MUST process serial 0 from Q5 even though serial 5 is stuck
         let result = shared_try_step_compress(&state, &mut worker);
 
-        // The function should have made progress (compressed serial 0)
-        assert_eq!(result, StepResult::Success, "should compress serial 0 despite held serial 5");
+        assert_eq!(result, StepResult::Success, "should succeed");
 
-        // Serial 0 should now be in Q6
-        let popped = state.q6.pop();
-        assert!(popped.is_some(), "serial 0 should be in Q6");
-        assert_eq!(popped.unwrap().0, 0, "the batch in Q6 should be serial 0");
+        // Serial 5 was pushed first (Priority 1), then serial 0 (Priority 5)
+        let first = state.q6.pop();
+        assert!(first.is_some(), "Q6 should have serial 5");
+        assert_eq!(first.unwrap().0, 5);
 
-        // Worker should still hold serial 5 (it couldn't be advanced)
-        assert!(worker.held_compressed.is_some(), "serial 5 should still be held");
-        assert_eq!(worker.held_compressed.as_ref().unwrap().0, 5);
+        let second = state.q6.pop();
+        assert!(second.is_some(), "Q6 should have serial 0");
+        assert_eq!(second.unwrap().0, 0);
+
+        // Worker's held slot should be empty
+        assert!(worker.held_compressed.is_none(), "held slot should be empty");
     }
 
     /// Verify that when the held item IS the `next_seq`, it gets advanced normally.
@@ -6270,41 +6276,249 @@ mod tests {
         assert_eq!(result, StepResult::InputEmpty);
     }
 
-    /// Regression test: when `held_blocked` is true and Q6 is physically full,
-    /// the original held batch must NOT be overwritten by the freshly compressed
-    /// batch. Instead, the function should set an error (we can't hold two batches).
+    /// When Q6 is physically full and the worker holds a compressed batch,
+    /// Priority 1 fails to push and the function returns `OutputFull` without
+    /// popping Q5.
     #[test]
-    fn test_compress_held_blocked_q6_full_no_data_loss() {
+    fn test_compress_held_blocked_by_full_q6() {
         // capacity=1 → Q6 will be full after one push
         let state = MockCompressState::new(1, 1000);
 
-        // Push heap_bytes over 50% threshold so non-next-seq serials are blocked
-        state.reorder.add_heap_bytes(600);
-
-        // Fill Q6 with a dummy batch so the push at Priority 5 will fail
+        // Fill Q6 so it is physically full
         let dummy = CompressedBlockBatch::new();
         assert!(state.q6.push((99, dummy)).is_ok());
 
-        // Put the next-seq batch (serial 0) in Q5
+        // Put a batch in Q5
         let batch_0 =
             SerializedBatch { data: vec![0u8; 10], record_count: 1, secondary_data: None };
         assert!(state.q5.push((0, batch_0)).is_ok());
 
         let mut worker = MockCompressWorker::new();
-        // Worker holds serial 5 — blocked because 5 != next_seq(0) and heap > 500
         let held_batch = CompressedBlockBatch::new();
         worker.held_compressed = Some((5, held_batch, 100));
 
         let result = shared_try_step_compress(&state, &mut worker);
 
-        // Should set an error — Q6 is full and we can't hold two batches
-        assert!(state.has_error(), "should set error when Q6 full and held_blocked");
+        assert!(!state.has_error(), "should NOT set error");
 
-        // Original held batch (serial 5) must still be there — not overwritten
-        assert!(worker.held_compressed.is_some(), "original held batch should be preserved");
+        // Held batch should still be there — Priority 1 push failed
+        assert!(worker.held_compressed.is_some(), "held batch should be preserved");
         assert_eq!(worker.held_compressed.as_ref().unwrap().0, 5, "serial 5 should still be held");
 
-        // Return value should indicate output full
+        // Q5 should NOT have been drained
+        assert!(!state.q5.is_empty(), "Q5 should not have been popped");
+
         assert_eq!(result, StepResult::OutputFull);
+    }
+
+    /// Regression test: Compress must pop Q5 even when the write reorder
+    /// buffer is memory-high. Q5 is fed by parallel Serialize workers so it is
+    /// NOT serial-ordered; blocking pops based on write reorder memory alone
+    /// can trap `next_seq` in Q5 forever — Write can't drain the reorder heap
+    /// because the missing serial is still sitting in Q5 waiting to be
+    /// compressed.
+    ///
+    /// Scenario:
+    /// 1. `write_reorder_state.heap_bytes` is over the memory-high threshold
+    ///    (simulating later serials buffered in the write reorder heap).
+    /// 2. `next_seq = 0` — Write is waiting for serial 0 to drain the heap.
+    /// 3. Q5 contains serial 0 (produced by a Serialize worker, not yet
+    ///    compressed).
+    /// 4. Worker has no held batch; Q6 has plenty of room.
+    ///
+    /// Required behavior: Compress must pop serial 0 from Q5, compress it,
+    /// and push it to Q6 so Write can eventually make progress. The previous
+    /// implementation returned `OutputFull` here and deadlocked.
+    #[test]
+    fn test_compress_memory_high_does_not_block_new_work() {
+        let state = MockCompressState::new(8, 1000);
+
+        // Drive heap_bytes over the is_memory_high threshold (>= memory_limit).
+        // This simulates the write reorder buffer holding later serials while
+        // waiting for the missing next_seq.
+        state.reorder.add_heap_bytes(1200);
+        assert!(state.write_reorder_is_memory_high(), "precondition: reorder must be memory-high");
+
+        // next_seq = 0 (Write is waiting for serial 0).
+        assert_eq!(state.reorder.next_seq.load(Ordering::SeqCst), 0);
+
+        // Q5 contains the missing next_seq. Q5 is unordered across parallel
+        // Serialize workers, so this is the only path by which Compress can
+        // produce serial 0.
+        let batch_0 =
+            SerializedBatch { data: vec![0u8; 32], record_count: 1, secondary_data: None };
+        assert!(state.q5.push((0, batch_0)).is_ok());
+
+        // No held batch, Q6 has capacity.
+        let mut worker = MockCompressWorker::new();
+        assert!(worker.held_compressed.is_none());
+
+        let result = shared_try_step_compress(&state, &mut worker);
+
+        assert!(!state.has_error(), "should NOT set error");
+        assert_eq!(
+            result,
+            StepResult::Success,
+            "Compress must proceed past memory-high; Q5 is not serial-ordered so \
+             blocking here deadlocks Write"
+        );
+        assert!(state.q5.is_empty(), "Q5 should have been drained");
+
+        let pushed = state.q6.pop();
+        assert!(pushed.is_some(), "serial 0 should have been compressed into Q6");
+        assert_eq!(pushed.unwrap().0, 0, "pushed serial should be 0 (the waited-for next_seq)");
+    }
+
+    // ========================================================================
+    // shared_try_step_compress TOCTOU race regression tests
+    // ========================================================================
+
+    /// Mock state that can simulate a TOCTOU race between Priority 2's
+    /// `q6_is_full` check and Priority 5's `q6_push`: `q6_is_full` always
+    /// reports `false` so the function reaches P5, and `q6_push` accepts a
+    /// bounded number of pushes before returning `Err` to simulate another
+    /// thread filling Q6 mid-iteration.
+    struct MockToctouCompressState {
+        q5: ArrayQueue<(u64, SerializedBatch)>,
+        q6_items: std::sync::Mutex<Vec<(u64, CompressedBlockBatch)>>,
+        q6_push_budget: std::sync::atomic::AtomicUsize,
+        reorder: ReorderBufferState,
+        error: std::sync::Mutex<Option<io::Error>>,
+    }
+
+    impl MockToctouCompressState {
+        fn new(q5_capacity: usize, q6_push_budget: usize) -> Self {
+            Self {
+                q5: ArrayQueue::new(q5_capacity),
+                q6_items: std::sync::Mutex::new(Vec::new()),
+                q6_push_budget: std::sync::atomic::AtomicUsize::new(q6_push_budget),
+                reorder: ReorderBufferState::new(1024),
+                error: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    impl OutputPipelineState for MockToctouCompressState {
+        type Processed = Vec<u8>;
+
+        fn has_error(&self) -> bool {
+            self.error.lock().unwrap().is_some()
+        }
+        fn set_error(&self, error: io::Error) {
+            *self.error.lock().unwrap() = Some(error);
+        }
+        fn q5_pop(&self) -> Option<(u64, SerializedBatch)> {
+            self.q5.pop()
+        }
+        fn q5_push(&self, item: (u64, SerializedBatch)) -> Result<(), (u64, SerializedBatch)> {
+            self.q5.push(item)
+        }
+        fn q5_is_full(&self) -> bool {
+            self.q5.is_full()
+        }
+        fn q6_pop(&self) -> Option<(u64, CompressedBlockBatch)> {
+            self.q6_items.lock().unwrap().pop()
+        }
+        fn q6_push(
+            &self,
+            item: (u64, CompressedBlockBatch),
+        ) -> Result<(), (u64, CompressedBlockBatch)> {
+            let decremented =
+                self.q6_push_budget.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| {
+                    if x > 0 { Some(x - 1) } else { None }
+                });
+            if decremented.is_ok() {
+                self.q6_items.lock().unwrap().push(item);
+                Ok(())
+            } else {
+                Err(item)
+            }
+        }
+        fn q6_is_full(&self) -> bool {
+            // Always report capacity available — this is the TOCTOU snapshot
+            // that lets the function proceed past Priority 2 to Priority 5.
+            false
+        }
+        fn q6_reorder_insert(&self, _serial: u64, _batch: CompressedBlockBatch) {}
+        fn q6_reorder_try_pop_next(&self) -> Option<CompressedBlockBatch> {
+            None
+        }
+        fn output_try_lock(
+            &self,
+        ) -> Option<parking_lot::MutexGuard<'_, Option<Box<dyn Write + Send>>>> {
+            None
+        }
+        fn increment_written(&self) -> u64 {
+            0
+        }
+        fn write_reorder_can_proceed(&self, serial: u64) -> bool {
+            self.reorder.can_proceed(serial)
+        }
+        fn write_reorder_is_memory_high(&self) -> bool {
+            self.reorder.is_memory_high()
+        }
+    }
+
+    /// Regression test: `shared_try_step_compress` must preserve Priority 1
+    /// progress when Priority 5 loses a TOCTOU race against Q6.
+    ///
+    /// Scenario:
+    /// 1. Worker holds compressed serial 5 — P1 pushes it successfully
+    ///    (consuming the mock's single-push budget).
+    /// 2. `q6_is_full()` reports false so P2 proceeds.
+    /// 3. P3 pops serial 0 from Q5 and P4 compresses it.
+    /// 4. P5's `q6_push` fails (budget exhausted — simulating another
+    ///    thread filling Q6 between the P2 snapshot and the P5 push).
+    ///
+    /// Required: the function returns `StepResult::Success` because P1 made
+    /// forward progress. Before the fix, the P5 `Err` branch unconditionally
+    /// returned `OutputFull`, which `try_step_compress` collapsed via
+    /// `is_success()` to `false`, telling the scheduler the iteration was
+    /// idle and discarding P1's progress signal.
+    #[test]
+    fn test_compress_advanced_held_survives_p5_toctou_failure() {
+        let state = MockToctouCompressState::new(8, 1);
+
+        // Q5 has the fresh batch that P3 will pop.
+        let batch_0 =
+            SerializedBatch { data: vec![0u8; 32], record_count: 1, secondary_data: None };
+        assert!(state.q5.push((0, batch_0)).is_ok());
+
+        // Worker holds a compressed batch (non-next-seq serial 5) that P1
+        // will drain into the mock Q6, consuming the budget.
+        let mut worker = MockCompressWorker::new();
+        let held_batch = CompressedBlockBatch::new();
+        worker.held_compressed = Some((5, held_batch, 100));
+
+        let result = shared_try_step_compress(&state, &mut worker);
+
+        assert!(!state.has_error(), "should NOT set error");
+
+        // P1 successfully pushed serial 5 into Q6.
+        let pushes = state.q6_items.lock().unwrap();
+        assert_eq!(pushes.len(), 1, "P1 should have pushed exactly one item into Q6");
+        assert_eq!(pushes[0].0, 5, "P1 should have pushed the held serial 5");
+        drop(pushes);
+
+        // Q5 was drained (P3 popped serial 0).
+        assert!(state.q5.is_empty(), "Q5 should have been drained at P3");
+
+        // P5's push of the fresh serial 0 lost the simulated race → it is
+        // now sitting in the worker's held slot for the next iteration.
+        let held = worker
+            .held_compressed
+            .as_ref()
+            .expect("fresh batch must be held after P5 TOCTOU failure");
+        assert_eq!(held.0, 0, "the held fresh batch should be serial 0");
+
+        // The key assertion: the iteration must report Success, not
+        // OutputFull. P1 made forward progress (drained a held batch into
+        // Q6) and the scheduler must see that, or it will treat the
+        // iteration as idle and lose the signal.
+        assert_eq!(
+            result,
+            StepResult::Success,
+            "P1's successful held-batch push must survive a P5 TOCTOU failure"
+        );
     }
 }

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -1904,6 +1904,10 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipe
         self.output.write_reorder_state.can_proceed(serial)
     }
 
+    fn write_reorder_is_memory_high(&self) -> bool {
+        self.output.write_reorder_state.is_memory_high()
+    }
+
     fn stats(&self) -> Option<&PipelineStats> {
         self.output.stats.as_deref()
     }
@@ -3559,8 +3563,9 @@ where
             output_high: self.state.output.compressed.len() > cap * 3 / 4,
             input_low: self.state.q0_chunks.len() < cap / 4,
             read_done,
-            memory_high: false, // Per-stream pipeline uses bounded queues for backpressure
-            memory_drained: true,
+            memory_high: !self.state.is_draining()
+                && self.state.output.write_reorder_state.is_memory_high(),
+            memory_drained: self.state.output.write_reorder_state.is_memory_drained(),
         }
     }
 
@@ -5348,5 +5353,76 @@ mod tests {
         assert!(state.r1_suffix_bytes.is_empty());
         assert!(state.r2_suffix_bytes.is_empty());
         assert_eq!(state.serial_out, 0);
+    }
+
+    /// Helper to create a minimal FASTQ pipeline state for backpressure tests.
+    fn make_fastq_state() -> FastqPipelineState<Cursor<Vec<u8>>, Vec<u8>> {
+        let config = FastqPipelineConfig::new(2, false, 6);
+        let readers = vec![StreamReader::Decompressed(Cursor::new(Vec::new()))];
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        FastqPipelineState::new(config, readers, output)
+    }
+
+    /// Verify that the FASTQ pipeline's scheduler backpressure reports memory
+    /// state from the write reorder buffer, matching the BAM pipeline's behavior.
+    ///
+    /// When the write reorder buffer is above its memory threshold, the scheduler
+    /// must see `memory_high: true` so it can redirect threads to drain Compress→Write.
+    /// Without this, threads pile up on upstream steps while nobody does output work.
+    #[test]
+    fn test_fastq_backpressure_reports_write_reorder_memory() {
+        let state = make_fastq_state();
+        let header = Header::default();
+        let process_fn = |_t: FastqTemplate| -> io::Result<Vec<u8>> { Ok(Vec::new()) };
+        let serialize_fn =
+            |_p: Vec<u8>, _h: &Header, _buf: &mut Vec<u8>| -> io::Result<u64> { Ok(0) };
+
+        let ctx = FastqStepContext {
+            state: &state,
+            header: &header,
+            process_fn: &process_fn,
+            serialize_fn: &serialize_fn,
+            is_reader: false,
+        };
+
+        let active = ActiveSteps::all();
+        let worker = FastqWorkerState::new(6, 0, 2, SchedulerStrategy::default(), active);
+
+        // Initially: memory should not be high
+        let bp = ctx.get_backpressure(&worker);
+        assert!(!bp.memory_high, "memory_high should be false when write reorder buffer is empty");
+        assert!(
+            bp.memory_drained,
+            "memory_drained should be true when write reorder buffer is empty"
+        );
+
+        // Push write reorder buffer above its threshold (512 MB default)
+        let threshold = BACKPRESSURE_THRESHOLD_BYTES;
+        state.output.write_reorder_state.add_heap_bytes(threshold + 1);
+
+        let bp = ctx.get_backpressure(&worker);
+        assert!(
+            bp.memory_high,
+            "memory_high should be true when write reorder buffer exceeds limit"
+        );
+        assert!(
+            !bp.memory_drained,
+            "memory_drained should be false when write reorder buffer exceeds limit"
+        );
+
+        // When draining, memory_high should be suppressed (same as BAM pipeline)
+        state.output.set_draining(true);
+        let bp = ctx.get_backpressure(&worker);
+        assert!(!bp.memory_high, "memory_high should be false during drain even with high memory");
+
+        // Drain memory below low-water mark (50% of threshold)
+        state.output.write_reorder_state.sub_heap_bytes(threshold + 1);
+        state.output.set_draining(false);
+        let bp = ctx.get_backpressure(&worker);
+        assert!(!bp.memory_high, "memory_high should be false after draining memory");
+        assert!(
+            bp.memory_drained,
+            "memory_drained should be true after draining below low-water mark"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three fixes for the unified pipeline:

### 1. Remove `can_proceed` deadlock from Compress (root cause: PR #242)

PR #242 (`5df7e17`) added `write_reorder_can_proceed` checks to the Compress step at P1 and P5, extending the same `can_proceed` pattern that Decompress and Decode had since the initial commit. This made the pipeline deadlock-prone under real workloads: when all workers hold non-`next_seq` batches, `can_proceed` blocks everyone at P1 and nobody can produce `next_seq` to advance the reorder buffer.

Removing `can_proceed` entirely (as done in earlier iterations of this PR) fixed deadlocks but caused OOM kills — reorder buffers grew without bound since nothing limited how fast workers could feed them.

**Fix:** Remove `can_proceed` from P1 and P5 entirely. Held batches push unconditionally at P1, subject only to physical queue capacity (`is_full`). New batches hold at P5 if the queue is full. This matches the pattern Process and Serialize already use. `held_blocked` and `push_with_toctou_retry` (from PRs #251/#253) are fully removed.

### 2. Restore memory backpressure via `is_memory_high()` at P2

Add `is_memory_high()` checks between the held push (P1) and the input pop (P3). If the downstream reorder buffer is over its memory threshold, skip new work — the worker yields back to the scheduler, which prioritizes draining. This is the same pattern the Process step uses via `should_apply_process_backpressure()`.

Applied to all three reorder-buffer-feeding steps:
- **Decompress P2**: gates on `q2_reorder_state.is_memory_high()`
- **Decode P2**: gates on `q3_reorder_state.is_memory_high()`
- **Compress P2**: gates on `write_reorder_state.is_memory_high()`

**Why P2 memory checks are deadlock-safe:** Q1 is FIFO, so if serial N+1 exists in a reorder buffer, serial N (`next_seq`) was already produced. It's either in the ArrayQueue, the reorder buffer, or a held slot (pushed unconditionally at P1). The exclusive consumer step (FindBoundaries/Group/Write) continues draining the reorder buffer, memory drops below threshold, and blocked workers resume.

### 3. Wire FASTQ pipeline scheduler backpressure

The FASTQ pipeline's `get_backpressure` hardcoded `memory_high: false` and `memory_drained: true`, so the scheduler never redirected threads to drain Compress→Write when the write reorder buffer grew large. Now reports actual `write_reorder_state.is_memory_high()` / `is_memory_drained()`, matching the BAM pipeline's behavior.

### 4. Replace bounded Group flush retry with non-blocking return

The three `flush_all` retry loops in `try_step_group` finalization used `MAX_RETRIES=10,000` with `yield_now()`, giving only ~milliseconds of total wait. When Process takes >10ms per batch (e.g. duplex consensus on large groups), the retry budget expires and the pipeline aborts with "Failed to flush final groups" — a false positive that appeared intermittently under load.

**Fix:** Replace bounded retry loops with a single non-blocking `flush_all` attempt. On failure (Q4 full), the thread returns to the scheduler, does useful Process work to drain Q4, and the scheduler retries Group via the `is_finished()` re-entry check. The deadlock detector (running every ~1s) handles true deadlocks. This is consistent with the held-item pattern used everywhere else in the pipeline.

### Root cause timeline

| Commit | What happened |
|--------|--------------|
| `bc00145` (initial) | Decompress/Decode had `can_proceed` at P1/P5 — latent deadlock, never triggered because downstream always drained fast enough |
| `5df7e17` (PR #242) | Added `write_reorder_can_proceed` to Compress P1/P5 — deadlock now triggerable under load |
| `5a9de0a` (PR #251) | `held_blocked` workaround — introduced TOCTOU races |
| `906af30` (PR #252) | Deadlock detection abort — mitigation, not fix |
| `a74733f` (PR #253 v1) | Removed all `can_proceed` — fixed deadlock, caused OOM |
| `f069281` (PR #253 v2, this) | Removed `can_proceed` from P1/P5, added `is_memory_high()` at P2, wired FASTQ scheduler backpressure, replaced bounded Group flush retry |

## Benchmarks

Baseline (`f0b83c6`, parent of PR #242) vs current on c7g.4xlarge (16 vCPU, 30 GB RAM), 6.5 GB BAM input, averages of 2 runs:

### GROUP

| Threads | Baseline | Current | Delta | Baseline RSS | Current RSS |
|---------|----------|---------|-------|-------------|-------------|
| 2 | 1:58.3 | 2:00.4 | +1.7% | 12.6 GB | 12.9 GB |
| 4 | 1:02.0 | 1:00.7 | **-2.1%** | 12.9 GB | 12.9 GB |
| 8 | 0:33.8 | 0:33.8 | 0.0% | 12.5 GB | 12.5 GB |
| 16 | 0:33.5 | 0:33.6 | +0.1% | 12.7 GB | 12.7 GB |

### DEDUP

| Threads | Baseline | Current | Delta | Baseline RSS | Current RSS |
|---------|----------|---------|-------|-------------|-------------|
| 2 | 1:51.8 | 1:55.1 | +3.0% | 0.8 GB | 1.3 GB |
| 4 | 0:58.4 | 0:56.5 | **-3.2%** | 1.1 GB | 1.3 GB |
| 8 | 0:31.9 | 0:30.4 | **-4.9%** | 2.2 GB | 1.8 GB |
| 16 | 0:28.4 | 0:28.5 | +0.5% | 0.6 GB | 0.6 GB |

No wall-clock regressions. Dedup at 8 threads is 5% faster with 20% less RSS.

## Test plan

- [x] `cargo ci-test` — 2392 tests pass (1 new)
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Updated 3 existing tests + rewrote 4 tests for new behavior
- [x] New: `test_fastq_backpressure_reports_write_reorder_memory` — RED before fix, GREEN after
- [x] Verified on EC2 (c7g.4xlarge, 30 GB RAM): group/dedup at 2/4/8/16 threads, no regressions vs pre-backpressure baseline