### PR TITLE
fix: add fgumi-simd-fastq to publish list and verify completeness

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,7 @@ jobs:
           CRATES=(
             fgumi-dna
             fgumi-bgzf
+            fgumi-simd-fastq
             fgumi-raw-bam
             fgumi-umi
             fgumi-sam
@@ -95,6 +96,26 @@ jobs:
             fgumi-consensus
             fgumi
           )
+
+          # Verify every workspace crate is in the publish list
+          WORKSPACE_CRATES=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[].name' | sort)
+          LISTED_CRATES=$(printf '%s\n' "${CRATES[@]}" | sort)
+          MISSING=$(comm -23 <(echo "$WORKSPACE_CRATES") <(echo "$LISTED_CRATES"))
+          if [ -n "$MISSING" ]; then
+            echo "ERROR: workspace crates missing from CRATES publish list:"
+            echo "$MISSING"
+            echo "Add them to the CRATES array in the correct dependency order."
+            exit 1
+          fi
+
+          EXTRA=$(comm -13 <(echo "$WORKSPACE_CRATES") <(echo "$LISTED_CRATES"))
+          if [ -n "$EXTRA" ]; then
+            echo "ERROR: CRATES publish list contains entries not in workspace:"
+            echo "$EXTRA"
+            echo "Remove or rename stale entries before publishing."
+            exit 1
+          fi
 
           for crate in "${CRATES[@]}"; do
             CRATE_MAX_VERSION=$(curl -sS \


### PR DESCRIPTION
## Summary

- Add `fgumi-simd-fastq` to the `CRATES` publish array in the correct dependency order (it's a leaf crate with no workspace dependencies)
- Add a verification step that compares the `CRATES` array against `cargo metadata` workspace members, failing early if any crate is missing

The v0.1.3 release failed because `fgumi-simd-fastq` (added in #180) was not in the publish list. The root `fgumi` crate depends on it, so `cargo publish` could not resolve it on crates.io. We manually published the crate and re-ran the workflow to unblock the release; this PR prevents the same issue on future releases.

## Test plan

- [ ] CI passes (format, lint, test, coverage)
- [ ] Inspect the verification logic: `comm -23` diffs sorted workspace crates against sorted listed crates and fails if any are missing