### PR TITLE
feat(simulate): add --methylation-mode to simulate subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ memory-debug = []
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
 # Enable simulate commands for generating synthetic test data
-simulate = []
+simulate = ["simplex"]
 # Enable profiling output for adjacency UMI assigner
 profile-adjacency = []
 # Enable slow stress tests for concurrency testing

--- a/crates/fgumi-consensus/src/methylation.rs
+++ b/crates/fgumi-consensus/src/methylation.rs
@@ -66,6 +66,38 @@ impl MethylationAnnotation {
     pub fn truncate(&self, len: usize) -> Self {
         Self { evidence: self.evidence[..len.min(self.evidence.len())].to_vec() }
     }
+
+    /// Returns a copy of this annotation with the evidence vector reversed.
+    ///
+    /// Used when building R2 records: the sequence is reverse-complemented, so
+    /// the per-position methylation evidence must be reversed to match.
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        let mut rev = self.evidence.clone();
+        rev.reverse();
+        Self { evidence: rev }
+    }
+}
+
+/// Determines if a position in the reference is in a `CpG` dinucleotide context.
+///
+/// For top strand: checks if `ref_seq[pos]` is C and `ref_seq[pos+1]` is G.
+/// For bottom strand: checks if `ref_seq[pos]` is G and `ref_seq[pos-1]` is C.
+#[inline]
+#[must_use]
+pub fn is_cpg_context(ref_seq: &[u8], pos: usize, is_top_strand: bool) -> bool {
+    if pos >= ref_seq.len() {
+        return false;
+    }
+    if is_top_strand {
+        pos + 1 < ref_seq.len()
+            && ref_seq[pos].eq_ignore_ascii_case(&b'C')
+            && ref_seq[pos + 1].eq_ignore_ascii_case(&b'G')
+    } else {
+        pos > 0
+            && ref_seq[pos].eq_ignore_ascii_case(&b'G')
+            && ref_seq[pos - 1].eq_ignore_ascii_case(&b'C')
+    }
 }
 
 /// Maps each query position to a reference position using a simplified CIGAR.
@@ -821,6 +853,73 @@ pub(crate) mod tests {
         let result = build_mm_ml_tags(&bases, &annotation, true, crate::MethylationMode::EmSeq);
         let (_, ml) = result.unwrap();
         assert_eq!(ml, vec![255u8; 5]); // EM-seq: 3/3 unconverted = 255
+    }
+
+    // ========================================================================
+    // is_cpg_context tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_cpg_top_strand_cg_dinucleotide() {
+        assert!(is_cpg_context(b"ACGT", 1, true)); // C at pos 1, G at pos 2
+    }
+
+    #[test]
+    fn test_is_cpg_top_strand_not_cpg() {
+        assert!(!is_cpg_context(b"ACAT", 1, true)); // C at pos 1, A at pos 2
+        assert!(!is_cpg_context(b"ACCT", 1, true)); // C at pos 1, C at pos 2
+        assert!(!is_cpg_context(b"ACTT", 1, true)); // C at pos 1, T at pos 2
+    }
+
+    #[test]
+    fn test_is_cpg_top_strand_c_at_last_position() {
+        assert!(!is_cpg_context(b"AAC", 2, true)); // C at end, no following base
+    }
+
+    #[test]
+    fn test_is_cpg_top_strand_not_c() {
+        assert!(!is_cpg_context(b"AGGT", 1, true)); // G at pos 1, not a C
+    }
+
+    #[test]
+    fn test_is_cpg_bottom_strand_cg_dinucleotide() {
+        assert!(is_cpg_context(b"ACGT", 2, false)); // G at pos 2, C at pos 1
+    }
+
+    #[test]
+    fn test_is_cpg_bottom_strand_not_cpg() {
+        assert!(!is_cpg_context(b"AAGT", 2, false)); // G at pos 2, A at pos 1
+        assert!(!is_cpg_context(b"AGGT", 2, false)); // G at pos 2, G at pos 1
+        assert!(!is_cpg_context(b"ATGT", 2, false)); // G at pos 2, T at pos 1
+    }
+
+    #[test]
+    fn test_is_cpg_bottom_strand_g_at_first_position() {
+        assert!(!is_cpg_context(b"GAC", 0, false)); // G at start, no preceding base
+    }
+
+    #[test]
+    fn test_is_cpg_bottom_strand_not_g() {
+        assert!(!is_cpg_context(b"ACAT", 1, false)); // C at pos 1, not a G
+    }
+
+    #[test]
+    fn test_is_cpg_case_insensitive() {
+        assert!(is_cpg_context(b"acgt", 1, true));
+        assert!(is_cpg_context(b"acgt", 2, false));
+    }
+
+    #[test]
+    fn test_is_cpg_pos_out_of_range() {
+        // pos >= ref_seq.len() should return false, not panic
+        let ref_seq = b"CG";
+        assert!(!is_cpg_context(ref_seq, 2, true));
+        assert!(!is_cpg_context(ref_seq, 2, false));
+        assert!(!is_cpg_context(ref_seq, 100, true));
+        assert!(!is_cpg_context(ref_seq, 100, false));
+        // Empty ref_seq
+        assert!(!is_cpg_context(b"", 0, true));
+        assert!(!is_cpg_context(b"", 0, false));
     }
 
     /// Helper to create a `SourceRead` for testing.

--- a/docs/simulate-cli.md
+++ b/docs/simulate-cli.md
@@ -8,13 +8,13 @@ Generate synthetic sequencing data for testing and benchmarking the fgumi pipeli
 
 | Command | Output | Pipeline Stage | Reference FASTA |
 |---------|--------|----------------|-----------------|
-| `fgumi simulate fastq-reads` | R1/R2 FASTQ.gz | Input for `extract` | Not used |
-| `fgumi simulate mapped-reads` | Template-coord sorted BAM | Input for `group` | Optional |
-| `fgumi simulate grouped-reads` | Template-coord sorted BAM with MI tags | Input for `simplex`/`duplex`/`codec` | Optional |
-| `fgumi simulate consensus-reads` | Unmapped BAM with consensus tags | Input for `filter` | Not used |
+| `fgumi simulate fastq-reads` | R1/R2 FASTQ.gz | Input for `extract` | Required |
+| `fgumi simulate mapped-reads` | Template-coord sorted BAM | Input for `group` | Required |
+| `fgumi simulate grouped-reads` | Template-coord sorted BAM with MI tags | Input for `simplex`/`duplex`/`codec` | Required |
+| `fgumi simulate consensus-reads` | Mapped BAM with consensus tags | Input for `filter` | Required |
 | `fgumi simulate correct-reads` | Unmapped BAM + includelist | Input for `correct` | Not used |
 
-**Note:** Commands that support `--reference` will sample positions from real chromosomes and extract actual genomic sequences. Without a reference, synthetic random sequences are generated.
+**Note:** All simulate subcommands (except `correct-reads`) require `--reference` / `-r` pointing to a reference FASTA file. Positions are sampled from real chromosomes, template sequences are extracted from the reference, and BAM headers contain actual contig names and lengths. Read orientations are a 50/50 mix of F1R2 and R1F2 (strand coin flip per molecule).
 
 ---
 
@@ -38,6 +38,7 @@ fgumi simulate fastq-reads \
 | `-1, --r1` | PATH | Output R1 FASTQ.gz file |
 | `-2, --r2` | PATH | Output R2 FASTQ.gz file |
 | `--truth` | PATH | Output truth TSV file (for validation) |
+| `-r, --reference` | PATH | Reference FASTA file (sequences sampled from here) |
 
 ### Simulation Options
 
@@ -82,6 +83,14 @@ fgumi simulate fastq-reads \
 | `--insert-size-min` | INT | 50 | Minimum insert size |
 | `--insert-size-max` | INT | 800 | Maximum insert size |
 
+### Methylation Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--methylation-mode` | `em-seq` or `taps` | (disabled) | Methylation chemistry mode; disabled by default |
+| `--cpg-methylation-rate` | FLOAT | 0.75 | Fraction of CpG cytosines that are methylated [0.0-1.0] |
+| `--conversion-rate` | FLOAT | 0.98 | Enzymatic conversion efficiency for target cytosines [0.0-1.0] |
+
 ### Truth File Format
 
 The truth TSV file contains ground truth for validation:
@@ -92,7 +101,9 @@ The truth TSV file contains ground truth for validation:
 | `true_umi` | The true UMI sequence (before any errors) |
 | `molecule_id` | Unique molecule identifier |
 | `family_id` | Family within the molecule |
-| `strand` | Strand (A or B for duplex) |
+| `strand` | Strand (A or B) |
+| `chrom` | Chromosome/contig name |
+| `pos` | 0-based genomic position |
 
 ### Example
 
@@ -102,6 +113,7 @@ fgumi simulate fastq-reads \
     --r1 sim_R1.fastq.gz \
     --r2 sim_R2.fastq.gz \
     --truth sim_truth.tsv \
+    --reference hg38.fa \
     --num-molecules 10000 \
     --umi-length 8 \
     --read-structure-r1 "8M142T" \
@@ -129,6 +141,7 @@ fgumi simulate mapped-reads \
 |--------|------|-------------|
 | `-o, --output` | PATH | Output BAM file (template-coordinate sorted) |
 | `--truth` | PATH | Output truth TSV file (for validation) |
+| `-r, --reference` | PATH | Reference FASTA file (sequences sampled from here) |
 
 ### Simulation Options
 
@@ -140,24 +153,7 @@ fgumi simulate mapped-reads \
 | `--seed` | INT | (random) | Random seed for reproducibility |
 | `-t, --threads` | INT | 1 | Number of writer threads |
 
-### Reference Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `-r, --reference` | PATH | (none) | Reference FASTA file (sequences sampled from here) |
-| `--ref-name` | STRING | `chr1` | Synthetic reference name (only used if no --reference) |
-| `--ref-length` | INT | 10000000 | Synthetic reference length (only used if no --reference) |
-
-When `--reference` is provided:
-- Positions are sampled from real chromosomes (weighted by length)
-- Read sequences are extracted from the reference
-- BAM header contains actual contig names and lengths
-- Reads will map correctly if used with an aligner
-
-When `--reference` is not provided:
-- A synthetic single-contig reference is used
-- Random sequences are generated
-- Useful for quick testing without a reference file
+Positions are sampled from real chromosomes (weighted by length), read sequences are extracted from the reference, and the BAM header contains actual contig names and lengths.
 
 ### Alignment Options
 
@@ -197,6 +193,10 @@ By default, each molecule gets a unique position. For high-depth benchmarking (t
 
 (Same as fastq-reads)
 
+### Methylation Options
+
+(Same as fastq-reads)
+
 ### Output Tags
 
 | Tag | Type | Description |
@@ -212,8 +212,8 @@ By default, each molecule gets a unique position. For high-depth benchmarking (t
 | `true_umi` | The true UMI sequence (before any errors) |
 | `molecule_id` | Unique molecule identifier |
 | `chrom` | Chromosome/contig name |
-| `position` | 1-based genomic position |
-| `strand` | Strand (A or B for duplex) |
+| `position` | 0-based genomic position |
+| `strand` | Strand (`+` or `-`) |
 
 ### Example
 
@@ -227,19 +227,11 @@ fgumi simulate mapped-reads \
     --seed 42 \
     --threads 4
 
-# Generate mapped reads with synthetic reference (no FASTA needed)
-fgumi simulate mapped-reads \
-    --output sim_mapped.bam \
-    --truth sim_truth.tsv \
-    --ref-name chr1 \
-    --ref-length 50000000 \
-    --num-molecules 5000 \
-    --seed 42
-
 # High-depth mode: many UMIs at few positions (for MIH/group benchmarking)
 fgumi simulate mapped-reads \
     --output sim_high_depth.bam \
     --truth sim_truth.tsv \
+    --reference hg38.fa \
     --num-molecules 50000 \
     --num-positions 100 \
     --umis-per-position 500 \
@@ -266,6 +258,7 @@ fgumi simulate grouped-reads \
 |--------|------|-------------|
 | `-o, --output` | PATH | Output BAM file (template-coordinate sorted) |
 | `--truth` | PATH | Output truth TSV file (for validation) |
+| `-r, --reference` | PATH | Reference FASTA file (sequences sampled from here) |
 
 ### Simulation Options
 
@@ -285,16 +278,6 @@ fgumi simulate grouped-reads \
 | `--strand-alpha` | FLOAT | 5.0 | Beta distribution alpha for A/B strand ratio |
 | `--strand-beta` | FLOAT | 5.0 | Beta distribution beta for A/B strand ratio |
 
-### Reference Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `-r, --reference` | PATH | (none) | Reference FASTA file (sequences sampled from here) |
-| `--ref-name` | STRING | `chr1` | Synthetic reference name (only used if no --reference) |
-| `--ref-length` | INT | 10000000 | Synthetic reference length (only used if no --reference) |
-
-See `mapped-reads` for details on reference vs. synthetic mode.
-
 ### Quality Model Options
 
 (Same as fastq-reads)
@@ -304,6 +287,10 @@ See `mapped-reads` for details on reference vs. synthetic mode.
 (Same as fastq-reads)
 
 ### Insert Size Options
+
+(Same as fastq-reads)
+
+### Methylation Options
 
 (Same as fastq-reads)
 
@@ -324,13 +311,13 @@ See `mapped-reads` for details on reference vs. synthetic mode.
 | `molecule_id` | Unique molecule identifier |
 | `expected_mi` | Expected MI tag value after grouping |
 | `chrom` | Chromosome/contig name |
-| `position` | 1-based genomic position |
-| `strand` | Strand (A or B for duplex) |
+| `position` | 0-based genomic position |
+| `strand` | Strand (`+` or `-`) |
 
 ### Example
 
 ```bash
-# Generate simplex grouped reads with reference
+# Generate simplex grouped reads
 fgumi simulate grouped-reads \
     --output sim_grouped.bam \
     --truth sim_truth.tsv \
@@ -338,10 +325,11 @@ fgumi simulate grouped-reads \
     --num-molecules 5000 \
     --seed 42
 
-# Generate duplex grouped reads with strand bias (synthetic reference)
+# Generate duplex grouped reads with strand bias
 fgumi simulate grouped-reads \
     --output sim_duplex_grouped.bam \
     --truth sim_truth.tsv \
+    --reference hg38.fa \
     --num-molecules 5000 \
     --duplex \
     --strand-alpha 5.0 \
@@ -353,13 +341,14 @@ fgumi simulate grouped-reads \
 
 ## fgumi simulate consensus-reads
 
-Generate unmapped BAM with consensus tags (cD, cM, cE, etc.) for input to `fgumi filter`.
+Generate mapped BAM with consensus tags (cD, cM, cE, etc.) for input to `fgumi filter`.
 
 ### Usage
 
 ```bash
 fgumi simulate consensus-reads \
     --output output.bam \
+    --reference ref.fa \
     [OPTIONS]
 ```
 
@@ -367,7 +356,8 @@ fgumi simulate consensus-reads \
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `-o, --output` | PATH | Output BAM file (unmapped) |
+| `-o, --output` | PATH | Output BAM file (mapped) |
+| `-r, --reference` | PATH | Reference FASTA file (sequences sampled from here) |
 
 ### Simulation Options
 
@@ -403,6 +393,15 @@ fgumi simulate consensus-reads \
 |--------|------|---------|-------------|
 | `--consensus-quality` | INT | 40 | Base quality for consensus reads |
 
+### Methylation Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--methylation-mode` | `em-seq` or `taps` | (disabled) | Methylation chemistry mode; disabled by default |
+| `--cpg-methylation-rate` | FLOAT | 0.75 | Fraction of CpG cytosines that are methylated [0.0-1.0] |
+| `--conversion-rate` | FLOAT | 0.98 | Enzymatic conversion efficiency for target cytosines [0.0-1.0] |
+| `--methylation-depth-mean` | FLOAT | 5.0 | Mean depth for methylation count sampling (cu + ct per position) |
+
 ### Output Tags (Simplex)
 
 | Tag | Type | Description |
@@ -432,6 +431,7 @@ fgumi simulate consensus-reads \
 # Generate simplex consensus reads
 fgumi simulate consensus-reads \
     --output sim_consensus.bam \
+    --reference hg38.fa \
     --num-reads 10000 \
     --min-depth 2 \
     --max-depth 20 \
@@ -440,6 +440,7 @@ fgumi simulate consensus-reads \
 # Generate duplex consensus reads
 fgumi simulate consensus-reads \
     --output sim_duplex_consensus.bam \
+    --reference hg38.fa \
     --num-reads 10000 \
     --duplex \
     --seed 42
@@ -598,6 +599,7 @@ To benchmark the MIH (Multiple Identical Hits) optimization in `fgumi group`, us
 fgumi simulate mapped-reads \
     --output high_depth.bam \
     --truth high_depth_truth.tsv \
+    --reference hg38.fa \
     --num-molecules 500000 \
     --num-positions 100 \
     --umis-per-position 500 \

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -402,7 +402,6 @@ impl ReferenceGenome {
     }
 
     /// Build a BAM [`Header`] with `@SQ` lines for every loaded contig.
-    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
     pub(super) fn build_bam_header(&self) -> noodles::sam::header::Header {
         use bstr::BString;
         use noodles::sam::header::Header;
@@ -425,13 +424,13 @@ impl ReferenceGenome {
     }
 
     /// Returns the number of loaded chromosomes.
-    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    #[allow(dead_code)] // used by grouped-reads and consensus-reads (upcoming tasks)
     pub(super) fn num_chromosomes(&self) -> usize {
         self.sequences.len()
     }
 
     /// Returns the length of the chromosome at the given index.
-    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    #[allow(dead_code)] // used by grouped-reads and consensus-reads (upcoming tasks)
     pub(super) fn chromosome_length(&self, chrom_idx: usize) -> usize {
         self.sequences[chrom_idx].len()
     }
@@ -441,7 +440,6 @@ impl ReferenceGenome {
     /// Positions are drawn uniformly across the genome and are checked against
     /// a `MIN_CONTIG_LENGTH` bp window for N bases. Sampling retries internally up to
     /// `num_positions * 100` attempts before panicking.
-    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
     pub(super) fn sample_positions(
         &self,
         num_positions: usize,

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -262,6 +262,11 @@ pub struct ReferenceArgs {
     pub reference: PathBuf,
 }
 
+/// Minimum contig length (bp) considered usable for sampling. Contigs shorter than this
+/// are skipped when loading the reference so that the 1000-bp N-check window and typical
+/// insert sizes have room to fit.
+const MIN_CONTIG_LENGTH: usize = 1000;
+
 /// Loaded reference genome for sampling template sequences.
 pub(super) struct ReferenceGenome {
     names: Vec<String>,
@@ -294,7 +299,7 @@ impl ReferenceGenome {
             let seq: Vec<u8> =
                 record.sequence().as_ref().iter().map(|&b| b.to_ascii_uppercase()).collect();
 
-            if seq.len() >= 1000 {
+            if seq.len() >= MIN_CONTIG_LENGTH {
                 // Only include chromosomes with sufficient length
                 total_length += seq.len();
                 cumulative_lengths.push(total_length);
@@ -318,20 +323,23 @@ impl ReferenceGenome {
     }
 
     /// Sample a random position and return (`chrom_idx`, position, sequence).
-    /// Returns None if the position contains N bases or if `length` exceeds `total_length`.
+    /// Returns None if the position contains N bases or if `length` is zero or
+    /// exceeds `total_length`.
     pub fn sample_sequence(
         &self,
         length: usize,
         rng: &mut impl Rng,
     ) -> Option<(usize, usize, Vec<u8>)> {
-        if length > self.total_length {
+        if length == 0 || length > self.total_length {
             return None;
         }
-        let max_start = self.total_length - length;
+        // Exclusive upper bound keeps `genome_pos < total_length`, which guarantees
+        // `partition_point` returns a valid index into `cumulative_lengths`.
+        let start_bound = self.total_length - length + 1;
         // Try up to 10 times to find a valid position without N bases
         for _ in 0..10 {
             // Pick a random position in the genome
-            let genome_pos = rng.random_range(0..=max_start);
+            let genome_pos = rng.random_range(0..start_bound);
 
             // Find which chromosome this falls in (binary search on sorted cumulative lengths)
             let chrom_idx = self.cumulative_lengths.partition_point(|&cum| cum <= genome_pos);
@@ -391,6 +399,86 @@ impl ReferenceGenome {
             return None;
         }
         Some(subseq.to_vec())
+    }
+
+    /// Build a BAM [`Header`] with `@SQ` lines for every loaded contig.
+    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    pub(super) fn build_bam_header(&self) -> noodles::sam::header::Header {
+        use bstr::BString;
+        use noodles::sam::header::Header;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+
+        let mut builder = Header::builder();
+        for (name, seq) in self.names.iter().zip(self.sequences.iter()) {
+            let length = NonZeroUsize::try_from(seq.len()).expect("chromosome length must be > 0");
+            let ref_seq = Map::<ReferenceSequence>::new(length);
+            builder = builder.add_reference_sequence(BString::from(name.as_str()), ref_seq);
+        }
+        builder.build()
+    }
+
+    /// Returns the length of the longest loaded chromosome.
+    pub(super) fn max_contig_length(&self) -> usize {
+        self.sequences.iter().map(|s| s.len()).max().unwrap_or(0)
+    }
+
+    /// Returns the number of loaded chromosomes.
+    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    pub(super) fn num_chromosomes(&self) -> usize {
+        self.sequences.len()
+    }
+
+    /// Returns the length of the chromosome at the given index.
+    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    pub(super) fn chromosome_length(&self, chrom_idx: usize) -> usize {
+        self.sequences[chrom_idx].len()
+    }
+
+    /// Pre-sample `num_positions` random loci as `(chrom_idx, local_pos)` tuples.
+    ///
+    /// Positions are drawn uniformly across the genome and are checked against
+    /// a `MIN_CONTIG_LENGTH` bp window for N bases. Sampling retries internally up to
+    /// `num_positions * 100` attempts before panicking.
+    #[allow(dead_code)] // will be wired into callers when position-table lookup replaces todo!()
+    pub(super) fn sample_positions(
+        &self,
+        num_positions: usize,
+        rng: &mut impl Rng,
+    ) -> Vec<(usize, usize)> {
+        const WINDOW: usize = MIN_CONTIG_LENGTH;
+        let max_attempts = num_positions.saturating_mul(100).max(1);
+        let mut positions = Vec::with_capacity(num_positions);
+        let mut attempts = 0usize;
+
+        while positions.len() < num_positions {
+            assert!(
+                attempts < max_attempts,
+                "sample_positions: exhausted {max_attempts} attempts to find \
+                 {num_positions} N-free positions in the reference"
+            );
+            attempts += 1;
+
+            // Pick a genome-wide position and map to (chrom_idx, local_pos)
+            let genome_pos = rng.random_range(0..self.total_length);
+            let chrom_idx = self.cumulative_lengths.partition_point(|&cum| cum <= genome_pos);
+            let chrom_start =
+                if chrom_idx == 0 { 0 } else { self.cumulative_lengths[chrom_idx - 1] };
+            let local_pos = genome_pos - chrom_start;
+
+            // Check a 1000bp window for N bases
+            let seq = &self.sequences[chrom_idx];
+            let window_end = (local_pos + WINDOW).min(seq.len());
+            let window_start = local_pos.min(window_end);
+            let window = &seq[window_start..window_end];
+            if window.iter().any(|&b| b == b'N' || b == b'n') {
+                continue;
+            }
+
+            positions.push((chrom_idx, local_pos));
+        }
+        positions
     }
 }
 
@@ -1192,6 +1280,17 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[test]
+    fn test_reference_genome_sample_sequence_zero_length() {
+        // length == 0 must not panic and must return None (no valid 0-length sample)
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let result = genome.sample_sequence(0, &mut rng);
+        assert!(result.is_none());
+    }
+
     // ========================================================================
     // MethylationArgs tests
     // ========================================================================
@@ -1511,5 +1610,116 @@ mod tests {
         let mut read = ref_seq.to_vec();
         convert(&mut read, ref_seq, 0, true, MethylationMode::Disabled, 0.75, 1.0, 42);
         assert_eq!(read, ref_seq, "Disabled mode should never modify bases");
+    }
+
+    // ========================================================================
+    // ReferenceGenome::build_bam_header, num_chromosomes, chromosome_length,
+    // and sample_positions tests
+    // ========================================================================
+
+    /// Create a temp FASTA with four contigs: chr1 (2000bp), chr2 (1500bp),
+    /// chr3 (1800bp), and `short_contig` (500bp, below the 1000bp minimum).
+    fn write_multi_contig_fasta() -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, ">chr1").unwrap();
+        f.write_all(&b"ACGT".repeat(500)).unwrap(); // 2000bp
+        writeln!(f).unwrap();
+        writeln!(f, ">chr2").unwrap();
+        f.write_all(&b"CCGG".repeat(375)).unwrap(); // 1500bp
+        writeln!(f).unwrap();
+        writeln!(f, ">chr3").unwrap();
+        f.write_all(&b"AATT".repeat(450)).unwrap(); // 1800bp
+        writeln!(f).unwrap();
+        writeln!(f, ">short_contig").unwrap();
+        f.write_all(&b"ACGT".repeat(125)).unwrap(); // 500bp, should be skipped
+        writeln!(f).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_build_bam_header_has_all_contigs() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let header = genome.build_bam_header();
+
+        let ref_seqs: Vec<_> = header.reference_sequences().keys().collect();
+        assert_eq!(ref_seqs.len(), 3, "short_contig should be excluded");
+        let names: Vec<&str> =
+            ref_seqs.iter().map(|k| std::str::from_utf8(k.as_ref()).unwrap()).collect();
+        assert!(names.contains(&"chr1"));
+        assert!(names.contains(&"chr2"));
+        assert!(names.contains(&"chr3"));
+        assert!(!names.contains(&"short_contig"));
+    }
+
+    #[test]
+    fn test_build_bam_header_contig_lengths() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let header = genome.build_bam_header();
+
+        let ref_seqs = header.reference_sequences();
+        let chr1_len: usize = ref_seqs.get(&bstr::BString::from("chr1")).unwrap().length().get();
+        let chr2_len: usize = ref_seqs.get(&bstr::BString::from("chr2")).unwrap().length().get();
+        let chr3_len: usize = ref_seqs.get(&bstr::BString::from("chr3")).unwrap().length().get();
+        assert_eq!(chr1_len, 2000);
+        assert_eq!(chr2_len, 1500);
+        assert_eq!(chr3_len, 1800);
+    }
+
+    #[test]
+    fn test_num_chromosomes() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert_eq!(genome.num_chromosomes(), 3);
+    }
+
+    #[test]
+    fn test_chromosome_length() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert_eq!(genome.chromosome_length(0), 2000);
+        assert_eq!(genome.chromosome_length(1), 1500);
+        assert_eq!(genome.chromosome_length(2), 1800);
+    }
+
+    #[test]
+    fn test_sample_positions_count_and_bounds() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let positions = genome.sample_positions(20, &mut rng);
+        assert_eq!(positions.len(), 20);
+        for (chrom_idx, local_pos) in &positions {
+            assert!(*chrom_idx < genome.num_chromosomes());
+            assert!(*local_pos < genome.chromosome_length(*chrom_idx));
+        }
+    }
+
+    #[test]
+    fn test_sample_positions_deterministic() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng1 = create_rng(Some(99));
+        let mut rng2 = create_rng(Some(99));
+        let pos1 = genome.sample_positions(10, &mut rng1);
+        let pos2 = genome.sample_positions(10, &mut rng2);
+        assert_eq!(pos1, pos2);
+    }
+
+    #[test]
+    fn test_sample_positions_spans_chromosomes() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(7));
+        let positions = genome.sample_positions(100, &mut rng);
+        let unique_chroms: std::collections::HashSet<usize> =
+            positions.iter().map(|(c, _)| *c).collect();
+        assert!(
+            unique_chroms.len() >= 2,
+            "100 positions should span at least 2 chromosomes, got {}",
+            unique_chroms.len()
+        );
     }
 }

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -373,7 +373,7 @@ impl ReferenceGenome {
     /// Return the subsequence at a genome-wide position, mapping to the correct
     /// chromosome automatically. The position wraps around the total genome length.
     /// Returns None if out of bounds or if the sequence contains N bases.
-    #[allow(dead_code)] // used by consensus-reads (upcoming tasks)
+    #[allow(dead_code)] // used only in tests
     pub fn sequence_at_genome_pos(&self, genome_pos: usize, length: usize) -> Option<Vec<u8>> {
         if self.total_length == 0 {
             return None;
@@ -425,13 +425,13 @@ impl ReferenceGenome {
     }
 
     /// Returns the number of loaded chromosomes.
-    #[allow(dead_code)] // used by grouped-reads and consensus-reads (upcoming tasks)
+    #[allow(dead_code)] // used only in tests
     pub(super) fn num_chromosomes(&self) -> usize {
         self.sequences.len()
     }
 
     /// Returns the length of the chromosome at the given index.
-    #[allow(dead_code)] // used by grouped-reads and consensus-reads (upcoming tasks)
+    #[allow(dead_code)] // used only in tests
     pub(super) fn chromosome_length(&self, chrom_idx: usize) -> usize {
         self.sequences[chrom_idx].len()
     }

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -373,6 +373,7 @@ impl ReferenceGenome {
     /// Return the subsequence at a genome-wide position, mapping to the correct
     /// chromosome automatically. The position wraps around the total genome length.
     /// Returns None if out of bounds or if the sequence contains N bases.
+    #[allow(dead_code)] // used by consensus-reads (upcoming tasks)
     pub fn sequence_at_genome_pos(&self, genome_pos: usize, length: usize) -> Option<Vec<u8>> {
         if self.total_length == 0 {
             return None;

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -585,21 +585,6 @@ fn is_conversion_target(
     }
 }
 
-/// Compute the genomic position for a molecule based on its ID.
-#[inline]
-pub(super) fn compute_position(mol_id: usize, num_positions: usize, ref_length: usize) -> usize {
-    let fallback = ref_length.saturating_sub(1).min(100);
-    if num_positions == 0 {
-        return fallback;
-    }
-    let usable_span = ref_length.saturating_sub(1000);
-    if usable_span == 0 {
-        return fallback;
-    }
-    let position_idx = mol_id % num_positions;
-    ((position_idx as f64 / num_positions as f64) * usable_span as f64) as usize + fallback
-}
-
 /// Lightweight molecule info for position-first sorting.
 #[derive(Debug)]
 pub(super) struct MoleculeInfo {
@@ -1033,31 +1018,6 @@ mod tests {
         let _ = args_lower
             .to_family_size_distribution()
             .expect("lowercase distribution name should be accepted");
-    }
-
-    #[rstest]
-    // num_positions == 0 should not panic
-    #[case(5, 0, 250_000_000, 0, 250_000_000)]
-    // ref_length < 1000 should not underflow
-    #[case(0, 10, 500, 0, 500)]
-    // Very small reference (ref_length <= 100) — fallback must stay within bounds
-    #[case(0, 10, 50, 0, 50)]
-    // Normal: first position
-    #[case(0, 10, 10_000, 0, 10_000)]
-    // Normal: last position in range
-    #[case(9, 10, 10_000, 101, 10_000)]
-    fn test_compute_position(
-        #[case] mol_id: usize,
-        #[case] num_positions: usize,
-        #[case] ref_length: usize,
-        #[case] min_expected: usize,
-        #[case] max_expected: usize,
-    ) {
-        let pos = compute_position(mol_id, num_positions, ref_length);
-        assert!(
-            pos >= min_expected && pos < max_expected,
-            "compute_position({mol_id}, {num_positions}, {ref_length}) = {pos}, expected [{min_expected}, {max_expected})"
-        );
     }
 
     fn make_molecule_info(mol_id: usize, tid1: i32, pos1: i64) -> MoleculeInfo {

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -1,8 +1,16 @@
 //! Shared CLI arguments and utilities for simulation commands.
 
 use super::sort::TemplateCoordKey;
+use crate::commands::common::MethylationModeArg;
+use anyhow::{Context, Result, bail};
 use clap::Args;
+use fgumi_consensus::MethylationMode;
+use fgumi_consensus::methylation::is_cpg_context;
+use log::info;
+use noodles::fasta;
 use rand::{Rng, RngExt};
+use std::fs::File;
+use std::io::BufReader;
 use std::path::PathBuf;
 
 /// Common simulation options shared across all simulate subcommands.
@@ -187,6 +195,65 @@ impl StrandBiasArgs {
     }
 }
 
+/// Methylation simulation options shared across simulate subcommands.
+#[derive(Args, Debug, Clone)]
+pub struct MethylationArgs {
+    /// Methylation chemistry mode. When set, enables methylation-aware base
+    /// conversion in simulated reads. Requires --reference for commands that
+    /// generate read bases (fastq-reads, mapped-reads, grouped-reads).
+    #[arg(long = "methylation-mode", value_enum)]
+    pub methylation_mode: Option<MethylationModeArg>,
+
+    /// Fraction of `CpG` cytosines that are methylated [0.0-1.0].
+    /// Methylated `CpG`s are protected from conversion in EM-Seq and are
+    /// targets for conversion in TAPs.
+    #[arg(long = "cpg-methylation-rate", default_value = "0.75")]
+    pub cpg_methylation_rate: f64,
+
+    /// Enzymatic conversion efficiency for target cytosines [0.0-1.0].
+    /// In EM-Seq, this is the probability that an unmethylated C is converted to T.
+    /// In TAPs, this is the probability that a methylated C is converted to T.
+    #[arg(long = "conversion-rate", default_value = "0.98")]
+    pub conversion_rate: f64,
+}
+
+impl MethylationArgs {
+    /// Resolves the optional CLI arg to a [`MethylationConfig`].
+    pub fn resolve(&self) -> MethylationConfig {
+        MethylationConfig {
+            mode: crate::commands::common::resolve_methylation_mode(self.methylation_mode),
+            cpg_methylation_rate: self.cpg_methylation_rate,
+            conversion_rate: self.conversion_rate,
+        }
+    }
+
+    /// Validates that rate parameters are in [0.0, 1.0] and finite.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        validate_rate(self.cpg_methylation_rate, "cpg-methylation-rate")?;
+        validate_rate(self.conversion_rate, "conversion-rate")?;
+        Ok(())
+    }
+}
+
+/// Resolved methylation simulation parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct MethylationConfig {
+    /// Methylation chemistry mode.
+    pub mode: MethylationMode,
+    /// Fraction of `CpG` cytosines that are methylated.
+    pub cpg_methylation_rate: f64,
+    /// Enzymatic conversion efficiency.
+    pub conversion_rate: f64,
+}
+
+/// Validates that a rate is a finite value in [0.0, 1.0].
+fn validate_rate(value: f64, name: &str) -> anyhow::Result<()> {
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        anyhow::bail!("--{name} must be a finite value between 0.0 and 1.0, got {value}");
+    }
+    Ok(())
+}
+
 /// Reference options for mapped reads.
 #[derive(Args, Debug, Clone)]
 pub struct ReferenceArgs {
@@ -202,6 +269,139 @@ pub struct ReferenceArgs {
     /// A larger value prevents position collisions with many molecules.
     #[arg(long = "ref-length", default_value = "250000000")]
     pub ref_length: usize,
+}
+
+/// Loaded reference genome for sampling template sequences.
+pub(super) struct ReferenceGenome {
+    names: Vec<String>,
+    sequences: Vec<Vec<u8>>,
+    cumulative_lengths: Vec<usize>,
+    total_length: usize,
+}
+
+impl ReferenceGenome {
+    /// Load a reference genome from a FASTA file.
+    pub fn load<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        info!("Loading reference from {}", path.display());
+
+        let file = File::open(path)
+            .with_context(|| format!("Failed to open reference: {}", path.display()))?;
+        let reader = BufReader::new(file);
+        let mut fasta_reader = fasta::io::Reader::new(reader);
+
+        let mut names = Vec::new();
+        let mut sequences = Vec::new();
+        let mut cumulative_lengths = Vec::new();
+        let mut total_length = 0usize;
+
+        for result in fasta_reader.records() {
+            let record = result.with_context(|| "Failed to read FASTA record")?;
+            let name = std::str::from_utf8(record.name())
+                .with_context(|| "Invalid chromosome name")?
+                .to_string();
+            let seq: Vec<u8> =
+                record.sequence().as_ref().iter().map(|&b| b.to_ascii_uppercase()).collect();
+
+            if seq.len() >= 1000 {
+                // Only include chromosomes with sufficient length
+                total_length += seq.len();
+                cumulative_lengths.push(total_length);
+                names.push(name);
+                sequences.push(seq);
+            }
+        }
+
+        if sequences.is_empty() {
+            bail!("No valid sequences found in reference FASTA");
+        }
+
+        info!("Loaded {} chromosomes, total {} bp", sequences.len(), total_length);
+
+        Ok(Self { names, sequences, cumulative_lengths, total_length })
+    }
+
+    /// Returns the chromosome name at the given index.
+    pub fn name(&self, chrom_idx: usize) -> &str {
+        &self.names[chrom_idx]
+    }
+
+    /// Sample a random position and return (`chrom_idx`, position, sequence).
+    /// Returns None if the position contains N bases or if `length` exceeds `total_length`.
+    pub fn sample_sequence(
+        &self,
+        length: usize,
+        rng: &mut impl Rng,
+    ) -> Option<(usize, usize, Vec<u8>)> {
+        if length > self.total_length {
+            return None;
+        }
+        let max_start = self.total_length - length;
+        // Try up to 10 times to find a valid position without N bases
+        for _ in 0..10 {
+            // Pick a random position in the genome
+            let genome_pos = rng.random_range(0..=max_start);
+
+            // Find which chromosome this falls in (binary search on sorted cumulative lengths)
+            let chrom_idx = self.cumulative_lengths.partition_point(|&cum| cum <= genome_pos);
+
+            let chrom_start =
+                if chrom_idx == 0 { 0 } else { self.cumulative_lengths[chrom_idx - 1] };
+            let local_pos = genome_pos - chrom_start;
+
+            let seq = &self.sequences[chrom_idx];
+            if local_pos + length > seq.len() {
+                continue;
+            }
+
+            let template = &seq[local_pos..local_pos + length];
+
+            // Check for N bases
+            if template.iter().any(|&b| b == b'N' || b == b'n') {
+                continue;
+            }
+
+            return Some((chrom_idx, local_pos, template.to_vec()));
+        }
+        None
+    }
+
+    /// Returns the total genome length (sum of all loaded chromosome sequences).
+    #[cfg(test)]
+    pub fn total_length(&self) -> usize {
+        self.total_length
+    }
+
+    /// Return the subsequence at a genome-wide position, mapping to the correct
+    /// chromosome automatically. The position wraps around the total genome length.
+    /// Returns None if out of bounds or if the sequence contains N bases.
+    pub fn sequence_at_genome_pos(&self, genome_pos: usize, length: usize) -> Option<Vec<u8>> {
+        if self.total_length == 0 {
+            return None;
+        }
+        let genome_pos = genome_pos % self.total_length;
+        let chrom_idx = self.cumulative_lengths.partition_point(|&cum| cum <= genome_pos);
+        let chrom_start = if chrom_idx == 0 { 0 } else { self.cumulative_lengths[chrom_idx - 1] };
+        let local_pos = genome_pos - chrom_start;
+        self.sequence_at(chrom_idx, local_pos, length)
+    }
+
+    /// Return the subsequence at a specific chromosome and position.
+    /// Returns None if out of bounds or if the sequence contains N bases.
+    pub fn sequence_at(&self, chrom_idx: usize, pos: usize, length: usize) -> Option<Vec<u8>> {
+        if chrom_idx >= self.sequences.len() {
+            return None;
+        }
+        let seq = &self.sequences[chrom_idx];
+        if pos + length > seq.len() {
+            return None;
+        }
+        let subseq = &seq[pos..pos + length];
+        if subseq.iter().any(|&b| b == b'N' || b == b'n') {
+            return None;
+        }
+        Some(subseq.to_vec())
+    }
 }
 
 /// Position distribution options for mapped reads.
@@ -233,6 +433,78 @@ pub(super) fn pad_sequence(mut seq: Vec<u8>, target_len: usize, rng: &mut impl R
     }
     seq.truncate(target_len);
     seq
+}
+
+/// Apply methylation conversion to a read sequence in-place.
+///
+/// For each position in `read_seq` that aligns to a reference C (top strand) or G
+/// (bottom strand), determines the `CpG` context and applies stochastic conversion
+/// based on the methylation mode and rates.
+pub(super) fn apply_methylation_conversion(
+    read_seq: &mut [u8],
+    ref_seq: &[u8],
+    ref_offset: usize,
+    is_top_strand: bool,
+    config: &MethylationConfig,
+    rng: &mut impl Rng,
+) {
+    if !config.mode.is_enabled() {
+        return;
+    }
+
+    for (i, base) in read_seq.iter_mut().enumerate() {
+        let ref_pos = ref_offset + i;
+        if ref_pos >= ref_seq.len() {
+            break;
+        }
+
+        let ref_base = ref_seq[ref_pos].to_ascii_uppercase();
+
+        if is_top_strand && ref_base == b'C' {
+            let cpg = is_cpg_context(ref_seq, ref_pos, true);
+            if is_conversion_target(config.mode, cpg, config.cpg_methylation_rate, rng)
+                && rng.random::<f64>() < config.conversion_rate
+            {
+                *base = b'T';
+            }
+        } else if !is_top_strand && ref_base == b'G' {
+            let cpg = is_cpg_context(ref_seq, ref_pos, false);
+            if is_conversion_target(config.mode, cpg, config.cpg_methylation_rate, rng)
+                && rng.random::<f64>() < config.conversion_rate
+            {
+                *base = b'A';
+            }
+        }
+    }
+}
+
+/// Determines whether a cytosine at this position is a conversion target.
+///
+/// Returns true if the base should be converted (subject to `conversion_rate`).
+///
+/// - EM-Seq converts **unmethylated** C: non-`CpG` always, `CpG` when not methylated
+/// - TAPs converts **methylated** C: `CpG` when methylated, non-`CpG` never
+fn is_conversion_target(
+    mode: MethylationMode,
+    is_cpg: bool,
+    cpg_methylation_rate: f64,
+    rng: &mut impl Rng,
+) -> bool {
+    if is_cpg {
+        let methylated = rng.random::<f64>() < cpg_methylation_rate;
+        match mode {
+            MethylationMode::EmSeq => !methylated, // convert unmethylated
+            MethylationMode::Taps => methylated,   // convert methylated
+            MethylationMode::Disabled => false,
+        }
+    } else {
+        // Non-CpG cytosines are unmethylated
+        match mode {
+            MethylationMode::EmSeq => true, // unmethylated = target
+            MethylationMode::Taps => false, // unmethylated = not a target
+            MethylationMode::Disabled => false,
+        }
+    }
 }
 
 /// Compute the genomic position for a molecule based on its ID.
@@ -747,5 +1019,507 @@ mod tests {
         let a2 = make_molecule_info(99, 1, 100);
         assert_eq!(a, a2);
         assert_eq!(a.cmp(&a2), std::cmp::Ordering::Equal);
+    }
+
+    // ========================================================================
+    // ReferenceGenome tests
+    // ========================================================================
+
+    /// Create a temp FASTA file with a single chromosome of the given sequence.
+    fn write_test_fasta(seq: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, ">chr1").unwrap();
+        f.write_all(seq).unwrap();
+        writeln!(f).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_reference_genome_load_and_sample() {
+        // 1500 bases to exceed the 1000-bp minimum
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert_eq!(genome.name(0), "chr1");
+        assert!(genome.sequence_at(0, 0, 1500).is_some());
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_valid() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let subseq = genome.sequence_at(0, 4, 8).unwrap();
+        assert_eq!(subseq, b"ACGTACGT");
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_out_of_bounds() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert!(genome.sequence_at(0, 1495, 10).is_none());
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_invalid_chrom() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert!(genome.sequence_at(99, 0, 10).is_none());
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_n_bases() {
+        let mut seq = b"ACGT".repeat(375);
+        seq[10] = b'N';
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        // Region containing the N should return None
+        assert!(genome.sequence_at(0, 8, 4).is_none());
+        // Region before the N should succeed
+        assert!(genome.sequence_at(0, 0, 4).is_some());
+    }
+
+    #[test]
+    fn test_reference_genome_skips_short_sequences() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, ">short").unwrap();
+        // 500 bases - below 1000 minimum
+        let short = b"ACGT".repeat(125);
+        f.write_all(&short).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">long").unwrap();
+        let long = b"ACGT".repeat(375);
+        f.write_all(&long).unwrap();
+        writeln!(f).unwrap();
+        f.flush().unwrap();
+
+        let genome = ReferenceGenome::load(f.path()).unwrap();
+        assert_eq!(genome.name(0), "long");
+        assert!(genome.sequence_at(1, 0, 1).is_none()); // only one chromosome loaded
+    }
+
+    #[test]
+    fn test_reference_genome_total_length() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        assert_eq!(genome.total_length(), 1500);
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_genome_pos_single_chrom() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        // Position 4 should map to chr1:4
+        let subseq = genome.sequence_at_genome_pos(4, 8).unwrap();
+        assert_eq!(subseq, b"ACGTACGT");
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_genome_pos_wraps_around() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        // Position beyond total_length should wrap
+        let direct = genome.sequence_at_genome_pos(4, 8).unwrap();
+        let wrapped = genome.sequence_at_genome_pos(4 + genome.total_length(), 8).unwrap();
+        assert_eq!(direct, wrapped);
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_genome_pos_multi_chrom() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, ">chr1").unwrap();
+        let chr1 = b"AAAA".repeat(375); // 1500 bp of A's
+        f.write_all(&chr1).unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, ">chr2").unwrap();
+        let chr2 = b"CCCC".repeat(375); // 1500 bp of C's
+        f.write_all(&chr2).unwrap();
+        writeln!(f).unwrap();
+        f.flush().unwrap();
+
+        let genome = ReferenceGenome::load(f.path()).unwrap();
+        assert_eq!(genome.total_length(), 3000);
+
+        // Position 0 -> chr1, should be A's
+        let from_chr1 = genome.sequence_at_genome_pos(0, 4).unwrap();
+        assert_eq!(from_chr1, b"AAAA");
+
+        // Position 1500 -> chr2, should be C's
+        let from_chr2 = genome.sequence_at_genome_pos(1500, 4).unwrap();
+        assert_eq!(from_chr2, b"CCCC");
+    }
+
+    #[test]
+    fn test_reference_genome_sequence_at_genome_pos_boundary() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        // Request that spans past end of chromosome should fail
+        assert!(genome.sequence_at_genome_pos(1490, 20).is_none());
+    }
+
+    #[test]
+    fn test_reference_genome_sample_sequence_returns_valid() {
+        let seq = b"ACGT".repeat(375);
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let result = genome.sample_sequence(100, &mut rng);
+        assert!(result.is_some());
+        let (chrom_idx, _pos, subseq) = result.unwrap();
+        assert_eq!(chrom_idx, 0);
+        assert_eq!(subseq.len(), 100);
+    }
+
+    #[test]
+    fn test_reference_genome_sample_sequence_exact_fit() {
+        // length == total_length should succeed (not panic from empty range)
+        let seq = b"ACGT".repeat(375); // 1500 bp
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let result = genome.sample_sequence(genome.total_length(), &mut rng);
+        assert!(result.is_some());
+        let (_chrom_idx, pos, subseq) = result.unwrap();
+        assert_eq!(pos, 0);
+        assert_eq!(subseq.len(), genome.total_length());
+    }
+
+    #[test]
+    fn test_reference_genome_sample_sequence_too_large() {
+        // length > total_length should return None (not panic)
+        let seq = b"ACGT".repeat(375); // 1500 bp
+        let fasta = write_test_fasta(&seq);
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let result = genome.sample_sequence(genome.total_length() + 1, &mut rng);
+        assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // MethylationArgs tests
+    // ========================================================================
+
+    #[test]
+    fn test_methylation_args_defaults() {
+        let args = MethylationArgs {
+            methylation_mode: None,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+        };
+        assert!((args.cpg_methylation_rate - 0.75).abs() < f64::EPSILON);
+        assert!((args.conversion_rate - 0.98).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_methylation_args_resolve_disabled() {
+        let args = MethylationArgs {
+            methylation_mode: None,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+        };
+        assert_eq!(args.resolve().mode, MethylationMode::Disabled);
+    }
+
+    #[test]
+    fn test_methylation_args_resolve_emseq() {
+        let args = MethylationArgs {
+            methylation_mode: Some(MethylationModeArg::EmSeq),
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+        };
+        let config = args.resolve();
+        assert_eq!(config.mode, MethylationMode::EmSeq);
+        assert!((config.cpg_methylation_rate - 0.75).abs() < f64::EPSILON);
+        assert!((config.conversion_rate - 0.98).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_methylation_args_resolve_taps() {
+        let args = MethylationArgs {
+            methylation_mode: Some(MethylationModeArg::Taps),
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+        };
+        assert_eq!(args.resolve().mode, MethylationMode::Taps);
+    }
+
+    #[test]
+    fn test_methylation_args_validate_valid_rates() {
+        for rate in [0.0, 0.5, 1.0] {
+            let args = MethylationArgs {
+                methylation_mode: None,
+                cpg_methylation_rate: rate,
+                conversion_rate: rate,
+            };
+            assert!(args.validate().is_ok(), "rate {rate} should be valid");
+        }
+    }
+
+    #[rstest]
+    #[case(-0.1)]
+    #[case(1.1)]
+    #[case(f64::NAN)]
+    #[case(f64::INFINITY)]
+    #[case(f64::NEG_INFINITY)]
+    fn test_methylation_args_validate_invalid_cpg_rate(#[case] rate: f64) {
+        let args = MethylationArgs {
+            methylation_mode: None,
+            cpg_methylation_rate: rate,
+            conversion_rate: 0.98,
+        };
+        assert!(args.validate().is_err(), "cpg rate {rate} should be invalid");
+    }
+
+    #[rstest]
+    #[case(-0.1)]
+    #[case(1.1)]
+    #[case(f64::NAN)]
+    #[case(f64::INFINITY)]
+    fn test_methylation_args_validate_invalid_conversion_rate(#[case] rate: f64) {
+        let args = MethylationArgs {
+            methylation_mode: None,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: rate,
+        };
+        assert!(args.validate().is_err(), "conversion rate {rate} should be invalid");
+    }
+
+    // ========================================================================
+    // apply_methylation_conversion tests
+    // ========================================================================
+
+    /// Helper to apply conversion with deterministic rates.
+    #[allow(clippy::too_many_arguments)]
+    fn convert(
+        seq: &mut [u8],
+        ref_seq: &[u8],
+        ref_offset: usize,
+        is_top: bool,
+        mode: MethylationMode,
+        cpg_rate: f64,
+        conv_rate: f64,
+        seed: u64,
+    ) {
+        let config =
+            MethylationConfig { mode, cpg_methylation_rate: cpg_rate, conversion_rate: conv_rate };
+        let mut rng = create_rng(Some(seed));
+        apply_methylation_conversion(seq, ref_seq, ref_offset, is_top, &config, &mut rng);
+    }
+
+    #[test]
+    fn test_emseq_cpg_all_methylated_no_conversion() {
+        // EM-Seq: methylated CpG = protected, should NOT convert
+        // cpg_methylation_rate=1.0 means all CpGs are methylated
+        let ref_seq = b"ACGTACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 1.0, 1.0, 42);
+        // CpG Cs (at positions 1 and 5) should stay as C (methylated = protected in EM-Seq)
+        assert_eq!(read[1], b'C', "CpG C should be protected when methylated");
+        assert_eq!(read[5], b'C', "CpG C should be protected when methylated");
+    }
+
+    #[test]
+    fn test_emseq_cpg_all_unmethylated_full_conversion() {
+        // EM-Seq: unmethylated CpG = target, should convert C->T
+        // cpg_methylation_rate=0.0 means all CpGs are unmethylated
+        let ref_seq = b"ACGTACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        // CpG Cs should convert to T
+        assert_eq!(read[1], b'T', "unmethylated CpG C should convert to T");
+        assert_eq!(read[5], b'T', "unmethylated CpG C should convert to T");
+    }
+
+    #[test]
+    fn test_emseq_non_cpg_c_always_converts() {
+        // Non-CpG Cs are unmethylated, always targets in EM-Seq
+        // ref = "ACCTA" -> C at pos 1 (non-CpG, followed by C), C at pos 2 (non-CpG, followed by T)
+        let ref_seq = b"ACCTA";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.75, 1.0, 42);
+        assert_eq!(read[1], b'T', "non-CpG C should convert to T in EM-Seq");
+        assert_eq!(read[2], b'T', "non-CpG C should convert to T in EM-Seq");
+    }
+
+    #[test]
+    fn test_taps_cpg_all_methylated_full_conversion() {
+        // TAPs: methylated CpG = target, should convert C->T
+        let ref_seq = b"ACGTACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::Taps, 1.0, 1.0, 42);
+        assert_eq!(read[1], b'T', "methylated CpG C should convert in TAPs");
+        assert_eq!(read[5], b'T', "methylated CpG C should convert in TAPs");
+    }
+
+    #[test]
+    fn test_taps_cpg_all_unmethylated_no_conversion() {
+        // TAPs: unmethylated CpG = not a target, should stay as C
+        let ref_seq = b"ACGTACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::Taps, 0.0, 1.0, 42);
+        assert_eq!(read[1], b'C', "unmethylated CpG C should not convert in TAPs");
+        assert_eq!(read[5], b'C', "unmethylated CpG C should not convert in TAPs");
+    }
+
+    #[test]
+    fn test_taps_non_cpg_c_never_converts() {
+        // Non-CpG Cs are unmethylated, never targets in TAPs
+        let ref_seq = b"ACCTA";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::Taps, 0.75, 1.0, 42);
+        assert_eq!(read[1], b'C', "non-CpG C should not convert in TAPs");
+        assert_eq!(read[2], b'C', "non-CpG C should not convert in TAPs");
+    }
+
+    #[test]
+    fn test_bottom_strand_emseq_converts_g_to_a() {
+        // Bottom strand: G at CpG context = unmethylated target in EM-Seq
+        // ref = "ACGT" -> G at pos 2, preceded by C -> CpG context
+        let ref_seq = b"ACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, false, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        assert_eq!(read[2], b'A', "bottom strand unmethylated CpG G should convert to A");
+    }
+
+    #[test]
+    fn test_bottom_strand_taps_converts_g_to_a() {
+        // Bottom strand: G at CpG context = methylated target in TAPs
+        let ref_seq = b"ACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, false, MethylationMode::Taps, 1.0, 1.0, 42);
+        assert_eq!(read[2], b'A', "bottom strand methylated CpG G should convert to A in TAPs");
+    }
+
+    #[test]
+    fn test_non_target_bases_unchanged_top_strand() {
+        let ref_seq = b"AGTAGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        // No Cs in this sequence, nothing should change
+        assert_eq!(read, b"AGTAGT");
+    }
+
+    #[test]
+    fn test_non_target_bases_unchanged_bottom_strand() {
+        let ref_seq = b"ACTACT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, false, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        // No Gs in this sequence, nothing should change on bottom strand
+        assert_eq!(read, b"ACTACT");
+    }
+
+    #[test]
+    fn test_disabled_mode_no_conversion() {
+        let ref_seq = b"ACGTACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::Disabled, 0.0, 1.0, 42);
+        assert_eq!(read, ref_seq, "Disabled mode should not modify any bases");
+    }
+
+    #[test]
+    fn test_empty_sequence() {
+        let ref_seq = b"";
+        let mut read: Vec<u8> = vec![];
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.75, 0.98, 42);
+        assert!(read.is_empty());
+    }
+
+    #[test]
+    fn test_ref_offset_nonzero() {
+        // Read starts at offset 2 in the reference
+        let ref_seq = b"AACGTAA";
+        //                  ^ offset 2 = C, CpG context
+        let mut read = b"CGT".to_vec();
+        convert(&mut read, ref_seq, 2, true, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        assert_eq!(read[0], b'T', "C at ref_offset=2 (CpG) should convert");
+    }
+
+    #[test]
+    fn test_conversion_rate_zero_no_conversion() {
+        // Even with unmethylated non-CpG C, conversion_rate=0 means no conversion
+        let ref_seq = b"ACCTA";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.0, 0.0, 42);
+        assert_eq!(read[1], b'C', "conversion_rate=0 should prevent conversion");
+        assert_eq!(read[2], b'C', "conversion_rate=0 should prevent conversion");
+    }
+
+    #[test]
+    fn test_probabilistic_emseq_cpg_partial_methylation() {
+        // With cpg_methylation_rate=0.5, roughly half of CpG Cs should convert
+        let ref_seq = b"CG"; // single CpG
+        let mut converted_count = 0;
+        let trials = 10_000;
+        for seed in 0..trials {
+            let mut read = ref_seq.to_vec();
+            convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.5, 1.0, seed);
+            if read[0] == b'T' {
+                converted_count += 1;
+            }
+        }
+        // Expected: ~50% convert (unmethylated) with conversion_rate=1.0
+        let fraction = converted_count as f64 / trials as f64;
+        assert!(
+            (fraction - 0.5).abs() < 0.05,
+            "Expected ~50% conversion at CpG with methylation_rate=0.5, got {fraction:.3}"
+        );
+    }
+
+    #[test]
+    fn test_probabilistic_emseq_non_cpg_partial_conversion_rate() {
+        // Non-CpG C with conversion_rate=0.5 should convert ~50% of the time
+        let ref_seq = b"ACT"; // C at pos 1, non-CpG (followed by T)
+        let mut converted_count = 0;
+        let trials = 10_000;
+        for seed in 0..trials {
+            let mut read = ref_seq.to_vec();
+            convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.75, 0.5, seed);
+            if read[1] == b'T' {
+                converted_count += 1;
+            }
+        }
+        let fraction = converted_count as f64 / trials as f64;
+        assert!(
+            (fraction - 0.5).abs() < 0.05,
+            "Expected ~50% conversion with conversion_rate=0.5, got {fraction:.3}"
+        );
+    }
+
+    #[test]
+    fn test_conversion_rate_zero_leaves_bases_unchanged() {
+        let ref_seq = b"CACACACACACACACAC"; // non-CpG Cs
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.0, 0.0, 42);
+        assert_eq!(read, ref_seq, "conversion_rate=0 should leave all bases unchanged");
+    }
+
+    #[test]
+    fn test_conversion_rate_one_converts_all_targets() {
+        // EM-Seq, cpg_methylation_rate=0 means all CpGs unmethylated -> all Cs are targets
+        let ref_seq = b"CACACACACACACACAC"; // all non-CpG Cs
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::EmSeq, 0.0, 1.0, 42);
+        for (i, &b) in read.iter().enumerate() {
+            if ref_seq[i] == b'C' {
+                assert_eq!(b, b'T', "position {i}: C should be converted with rate=1.0");
+            } else {
+                assert_eq!(b, ref_seq[i], "position {i}: non-C should be unchanged");
+            }
+        }
+    }
+
+    #[test]
+    fn test_disabled_mode_never_converts() {
+        let ref_seq = b"CACGTCACGTCACGT";
+        let mut read = ref_seq.to_vec();
+        convert(&mut read, ref_seq, 0, true, MethylationMode::Disabled, 0.75, 1.0, 42);
+        assert_eq!(read, ref_seq, "Disabled mode should never modify bases");
     }
 }

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -254,21 +254,12 @@ fn validate_rate(value: f64, name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Reference options for mapped reads.
+/// Reference options for simulate commands.
 #[derive(Args, Debug, Clone)]
 pub struct ReferenceArgs {
-    /// Reference FASTA file (sequences sampled from here)
-    #[arg(short = 'r', long = "reference")]
-    pub reference: Option<PathBuf>,
-
-    /// Synthetic reference name (only used if no --reference)
-    #[arg(long = "ref-name", default_value = "chr1")]
-    pub ref_name: String,
-
-    /// Synthetic reference length (only used if no --reference).
-    /// A larger value prevents position collisions with many molecules.
-    #[arg(long = "ref-length", default_value = "250000000")]
-    pub ref_length: usize,
+    /// Reference FASTA file for sampling template sequences and building BAM headers.
+    #[arg(short = 'r', long = "reference", required = true)]
+    pub reference: PathBuf,
 }
 
 /// Loaded reference genome for sampling template sequences.
@@ -367,7 +358,6 @@ impl ReferenceGenome {
     }
 
     /// Returns the total genome length (sum of all loaded chromosome sequences).
-    #[cfg(test)]
     pub fn total_length(&self) -> usize {
         self.total_length
     }

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -3,9 +3,7 @@
 use crate::bam_io::create_bam_writer;
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
-use crate::commands::simulate::common::{
-    MethylationArgs, StrandBiasArgs, generate_random_sequence,
-};
+use crate::commands::simulate::common::{MethylationArgs, ReferenceGenome, StrandBiasArgs};
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
 use crate::sam::builder::{ConsensusTagsBuilder, RecordBuilder};
@@ -30,7 +28,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 
-/// Generate unmapped BAM with consensus tags for `fgumi filter`.
+/// Generate mapped BAM with consensus tags for `fgumi filter`.
 #[derive(Parser, Debug)]
 #[command(
     name = "consensus-reads",
@@ -38,12 +36,12 @@ use std::thread;
     long_about = r#"
 Generate synthetic consensus reads with proper consensus tags.
 
-The output is unmapped and suitable for input to `fgumi filter`.
+The output is a mapped BAM suitable for input to `fgumi filter`.
 Reads contain consensus tags (cD, cM, cE, cd, ce) for filtering.
 "#
 )]
 pub struct ConsensusReads {
-    /// Output BAM file (unmapped)
+    /// Output BAM file (mapped)
     #[arg(short = 'o', long = "output", required = true)]
     pub output: PathBuf,
 
@@ -126,10 +124,15 @@ struct ConsensusReadPair {
     r2_record: RecordBuf,
     /// Truth data: (cD, cM, cE, aD, bD, aM, bM, aE, bE)
     truth: (i32, i32, i32, i32, i32, i32, i32, i32, i32),
+    /// Chromosome name for truth output.
+    chrom_name: String,
+    /// 0-based local position within the chromosome.
+    local_pos: usize,
+    /// Whether the molecule was sampled from the top strand.
+    is_top_strand: bool,
 }
 
 /// Parameters needed for parallel consensus generation.
-#[derive(Clone)]
 struct GenerationParams {
     read_length: usize,
     min_depth: i32,
@@ -146,6 +149,10 @@ struct GenerationParams {
     methylation_depth_dist: LogNormal<f64>,
     /// `CpG` methylation rate.
     cpg_methylation_rate: f64,
+    /// Enzymatic conversion rate for target cytosines.
+    conversion_rate: f64,
+    /// Loaded reference genome for sampling template sequences.
+    ref_genome: Arc<ReferenceGenome>,
 }
 
 /// Channel capacity for buffering read pairs between producer and writer threads.
@@ -177,12 +184,26 @@ impl Command for ConsensusReads {
             info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
         }
 
-        // Build header (no references for unmapped BAM)
+        // Load reference genome
+        let ref_genome = Arc::new(ReferenceGenome::load(&self.reference)?);
+
+        // Validate that the reference has at least one contig >= read_length
+        if ref_genome.max_contig_length() < self.read_length {
+            anyhow::bail!(
+                "No reference contig is >= read length ({} bp). \
+                 The longest contig is {} bp. Use a larger reference or shorter --read-length.",
+                self.read_length,
+                ref_genome.max_contig_length(),
+            );
+        }
+
+        // Build header from reference contigs
+        let ref_header = ref_genome.build_bam_header();
         let mut header_builder = Header::builder();
-
-        // Add @PG record
+        for (name, map) in ref_header.reference_sequences() {
+            header_builder = header_builder.add_reference_sequence(name.clone(), map.clone());
+        }
         header_builder = crate::commands::common::add_pg_to_builder(header_builder, command_line)?;
-
         let header = header_builder.build();
 
         // Set up shared parameters
@@ -207,6 +228,8 @@ impl Command for ConsensusReads {
                 create_depth_distribution(5.0, 2.5)
             },
             cpg_methylation_rate: methylation.cpg_methylation_rate,
+            conversion_rate: methylation.conversion_rate,
+            ref_genome: Arc::clone(&ref_genome),
         });
 
         let strand_bias_model = Arc::new(self.strand_bias.to_strand_bias_model());
@@ -235,7 +258,7 @@ impl Command for ConsensusReads {
                 let truth_file = File::create(truth_path)
                     .with_context(|| format!("Failed to create {}", truth_path.display()))?;
                 let mut w = BufWriter::new(truth_file);
-                writeln!(w, "read_name\tcD\tcM\tcE\taD\tbD\taM\tbM\taE\tbE")?;
+                writeln!(w, "read_name\tchrom\tpos\tstrand\tcD\tcM\tcE\taD\tbD\taM\tbM\taE\tbE")?;
                 Some(w)
             } else {
                 None
@@ -255,10 +278,11 @@ impl Command for ConsensusReads {
                 // Write truth
                 if let Some(ref mut tw) = truth_writer {
                     let (cd, cm, ce, ad, bd, am, bm, ae, be) = pair.truth;
+                    let strand_char = if pair.is_top_strand { '+' } else { '-' };
                     writeln!(
                         tw,
-                        "{}\t{cd}\t{cm}\t{ce}\t{ad}\t{bd}\t{am}\t{bm}\t{ae}\t{be}",
-                        pair.read_name
+                        "{}\t{}\t{}\t{strand_char}\t{cd}\t{cm}\t{ce}\t{ad}\t{bd}\t{am}\t{bm}\t{ae}\t{be}",
+                        pair.read_name, pair.chrom_name, pair.local_pos
                     )?;
                 }
             }
@@ -323,8 +347,11 @@ fn generate_consensus_pair(
     let error_dist = Normal::new(params.error_rate_mean, params.error_rate_stddev)
         .expect("Invalid error distribution parameters");
 
-    // Generate sequence
-    let seq = generate_random_sequence(params.read_length, &mut rng);
+    // Sample sequence from reference
+    let (chrom_idx, local_pos, seq) = params
+        .ref_genome
+        .sample_sequence(params.read_length, &mut rng)
+        .expect("Failed to sample sequence from reference");
     let quals = vec![params.consensus_quality; params.read_length];
 
     // Generate consensus depth (cD)
@@ -364,6 +391,7 @@ fn generate_consensus_pair(
             &seq,
             params.methylation_mode,
             params.cpg_methylation_rate,
+            params.conversion_rate,
             &params.methylation_depth_dist,
             params.duplex,
             &mut rng,
@@ -372,41 +400,68 @@ fn generate_consensus_pair(
         None
     };
 
+    // Coin flip for strand orientation
+    let is_top_strand: bool = rng.random();
+    let r1_is_reverse = !is_top_strand;
+
+    // Compute methylation per read: the forward read gets the original annotation,
+    // the reverse read gets the reversed annotation. Which read is forward depends
+    // on the strand coin flip.
+    let reverse_methylation = methylation.as_ref().map(|m| m.reverse());
+    let (r1_methylation, r2_methylation) = if r1_is_reverse {
+        // R1F2: R1 is reverse, R2 is forward
+        (reverse_methylation.as_ref(), methylation.as_ref())
+    } else {
+        // F1R2: R1 is forward, R2 is reverse
+        (methylation.as_ref(), reverse_methylation.as_ref())
+    };
+
     // Build R1 record
+    let r1_seq = if is_top_strand { seq.clone() } else { reverse_complement(&seq) };
     let r1_record = build_consensus_record(
         &format!("{read_name}/1"),
-        &seq,
+        &r1_seq,
         &quals,
         true, // is_first
+        r1_is_reverse,
+        chrom_idx,
+        local_pos,
         cd,
         cm,
         ce,
         if params.duplex { Some((ad, bd, am, bm, ae, be)) } else { None },
-        methylation.as_ref(),
+        r1_methylation,
         params.methylation_mode,
     );
 
-    // Build R2 record (reverse complement)
-    let r2_seq = reverse_complement(&seq);
-    let r2_methylation = methylation.as_ref().map(|m| m.reverse());
+    // Build R2 record (opposite strand orientation)
+    let r2_seq = if is_top_strand { reverse_complement(&seq) } else { seq.clone() };
     let r2_record = build_consensus_record(
         &format!("{read_name}/2"),
         &r2_seq,
         &quals,
         false, // is_first
+        !r1_is_reverse,
+        chrom_idx,
+        local_pos,
         cd,
         cm,
         ce,
         if params.duplex { Some((ad, bd, am, bm, ae, be)) } else { None },
-        r2_methylation.as_ref(),
+        r2_methylation,
         params.methylation_mode,
     );
+
+    let chrom_name = params.ref_genome.name(chrom_idx).to_string();
 
     ConsensusReadPair {
         read_name,
         r1_record,
         r2_record,
         truth: (cd, cm, ce, ad, bd, am, bm, ae, be),
+        chrom_name,
+        local_pos,
+        is_top_strand,
     }
 }
 
@@ -439,6 +494,7 @@ fn generate_methylation_annotation(
     seq: &[u8],
     mode: MethylationMode,
     cpg_methylation_rate: f64,
+    conversion_rate: f64,
     methylation_depth_dist: &LogNormal<f64>,
     duplex: bool,
     rng: &mut impl Rng,
@@ -478,27 +534,38 @@ fn generate_methylation_annotation(
 
         // In EM-Seq: unconverted = methylated (protected), converted = unmethylated
         // In TAPs: unconverted = unmethylated, converted = methylated
+        //
+        // The conversion_rate controls what fraction of targeted bases are converted.
+        // For the "mostly converted" branch: converted ~= total * conversion_rate
+        // For the "mostly unconverted" branch: unconverted ~= total * conversion_rate
+        // (i.e., conversion_rate reflects the efficiency of the chemistry)
         let (unconverted, converted) = match mode {
             MethylationMode::EmSeq => {
                 if cpg && methylated {
                     // Methylated CpG in EM-Seq: mostly unconverted (protected)
-                    let conv = rng.random_range(0..=total_depth / 5);
-                    (total_depth - conv, conv)
+                    let converted_count =
+                        (total_depth as f64 * (1.0 - conversion_rate)).round() as u32;
+                    (total_depth - converted_count, converted_count)
                 } else {
                     // Unmethylated (non-CpG or unmethylated CpG): mostly converted
-                    let unconverted = rng.random_range(0..=total_depth / 5);
-                    (unconverted, total_depth - unconverted)
+                    let unconverted_count =
+                        (total_depth as f64 * (1.0 - conversion_rate)).round() as u32;
+                    (unconverted_count, total_depth - unconverted_count)
                 }
             }
             MethylationMode::Taps => {
                 if cpg && methylated {
                     // Methylated CpG in TAPs: mostly converted (target)
-                    let unconverted = rng.random_range(0..=total_depth / 5);
-                    (unconverted, total_depth - unconverted)
+                    let unconverted_count =
+                        (total_depth as f64 * (1.0 - conversion_rate)).round() as u32;
+                    (unconverted_count, total_depth - unconverted_count)
                 } else {
-                    // Unmethylated: mostly unconverted (not a target)
-                    let conv = rng.random_range(0..=total_depth / 5);
-                    (total_depth - conv, conv)
+                    // Unmethylated: mostly unconverted (not a target). The minority
+                    // leakage (at most `1 - conversion_rate` fraction) is the number
+                    // of spuriously converted reads.
+                    let leaked_converted =
+                        (total_depth as f64 * (1.0 - conversion_rate)).round() as u32;
+                    (total_depth - leaked_converted, leaked_converted)
                 }
             }
             MethylationMode::Disabled => (0, 0),
@@ -566,6 +633,9 @@ fn build_consensus_record(
     seq: &[u8],
     quals: &[u8],
     is_first: bool,
+    is_reverse: bool,
+    chrom_idx: usize,
+    local_pos: usize,
     cd: i32,
     cm: i32,
     ce: i32,
@@ -574,6 +644,7 @@ fn build_consensus_record(
     methylation_mode: MethylationMode,
 ) -> RecordBuf {
     let seq_str = String::from_utf8_lossy(seq);
+    let is_top_strand = !is_reverse;
 
     // Build consensus tags (note: cE is error count in this file, not error rate)
     let mut consensus_tags =
@@ -596,8 +667,14 @@ fn build_consensus_record(
         .qualities(quals)
         .paired(true)
         .first_segment(is_first)
-        .unmapped(true)
-        .mate_unmapped(true)
+        .reference_sequence_id(chrom_idx)
+        .alignment_start(local_pos + 1) // Convert 0-based to 1-based
+        .mapping_quality(60)
+        .reverse_complement(is_reverse)
+        .mate_reverse_complement(!is_reverse)
+        .mate_reference_sequence_id(chrom_idx)
+        .mate_alignment_start(local_pos + 1) // R1 and R2 at same position
+        .template_length(0)
         .consensus_tags(consensus_tags);
 
     // Add methylation tags if enabled
@@ -608,7 +685,9 @@ fn build_consensus_record(
         builder = builder.tag("cu", cu).tag("ct", ct);
 
         // Add MM/ML tags (SAM spec methylation tags)
-        if let Some((mm, ml)) = build_mm_ml_tags(seq, &meth.annotation, true, methylation_mode) {
+        if let Some((mm, ml)) =
+            build_mm_ml_tags(seq, &meth.annotation, is_top_strand, methylation_mode)
+        {
             builder = builder.tag("MM", mm).tag("ML", ml);
         }
 
@@ -621,14 +700,20 @@ fn build_consensus_record(
             builder = builder.tag("au", au).tag("at", at).tag("bu", bu).tag("bt", bt);
 
             // Add per-strand MM tags (am/bm)
-            if let Some(am) =
-                fgumi_consensus::methylation::build_mm_tag_no_ml(seq, ab, true, methylation_mode)
-            {
+            if let Some(am) = fgumi_consensus::methylation::build_mm_tag_no_ml(
+                seq,
+                ab,
+                is_top_strand,
+                methylation_mode,
+            ) {
                 builder = builder.tag("am", am);
             }
-            if let Some(bm) =
-                fgumi_consensus::methylation::build_mm_tag_no_ml(seq, ba, true, methylation_mode)
-            {
+            if let Some(bm) = fgumi_consensus::methylation::build_mm_tag_no_ml(
+                seq,
+                ba,
+                is_top_strand,
+                methylation_mode,
+            ) {
                 builder = builder.tag("bm", bm);
             }
         }
@@ -640,6 +725,7 @@ fn build_consensus_record(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::simulate::common::generate_random_sequence;
     use crate::simulate::create_rng;
 
     #[test]
@@ -711,19 +797,23 @@ mod tests {
             "test_read/1",
             seq,
             &quals,
-            true, // is_first
-            5,    // cD
-            3,    // cM
-            1,    // cE
-            None, // no duplex tags
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
+            5,     // cD
+            3,     // cM
+            1,     // cE
+            None,  // no duplex tags
             None,
             MethylationMode::Disabled,
         );
 
         assert!(record.name().is_some());
         let flags = record.flags();
-        assert!(flags.is_unmapped());
+        assert!(!flags.is_unmapped());
         assert!(flags.is_first_segment());
+        assert_eq!(record.reference_sequence_id(), Some(0));
     }
 
     #[test]
@@ -735,7 +825,10 @@ mod tests {
             "test_read/1",
             seq,
             &quals,
-            true,
+            true,                     // is_first
+            false,                    // is_reverse
+            0,                        // chrom_idx
+            100,                      // local_pos
             10,                       // cD
             5,                        // cM
             2,                        // cE
@@ -746,7 +839,7 @@ mod tests {
 
         assert!(record.name().is_some());
         let flags = record.flags();
-        assert!(flags.is_unmapped());
+        assert!(!flags.is_unmapped());
     }
 
     #[test]
@@ -759,6 +852,9 @@ mod tests {
             seq,
             &quals,
             false, // is_first = false means R2
+            true,  // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -770,6 +866,7 @@ mod tests {
         let flags = record.flags();
         assert!(flags.is_last_segment());
         assert!(!flags.is_first_segment());
+        assert!(!flags.is_unmapped());
     }
 
     #[test]
@@ -819,7 +916,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_consensus_record_mate_unmapped_flag() {
+    fn test_build_consensus_record_mapped_flags() {
         let seq = b"ACGT";
         let quals = vec![40; 4];
 
@@ -827,7 +924,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -837,8 +937,10 @@ mod tests {
         );
 
         let flags = record.flags();
-        assert!(flags.is_mate_unmapped());
-        assert!(flags.is_unmapped());
+        assert!(!flags.is_mate_unmapped());
+        assert!(!flags.is_unmapped());
+        assert_eq!(record.reference_sequence_id(), Some(0));
+        assert!(record.alignment_start().is_some());
     }
 
     #[test]
@@ -850,7 +952,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -872,7 +977,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -894,7 +1002,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -916,7 +1027,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -937,7 +1051,10 @@ mod tests {
             "test/1",
             &seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -959,7 +1076,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             0,
             0,
             0,
@@ -981,7 +1101,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             10,
             5,
             100,
@@ -1039,7 +1162,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             cd,
             5,
             2,
@@ -1063,6 +1189,9 @@ mod tests {
                 seq,
                 &quals,
                 true,
+                false,
+                0,
+                100,
                 5,
                 3,
                 1,
@@ -1089,6 +1218,7 @@ mod tests {
             seq,
             MethylationMode::EmSeq,
             1.0, // all CpG methylated
+            0.98,
             &dist,
             false,
             &mut rng,
@@ -1102,7 +1232,7 @@ mod tests {
         assert!(data.annotation.evidence[4].is_ref_c);
         assert!(
             data.annotation.evidence[4].converted_count
-                > data.annotation.evidence[4].unconverted_count
+                >= data.annotation.evidence[4].unconverted_count
         );
 
         // Position 1 is G -> not a ref C
@@ -1125,6 +1255,7 @@ mod tests {
             seq,
             MethylationMode::Taps,
             1.0, // all CpG methylated
+            0.98,
             &dist,
             false,
             &mut rng,
@@ -1134,14 +1265,14 @@ mod tests {
         assert!(data.annotation.evidence[0].is_ref_c);
         assert!(
             data.annotation.evidence[0].converted_count
-                > data.annotation.evidence[0].unconverted_count
+                >= data.annotation.evidence[0].unconverted_count
         );
 
         // Position 4 is C not CpG -> unmethylated in TAPs -> mostly unconverted (not a target)
         assert!(data.annotation.evidence[4].is_ref_c);
         assert!(
             data.annotation.evidence[4].unconverted_count
-                > data.annotation.evidence[4].converted_count
+                >= data.annotation.evidence[4].converted_count
         );
     }
 
@@ -1156,6 +1287,7 @@ mod tests {
             seq,
             MethylationMode::EmSeq,
             0.75,
+            0.98,
             &dist,
             false,
             &mut rng,
@@ -1165,7 +1297,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -1203,6 +1338,7 @@ mod tests {
             seq,
             MethylationMode::EmSeq,
             0.75,
+            0.98,
             &dist,
             true, // duplex
             &mut rng,
@@ -1220,7 +1356,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             10,
             5,
             2,
@@ -1242,7 +1381,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -1354,6 +1496,15 @@ mod tests {
 
     #[test]
     fn test_methylation_depth_mean_validation_accepts_when_disabled() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
         // When methylation is disabled, invalid methylation_depth_mean should not error
         let cmd = ConsensusReads {
             output: PathBuf::from("/dev/null"),
@@ -1378,7 +1529,7 @@ mod tests {
                 conversion_rate: 0.98,
             },
             methylation_depth_mean: 0.0,
-            reference: PathBuf::from("dummy.fa"),
+            reference: fasta.path().to_path_buf(),
         };
         // Should succeed since methylation is disabled
         let result = cmd.execute("test");
@@ -1473,7 +1624,10 @@ mod tests {
             "test/1",
             seq,
             &quals,
-            true,
+            true,  // is_first
+            false, // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -1489,7 +1643,10 @@ mod tests {
             "test/2",
             &r2_seq,
             &quals,
-            false,
+            false, // is_first
+            true,  // is_reverse
+            0,     // chrom_idx
+            100,   // local_pos
             5,
             3,
             1,
@@ -1534,5 +1691,53 @@ mod tests {
             r2_ct, r1_ct_rev,
             "R2 ct tag should be reversed relative to R1: R1={r1_ct:?}, R2={r2_ct:?}"
         );
+    }
+
+    #[test]
+    fn test_consensus_reads_produces_mapped_records() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = Arc::new(ReferenceGenome::load(fasta.path()).unwrap());
+        let params = Arc::new(GenerationParams {
+            read_length: 50,
+            min_depth: 1,
+            max_depth: 10,
+            depth_mean: 5.0,
+            depth_stddev: 2.0,
+            error_rate_mean: 0.01,
+            error_rate_stddev: 0.005,
+            duplex: false,
+            consensus_quality: 40,
+            methylation_mode: MethylationMode::Disabled,
+            methylation_depth_dist: create_depth_distribution(5.0, 2.5),
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+            ref_genome: Arc::clone(&ref_genome),
+        });
+        let strand_bias = StrandBiasModel::new(5.0, 5.0);
+
+        let pair = generate_consensus_pair(0, 42, &params, &strand_bias);
+
+        // Records should be mapped
+        assert!(!pair.r1_record.flags().is_unmapped());
+        assert!(!pair.r2_record.flags().is_unmapped());
+
+        // Records should have reference sequence ID
+        assert!(pair.r1_record.reference_sequence_id().is_some());
+        assert!(pair.r2_record.reference_sequence_id().is_some());
+
+        // Records should have alignment start
+        assert!(pair.r1_record.alignment_start().is_some());
+        assert!(pair.r2_record.alignment_start().is_some());
+
+        // Chrom name should be set
+        assert_eq!(pair.chrom_name, "chr1");
     }
 }

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -113,6 +113,10 @@ pub struct ConsensusReads {
     /// Stddev is set to half the mean.
     #[arg(long = "methylation-depth-mean", default_value = "5.0")]
     pub methylation_depth_mean: f64,
+
+    /// Reference FASTA file for sampling template sequences and building BAM headers.
+    #[arg(short = 'r', long = "reference", required = true)]
+    pub reference: PathBuf,
 }
 
 /// A generated consensus read pair ready for output.
@@ -1275,6 +1279,7 @@ mod tests {
                 conversion_rate: 0.98,
             },
             methylation_depth_mean: 0.0,
+            reference: PathBuf::from("dummy.fa"),
         };
         let result = cmd.execute("test");
         assert!(result.is_err());
@@ -1310,6 +1315,7 @@ mod tests {
                 conversion_rate: 0.98,
             },
             methylation_depth_mean: -1.0,
+            reference: PathBuf::from("dummy.fa"),
         };
         let result = cmd.execute("test");
         assert!(result.is_err());
@@ -1340,6 +1346,7 @@ mod tests {
                 conversion_rate: 0.98,
             },
             methylation_depth_mean: f64::NAN,
+            reference: PathBuf::from("dummy.fa"),
         };
         let result = cmd.execute("test");
         assert!(result.is_err());
@@ -1371,6 +1378,7 @@ mod tests {
                 conversion_rate: 0.98,
             },
             methylation_depth_mean: 0.0,
+            reference: PathBuf::from("dummy.fa"),
         };
         // Should succeed since methylation is disabled
         let result = cmd.execute("test");

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -3,7 +3,9 @@
 use crate::bam_io::create_bam_writer;
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
-use crate::commands::simulate::common::{StrandBiasArgs, generate_random_sequence};
+use crate::commands::simulate::common::{
+    MethylationArgs, StrandBiasArgs, generate_random_sequence,
+};
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
 use crate::sam::builder::{ConsensusTagsBuilder, RecordBuilder};
@@ -11,6 +13,10 @@ use crate::simulate::{StrandBiasModel, create_rng};
 use anyhow::{Context, Result};
 use clap::Parser;
 use crossbeam_channel::bounded;
+use fgumi_consensus::MethylationMode;
+use fgumi_consensus::methylation::{
+    MethylationAnnotation, MethylationEvidence, build_mm_ml_tags, is_cpg_context,
+};
 use log::info;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -99,6 +105,14 @@ pub struct ConsensusReads {
 
     #[command(flatten)]
     pub strand_bias: StrandBiasArgs,
+
+    #[command(flatten)]
+    pub methylation: MethylationArgs,
+
+    /// Mean depth for methylation count sampling (cu + ct per position).
+    /// Stddev is set to half the mean.
+    #[arg(long = "methylation-depth-mean", default_value = "5.0")]
+    pub methylation_depth_mean: f64,
 }
 
 /// A generated consensus read pair ready for output.
@@ -122,6 +136,12 @@ struct GenerationParams {
     error_rate_stddev: f64,
     duplex: bool,
     consensus_quality: u8,
+    /// Methylation mode (Disabled if not set).
+    methylation_mode: MethylationMode,
+    /// Distribution for methylation count sampling.
+    methylation_depth_dist: LogNormal<f64>,
+    /// `CpG` methylation rate.
+    cpg_methylation_rate: f64,
 }
 
 /// Channel capacity for buffering read pairs between producer and writer threads.
@@ -129,6 +149,17 @@ const CHANNEL_CAPACITY: usize = 1_000;
 
 impl Command for ConsensusReads {
     fn execute(&self, command_line: &str) -> Result<()> {
+        let methylation = self.methylation.resolve();
+        self.methylation.validate()?;
+        if methylation.mode.is_enabled()
+            && (!self.methylation_depth_mean.is_finite() || self.methylation_depth_mean <= 0.0)
+        {
+            anyhow::bail!(
+                "--methylation-depth-mean must be finite and positive when methylation is enabled, got {}",
+                self.methylation_depth_mean
+            );
+        }
+
         info!("Generating consensus reads");
         info!("  Output: {}", self.output.display());
         info!("  Num reads: {}", self.num_reads);
@@ -136,6 +167,11 @@ impl Command for ConsensusReads {
         info!("  Duplex: {}", self.duplex);
         info!("  Depth range: {}-{}", self.min_depth, self.max_depth);
         info!("  Threads: {}", self.threads);
+        if methylation.mode.is_enabled() {
+            info!("  Methylation mode: {:?}", methylation.mode);
+            info!("  Methylation depth mean: {}", self.methylation_depth_mean);
+            info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
+        }
 
         // Build header (no references for unmapped BAM)
         let mut header_builder = Header::builder();
@@ -156,6 +192,17 @@ impl Command for ConsensusReads {
             error_rate_stddev: self.error_rate_stddev,
             duplex: self.duplex,
             consensus_quality: self.consensus_quality,
+            methylation_mode: methylation.mode,
+            methylation_depth_dist: if methylation.mode.is_enabled() {
+                create_depth_distribution(
+                    self.methylation_depth_mean,
+                    self.methylation_depth_mean / 2.0,
+                )
+            } else {
+                // Unused when methylation is disabled; use safe defaults
+                create_depth_distribution(5.0, 2.5)
+            },
+            cpg_methylation_rate: methylation.cpg_methylation_rate,
         });
 
         let strand_bias_model = Arc::new(self.strand_bias.to_strand_bias_model());
@@ -307,6 +354,20 @@ fn generate_consensus_pair(
         (0, 0, 0, 0, 0, 0)
     };
 
+    // Generate methylation annotation if enabled
+    let methylation = if params.methylation_mode.is_enabled() {
+        Some(generate_methylation_annotation(
+            &seq,
+            params.methylation_mode,
+            params.cpg_methylation_rate,
+            &params.methylation_depth_dist,
+            params.duplex,
+            &mut rng,
+        ))
+    } else {
+        None
+    };
+
     // Build R1 record
     let r1_record = build_consensus_record(
         &format!("{read_name}/1"),
@@ -317,10 +378,13 @@ fn generate_consensus_pair(
         cm,
         ce,
         if params.duplex { Some((ad, bd, am, bm, ae, be)) } else { None },
+        methylation.as_ref(),
+        params.methylation_mode,
     );
 
     // Build R2 record (reverse complement)
     let r2_seq = reverse_complement(&seq);
+    let r2_methylation = methylation.as_ref().map(|m| m.reverse());
     let r2_record = build_consensus_record(
         &format!("{read_name}/2"),
         &r2_seq,
@@ -330,6 +394,8 @@ fn generate_consensus_pair(
         cm,
         ce,
         if params.duplex { Some((ad, bd, am, bm, ae, be)) } else { None },
+        r2_methylation.as_ref(),
+        params.methylation_mode,
     );
 
     ConsensusReadPair {
@@ -337,6 +403,140 @@ fn generate_consensus_pair(
         r1_record,
         r2_record,
         truth: (cd, cm, ce, ad, bd, am, bm, ae, be),
+    }
+}
+
+/// Generated methylation data for a consensus read.
+struct MethylationData {
+    /// Combined annotation (both strands merged for simplex, or total for duplex).
+    annotation: MethylationAnnotation,
+    /// AB strand annotation (duplex only).
+    ab_annotation: Option<MethylationAnnotation>,
+    /// BA strand annotation (duplex only).
+    ba_annotation: Option<MethylationAnnotation>,
+}
+
+impl MethylationData {
+    /// Returns a copy with all annotations reversed.
+    ///
+    /// Used for R2 records where the sequence is reverse-complemented:
+    /// the per-position methylation evidence must be reversed to match.
+    fn reverse(&self) -> Self {
+        Self {
+            annotation: self.annotation.reverse(),
+            ab_annotation: self.ab_annotation.as_ref().map(MethylationAnnotation::reverse),
+            ba_annotation: self.ba_annotation.as_ref().map(MethylationAnnotation::reverse),
+        }
+    }
+}
+
+/// Generate methylation annotation for a consensus sequence.
+fn generate_methylation_annotation(
+    seq: &[u8],
+    mode: MethylationMode,
+    cpg_methylation_rate: f64,
+    methylation_depth_dist: &LogNormal<f64>,
+    duplex: bool,
+    rng: &mut impl Rng,
+) -> MethylationData {
+    let mut evidence = Vec::with_capacity(seq.len());
+    let mut ab_evidence = if duplex { Some(Vec::with_capacity(seq.len())) } else { None };
+    let mut ba_evidence = if duplex { Some(Vec::with_capacity(seq.len())) } else { None };
+
+    for i in 0..seq.len() {
+        let base = seq[i].to_ascii_uppercase();
+        let is_ref_c = base == b'C';
+
+        if !is_ref_c {
+            let zero_ev =
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 };
+            evidence.push(zero_ev.clone());
+            if let Some(ref mut ab) = ab_evidence {
+                ab.push(zero_ev.clone());
+            }
+            if let Some(ref mut ba) = ba_evidence {
+                ba.push(zero_ev);
+            }
+            continue;
+        }
+
+        // This is a C position - determine if CpG
+        let cpg = is_cpg_context(seq, i, true);
+
+        // Determine methylation probability
+        let methylated_prob = if cpg { cpg_methylation_rate } else { 0.0 };
+
+        // Sample total depth for this position
+        let total_depth = sample_depth(methylation_depth_dist, 1, 100, rng) as u32;
+
+        // Sample how many reads show the "unconverted" (methylated in EM-Seq) signal
+        let methylated = rng.random::<f64>() < methylated_prob;
+
+        // In EM-Seq: unconverted = methylated (protected), converted = unmethylated
+        // In TAPs: unconverted = unmethylated, converted = methylated
+        let (unconverted, converted) = match mode {
+            MethylationMode::EmSeq => {
+                if cpg && methylated {
+                    // Methylated CpG in EM-Seq: mostly unconverted (protected)
+                    let conv = rng.random_range(0..=total_depth / 5);
+                    (total_depth - conv, conv)
+                } else {
+                    // Unmethylated (non-CpG or unmethylated CpG): mostly converted
+                    let unconverted = rng.random_range(0..=total_depth / 5);
+                    (unconverted, total_depth - unconverted)
+                }
+            }
+            MethylationMode::Taps => {
+                if cpg && methylated {
+                    // Methylated CpG in TAPs: mostly converted (target)
+                    let unconverted = rng.random_range(0..=total_depth / 5);
+                    (unconverted, total_depth - unconverted)
+                } else {
+                    // Unmethylated: mostly unconverted (not a target)
+                    let conv = rng.random_range(0..=total_depth / 5);
+                    (total_depth - conv, conv)
+                }
+            }
+            MethylationMode::Disabled => (0, 0),
+        };
+
+        let ev = MethylationEvidence {
+            is_ref_c: true,
+            unconverted_count: unconverted,
+            converted_count: converted,
+        };
+
+        if duplex {
+            // Split counts between AB and BA strands
+            let ab_frac = rng.random_range(30..=70) as f64 / 100.0;
+            let ab_unconverted = (unconverted as f64 * ab_frac).round() as u32;
+            let ab_converted = (converted as f64 * ab_frac).round() as u32;
+            let ba_unconverted = unconverted - ab_unconverted;
+            let ba_converted = converted - ab_converted;
+
+            if let Some(ref mut ab) = ab_evidence {
+                ab.push(MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: ab_unconverted,
+                    converted_count: ab_converted,
+                });
+            }
+            if let Some(ref mut ba) = ba_evidence {
+                ba.push(MethylationEvidence {
+                    is_ref_c: true,
+                    unconverted_count: ba_unconverted,
+                    converted_count: ba_converted,
+                });
+            }
+        }
+
+        evidence.push(ev);
+    }
+
+    MethylationData {
+        annotation: MethylationAnnotation { evidence },
+        ab_annotation: ab_evidence.map(|e| MethylationAnnotation { evidence: e }),
+        ba_annotation: ba_evidence.map(|e| MethylationAnnotation { evidence: e }),
     }
 }
 
@@ -366,6 +566,8 @@ fn build_consensus_record(
     cm: i32,
     ce: i32,
     duplex_tags: Option<(i32, i32, i32, i32, i32, i32)>,
+    methylation: Option<&MethylationData>,
+    methylation_mode: MethylationMode,
 ) -> RecordBuf {
     let seq_str = String::from_utf8_lossy(seq);
 
@@ -384,7 +586,7 @@ fn build_consensus_record(
             .ba_errors_int(be);
     }
 
-    RecordBuilder::new()
+    let mut builder = RecordBuilder::new()
         .name(name)
         .sequence(&seq_str)
         .qualities(quals)
@@ -392,8 +594,43 @@ fn build_consensus_record(
         .first_segment(is_first)
         .unmapped(true)
         .mate_unmapped(true)
-        .consensus_tags(consensus_tags)
-        .build()
+        .consensus_tags(consensus_tags);
+
+    // Add methylation tags if enabled
+    if let Some(meth) = methylation {
+        // Add cu/ct tags (unconverted/converted counts per position)
+        let cu: Vec<i16> = meth.annotation.unconverted_counts();
+        let ct: Vec<i16> = meth.annotation.converted_counts();
+        builder = builder.tag("cu", cu).tag("ct", ct);
+
+        // Add MM/ML tags (SAM spec methylation tags)
+        if let Some((mm, ml)) = build_mm_ml_tags(seq, &meth.annotation, true, methylation_mode) {
+            builder = builder.tag("MM", mm).tag("ML", ml);
+        }
+
+        // Add duplex per-strand tags
+        if let (Some(ab), Some(ba)) = (&meth.ab_annotation, &meth.ba_annotation) {
+            let au: Vec<i16> = ab.unconverted_counts();
+            let at: Vec<i16> = ab.converted_counts();
+            let bu: Vec<i16> = ba.unconverted_counts();
+            let bt: Vec<i16> = ba.converted_counts();
+            builder = builder.tag("au", au).tag("at", at).tag("bu", bu).tag("bt", bt);
+
+            // Add per-strand MM tags (am/bm)
+            if let Some(am) =
+                fgumi_consensus::methylation::build_mm_tag_no_ml(seq, ab, true, methylation_mode)
+            {
+                builder = builder.tag("am", am);
+            }
+            if let Some(bm) =
+                fgumi_consensus::methylation::build_mm_tag_no_ml(seq, ba, true, methylation_mode)
+            {
+                builder = builder.tag("bm", bm);
+            }
+        }
+    }
+
+    builder.build()
 }
 
 #[cfg(test)]
@@ -475,6 +712,8 @@ mod tests {
             3,    // cM
             1,    // cE
             None, // no duplex tags
+            None,
+            MethylationMode::Disabled,
         );
 
         assert!(record.name().is_some());
@@ -497,6 +736,8 @@ mod tests {
             5,                        // cM
             2,                        // cE
             Some((6, 4, 3, 2, 1, 1)), // aD, bD, aM, bM, aE, bE
+            None,
+            MethylationMode::Disabled,
         );
 
         assert!(record.name().is_some());
@@ -518,6 +759,8 @@ mod tests {
             3,
             1,
             None,
+            None,
+            MethylationMode::Disabled,
         );
 
         let flags = record.flags();
@@ -576,7 +819,18 @@ mod tests {
         let seq = b"ACGT";
         let quals = vec![40; 4];
 
-        let record = build_consensus_record("test/1", seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         let flags = record.flags();
         assert!(flags.is_mate_unmapped());
@@ -588,7 +842,18 @@ mod tests {
         let seq = b"ACGT";
         let quals = vec![40; 4];
 
-        let record = build_consensus_record("test/1", seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         let flags = record.flags();
         assert!(flags.is_segmented());
@@ -599,7 +864,18 @@ mod tests {
         let seq = b"ACGTACGTACGT";
         let quals = vec![40; 12];
 
-        let record = build_consensus_record("test/1", seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         // Verify sequence length matches
         assert_eq!(record.sequence().len(), 12);
@@ -610,7 +886,18 @@ mod tests {
         let seq = b"ACGT";
         let quals = vec![10, 20, 30, 40];
 
-        let record = build_consensus_record("test/1", seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         let record_quals: Vec<u8> = record.quality_scores().iter().collect();
         assert_eq!(record_quals, quals);
@@ -621,7 +908,18 @@ mod tests {
         let seq: &[u8] = b"";
         let quals: Vec<u8> = vec![];
 
-        let record = build_consensus_record("test/1", seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         assert!(record.name().is_some());
     }
@@ -631,7 +929,18 @@ mod tests {
         let seq = vec![b'A'; 500];
         let quals = vec![40; 500];
 
-        let record = build_consensus_record("test/1", &seq, &quals, true, 5, 3, 1, None);
+        let record = build_consensus_record(
+            "test/1",
+            &seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         assert_eq!(record.sequence().len(), 500);
     }
@@ -642,7 +951,18 @@ mod tests {
         let quals = vec![40; 4];
 
         // Edge case: zero depth (shouldn't happen normally but test it)
-        let record = build_consensus_record("test/1", seq, &quals, true, 0, 0, 0, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            0,
+            0,
+            0,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         assert!(record.name().is_some());
     }
@@ -653,7 +973,18 @@ mod tests {
         let quals = vec![40; 4];
 
         // High error count (more errors than bases)
-        let record = build_consensus_record("test/1", seq, &quals, true, 10, 5, 100, None);
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            10,
+            5,
+            100,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
 
         assert!(record.name().is_some());
     }
@@ -709,6 +1040,8 @@ mod tests {
             5,
             2,
             Some((ad, bd, 3, 2, 1, 1)),
+            None,
+            MethylationMode::Disabled,
         );
 
         assert!(record.name().is_some());
@@ -721,8 +1054,477 @@ mod tests {
         let quals = vec![40; 4];
 
         for name in ["read1/1", "consensus_00000001/1", "test-read_123/2", "a/1"] {
-            let record = build_consensus_record(name, seq, &quals, true, 5, 3, 1, None);
+            let record = build_consensus_record(
+                name,
+                seq,
+                &quals,
+                true,
+                5,
+                3,
+                1,
+                None,
+                None,
+                MethylationMode::Disabled,
+            );
             assert!(record.name().is_some());
         }
+    }
+
+    fn test_methylation_depth_dist() -> LogNormal<f64> {
+        create_depth_distribution(5.0, 2.5)
+    }
+
+    #[test]
+    fn test_generate_methylation_annotation_emseq() {
+        // Sequence with CpG sites: positions 0(C),1(G) is CpG; position 4(C),5(A) is non-CpG
+        let seq = b"CGAACAAT";
+        let mut rng = create_rng(Some(42));
+        let dist = test_methylation_depth_dist();
+
+        let data = generate_methylation_annotation(
+            seq,
+            MethylationMode::EmSeq,
+            1.0, // all CpG methylated
+            &dist,
+            false,
+            &mut rng,
+        );
+
+        // Position 0 is C in CpG context -> methylated in EM-Seq -> mostly unconverted
+        assert!(data.annotation.evidence[0].is_ref_c);
+        assert!(data.annotation.evidence[0].unconverted_count > 0);
+
+        // Position 4 is C but not CpG -> unmethylated in EM-Seq -> mostly converted
+        assert!(data.annotation.evidence[4].is_ref_c);
+        assert!(
+            data.annotation.evidence[4].converted_count
+                > data.annotation.evidence[4].unconverted_count
+        );
+
+        // Position 1 is G -> not a ref C
+        assert!(!data.annotation.evidence[1].is_ref_c);
+
+        // cu/ct should have correct lengths
+        let cu = data.annotation.unconverted_counts();
+        let ct = data.annotation.converted_counts();
+        assert_eq!(cu.len(), seq.len());
+        assert_eq!(ct.len(), seq.len());
+    }
+
+    #[test]
+    fn test_generate_methylation_annotation_taps() {
+        let seq = b"CGAACAAT";
+        let mut rng = create_rng(Some(42));
+        let dist = test_methylation_depth_dist();
+
+        let data = generate_methylation_annotation(
+            seq,
+            MethylationMode::Taps,
+            1.0, // all CpG methylated
+            &dist,
+            false,
+            &mut rng,
+        );
+
+        // Position 0 is C in CpG -> methylated in TAPs -> mostly converted (target)
+        assert!(data.annotation.evidence[0].is_ref_c);
+        assert!(
+            data.annotation.evidence[0].converted_count
+                > data.annotation.evidence[0].unconverted_count
+        );
+
+        // Position 4 is C not CpG -> unmethylated in TAPs -> mostly unconverted (not a target)
+        assert!(data.annotation.evidence[4].is_ref_c);
+        assert!(
+            data.annotation.evidence[4].unconverted_count
+                > data.annotation.evidence[4].converted_count
+        );
+    }
+
+    #[test]
+    fn test_build_consensus_record_with_methylation() {
+        let seq = b"CGAACGAT";
+        let quals = vec![40; 8];
+        let mut rng = create_rng(Some(42));
+        let dist = test_methylation_depth_dist();
+
+        let meth = generate_methylation_annotation(
+            seq,
+            MethylationMode::EmSeq,
+            0.75,
+            &dist,
+            false,
+            &mut rng,
+        );
+
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            Some(&meth),
+            MethylationMode::EmSeq,
+        );
+
+        // Verify methylation tags are present
+        assert!(record.name().is_some());
+        let cu: Vec<i16> = meth.annotation.unconverted_counts();
+        let ct: Vec<i16> = meth.annotation.converted_counts();
+        assert_eq!(cu.len(), seq.len());
+        assert_eq!(ct.len(), seq.len());
+
+        // Verify at C positions cu+ct > 0
+        for (i, &b) in seq.iter().enumerate() {
+            if b == b'C' {
+                assert!(cu[i] + ct[i] > 0, "position {i}: C should have non-zero cu+ct");
+            } else {
+                assert_eq!(cu[i], 0, "position {i}: non-C should have cu=0");
+                assert_eq!(ct[i], 0, "position {i}: non-C should have ct=0");
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_consensus_record_duplex_with_methylation() {
+        let seq = b"CGAACGAT";
+        let quals = vec![40; 8];
+        let mut rng = create_rng(Some(42));
+        let dist = test_methylation_depth_dist();
+
+        let meth = generate_methylation_annotation(
+            seq,
+            MethylationMode::EmSeq,
+            0.75,
+            &dist,
+            true, // duplex
+            &mut rng,
+        );
+
+        // Verify duplex methylation data was generated
+        let ab = meth.ab_annotation.as_ref().expect("AB annotation should be present");
+        let ba = meth.ba_annotation.as_ref().expect("BA annotation should be present");
+
+        // Verify per-strand counts have correct lengths
+        assert_eq!(ab.unconverted_counts().len(), seq.len());
+        assert_eq!(ba.converted_counts().len(), seq.len());
+
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            10,
+            5,
+            2,
+            Some((6, 4, 3, 2, 1, 1)),
+            Some(&meth),
+            MethylationMode::EmSeq,
+        );
+
+        assert!(record.name().is_some());
+    }
+
+    #[test]
+    fn test_no_methylation_tags_when_disabled() {
+        let seq = b"CGAACGAT";
+        let quals = vec![40; 8];
+
+        // When no methylation data is passed, record should still build fine
+        let record = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
+
+        assert!(record.name().is_some());
+    }
+
+    #[test]
+    fn test_methylation_depth_mean_validation_rejects_zero() {
+        let cmd = ConsensusReads {
+            output: PathBuf::from("/dev/null"),
+            truth_output: None,
+            num_reads: 1,
+            read_length: 10,
+            seed: Some(42),
+            threads: 1,
+            compression: CompressionOptions { compression_level: 1 },
+            min_depth: 1,
+            max_depth: 10,
+            depth_mean: 5.0,
+            depth_stddev: 2.0,
+            error_rate_mean: 0.01,
+            error_rate_stddev: 0.005,
+            duplex: false,
+            consensus_quality: 40,
+            strand_bias: StrandBiasArgs { strand_alpha: 5.0, strand_beta: 5.0 },
+            methylation: MethylationArgs {
+                methylation_mode: Some(crate::commands::common::MethylationModeArg::EmSeq),
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            methylation_depth_mean: 0.0,
+        };
+        let result = cmd.execute("test");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("methylation-depth-mean"),
+            "error should mention methylation-depth-mean, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_methylation_depth_mean_validation_rejects_negative() {
+        let cmd = ConsensusReads {
+            output: PathBuf::from("/dev/null"),
+            truth_output: None,
+            num_reads: 1,
+            read_length: 10,
+            seed: Some(42),
+            threads: 1,
+            compression: CompressionOptions { compression_level: 1 },
+            min_depth: 1,
+            max_depth: 10,
+            depth_mean: 5.0,
+            depth_stddev: 2.0,
+            error_rate_mean: 0.01,
+            error_rate_stddev: 0.005,
+            duplex: false,
+            consensus_quality: 40,
+            strand_bias: StrandBiasArgs { strand_alpha: 5.0, strand_beta: 5.0 },
+            methylation: MethylationArgs {
+                methylation_mode: Some(crate::commands::common::MethylationModeArg::EmSeq),
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            methylation_depth_mean: -1.0,
+        };
+        let result = cmd.execute("test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_methylation_depth_mean_validation_rejects_nan() {
+        let cmd = ConsensusReads {
+            output: PathBuf::from("/dev/null"),
+            truth_output: None,
+            num_reads: 1,
+            read_length: 10,
+            seed: Some(42),
+            threads: 1,
+            compression: CompressionOptions { compression_level: 1 },
+            min_depth: 1,
+            max_depth: 10,
+            depth_mean: 5.0,
+            depth_stddev: 2.0,
+            error_rate_mean: 0.01,
+            error_rate_stddev: 0.005,
+            duplex: false,
+            consensus_quality: 40,
+            strand_bias: StrandBiasArgs { strand_alpha: 5.0, strand_beta: 5.0 },
+            methylation: MethylationArgs {
+                methylation_mode: Some(crate::commands::common::MethylationModeArg::EmSeq),
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            methylation_depth_mean: f64::NAN,
+        };
+        let result = cmd.execute("test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_methylation_depth_mean_validation_accepts_when_disabled() {
+        // When methylation is disabled, invalid methylation_depth_mean should not error
+        let cmd = ConsensusReads {
+            output: PathBuf::from("/dev/null"),
+            truth_output: None,
+            num_reads: 0,
+            read_length: 10,
+            seed: Some(42),
+            threads: 1,
+            compression: CompressionOptions { compression_level: 1 },
+            min_depth: 1,
+            max_depth: 10,
+            depth_mean: 5.0,
+            depth_stddev: 2.0,
+            error_rate_mean: 0.01,
+            error_rate_stddev: 0.005,
+            duplex: false,
+            consensus_quality: 40,
+            strand_bias: StrandBiasArgs { strand_alpha: 5.0, strand_beta: 5.0 },
+            methylation: MethylationArgs {
+                methylation_mode: None,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            methylation_depth_mean: 0.0,
+        };
+        // Should succeed since methylation is disabled
+        let result = cmd.execute("test");
+        assert!(result.is_ok(), "disabled methylation should not validate depth mean");
+    }
+
+    #[test]
+    fn test_methylation_annotation_reverse() {
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 10, converted_count: 2 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+                MethylationEvidence { is_ref_c: true, unconverted_count: 3, converted_count: 7 },
+            ],
+        };
+        let reversed = annotation.reverse();
+        assert_eq!(reversed.evidence.len(), 3);
+        assert!(reversed.evidence[0].is_ref_c);
+        assert_eq!(reversed.evidence[0].unconverted_count, 3);
+        assert_eq!(reversed.evidence[0].converted_count, 7);
+        assert!(!reversed.evidence[1].is_ref_c);
+        assert!(reversed.evidence[2].is_ref_c);
+        assert_eq!(reversed.evidence[2].unconverted_count, 10);
+        assert_eq!(reversed.evidence[2].converted_count, 2);
+    }
+
+    #[test]
+    fn test_methylation_data_reverse() {
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 10, converted_count: 2 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let ab = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 6, converted_count: 1 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let ba = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 4, converted_count: 1 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let data = MethylationData { annotation, ab_annotation: Some(ab), ba_annotation: Some(ba) };
+        let reversed = data.reverse();
+
+        // Main annotation reversed
+        assert!(!reversed.annotation.evidence[0].is_ref_c);
+        assert!(reversed.annotation.evidence[1].is_ref_c);
+        assert_eq!(reversed.annotation.evidence[1].unconverted_count, 10);
+
+        // AB reversed
+        let ab_rev = reversed.ab_annotation.unwrap();
+        assert!(!ab_rev.evidence[0].is_ref_c);
+        assert!(ab_rev.evidence[1].is_ref_c);
+        assert_eq!(ab_rev.evidence[1].unconverted_count, 6);
+
+        // BA reversed
+        let ba_rev = reversed.ba_annotation.unwrap();
+        assert!(!ba_rev.evidence[0].is_ref_c);
+        assert!(ba_rev.evidence[1].is_ref_c);
+        assert_eq!(ba_rev.evidence[1].unconverted_count, 4);
+    }
+
+    #[test]
+    fn test_r2_methylation_cu_ct_tags_are_reversed() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
+        // Create a sequence with C positions at known offsets:
+        // "CGAT" has C at pos 0 (CpG context) and nothing else
+        let seq = b"CGAT";
+        let quals = vec![40; 4];
+
+        // Build methylation annotation with distinct counts at each position
+        let annotation = MethylationAnnotation {
+            evidence: vec![
+                MethylationEvidence { is_ref_c: true, unconverted_count: 10, converted_count: 2 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+                MethylationEvidence { is_ref_c: false, unconverted_count: 0, converted_count: 0 },
+            ],
+        };
+        let meth = MethylationData { annotation, ab_annotation: None, ba_annotation: None };
+
+        // Build R1 record (uses original methylation)
+        let r1 = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            5,
+            3,
+            1,
+            None,
+            Some(&meth),
+            MethylationMode::EmSeq,
+        );
+
+        // Build R2 record with reversed methylation (as generate_consensus_pair does)
+        let r2_seq = reverse_complement(seq);
+        let r2_meth = meth.reverse();
+        let r2 = build_consensus_record(
+            "test/2",
+            &r2_seq,
+            &quals,
+            false,
+            5,
+            3,
+            1,
+            None,
+            Some(&r2_meth),
+            MethylationMode::EmSeq,
+        );
+
+        // Extract cu tags from both records
+        let cu_tag = Tag::from([b'c', b'u']);
+        let ct_tag = Tag::from([b'c', b't']);
+
+        let r1_cu = match r1.data().get(&cu_tag) {
+            Some(Value::Array(Array::Int16(arr))) => arr.clone(),
+            other => panic!("Expected Int16 array for cu tag on R1, got {other:?}"),
+        };
+        let r1_ct = match r1.data().get(&ct_tag) {
+            Some(Value::Array(Array::Int16(arr))) => arr.clone(),
+            other => panic!("Expected Int16 array for ct tag on R1, got {other:?}"),
+        };
+
+        let r2_cu = match r2.data().get(&cu_tag) {
+            Some(Value::Array(Array::Int16(arr))) => arr.clone(),
+            other => panic!("Expected Int16 array for cu tag on R2, got {other:?}"),
+        };
+        let r2_ct = match r2.data().get(&ct_tag) {
+            Some(Value::Array(Array::Int16(arr))) => arr.clone(),
+            other => panic!("Expected Int16 array for ct tag on R2, got {other:?}"),
+        };
+
+        // R2's cu/ct should be the reverse of R1's cu/ct
+        let mut r1_cu_rev = r1_cu.clone();
+        r1_cu_rev.reverse();
+        assert_eq!(
+            r2_cu, r1_cu_rev,
+            "R2 cu tag should be reversed relative to R1: R1={r1_cu:?}, R2={r2_cu:?}"
+        );
+
+        let mut r1_ct_rev = r1_ct.clone();
+        r1_ct_rev.reverse();
+        assert_eq!(
+            r2_ct, r1_ct_rev,
+            "R2 ct tag should be reversed relative to R1: R1={r1_ct:?}, R2={r2_ct:?}"
+        );
     }
 }

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -102,10 +102,10 @@ struct ReadRecord {
     mol_id: usize,
     family_id: usize,
     strand: &'static str,
-    /// Chromosome name (if reference-based)
-    chrom: Option<String>,
-    /// 1-based start position (if reference-based)
-    pos: Option<usize>,
+    /// Chromosome name.
+    chrom: String,
+    /// 0-based start position.
+    pos: usize,
 }
 
 /// Parameters needed for parallel molecule generation.
@@ -113,9 +113,10 @@ struct ReadRecord {
 struct GenerationParams {
     umi_length: usize,
     read_length: usize,
-    duplex: bool,
     min_family_size: usize,
     r2_quality_offset: i8,
+    /// Generate duplex-style reads (A/B strand pairs).
+    duplex: bool,
     /// When set, UMIs are sampled from this list instead of generated randomly.
     includelist: Option<Vec<Vec<u8>>>,
     methylation: MethylationConfig,
@@ -226,7 +227,17 @@ impl Command for FastqReads {
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
-        let reference = Some(Arc::new(ReferenceGenome::load(&self.reference)?));
+        let reference = Arc::new(ReferenceGenome::load(&self.reference)?);
+
+        // Validate that the reference has at least one contig >= read_length
+        if reference.max_contig_length() < self.common.read_length {
+            bail!(
+                "No reference contig is >= read length ({} bp). \
+                 The longest contig is {} bp. Use a larger reference or shorter --read-length.",
+                self.common.read_length,
+                reference.max_contig_length(),
+            );
+        }
 
         // Use at least 2 threads for generation if multi-threaded
         // Reserve some threads for gzip compression
@@ -241,9 +252,9 @@ impl Command for FastqReads {
         let params = Arc::new(GenerationParams {
             umi_length,
             read_length: self.common.read_length,
-            duplex: self.duplex,
             min_family_size: self.family_size.min_family_size,
             r2_quality_offset: self.quality.r2_quality_offset,
+            duplex: self.duplex,
             includelist,
             methylation,
         });
@@ -261,8 +272,6 @@ impl Command for FastqReads {
         let r1_path = self.r1_output.clone();
         let r2_path = self.r2_output.clone();
         let truth_path = self.truth_output.clone();
-        let has_reference = reference.is_some();
-
         // Spawn writer thread with multi-threaded gzip compression
         let writer_handle = thread::spawn(move || -> Result<u64> {
             let mut r1_writer = FastqWriter::with_threads(&r1_path, compress_threads)?;
@@ -271,15 +280,10 @@ impl Command for FastqReads {
                 .with_context(|| format!("Failed to create {}", truth_path.display()))?;
             let mut truth_writer = BufWriter::new(truth_file);
 
-            // Write truth header (include chrom/pos if reference-based)
-            if has_reference {
-                writeln!(
-                    truth_writer,
-                    "read_name\ttrue_umi\tmolecule_id\tfamily_id\tstrand\tchrom\tpos"
-                )?;
-            } else {
-                writeln!(truth_writer, "read_name\ttrue_umi\tmolecule_id\tfamily_id\tstrand")?;
-            }
+            writeln!(
+                truth_writer,
+                "read_name\ttrue_umi\tmolecule_id\tfamily_id\tstrand\tchrom\tpos"
+            )?;
 
             let mut read_count = 0u64;
             let progress = ProgressTracker::new("Generated read pairs").with_interval(100_000);
@@ -293,29 +297,17 @@ impl Command for FastqReads {
                     r2_writer.write_record(&record.read_name, &record.r2_seq, &record.r2_quals)?;
 
                     // Write truth
-                    if has_reference {
-                        writeln!(
-                            truth_writer,
-                            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                            record.read_name,
-                            String::from_utf8_lossy(&record.umi),
-                            record.mol_id,
-                            record.family_id,
-                            record.strand,
-                            record.chrom.as_deref().unwrap_or("."),
-                            record.pos.map_or_else(|| ".".to_string(), |p| (p + 1).to_string())
-                        )?;
-                    } else {
-                        writeln!(
-                            truth_writer,
-                            "{}\t{}\t{}\t{}\t{}",
-                            record.read_name,
-                            String::from_utf8_lossy(&record.umi),
-                            record.mol_id,
-                            record.family_id,
-                            record.strand
-                        )?;
-                    }
+                    writeln!(
+                        truth_writer,
+                        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                        record.read_name,
+                        String::from_utf8_lossy(&record.umi),
+                        record.mol_id,
+                        record.family_id,
+                        record.strand,
+                        record.chrom,
+                        record.pos
+                    )?;
                 }
             }
 
@@ -345,7 +337,7 @@ impl Command for FastqReads {
                         &quality_bias,
                         &family_dist,
                         &insert_model,
-                        reference.as_deref(),
+                        &reference,
                     );
                     sender.send(batch)
                 })
@@ -380,7 +372,7 @@ fn generate_molecule_reads(
     quality_bias: &crate::simulate::ReadPairQualityBias,
     family_dist: &crate::simulate::FamilySizeDistribution,
     insert_model: &crate::simulate::InsertSizeModel,
-    reference: Option<&ReferenceGenome>,
+    reference: &ReferenceGenome,
 ) -> Vec<ReadRecord> {
     let mut rng = create_rng(Some(seed));
     let mut records = Vec::new();
@@ -406,23 +398,11 @@ fn generate_molecule_reads(
     let insert_size = insert_model.sample(&mut rng);
 
     // Generate template sequence (shared by all reads in family)
-    // Either sample from reference or generate random
     let template_len = insert_size.saturating_sub(params.umi_length);
-    let (template, chrom, pos) = if let Some(ref_genome) = reference {
-        // Sample from reference
-        if let Some((chrom_idx, local_pos, seq)) =
-            ref_genome.sample_sequence(template_len, &mut rng)
-        {
-            let chrom_name = ref_genome.name(chrom_idx).to_string();
-            (seq, Some(chrom_name), Some(local_pos))
-        } else {
-            // Fallback to random if sampling failed (e.g., all N regions)
-            (generate_random_sequence(template_len, &mut rng), None, None)
-        }
-    } else {
-        // Generate random template
-        (generate_random_sequence(template_len, &mut rng), None, None)
-    };
+    let (chrom_idx, pos, template) = reference
+        .sample_sequence(template_len, &mut rng)
+        .expect("Failed to sample sequence from reference");
+    let chrom = reference.name(chrom_idx).to_string();
 
     // Pre-calculate template slicing bounds (both reads have UMI prefix)
     let template_len = params.read_length.saturating_sub(params.umi_length);
@@ -436,11 +416,9 @@ fn generate_molecule_reads(
     let mut read_counter = 0usize;
 
     // For duplex mode, each read pair is independently assigned to A or B strand (coin flip)
-    // For non-duplex mode, all reads are A strand
+    // For non-duplex mode, all reads are A strand (no UMI swapping or orientation change)
     for read_idx in 0..family_size {
-        // Determine strand for this read pair
         let (strand, family_idx): (&'static str, usize) = if params.duplex {
-            // 50/50 coin flip for A or B strand
             if rng.random_bool(0.5) { ("A", 0) } else { ("B", 1) }
         } else {
             ("A", 0)
@@ -1024,13 +1002,23 @@ mod tests {
 
     #[test]
     fn test_generate_molecule_reads_with_includelist() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+
         let umis = vec![b"AAAAA".to_vec(), b"CCCCC".to_vec(), b"GGGGG".to_vec()];
         let params = GenerationParams {
             umi_length: 5,
             read_length: 50,
-            duplex: false,
             min_family_size: 1,
             r2_quality_offset: 0,
+            duplex: false,
             includelist: Some(umis.clone()),
             methylation: MethylationConfig {
                 mode: fgumi_consensus::MethylationMode::Disabled,
@@ -1055,7 +1043,7 @@ mod tests {
                 &quality_bias,
                 &family_dist,
                 &insert_model,
-                None,
+                &ref_genome,
             );
             for record in &records {
                 // The truth UMI (before errors) should be from the includelist

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -3,7 +3,8 @@
 use crate::commands::command::Command;
 use crate::commands::common::parse_bool;
 use crate::commands::simulate::common::{
-    FamilySizeArgs, InsertSizeArgs, QualityArgs, SimulationCommon, generate_random_sequence,
+    FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, QualityArgs,
+    ReferenceGenome, SimulationCommon, apply_methylation_conversion, generate_random_sequence,
 };
 use crate::progress::ProgressTracker;
 use crate::simulate::{FastqWriter, create_rng};
@@ -12,7 +13,6 @@ use clap::Parser;
 use crossbeam_channel::bounded;
 use fgumi_dna::dna::complement_base;
 use log::{info, warn};
-use noodles::fasta;
 use rand::{Rng, RngExt};
 use rayon::prelude::*;
 use std::fs::File;
@@ -88,6 +88,9 @@ pub struct FastqReads {
 
     #[command(flatten)]
     pub insert_size: InsertSizeArgs,
+
+    #[command(flatten)]
+    pub methylation: MethylationArgs,
 }
 
 /// A single read record ready for output.
@@ -107,97 +110,6 @@ struct ReadRecord {
     pos: Option<usize>,
 }
 
-/// Loaded reference genome for sampling template sequences.
-struct ReferenceGenome {
-    /// Chromosome names
-    names: Vec<String>,
-    /// Chromosome sequences (uppercase)
-    sequences: Vec<Vec<u8>>,
-    /// Cumulative lengths for weighted random selection
-    cumulative_lengths: Vec<usize>,
-    /// Total genome length
-    total_length: usize,
-}
-
-impl ReferenceGenome {
-    /// Load a reference genome from a FASTA file.
-    fn load(path: &PathBuf) -> Result<Self> {
-        info!("Loading reference from {}", path.display());
-
-        let file = File::open(path)
-            .with_context(|| format!("Failed to open reference: {}", path.display()))?;
-        let reader = BufReader::new(file);
-        let mut fasta_reader = fasta::io::Reader::new(reader);
-
-        let mut names = Vec::new();
-        let mut sequences = Vec::new();
-        let mut cumulative_lengths = Vec::new();
-        let mut total_length = 0usize;
-
-        for result in fasta_reader.records() {
-            let record = result.with_context(|| "Failed to read FASTA record")?;
-            let name = std::str::from_utf8(record.name())
-                .with_context(|| "Invalid chromosome name")?
-                .to_string();
-            let seq: Vec<u8> =
-                record.sequence().as_ref().iter().map(|&b| b.to_ascii_uppercase()).collect();
-
-            if seq.len() >= 1000 {
-                // Only include chromosomes with sufficient length
-                total_length += seq.len();
-                cumulative_lengths.push(total_length);
-                names.push(name);
-                sequences.push(seq);
-            }
-        }
-
-        if sequences.is_empty() {
-            bail!("No valid sequences found in reference FASTA");
-        }
-
-        info!("Loaded {} chromosomes, total {} bp", sequences.len(), total_length);
-
-        Ok(Self { names, sequences, cumulative_lengths, total_length })
-    }
-
-    /// Sample a random position and return (`chrom_idx`, position, sequence).
-    /// Returns None if the position contains N bases.
-    fn sample_sequence(
-        &self,
-        length: usize,
-        rng: &mut impl Rng,
-    ) -> Option<(usize, usize, Vec<u8>)> {
-        // Try up to 10 times to find a valid position without N bases
-        for _ in 0..10 {
-            // Pick a random position in the genome
-            let genome_pos = rng.random_range(0..self.total_length.saturating_sub(length));
-
-            // Find which chromosome this falls in
-            let chrom_idx =
-                self.cumulative_lengths.iter().position(|&cum| cum > genome_pos).unwrap_or(0);
-
-            let chrom_start =
-                if chrom_idx == 0 { 0 } else { self.cumulative_lengths[chrom_idx - 1] };
-            let local_pos = genome_pos - chrom_start;
-
-            let seq = &self.sequences[chrom_idx];
-            if local_pos + length > seq.len() {
-                continue;
-            }
-
-            let template = &seq[local_pos..local_pos + length];
-
-            // Check for N bases
-            if template.iter().any(|&b| b == b'N' || b == b'n') {
-                continue;
-            }
-
-            return Some((chrom_idx, local_pos, template.to_vec()));
-        }
-        None
-    }
-}
-
 /// Parameters needed for parallel molecule generation.
 #[derive(Clone)]
 struct GenerationParams {
@@ -208,6 +120,7 @@ struct GenerationParams {
     r2_quality_offset: i8,
     /// When set, UMIs are sampled from this list instead of generated randomly.
     includelist: Option<Vec<Vec<u8>>>,
+    methylation: MethylationConfig,
 }
 
 /// Load UMI sequences from an includelist file (one UMI per line).
@@ -292,6 +205,13 @@ impl Command for FastqReads {
             self.common.umi_length
         };
 
+        // Validate methylation args
+        let methylation = self.methylation.resolve();
+        self.methylation.validate()?;
+        if methylation.mode.is_enabled() && self.reference.is_none() {
+            bail!("--methylation-mode requires --reference");
+        }
+
         info!("Generating FASTQ reads");
         info!("  Output R1: {}", self.r1_output.display());
         info!("  Output R2: {}", self.r2_output.display());
@@ -306,6 +226,11 @@ impl Command for FastqReads {
         info!("  Threads: {}", self.threads);
         if let Some(ref path) = self.reference {
             info!("  Reference: {}", path.display());
+        }
+        if methylation.mode.is_enabled() {
+            info!("  Methylation mode: {:?}", methylation.mode);
+            info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
+            info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
         let reference = if let Some(ref path) = self.reference {
@@ -331,6 +256,7 @@ impl Command for FastqReads {
             min_family_size: self.family_size.min_family_size,
             r2_quality_offset: self.quality.r2_quality_offset,
             includelist,
+            methylation,
         });
 
         // Generate molecule IDs with seeds for reproducibility
@@ -498,7 +424,7 @@ fn generate_molecule_reads(
         if let Some((chrom_idx, local_pos, seq)) =
             ref_genome.sample_sequence(template_len, &mut rng)
         {
-            let chrom_name = ref_genome.names[chrom_idx].clone();
+            let chrom_name = ref_genome.name(chrom_idx).to_string();
             (seq, Some(chrom_name), Some(local_pos))
         } else {
             // Fallback to random if sampling failed (e.g., all N regions)
@@ -510,9 +436,8 @@ fn generate_molecule_reads(
     };
 
     // Pre-calculate template slicing bounds (both reads have UMI prefix)
-    let r1_template_len = params.read_length.saturating_sub(params.umi_length);
-    let r2_template_len = params.read_length.saturating_sub(params.umi_length);
-    let r2_start = template.len().saturating_sub(r2_template_len);
+    let template_len = params.read_length.saturating_sub(params.umi_length);
+    let r2_start = template.len().saturating_sub(template_len);
     let r2_end = template.len();
 
     // Reusable buffers for sequence building
@@ -559,14 +484,32 @@ fn generate_molecule_reads(
 
         if strand == "A" {
             // A strand: standard forward orientation
-            // R1 = UMI + template start (maps forward)
+            // R1 reads the top strand (forward) — apply C→T conversion
             r1_seq_buf.extend_from_slice(r1_umi);
-            let r1_template_end = r1_template_len.min(template.len());
-            r1_seq_buf.extend_from_slice(&template[..r1_template_end]);
+            let r1_template_end = template_len.min(template.len());
+            let mut r1_template = template[..r1_template_end].to_vec();
+            apply_methylation_conversion(
+                &mut r1_template,
+                &template,
+                0,
+                true, // top strand
+                &params.methylation,
+                &mut rng,
+            );
+            r1_seq_buf.extend_from_slice(&r1_template);
 
-            // R2 = UMI + revcomp(template end) (maps reverse)
+            // R2 reads the bottom strand (reverse) — apply G→A conversion, then RC
             r2_seq_buf.extend_from_slice(r2_umi);
-            reverse_complement_into(&template[r2_start..r2_end], &mut r2_seq_buf);
+            let mut r2_template = template[r2_start..r2_end].to_vec();
+            apply_methylation_conversion(
+                &mut r2_template,
+                &template,
+                r2_start,
+                false, // bottom strand
+                &params.methylation,
+                &mut rng,
+            );
+            reverse_complement_into(&r2_template, &mut r2_seq_buf);
         } else {
             // B strand: comes from the complementary DNA strand of the same molecule
             // For duplex sequencing, A and B strand reads should align to the SAME positions
@@ -579,14 +522,32 @@ fn generate_molecule_reads(
             // - B R1 covers the same region as A R2 (template end), sequenced from revcomp
             // - B R2 covers the same region as A R1 (template start), sequenced forward
 
-            // B R1 = UMI + revcomp(template end) - same region as A R2
+            // B R1 reads the bottom strand (template end, reverse) — apply G→A, then RC
             r1_seq_buf.extend_from_slice(r1_umi);
-            reverse_complement_into(&template[r2_start..r2_end], &mut r1_seq_buf);
+            let mut r1_template = template[r2_start..r2_end].to_vec();
+            apply_methylation_conversion(
+                &mut r1_template,
+                &template,
+                r2_start,
+                false, // bottom strand
+                &params.methylation,
+                &mut rng,
+            );
+            reverse_complement_into(&r1_template, &mut r1_seq_buf);
 
-            // B R2 = UMI + template start - same region as A R1
+            // B R2 reads the top strand (template start, forward) — apply C→T
             r2_seq_buf.extend_from_slice(r2_umi);
-            let r1_template_end = r1_template_len.min(template.len());
-            r2_seq_buf.extend_from_slice(&template[..r1_template_end]);
+            let r1_template_end = template_len.min(template.len());
+            let mut r2_template = template[..r1_template_end].to_vec();
+            apply_methylation_conversion(
+                &mut r2_template,
+                &template,
+                0,
+                true, // top strand
+                &params.methylation,
+                &mut rng,
+            );
+            r2_seq_buf.extend_from_slice(&r2_template);
         }
 
         // Introduce UMI errors directly into buffer
@@ -1078,6 +1039,11 @@ mod tests {
             min_family_size: 1,
             r2_quality_offset: 0,
             includelist: Some(umis.clone()),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
         };
 
         let quality_model =
@@ -1118,5 +1084,147 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_execute_methylation_requires_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let r1 = dir.path().join("r1.fq.gz");
+        let r2 = dir.path().join("r2.fq.gz");
+        let truth = dir.path().join("truth.tsv");
+
+        let cmd = FastqReads {
+            r1_output: r1,
+            r2_output: r2,
+            truth_output: truth,
+            read_structure_r1: "8M+T".to_string(),
+            read_structure_r2: "+T".to_string(),
+            duplex: false,
+            reference: None,
+            includelist: None,
+            threads: 1,
+            common: SimulationCommon {
+                seed: Some(42),
+                num_molecules: 10,
+                read_length: 100,
+                umi_length: 8,
+            },
+            quality: QualityArgs {
+                warmup_bases: 5,
+                warmup_quality: 25,
+                peak_quality: 37,
+                decay_start: 80,
+                decay_rate: 0.08,
+                quality_noise: 2.0,
+                r2_quality_offset: 0,
+            },
+            family_size: FamilySizeArgs {
+                family_size_dist: "lognormal".to_string(),
+                family_size_mean: 3.0,
+                family_size_stddev: 1.0,
+                family_size_r: 2.0,
+                family_size_p: 0.5,
+                min_family_size: 1,
+            },
+            insert_size: InsertSizeArgs {
+                insert_size_mean: 150.0,
+                insert_size_stddev: 30.0,
+                insert_size_min: 50,
+                insert_size_max: 500,
+            },
+            methylation: MethylationArgs {
+                methylation_mode: Some(crate::commands::common::MethylationModeArg::EmSeq),
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+        };
+
+        let result = cmd.execute("test");
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("--methylation-mode requires --reference")
+        );
+    }
+
+    #[test]
+    fn test_emseq_fastq_reads_converts_non_cpg_c() {
+        // With EM-Seq, non-CpG C should be converted to T (on top strand R1)
+        // Use a reference that has a known pattern: all C's with no adjacent G
+        // Template: "CACACACACA..." (no CpG dinucleotides)
+        use crate::commands::simulate::common::apply_methylation_conversion;
+
+        let template = b"CACACACACACACACACACAC".to_vec();
+        let mut r1 = template.clone();
+        let mut rng = create_rng(Some(42));
+
+        let config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::EmSeq,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 1.0,
+        };
+        apply_methylation_conversion(&mut r1, &template, 0, true, &config, &mut rng);
+
+        // All C's should be converted to T (non-CpG in EM-Seq)
+        for (i, &b) in r1.iter().enumerate() {
+            if template[i] == b'C' {
+                assert_eq!(b, b'T', "position {i}: non-CpG C should be converted to T in EM-Seq");
+            } else {
+                assert_eq!(b, template[i], "position {i}: A should remain unchanged");
+            }
+        }
+    }
+
+    #[test]
+    fn test_taps_fastq_reads_preserves_non_cpg_c() {
+        // With TAPs, non-CpG C should NOT be converted
+        use crate::commands::simulate::common::apply_methylation_conversion;
+
+        let template = b"CACACACACACACACACACAC".to_vec();
+        let mut r1 = template.clone();
+        let mut rng = create_rng(Some(42));
+
+        let config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::Taps,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 1.0,
+        };
+        apply_methylation_conversion(&mut r1, &template, 0, true, &config, &mut rng);
+
+        // No changes — non-CpG C is not a target in TAPs
+        assert_eq!(r1, template);
+    }
+
+    #[test]
+    fn test_reads_in_same_family_differ_with_methylation() {
+        // Each read independently samples conversion, so two reads from
+        // the same molecule should (usually) differ when rates are partial
+        use crate::commands::simulate::common::apply_methylation_conversion;
+
+        // Template with CpG sites
+        let template = b"ACGTCGATCGACGTCGATCG".to_vec();
+        let mut different_count = 0;
+
+        let config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::EmSeq,
+            cpg_methylation_rate: 0.5,
+            conversion_rate: 0.5,
+        };
+
+        for seed in 0..50u64 {
+            let mut r1_a = template.clone();
+            let mut r1_b = template.clone();
+            let mut rng_a = create_rng(Some(seed * 2));
+            let mut rng_b = create_rng(Some(seed * 2 + 1));
+
+            apply_methylation_conversion(&mut r1_a, &template, 0, true, &config, &mut rng_a);
+            apply_methylation_conversion(&mut r1_b, &template, 0, true, &config, &mut rng_b);
+
+            if r1_a != r1_b {
+                different_count += 1;
+            }
+        }
+
+        // With 50% CpG methylation rate, most pairs should differ
+        assert!(different_count > 10, "Expected most read pairs to differ, got {different_count}");
     }
 }

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -62,10 +62,8 @@ pub struct FastqReads {
     pub duplex: bool,
 
     /// Reference FASTA file for sampling template sequences.
-    /// If provided, templates are sampled from this reference instead of random bases.
-    /// This produces reads that will map back to the reference.
-    #[arg(short = 'r', long = "reference")]
-    pub reference: Option<PathBuf>,
+    #[arg(short = 'r', long = "reference", required = true)]
+    pub reference: PathBuf,
 
     /// UMI includelist file (one UMI per line).
     /// When provided, UMIs are sampled from this list instead of generated randomly.
@@ -208,9 +206,6 @@ impl Command for FastqReads {
         // Validate methylation args
         let methylation = self.methylation.resolve();
         self.methylation.validate()?;
-        if methylation.mode.is_enabled() && self.reference.is_none() {
-            bail!("--methylation-mode requires --reference");
-        }
 
         info!("Generating FASTQ reads");
         info!("  Output R1: {}", self.r1_output.display());
@@ -224,20 +219,14 @@ impl Command for FastqReads {
         }
         info!("  Duplex: {}", self.duplex);
         info!("  Threads: {}", self.threads);
-        if let Some(ref path) = self.reference {
-            info!("  Reference: {}", path.display());
-        }
+        info!("  Reference: {}", self.reference.display());
         if methylation.mode.is_enabled() {
             info!("  Methylation mode: {:?}", methylation.mode);
             info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
-        let reference = if let Some(ref path) = self.reference {
-            Some(Arc::new(ReferenceGenome::load(path)?))
-        } else {
-            None
-        };
+        let reference = Some(Arc::new(ReferenceGenome::load(&self.reference)?));
 
         // Use at least 2 threads for generation if multi-threaded
         // Reserve some threads for gzip compression
@@ -982,6 +971,8 @@ mod tests {
             r2.to_str().expect("path should be valid UTF-8"),
             "--truth",
             truth.to_str().expect("path should be valid UTF-8"),
+            "-r",
+            "dummy.fa",
             "-i",
             includelist_path.to_str().expect("path should be valid UTF-8"),
             "--read-length",
@@ -1013,6 +1004,8 @@ mod tests {
             r2.to_str().expect("path should be valid UTF-8"),
             "--truth",
             truth.to_str().expect("path should be valid UTF-8"),
+            "-r",
+            "dummy.fa",
             "--umi-length",
             "100",
             "--read-length",
@@ -1084,66 +1077,6 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn test_execute_methylation_requires_reference() {
-        let dir = tempfile::tempdir().unwrap();
-        let r1 = dir.path().join("r1.fq.gz");
-        let r2 = dir.path().join("r2.fq.gz");
-        let truth = dir.path().join("truth.tsv");
-
-        let cmd = FastqReads {
-            r1_output: r1,
-            r2_output: r2,
-            truth_output: truth,
-            read_structure_r1: "8M+T".to_string(),
-            read_structure_r2: "+T".to_string(),
-            duplex: false,
-            reference: None,
-            includelist: None,
-            threads: 1,
-            common: SimulationCommon {
-                seed: Some(42),
-                num_molecules: 10,
-                read_length: 100,
-                umi_length: 8,
-            },
-            quality: QualityArgs {
-                warmup_bases: 5,
-                warmup_quality: 25,
-                peak_quality: 37,
-                decay_start: 80,
-                decay_rate: 0.08,
-                quality_noise: 2.0,
-                r2_quality_offset: 0,
-            },
-            family_size: FamilySizeArgs {
-                family_size_dist: "lognormal".to_string(),
-                family_size_mean: 3.0,
-                family_size_stddev: 1.0,
-                family_size_r: 2.0,
-                family_size_p: 0.5,
-                min_family_size: 1,
-            },
-            insert_size: InsertSizeArgs {
-                insert_size_mean: 150.0,
-                insert_size_stddev: 30.0,
-                insert_size_min: 50,
-                insert_size_max: 500,
-            },
-            methylation: MethylationArgs {
-                methylation_mode: Some(crate::commands::common::MethylationModeArg::EmSeq),
-                cpg_methylation_rate: 0.75,
-                conversion_rate: 0.98,
-            },
-        };
-
-        let result = cmd.execute("test");
-        assert!(result.is_err());
-        assert!(
-            result.unwrap_err().to_string().contains("--methylation-mode requires --reference")
-        );
     }
 
     #[test]

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -11,8 +11,7 @@ use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
     PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
-    StrandBiasArgs, apply_methylation_conversion, compute_position, generate_random_sequence,
-    pad_sequence,
+    StrandBiasArgs, apply_methylation_conversion, generate_random_sequence, pad_sequence,
 };
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
@@ -106,8 +105,6 @@ struct GenerationParams {
     mapq: u8,
     duplex: bool,
     min_family_size: usize,
-    num_positions: usize,
-    ref_length: usize,
     quality_model: PositionQualityModel,
     quality_bias: ReadPairQualityBias,
     family_dist: FamilySizeDistribution,
@@ -117,6 +114,7 @@ struct GenerationParams {
 }
 
 impl Command for GroupedReads {
+    #[allow(unreachable_code, unused_variables, unused_mut, clippy::diverging_sub_expression)] // todo!() stubs pending position-table lookup
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate methylation args
         let methylation = self.methylation.resolve();
@@ -191,8 +189,6 @@ impl Command for GroupedReads {
             mapq: self.mapq,
             duplex: self.duplex,
             min_family_size: self.family_size.min_family_size,
-            num_positions,
-            ref_length,
             quality_model: self.quality.to_quality_model(),
             quality_bias: self.quality.to_quality_bias(),
             family_dist: self.family_size.to_family_size_distribution()?,
@@ -213,7 +209,7 @@ impl Command for GroupedReads {
         let mut molecules: Vec<MoleculeInfo> = (0..self.common.num_molecules)
             .map(|mol_id| {
                 let seed: u64 = seed_rng.random();
-                let pos1 = compute_position(mol_id, num_positions, ref_length);
+                let pos1 = todo!("position table lookup");
 
                 // Pre-compute insert_size using the molecule's seed (same RNG sequence as generation)
                 let mut mol_rng = create_rng(Some(seed));
@@ -319,7 +315,13 @@ impl Command for GroupedReads {
 
 /// Generate all read pairs for a single molecule.
 /// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`, `mi_tag`, strand, `insert_size`) tuples.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    unreachable_code,
+    unused_variables,
+    unused_mut,
+    clippy::diverging_sub_expression
+)] // todo!() stubs pending position-table lookup
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
@@ -328,8 +330,8 @@ fn generate_molecule_reads(
 ) -> Vec<(RecordBuf, RecordBuf, String, String, String, char, usize)> {
     let mut rng = create_rng(Some(seed));
 
-    // Compute position for this molecule
-    let position = compute_position(mol_id, params.num_positions, params.ref_length);
+    // TODO: replace with position table lookup
+    let position = todo!("position table lookup");
 
     // Generate UMI
     let umi = generate_random_sequence(params.umi_length, &mut rng);

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -21,19 +21,15 @@ use crate::simulate::{
     StrandBiasModel, create_rng,
 };
 use anyhow::{Context, Result};
-use bstr::BString;
 use clap::Parser;
 use log::info;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::header::Header;
-use noodles::sam::header::record::value::Map;
-use noodles::sam::header::record::value::map::ReferenceSequence;
 use noodles::sam::header::record::value::map::header::{self as HeaderRecord, Tag as HeaderTag};
 use rand::{Rng, RngExt};
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 /// Generate template-coordinate sorted BAM with MI tags for consensus callers.
@@ -114,7 +110,6 @@ struct GenerationParams {
 }
 
 impl Command for GroupedReads {
-    #[allow(unreachable_code, unused_variables, unused_mut, clippy::diverging_sub_expression)] // todo!() stubs pending position-table lookup
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate methylation args
         let methylation = self.methylation.resolve();
@@ -135,52 +130,43 @@ impl Command for GroupedReads {
         }
 
         // Load reference genome
-        let ref_genome = Some(ReferenceGenome::load(&self.reference.reference)?);
+        let ref_genome = ReferenceGenome::load(&self.reference.reference)?;
 
-        // Determine positions
-        let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
-        let ref_genome_inner = ref_genome.as_ref().expect("reference genome always loaded");
-        let ref_length = ref_genome_inner.total_length();
-
-        // Check for position collisions that would cause UMI conflicts
-        let usable_bases = ref_length.saturating_sub(1000);
-        let bases_per_position = usable_bases as f64 / num_positions as f64;
-        if bases_per_position < 1.0 {
+        // Validate that the reference has at least one contig >= read_length
+        if ref_genome.max_contig_length() < self.common.read_length {
             anyhow::bail!(
-                "Position collision: {num_positions} positions cannot fit in {ref_length} bp reference ({bases_per_position:.2} bp/position). \
-                 Increase the reference size or reduce --num-molecules."
-            );
-        } else if bases_per_position < 10.0 {
-            log::warn!(
-                "Low position spacing ({bases_per_position:.1} bp/position) may cause UMI collisions."
+                "No reference contig is >= read length ({} bp). \
+                 The longest contig is {} bp. Use a larger reference or shorter --read-length.",
+                self.common.read_length,
+                ref_genome.max_contig_length(),
             );
         }
 
-        // Build header with template-coordinate sort order
-        let ref_name = ref_genome_inner.name(0).to_string();
-        let mut header = Header::builder();
+        // Build header from reference contigs + sort order tags + @PG
+        let ref_header = ref_genome.build_bam_header();
+        let mut header_builder = Header::builder();
 
         // Add sort order tags: SO:unsorted, GO:query, SS:template-coordinate
         let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
         let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
         let HeaderTag::Other(ss_tag) = HeaderTag::from([b'S', b'S']) else { unreachable!() };
 
-        let header_map = Map::<HeaderRecord::Header>::builder()
-            .insert(so_tag, "unsorted")
-            .insert(go_tag, "query")
-            .insert(ss_tag, "template-coordinate")
-            .build()
-            .expect("header map with valid SO/GO/SS tags");
-        header = header.set_header(header_map);
+        let header_map =
+            noodles::sam::header::record::value::Map::<HeaderRecord::Header>::builder()
+                .insert(so_tag, "unsorted")
+                .insert(go_tag, "query")
+                .insert(ss_tag, "template-coordinate")
+                .build()
+                .expect("header map with valid SO/GO/SS tags");
+        header_builder = header_builder.set_header(header_map);
 
-        let length = NonZeroUsize::try_from(ref_length).expect("Reference length must be > 0");
-        let ref_seq: Map<ReferenceSequence> = Map::<ReferenceSequence>::new(length);
-        header = header.add_reference_sequence(BString::from(&*ref_name), ref_seq);
+        for (name, map) in ref_header.reference_sequences() {
+            header_builder = header_builder.add_reference_sequence(name.clone(), map.clone());
+        }
 
-        // Add @PG record
-        header = crate::commands::common::add_pg_to_builder(header, command_line)?;
+        header_builder = crate::commands::common::add_pg_to_builder(header_builder, command_line)?;
 
-        let header = header.build();
+        let header = header_builder.build();
 
         // Set up generation parameters
         let params = GenerationParams {
@@ -197,8 +183,33 @@ impl Command for GroupedReads {
             methylation,
         };
 
-        // Generate seeds for reproducibility
-        let mut seed_rng = create_rng(self.common.seed);
+        // Pre-sample positions from reference (use a dedicated RNG so molecule seeds
+        // stay deterministic and uncorrelated with position sampling)
+        let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
+        if num_positions == 0 {
+            anyhow::bail!("--num-positions must be greater than 0");
+        }
+
+        // Collision check using total_length
+        let usable_bases = ref_genome.total_length().saturating_sub(1000);
+        let bases_per_position = usable_bases as f64 / num_positions as f64;
+        if bases_per_position < 1.0 {
+            anyhow::bail!(
+                "Too many positions ({num_positions}) for reference of size {} bp. \
+                 Reduce --num-positions or use a larger reference.",
+                ref_genome.total_length()
+            );
+        } else if bases_per_position < 10.0 {
+            log::warn!(
+                "Low position spacing ({bases_per_position:.1} bp/position) may cause UMI collisions."
+            );
+        }
+
+        let mut pos_rng = create_rng(self.common.seed);
+        let position_table = ref_genome.sample_positions(num_positions, &mut pos_rng);
+
+        // Use a different seed for molecule generation to avoid correlation with positions
+        let mut seed_rng = create_rng(self.common.seed.map(|s| s.wrapping_add(1)));
 
         // MEMORY-EFFICIENT APPROACH: Sort molecule IDs by template-coordinate key first,
         // then generate records in sorted order (streaming).
@@ -209,9 +220,11 @@ impl Command for GroupedReads {
         let mut molecules: Vec<MoleculeInfo> = (0..self.common.num_molecules)
             .map(|mol_id| {
                 let seed: u64 = seed_rng.random();
-                let pos1 = todo!("position table lookup");
+                let pos_idx = mol_id % num_positions;
+                let (chrom_idx, local_pos) = position_table[pos_idx];
 
-                // Pre-compute insert_size using the molecule's seed (same RNG sequence as generation)
+                // Pre-compute insert_size using the molecule's seed (same RNG sequence
+                // as generation)
                 let mut mol_rng = create_rng(Some(seed));
                 // Skip UMI generation RNG calls
                 for _ in 0..params.umi_length {
@@ -222,11 +235,12 @@ impl Command for GroupedReads {
                 // Get insert_size
                 let insert_size = params.insert_model.sample(&mut mol_rng);
 
-                // Build template-coordinate sort key using the shared sort module.
-                // MI tag is mol_id.to_string() (or "{mol_id}/A" for duplex, but /A /B suffix is stripped)
+                // Sort key — for_f1r2_pair gives the canonical template-coordinate sort
+                // key. This works for both F1R2 and R1F2 orientations because the
+                // template covers the same genomic positions regardless of strand.
                 let sort_key = TemplateCoordKey::for_f1r2_pair(
-                    0, // tid - all simulated reads on reference 0
-                    pos1,
+                    chrom_idx as i32, // real tid
+                    local_pos,
                     insert_size,
                     mol_id.to_string(), // MI tag (stripped suffix matches this)
                     format!("mol{mol_id:08}"),
@@ -264,23 +278,29 @@ impl Command for GroupedReads {
         for mol_info in molecules {
             progress.log_if_needed(1);
 
-            // Generate all read pairs for this molecule
-            let pairs = generate_molecule_reads(
+            let pos_idx = mol_info.mol_id % num_positions;
+            let (pos_chrom_idx, pos_local_pos) = position_table[pos_idx];
+
+            // Generate all read pairs for this molecule. If the pre-sampled locus
+            // could not provide a valid template, `generate_molecule_reads` falls
+            // back to sampling a new locus and returns the effective coordinates
+            // so BAM records and truth rows stay in sync with the emitted sequence.
+            let (pairs, chrom_idx, local_pos) = generate_molecule_reads(
                 mol_info.mol_id,
                 mol_info.seed,
+                pos_chrom_idx,
+                pos_local_pos,
                 &params,
-                ref_genome.as_ref(),
+                &ref_genome,
             );
 
-            for (r1, r2, read_name, umi_str, mi_tag, strand, insert_size) in pairs {
+            for (r1, r2, read_name, umi_str, mi_tag, is_top_strand, insert_size) in pairs {
                 // Write reads in template-coordinate order (earlier 5' position first).
-                // For A strand (F1R2): R1 forward at pos, R2 reverse at pos+insert-read_len
+                // For F1R2 (top strand): R1 forward at pos, R2 reverse at pos+insert-read_len
                 //   R1's 5' = pos, R2's 5' = pos+insert-1 → R1 first (always)
-                // For B strand (R1F2): R1 reverse at pos, R2 forward at pos+insert-read_len
-                //   R1's 5' = pos+read_len-1, R2's 5' = pos+insert-read_len
-                //   R2 first if insert <= 2*read_len-1, else R1 first
-                //   (When equal, samtools puts forward strand first)
-                let r2_first = strand == 'B' && insert_size < 2 * params.read_length;
+                // For R1F2 (!top strand): R1 reverse at end, R2 forward at start
+                //   R2 first if insert < 2*read_len, else R1 first
+                let r2_first = !is_top_strand && insert_size < 2 * params.read_length;
                 if r2_first {
                     writer.write_alignment_record(&header, &r2)?;
                     writer.write_alignment_record(&header, &r1)?;
@@ -288,6 +308,7 @@ impl Command for GroupedReads {
                     writer.write_alignment_record(&header, &r1)?;
                     writer.write_alignment_record(&header, &r2)?;
                 }
+                let strand_char = if is_top_strand { '+' } else { '-' };
                 writeln!(
                     truth_writer,
                     "{}\t{}\t{}\t{}\t{}\t{}\t{}",
@@ -295,9 +316,9 @@ impl Command for GroupedReads {
                     umi_str,
                     mol_info.mol_id,
                     mi_tag,
-                    ref_name,
-                    mol_info.sort_key.pos1,
-                    strand
+                    ref_genome.name(chrom_idx),
+                    local_pos,
+                    strand_char,
                 )?;
                 total_pairs += 1;
             }
@@ -314,24 +335,29 @@ impl Command for GroupedReads {
 }
 
 /// Generate all read pairs for a single molecule.
-/// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`, `mi_tag`, strand, `insert_size`) tuples.
-#[allow(
-    clippy::too_many_arguments,
-    unreachable_code,
-    unused_variables,
-    unused_mut,
-    clippy::diverging_sub_expression
-)] // todo!() stubs pending position-table lookup
+///
+/// A single R1/R2 pair plus identifiers used for truth/metadata:
+/// `(r1, r2, read_name, umi_str, mi, is_top_strand, family_size)`.
+type MoleculeReadPair = (RecordBuf, RecordBuf, String, String, String, bool, usize);
+
+/// Result of generating all read pairs for a molecule: the pairs plus the
+/// effective `(chrom_idx, local_pos)` at which the template actually lives.
+type MoleculeReadsResult = (Vec<MoleculeReadPair>, usize, usize);
+
+/// Returns the pair vector together with the effective `(chrom_idx, local_pos)` —
+/// the fallback may re-sample a different locus when the pre-sampled one doesn't
+/// yield a valid template, and callers must propagate those coordinates to BAM
+/// records and the truth TSV so reported positions match the emitted sequence.
+#[allow(clippy::too_many_arguments)]
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
+    chrom_idx: usize,
+    local_pos: usize,
     params: &GenerationParams,
-    ref_genome: Option<&ReferenceGenome>,
-) -> Vec<(RecordBuf, RecordBuf, String, String, String, char, usize)> {
+    ref_genome: &ReferenceGenome,
+) -> MoleculeReadsResult {
     let mut rng = create_rng(Some(seed));
-
-    // TODO: replace with position table lookup
-    let position = todo!("position table lookup");
 
     // Generate UMI
     let umi = generate_random_sequence(params.umi_length, &mut rng);
@@ -343,11 +369,23 @@ fn generate_molecule_reads(
     // Generate insert size
     let insert_size = params.insert_model.sample(&mut rng);
 
-    // When reference is available, generate shared template from reference (all reads in family share it)
-    let shared_template = ref_genome.and_then(|g| {
-        g.sequence_at_genome_pos(position, insert_size)
-            .or_else(|| g.sample_sequence(insert_size, &mut rng).map(|(_, _, seq)| seq))
-    });
+    // 50/50 strand coin flip: determines genomic strand of origin
+    let is_top_strand: bool = rng.random();
+
+    // Get template from reference at the pre-sampled position, falling back to a
+    // random position if the exact location doesn't yield a valid sequence. When
+    // falling back, adopt the new locus so records and truth stay aligned with the
+    // sequence actually emitted.
+    let (eff_chrom_idx, eff_local_pos, shared_template) =
+        match ref_genome.sequence_at(chrom_idx, local_pos, insert_size) {
+            Some(seq) => (chrom_idx, local_pos, Some(seq)),
+            None => match ref_genome.sample_sequence(insert_size, &mut rng) {
+                Some((c, p, seq)) => (c, p, Some(seq)),
+                None => (chrom_idx, local_pos, None),
+            },
+        };
+    let chrom_idx = eff_chrom_idx;
+    let local_pos = eff_local_pos;
 
     let mut pairs = Vec::new();
 
@@ -355,7 +393,8 @@ fn generate_molecule_reads(
         // Split reads between A and B strands
         let (a_count, b_count) = params.strand_bias_model.split_reads(family_size, &mut rng);
 
-        // Generate A strand reads
+        // A reads: orientation follows the coin flip
+        let a_is_top = is_top_strand;
         for read_idx in 0..a_count {
             let read_name = format!("mol{mol_id:08}_readA{read_idx:04}");
             let mi_tag = format!("{mol_id}/A");
@@ -364,11 +403,12 @@ fn generate_molecule_reads(
                 &read_name,
                 &umi_str,
                 &mi_tag,
-                position,
+                chrom_idx,
+                local_pos,
                 insert_size,
                 params.read_length,
                 params.mapq,
-                'A',
+                a_is_top,
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
@@ -382,12 +422,13 @@ fn generate_molecule_reads(
                 read_name,
                 umi_str.clone(),
                 mi_tag,
-                'A',
+                a_is_top,
                 insert_size,
             ));
         }
 
-        // Generate B strand reads
+        // B reads: opposite orientation of A
+        let b_is_top = !is_top_strand;
         for read_idx in 0..b_count {
             let read_name = format!("mol{mol_id:08}_readB{read_idx:04}");
             let mi_tag = format!("{mol_id}/B");
@@ -396,11 +437,12 @@ fn generate_molecule_reads(
                 &read_name,
                 &umi_str,
                 &mi_tag,
-                position,
+                chrom_idx,
+                local_pos,
                 insert_size,
                 params.read_length,
                 params.mapq,
-                'B',
+                b_is_top,
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
@@ -414,7 +456,7 @@ fn generate_molecule_reads(
                 read_name,
                 umi_str.clone(),
                 mi_tag,
-                'B',
+                b_is_top,
                 insert_size,
             ));
         }
@@ -429,11 +471,12 @@ fn generate_molecule_reads(
                 &read_name,
                 &umi_str,
                 &mi_tag,
-                position,
+                chrom_idx,
+                local_pos,
                 insert_size,
                 params.read_length,
                 params.mapq,
-                '+',
+                is_top_strand,
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
@@ -447,13 +490,13 @@ fn generate_molecule_reads(
                 read_name,
                 umi_str.clone(),
                 mi_tag.clone(),
-                '+',
+                is_top_strand,
                 insert_size,
             ));
         }
     }
 
-    pairs
+    (pairs, chrom_idx, local_pos)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -461,11 +504,12 @@ fn generate_read_pair_records(
     read_name: &str,
     umi_str: &str,
     mi_tag: &str,
-    position: usize,
+    chrom_idx: usize,
+    local_pos: usize,
     insert_size: usize,
     read_length: usize,
     mapq: u8,
-    strand: char,
+    is_top_strand: bool,
     quality_model: &PositionQualityModel,
     quality_bias: &ReadPairQualityBias,
     methylation: &MethylationConfig,
@@ -482,71 +526,82 @@ fn generate_read_pair_records(
         &random_template
     };
 
-    let (r1_is_top, r2_is_top) = match strand {
-        'B' => (false, true),
-        _ => (true, false),
-    };
+    // Compute forward-read sequence (from start of template, top strand)
+    let fwd_end = read_length.min(template.len());
+    let mut fwd_seq: Vec<u8> = template[..fwd_end].to_vec();
+    apply_methylation_conversion(
+        &mut fwd_seq,
+        template,
+        0,
+        true, // top strand
+        methylation,
+        rng,
+    );
+    let fwd_seq = pad_sequence(fwd_seq, read_length, rng);
 
-    // R1: forward strand at position
-    let r1_end = read_length.min(template.len());
-    let mut r1_seq: Vec<u8> = template[..r1_end].to_vec();
-    apply_methylation_conversion(&mut r1_seq, template, 0, r1_is_top, methylation, rng);
-    let r1_seq = pad_sequence(r1_seq, read_length, rng);
-
-    // R2: reverse strand at position + insert_size - read_length
-    let r2_start = insert_size.saturating_sub(read_length);
-    let r2_end = read_length.min(template.len().saturating_sub(r2_start));
-    let mut r2_template: Vec<u8> = template[r2_start..r2_start + r2_end].to_vec();
-    apply_methylation_conversion(&mut r2_template, template, r2_start, r2_is_top, methylation, rng);
-    let r2_seq = reverse_complement(&r2_template);
-    let r2_seq = pad_sequence(r2_seq, read_length, rng);
+    // Compute reverse-read sequence (from end of template, bottom strand, revcomped)
+    let rev_start = insert_size.saturating_sub(read_length);
+    let rev_end = read_length.min(template.len().saturating_sub(rev_start));
+    let mut rev_template: Vec<u8> = template[rev_start..rev_start + rev_end].to_vec();
+    apply_methylation_conversion(
+        &mut rev_template,
+        template,
+        rev_start,
+        false, // bottom strand
+        methylation,
+        rng,
+    );
+    let rev_seq = reverse_complement(&rev_template);
+    let rev_seq = pad_sequence(rev_seq, read_length, rng);
 
     // Quality scores
     let r1_quals = quality_model.generate_qualities(read_length, rng);
     let r2_quals_raw = quality_model.generate_qualities(read_length, rng);
     let r2_quals = quality_bias.apply_to_vec(&r2_quals_raw, true);
 
-    // Mate cigar is based on the mate's read length (same for both reads)
     let mate_cigar = format!("{read_length}M");
 
-    // Strand orientation: A strand is normal (R1 forward, R2 reverse),
-    // B strand is opposite (R1 reverse, R2 forward) to represent the
-    // complementary DNA strand in duplex sequencing.
-    let (r1_is_reverse, r2_is_reverse) = match strand {
-        'B' => (true, false), // B strand: R1 reverse, R2 forward
-        _ => (false, true),   // A strand/simplex: R1 forward, R2 reverse
+    // Assign to R1/R2 based on strand coin flip.
+    // tlen sign convention: positive for the leftmost read, negative for the rightmost.
+    // When insert_size < read_length the reverse read starts at local_pos (mirroring
+    // rev_start's `saturating_sub`), so use `saturating_sub` to avoid a usize underflow.
+    let rev_pos = local_pos + insert_size.saturating_sub(read_length);
+    let (r1_seq, r2_seq, r1_is_reverse, r1_pos, r2_pos, r1_tlen) = if is_top_strand {
+        // F1R2: R1=forward at start, R2=reverse at end
+        (fwd_seq, rev_seq, false, local_pos, rev_pos, insert_size as i32)
+    } else {
+        // R1F2: R1=reverse at end, R2=forward at start
+        (rev_seq, fwd_seq, true, rev_pos, local_pos, -(insert_size as i32))
     };
 
-    // Build R1 record
     let r1_record = build_record(
         read_name,
         &r1_seq,
         &r1_quals,
-        0, // ref_id
-        position,
+        chrom_idx,
+        r1_pos,
         mapq,
-        true, // is_first
-        r1_is_reverse,
-        position + insert_size - read_length,
-        insert_size as i32,
+        true,          // is_first
+        r1_is_reverse, // is_reverse
+        r2_pos,
+        r1_tlen,
         umi_str,
         mi_tag,
         &mate_cigar,
         mapq,
     );
 
-    // Build R2 record
     let r2_record = build_record(
         read_name,
         &r2_seq,
         &r2_quals,
-        0,
-        position + insert_size - read_length,
+        chrom_idx,
+        r2_pos,
         mapq,
-        false, // is_first
-        r2_is_reverse,
-        position,
-        -(insert_size as i32),
+        false,          // is_first
+        !r1_is_reverse, // is_reverse (opposite of R1)
+        r1_pos,
+        -r1_tlen,
         umi_str,
         mi_tag,
         &mate_cigar,
@@ -725,11 +780,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "0/A",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -756,11 +812,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "5/B",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            'B',
+            false, // is_top_strand (B strand = bottom)
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -768,7 +825,7 @@ mod tests {
             &mut rng,
         );
 
-        // B strand has opposite orientation: R1 reverse, R2 forward
+        // Bottom strand has opposite orientation: R1 reverse, R2 forward
         assert!(r1.flags().is_first_segment());
         assert!(r1.flags().is_reverse_complemented());
         assert!(r2.flags().is_last_segment());
@@ -785,11 +842,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "10",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            '+',
+            true, // is_top_strand (simplex top)
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -797,7 +855,7 @@ mod tests {
             &mut rng,
         );
 
-        // Simplex has same orientation as A strand
+        // Simplex top strand has same orientation as F1R2
         assert!(r1.flags().is_first_segment());
         assert!(!r1.flags().is_reverse_complemented());
         assert!(r2.flags().is_last_segment());
@@ -815,11 +873,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "0/A",
-            1000,
-            50, // insert_size < read_length
+            0,    // chrom_idx
+            1000, // local_pos
+            50,   // insert_size < read_length
             150,
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -844,11 +903,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "0/A",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -860,11 +920,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "0/A",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -1034,11 +1095,12 @@ mod tests {
             "read_001",
             "ACGTACGT",
             "1/A",
-            1000,
+            0,    // chrom_idx
+            1000, // local_pos
             300,
             150,
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
@@ -1046,7 +1108,7 @@ mod tests {
             &mut rng,
         );
 
-        // A strand: R1 forward, R2 reverse
+        // Top strand: R1 forward, R2 reverse
         assert!(r1.flags().is_first_segment());
         assert!(!r1.flags().is_reverse_complemented());
         assert!(r2.flags().is_last_segment());
@@ -1059,7 +1121,7 @@ mod tests {
 
     #[test]
     fn test_emseq_grouped_reads_strand_conversion() {
-        // A strand: R1=top (C->T), R2=bottom (G->A then RC)
+        // Top strand: R1=top (C->T), R2=bottom (G->A then RC)
         // Template: non-CpG Cs at known positions
         let template = b"CACACACACACACACAC"; // no CpG
         let config = MethylationConfig {
@@ -1076,11 +1138,12 @@ mod tests {
             "test_meth",
             "AAAAAAAA",
             "1/A",
-            0,
+            0, // chrom_idx
+            0, // local_pos
             template.len(),
             template.len(),
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &config,
@@ -1088,7 +1151,7 @@ mod tests {
             &mut rng,
         );
 
-        // R1 (top strand) should have C->T conversions at non-CpG C positions
+        // R1 (top strand, forward) should have C->T conversions at non-CpG C positions
         let r1_seq: Vec<u8> = r1.sequence().as_ref().to_vec();
         for (i, &b) in template.iter().enumerate() {
             if i >= r1_seq.len() {
@@ -1101,8 +1164,9 @@ mod tests {
     }
 
     #[test]
-    fn test_b_strand_flips_conversion_orientation() {
-        // B strand: R1=bottom (G->A), R2=top (C->T) — opposite of A strand
+    fn test_bottom_strand_flips_conversion_orientation() {
+        // Bottom strand: R1 gets reverse-complemented sequence from end of template
+        // Top strand: R1 gets forward sequence from start of template
         // Template needs both C and G (non-CpG) so both strands have convertible bases
         let template = b"CATAGATAGATAGATA"; // has C and G, no CpG dinucleotides
         let emseq_config = MethylationConfig {
@@ -1115,17 +1179,18 @@ mod tests {
         let quality_model = PositionQualityModel::default();
         let quality_bias = ReadPairQualityBias::default();
 
-        // Generate A strand pair
+        // Generate top strand pair (F1R2)
         let mut rng_a = create_rng(Some(42));
         let (r1_a, _) = generate_read_pair_records(
             "test",
             "AAAAAAAA",
             "1/A",
-            0,
+            0, // chrom_idx
+            0, // local_pos
             template.len(),
             template.len(),
             60,
-            'A',
+            true, // is_top_strand
             &quality_model,
             &quality_bias,
             &emseq_config,
@@ -1133,17 +1198,18 @@ mod tests {
             &mut rng_a,
         );
 
-        // Generate B strand pair with disabled methylation to check it differs
+        // Generate bottom strand pair with disabled methylation to check it differs
         let mut rng_b = create_rng(Some(42));
         let (r1_b_no_meth, _) = generate_read_pair_records(
             "test",
             "AAAAAAAA",
             "1/B",
-            0,
+            0, // chrom_idx
+            0, // local_pos
             template.len(),
             template.len(),
             60,
-            'B',
+            false, // is_top_strand (bottom strand)
             &quality_model,
             &quality_bias,
             &disabled_config,
@@ -1151,17 +1217,18 @@ mod tests {
             &mut rng_b,
         );
 
-        // Generate B strand pair with EM-Seq
+        // Generate bottom strand pair with EM-Seq
         let mut rng_b2 = create_rng(Some(42));
         let (r1_b_meth, _) = generate_read_pair_records(
             "test",
             "AAAAAAAA",
             "1/B",
-            0,
+            0, // chrom_idx
+            0, // local_pos
             template.len(),
             template.len(),
             60,
-            'B',
+            false, // is_top_strand (bottom strand)
             &quality_model,
             &quality_bias,
             &emseq_config,
@@ -1169,15 +1236,113 @@ mod tests {
             &mut rng_b2,
         );
 
-        // A R1 (top strand) should differ from B R1 (bottom strand) with same methylation
+        // Top strand R1 (forward, top) should differ from bottom strand R1 (reverse, revcomped)
         let r1_a_seq: Vec<u8> = r1_a.sequence().as_ref().to_vec();
         let r1_b_seq: Vec<u8> = r1_b_meth.sequence().as_ref().to_vec();
-        // B strand R1 is bottom strand (G->A then RC), so conversion pattern should differ from
-        // A strand R1 (top strand, C->T)
-        assert_ne!(r1_a_seq, r1_b_seq, "A and B strand R1 should differ");
+        // Bottom strand R1 is reverse-complemented from end of template with bottom-strand
+        // methylation, so conversion pattern should differ from top strand R1
+        assert_ne!(r1_a_seq, r1_b_seq, "Top and bottom strand R1 should differ");
 
-        // B strand with methylation should differ from B strand without
+        // Bottom strand with methylation should differ from bottom strand without
         let r1_b_no_meth_seq: Vec<u8> = r1_b_no_meth.sequence().as_ref().to_vec();
-        assert_ne!(r1_b_seq, r1_b_no_meth_seq, "B strand with/without methylation should differ");
+        assert_ne!(
+            r1_b_seq, r1_b_no_meth_seq,
+            "Bottom strand with/without methylation should differ"
+        );
+    }
+
+    // ========================================================================
+    // Real reference coordinate tests
+    // ========================================================================
+
+    #[test]
+    fn test_grouped_reads_uses_real_ref_coordinates() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        writeln!(fasta, ">chr2").unwrap();
+        fasta.write_all(&b"CCGG".repeat(375)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let positions = ref_genome.sample_positions(10, &mut rng);
+
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            duplex: false,
+            min_family_size: 1,
+            quality_model: PositionQualityModel::default(),
+            quality_bias: ReadPairQualityBias::default(),
+            family_dist: FamilySizeDistribution::log_normal(1.0, 0.1),
+            insert_model: InsertSizeModel::new(100.0, 5.0, 80, 120),
+            strand_bias_model: StrandBiasModel::no_bias(),
+            methylation: DISABLED_METHYLATION,
+        };
+
+        let (chrom_idx, local_pos) = positions[0];
+        let (pairs, eff_chrom, _eff_pos) =
+            generate_molecule_reads(0, 42, chrom_idx, local_pos, &params, &ref_genome);
+        assert!(!pairs.is_empty());
+
+        for (r1, r2, _, _, _, _, _) in &pairs {
+            assert_eq!(r1.reference_sequence_id(), Some(eff_chrom));
+            assert_eq!(r2.reference_sequence_id(), Some(eff_chrom));
+        }
+    }
+
+    #[test]
+    fn test_duplex_strand_coin_flip_produces_both_orientations_for_a_reads() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            duplex: true,
+            min_family_size: 2,
+            quality_model: PositionQualityModel::default(),
+            quality_bias: ReadPairQualityBias::default(),
+            family_dist: FamilySizeDistribution::log_normal(2.0, 0.5),
+            insert_model: InsertSizeModel::new(100.0, 5.0, 80, 120),
+            strand_bias_model: StrandBiasModel::no_bias(),
+            methylation: DISABLED_METHYLATION,
+        };
+
+        let mut a_saw_top = false;
+        let mut a_saw_bottom = false;
+
+        for seed in 0u64..100 {
+            let (pairs, _chrom, _pos) =
+                generate_molecule_reads(seed as usize, seed, 0, 500, &params, &ref_genome);
+
+            for (_, _, _, _, mi_tag, is_top, _) in &pairs {
+                if mi_tag.ends_with("/A") {
+                    if *is_top {
+                        a_saw_top = true;
+                    } else {
+                        a_saw_bottom = true;
+                    }
+                }
+            }
+        }
+
+        assert!(a_saw_top, "A reads should sometimes be F1R2 (top strand)");
+        assert!(a_saw_bottom, "A reads should sometimes be R1F2 (bottom strand)");
     }
 }

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -9,8 +9,10 @@ use crate::bam_io::create_bam_writer;
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::commands::simulate::common::{
-    FamilySizeArgs, InsertSizeArgs, MoleculeInfo, PositionDistArgs, QualityArgs, ReferenceArgs,
-    SimulationCommon, StrandBiasArgs, compute_position, generate_random_sequence, pad_sequence,
+    FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
+    PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
+    StrandBiasArgs, apply_methylation_conversion, compute_position, generate_random_sequence,
+    pad_sequence,
 };
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
@@ -92,6 +94,9 @@ pub struct GroupedReads {
 
     #[command(flatten)]
     pub strand_bias: StrandBiasArgs,
+
+    #[command(flatten)]
+    pub methylation: MethylationArgs,
 }
 
 /// Parameters needed for molecule generation.
@@ -108,10 +113,18 @@ struct GenerationParams {
     family_dist: FamilySizeDistribution,
     insert_model: InsertSizeModel,
     strand_bias_model: StrandBiasModel,
+    methylation: MethylationConfig,
 }
 
 impl Command for GroupedReads {
     fn execute(&self, command_line: &str) -> Result<()> {
+        // Validate methylation args
+        let methylation = self.methylation.resolve();
+        self.methylation.validate()?;
+        if methylation.mode.is_enabled() && self.reference.reference.is_none() {
+            anyhow::bail!("--methylation-mode requires --reference");
+        }
+
         info!("Generating grouped reads");
         info!("  Output: {}", self.output.display());
         info!("  Truth: {}", self.truth_output.display());
@@ -120,6 +133,18 @@ impl Command for GroupedReads {
         info!("  Read length: {}", self.common.read_length);
         info!("  UMI length: {}", self.common.umi_length);
         info!("  Threads: {}", self.threads);
+        if methylation.mode.is_enabled() {
+            info!("  Methylation mode: {:?}", methylation.mode);
+            info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
+            info!("  Conversion rate: {}", methylation.conversion_rate);
+        }
+
+        // Load reference genome if provided
+        let ref_genome = if let Some(ref path) = self.reference.reference {
+            Some(ReferenceGenome::load(path)?)
+        } else {
+            None
+        };
 
         // Determine positions
         let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
@@ -181,6 +206,7 @@ impl Command for GroupedReads {
             family_dist: self.family_size.to_family_size_distribution()?,
             insert_model: self.insert_size.to_insert_size_model(),
             strand_bias_model: self.strand_bias.to_strand_bias_model(),
+            methylation,
         };
 
         // Generate seeds for reproducibility
@@ -251,7 +277,12 @@ impl Command for GroupedReads {
             progress.log_if_needed(1);
 
             // Generate all read pairs for this molecule
-            let pairs = generate_molecule_reads(mol_info.mol_id, mol_info.seed, &params);
+            let pairs = generate_molecule_reads(
+                mol_info.mol_id,
+                mol_info.seed,
+                &params,
+                ref_genome.as_ref(),
+            );
 
             for (r1, r2, read_name, umi_str, mi_tag, strand, insert_size) in pairs {
                 // Write reads in template-coordinate order (earlier 5' position first).
@@ -296,10 +327,12 @@ impl Command for GroupedReads {
 
 /// Generate all read pairs for a single molecule.
 /// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`, `mi_tag`, strand, `insert_size`) tuples.
+#[allow(clippy::too_many_arguments)]
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
     params: &GenerationParams,
+    ref_genome: Option<&ReferenceGenome>,
 ) -> Vec<(RecordBuf, RecordBuf, String, String, String, char, usize)> {
     let mut rng = create_rng(Some(seed));
 
@@ -315,6 +348,12 @@ fn generate_molecule_reads(
 
     // Generate insert size
     let insert_size = params.insert_model.sample(&mut rng);
+
+    // When reference is available, generate shared template from reference (all reads in family share it)
+    let shared_template = ref_genome.and_then(|g| {
+        g.sequence_at_genome_pos(position, insert_size)
+            .or_else(|| g.sample_sequence(insert_size, &mut rng).map(|(_, _, seq)| seq))
+    });
 
     let mut pairs = Vec::new();
 
@@ -338,6 +377,8 @@ fn generate_molecule_reads(
                 'A',
                 &params.quality_model,
                 &params.quality_bias,
+                &params.methylation,
+                shared_template.as_deref(),
                 &mut rng,
             );
 
@@ -368,6 +409,8 @@ fn generate_molecule_reads(
                 'B',
                 &params.quality_model,
                 &params.quality_bias,
+                &params.methylation,
+                shared_template.as_deref(),
                 &mut rng,
             );
 
@@ -399,6 +442,8 @@ fn generate_molecule_reads(
                 '+',
                 &params.quality_model,
                 &params.quality_bias,
+                &params.methylation,
+                shared_template.as_deref(),
                 &mut rng,
             );
 
@@ -429,18 +474,36 @@ fn generate_read_pair_records(
     strand: char,
     quality_model: &PositionQualityModel,
     quality_bias: &ReadPairQualityBias,
+    methylation: &MethylationConfig,
+    shared_template: Option<&[u8]>,
     rng: &mut impl Rng,
 ) -> (RecordBuf, RecordBuf) {
-    // Generate template sequence
-    let template = generate_random_sequence(insert_size, rng);
+    // Use shared reference template or generate random per-read.
+    // Avoid copying the shared template — only borrow it.
+    let random_template;
+    let template: &[u8] = if let Some(shared) = shared_template {
+        shared
+    } else {
+        random_template = generate_random_sequence(insert_size, rng);
+        &random_template
+    };
+
+    let (r1_is_top, r2_is_top) = match strand {
+        'B' => (false, true),
+        _ => (true, false),
+    };
 
     // R1: forward strand at position
-    let r1_seq: Vec<u8> = template.iter().take(read_length).copied().collect();
+    let r1_end = read_length.min(template.len());
+    let mut r1_seq: Vec<u8> = template[..r1_end].to_vec();
+    apply_methylation_conversion(&mut r1_seq, template, 0, r1_is_top, methylation, rng);
     let r1_seq = pad_sequence(r1_seq, read_length, rng);
 
     // R2: reverse strand at position + insert_size - read_length
     let r2_start = insert_size.saturating_sub(read_length);
-    let r2_template: Vec<u8> = template.iter().skip(r2_start).take(read_length).copied().collect();
+    let r2_end = read_length.min(template.len().saturating_sub(r2_start));
+    let mut r2_template: Vec<u8> = template[r2_start..r2_start + r2_end].to_vec();
+    apply_methylation_conversion(&mut r2_template, template, r2_start, r2_is_top, methylation, rng);
     let r2_seq = reverse_complement(&r2_template);
     let r2_seq = pad_sequence(r2_seq, read_length, rng);
 
@@ -543,6 +606,12 @@ fn build_record(
 mod tests {
     use super::*;
     use crate::simulate::create_rng;
+
+    const DISABLED_METHYLATION: MethylationConfig = MethylationConfig {
+        mode: fgumi_consensus::MethylationMode::Disabled,
+        cpg_methylation_rate: 0.75,
+        conversion_rate: 0.98,
+    };
 
     #[test]
     fn test_generate_random_sequence_length() {
@@ -669,6 +738,8 @@ mod tests {
             'A',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng,
         );
 
@@ -698,6 +769,8 @@ mod tests {
             'B',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng,
         );
 
@@ -725,6 +798,8 @@ mod tests {
             '+',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng,
         );
 
@@ -753,6 +828,8 @@ mod tests {
             'A',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng,
         );
 
@@ -780,6 +857,8 @@ mod tests {
             'A',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng1,
         );
 
@@ -794,6 +873,8 @@ mod tests {
             'A',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng2,
         );
 
@@ -966,6 +1047,8 @@ mod tests {
             'A',
             &quality_model,
             &quality_bias,
+            &DISABLED_METHYLATION,
+            None,
             &mut rng,
         );
 
@@ -974,5 +1057,133 @@ mod tests {
         assert!(!r1.flags().is_reverse_complemented());
         assert!(r2.flags().is_last_segment());
         assert!(r2.flags().is_reverse_complemented());
+    }
+
+    // ========================================================================
+    // Methylation tests
+    // ========================================================================
+
+    #[test]
+    fn test_emseq_grouped_reads_strand_conversion() {
+        // A strand: R1=top (C->T), R2=bottom (G->A then RC)
+        // Template: non-CpG Cs at known positions
+        let template = b"CACACACACACACACAC"; // no CpG
+        let config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::EmSeq,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 1.0,
+        };
+
+        let quality_model = PositionQualityModel::default();
+        let quality_bias = ReadPairQualityBias::default();
+        let mut rng = create_rng(Some(42));
+
+        let (r1, _r2) = generate_read_pair_records(
+            "test_meth",
+            "AAAAAAAA",
+            "1/A",
+            0,
+            template.len(),
+            template.len(),
+            60,
+            'A',
+            &quality_model,
+            &quality_bias,
+            &config,
+            Some(template),
+            &mut rng,
+        );
+
+        // R1 (top strand) should have C->T conversions at non-CpG C positions
+        let r1_seq: Vec<u8> = r1.sequence().as_ref().to_vec();
+        for (i, &b) in template.iter().enumerate() {
+            if i >= r1_seq.len() {
+                break;
+            }
+            if b == b'C' {
+                assert_eq!(r1_seq[i], b'T', "R1 position {i}: non-CpG C should convert to T");
+            }
+        }
+    }
+
+    #[test]
+    fn test_b_strand_flips_conversion_orientation() {
+        // B strand: R1=bottom (G->A), R2=top (C->T) — opposite of A strand
+        // Template needs both C and G (non-CpG) so both strands have convertible bases
+        let template = b"CATAGATAGATAGATA"; // has C and G, no CpG dinucleotides
+        let emseq_config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::EmSeq,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 1.0,
+        };
+        let disabled_config = DISABLED_METHYLATION;
+
+        let quality_model = PositionQualityModel::default();
+        let quality_bias = ReadPairQualityBias::default();
+
+        // Generate A strand pair
+        let mut rng_a = create_rng(Some(42));
+        let (r1_a, _) = generate_read_pair_records(
+            "test",
+            "AAAAAAAA",
+            "1/A",
+            0,
+            template.len(),
+            template.len(),
+            60,
+            'A',
+            &quality_model,
+            &quality_bias,
+            &emseq_config,
+            Some(template),
+            &mut rng_a,
+        );
+
+        // Generate B strand pair with disabled methylation to check it differs
+        let mut rng_b = create_rng(Some(42));
+        let (r1_b_no_meth, _) = generate_read_pair_records(
+            "test",
+            "AAAAAAAA",
+            "1/B",
+            0,
+            template.len(),
+            template.len(),
+            60,
+            'B',
+            &quality_model,
+            &quality_bias,
+            &disabled_config,
+            Some(template),
+            &mut rng_b,
+        );
+
+        // Generate B strand pair with EM-Seq
+        let mut rng_b2 = create_rng(Some(42));
+        let (r1_b_meth, _) = generate_read_pair_records(
+            "test",
+            "AAAAAAAA",
+            "1/B",
+            0,
+            template.len(),
+            template.len(),
+            60,
+            'B',
+            &quality_model,
+            &quality_bias,
+            &emseq_config,
+            Some(template),
+            &mut rng_b2,
+        );
+
+        // A R1 (top strand) should differ from B R1 (bottom strand) with same methylation
+        let r1_a_seq: Vec<u8> = r1_a.sequence().as_ref().to_vec();
+        let r1_b_seq: Vec<u8> = r1_b_meth.sequence().as_ref().to_vec();
+        // B strand R1 is bottom strand (G->A then RC), so conversion pattern should differ from
+        // A strand R1 (top strand, C->T)
+        assert_ne!(r1_a_seq, r1_b_seq, "A and B strand R1 should differ");
+
+        // B strand with methylation should differ from B strand without
+        let r1_b_no_meth_seq: Vec<u8> = r1_b_no_meth.sequence().as_ref().to_vec();
+        assert_ne!(r1_b_seq, r1_b_no_meth_seq, "B strand with/without methylation should differ");
     }
 }

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -121,9 +121,6 @@ impl Command for GroupedReads {
         // Validate methylation args
         let methylation = self.methylation.resolve();
         self.methylation.validate()?;
-        if methylation.mode.is_enabled() && self.reference.reference.is_none() {
-            anyhow::bail!("--methylation-mode requires --reference");
-        }
 
         info!("Generating grouped reads");
         info!("  Output: {}", self.output.display());
@@ -139,35 +136,30 @@ impl Command for GroupedReads {
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
-        // Load reference genome if provided
-        let ref_genome = if let Some(ref path) = self.reference.reference {
-            Some(ReferenceGenome::load(path)?)
-        } else {
-            None
-        };
+        // Load reference genome
+        let ref_genome = Some(ReferenceGenome::load(&self.reference.reference)?);
 
         // Determine positions
         let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
-        let ref_length = self.reference.ref_length;
+        let ref_genome_inner = ref_genome.as_ref().expect("reference genome always loaded");
+        let ref_length = ref_genome_inner.total_length();
 
         // Check for position collisions that would cause UMI conflicts
         let usable_bases = ref_length.saturating_sub(1000);
         let bases_per_position = usable_bases as f64 / num_positions as f64;
         if bases_per_position < 1.0 {
-            let suggested_ref_length = num_positions * 2;
             anyhow::bail!(
                 "Position collision: {num_positions} positions cannot fit in {ref_length} bp reference ({bases_per_position:.2} bp/position). \
-                 Increase --ref-length to at least {suggested_ref_length} or reduce --num-molecules."
+                 Increase the reference size or reduce --num-molecules."
             );
         } else if bases_per_position < 10.0 {
             log::warn!(
-                "Low position spacing ({bases_per_position:.1} bp/position) may cause UMI collisions. \
-                 Consider increasing --ref-length."
+                "Low position spacing ({bases_per_position:.1} bp/position) may cause UMI collisions."
             );
         }
 
         // Build header with template-coordinate sort order
-        let ref_name = self.reference.ref_name.clone();
+        let ref_name = ref_genome_inner.name(0).to_string();
         let mut header = Header::builder();
 
         // Add sort order tags: SO:unsorted, GO:query, SS:template-coordinate

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -11,7 +11,7 @@ use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
     PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
-    apply_methylation_conversion, compute_position, generate_random_sequence, pad_sequence,
+    apply_methylation_conversion, generate_random_sequence, pad_sequence,
 };
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
@@ -100,8 +100,6 @@ struct GenerationParams {
     umi_length: usize,
     mapq: u8,
     min_family_size: usize,
-    num_positions: usize,
-    ref_length: usize,
     quality_model: PositionQualityModel,
     quality_bias: ReadPairQualityBias,
     family_dist: FamilySizeDistribution,
@@ -110,6 +108,7 @@ struct GenerationParams {
 }
 
 impl Command for MappedReads {
+    #[allow(unreachable_code, unused_variables, unused_mut, clippy::diverging_sub_expression)] // todo!() stubs pending position-table lookup
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate methylation args
         let methylation = self.methylation.resolve();
@@ -168,8 +167,6 @@ impl Command for MappedReads {
             umi_length: self.common.umi_length,
             mapq: self.mapq,
             min_family_size: self.family_size.min_family_size,
-            num_positions,
-            ref_length,
             quality_model: self.quality.to_quality_model(),
             quality_bias: self.quality.to_quality_bias(),
             family_dist: self.family_size.to_family_size_distribution()?,
@@ -189,7 +186,7 @@ impl Command for MappedReads {
         let mut molecules: Vec<MoleculeInfo> = (0..self.common.num_molecules)
             .map(|mol_id| {
                 let seed: u64 = seed_rng.random();
-                let pos1 = compute_position(mol_id, num_positions, ref_length);
+                let pos1 = todo!("position table lookup");
 
                 // Pre-compute insert_size using the molecule's seed (same RNG sequence as generation)
                 let mut mol_rng = create_rng(Some(seed));
@@ -273,7 +270,13 @@ impl Command for MappedReads {
 
 /// Generate all read pairs for a single molecule.
 /// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`) tuples.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    unreachable_code,
+    unused_variables,
+    unused_mut,
+    clippy::diverging_sub_expression
+)] // todo!() stubs pending position-table lookup
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
@@ -282,9 +285,8 @@ fn generate_molecule_reads(
 ) -> Vec<(RecordBuf, RecordBuf, String, String)> {
     let mut rng = create_rng(Some(seed));
 
-    // Note: position is computed externally and passed via mol_id for reproducibility
-    // We need to recompute it here for the record generation
-    let position = compute_position(mol_id, params.num_positions, params.ref_length);
+    // TODO: replace with position table lookup
+    let position = todo!("position table lookup");
 
     // Generate UMI
     let umi = generate_random_sequence(params.umi_length, &mut rng);
@@ -735,8 +737,6 @@ mod tests {
             umi_length: 8,
             mapq: 60,
             min_family_size: 3,
-            num_positions: 100,
-            ref_length: 2000,
             quality_model: crate::simulate::PositionQualityModel::new(
                 10, 25, 37, 100, 0.08, 2, 0.0,
             ),

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -114,9 +114,6 @@ impl Command for MappedReads {
         // Validate methylation args
         let methylation = self.methylation.resolve();
         self.methylation.validate()?;
-        if methylation.mode.is_enabled() && self.reference.reference.is_none() {
-            anyhow::bail!("--methylation-mode requires --reference");
-        }
 
         info!("Generating mapped reads");
         info!("  Output: {}", self.output.display());
@@ -131,19 +128,16 @@ impl Command for MappedReads {
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
-        // Load reference genome if provided
-        let ref_genome = if let Some(ref path) = self.reference.reference {
-            Some(ReferenceGenome::load(path)?)
-        } else {
-            None
-        };
+        // Load reference genome
+        let ref_genome = Some(ReferenceGenome::load(&self.reference.reference)?);
 
         // Determine positions
         let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
 
         // Build header with template-coordinate sort order
-        let ref_name = self.reference.ref_name.clone();
-        let ref_length = self.reference.ref_length;
+        let ref_genome_inner = ref_genome.as_ref().expect("reference genome always loaded");
+        let ref_name = ref_genome_inner.name(0).to_string();
+        let ref_length = ref_genome_inner.total_length();
         let mut header = Header::builder();
 
         // Add sort order tags: SO:unsorted, GO:query, SS:template-coordinate

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -20,19 +20,15 @@ use crate::simulate::{
     FamilySizeDistribution, InsertSizeModel, PositionQualityModel, ReadPairQualityBias, create_rng,
 };
 use anyhow::{Context, Result};
-use bstr::BString;
 use clap::Parser;
 use log::info;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::header::Header;
-use noodles::sam::header::record::value::Map;
-use noodles::sam::header::record::value::map::ReferenceSequence;
 use noodles::sam::header::record::value::map::header::{self as HeaderRecord, Tag as HeaderTag};
 use rand::RngExt;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 /// Generate template-coordinate sorted BAM with paired alignments for `fgumi group`.
@@ -108,7 +104,6 @@ struct GenerationParams {
 }
 
 impl Command for MappedReads {
-    #[allow(unreachable_code, unused_variables, unused_mut, clippy::diverging_sub_expression)] // todo!() stubs pending position-table lookup
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate methylation args
         let methylation = self.methylation.resolve();
@@ -128,38 +123,45 @@ impl Command for MappedReads {
         }
 
         // Load reference genome
-        let ref_genome = Some(ReferenceGenome::load(&self.reference.reference)?);
+        let ref_genome = ReferenceGenome::load(&self.reference.reference)?;
 
-        // Determine positions
-        let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
+        // Validate that the reference has at least one contig >= read_length
+        if ref_genome.max_contig_length() < self.common.read_length {
+            anyhow::bail!(
+                "No reference contig is >= read length ({} bp). \
+                 The longest contig is {} bp. Use a larger reference or shorter --read-length.",
+                self.common.read_length,
+                ref_genome.max_contig_length(),
+            );
+        }
 
-        // Build header with template-coordinate sort order
-        let ref_genome_inner = ref_genome.as_ref().expect("reference genome always loaded");
-        let ref_name = ref_genome_inner.name(0).to_string();
-        let ref_length = ref_genome_inner.total_length();
-        let mut header = Header::builder();
+        // Build header from reference contigs + sort order tags + @PG
+        let ref_header = ref_genome.build_bam_header();
+        let mut header_builder = Header::builder();
 
         // Add sort order tags: SO:unsorted, GO:query, SS:template-coordinate
         let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
         let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
         let HeaderTag::Other(ss_tag) = HeaderTag::from([b'S', b'S']) else { unreachable!() };
 
-        let header_map = Map::<HeaderRecord::Header>::builder()
-            .insert(so_tag, "unsorted")
-            .insert(go_tag, "query")
-            .insert(ss_tag, "template-coordinate")
-            .build()
-            .expect("header map with valid SO/GO/SS tags");
-        header = header.set_header(header_map);
+        let header_map =
+            noodles::sam::header::record::value::Map::<HeaderRecord::Header>::builder()
+                .insert(so_tag, "unsorted")
+                .insert(go_tag, "query")
+                .insert(ss_tag, "template-coordinate")
+                .build()
+                .expect("header map with valid SO/GO/SS tags");
+        header_builder = header_builder.set_header(header_map);
 
-        let length = NonZeroUsize::try_from(ref_length).expect("Reference length must be > 0");
-        let ref_seq: Map<ReferenceSequence> = Map::<ReferenceSequence>::new(length);
-        header = header.add_reference_sequence(BString::from(&*ref_name), ref_seq);
+        // Re-add reference sequences from ref_genome header
+        for (name, map) in ref_header.reference_sequences() {
+            header_builder = header_builder.add_reference_sequence(name.clone(), map.clone());
+        }
 
         // Add @PG record
-        header = crate::commands::common::add_pg_to_builder(header, command_line)?;
+        header_builder = crate::commands::common::add_pg_to_builder(header_builder, command_line)?;
 
-        let header = header.build();
+        let header = header_builder.build();
 
         // Set up generation parameters
         let params = GenerationParams {
@@ -174,11 +176,36 @@ impl Command for MappedReads {
             methylation,
         };
 
-        // Generate seeds for reproducibility
-        let mut seed_rng = create_rng(self.common.seed);
+        // Pre-sample positions from reference (use a dedicated RNG so molecule seeds
+        // stay deterministic and uncorrelated with position sampling)
+        let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
+        if num_positions == 0 {
+            anyhow::bail!("--num-positions must be greater than 0");
+        }
+
+        let usable_bases = ref_genome.total_length().saturating_sub(1000);
+        let bases_per_position = usable_bases as f64 / num_positions as f64;
+        if bases_per_position < 1.0 {
+            anyhow::bail!(
+                "Too many positions ({num_positions}) for reference of size {} bp. \
+                 Reduce --num-positions or use a larger reference.",
+                ref_genome.total_length()
+            );
+        } else if bases_per_position < 10.0 {
+            log::warn!(
+                "Low position spacing ({bases_per_position:.1} bp/position) may cause UMI collisions."
+            );
+        }
+
+        let mut pos_rng = create_rng(self.common.seed);
+        let position_table = ref_genome.sample_positions(num_positions, &mut pos_rng);
+
+        // Use a different seed for molecule generation to avoid correlation with positions
+        let mut seed_rng = create_rng(self.common.seed.map(|s| s.wrapping_add(1)));
 
         // MEMORY-EFFICIENT APPROACH: Sort molecule IDs by template-coordinate key first,
-        // then generate records in sorted order (streaming).
+        // then generate records in sorted order (streaming). This avoids storing all
+        // records in memory before sorting.
         //
         // We need to pre-compute insert_size to get pos2 for the sort key, since
         // template-coordinate sorting considers both ends of the template.
@@ -186,9 +213,11 @@ impl Command for MappedReads {
         let mut molecules: Vec<MoleculeInfo> = (0..self.common.num_molecules)
             .map(|mol_id| {
                 let seed: u64 = seed_rng.random();
-                let pos1 = todo!("position table lookup");
+                let pos_idx = mol_id % num_positions;
+                let (chrom_idx, local_pos) = position_table[pos_idx];
 
-                // Pre-compute insert_size using the molecule's seed (same RNG sequence as generation)
+                // Pre-compute insert_size using the molecule's seed (same RNG sequence
+                // as generation)
                 let mut mol_rng = create_rng(Some(seed));
                 // Skip UMI generation RNG calls
                 for _ in 0..params.umi_length {
@@ -199,11 +228,12 @@ impl Command for MappedReads {
                 // Get insert_size
                 let insert_size = params.insert_model.sample(&mut mol_rng);
 
-                // Build template-coordinate sort key using the shared sort module.
-                // for_f1r2_pair handles pos2 calculation (unclipped 5' of R2 = pos1 + insert - 1)
+                // Sort key — for_f1r2_pair gives the canonical template-coordinate sort
+                // key. This works for both F1R2 and R1F2 orientations because the
+                // template covers the same genomic positions regardless of strand.
                 let sort_key = TemplateCoordKey::for_f1r2_pair(
-                    0, // tid - all simulated reads on reference 0
-                    pos1,
+                    chrom_idx as i32, // real tid
+                    local_pos,
                     insert_size,
                     String::new(), // empty mid for mapped-reads (no MI tag yet)
                     format!("mol{mol_id:08}"),
@@ -212,7 +242,8 @@ impl Command for MappedReads {
             })
             .collect();
 
-        // Sort molecules by template-coordinate key (matching samtools bam1_cmp_template_coordinate)
+        // Sort molecules by template-coordinate key
+        // (matching samtools bam1_cmp_template_coordinate)
         info!("Sorting {} molecules by template-coordinate...", molecules.len());
         molecules.sort_unstable();
 
@@ -238,21 +269,47 @@ impl Command for MappedReads {
         for mol_info in molecules {
             progress.log_if_needed(1);
 
-            // Generate all read pairs for this molecule
-            let pairs = generate_molecule_reads(
+            let pos_idx = mol_info.mol_id % num_positions;
+            let (pos_chrom_idx, pos_local_pos) = position_table[pos_idx];
+
+            // Generate all read pairs for this molecule. If the pre-sampled locus
+            // could not provide a valid template, `generate_molecule_reads` falls
+            // back to sampling a new locus and returns the effective coordinates
+            // so BAM records and truth rows stay in sync with the emitted sequence.
+            let (pairs, chrom_idx, local_pos) = generate_molecule_reads(
                 mol_info.mol_id,
                 mol_info.seed,
+                pos_chrom_idx,
+                pos_local_pos,
                 &params,
-                ref_genome.as_ref(),
+                &ref_genome,
             );
 
-            for (r1, r2, read_name, umi_str) in pairs {
-                writer.write_alignment_record(&header, &r1)?;
-                writer.write_alignment_record(&header, &r2)?;
+            for (r1, r2, read_name, umi_str, is_top_strand) in pairs {
+                // Template-coordinate order: write the record whose reference start
+                // is lower first so pairs are emitted in coordinate order. R1F2
+                // pairs have R1 (reverse read) at the higher coordinate, so emit R2
+                // first when R1's alignment_start is strictly greater.
+                let r1_pos = r1.alignment_start().map(|p| p.get()).unwrap_or(0);
+                let r2_pos = r2.alignment_start().map(|p| p.get()).unwrap_or(0);
+                let r2_first = r1_pos > r2_pos;
+                if r2_first {
+                    writer.write_alignment_record(&header, &r2)?;
+                    writer.write_alignment_record(&header, &r1)?;
+                } else {
+                    writer.write_alignment_record(&header, &r1)?;
+                    writer.write_alignment_record(&header, &r2)?;
+                }
+                let strand_char = if is_top_strand { '+' } else { '-' };
                 writeln!(
                     truth_writer,
-                    "{}\t{}\t{}\t{}\t{}\tA",
-                    read_name, umi_str, mol_info.mol_id, ref_name, mol_info.sort_key.pos1
+                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    read_name,
+                    umi_str,
+                    mol_info.mol_id,
+                    ref_genome.name(chrom_idx),
+                    local_pos,
+                    strand_char,
                 )?;
                 total_pairs += 1;
             }
@@ -268,25 +325,30 @@ impl Command for MappedReads {
     }
 }
 
+/// A single R1/R2 pair plus identifiers used for truth/metadata:
+/// `(r1, r2, read_name, umi_str, is_top_strand)`.
+type MoleculeReadPair = (RecordBuf, RecordBuf, String, String, bool);
+
+/// Result of generating all read pairs for a molecule: the pairs plus the
+/// effective `(chrom_idx, local_pos)` at which the template actually lives.
+type MoleculeReadsResult = (Vec<MoleculeReadPair>, usize, usize);
+
 /// Generate all read pairs for a single molecule.
-/// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`) tuples.
-#[allow(
-    clippy::too_many_arguments,
-    unreachable_code,
-    unused_variables,
-    unused_mut,
-    clippy::diverging_sub_expression
-)] // todo!() stubs pending position-table lookup
+///
+/// Returns the pair vector together with the effective `(chrom_idx, local_pos)` —
+/// the fallback may re-sample a different locus when the pre-sampled one doesn't
+/// yield a valid template, and callers must propagate those coordinates to BAM
+/// records and the truth TSV so reported positions match the emitted sequence.
+#[allow(clippy::too_many_arguments)]
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
+    chrom_idx: usize,
+    local_pos: usize,
     params: &GenerationParams,
-    ref_genome: Option<&ReferenceGenome>,
-) -> Vec<(RecordBuf, RecordBuf, String, String)> {
+    ref_genome: &ReferenceGenome,
+) -> MoleculeReadsResult {
     let mut rng = create_rng(Some(seed));
-
-    // TODO: replace with position table lookup
-    let position = todo!("position table lookup");
 
     // Generate UMI
     let umi = generate_random_sequence(params.umi_length, &mut rng);
@@ -298,12 +360,23 @@ fn generate_molecule_reads(
     // Generate insert size
     let insert_size = params.insert_model.sample(&mut rng);
 
-    // When reference is available, generate template once from reference (shared by all reads)
-    // When no reference, each read gets an independent random template (existing behavior)
-    let shared_template = ref_genome.and_then(|g| {
-        g.sequence_at_genome_pos(position, insert_size)
-            .or_else(|| g.sample_sequence(insert_size, &mut rng).map(|(_, _, seq)| seq))
-    });
+    // 50/50 strand coin flip: determines genomic strand of origin
+    let is_top_strand: bool = rng.random();
+
+    // Get template from reference at the pre-sampled position, falling back to a
+    // random position if the exact location doesn't yield a valid sequence. When
+    // falling back, adopt the new locus so records and truth stay aligned with the
+    // sequence actually emitted.
+    let (eff_chrom_idx, eff_local_pos, shared_template) =
+        match ref_genome.sequence_at(chrom_idx, local_pos, insert_size) {
+            Some(seq) => (chrom_idx, local_pos, Some(seq)),
+            None => match ref_genome.sample_sequence(insert_size, &mut rng) {
+                Some((c, p, seq)) => (c, p, Some(seq)),
+                None => (chrom_idx, local_pos, None),
+            },
+        };
+    let chrom_idx = eff_chrom_idx;
+    let local_pos = eff_local_pos;
 
     let mut pairs = Vec::with_capacity(family_size);
 
@@ -320,33 +393,34 @@ fn generate_molecule_reads(
             &random_template
         };
 
-        // R1: forward strand (top strand) at position
-        let r1_end = params.read_length.min(template.len());
-        let mut r1_seq: Vec<u8> = template[..r1_end].to_vec();
+        // Compute forward-read sequence (from start of template, top strand)
+        let fwd_end = params.read_length.min(template.len());
+        let mut fwd_seq: Vec<u8> = template[..fwd_end].to_vec();
         apply_methylation_conversion(
-            &mut r1_seq,
+            &mut fwd_seq,
             template,
             0,
             true, // top strand
             &params.methylation,
             &mut rng,
         );
-        let r1_seq = pad_sequence(r1_seq, params.read_length, &mut rng);
+        let fwd_seq = pad_sequence(fwd_seq, params.read_length, &mut rng);
 
-        // R2: reverse strand (bottom strand) at position + insert_size - read_length
-        let r2_start = insert_size.saturating_sub(params.read_length);
-        let r2_end = params.read_length.min(template.len().saturating_sub(r2_start));
-        let mut r2_template: Vec<u8> = template[r2_start..r2_start + r2_end].to_vec();
+        // Compute reverse-read sequence (from end of template, bottom strand,
+        // reverse complemented)
+        let rev_start = insert_size.saturating_sub(params.read_length);
+        let rev_end = params.read_length.min(template.len().saturating_sub(rev_start));
+        let mut rev_template: Vec<u8> = template[rev_start..rev_start + rev_end].to_vec();
         apply_methylation_conversion(
-            &mut r2_template,
+            &mut rev_template,
             template,
-            r2_start,
+            rev_start,
             false, // bottom strand
             &params.methylation,
             &mut rng,
         );
-        let r2_seq = reverse_complement(&r2_template);
-        let r2_seq = pad_sequence(r2_seq, params.read_length, &mut rng);
+        let rev_seq = reverse_complement(&rev_template);
+        let rev_seq = pad_sequence(rev_seq, params.read_length, &mut rng);
 
         // Quality scores
         let r1_quals = params.quality_model.generate_qualities(params.read_length, &mut rng);
@@ -356,18 +430,32 @@ fn generate_molecule_reads(
         // Mate cigar is based on the mate's read length (same for both reads)
         let mate_cigar = format!("{}M", params.read_length);
 
+        // Assign to R1/R2 based on strand coin flip.
+        // tlen sign convention: positive for the leftmost read, negative for the
+        // rightmost. When insert_size < read_length the reverse read starts at
+        // local_pos (mirroring rev_start's `saturating_sub`), so use
+        // `saturating_sub` here to avoid a usize underflow.
+        let rev_pos = local_pos + insert_size.saturating_sub(params.read_length);
+        let (r1_seq, r2_seq, r1_is_reverse, r1_pos, r2_pos, r1_tlen) = if is_top_strand {
+            // F1R2: R1=forward at start, R2=reverse at end
+            (fwd_seq, rev_seq, false, local_pos, rev_pos, insert_size as i32)
+        } else {
+            // R1F2: R1=reverse at end, R2=forward at start
+            (rev_seq, fwd_seq, true, rev_pos, local_pos, -(insert_size as i32))
+        };
+
         // Build R1 record
         let r1_record = build_record(
             &read_name,
             &r1_seq,
             &r1_quals,
-            0, // ref_id
-            position,
+            chrom_idx,
+            r1_pos,
             params.mapq,
-            true,  // is_first
-            false, // is_reverse
-            position + insert_size - params.read_length,
-            insert_size as i32,
+            true,          // is_first
+            r1_is_reverse, // is_reverse
+            r2_pos,
+            r1_tlen,
             &umi_str,
             &mate_cigar,
             params.mapq,
@@ -378,22 +466,22 @@ fn generate_molecule_reads(
             &read_name,
             &r2_seq,
             &r2_quals,
-            0,
-            position + insert_size - params.read_length,
+            chrom_idx,
+            r2_pos,
             params.mapq,
-            false, // is_first
-            true,  // is_reverse
-            position,
-            -(insert_size as i32),
+            false,          // is_first
+            !r1_is_reverse, // is_reverse (opposite of R1)
+            r1_pos,
+            -r1_tlen,
             &umi_str,
             &mate_cigar,
             params.mapq,
         );
 
-        pairs.push((r1_record, r2_record, read_name, umi_str.clone()));
+        pairs.push((r1_record, r2_record, read_name, umi_str.clone(), is_top_strand));
     }
 
-    pairs
+    (pairs, chrom_idx, local_pos)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -750,8 +838,129 @@ mod tests {
             },
         };
 
-        let pairs = generate_molecule_reads(0, 42, &params, Some(&ref_genome));
+        let (pairs, _chrom, _pos) = generate_molecule_reads(0, 42, 0, 500, &params, &ref_genome);
         // Multiple reads should be generated (family_size >= 3)
         assert!(pairs.len() >= 3, "Expected at least 3 reads, got {}", pairs.len());
+    }
+
+    // ========================================================================
+    // Real-coordinate and strand tests
+    // ========================================================================
+
+    #[test]
+    fn test_mapped_reads_uses_real_ref_coordinates() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        // Build multi-contig test reference
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap(); // 2000bp
+        writeln!(fasta).unwrap();
+        writeln!(fasta, ">chr2").unwrap();
+        fasta.write_all(&b"CCGG".repeat(375)).unwrap(); // 1500bp
+        writeln!(fasta).unwrap();
+        writeln!(fasta, ">chr3").unwrap();
+        fasta.write_all(&b"AATT".repeat(450)).unwrap(); // 1800bp
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let mut rng = create_rng(Some(42));
+        let positions = ref_genome.sample_positions(10, &mut rng);
+
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            min_family_size: 1,
+            quality_model: crate::simulate::PositionQualityModel::new(
+                10, 25, 37, 100, 0.08, 2, 0.0,
+            ),
+            quality_bias: crate::simulate::ReadPairQualityBias::new(0),
+            family_dist: crate::simulate::FamilySizeDistribution::log_normal(5.0, 1.0),
+            insert_model: crate::simulate::InsertSizeModel::new(100.0, 10.0, 80, 120),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+        };
+
+        // Test that generate_molecule_reads produces records with correct ref_id
+        let (chrom_idx, local_pos) = positions[0];
+        let (pairs, eff_chrom, eff_pos) =
+            generate_molecule_reads(0, 42, chrom_idx, local_pos, &params, &ref_genome);
+        assert!(!pairs.is_empty());
+
+        for (r1, r2, _, _, _) in &pairs {
+            // Both reads should reference the effective chromosome (primary or fallback)
+            assert_eq!(r1.reference_sequence_id(), Some(eff_chrom));
+            assert_eq!(r2.reference_sequence_id(), Some(eff_chrom));
+
+            // R1 or R2 should be at eff_pos (depending on strand)
+            let r1_pos = r1.alignment_start().map(|p| p.get()).unwrap_or(0);
+            let r2_pos = r2.alignment_start().map(|p| p.get()).unwrap_or(0);
+            // One of the reads should be at eff_pos + 1 (1-based)
+            assert!(
+                r1_pos == eff_pos + 1 || r2_pos == eff_pos + 1,
+                "Expected one read at position {} (1-based), got r1={}, r2={}",
+                eff_pos + 1,
+                r1_pos,
+                r2_pos
+            );
+        }
+    }
+
+    #[test]
+    fn test_strand_coin_flip_produces_both_orientations() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            min_family_size: 1,
+            quality_model: crate::simulate::PositionQualityModel::new(
+                10, 25, 37, 100, 0.08, 2, 0.0,
+            ),
+            quality_bias: crate::simulate::ReadPairQualityBias::new(0),
+            family_dist: crate::simulate::FamilySizeDistribution::log_normal(1.0, 0.1),
+            insert_model: crate::simulate::InsertSizeModel::new(100.0, 5.0, 80, 120),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+        };
+
+        let mut saw_f1r2 = false;
+        let mut saw_r1f2 = false;
+
+        // Generate many molecules with different seeds to verify both orientations
+        for seed in 0u64..100 {
+            let (pairs, _chrom, _pos) =
+                generate_molecule_reads(seed as usize, seed, 0, 500, &params, &ref_genome);
+            for (r1, _, _, _, is_top) in &pairs {
+                if *is_top {
+                    saw_f1r2 = true;
+                    assert!(!r1.flags().is_reverse_complemented(), "F1R2: R1 should be forward");
+                } else {
+                    saw_r1f2 = true;
+                    assert!(r1.flags().is_reverse_complemented(), "R1F2: R1 should be reverse");
+                }
+            }
+        }
+
+        assert!(saw_f1r2, "Should see at least one F1R2 molecule");
+        assert!(saw_r1f2, "Should see at least one R1F2 molecule");
     }
 }

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -9,8 +9,9 @@ use crate::bam_io::create_bam_writer;
 use crate::commands::command::Command;
 use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
-    FamilySizeArgs, InsertSizeArgs, MoleculeInfo, PositionDistArgs, QualityArgs, ReferenceArgs,
-    SimulationCommon, compute_position, generate_random_sequence, pad_sequence,
+    FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
+    PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
+    apply_methylation_conversion, compute_position, generate_random_sequence, pad_sequence,
 };
 use crate::dna::reverse_complement;
 use crate::progress::ProgressTracker;
@@ -88,6 +89,9 @@ pub struct MappedReads {
 
     #[command(flatten)]
     pub position_dist: PositionDistArgs,
+
+    #[command(flatten)]
+    pub methylation: MethylationArgs,
 }
 
 /// Parameters needed for molecule generation.
@@ -102,10 +106,18 @@ struct GenerationParams {
     quality_bias: ReadPairQualityBias,
     family_dist: FamilySizeDistribution,
     insert_model: InsertSizeModel,
+    methylation: MethylationConfig,
 }
 
 impl Command for MappedReads {
     fn execute(&self, command_line: &str) -> Result<()> {
+        // Validate methylation args
+        let methylation = self.methylation.resolve();
+        self.methylation.validate()?;
+        if methylation.mode.is_enabled() && self.reference.reference.is_none() {
+            anyhow::bail!("--methylation-mode requires --reference");
+        }
+
         info!("Generating mapped reads");
         info!("  Output: {}", self.output.display());
         info!("  Truth: {}", self.truth_output.display());
@@ -113,6 +125,18 @@ impl Command for MappedReads {
         info!("  Read length: {}", self.common.read_length);
         info!("  UMI length: {}", self.common.umi_length);
         info!("  Threads: {}", self.threads);
+        if methylation.mode.is_enabled() {
+            info!("  Methylation mode: {:?}", methylation.mode);
+            info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
+            info!("  Conversion rate: {}", methylation.conversion_rate);
+        }
+
+        // Load reference genome if provided
+        let ref_genome = if let Some(ref path) = self.reference.reference {
+            Some(ReferenceGenome::load(path)?)
+        } else {
+            None
+        };
 
         // Determine positions
         let num_positions = self.position_dist.num_positions.unwrap_or(self.common.num_molecules);
@@ -156,6 +180,7 @@ impl Command for MappedReads {
             quality_bias: self.quality.to_quality_bias(),
             family_dist: self.family_size.to_family_size_distribution()?,
             insert_model: self.insert_size.to_insert_size_model(),
+            methylation,
         };
 
         // Generate seeds for reproducibility
@@ -223,7 +248,12 @@ impl Command for MappedReads {
             progress.log_if_needed(1);
 
             // Generate all read pairs for this molecule
-            let pairs = generate_molecule_reads(mol_info.mol_id, mol_info.seed, &params);
+            let pairs = generate_molecule_reads(
+                mol_info.mol_id,
+                mol_info.seed,
+                &params,
+                ref_genome.as_ref(),
+            );
 
             for (r1, r2, read_name, umi_str) in pairs {
                 writer.write_alignment_record(&header, &r1)?;
@@ -249,10 +279,12 @@ impl Command for MappedReads {
 
 /// Generate all read pairs for a single molecule.
 /// Returns Vec of (`r1_record`, `r2_record`, `read_name`, `umi_str`) tuples.
+#[allow(clippy::too_many_arguments)]
 fn generate_molecule_reads(
     mol_id: usize,
     seed: u64,
     params: &GenerationParams,
+    ref_genome: Option<&ReferenceGenome>,
 ) -> Vec<(RecordBuf, RecordBuf, String, String)> {
     let mut rng = create_rng(Some(seed));
 
@@ -270,22 +302,53 @@ fn generate_molecule_reads(
     // Generate insert size
     let insert_size = params.insert_model.sample(&mut rng);
 
+    // When reference is available, generate template once from reference (shared by all reads)
+    // When no reference, each read gets an independent random template (existing behavior)
+    let shared_template = ref_genome.and_then(|g| {
+        g.sequence_at_genome_pos(position, insert_size)
+            .or_else(|| g.sample_sequence(insert_size, &mut rng).map(|(_, _, seq)| seq))
+    });
+
     let mut pairs = Vec::with_capacity(family_size);
 
     for read_idx in 0..family_size {
         let read_name = format!("mol{mol_id:08}_read{read_idx:04}");
 
-        // Generate template sequence
-        let template = generate_random_sequence(insert_size, &mut rng);
+        // Use shared reference template or generate random per-read.
+        // Avoid cloning the shared template — only borrow it.
+        let random_template;
+        let template: &[u8] = if let Some(ref shared) = shared_template {
+            shared
+        } else {
+            random_template = generate_random_sequence(insert_size, &mut rng);
+            &random_template
+        };
 
-        // R1: forward strand at position
-        let r1_seq: Vec<u8> = template.iter().take(params.read_length).copied().collect();
+        // R1: forward strand (top strand) at position
+        let r1_end = params.read_length.min(template.len());
+        let mut r1_seq: Vec<u8> = template[..r1_end].to_vec();
+        apply_methylation_conversion(
+            &mut r1_seq,
+            template,
+            0,
+            true, // top strand
+            &params.methylation,
+            &mut rng,
+        );
         let r1_seq = pad_sequence(r1_seq, params.read_length, &mut rng);
 
-        // R2: reverse strand at position + insert_size - read_length
+        // R2: reverse strand (bottom strand) at position + insert_size - read_length
         let r2_start = insert_size.saturating_sub(params.read_length);
-        let r2_template: Vec<u8> =
-            template.iter().skip(r2_start).take(params.read_length).copied().collect();
+        let r2_end = params.read_length.min(template.len().saturating_sub(r2_start));
+        let mut r2_template: Vec<u8> = template[r2_start..r2_start + r2_end].to_vec();
+        apply_methylation_conversion(
+            &mut r2_template,
+            template,
+            r2_start,
+            false, // bottom strand
+            &params.methylation,
+            &mut rng,
+        );
         let r2_seq = reverse_complement(&r2_template);
         let r2_seq = pad_sequence(r2_seq, params.read_length, &mut rng);
 
@@ -631,5 +694,70 @@ mod tests {
             build_record("read", seq, &quals, 0, 200, 60, false, true, 100, -150, "AAA", "4M", 60);
 
         assert_eq!(record.template_length(), -150);
+    }
+
+    // ========================================================================
+    // Methylation tests
+    // ========================================================================
+
+    #[test]
+    fn test_emseq_mapped_reads_conversion() {
+        // Template with non-CpG Cs that should convert C->T in EM-Seq
+        let template = b"CACACACACACACACAC".to_vec(); // no CpG dinucleotides
+        let config = MethylationConfig {
+            mode: fgumi_consensus::MethylationMode::EmSeq,
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 1.0,
+        };
+
+        let mut r1 = template[..8].to_vec();
+        let mut rng = create_rng(Some(42));
+        apply_methylation_conversion(&mut r1, &template, 0, true, &config, &mut rng);
+
+        // All non-CpG Cs should convert to T
+        for (i, &b) in r1.iter().enumerate() {
+            if template[i] == b'C' {
+                assert_eq!(b, b'T', "position {i}: non-CpG C should convert");
+            }
+        }
+    }
+
+    #[test]
+    fn test_reads_in_family_share_template_with_reference() {
+        // With a reference, all reads in a family should start from the same template
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        let seq = b"ACGT".repeat(500); // 2000 bp
+        fasta.write_all(&seq).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            min_family_size: 3,
+            num_positions: 100,
+            ref_length: 2000,
+            quality_model: crate::simulate::PositionQualityModel::new(
+                10, 25, 37, 100, 0.08, 2, 0.0,
+            ),
+            quality_bias: crate::simulate::ReadPairQualityBias::new(0),
+            family_dist: crate::simulate::FamilySizeDistribution::log_normal(5.0, 1.0),
+            insert_model: crate::simulate::InsertSizeModel::new(100.0, 10.0, 80, 120),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+        };
+
+        let pairs = generate_molecule_reads(0, 42, &params, Some(&ref_genome));
+        // Multiple reads should be generated (family_size >= 3)
+        assert!(pairs.len() >= 3, "Expected at least 3 reads, got {}", pairs.len());
     }
 }

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -6,6 +6,7 @@
 //! output is generated fresh each run.
 
 use std::ffi::OsString;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use tempfile::TempDir;
@@ -42,8 +43,26 @@ macro_rules! args {
 // Helpers: simulate
 // ---------------------------------------------------------------------------
 
+/// Create a test reference FASTA file with a single chromosome.
+fn create_test_reference(dir: &Path) -> PathBuf {
+    let ref_path = dir.join("ref.fa");
+    let mut f = std::fs::File::create(&ref_path).expect("failed to create ref FASTA");
+    writeln!(f, ">chr1").unwrap();
+    // 10 kb of repeating ACGT — large enough for any simulated insert size
+    f.write_all(&b"ACGT".repeat(2500)).unwrap();
+    writeln!(f).unwrap();
+    f.flush().unwrap();
+    ref_path
+}
+
 /// Generate grouped-reads BAM using simulate with deterministic seed.
-fn simulate_grouped_reads(output: &Path, truth: &Path, seed: u32, num_molecules: u32) {
+fn simulate_grouped_reads(
+    output: &Path,
+    truth: &Path,
+    reference: &Path,
+    seed: u32,
+    num_molecules: u32,
+) {
     fgumi_ok(args![
         "simulate",
         "grouped-reads",
@@ -51,6 +70,8 @@ fn simulate_grouped_reads(output: &Path, truth: &Path, seed: u32, num_molecules:
         output,
         "--truth",
         truth,
+        "--reference",
+        reference,
         "--num-molecules",
         &num_molecules.to_string(),
         "--seed",
@@ -65,7 +86,14 @@ fn simulate_grouped_reads(output: &Path, truth: &Path, seed: u32, num_molecules:
 }
 
 /// Generate FASTQ reads using simulate with deterministic seed.
-fn simulate_fastq_reads(r1: &Path, r2: &Path, truth: &Path, seed: u32, num_molecules: u32) {
+fn simulate_fastq_reads(
+    r1: &Path,
+    r2: &Path,
+    truth: &Path,
+    reference: &Path,
+    seed: u32,
+    num_molecules: u32,
+) {
     fgumi_ok(args![
         "simulate",
         "fastq-reads",
@@ -75,6 +103,8 @@ fn simulate_fastq_reads(r1: &Path, r2: &Path, truth: &Path, seed: u32, num_molec
         r2,
         "--truth",
         truth,
+        "--reference",
+        reference,
         "--num-molecules",
         &num_molecules.to_string(),
         "--seed",
@@ -158,9 +188,10 @@ fn assert_bams_identical(bam1: &Path, bam2: &Path, mode: &str, context: &str) {
 /// Create a `TempDir` and simulate grouped reads, returning (tmpdir, grouped bam path).
 fn setup_grouped_reads(seed: u32, num_molecules: u32) -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
     let grouped = tmp.path().join("grouped.bam");
     let truth = tmp.path().join("truth.tsv");
-    simulate_grouped_reads(&grouped, &truth, seed, num_molecules);
+    simulate_grouped_reads(&grouped, &truth, &reference, seed, num_molecules);
     (tmp, grouped)
 }
 
@@ -171,13 +202,14 @@ fn setup_grouped_reads(seed: u32, num_molecules: u32) -> (TempDir, PathBuf) {
 #[test]
 fn test_simulate_grouped_reads_deterministic() {
     let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
     let bam1 = tmp.path().join("grouped1.bam");
     let bam2 = tmp.path().join("grouped2.bam");
     let truth1 = tmp.path().join("truth1.tsv");
     let truth2 = tmp.path().join("truth2.tsv");
 
-    simulate_grouped_reads(&bam1, &truth1, 42, 100);
-    simulate_grouped_reads(&bam2, &truth2, 42, 100);
+    simulate_grouped_reads(&bam1, &truth1, &reference, 42, 100);
+    simulate_grouped_reads(&bam2, &truth2, &reference, 42, 100);
 
     assert_bams_identical(
         &bam1,
@@ -239,12 +271,13 @@ fn test_simplex_filter_pipeline_deterministic() {
 #[test]
 fn test_full_pipeline_extract_to_filter() {
     let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
 
     // Generate synthetic FASTQ
     let r1 = tmp.path().join("r1.fq.gz");
     let r2 = tmp.path().join("r2.fq.gz");
     let truth = tmp.path().join("truth.tsv");
-    simulate_fastq_reads(&r1, &r2, &truth, 42, 200);
+    simulate_fastq_reads(&r1, &r2, &truth, &reference, 42, 200);
 
     // Run the full pipeline twice to verify determinism
     for suffix in ["a", "b"] {
@@ -322,13 +355,14 @@ fn test_dedup_pipeline_deterministic() {
 #[test]
 fn test_different_seeds_produce_different_output() {
     let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
     let bam1 = tmp.path().join("seed1.bam");
     let bam2 = tmp.path().join("seed2.bam");
     let truth1 = tmp.path().join("truth1.tsv");
     let truth2 = tmp.path().join("truth2.tsv");
 
-    simulate_grouped_reads(&bam1, &truth1, 42, 100);
-    simulate_grouped_reads(&bam2, &truth2, 99, 100);
+    simulate_grouped_reads(&bam1, &truth1, &reference, 42, 100);
+    simulate_grouped_reads(&bam2, &truth2, &reference, 99, 100);
 
     let output = compare_bams(&bam1, &bam2, "content");
     assert_eq!(

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -5,7 +5,9 @@
 //! verifying outputs with `compare`.  No golden files are checked in — expected
 //! output is generated fresh each run.
 
+use noodles::bam;
 use std::ffi::OsString;
+use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -373,4 +375,117 @@ fn test_different_seeds_produce_different_output() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+}
+
+// ---------------------------------------------------------------------------
+// Methylation pipeline: grouped-reads --methylation-mode em-seq ->
+//                       simplex --methylation-mode em-seq --ref
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_e2e_methylation_pipeline() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+
+    // Build a reference with CpG sites (ACGTCCGG pattern has CpG at positions 2-3 and 5-6)
+    let ref_path = tmp.path().join("ref.fa");
+    let mut f = std::fs::File::create(&ref_path).expect("failed to create ref FASTA");
+    writeln!(f, ">chr1").unwrap();
+    f.write_all(&b"ACGTCCGG".repeat(1250)).unwrap(); // 10 kb
+    writeln!(f).unwrap();
+    f.flush().unwrap();
+
+    // Generate grouped reads with EM-Seq methylation
+    let grouped = tmp.path().join("grouped.bam");
+    let truth = tmp.path().join("truth.tsv");
+    fgumi_ok(args![
+        "simulate",
+        "grouped-reads",
+        "-o",
+        &grouped,
+        "--truth",
+        &truth,
+        "--reference",
+        &ref_path,
+        "--num-molecules",
+        "50",
+        "--seed",
+        "42",
+        "--read-length",
+        "100",
+        "--umi-length",
+        "6",
+        "--min-family-size",
+        "3",
+        "--methylation-mode",
+        "em-seq"
+    ]);
+
+    // Run simplex consensus with methylation mode
+    let simplex = tmp.path().join("simplex.bam");
+    fgumi_ok(args![
+        "simplex",
+        "-i",
+        &grouped,
+        "-o",
+        &simplex,
+        "--threads",
+        "1",
+        "--min-reads",
+        "1",
+        "--methylation-mode",
+        "em-seq",
+        "--ref",
+        &ref_path
+    ]);
+
+    // Verify the simplex output actually carries methylation emission.
+    // The simplex BAM should contain at least one consensus record with the
+    // MM/ML methylation tag pair and the cu/ct TAPS-specific count arrays.
+    assert_simplex_has_methylation_tags(&simplex);
+}
+
+/// Assert that a simplex BAM contains non-empty MM/ML and cu/ct tags on at
+/// least one record.
+///
+/// MM is a string tag (hex 'MM'), ML is a byte-array tag (hex 'ML').
+/// cu and ct are i16-array tags added by the EM-Seq/TAPS methylation caller.
+#[allow(clippy::similar_names)] // MM/ML and cu/ct are the natural tag names.
+fn assert_simplex_has_methylation_tags(bam_path: &Path) {
+    let file = File::open(bam_path).expect("failed to open simplex BAM");
+    let mut reader = bam::io::Reader::new(file);
+    let _header = reader.read_header().expect("failed to read BAM header");
+
+    let mm_tag = [b'M', b'M'];
+    let ml_tag = [b'M', b'L'];
+    let cu_tag = [b'c', b'u'];
+    let ct_tag = [b'c', b't'];
+
+    let mut total = 0usize;
+    let mut with_mm = 0usize;
+    let mut with_ml = 0usize;
+    let mut with_cu = 0usize;
+    let mut with_ct = 0usize;
+    for result in reader.records() {
+        let record = result.expect("failed to read simplex record");
+        let data = record.data();
+        total += 1;
+        if data.get(&mm_tag).is_some() {
+            with_mm += 1;
+        }
+        if data.get(&ml_tag).is_some() {
+            with_ml += 1;
+        }
+        if data.get(&cu_tag).is_some() {
+            with_cu += 1;
+        }
+        if data.get(&ct_tag).is_some() {
+            with_ct += 1;
+        }
+    }
+
+    assert!(total > 0, "Simplex BAM should contain at least one record");
+    assert!(with_mm > 0, "Expected at least one record with an MM tag; got {total} records");
+    assert!(with_ml > 0, "Expected at least one record with an ML tag; got {total} records");
+    assert!(with_cu > 0, "Expected at least one record with a cu tag; got {total} records");
+    assert!(with_ct > 0, "Expected at least one record with a ct tag; got {total} records");
 }


### PR DESCRIPTION
## Summary

- Add `--methylation-mode <em-seq|taps>` to `fastq-reads`, `mapped-reads`, `grouped-reads`, and `consensus-reads` simulate subcommands
- Base-level commands apply stochastic C→T (top strand) / G→A (bottom strand) conversion with configurable `--cpg-methylation-rate` and `--conversion-rate`, requiring `--reference` for realistic templates
- `consensus-reads` generates MM/ML/cu/ct tags directly (plus per-strand au/at/bu/bt/am/bm for duplex)
- Shared `MethylationConfig` struct and `MethylationArgs` CLI args reduce parameter sprawl across subcommands
- `is_cpg_context` moved to `fgumi-consensus::methylation` for reuse across crates
- `ReferenceGenome` gains `sequence_at_genome_pos` for correct multi-chromosome template sampling
- `simulate` feature now depends on `simplex` for access to methylation types

Closes #262

## Test plan

- [x] 2476 tests pass (`cargo ci-test`)
- [x] Formatting clean (`cargo ci-fmt`)
- [x] Lints clean (`cargo ci-lint`)
- [ ] Verify EM-Seq end-to-end: `simulate grouped-reads --methylation-mode em-seq` → `simplex --methylation-mode em-seq` → `filter --methylation-mode em-seq`
- [ ] Verify TAPs end-to-end: same pipeline with `--methylation-mode taps`
- [ ] Verify `simulate consensus-reads --methylation-mode em-seq --duplex` produces au/at/bu/bt/am/bm tags