### PR TITLE
docs(reorder-buffer): correct insert complexity and add micro-bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,10 @@ fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 name = "core_functions"
 harness = false
 
+[[bench]]
+name = "reorder_buffer"
+harness = false
+
 [build-dependencies]
 built = { version = "0", features = ["git2"] }
 

--- a/benches/reorder_buffer.rs
+++ b/benches/reorder_buffer.rs
@@ -1,0 +1,106 @@
+//! Benchmarks for `ReorderBuffer::insert_with_size` under varying gap patterns.
+//!
+//! This exists so future data-structure swaps (e.g. `BTreeMap`, `BinaryHeap`,
+//! ring buffer) can be measured honestly against the current sparse-`VecDeque`
+//! implementation. The sparse `VecDeque` makes inserts O(gap) when a sequence
+//! number arrives ahead of the current buffer end (the gap is filled with
+//! `None` sentinels), so the cost is sensitive to gap size — the scenarios
+//! below sweep a few realistic steady-state patterns.
+//!
+//! Run with: `cargo bench --bench reorder_buffer`
+//! Quick sanity: `cargo bench --bench reorder_buffer -- --quick`
+//! View reports in: `target/criterion/report/index.html`
+#![deny(unsafe_code)]
+#![allow(clippy::cast_possible_truncation)]
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use fgumi_lib::reorder_buffer::ReorderBuffer;
+
+/// Number of inserts per bench iteration. Large enough that per-call overhead
+/// is amortized, small enough to keep the bench quick.
+const BATCH_SIZE: usize = 256;
+
+/// Run a fill+drain cycle where inserts arrive in perfect sequence order.
+///
+/// With `k == 0`, no gap slots are ever pushed — this is the O(1)-per-insert
+/// best case and a baseline for the other scenarios.
+fn bench_in_order(buffer: &mut ReorderBuffer<u64>, batch_size: usize) {
+    let base = buffer.next_seq();
+    for i in 0..batch_size as u64 {
+        let seq = base + i;
+        buffer.insert_with_size(black_box(seq), black_box(seq), black_box(8));
+    }
+    // Drain everything so the next iteration starts from a known empty state.
+    while let Some((val, size)) = buffer.try_pop_next_with_size() {
+        black_box((val, size));
+    }
+}
+
+/// Insert in chunks of size `k+1` where the far slot is filled first, then the
+/// near slots 0..k are filled in order, then drain.
+///
+/// This models a slow producer that is `k` ahead of the in-order stream:
+/// - Chunk layout for k=1: insert [base+1, base+0], drain 2 items
+/// - Chunk layout for k=8: insert [base+8, base+0..=7], drain 9 items
+/// - Chunk layout for k=64: insert [base+64, base+0..=63], drain 65 items
+///
+/// The first insert in each chunk walks k slots ahead, pushing k `None`
+/// sentinels, so each chunk pays O(k) for the lead insert plus O(1) for the
+/// rest — this is exactly the pattern the fixed doc comment is warning about.
+fn bench_leading_gap(buffer: &mut ReorderBuffer<u64>, batch_size: usize, k: u64) {
+    let chunk = k as usize + 1;
+    let mut base = buffer.next_seq();
+    let mut remaining = batch_size;
+    while remaining > 0 {
+        let this_chunk = remaining.min(chunk);
+        let lead = this_chunk as u64 - 1;
+        // Insert the far slot first (walks `lead` gap slots forward).
+        buffer.insert_with_size(black_box(base + lead), black_box(base + lead), black_box(8));
+        // Fill the near slots 0..lead in order.
+        for i in 0..lead {
+            let seq = base + i;
+            buffer.insert_with_size(black_box(seq), black_box(seq), black_box(8));
+        }
+        // Drain this chunk before starting the next so steady-state depth
+        // stays bounded and the pattern is repeatable.
+        while let Some((val, size)) = buffer.try_pop_next_with_size() {
+            black_box((val, size));
+        }
+        base += this_chunk as u64;
+        remaining -= this_chunk;
+    }
+}
+
+fn bench_reorder_buffer_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reorder_buffer_insert");
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    // Scenario 1: purely in-order (k=0).
+    group.bench_function(BenchmarkId::from_parameter("in_order_k0"), |b| {
+        b.iter_batched_ref(
+            ReorderBuffer::<u64>::new,
+            |buffer| bench_in_order(buffer, BATCH_SIZE),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    // Scenarios 2-4: leading-gap patterns for k in {1, 8, 64}.
+    for &k in &[1u64, 8, 64] {
+        let id = BenchmarkId::new("leading_gap", k);
+        group.bench_with_input(id, &k, |b, &k| {
+            b.iter_batched_ref(
+                ReorderBuffer::<u64>::new,
+                |buffer| bench_leading_gap(buffer, BATCH_SIZE, k),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_reorder_buffer_insert);
+criterion_main!(benches);

--- a/src/lib/reorder_buffer.rs
+++ b/src/lib/reorder_buffer.rs
@@ -34,7 +34,9 @@ use crate::unified_pipeline::MemoryEstimate;
 /// This enables ordered output from parallel processing where
 /// items may complete out of order.
 ///
-/// Uses a sparse `VecDeque` for O(1) insert and pop operations.
+/// Uses a sparse `VecDeque`: pop is O(1); insert is O(1) when the sequence
+/// number arrives in order, and O(gap) when it arrives ahead of the current
+/// buffer end (the gap is filled with `None` sentinels).
 ///
 /// # Memory Tracking
 ///


### PR DESCRIPTION
## Summary

- Fix a misleading complexity claim in `ReorderBuffer`'s docstring. It said "O(1) insert and pop operations," but `insert_with_size` runs a `while self.buffer.len() <= index { push_back(None) }` loop, so insert is O(gap) when a sequence number arrives ahead of the current buffer end. Pop remains O(1). The docstring now states the actual contract.
- Add a criterion micro-bench at `benches/reorder_buffer.rs` covering four realistic insert patterns — purely in-order (k=0) and leading-gap (k=1, 8, 64) — over a 256-insert fill+drain cycle per iteration. Bench target registered in `Cargo.toml` mirroring the existing `core_functions` block with `harness = false`.

The bench exists so future data-structure swaps (BTreeMap, BinaryHeap, fixed-capacity ring buffer) can be measured honestly against the current sparse-`VecDeque` behavior, including the O(gap) path the corrected doc now advertises.

No functional change; no API change.

## Test plan

- [x] `cargo build --release --bench reorder_buffer`
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo bench --bench reorder_buffer -- --test`
- [ ] Reviewer: spot-check bench output is stable across runs