### PR TITLE
perf(io): async prefetch reader with POSIX_FADV_WILLNEED for BAM/FASTQ inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +680,7 @@ dependencies = [
  "memchr",
  "mimalloc",
  "murmur3",
+ "nix",
  "noodles",
  "noodles-bgzf",
  "noodles-csi",
@@ -1453,6 +1460,18 @@ dependencies = [
  "rand_distr 0.4.3",
  "simba",
  "typenum",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ fgumi-consensus = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.29", default-features = false, features = ["fs"] }
+
 [features]
 default = ["simplex", "duplex", "codec"]
 simplex = ["fgumi-consensus/simplex"]

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -84,6 +84,70 @@ fgumi filter --queue-memory 4096 --queue-memory-per-thread false
 - **Override**: `--compression-threads N`
 - **Best practice**: Usually leave at default
 
+## I/O and Storage Tuning
+
+For sequential workloads like BAM and FASTQ processing, I/O throughput is often the
+bottleneck — not CPU. Two areas to check: OS readahead and volume throughput.
+
+### OS Readahead
+
+The Linux kernel prefetches file data into the page cache ahead of the application.
+The default readahead window is typically 128 KB, which fgumi's decompression threads
+can easily outpace. When that happens the processing thread stalls waiting on disk.
+
+Check the current readahead (in 512-byte sectors):
+
+```bash
+blockdev --getra /dev/nvme1n1    # e.g. 256 = 128 KB
+```
+
+For sequential BAM/FASTQ workloads, increasing to 4 MB eliminates most I/O stalls:
+
+```bash
+# 4 MB = 8192 sectors (requires root)
+sudo blockdev --setra 8192 /dev/nvme1n1
+```
+
+This setting does not persist across reboots. Add it to a startup script or udev rule
+if needed.
+
+### `--async-reader` (Experimental)
+
+When you cannot tune OS readahead — containers, managed cloud instances, network
+mounts — `--async-reader` provides a similar benefit from userspace. It spawns a
+dedicated I/O thread that reads raw bytes into a bounded queue ahead of the
+decompression step, so processing threads do not block on disk.
+
+```bash
+fgumi group \
+  --async-reader \
+  --threads 8 \
+  --input reads.bam \
+  --output grouped.bam
+```
+
+`--async-reader` works with all input types: BAM files, BGZF/gzip/plain FASTQs,
+and piped stdin. It is most effective when I/O latency is high (network storage,
+cold page cache, small OS readahead). On systems where you can already set 4 MB+
+readahead, the additional benefit is modest.
+
+### AWS EBS Volume Throughput
+
+On AWS, `gp3` volumes default to 125 MB/s throughput regardless of size. For BAM
+processing this is often the binding constraint. Increasing to 300-500 MB/s is
+inexpensive and has a large impact:
+
+```bash
+# Increase throughput on an existing volume (takes effect within minutes)
+aws ec2 modify-volume \
+  --volume-id vol-0123456789abcdef0 \
+  --throughput 500
+```
+
+For sustained sequential I/O, also consider increasing IOPS (default 3000) if your
+reads are small. Monitor with `iostat -x 1` to confirm the volume is the bottleneck
+before spending on higher provisioned throughput.
+
 ## Scenario-Based Configurations
 
 ### High-Throughput Server
@@ -142,6 +206,7 @@ fgumi filter \
 
 ```bash
 fgumi filter \
+  --async-reader \
   --threads 4 \
   --queue-memory 512 \
   --compression-level 9 \
@@ -150,6 +215,7 @@ fgumi filter \
 ```
 
 **Rationale**:
+- `--async-reader` hides network I/O latency (see [I/O and Storage Tuning](#io-and-storage-tuning))
 - Moderate threading to avoid overwhelming network
 - Conservative memory usage
 - Maximum compression to reduce network transfer
@@ -235,7 +301,8 @@ With `--deadlock-recover`, the pipeline progressively doubles queue memory limit
 - Consider reducing threads if not fully utilized
 
 ### I/O Patterns
-- Monitor disk I/O with `iotop`
+- Monitor disk I/O with `iotop` or `iostat -x 1`
+- If threads are idle waiting on I/O, increase OS readahead or try `--async-reader` (see [I/O and Storage Tuning](#io-and-storage-tuning))
 - Network storage may benefit from lower thread counts
 - SSD storage can handle higher thread counts
 
@@ -250,6 +317,7 @@ With `--deadlock-recover`, the pipeline progressively doubles queue memory limit
 1. Increase `--threads` if CPU usage is low
 2. Increase `--queue-memory` if I/O bound
 3. Reduce `--compression-level` if CPU bound
+4. Check OS readahead and EBS throughput if disk I/O is the bottleneck (see [I/O and Storage Tuning](#io-and-storage-tuning))
 
 ### Pipeline Appears Stuck
 If a command hangs without producing output:

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -48,9 +48,9 @@ const MAX_BLOCK_SIZE: usize = 65280;
 /// This allows functions to accept either reader type through a unified interface.
 pub enum BgzfReaderEnum {
     /// Single-threaded BGZF reader (lower overhead for small files)
-    SingleThreaded(BgzfReader<File>),
+    SingleThreaded(BgzfReader<Box<dyn Read + Send>>),
     /// Multi-threaded BGZF reader (noodles built-in threading)
-    MultiThreaded(MultithreadedReader<File>),
+    MultiThreaded(MultithreadedReader<Box<dyn Read + Send>>),
 }
 
 impl Read for BgzfReaderEnum {
@@ -133,12 +133,12 @@ impl BgzfWriterEnum {
 pub type BamWriter = noodles::bam::io::Writer<BgzfWriterEnum>;
 
 /// Create a [`BgzfReaderEnum`] from a file, selecting single- or multi-threaded based on `threads`.
-fn make_bgzf_reader(file: File, threads: usize) -> BgzfReaderEnum {
+fn make_bgzf_reader(reader: Box<dyn Read + Send>, threads: usize) -> BgzfReaderEnum {
     if threads > 1 {
         let worker_count = NonZero::new(threads).expect("threads > 1 checked above");
-        BgzfReaderEnum::MultiThreaded(MultithreadedReader::with_worker_count(worker_count, file))
+        BgzfReaderEnum::MultiThreaded(MultithreadedReader::with_worker_count(worker_count, reader))
     } else {
-        BgzfReaderEnum::SingleThreaded(BgzfReader::new(file))
+        BgzfReaderEnum::SingleThreaded(BgzfReader::new(reader))
     }
 }
 
@@ -689,11 +689,38 @@ pub fn create_bam_reader<P: AsRef<Path>>(
     path: P,
     threads: usize,
 ) -> Result<(BamReaderAuto, Header)> {
+    create_bam_reader_with_opts(path, threads, PipelineReaderOpts::default())
+}
+
+/// Variant of [`create_bam_reader`] that accepts [`PipelineReaderOpts`].
+///
+/// When `opts.async_reader` is true the file is wrapped in a
+/// [`PrefetchReader`](crate::prefetch_reader::PrefetchReader) before the BGZF
+/// decompression layer, overlapping disk I/O with BGZF decoding.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or the BAM header cannot be parsed.
+pub fn create_bam_reader_with_opts<P: AsRef<Path>>(
+    path: P,
+    threads: usize,
+    opts: PipelineReaderOpts,
+) -> Result<(BamReaderAuto, Header)> {
     let path_ref = path.as_ref();
     let file = File::open(path_ref)
         .with_context(|| format!("Failed to open input BAM: {}", path_ref.display()))?;
 
-    let bgzf_reader = make_bgzf_reader(file, threads);
+    crate::os_hints::advise_sequential(&file);
+    let reader: Box<dyn Read + Send> = if opts.async_reader {
+        log::info!(
+            "async BAM reader enabled: spawning fgumi-prefetch thread for {}",
+            path_ref.display()
+        );
+        Box::new(crate::prefetch_reader::PrefetchReader::from_file(file))
+    } else {
+        Box::new(file)
+    };
+    let bgzf_reader = make_bgzf_reader(reader, threads);
 
     let mut reader = noodles::bam::io::Reader::from(bgzf_reader);
     let header = reader
@@ -727,11 +754,38 @@ pub fn create_raw_bam_reader<P: AsRef<Path>>(
     path: P,
     threads: usize,
 ) -> Result<(RawBamReaderAuto, Header)> {
+    create_raw_bam_reader_with_opts(path, threads, PipelineReaderOpts::default())
+}
+
+/// Variant of [`create_raw_bam_reader`] that accepts [`PipelineReaderOpts`].
+///
+/// When `opts.async_reader` is true the file is wrapped in a
+/// [`PrefetchReader`](crate::prefetch_reader::PrefetchReader) before the BGZF
+/// decompression layer, overlapping disk I/O with BGZF decoding.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or the BAM header cannot be parsed.
+pub fn create_raw_bam_reader_with_opts<P: AsRef<Path>>(
+    path: P,
+    threads: usize,
+    opts: PipelineReaderOpts,
+) -> Result<(RawBamReaderAuto, Header)> {
     let path_ref = path.as_ref();
     let file = File::open(path_ref)
         .with_context(|| format!("Failed to open input BAM: {}", path_ref.display()))?;
 
-    let bgzf_reader = make_bgzf_reader(file, threads);
+    crate::os_hints::advise_sequential(&file);
+    let reader: Box<dyn Read + Send> = if opts.async_reader {
+        log::info!(
+            "async raw BAM reader enabled: spawning fgumi-prefetch thread for {}",
+            path_ref.display()
+        );
+        Box::new(crate::prefetch_reader::PrefetchReader::from_file(file))
+    } else {
+        Box::new(file)
+    };
+    let bgzf_reader = make_bgzf_reader(reader, threads);
 
     // Use noodles to read the header, then extract the BGZF reader
     let mut noodles_reader = noodles::bam::io::Reader::from(bgzf_reader);
@@ -1079,6 +1133,9 @@ impl<R: Read> Read for ChainedReader<R> {
 /// For stdin: Buffers all bytes read while parsing header, returns a chained reader
 ///            that first yields the buffered bytes then continues from stdin.
 ///
+/// This is a convenience wrapper that disables the async prefetch reader. Use
+/// [`create_bam_reader_for_pipeline_with_opts`] to opt in.
+///
 /// # Arguments
 /// * `path` - Path to the input BAM file, or "-" / "/dev/stdin" for stdin
 ///
@@ -1103,6 +1160,34 @@ impl<R: Read> Read for ChainedReader<R> {
 pub fn create_bam_reader_for_pipeline<P: AsRef<Path>>(
     path: P,
 ) -> Result<(Box<dyn Read + Send>, Header)> {
+    create_bam_reader_for_pipeline_with_opts(path, PipelineReaderOpts::default())
+}
+
+/// Options controlling how [`create_bam_reader_for_pipeline_with_opts`] opens
+/// and wraps its input file.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PipelineReaderOpts {
+    /// If true, wrap inputs in a [`crate::prefetch_reader::PrefetchReader`]
+    /// so that disk reads happen on a dedicated I/O thread.
+    pub async_reader: bool,
+}
+
+/// Variant of [`create_bam_reader_for_pipeline`] that accepts tuning options.
+///
+/// For regular files, `POSIX_FADV_SEQUENTIAL` is applied to the file descriptor
+/// on Linux (a no-op elsewhere). If `opts.async_reader` is true the input is
+/// wrapped in a [`crate::prefetch_reader::PrefetchReader`] — for regular files
+/// using [`from_file`](crate::prefetch_reader::PrefetchReader::from_file) (with
+/// kernel WILLNEED hints), for stdin via the generic
+/// [`new`](crate::prefetch_reader::PrefetchReader::new) constructor.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or the header cannot be read.
+pub fn create_bam_reader_for_pipeline_with_opts<P: AsRef<Path>>(
+    path: P,
+    opts: PipelineReaderOpts,
+) -> Result<(Box<dyn Read + Send>, Header)> {
     use std::io::{Seek, SeekFrom};
 
     let path_ref = path.as_ref();
@@ -1126,11 +1211,21 @@ pub fn create_bam_reader_for_pipeline<P: AsRef<Path>>(
         // Create a chained reader: buffered bytes first, then remaining stdin
         let chained = ChainedReader::new(buffered_bytes, stdin);
 
-        Ok((Box::new(chained), header))
+        if opts.async_reader {
+            log::info!("async BAM reader enabled: spawning fgumi-prefetch thread for stdin");
+            let prefetch = crate::prefetch_reader::PrefetchReader::new(chained);
+            Ok((Box::new(prefetch), header))
+        } else {
+            Ok((Box::new(chained), header))
+        }
     } else {
         // Read from file - we can seek back
         let mut file = File::open(path_ref)
             .with_context(|| format!("Failed to open input BAM: {}", path_ref.display()))?;
+
+        // Tell the kernel to grow the per-fd read-ahead window. Best-effort;
+        // failure is logged and ignored. On non-Linux targets this is a no-op.
+        crate::os_hints::advise_sequential(&file);
 
         // Read header using noodles
         let bgzf_reader = BgzfReader::new(&file);
@@ -1143,7 +1238,16 @@ pub fn create_bam_reader_for_pipeline<P: AsRef<Path>>(
         file.seek(SeekFrom::Start(0))
             .with_context(|| format!("Failed to seek in file: {}", path_ref.display()))?;
 
-        Ok((Box::new(file), header))
+        if opts.async_reader {
+            log::info!(
+                "async BAM reader enabled: spawning fgumi-prefetch thread for {}",
+                path_ref.display()
+            );
+            let prefetch = crate::prefetch_reader::PrefetchReader::from_file(file);
+            Ok((Box::new(prefetch), header))
+        } else {
+            Ok((Box::new(file), header))
+        }
     }
 }
 
@@ -1680,5 +1784,33 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().expect("result should be Err");
         assert!(err.to_string().contains("stdout"));
+    }
+
+    #[test]
+    fn test_create_bam_reader_for_pipeline_with_async_reader() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let header = create_test_header();
+
+        // Write a BAM file first
+        {
+            let _writer = create_bam_writer(temp_file.path(), &header, 1, 6)?;
+        }
+
+        // Read using async reader opts — exercises the PrefetchReader branch
+        let opts = PipelineReaderOpts { async_reader: true };
+        let (mut reader, read_header) =
+            create_bam_reader_for_pipeline_with_opts(temp_file.path(), opts)?;
+        assert_eq!(read_header.reference_sequences().len(), 1);
+
+        // The reader returns raw bytes; verify it is usable
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf)?;
+        assert!(n > 0, "Should read some bytes from the async reader");
+
+        // Ensure read_to_end works through the PrefetchReader
+        let mut rest = Vec::new();
+        reader.read_to_end(&mut rest)?;
+
+        Ok(())
     }
 }

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -6,7 +6,8 @@
 
 use crate::alignment_tags::regenerate_alignment_tags;
 use crate::bam_io::{
-    create_bam_reader, create_bam_reader_for_pipeline, create_bam_writer, is_stdin_path,
+    create_bam_reader_for_pipeline_with_opts, create_bam_reader_with_opts, create_bam_writer,
+    is_stdin_path,
 };
 use crate::clipper::{ClippingMode, SamRecordClipper};
 use crate::grouper::TemplateGrouper;
@@ -237,7 +238,10 @@ impl Command for Clip {
         // ========================================================================
         let total_records = if let Some(threads) = self.threading.threads {
             // Read header for the 7-step pipeline (supports stdin)
-            let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+            )?;
 
             // Load reference (always required for clip)
             let reference = Arc::new(ReferenceReader::new(&self.reference)?);
@@ -278,7 +282,11 @@ impl Clip {
 
         // Open input BAM with MT BGZF decompression
         let reader_threads = self.threading.num_threads();
-        let (mut reader, header) = create_bam_reader(&self.io.input, reader_threads)?;
+        let (mut reader, header) = create_bam_reader_with_opts(
+            &self.io.input,
+            reader_threads,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Update header sort order if specified
         let header = self.update_header_sort_order(header)?;
@@ -892,10 +900,7 @@ mod tests {
     #[test]
     fn test_default_clip_parameters() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -923,10 +928,7 @@ mod tests {
     #[test]
     fn test_clip_with_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -955,10 +957,7 @@ mod tests {
     #[test]
     fn test_clip_with_overlapping_enabled() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -986,10 +985,7 @@ mod tests {
     #[test]
     fn test_clip_with_metrics_output() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: false,
@@ -1017,10 +1013,7 @@ mod tests {
     #[test]
     fn test_clip_with_tag_regeneration() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1047,10 +1040,7 @@ mod tests {
     #[test]
     fn test_clip_all_modes_enabled() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1082,10 +1072,7 @@ mod tests {
     fn test_clipping_mode_enum_values() {
         // Test that clipping_mode enum variants are set properly
         let soft = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1111,10 +1098,7 @@ mod tests {
     #[test]
     fn test_clip_with_sort_order_specification() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1140,10 +1124,7 @@ mod tests {
     #[test]
     fn test_clip_asymmetric_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,
@@ -1173,10 +1154,7 @@ mod tests {
     #[test]
     fn test_clip_with_upgrade_all_clipping() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1204,10 +1182,7 @@ mod tests {
     #[test]
     fn test_clip_extending_past_mate_only() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1235,10 +1210,7 @@ mod tests {
     #[test]
     fn test_clip_overlapping_reads_only() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1266,10 +1238,7 @@ mod tests {
     #[test]
     fn test_clip_modes_with_auto_clip_attributes() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1297,10 +1266,7 @@ mod tests {
     #[test]
     fn test_clip_zero_bases_all_positions() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1330,10 +1296,7 @@ mod tests {
     #[test]
     fn test_clip_soft_with_mask_mode() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: true,
@@ -1361,10 +1324,7 @@ mod tests {
     #[test]
     fn test_clip_large_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1394,10 +1354,7 @@ mod tests {
     #[test]
     fn test_clip_combination_overlapping_and_fixed() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1426,10 +1383,7 @@ mod tests {
     #[test]
     fn test_clip_all_three_modes_comparison() {
         let soft = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,
@@ -1450,10 +1404,7 @@ mod tests {
         };
 
         let soft_mask = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: false,
@@ -1474,10 +1425,7 @@ mod tests {
         };
 
         let hard = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1506,10 +1454,7 @@ mod tests {
     #[test]
     fn test_clip_with_queryname_sort_order() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1535,10 +1480,7 @@ mod tests {
     #[test]
     fn test_clip_with_unsorted_sort_order() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1564,10 +1506,7 @@ mod tests {
     #[test]
     fn test_clip_single_read_end_clipping() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1597,10 +1536,7 @@ mod tests {
     #[test]
     fn test_clip_with_metrics_and_upgrade() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1628,10 +1564,7 @@ mod tests {
     #[test]
     fn test_clip_both_extending_and_overlapping() {
         let clip = Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1701,7 +1634,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1748,7 +1681,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1794,7 +1727,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: true,
@@ -1840,7 +1773,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1886,7 +1819,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1932,7 +1865,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1979,7 +1912,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2026,7 +1959,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2072,7 +2005,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -2119,7 +2052,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2166,7 +2099,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2213,7 +2146,7 @@ mod tests {
         builder.write(&input_path).expect("failed to write test BAM");
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path },
+            io: BamIoOptions::new(input_path, output_path),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -2266,7 +2199,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2327,10 +2260,7 @@ mod tests {
         read_two_three_prime: usize,
     ) -> Clip {
         Clip {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -7,8 +7,8 @@
 //! allowing even a single read-pair to generate duplex consensus.
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 use crate::commands::command::Command;
 use crate::commands::consensus_runner::{ConsensusStatsOps, create_unmapped_consensus_header};
@@ -263,7 +263,10 @@ impl Command for Codec {
         // (matching fgbio's CallCodecConsensusReads which has no such option).
 
         // Open input BAM using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Create output header for unmapped consensus reads
         let output_header = create_unmapped_consensus_header(
@@ -354,7 +357,8 @@ impl Command for Codec {
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
         // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) = create_raw_bam_reader(&self.io.input, 1)?;
+        let (mut raw_reader, _) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
         let raw_record_iter = std::iter::from_fn(move || {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
@@ -689,7 +693,7 @@ mod tests {
     /// Helper to create a Codec with specified input/output paths
     fn create_codec_with_paths(input: PathBuf, output: PathBuf) -> Codec {
         Codec {
-            io: BamIoOptions { input, output },
+            io: BamIoOptions::new(input, output),
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions::default(),

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::bam_io::is_stdin_path;
+use crate::bam_io::{PipelineReaderOpts, is_stdin_path};
 use crate::logging::OperationTimer;
 use crate::unified_pipeline::{BamPipelineConfig, SchedulerStrategy};
 use crate::validation::validate_file_exists;
@@ -100,9 +100,34 @@ pub struct BamIoOptions {
     /// Output BAM file
     #[arg(short = 'o', long = "output")]
     pub output: PathBuf,
+
+    /// Enable async userspace prefetch on the input BAM.
+    ///
+    /// Spawns a dedicated I/O thread that reads raw bytes into a bounded
+    /// queue ahead of the decompression step, so processing threads do
+    /// not block on disk. Prototype flag; defaults to off.
+    #[arg(long = "async-reader", default_value_t = false, hide = true)]
+    pub async_reader: bool,
+}
+
+impl Default for BamIoOptions {
+    fn default() -> Self {
+        Self { input: PathBuf::new(), output: PathBuf::new(), async_reader: false }
+    }
 }
 
 impl BamIoOptions {
+    /// Construct a `BamIoOptions` from input and output paths. Leaves
+    /// opt-in tuning flags (e.g. `async_reader`) at their default values.
+    pub fn new(input: impl Into<PathBuf>, output: impl Into<PathBuf>) -> Self {
+        Self { input: input.into(), output: output.into(), async_reader: false }
+    }
+
+    /// Build [`PipelineReaderOpts`] from the async-reader flag.
+    pub fn pipeline_reader_opts(&self) -> PipelineReaderOpts {
+        PipelineReaderOpts { async_reader: self.async_reader }
+    }
+
     /// Validates that the input file exists (skipped for stdin paths).
     ///
     /// # Errors

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -16,10 +16,10 @@
 //! };
 //!
 //! let corrector = CorrectUmis {
-//!     io: BamIoOptions {
-//!         input: PathBuf::from("input.bam"),
-//!         output: PathBuf::from("corrected.bam"),
-//!     },
+//!     io: BamIoOptions::new(
+//!         PathBuf::from("input.bam"),
+//!         PathBuf::from("corrected.bam"),
+//!     ),
 //!     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 //!     metrics: Some(PathBuf::from("metrics.txt")),
 //!     max_mismatches: 2,
@@ -40,8 +40,8 @@
 //! ```
 
 use crate::bam_io::{
-    BamWriter, create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader,
+    BamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts,
 };
 use crate::bitenc::BitEnc;
 use crate::dna::reverse_complement_str;
@@ -119,10 +119,10 @@ pub struct UmiMatch {
 /// # };
 /// # use std::path::PathBuf;
 /// let corrector = CorrectUmis {
-///     io: BamIoOptions {
-///         input: PathBuf::from("input.bam"),
-///         output: PathBuf::from("corrected.bam"),
-///     },
+///     io: BamIoOptions::new(
+///         PathBuf::from("input.bam"),
+///         PathBuf::from("corrected.bam"),
+///     ),
 ///     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 ///     metrics: Some(PathBuf::from("metrics.txt")),
 ///     max_mismatches: 2,
@@ -373,7 +373,7 @@ impl Command for CorrectUmis {
     /// # use crate::commands::command::Command;
     /// let corrector = CorrectUmis {
     ///     /* ... field initialization ... */
-    /// #   io: BamIoOptions { input: PathBuf::new(), output: PathBuf::new() },
+    /// #   io: BamIoOptions::new(PathBuf::new(), PathBuf::new()),
     /// #   rejects_opts: RejectsOptions::default(),
     /// #   metrics: None,
     /// #   max_mismatches: 2,
@@ -404,7 +404,10 @@ impl Command for CorrectUmis {
         self.check_umi_distances(&umi_sequences);
 
         // Open input using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Add @PG record with PP chaining to input's last program
         let header = crate::commands::common::add_pg_record(header, command_line)?;
@@ -1113,7 +1116,8 @@ impl CorrectUmis {
         info!("Using single-threaded mode with template-level UMI correction");
 
         // Open input BAM reader (raw-byte reader for zero-copy processing)
-        let (mut bam_reader, _) = create_raw_bam_reader(&self.io.input, 1)?;
+        let (mut bam_reader, _) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
 
         // Open output writer (single-threaded)
         let mut writer =
@@ -1788,10 +1792,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions {
-                input: input_file.path().to_path_buf(),
-                output: paths.output.clone(),
-            },
+            io: BamIoOptions::new(input_file.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -1822,10 +1823,10 @@ mod tests {
         let temp_output = NamedTempFile::new().expect("failed to create temp file");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions {
-                input: temp_input.path().to_path_buf(),
-                output: temp_output.path().to_path_buf(),
-            },
+            io: BamIoOptions::new(
+                temp_input.path().to_path_buf(),
+                temp_output.path().to_path_buf(),
+            ),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -1853,7 +1854,7 @@ mod tests {
         let rejects = dir.path().join("rejects.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -1899,7 +1900,7 @@ mod tests {
         let metrics = dir.path().join("metrics.txt");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: Some(metrics.clone()),
             max_mismatches: 3,
@@ -1961,7 +1962,7 @@ mod tests {
         let rejects = dir.path().join("rejects.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
             max_mismatches: 3,
@@ -2017,7 +2018,7 @@ mod tests {
 
         // Run with command line UMIs
         let corrector1 = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output1.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output1.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics1.clone()),
             max_mismatches: 3,
@@ -2042,7 +2043,7 @@ mod tests {
 
         // Run with UMI file
         let corrector2 = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output2.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output2.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics2.clone()),
             max_mismatches: 3,
@@ -2083,7 +2084,7 @@ mod tests {
 
         // Test with original UMI storage (default)
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2122,7 +2123,7 @@ mod tests {
         // Test with original UMI storage disabled
         let output2 = dir.path().join("output2.bam");
         let corrector2 = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output2.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output2.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2162,7 +2163,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2215,7 +2216,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 0, // Exact match only
@@ -2259,7 +2260,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 2,
@@ -2314,7 +2315,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -2355,7 +2356,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -2395,7 +2396,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 1,
@@ -2434,7 +2435,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 1,
@@ -2467,7 +2468,7 @@ mod tests {
         let output2 = paths.output_n(2);
 
         let corrector2 = CorrectUmis {
-            io: BamIoOptions { input: input2.path().to_path_buf(), output: output2.clone() },
+            io: BamIoOptions::new(input2.path().to_path_buf(), output2.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 1,
@@ -2504,7 +2505,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 0, // Exact match
@@ -2552,7 +2553,7 @@ mod tests {
 
         // Run with 4 threads to test parallel processing order
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2610,7 +2611,7 @@ mod tests {
         let output = dir.path().join("output.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2768,7 +2769,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1, // Strict matching
@@ -2823,7 +2824,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1,
@@ -2908,7 +2909,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1,
@@ -2976,10 +2977,7 @@ mod tests {
         let output = NamedTempFile::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions {
-                input: input.path().to_path_buf(),
-                output: output.path().to_path_buf(),
-            },
+            io: BamIoOptions::new(input.path().to_path_buf(), output.path().to_path_buf()),
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -3220,7 +3218,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 2,

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
-use crate::bam_io::{create_bam_reader_for_pipeline, is_stdin_path};
+use crate::bam_io::{create_bam_reader_for_pipeline_with_opts, is_stdin_path};
 use crate::grouper::{
     FilterMetrics, RawPositionGroup, RecordPositionGrouper, build_templates_from_records,
 };
@@ -1179,7 +1179,10 @@ impl Command for MarkDuplicates {
         info!("{}", self.threading.log_message());
 
         // Open input BAM
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         if !is_template_coordinate_sorted(&header) {
             bail!(

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -446,10 +446,7 @@ mod tests {
     #[test]
     fn test_validate_fraction_too_low() {
         let cmd = Downsample {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             fraction: 0.0,
             rejects: None,
             seed: None,
@@ -466,10 +463,7 @@ mod tests {
     #[test]
     fn test_validate_fraction_too_high() {
         let cmd = Downsample {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             fraction: 1.5,
             rejects: None,
             seed: None,
@@ -485,10 +479,7 @@ mod tests {
     #[test]
     fn test_validate_fraction_valid() {
         let cmd = Downsample {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             fraction: 0.5,
             rejects: None,
             seed: None,
@@ -526,10 +517,7 @@ mod tests {
     #[allow(clippy::float_cmp)] // Testing exact value assignment, not computation
     fn test_downsample_parameters() {
         let cmd = Downsample {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             fraction: 0.1,
             rejects: Some(PathBuf::from("rejects.bam")),
             seed: Some(42),

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -6,8 +6,8 @@
 //! 2. Duplex consensus from paired single-strand consensuses
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -239,10 +239,10 @@ impl Command for Duplex {
     /// # };
     /// # use std::path::PathBuf;
     /// let duplex = Duplex {
-    ///     io: BamIoOptions {
-    ///         input: PathBuf::from("grouped.bam"),
-    ///         output: PathBuf::from("duplex.bam"),
-    ///     },
+    ///     io: BamIoOptions::new(
+    ///         PathBuf::from("grouped.bam"),
+    ///         PathBuf::from("duplex.bam"),
+    ///     ),
     ///     rejects_opts: RejectsOptions::default(),
     ///     stats_opts: StatsOptions::default(),
     ///     read_group: ReadGroupOptions {
@@ -294,7 +294,10 @@ impl Command for Duplex {
         );
 
         // Open input BAM using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Add @PG record with PP chaining to input's last program
         let header = crate::commands::common::add_pg_record(header, command_line)?;
@@ -393,7 +396,8 @@ impl Command for Duplex {
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
         // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) = create_raw_bam_reader(&self.io.input, 1)?;
+        let (mut raw_reader, _) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
         // Create raw byte iterator, filtering out secondary/supplementary and keeping
         // only mapped or mate-mapped reads
         let raw_record_iter = std::iter::from_fn(move || {
@@ -875,7 +879,7 @@ mod tests {
     /// Uses sensible test defaults: disabled per-base tags, disabled overlapping consensus.
     fn create_duplex_with_paths(input: PathBuf, output: PathBuf) -> Duplex {
         Duplex {
-            io: BamIoOptions { input, output },
+            io: BamIoOptions::new(input, output),
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions {

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -31,7 +31,6 @@ use crate::validation::validate_file_exists;
 use anyhow::{Result, bail, ensure};
 use bstr::{BString, ByteSlice};
 use clap::Parser;
-use fgoxide::io::Io;
 use fgumi_raw_bam::UnmappedBamRecordBuilder;
 use fgumi_raw_bam::fields::flags;
 use log::{debug, info};
@@ -53,7 +52,7 @@ use noodles::sam::header::record::value::{
 };
 use read_structure::{ReadStructure, SegmentType};
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -135,38 +134,64 @@ fn detect_compression_format(path: &Path) -> Result<CompressionFormat> {
 /// Open a FASTQ file with automatic detection of compression format.
 ///
 /// For BGZF-compressed files, uses noodles `MultithreadedReader` when threads > 1.
-/// For regular gzip files, uses fgoxide (flate2/zlib-ng) single-threaded decompression.
-/// For uncompressed files, opens directly.
+/// For regular gzip files, uses flate2 `MultiGzDecoder` single-threaded decompression.
+/// For uncompressed files, opens directly with buffering.
+///
+/// When `async_reader` is true the underlying file is wrapped in a
+/// [`PrefetchReader`](crate::prefetch_reader::PrefetchReader) before the
+/// decompression layer, overlapping disk I/O with decompression.
 ///
 /// # Arguments
 /// * `path` - Path to the FASTQ file
 /// * `threads` - Number of decompression threads (only used for BGZF)
+/// * `async_reader` - If true, wrap the file in an async prefetch reader
 ///
 /// # Returns
 /// A boxed reader that implements `BufRead` + `Send`
-fn open_fastq_reader(path: &Path, threads: usize) -> Result<Box<dyn BufRead + Send>> {
+fn open_fastq_reader(
+    path: &Path,
+    threads: usize,
+    async_reader: bool,
+) -> Result<Box<dyn BufRead + Send>> {
+    use flate2::read::MultiGzDecoder;
+
     let format = detect_compression_format(path)?;
-    let fgio = Io::new(5, BUFFER_SIZE);
+
+    // Open file, optionally wrap in PrefetchReader for async I/O.
+    let open_reader = |path: &Path| -> Result<Box<dyn Read + Send>> {
+        let file = File::open(path)?;
+        if async_reader {
+            crate::os_hints::advise_sequential(&file);
+            log::info!(
+                "async FASTQ reader enabled: spawning fgumi-prefetch thread for {}",
+                path.display()
+            );
+            Ok(Box::new(crate::prefetch_reader::PrefetchReader::from_file(file)))
+        } else {
+            Ok(Box::new(file))
+        }
+    };
 
     match format {
         CompressionFormat::Bgzf if threads > 1 => {
             info!("Detected BGZF-compressed FASTQ, using {threads} decompression threads");
-            let file = File::open(path)?;
+            let reader = open_reader(path)?;
             let worker_count = std::num::NonZero::new(threads).expect("threads > 1 checked above");
-            let reader = MultithreadedReader::with_worker_count(worker_count, file);
-            Ok(Box::new(BufReader::new(reader)))
+            let reader = MultithreadedReader::with_worker_count(worker_count, reader);
+            Ok(Box::new(BufReader::with_capacity(BUFFER_SIZE, reader)))
         }
-        CompressionFormat::Bgzf => {
-            debug!("Detected BGZF-compressed FASTQ, using single-threaded decompression");
-            Ok(fgio.new_reader(path)?)
-        }
-        CompressionFormat::Gzip => {
-            debug!("Detected gzip-compressed FASTQ, using single-threaded decompression");
-            Ok(fgio.new_reader(path)?)
+        CompressionFormat::Bgzf | CompressionFormat::Gzip => {
+            debug!("Detected {format:?}-compressed FASTQ, using single-threaded decompression");
+            let reader = open_reader(path)?;
+            Ok(Box::new(BufReader::with_capacity(
+                BUFFER_SIZE,
+                MultiGzDecoder::new(BufReader::with_capacity(BUFFER_SIZE, reader)),
+            )))
         }
         CompressionFormat::Plain => {
             debug!("Detected uncompressed FASTQ");
-            Ok(fgio.new_reader(path)?)
+            let reader = open_reader(path)?;
+            Ok(Box::new(BufReader::with_capacity(BUFFER_SIZE, reader)))
         }
     }
 }
@@ -481,6 +506,12 @@ pub struct Extract {
     /// Queue memory options.
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
+
+    /// Wrap FASTQ inputs in a userspace async prefetch reader. Dedicates one
+    /// OS thread per input stream to issue reads ahead of decompression/parsing.
+    /// Hidden experimental flag.
+    #[arg(long = "async-reader", default_value_t = false, hide = true)]
+    pub async_reader: bool,
 }
 
 impl Extract {
@@ -921,7 +952,8 @@ impl Extract {
                 .with_stats(self.scheduler_opts.collect_stats())
                 .with_scheduler_strategy(self.scheduler_opts.strategy())
                 .with_deadlock_timeout(self.scheduler_opts.deadlock_timeout_secs())
-                .with_deadlock_recovery(self.scheduler_opts.deadlock_recover_enabled());
+                .with_deadlock_recovery(self.scheduler_opts.deadlock_recover_enabled())
+                .with_async_reader(self.async_reader);
 
         // Calculate and apply queue memory limit
         let queue_memory_limit_bytes = self.queue_memory.calculate_memory_limit(num_threads)?;
@@ -937,7 +969,7 @@ impl Extract {
             Some(
                 self.inputs
                     .iter()
-                    .map(|p| open_fastq_reader(p, decomp_threads))
+                    .map(|p| open_fastq_reader(p, decomp_threads, self.async_reader))
                     .collect::<Result<Vec<_>>>()?,
             )
         };
@@ -1199,8 +1231,10 @@ impl Command for Extract {
         // Detect quality encoding from first 400 records
         // Use a separate reader for sampling to avoid consuming records from the main reader
         let mut sample_quals = Vec::new();
-        let mut temp_reader =
-            SimdFastqReader::with_capacity(open_fastq_reader(&self.inputs[0], 1)?, BUFFER_SIZE);
+        let mut temp_reader = SimdFastqReader::with_capacity(
+            open_fastq_reader(&self.inputs[0], 1, false)?,
+            BUFFER_SIZE,
+        );
         for _i in 0..QUALITY_DETECTION_SAMPLE_SIZE {
             match temp_reader.next() {
                 Some(Ok(rec)) => sample_quals.push(rec.quality),
@@ -1231,7 +1265,7 @@ impl Command for Extract {
             let fq_readers: Vec<Box<dyn BufRead + Send>> = self
                 .inputs
                 .iter()
-                .map(|p| open_fastq_reader(p, decomp_threads))
+                .map(|p| open_fastq_reader(p, decomp_threads, self.async_reader))
                 .collect::<Result<Vec<_>>>()?;
 
             let fq_sources: Vec<SimdFastqReader<Box<dyn BufRead + Send>>> = fq_readers
@@ -1400,6 +1434,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1454,6 +1489,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1512,6 +1548,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1560,6 +1597,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1617,6 +1655,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1667,6 +1706,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1724,6 +1764,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1778,6 +1819,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1839,6 +1881,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1885,6 +1928,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -1954,6 +1998,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2019,6 +2064,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         let err = extract
@@ -2071,6 +2117,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2116,6 +2163,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract2.execute("test").expect("execute should succeed");
@@ -2168,6 +2216,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2221,6 +2270,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2273,6 +2323,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2320,6 +2371,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2364,6 +2416,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2406,6 +2459,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2448,6 +2502,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2498,6 +2553,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2547,6 +2603,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2598,6 +2655,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2640,6 +2698,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2696,6 +2755,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         let err =
@@ -2747,6 +2807,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -2958,6 +3019,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         // Should succeed without panicking
@@ -3021,6 +3083,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -3075,6 +3138,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -3144,6 +3208,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -3205,6 +3270,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");
@@ -3260,6 +3326,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         // Should succeed with all quality tag parameters specified
@@ -3308,6 +3375,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test")?;
@@ -3437,6 +3505,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test")?;
@@ -3490,6 +3559,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test")?;

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -9,7 +9,7 @@
 //!    (min reads, max read error rate, max no-calls, min mean quality)
 
 use crate::alignment_tags::regenerate_alignment_tags_raw;
-use crate::bam_io::create_bam_reader_for_pipeline;
+use crate::bam_io::create_bam_reader_for_pipeline_with_opts;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, compute_read_stats_raw, filter_duplex_read_raw, filter_read_raw,
     is_duplex_consensus_raw, mask_bases_raw, mask_duplex_bases_raw, template_passes_raw,
@@ -295,7 +295,10 @@ impl Command for Filter {
         info!("Max no-call fraction: {}", self.max_no_call_fraction);
 
         // Open input using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Add @PG record with PP chaining to input's last program
         let header = crate::commands::common::add_pg_record(header, command_line)?;
@@ -920,7 +923,7 @@ mod tests {
     /// Helper function to create a Filter command with commonly used test defaults.
     fn create_filter_with_paths(input: PathBuf, output: PathBuf, reference: PathBuf) -> Filter {
         Filter {
-            io: BamIoOptions { input, output },
+            io: BamIoOptions::new(input, output),
             reference: Some(reference),
             min_reads: vec![1],
             max_read_error_rate: vec![0.025],
@@ -980,10 +983,7 @@ mod tests {
     #[test]
     fn test_default_filter_parameters() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1011,10 +1011,7 @@ mod tests {
     #[test]
     fn test_multithreaded_filter_configuration() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1040,10 +1037,7 @@ mod tests {
     #[test]
     fn test_filter_with_optional_outputs() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1071,10 +1065,7 @@ mod tests {
     #[test]
     fn test_validate_parameters_too_many_values() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![1, 2, 3, 4], // Too many values
             max_read_error_rate: vec![0.1],
@@ -1100,10 +1091,7 @@ mod tests {
     #[test]
     fn test_validate_parameters_invalid_stringency_order() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![1, 10], // Invalid: AB > CC
             max_read_error_rate: vec![0.1],
@@ -1462,10 +1450,7 @@ mod tests {
     fn test_validate_max_no_call_fraction_integer() {
         // When max_no_call_fraction >= 1.0, it should be an integer
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1497,10 +1482,7 @@ mod tests {
     fn test_validate_max_no_call_fraction_integer_valid() {
         // When max_no_call_fraction >= 1.0 and IS an integer, it should pass
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1530,10 +1512,7 @@ mod tests {
     #[test]
     fn test_filter_with_rejects_output() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1560,10 +1539,7 @@ mod tests {
     #[test]
     fn test_filter_with_stats_output() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1590,10 +1566,7 @@ mod tests {
     #[test]
     fn test_filter_multithreaded() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1619,10 +1592,7 @@ mod tests {
     #[test]
     fn test_filter_require_single_strand_agreement() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1648,10 +1618,7 @@ mod tests {
     #[test]
     fn test_filter_by_read_not_template() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1677,10 +1644,7 @@ mod tests {
     #[test]
     fn test_filter_reverse_per_base_tags_disabled() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1706,10 +1670,7 @@ mod tests {
     #[test]
     fn test_filter_high_min_base_quality() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1735,10 +1696,7 @@ mod tests {
     #[test]
     fn test_filter_with_min_mean_base_quality() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1764,10 +1722,7 @@ mod tests {
     #[test]
     fn test_filter_strict_error_rates() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.01],
@@ -1795,10 +1750,7 @@ mod tests {
     #[test]
     fn test_filter_lenient_error_rates() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.5],
@@ -1826,10 +1778,7 @@ mod tests {
     #[test]
     fn test_filter_high_min_reads_threshold() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![10],
             max_read_error_rate: vec![0.1],
@@ -1856,10 +1805,7 @@ mod tests {
     fn test_filter_duplex_different_thresholds() {
         // Test duplex with different thresholds for CC, AB, BA
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 3, 3], // CC=5, AB=3, BA=3
             max_read_error_rate: vec![0.05, 0.1, 0.1],
@@ -1888,10 +1834,7 @@ mod tests {
     #[test]
     fn test_filter_all_optional_outputs() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1919,10 +1862,7 @@ mod tests {
     #[test]
     fn test_filter_zero_no_call_fraction() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1948,10 +1888,7 @@ mod tests {
     #[test]
     fn test_filter_low_min_base_quality() {
         let filter = Filter {
-            io: BamIoOptions {
-                input: PathBuf::from("input.bam"),
-                output: PathBuf::from("output.bam"),
-            },
+            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2054,7 +1991,7 @@ mod tests {
         min_base_quality: Option<u8>,
     ) -> Result<()> {
         let cmd = Filter {
-            io: BamIoOptions { input: input.to_path_buf(), output: output.to_path_buf() },
+            io: BamIoOptions::new(input.to_path_buf(), output.to_path_buf()),
             reference: Some(reference.to_path_buf()),
             min_reads,
             max_read_error_rate,
@@ -2174,7 +2111,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![0.5],
@@ -2327,7 +2264,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2399,7 +2336,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2465,7 +2402,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2588,7 +2525,7 @@ mod tests {
 
         // Use 3-value thresholds: duplex=5, AB=5, BA=5 (must be high-to-low)
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds (duplex >= AB >= BA)
             max_read_error_rate: vec![0.1],
@@ -2656,7 +2593,7 @@ mod tests {
 
         // With filter_by_template: false, reads are filtered independently
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2722,7 +2659,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2792,7 +2729,7 @@ mod tests {
 
         // Run single-threaded
         let cmd_single = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_single.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_single.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2815,7 +2752,7 @@ mod tests {
 
         // Run multi-threaded with 4 threads
         let cmd_multi = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_multi.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_multi.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2878,7 +2815,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2932,7 +2869,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2989,7 +2926,7 @@ mod tests {
 
         // Run multi-threaded with rejects output
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3055,7 +2992,7 @@ mod tests {
 
         // Run single-threaded
         let cmd_single = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_single.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_single.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA (must be high-to-low)
             max_read_error_rate: vec![0.1],
@@ -3078,7 +3015,7 @@ mod tests {
 
         // Run multi-threaded
         let cmd_multi = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_multi.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_multi.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1],
@@ -3159,7 +3096,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds
             max_read_error_rate: vec![0.1],
@@ -3268,7 +3205,7 @@ mod tests {
         drop(writer);
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3383,7 +3320,7 @@ mod tests {
         drop(writer);
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3419,7 +3356,7 @@ mod tests {
     fn test_validate_error_rate_ordering_ab_ba() {
         // Test validation of error rate ordering (AB <= BA)
         let cmd = Filter {
-            io: BamIoOptions { input: PathBuf::from("test.bam"), output: PathBuf::from("out.bam") },
+            io: BamIoOptions::new(PathBuf::from("test.bam"), PathBuf::from("out.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1, 0.2, 0.1], // AB (0.2) > BA (0.1) - invalid!
@@ -3450,7 +3387,7 @@ mod tests {
     fn test_validate_base_error_rate_ordering_ab_ba() {
         // Test validation of base error rate ordering (AB <= BA)
         let cmd = Filter {
-            io: BamIoOptions { input: PathBuf::from("test.bam"), output: PathBuf::from("out.bam") },
+            io: BamIoOptions::new(PathBuf::from("test.bam"), PathBuf::from("out.bam")),
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1],
@@ -3505,7 +3442,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3565,7 +3502,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path.clone(), output: output_path.clone() },
+            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds
             max_read_error_rate: vec![0.1],
@@ -3628,7 +3565,7 @@ mod tests {
         builder.write(&input_path)?;
 
         let cmd = Filter {
-            io: BamIoOptions { input: input_path, output: output_path.clone() },
+            io: BamIoOptions::new(input_path, output_path.clone()),
             reference: Some(ref_path),
             min_reads: vec![1],
             max_read_error_rate: vec![0.5],

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -1,7 +1,7 @@
 //! Groups reads by UMI to identify reads from the same original molecule.
 
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
-use crate::bam_io::{create_bam_reader_for_pipeline, create_bam_writer, is_stdin_path};
+use crate::bam_io::{create_bam_reader_for_pipeline_with_opts, create_bam_writer, is_stdin_path};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
@@ -955,7 +955,10 @@ impl Command for GroupReadsByUmi {
 
         // Open input BAM using streaming-capable reader for pipeline use
         info!("Reading input BAM");
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Check sort order - template-coordinate sorted is required,
         // but queryname-sorted is also accepted when --allow-unmapped is set
@@ -1864,10 +1867,10 @@ mod tests {
     /// Tests override specific fields as needed via struct update syntax.
     fn test_group_cmd(strategy: Strategy, edits: u32) -> GroupReadsByUmi {
         GroupReadsByUmi {
-            io: BamIoOptions {
-                input: std::path::PathBuf::from("/dev/null"),
-                output: std::path::PathBuf::from("/dev/null"),
-            },
+            io: BamIoOptions::new(
+                std::path::PathBuf::from("/dev/null"),
+                std::path::PathBuf::from("/dev/null"),
+            ),
             family_size_histogram: None,
             grouping_metrics: None,
             metrics: None,
@@ -2222,7 +2225,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Edit, 1)
         };
@@ -2264,7 +2267,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2301,7 +2304,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2335,7 +2338,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -2379,7 +2382,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             family_size_histogram: Some(paths.histogram.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2473,7 +2476,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             metrics: Some(paths.metrics_prefix.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2582,7 +2585,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             family_size_histogram: Some(paths.histogram.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             metrics: Some(paths.metrics_prefix.clone()),
@@ -2648,7 +2651,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             metrics: Some(paths.metrics_prefix.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2702,7 +2705,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
@@ -2740,7 +2743,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_umi_length: Some(6),
             ..test_group_cmd(Strategy::Edit, 0)
@@ -2782,7 +2785,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_umi_length: Some(5),
             ..test_group_cmd(Strategy::Edit, 0)
         };
@@ -2844,7 +2847,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -2962,7 +2965,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -2998,7 +3001,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3036,7 +3039,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Identity, 0);
-        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
         cmd.no_umi = true;
 
         cmd.execute("test")?;
@@ -3073,7 +3076,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Adjacency, 1);
-        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
         cmd.no_umi = true; // Will be overridden to identity
 
         cmd.execute("test")?;
@@ -3104,7 +3107,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Identity, 0);
-        cmd.io = BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() };
+        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
         cmd.no_umi = true;
 
         cmd.execute("test")?;
@@ -3172,7 +3175,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3233,7 +3236,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3294,7 +3297,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3378,7 +3381,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3462,7 +3465,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 2)
         };
 
@@ -3525,7 +3528,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading: ThreadingOptions::new(4), // Use 4 threads
             ..test_group_cmd(Strategy::Adjacency, 2)
         };
@@ -3570,7 +3573,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -3610,7 +3613,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading: ThreadingOptions::new(4), // Use 4 threads
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -3656,7 +3659,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -3702,7 +3705,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3735,7 +3738,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3771,7 +3774,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -3807,7 +3810,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -3844,7 +3847,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -3873,7 +3876,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -3908,7 +3911,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_umi_length: Some(8), // Require at least 8 bases
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -3944,7 +3947,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -3980,7 +3983,7 @@ mod tests {
 
         // With edits=2, all should group together
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 2)
         };
 
@@ -4013,7 +4016,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4043,7 +4046,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Adjacency, 0) // No edits allowed
         };
 
@@ -4078,7 +4081,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Edit, 3) // Allow up to 3 edits
         };
 
@@ -4108,7 +4111,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4143,7 +4146,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             family_size_histogram: Some(paths.histogram.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4169,7 +4172,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4201,7 +4204,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_map_q: Some(20), // Filter reads with mapq < 20
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4229,7 +4232,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4261,7 +4264,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4291,7 +4294,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4334,7 +4337,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             min_map_q: Some(30), // Threshold is 30, "bad" pair has MAPQ=10
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4483,7 +4486,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4540,7 +4543,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4598,7 +4601,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading,
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -4653,7 +4656,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading: ThreadingOptions::new(4),
             ..test_group_cmd(strategy, edits)
         };
@@ -4697,7 +4700,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading: ThreadingOptions::new(4),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
@@ -4740,7 +4743,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             threading: ThreadingOptions::new(4),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5140,7 +5143,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5173,7 +5176,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -5208,7 +5211,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             allow_unmapped: false,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5240,7 +5243,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5275,7 +5278,7 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions { input: input.path().to_path_buf(), output: paths.output.clone() },
+            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
             allow_unmapped: true,
             threading,
             ..test_group_cmd(Strategy::Identity, 0)

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -5,8 +5,8 @@
 //! errors introduced during sample preparation.
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 use crate::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
@@ -243,7 +243,10 @@ impl Command for Simplex {
         // Get threading configuration
         let writer_threads = self.threading.num_threads();
 
-        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Create output header (cleared for unmapped consensus reads)
         let output_header = create_unmapped_consensus_header(
@@ -353,7 +356,8 @@ impl Command for Simplex {
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
         // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) = create_raw_bam_reader(&self.io.input, 1)?;
+        let (mut raw_reader, _) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
         let raw_record_iter = std::iter::from_fn(move || {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
@@ -737,7 +741,7 @@ mod tests {
     /// Creates a Simplex command with the given input/output paths and default parameters.
     fn create_simplex_with_paths(input: PathBuf, output: PathBuf) -> Simplex {
         Simplex {
-            io: BamIoOptions { input, output },
+            io: BamIoOptions::new(input, output),
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions::default(),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -145,6 +145,8 @@ pub mod logging;
 pub mod metrics;
 pub mod mi_group;
 pub use fgumi_consensus::phred;
+pub mod os_hints;
+pub mod prefetch_reader;
 pub mod progress;
 pub mod read_info;
 pub mod reference;

--- a/src/lib/os_hints.rs
+++ b/src/lib/os_hints.rs
@@ -1,0 +1,114 @@
+#![deny(unsafe_code)]
+//! OS-specific I/O hints.
+//!
+//! This module provides small, portable wrappers around OS-specific advisory
+//! calls. The primary use case is informing the kernel about a file's expected
+//! access pattern before streaming through it, which on Linux can enlarge the
+//! per-fd read-ahead window well beyond the 128 KiB default set by
+//! `/sys/block/*/queue/read_ahead_kb`.
+//!
+//! All functions are best-effort: they are no-ops on non-supported platforms
+//! and never panic. Errors are logged at `debug` level and swallowed so that
+//! I/O hints can be wired in at the open site without error-handling
+//! boilerplate at every call.
+
+use std::fs::File;
+
+/// Hint to the kernel that `file` will be read from start to finish in a
+/// single forward pass. On Linux this enlarges the per-fd read-ahead window;
+/// on other platforms this is a no-op.
+///
+/// Failure is logged at `debug` level and otherwise ignored — the file
+/// remains usable, the hint simply wasn't applied.
+pub fn advise_sequential(file: &File) {
+    #[cfg(target_os = "linux")]
+    linux::advise_sequential(file);
+    #[cfg(not(target_os = "linux"))]
+    let _ = file;
+}
+
+/// Hint to the kernel that `len` bytes starting at `offset` on raw file
+/// descriptor `fd` will be needed soon. On Linux this triggers asynchronous
+/// page-in via `posix_fadvise(POSIX_FADV_WILLNEED)` — the kernel starts I/O
+/// immediately and returns without blocking. On other platforms this is a
+/// no-op.
+///
+/// This is the raw-fd variant for use inside the [`PrefetchReader`] producer
+/// thread, which owns the `File` and cannot lend a reference back. The fd
+/// remains valid because the producer thread keeps the `File` alive for the
+/// duration of its loop.
+///
+/// [`PrefetchReader`]: crate::prefetch_reader::PrefetchReader
+pub fn advise_willneed_raw(fd: i32, offset: i64, len: i64) {
+    // Intentionally takes a bare `i32` rather than `RawFd` so callers outside
+    // `cfg(unix)` can still compile without importing platform-specific types.
+    #[cfg(target_os = "linux")]
+    linux::advise_willneed_raw(fd, offset, len);
+    #[cfg(not(target_os = "linux"))]
+    let _ = (fd, offset, len);
+}
+
+/// Extract the raw file descriptor from `file` on Linux so it can be passed to
+/// [`advise_willneed_raw`] from a thread that owns the `File`. Returns `None`
+/// on non-Linux platforms where `posix_fadvise` is unavailable.
+#[must_use]
+#[cfg(target_os = "linux")]
+pub fn hint_fd(file: &File) -> Option<i32> {
+    use std::os::fd::AsRawFd;
+    Some(file.as_raw_fd())
+}
+
+/// Non-Linux stub — always returns `None`.
+#[must_use]
+#[cfg(not(target_os = "linux"))]
+pub fn hint_fd(_file: &File) -> Option<i32> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+
+    use nix::fcntl::{PosixFadviseAdvice, posix_fadvise};
+
+    pub(super) fn advise_sequential(file: &File) {
+        // offset = 0, len = 0 applies the hint to the entire file (current and
+        // future contents). Errors are non-fatal — log and move on.
+        let fd = file.as_raw_fd();
+        if let Err(e) = posix_fadvise(fd, 0, 0, PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL) {
+            log::debug!("posix_fadvise(POSIX_FADV_SEQUENTIAL) failed on fd {fd}: {e}");
+        }
+    }
+
+    pub(super) fn advise_willneed_raw(fd: i32, offset: i64, len: i64) {
+        if let Err(e) = posix_fadvise(fd, offset, len, PosixFadviseAdvice::POSIX_FADV_WILLNEED) {
+            log::debug!("posix_fadvise(POSIX_FADV_WILLNEED) failed on fd {fd}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn advise_sequential_does_not_error_on_regular_file() {
+        let mut tmp = NamedTempFile::new().expect("create temp file");
+        tmp.write_all(b"hello world").expect("write temp file");
+        let f = File::open(tmp.path()).expect("reopen temp file for read");
+        // The call should succeed or be a no-op. It must not panic.
+        advise_sequential(&f);
+    }
+
+    #[test]
+    fn advise_sequential_is_callable_repeatedly() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let f = File::open(tmp.path()).expect("open temp file");
+        for _ in 0..16 {
+            advise_sequential(&f);
+        }
+    }
+}

--- a/src/lib/prefetch_reader.rs
+++ b/src/lib/prefetch_reader.rs
@@ -1,0 +1,637 @@
+#![deny(unsafe_code)]
+//! Async userspace read-ahead adapter.
+//!
+//! [`PrefetchReader`] is a drop-in replacement for [`std::io::BufReader<File>`]
+//! that performs asynchronous read-ahead on a dedicated OS thread. It exists to
+//! decouple the blocking `read()` wait on a file descriptor from the pipeline
+//! worker threads that consume the bytes.
+//!
+//! ## Motivation
+//!
+//! On Linux, the kernel's per-device read-ahead window (`read_ahead_kb`) is
+//! 128 KB by default. A plain `BufReader<File>` is synchronous: when its
+//! internal buffer drains, the next refill blocks in the kernel until pages
+//! arrive from disk. During that stall the calling thread is parked and
+//! cannot make progress on other work. In the fgumi unified pipeline, the
+//! reader thread is also a pipeline worker, so a blocked read translates
+//! directly into lost downstream throughput.
+//!
+//! `PrefetchReader` moves the blocking `read()` onto a dedicated producer
+//! thread that pushes fixed-size chunks through a bounded
+//! [`crossbeam_channel`]. Consumers see a normal [`std::io::Read`] interface;
+//! internally, [`Read::read`] serves bytes out of the currently-held chunk and
+//! only blocks when the producer has not yet delivered the next one. The
+//! upshot is that stalls on the disk become independent of stalls in the
+//! pipeline: the producer overlaps its disk wait with the consumer's CPU
+//! work.
+//!
+//! This is essentially what the kernel's block-layer read-ahead does, but in
+//! userspace — so it works without root, on any OS, and without having to
+//! tune `/sys/block/*/queue/read_ahead_kb`.
+//!
+//! ## Lifecycle
+//!
+//! Constructing a `PrefetchReader` spawns exactly one OS thread, named
+//! `fgumi-prefetch`. The thread owns the inner reader and exits when any of
+//! the following happen:
+//!
+//! - The inner reader signals EOF (`Ok(0)` from `read`).
+//! - The inner reader returns an error (the error is sent through the
+//!   channel, then the thread exits).
+//! - The [`PrefetchReader`] is dropped (the consumer-side receiver is
+//!   destroyed, the producer's next `send` returns `Disconnected`, and the
+//!   loop exits).
+//!
+//! `Drop` joins the producer thread, so leaks are impossible on well-behaved
+//! inner readers. If the inner reader is currently parked in a long `read`
+//! syscall, `Drop` will wait for it to return.
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::thread::{self, JoinHandle};
+
+use crossbeam_channel::{Receiver, Sender, TryRecvError, bounded};
+
+/// Default chunk size used by [`PrefetchReader::new`].
+pub const DEFAULT_CHUNK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Default channel depth used by [`PrefetchReader::new`]. The producer will
+/// keep up to this many filled chunks buffered ahead of the consumer.
+pub const DEFAULT_PREFETCH_DEPTH: usize = 4;
+
+/// How far ahead (in bytes) the producer thread asks the kernel to page in via
+/// `posix_fadvise(POSIX_FADV_WILLNEED)` after each chunk fill. Only used when
+/// the reader was constructed via [`PrefetchReader::from_file`], which captures
+/// the raw fd needed for the syscall. 128 MiB is generous enough to cover
+/// ~1 second of EBS gp3 baseline throughput (125 MiB/s), ensuring pages are
+/// warm by the time the producer's `read()` reaches them.
+///
+/// Stored as `i64` to match `posix_fadvise`'s `off_t` signature directly.
+const WILLNEED_LOOKAHEAD: i64 = 128 * 1024 * 1024;
+
+/// An item handed from the producer thread to the consumer. Carries either a
+/// filled chunk of bytes or a terminal I/O error.
+type Item = io::Result<Vec<u8>>;
+
+/// A `Read` adapter that performs asynchronous userspace prefetch on a
+/// dedicated background thread.
+///
+/// See the [module docs](self) for the rationale and lifecycle model.
+///
+/// # Example
+///
+/// ```
+/// use std::io::{Cursor, Read};
+/// use fgumi_lib::prefetch_reader::PrefetchReader;
+///
+/// let data: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+/// let mut reader = PrefetchReader::new(Cursor::new(data.clone()));
+/// let mut out = Vec::new();
+/// reader.read_to_end(&mut out).unwrap();
+/// assert_eq!(out, data);
+/// ```
+#[derive(Debug)]
+pub struct PrefetchReader {
+    /// The chunk currently being served out to callers of `read`.
+    ///
+    /// Stored as `(data, position)`. `None` means we need to pull the next
+    /// chunk from the channel on the next `read` call.
+    current: Option<(Vec<u8>, usize)>,
+
+    /// Receiving half of the prefetch channel. Held in `Option` so we can
+    /// drop it explicitly in `Drop::drop` before joining the producer thread;
+    /// dropping the receiver is what causes the producer's `send` to fail
+    /// with `Disconnected`, which in turn terminates the producer loop.
+    rx: Option<Receiver<Item>>,
+
+    /// Join handle for the producer thread. `None` after join in `Drop`.
+    handle: Option<JoinHandle<()>>,
+
+    /// Number of times a consumer `read` call had to block on the channel
+    /// because the producer had not yet delivered the next chunk. A high
+    /// value relative to total reads suggests the prefetch depth is too
+    /// shallow or the consumer is faster than the producer.
+    consumer_stalls: u64,
+
+    /// Total bytes handed back to callers of `read` so far.
+    bytes_consumed: u64,
+}
+
+impl PrefetchReader {
+    /// Construct a `PrefetchReader` from an arbitrary reader with default
+    /// chunk size and prefetch depth.
+    ///
+    /// No `posix_fadvise(WILLNEED)` hints are issued because the inner reader
+    /// may not be backed by a file descriptor. Use [`from_file`](Self::from_file)
+    /// when wrapping a [`File`] to get kernel page-cache warming for free.
+    #[must_use]
+    pub fn new<R: Read + Send + 'static>(inner: R) -> Self {
+        Self::with_config(inner, DEFAULT_CHUNK_SIZE, DEFAULT_PREFETCH_DEPTH)
+    }
+
+    /// Construct a `PrefetchReader` from an arbitrary reader with explicit
+    /// `chunk_size` and `prefetch_depth`.
+    ///
+    /// Steady-state memory usage is bounded by `chunk_size * prefetch_depth`
+    /// (plus one chunk being filled by the producer and one being consumed).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_size == 0` or `prefetch_depth == 0`.
+    #[must_use]
+    pub fn with_config<R: Read + Send + 'static>(
+        inner: R,
+        chunk_size: usize,
+        prefetch_depth: usize,
+    ) -> Self {
+        Self::build(inner, chunk_size, prefetch_depth, None)
+    }
+
+    /// Construct a `PrefetchReader` from a [`File`] with default chunk size
+    /// and prefetch depth.
+    ///
+    /// On Linux the producer thread will call
+    /// `posix_fadvise(POSIX_FADV_WILLNEED)` after each chunk fill to
+    /// proactively page in the next [`WILLNEED_LOOKAHEAD`] bytes,
+    /// making the reader independent of the kernel's default read-ahead
+    /// window (`read_ahead_kb`). On non-Linux platforms this behaves
+    /// identically to [`new`](Self::new).
+    ///
+    /// The file should be positioned at offset 0 when passed in — the
+    /// WILLNEED hints assume reading starts from the beginning of the file.
+    #[must_use]
+    pub fn from_file(file: File) -> Self {
+        Self::from_file_with_config(file, DEFAULT_CHUNK_SIZE, DEFAULT_PREFETCH_DEPTH)
+    }
+
+    /// Construct a `PrefetchReader` from a [`File`] with explicit `chunk_size`
+    /// and `prefetch_depth`, plus kernel WILLNEED hints on Linux.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_size == 0` or `prefetch_depth == 0`.
+    #[must_use]
+    pub fn from_file_with_config(file: File, chunk_size: usize, prefetch_depth: usize) -> Self {
+        let hint_fd = crate::os_hints::hint_fd(&file);
+        Self::build(file, chunk_size, prefetch_depth, hint_fd)
+    }
+
+    /// Shared construction logic.
+    fn build<R: Read + Send + 'static>(
+        inner: R,
+        chunk_size: usize,
+        prefetch_depth: usize,
+        hint_fd: Option<i32>,
+    ) -> Self {
+        assert!(chunk_size > 0, "PrefetchReader chunk_size must be > 0");
+        assert!(prefetch_depth > 0, "PrefetchReader prefetch_depth must be > 0");
+
+        let (tx, rx) = bounded::<Item>(prefetch_depth);
+        let handle = thread::Builder::new()
+            .name("fgumi-prefetch".to_string())
+            .spawn(move || producer_main(inner, chunk_size, hint_fd, &tx))
+            .expect("failed to spawn fgumi-prefetch thread");
+
+        Self {
+            current: None,
+            rx: Some(rx),
+            handle: Some(handle),
+            consumer_stalls: 0,
+            bytes_consumed: 0,
+        }
+    }
+
+    /// Total bytes served to callers of [`Read::read`] so far.
+    #[must_use]
+    pub fn bytes_consumed(&self) -> u64 {
+        self.bytes_consumed
+    }
+
+    /// Number of times a `read` call had to block waiting for the producer
+    /// to deliver the next chunk. Useful as a prototype-phase signal for
+    /// whether [`DEFAULT_PREFETCH_DEPTH`] is large enough.
+    #[must_use]
+    pub fn consumer_stalls(&self) -> u64 {
+        self.consumer_stalls
+    }
+}
+
+/// Entry point for the producer thread. Wraps [`producer_loop`] so that a
+/// panic inside the inner reader surfaces on the consumer side as an
+/// [`io::Error`] instead of a silently-truncated stream.
+fn producer_main<R: Read>(inner: R, chunk_size: usize, hint_fd: Option<i32>, tx: &Sender<Item>) {
+    let tx_for_panic = tx.clone();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        producer_loop(inner, chunk_size, hint_fd, tx);
+    }));
+    if let Err(payload) = result {
+        let msg = match payload.downcast_ref::<&'static str>() {
+            Some(s) => (*s).to_string(),
+            None => match payload.downcast_ref::<String>() {
+                Some(s) => s.clone(),
+                None => "fgumi-prefetch producer thread panicked".to_string(),
+            },
+        };
+        let _ = tx_for_panic.send(Err(io::Error::other(msg)));
+    }
+}
+
+/// The actual producer loop. Allocates a `chunk_size`-byte buffer, issues a
+/// single `read()` call, and sends whatever bytes were returned through the
+/// channel. Emitting after the first successful read (rather than looping to
+/// fill the full chunk) ensures that short reads from pipes or throttled
+/// readers are delivered promptly. For file-backed readers, the OS typically
+/// returns a full page-aligned read in one call, so this rarely increases
+/// channel traffic. Tolerates `Interrupted` errors. Exits on EOF, I/O error,
+/// or when the consumer drops the receiver.
+///
+/// When `hint_fd` is `Some`, the loop calls
+/// `posix_fadvise(POSIX_FADV_WILLNEED)` after each chunk to proactively page
+/// in the next [`WILLNEED_LOOKAHEAD`] bytes. This removes the
+/// dependence on the kernel's default `read_ahead_kb` setting.
+fn producer_loop<R: Read>(
+    mut inner: R,
+    chunk_size: usize,
+    hint_fd: Option<i32>,
+    tx: &Sender<Item>,
+) {
+    let mut position: i64 = 0;
+
+    loop {
+        let mut buf = vec![0u8; chunk_size];
+        let mut filled: usize = 0;
+        let mut eof = false;
+
+        loop {
+            match inner.read(&mut buf[filled..]) {
+                Ok(0) => {
+                    eof = true;
+                    break;
+                }
+                Ok(n) => {
+                    filled += n;
+                    break;
+                }
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => (),
+                Err(e) => {
+                    // Flush any bytes we already managed to read *before*
+                    // surfacing the error. Otherwise a mid-chunk failure
+                    // would silently discard data that was successfully
+                    // returned by the inner reader.
+                    if filled > 0 {
+                        buf.truncate(filled);
+                        let _ = tx.send(Ok(buf));
+                    }
+                    let _ = tx.send(Err(e));
+                    return;
+                }
+            }
+        }
+
+        if filled == 0 && eof {
+            return;
+        }
+
+        position = position.saturating_add(i64::try_from(filled).unwrap_or(i64::MAX));
+
+        // Ask the kernel to start paging in bytes ahead of our current
+        // position. The call is non-blocking — the kernel initiates the I/O
+        // and returns immediately.
+        if let Some(fd) = hint_fd {
+            crate::os_hints::advise_willneed_raw(fd, position, WILLNEED_LOOKAHEAD);
+        }
+
+        buf.truncate(filled);
+        if tx.send(Ok(buf)).is_err() {
+            // Consumer dropped the receiver; shutdown cleanly.
+            return;
+        }
+
+        if eof {
+            return;
+        }
+    }
+}
+
+impl Read for PrefetchReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            // Serve from the current chunk if any bytes remain.
+            if let Some((data, pos)) = self.current.as_mut() {
+                if *pos < data.len() {
+                    let n = std::cmp::min(buf.len(), data.len() - *pos);
+                    buf[..n].copy_from_slice(&data[*pos..*pos + n]);
+                    *pos += n;
+                    self.bytes_consumed += n as u64;
+                    return Ok(n);
+                }
+                // Current chunk exhausted; drop it and pull the next one.
+                self.current = None;
+            }
+
+            // No current chunk. Pull the next one from the producer.
+            let Some(rx) = self.rx.as_ref() else {
+                return Ok(0);
+            };
+
+            // Fast path: a chunk is already waiting.
+            let item = match rx.try_recv() {
+                Ok(item) => item,
+                Err(TryRecvError::Disconnected) => return Ok(0),
+                Err(TryRecvError::Empty) => {
+                    // Slow path: producer hasn't delivered yet; we block.
+                    self.consumer_stalls += 1;
+                    match rx.recv() {
+                        Ok(item) => item,
+                        Err(_) => return Ok(0),
+                    }
+                }
+            };
+
+            match item {
+                Ok(data) if !data.is_empty() => self.current = Some((data, 0)),
+                Ok(_) => {} // defensive: skip empty chunks
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl Drop for PrefetchReader {
+    fn drop(&mut self) {
+        // Drop the receiver first so the producer's next `send` returns
+        // `Disconnected` and the loop exits. Then join the thread to
+        // guarantee no leak.
+        self.rx = None;
+        self.current = None;
+        if let Some(handle) = self.handle.take() {
+            if handle.join().is_err() {
+                log::debug!("fgumi-prefetch producer thread panicked during shutdown");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::io::Cursor;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Build a deterministic byte stream of the given length.
+    fn sample_bytes(len: usize) -> Vec<u8> {
+        (0..len).map(|i| u8::try_from(i % 251).expect("mod 251 fits in u8")).collect()
+    }
+
+    #[test]
+    fn empty_input_returns_zero_immediately() {
+        let mut reader = PrefetchReader::new(Cursor::new(Vec::<u8>::new()));
+        let mut buf = [0u8; 16];
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+        // Bytes counter unchanged.
+        assert_eq!(reader.bytes_consumed(), 0);
+    }
+
+    #[test]
+    fn from_file_reads_correctly() {
+        use std::io::Write;
+        let data = sample_bytes(50_000);
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        tmp.write_all(&data).expect("write temp file");
+        let file = File::open(tmp.path()).expect("reopen temp file");
+        let mut reader = PrefetchReader::from_file(file);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+        assert_eq!(reader.bytes_consumed(), data.len() as u64);
+    }
+
+    #[test]
+    fn read_to_end_small_matches_input() {
+        let data = b"hello, fgumi prefetch".to_vec();
+        let mut reader = PrefetchReader::new(Cursor::new(data.clone()));
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+        assert_eq!(reader.bytes_consumed(), data.len() as u64);
+    }
+
+    #[test]
+    fn read_to_end_large_matches_input() {
+        // ~1 MiB — exercises multiple chunks through the channel.
+        let data = sample_bytes(1_000_003);
+        let mut reader = PrefetchReader::with_config(Cursor::new(data.clone()), 8 * 1024, 2);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, data);
+        assert_eq!(reader.bytes_consumed(), data.len() as u64);
+    }
+
+    #[test]
+    fn tiny_chunk_size_and_many_small_reads() {
+        let data = sample_bytes(5_000);
+        let mut reader = PrefetchReader::with_config(Cursor::new(data.clone()), 17, 2);
+        let mut out = Vec::new();
+        let mut tmp = [0u8; 7];
+        loop {
+            let n = reader.read(&mut tmp).unwrap();
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&tmp[..n]);
+        }
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn repeated_read_after_eof_returns_zero_forever() {
+        let mut reader = PrefetchReader::new(Cursor::new(b"abc".to_vec()));
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"abc");
+
+        let mut tmp = [0u8; 8];
+        for _ in 0..10 {
+            assert_eq!(reader.read(&mut tmp).unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn drop_before_consuming_does_not_hang() {
+        // 1 MB of data, tiny chunks, shallow channel: the producer will fill
+        // the channel quickly and then block on send. When we drop the
+        // reader, the send must unblock so `Drop::join` returns.
+        let data = vec![0u8; 1_000_000];
+        let _reader = PrefetchReader::with_config(Cursor::new(data), 4 * 1024, 2);
+        // Drop happens at end of scope.
+    }
+
+    #[test]
+    fn partial_read_then_drop_does_not_hang() {
+        let data = sample_bytes(500_000);
+        let mut reader = PrefetchReader::with_config(Cursor::new(data), 4 * 1024, 2);
+        let mut tmp = [0u8; 32];
+        // Read a bit, then drop without finishing.
+        let n = reader.read(&mut tmp).unwrap();
+        assert!(n > 0);
+    }
+
+    #[test]
+    fn error_from_inner_reader_propagates_once() {
+        struct AlwaysErr;
+        impl Read for AlwaysErr {
+            fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::PermissionDenied, "nope"))
+            }
+        }
+        let mut reader = PrefetchReader::new(AlwaysErr);
+        let mut buf = [0u8; 16];
+        let err = reader.read(&mut buf).expect_err("first read should error");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        // After the error is propagated, subsequent reads see the producer
+        // exit and return EOF.
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn error_after_some_data_delivers_data_then_error() {
+        // Reader that returns one chunk of data, then an error forever.
+        struct DataThenErr {
+            sent: bool,
+        }
+        impl Read for DataThenErr {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if self.sent {
+                    Err(io::Error::other("subsequent error"))
+                } else {
+                    self.sent = true;
+                    let n = buf.len().min(128);
+                    for (i, b) in buf.iter_mut().take(n).enumerate() {
+                        *b = u8::try_from(i).expect("n <= 128 so i fits in u8");
+                    }
+                    Ok(n)
+                }
+            }
+        }
+        // chunk_size > 128 forces the producer to call read() again after
+        // the first short read, which triggers the error.
+        let mut reader = PrefetchReader::with_config(DataThenErr { sent: false }, 1024, 2);
+        let mut out = Vec::new();
+        let mut tmp = [0u8; 256];
+
+        // First read should deliver the 128 bytes of data.
+        let n = reader.read(&mut tmp).unwrap();
+        assert_eq!(n, 128);
+        out.extend_from_slice(&tmp[..n]);
+        assert_eq!(out.len(), 128);
+
+        // Next read should surface the error.
+        let err = reader.read(&mut tmp).expect_err("second read should error");
+        assert!(matches!(err.kind(), io::ErrorKind::Other | io::ErrorKind::UnexpectedEof));
+    }
+
+    #[test]
+    fn interrupted_errors_are_retried_transparently() {
+        struct FlakyThenEof {
+            call: usize,
+        }
+        impl Read for FlakyThenEof {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                self.call += 1;
+                if self.call <= 3 {
+                    return Err(io::Error::new(io::ErrorKind::Interrupted, "try again"));
+                }
+                if self.call == 4 {
+                    let n = buf.len().min(10);
+                    for (i, b) in buf.iter_mut().take(n).enumerate() {
+                        *b = u8::try_from(i + 1).expect("n <= 10 so i+1 fits in u8");
+                    }
+                    return Ok(n);
+                }
+                Ok(0)
+            }
+        }
+        let mut reader = PrefetchReader::with_config(FlakyThenEof { call: 0 }, 64, 2);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, (1..=10).collect::<Vec<u8>>());
+    }
+
+    #[test]
+    fn drop_joins_producer_thread() {
+        /// A reader that sets a flag inside its `Drop` impl so we can
+        /// observe that the producer thread has actually been torn down.
+        struct Tracked {
+            flag: Arc<AtomicBool>,
+            data: Vec<u8>,
+            pos: usize,
+        }
+        impl Read for Tracked {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if self.pos >= self.data.len() {
+                    return Ok(0);
+                }
+                let n = buf.len().min(self.data.len() - self.pos);
+                buf[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+                self.pos += n;
+                Ok(n)
+            }
+        }
+        impl Drop for Tracked {
+            fn drop(&mut self) {
+                self.flag.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let inner = Tracked { flag: Arc::clone(&flag), data: sample_bytes(1024), pos: 0 };
+        {
+            let mut reader = PrefetchReader::with_config(inner, 64, 2);
+            let mut out = Vec::new();
+            reader.read_to_end(&mut out).unwrap();
+            assert_eq!(out.len(), 1024);
+            // reader is dropped here; `Tracked::drop` must fire on the
+            // producer thread before `Drop::drop` returns.
+        }
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "producer thread should have dropped the inner reader"
+        );
+    }
+
+    proptest! {
+        /// Property test: for any input bytes, any chunk size, any prefetch
+        /// depth, and any consumer read size, `PrefetchReader` yields exactly
+        /// the same byte sequence as a plain in-memory cursor.
+        #[test]
+        fn prop_byte_identical_to_cursor(
+            data in prop::collection::vec(any::<u8>(), 0..8_192),
+            chunk_size in 1usize..2_048,
+            depth in 1usize..6,
+            read_size in 1usize..256,
+        ) {
+            let expected = data.clone();
+            let mut reader = PrefetchReader::with_config(
+                Cursor::new(data),
+                chunk_size,
+                depth,
+            );
+            let mut out = Vec::with_capacity(expected.len());
+            let mut tmp = vec![0u8; read_size];
+            loop {
+                let n = reader.read(&mut tmp).expect("read should not fail on Cursor");
+                if n == 0 {
+                    break;
+                }
+                out.extend_from_slice(&tmp[..n]);
+            }
+            prop_assert_eq!(out, expected);
+        }
+    }
+}

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -66,7 +66,11 @@ use super::scheduler::{BackpressureState, SchedulerStrategy};
 /// to allow multiple threads to read different streams concurrently.
 pub enum StreamReader<R: BufRead + Send> {
     /// Raw BGZF file — Read step produces raw blocks, Decompress step decompresses.
-    Bgzf(BufReader<File>),
+    ///
+    /// Boxed to allow wrapping the underlying file in optional helpers such as
+    /// the userspace async prefetch reader (`PrefetchReader`) without changing
+    /// the enum signature.
+    Bgzf(Box<dyn BufRead + Send>),
     /// Pre-decompressed reader (gzip/plain) — Read step produces record-aligned data.
     Decompressed(R),
 }
@@ -804,6 +808,9 @@ pub struct FastqPipelineConfig {
     /// Scales with thread count to reduce queue contention at higher parallelism.
     /// Default: 200 (auto-scaled in `new()` based on thread count).
     pub records_per_batch: usize,
+    /// Wrap BGZF FASTQ inputs in a userspace async prefetch reader (opt-in).
+    /// Only applies when `inputs_are_bgzf` is true; ignored otherwise.
+    pub async_reader: bool,
 }
 
 impl FastqPipelineConfig {
@@ -835,6 +842,7 @@ impl FastqPipelineConfig {
             deadlock_recover_enabled: false,
             shared_stats: None, // No shared stats by default
             records_per_batch,
+            async_reader: false,
         }
     }
 
@@ -893,6 +901,13 @@ impl FastqPipelineConfig {
     #[must_use]
     pub fn with_deadlock_recovery(mut self, enabled: bool) -> Self {
         self.deadlock_recover_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable the userspace async prefetch reader for BGZF FASTQ inputs.
+    #[must_use]
+    pub fn with_async_reader(mut self, enabled: bool) -> Self {
+        self.async_reader = enabled;
         self
     }
 
@@ -3681,13 +3696,30 @@ where
             log::debug!("run_fastq_pipeline: using {num_readers} Decompressed readers");
             readers.into_iter().map(StreamReader::Decompressed).collect()
         } else {
-            // BGZF: open each file as StreamReader::Bgzf
-            log::debug!("run_fastq_pipeline: using {} BGZF readers", fastq_paths.len());
+            // BGZF: open each file as StreamReader::Bgzf. Apply POSIX_FADV_SEQUENTIAL
+            // unconditionally on Linux to enlarge the per-fd read-ahead window, and
+            // optionally wrap in a userspace async prefetch reader when enabled.
+            log::debug!(
+                "run_fastq_pipeline: using {} BGZF readers (async_reader={})",
+                fastq_paths.len(),
+                config.async_reader,
+            );
             fastq_paths
                 .iter()
                 .map(|p| {
                     let file = File::open(p)?;
-                    Ok(StreamReader::Bgzf(BufReader::with_capacity(256 * 1024, file)))
+                    crate::os_hints::advise_sequential(&file);
+                    let inner: Box<dyn BufRead + Send> = if config.async_reader {
+                        // PrefetchReader dedicates one OS thread per input file to
+                        // issue reads ahead of the consumer, overlapping I/O with
+                        // processing. For paired/indexed inputs this adds 2-4 extra
+                        // threads beyond the pipeline worker count.
+                        let prefetch = crate::prefetch_reader::PrefetchReader::from_file(file);
+                        Box::new(BufReader::with_capacity(256 * 1024, prefetch))
+                    } else {
+                        Box::new(BufReader::with_capacity(256 * 1024, file))
+                    };
+                    Ok(StreamReader::Bgzf(inner))
                 })
                 .collect::<io::Result<Vec<_>>>()?
         };

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -6,6 +6,7 @@
 //! ensuring that module interactions work correctly.
 
 mod helpers;
+mod test_async_reader;
 mod test_bam_pipeline;
 mod test_bgzf_eof;
 mod test_clip_command;

--- a/tests/integration/test_async_reader.rs
+++ b/tests/integration/test_async_reader.rs
@@ -1,0 +1,488 @@
+//! Integration tests for the `--async-reader` flag across all supported input paths.
+//!
+//! Each test runs a command twice — once without `--async-reader` and once with it —
+//! then asserts that the outputs are identical record-by-record. This ensures the
+//! prefetch reader is transparent across:
+//!
+//! - **Extract:** BGZF, gzip, and plain FASTQ inputs (single- and multi-threaded)
+//! - **BAM commands:** file input with/without `--threads`, and piped stdin
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use noodles::bam;
+use noodles::sam::alignment::RecordBuf;
+use noodles::sam::alignment::io::Write as AlignmentWrite;
+use noodles::sam::alignment::record::data::field::Tag;
+use noodles::sam::alignment::record_buf::data::field::Value;
+use noodles_bgzf::io::Writer as BgzfWriter;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Type alias for FASTQ test records (name, sequence, quality).
+type FastqRecords = Vec<(&'static str, &'static str, &'static str)>;
+
+/// Standard paired-end test records with a 5-base UMI prefix on each read.
+fn paired_end_records() -> (FastqRecords, FastqRecords) {
+    let r1 = vec![
+        ("read1", "AAAAACGTACGTAAAA", "IIIIIIIIIIIIIIII"),
+        ("read2", "TTTTTCCCCCCCCCCC", "IIIIIIIIIIIIIIII"),
+        ("read3", "CCCCCTTTTTAAAAAG", "IIIIIIIIIIIIIIII"),
+    ];
+    let r2 = vec![
+        ("read1", "GGGGGCGTACGTCCCC", "IIIIIIIIIIIIIIII"),
+        ("read2", "AAAAATTTTTTTTGGG", "IIIIIIIIIIIIIIII"),
+        ("read3", "TTTTTCCCCGGGGAAA", "IIIIIIIIIIIIIIII"),
+    ];
+    (r1, r2)
+}
+
+fn create_plain_fastq(dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut file = File::create(&path).unwrap();
+    for (name, seq, qual) in records {
+        writeln!(file, "@{name}").unwrap();
+        writeln!(file, "{seq}").unwrap();
+        writeln!(file, "+").unwrap();
+        writeln!(file, "{qual}").unwrap();
+    }
+    path
+}
+
+fn create_gzip_fastq(dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) -> PathBuf {
+    let path = dir.path().join(name);
+    let file = File::create(&path).unwrap();
+    let mut encoder = GzEncoder::new(file, Compression::default());
+    for (name, seq, qual) in records {
+        writeln!(encoder, "@{name}").unwrap();
+        writeln!(encoder, "{seq}").unwrap();
+        writeln!(encoder, "+").unwrap();
+        writeln!(encoder, "{qual}").unwrap();
+    }
+    encoder.finish().unwrap();
+    path
+}
+
+fn create_bgzf_fastq(dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) -> PathBuf {
+    let path = dir.path().join(name);
+    let file = File::create(&path).unwrap();
+    let mut writer = BgzfWriter::new(file);
+    for (name, seq, qual) in records {
+        writeln!(writer, "@{name}").unwrap();
+        writeln!(writer, "{seq}").unwrap();
+        writeln!(writer, "+").unwrap();
+        writeln!(writer, "{qual}").unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+/// Read BAM records from a file.
+fn read_bam_records(path: &Path) -> Vec<RecordBuf> {
+    let mut reader = File::open(path).map(bam::io::Reader::new).unwrap();
+    let header = reader.read_header().unwrap();
+    reader.record_bufs(&header).map(|r| r.expect("Failed to read BAM record")).collect()
+}
+
+/// Assert that two BAM files contain identical records (ignoring header @PG differences).
+fn assert_bam_records_equal(path1: &Path, path2: &Path) {
+    let records1 = read_bam_records(path1);
+    let records2 = read_bam_records(path2);
+
+    assert_eq!(
+        records1.len(),
+        records2.len(),
+        "Record count differs: {} (without --async-reader) vs {} (with --async-reader)",
+        records1.len(),
+        records2.len(),
+    );
+
+    for (i, (r1, r2)) in records1.iter().zip(records2.iter()).enumerate() {
+        assert_eq!(r1.name(), r2.name(), "Record {i} name mismatch");
+        assert_eq!(r1.flags(), r2.flags(), "Record {i} flags mismatch");
+        assert_eq!(
+            r1.alignment_start(),
+            r2.alignment_start(),
+            "Record {i} alignment_start mismatch"
+        );
+        assert_eq!(
+            r1.mapping_quality(),
+            r2.mapping_quality(),
+            "Record {i} mapping_quality mismatch"
+        );
+        assert_eq!(r1.cigar(), r2.cigar(), "Record {i} cigar mismatch");
+        assert_eq!(r1.sequence(), r2.sequence(), "Record {i} sequence mismatch");
+        assert_eq!(r1.quality_scores(), r2.quality_scores(), "Record {i} quality mismatch");
+        assert_eq!(r1.data(), r2.data(), "Record {i} aux tags mismatch");
+    }
+}
+
+/// Run `fgumi extract` with the given args, return the output BAM path.
+fn run_extract(
+    tmp: &TempDir,
+    r1: &Path,
+    r2: &Path,
+    output_name: &str,
+    threads: Option<usize>,
+    async_reader: bool,
+) -> PathBuf {
+    let output = tmp.path().join(output_name);
+    let mut args = vec![
+        "extract".to_string(),
+        "--inputs".into(),
+        r1.to_str().unwrap().into(),
+        r2.to_str().unwrap().into(),
+        "--output".into(),
+        output.to_str().unwrap().into(),
+        "--read-structures".into(),
+        "5M+T".into(),
+        "5M+T".into(),
+        "--sample".into(),
+        "test_sample".into(),
+        "--library".into(),
+        "test_library".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if let Some(t) = threads {
+        args.push("--threads".into());
+        args.push(t.to_string());
+    }
+    if async_reader {
+        args.push("--async-reader".into());
+    }
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(&args)
+        .status()
+        .expect("Failed to execute extract command");
+    assert!(status.success(), "Extract command failed (async_reader={async_reader})");
+    output
+}
+
+/// Create a test BAM with UMI families for grouping.
+fn create_test_bam(path: &Path) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+
+    let family1 = create_umi_family("AAAAAAAA", 5, "family1", "ACGTACGT", 30);
+    let family2 = create_umi_family("CCCCCCCC", 3, "family2", "TGCATGCA", 30);
+    let family3 = create_umi_family("GGGGGGGG", 4, "family3", "TTTTAAAA", 30);
+
+    for record in family1.iter().chain(family2.iter()).chain(family3.iter()) {
+        writer.write_alignment_record(&header, record).expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Create a test BAM with grouped reads (MI tag set) for simplex.
+fn create_grouped_bam(path: &Path) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+
+    let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
+
+    for (mi, umi, depth, base) in
+        [(1, "AAAAAAAA", 5, "mol1"), (2, "CCCCCCCC", 3, "mol2"), (3, "GGGGGGGG", 4, "mol3")]
+    {
+        let records = create_umi_family(umi, depth, base, "ACGTACGT", 30);
+        for record in records {
+            let mut rec = record.clone();
+            rec.data_mut().insert(mi_tag, Value::from(mi));
+            writer.write_alignment_record(&header, &rec).expect("Failed to write record");
+        }
+    }
+
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+// ============================================================================
+// Extract: BGZF FASTQ inputs
+// ============================================================================
+
+#[test]
+fn test_extract_bgzf_async_reader_single_threaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_bgzf_fastq(&tmp, "r1.fq.bgz", &r1_recs);
+    let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", None, false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", None, true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_extract_bgzf_async_reader_multithreaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_bgzf_fastq(&tmp, "r1.fq.bgz", &r1_recs);
+    let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", Some(4), false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", Some(4), true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// Extract: gzip FASTQ inputs
+// ============================================================================
+
+#[test]
+fn test_extract_gzip_async_reader_single_threaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_gzip_fastq(&tmp, "r1.fq.gz", &r1_recs);
+    let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", None, false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", None, true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_extract_gzip_async_reader_multithreaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_gzip_fastq(&tmp, "r1.fq.gz", &r1_recs);
+    let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", Some(4), false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", Some(4), true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// Extract: plain (uncompressed) FASTQ inputs
+// ============================================================================
+
+#[test]
+fn test_extract_plain_async_reader_single_threaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_plain_fastq(&tmp, "r1.fq", &r1_recs);
+    let r2 = create_plain_fastq(&tmp, "r2.fq", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", None, false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", None, true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_extract_plain_async_reader_multithreaded() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_plain_fastq(&tmp, "r1.fq", &r1_recs);
+    let r2 = create_plain_fastq(&tmp, "r2.fq", &r2_recs);
+
+    let baseline = run_extract(&tmp, &r1, &r2, "baseline.bam", Some(4), false);
+    let async_out = run_extract(&tmp, &r1, &r2, "async.bam", Some(4), true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// BAM commands: group (file input, with and without --threads)
+// ============================================================================
+
+/// Run `fgumi group` and return the output BAM path.
+fn run_group(
+    tmp: &TempDir,
+    input: &str,
+    output_name: &str,
+    threads: Option<usize>,
+    async_reader: bool,
+    stdin: Option<Stdio>,
+) -> PathBuf {
+    let output = tmp.path().join(output_name);
+    let mut args = vec![
+        "group".to_string(),
+        "--input".into(),
+        input.into(),
+        "--output".into(),
+        output.to_str().unwrap().into(),
+        "--strategy".into(),
+        "identity".into(),
+        "--edits".into(),
+        "0".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if let Some(t) = threads {
+        args.push("--threads".into());
+        args.push(t.to_string());
+    }
+    if async_reader {
+        args.push("--async-reader".into());
+    }
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fgumi"));
+    cmd.args(&args);
+    if let Some(stdin) = stdin {
+        cmd.stdin(stdin);
+    }
+    let status = cmd.status().expect("Failed to execute group command");
+    assert!(status.success(), "Group command failed (async_reader={async_reader})");
+    output
+}
+
+#[test]
+fn test_group_async_reader_multithreaded() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_test_bam(&input);
+
+    let baseline = run_group(&tmp, input.to_str().unwrap(), "baseline.bam", Some(2), false, None);
+    let async_out = run_group(&tmp, input.to_str().unwrap(), "async.bam", Some(2), true, None);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_group_async_reader_single_threaded() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_test_bam(&input);
+
+    let baseline = run_group(&tmp, input.to_str().unwrap(), "baseline.bam", None, false, None);
+    let async_out = run_group(&tmp, input.to_str().unwrap(), "async.bam", None, true, None);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// BAM commands: group with stdin input
+// ============================================================================
+
+#[test]
+fn test_group_async_reader_stdin() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_test_bam(&input);
+
+    // Baseline: stdin without --async-reader
+    let baseline = run_group(
+        &tmp,
+        "-",
+        "baseline.bam",
+        Some(2),
+        false,
+        Some(Stdio::from(File::open(&input).unwrap())),
+    );
+
+    // Async: stdin with --async-reader
+    let async_out = run_group(
+        &tmp,
+        "-",
+        "async_stdin.bam",
+        Some(2),
+        true,
+        Some(Stdio::from(File::open(&input).unwrap())),
+    );
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// BAM commands: simplex (file input, with and without --threads)
+// ============================================================================
+
+/// Run `fgumi simplex` and return the output BAM path.
+fn run_simplex(
+    tmp: &TempDir,
+    input: &str,
+    output_name: &str,
+    threads: Option<usize>,
+    async_reader: bool,
+    stdin: Option<Stdio>,
+) -> PathBuf {
+    let output = tmp.path().join(output_name);
+    let mut args = vec![
+        "simplex".to_string(),
+        "--input".into(),
+        input.into(),
+        "--output".into(),
+        output.to_str().unwrap().into(),
+        "--min-reads".into(),
+        "1".into(),
+        "--min-consensus-base-quality".into(),
+        "0".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if let Some(t) = threads {
+        args.push("--threads".into());
+        args.push(t.to_string());
+    }
+    if async_reader {
+        args.push("--async-reader".into());
+    }
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fgumi"));
+    cmd.args(&args);
+    if let Some(stdin) = stdin {
+        cmd.stdin(stdin);
+    }
+    let status = cmd.status().expect("Failed to execute simplex command");
+    assert!(status.success(), "Simplex command failed (async_reader={async_reader})");
+    output
+}
+
+#[test]
+fn test_simplex_async_reader_multithreaded() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_grouped_bam(&input);
+
+    let baseline = run_simplex(&tmp, input.to_str().unwrap(), "baseline.bam", Some(2), false, None);
+    let async_out = run_simplex(&tmp, input.to_str().unwrap(), "async.bam", Some(2), true, None);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_simplex_async_reader_single_threaded() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_grouped_bam(&input);
+
+    let baseline = run_simplex(&tmp, input.to_str().unwrap(), "baseline.bam", None, false, None);
+    let async_out = run_simplex(&tmp, input.to_str().unwrap(), "async.bam", None, true, None);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+fn test_simplex_async_reader_stdin() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("input.bam");
+    create_grouped_bam(&input);
+
+    // Baseline: stdin without --async-reader
+    let baseline = run_simplex(
+        &tmp,
+        "-",
+        "baseline.bam",
+        Some(2),
+        false,
+        Some(Stdio::from(File::open(&input).unwrap())),
+    );
+
+    // Async: stdin with --async-reader
+    let async_out = run_simplex(
+        &tmp,
+        "-",
+        "async_stdin.bam",
+        Some(2),
+        true,
+        Some(Stdio::from(File::open(&input).unwrap())),
+    );
+    assert_bam_records_equal(&baseline, &async_out);
+}


### PR DESCRIPTION
## Summary

- Adds `PrefetchReader`, a userspace async read-ahead adapter that decouples blocking `read()` syscalls from pipeline worker threads via a dedicated I/O thread + bounded crossbeam channel
- On Linux, applies `posix_fadvise(POSIX_FADV_SEQUENTIAL)` at file open and `POSIX_FADV_WILLNEED` with 128 MiB lookahead after each chunk fill, removing the dependence on the kernel's default 128 KiB `read_ahead_kb` setting
- Activated by a hidden `--async-reader` CLI flag on all BAM-input commands and `extract`
- Falls back to plain `File` I/O when the flag is not set (no behavioral change to existing workflows)

## Benchmark results (c7g.4xlarge, ARM Graviton3, 8 threads, 5 trials)

### readahead = 128 kB (Linux default)

| Workload | main | --async-reader | delta |
|---|---|---|---|
| FASTQ extract (2.9 GB) | 15.16s (σ=0.20) | 13.72s (σ=0.05) | **-9.5%** |
| BAM group (6.4 GB) | 34.02s (σ=0.36) | 31.28s (σ=0.17) | **-8.1%** |

### readahead = 4096 kB (tuned)

| Workload | main | --async-reader | delta |
|---|---|---|---|
| FASTQ extract | 13.71s | 13.61s | -0.7% |
| BAM group | 28.18s | 28.12s | -0.2% |

Key finding: at default 128 kB readahead, `--async-reader` nearly eliminates the FASTQ readahead dependency (13.72s vs 13.61s at 4 MB) and tightens variance significantly across both workloads. No regression at tuned readahead.

## Test plan

- [x] `cargo ci-test` — 2409/2409 tests pass (includes new `from_file` test)
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean (clippy pedantic)
- [x] Benchmarked on c7g.4xlarge at both 128 kB and 4096 kB kernel readahead
- [ ] Verify on a larger BAM (WGS) before promoting flag to visible