### PR TITLE
feat(sort): add --async-reader for prefetch I/O on input BAM

### DIFF
--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -127,7 +127,8 @@ fgumi group \
 ```
 
 `--async-reader` works with all input types: BAM files, BGZF/gzip/plain FASTQs,
-and piped stdin. It is most effective when I/O latency is high (network storage,
+and piped stdin. It is supported by all commands that read BAM/FASTQ input,
+including `sort`. It is most effective when I/O latency is high (network storage,
 cold page cache, small OS readahead). On systems where you can already set 4 MB+
 readahead, the additional benefit is modest.
 
@@ -353,6 +354,8 @@ Requested memory 16GB exceeds 90% of system memory (14.4GB)
 - `--max-memory` controls how much RAM is used for sort buffers; increase for large files to
   reduce the number of intermediate merge passes
 - For template-coordinate sort with single-cell data, the `CB` tag is included automatically
+- `--async-reader` is supported and can improve Phase 1 (input reading) throughput when disk
+  latency is high or the OS page cache readahead is small
 
 ### Merge
 - `fgumi merge` performs a k-way merge using a LoserTree for efficient multi-file merging

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -805,7 +805,14 @@ pub fn create_raw_bam_reader_with_opts<P: AsRef<Path>>(
 /// Create a raw BAM reader using the pool's Phase 1 integrated reading.
 ///
 /// Workers in the pool do `ReadInputBlocks` + `DecompressInput`. The main thread
-/// consumes decompressed bytes via `PooledInputStream`. No extra threads are spawned.
+/// consumes decompressed bytes via `PooledInputStream`.
+///
+/// When `async_reader` is false, no extra threads are spawned: the pool's block
+/// reader reads directly from the input file. When `async_reader` is true, the
+/// input file is wrapped in a `PrefetchReader`, which spawns one dedicated OS
+/// thread (`fgumi-prefetch`) that reads raw bytes ahead into a bounded queue so
+/// the pool's block reader never blocks on disk I/O. The prefetch thread lives
+/// for the duration of Phase 1 and is joined when the reader is dropped.
 ///
 /// # Flow
 ///
@@ -828,6 +835,7 @@ pub fn create_raw_bam_reader_with_opts<P: AsRef<Path>>(
 pub fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
     path: P,
     pool: &std::sync::Arc<crate::sort::worker_pool::SortWorkerPool>,
+    async_reader: bool,
 ) -> Result<(RawBamReader<crate::sort::read_ahead::PooledInputStream>, Header)> {
     use crate::sort::read_ahead::PooledInputStream;
     use crate::sort::worker_pool::phase;
@@ -869,7 +877,17 @@ pub fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
         file.seek(SeekFrom::Start(0))
             .with_context(|| format!("Failed to rewind input BAM: {}", path_ref.display()))?;
 
-        (header, Box::new(io::BufReader::with_capacity(2 * 1024 * 1024, file)))
+        let reader: Box<dyn io::Read + Send> = if async_reader {
+            crate::os_hints::advise_sequential(&file);
+            log::info!(
+                "async sort reader enabled: spawning fgumi-prefetch thread for {}",
+                path_ref.display()
+            );
+            Box::new(crate::prefetch_reader::PrefetchReader::from_file(file))
+        } else {
+            Box::new(io::BufReader::with_capacity(2 * 1024 * 1024, file))
+        };
+        (header, reader)
     };
 
     // Set the input file for pool workers and activate Phase 1

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -2441,6 +2441,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
         };
 
         extract.execute("test").expect("execute should succeed");

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -257,6 +257,14 @@ pub struct Sort {
     /// position tracking.
     #[arg(long = "write-index", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub write_index: bool,
+
+    /// Enable async userspace prefetch on the input BAM.
+    ///
+    /// Spawns a dedicated I/O thread that reads raw bytes into a bounded
+    /// queue ahead of the decompression step, so pool workers do not block
+    /// on disk. Prototype flag; defaults to off.
+    #[arg(long = "async-reader", default_value_t = false, hide = true)]
+    pub async_reader: bool,
 }
 
 /// Represents the memory limit configuration for sorting.
@@ -554,6 +562,7 @@ impl Sort {
             .output_compression(self.compression.compression_level)
             .temp_compression(self.temp_compression)
             .write_index(self.write_index)
+            .async_reader(self.async_reader)
             .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
 
         // For auto mode, cap initial buffer pre-allocation at 768 MiB/thread
@@ -700,6 +709,7 @@ mod tests {
             compression: CompressionOptions::default(),
             temp_compression: 1,
             write_index: false,
+            async_reader: false,
         }
     }
 

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -1160,6 +1160,8 @@ pub struct RawExternalSorter {
     /// a modest allocation and let `Vec` grow on demand, while explicit limits
     /// pre-allocate the full budget upfront (preserving prior behavior).
     initial_capacity: Option<usize>,
+    /// When true, wrap input in a `PrefetchReader` for async I/O.
+    async_reader: bool,
 }
 
 /// RAII guard that ensures Phase 2 teardown runs on every exit path between
@@ -1211,6 +1213,7 @@ impl RawExternalSorter {
             max_temp_files: DEFAULT_MAX_TEMP_FILES,
             cell_tag: None,
             initial_capacity: None,
+            async_reader: false,
         }
     }
 
@@ -1300,6 +1303,13 @@ impl RawExternalSorter {
     #[must_use]
     pub fn initial_capacity(mut self, bytes: usize) -> Self {
         self.initial_capacity = Some(bytes);
+        self
+    }
+
+    /// Enable async prefetch reader for input I/O.
+    #[must_use]
+    pub fn async_reader(mut self, enabled: bool) -> Self {
+        self.async_reader = enabled;
         self
     }
 
@@ -1478,8 +1488,11 @@ impl RawExternalSorter {
         // main thread reads records directly from PooledInputStream.
         info!("Phase 1: Pool-integrated input reading ({} workers, N+2 model)", pool.num_workers());
         let (record_source, header) = {
-            let (reader, header) =
-                crate::bam_io::create_raw_bam_reader_pool_integrated(input, &pool)?;
+            let (reader, header) = crate::bam_io::create_raw_bam_reader_pool_integrated(
+                input,
+                &pool,
+                self.async_reader,
+            )?;
             (RecordSource::direct(reader), header)
         };
 

--- a/tests/integration/test_async_reader.rs
+++ b/tests/integration/test_async_reader.rs
@@ -93,8 +93,24 @@ fn read_bam_records(path: &Path) -> Vec<RecordBuf> {
     reader.record_bufs(&header).map(|r| r.expect("Failed to read BAM record")).collect()
 }
 
-/// Assert that two BAM files contain identical records (ignoring header @PG differences).
+/// Read the BAM header from a file.
+fn read_bam_header(path: &Path) -> noodles::sam::Header {
+    let mut reader = File::open(path).map(bam::io::Reader::new).unwrap();
+    reader.read_header().unwrap()
+}
+
+/// Assert that two BAM files contain identical records and identical headers
+/// (ignoring `@PG` entries, which differ by command line).
 fn assert_bam_records_equal(path1: &Path, path2: &Path) {
+    // Compare headers with @PG entries stripped: those differ by command line
+    // (--async-reader is in one and not the other) but everything else —
+    // @HD, @SQ, @RG, @CO, sort order — must match.
+    let mut header1 = read_bam_header(path1);
+    let mut header2 = read_bam_header(path2);
+    header1.programs_mut().as_mut().clear();
+    header2.programs_mut().as_mut().clear();
+    assert_eq!(header1, header2, "BAM headers differ (excluding @PG)");
+
     let records1 = read_bam_records(path1);
     let records2 = read_bam_records(path2);
 
@@ -484,5 +500,170 @@ fn test_simplex_async_reader_stdin() {
         true,
         Some(Stdio::from(File::open(&input).unwrap())),
     );
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+// ============================================================================
+// Sort: async-reader regression tests
+// ============================================================================
+
+/// Check if samtools is available for sort tests.
+fn samtools_available() -> bool {
+    Command::new("samtools").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Create an unsorted BAM with many records spread across chromosomes using samtools.
+fn create_unsorted_bam(dir: &Path, num_reads: usize) -> PathBuf {
+    use std::fmt::Write as _;
+
+    let bam_path = dir.join("unsorted.bam");
+    let mut sam_content = String::new();
+    sam_content.push_str("@HD\tVN:1.6\tSO:unsorted\n");
+    sam_content.push_str("@SQ\tSN:chr1\tLN:100000\n");
+    sam_content.push_str("@SQ\tSN:chr2\tLN:100000\n");
+    sam_content.push_str("@SQ\tSN:chr3\tLN:100000\n");
+    sam_content.push_str("@RG\tID:rg1\tSM:sample1\tLB:lib1\n");
+
+    let seq = "ACGTACGTAC";
+    let qual = "IIIIIIIIII";
+
+    for i in 0..num_reads {
+        let chrom = match i % 3 {
+            0 => "chr2",
+            1 => "chr1",
+            _ => "chr3",
+        };
+        let pos = 50000 - (i % 1000) * 50 + 1;
+        let name = format!("read_{i}");
+        let mate_pos = pos + 200;
+        let cell = format!("cell{}", i % 4);
+
+        // R1
+        writeln!(
+            sam_content,
+            "{name}\t99\t{chrom}\t{pos}\t60\t10M\t=\t{mate_pos}\t210\t{seq}\t{qual}\tRG:Z:rg1\tMI:Z:umi_{i}\tCB:Z:{cell}"
+        )
+        .unwrap();
+        // R2
+        writeln!(
+            sam_content,
+            "{name}\t147\t{chrom}\t{mate_pos}\t60\t10M\t=\t{pos}\t-210\t{seq}\t{qual}\tRG:Z:rg1\tMI:Z:umi_{i}\tCB:Z:{cell}"
+        )
+        .unwrap();
+    }
+
+    // Add unmapped reads
+    for i in 0..10 {
+        let name = format!("unmapped_{i:04}");
+        writeln!(sam_content, "{name}\t77\t*\t0\t0\t*\t*\t0\t0\t{seq}\t{qual}\tRG:Z:rg1").unwrap();
+        writeln!(sam_content, "{name}\t141\t*\t0\t0\t*\t*\t0\t0\t{seq}\t{qual}\tRG:Z:rg1").unwrap();
+    }
+
+    let sam_path = dir.join("unsorted.sam");
+    std::fs::write(&sam_path, sam_content).expect("write SAM");
+
+    let status = Command::new("samtools")
+        .args(["view", "-b", "-o", bam_path.to_str().unwrap(), sam_path.to_str().unwrap()])
+        .status()
+        .expect("samtools view");
+    assert!(status.success(), "samtools view failed");
+    bam_path
+}
+
+/// Run `fgumi sort` and return the output BAM path.
+fn run_sort(
+    tmp: &TempDir,
+    input: &Path,
+    output_name: &str,
+    order: &str,
+    threads: usize,
+    max_memory: &str,
+    async_reader: bool,
+) -> PathBuf {
+    let output = tmp.path().join(output_name);
+    let mut args: Vec<std::ffi::OsString> = vec![
+        "sort".into(),
+        "-i".into(),
+        input.as_os_str().to_owned(),
+        "-o".into(),
+        output.as_os_str().to_owned(),
+        "--order".into(),
+        order.into(),
+        "--threads".into(),
+        threads.to_string().into(),
+        "-m".into(),
+        max_memory.into(),
+        "--temp-compression".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if async_reader {
+        args.push("--async-reader".into());
+    }
+
+    let result =
+        Command::new(env!("CARGO_BIN_EXE_fgumi")).args(&args).output().expect("fgumi sort");
+    assert!(
+        result.status.success(),
+        "fgumi sort failed (order={order}, threads={threads}, async={async_reader}):\n{}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    output
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_async_reader_single_threaded() {
+    if !samtools_available() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let input = create_unsorted_bam(tmp.path(), 500);
+
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 1, "100M", false);
+    let async_out = run_sort(&tmp, &input, "async.bam", "coordinate", 1, "100M", true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_coordinate_async_reader_multithreaded() {
+    if !samtools_available() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let input = create_unsorted_bam(tmp.path(), 2000);
+
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 4, "50K", false);
+    let async_out = run_sort(&tmp, &input, "async.bam", "coordinate", 4, "50K", true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_queryname_async_reader_multithreaded() {
+    if !samtools_available() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let input = create_unsorted_bam(tmp.path(), 2000);
+
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "queryname", 4, "50K", false);
+    let async_out = run_sort(&tmp, &input, "async.bam", "queryname", 4, "50K", true);
+    assert_bam_records_equal(&baseline, &async_out);
+}
+
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_template_coordinate_async_reader_multithreaded() {
+    if !samtools_available() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let input = create_unsorted_bam(tmp.path(), 2000);
+
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "template-coordinate", 4, "50K", false);
+    let async_out = run_sort(&tmp, &input, "async.bam", "template-coordinate", 4, "50K", true);
     assert_bam_records_equal(&baseline, &async_out);
 }


### PR DESCRIPTION
## Summary

- Wire `PrefetchReader` (from #258) into the sort command's pool-integrated input path
- When `--async-reader` is enabled, a dedicated I/O thread reads raw bytes into a bounded channel ahead of the pool's BGZF decompression workers, hiding disk latency during Phase 1
- Add hidden `--async-reader` flag to Sort CLI, `async_reader` field + builder to `RawExternalSorter`, and conditional `PrefetchReader` wrapping in `create_raw_bam_reader_pool_integrated`
- Add 4 integration tests (coordinate 1T/4T, queryname 4T, template-coordinate 4T) comparing output with/without the flag
- Update performance-tuning docs to mention sort support

## Benchmark (c7g.4xlarge, 6.5 GB BAM, template-coordinate, 8 threads, cold cache, gp3 @ 500 MB/s)

| Phase | Baseline | --async-reader | Delta |
|-------|----------|----------------|-------|
| Read + decompress | 24.3s (44%) | 21.9s (42%) | **-10%** |
| In-memory sort | 2.1s (4%) | 2.1s (4%) | 0% |
| Spill write | 12.1s (23%) | 12.1s (24%) | 0% |
| K-way merge | 15.6s (29%) | 15.6s (30%) | 0% |
| **Total wall** | **54.1s** | **51.6s** | **-4.6%** |

Async reader also reduces variance (baseline 52.9–55.9s vs async 51.0–52.9s).

## Stacked on

- #258 (`nh/async-prefetch-reader`)

## Test plan

- [x] `cargo ci-test` (2426 passed)
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] 4 sort-specific `--ignored` integration tests pass (require samtools)
- [x] Benchmarked on EC2 c7g.4xlarge with cold cache