### PR TITLE
feat(zipper): auto-detect BAM input on stdin via BGZF magic

### DIFF
--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -75,7 +75,7 @@ use noodles::sam::alignment::record_buf::Data;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 /// Command-line arguments for `zipper`
@@ -119,8 +119,8 @@ workflows like:
 )]
 #[command(verbatim_doc_comment)]
 pub struct Zipper {
-    /// Input mapped SAM or BAM file (or `-` for stdin, SAM only). BAM input is
-    /// discouraged; prefer piping SAM directly from the aligner for best performance.
+    /// Input mapped SAM or BAM file (or `-` for stdin; SAM or BAM is auto-detected).
+    /// BAM input is discouraged; prefer piping SAM directly from the aligner for best performance.
     #[arg(short = 'i', long, default_value = "-")]
     pub input: PathBuf,
 
@@ -1270,11 +1270,52 @@ impl Zipper {
     }
 }
 
+/// BAM reader for stdin: single-threaded BGZF over a buffered `Box<dyn Read + Send>`.
+///
+/// Stdin is non-seekable, so we use a single-threaded BGZF reader (the multi-threaded
+/// variant in [`BamReaderAuto`] requires `Seek`). `BufReader` wraps stdin so we can peek
+/// the BGZF magic bytes for format auto-detection without consuming them.
+type BamStdinReader =
+    noodles::bam::io::Reader<noodles::bgzf::io::Reader<BufReader<Box<dyn Read + Send>>>>;
+
 /// Wraps SAM and BAM readers so the mapped-reader thread can handle either format.
 /// Moved into the thread where `record_bufs()` is called, since it borrows `&self`.
 enum MappedReader {
     Sam(noodles::sam::io::Reader<Box<dyn BufRead + Send>>),
     Bam(BamReaderAuto),
+    StdinBam(BamStdinReader),
+}
+
+/// First four bytes of a BGZF stream (gzip magic + extra-flag byte unique to BGZF).
+const BGZF_MAGIC: [u8; 4] = [0x1f, 0x8b, 0x08, 0x04];
+
+/// Peeks up to [`BGZF_MAGIC.len()`] bytes from `stdin` to classify it as BGZF (BAM) vs SAM text.
+///
+/// A single `read()` on a pipe may return fewer bytes than requested even when more
+/// data is coming (e.g. the aligner hasn't flushed its first block yet), so this loops
+/// until the peek buffer is full or EOF is reached. The peeked bytes are then chained
+/// back onto the stream so downstream parsers see the complete input.
+///
+/// # Returns
+///
+/// `(is_bgzf, reader)` where `reader` yields the peeked bytes followed by the rest of
+/// the original stream.
+fn peek_stdin_bgzf(mut stdin: Box<dyn Read + Send>) -> Result<(bool, Box<dyn Read + Send>)> {
+    let mut prefix = [0u8; BGZF_MAGIC.len()];
+    let mut filled = 0usize;
+    while filled < prefix.len() {
+        match stdin.read(&mut prefix[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e).context("Failed to peek stdin"),
+        }
+    }
+    let is_bgzf = filled == BGZF_MAGIC.len() && prefix == BGZF_MAGIC;
+    // Prepend the peeked bytes back onto the stream so the chosen reader sees them.
+    let restored: Box<dyn Read + Send> =
+        Box::new(std::io::Cursor::new(prefix[..filled].to_vec()).chain(stdin));
+    Ok((is_bgzf, restored))
 }
 
 impl Command for Zipper {
@@ -1327,13 +1368,37 @@ impl Command for Zipper {
         // The reader and header are separated here; record_bufs() is called inside
         // the spawned thread (it borrows &self, so the reader must live there).
         let (mapped_reader, mapped_header) = if is_stdin_path(&self.input) {
-            // Stdin is always SAM (streaming from aligner)
-            info!("Reading SAM from stdin with adaptive buffer (bwa -K {})", self.bwa_chunk_size);
-            let reader: Box<dyn BufRead + Send> =
-                Box::new(BatchedSamReader::new(std::io::stdin(), self.bwa_chunk_size));
-            let mut sam_reader = noodles::sam::io::Reader::new(reader);
-            let header = sam_reader.read_header()?;
-            (MappedReader::Sam(sam_reader), header)
+            // Auto-detect BAM (BGZF magic) vs SAM text on stdin so callers can pipe either,
+            // matching the file-input path. Without this, piping `samtools view -b ...` to
+            // zipper crashes with a confusing "invalid flags / lexical parse error" because
+            // the SAM text parser misreads the binary BGZF stream.
+            //
+            // `peek_stdin_bgzf` reads up to the magic length in a loop (a single `read()` on
+            // a pipe may return fewer bytes than requested) and returns a reader that prepends
+            // the peeked bytes back onto the stream for the chosen downstream reader.
+            let stdin: Box<dyn Read + Send> = Box::new(std::io::stdin());
+            let (is_bgzf, stdin) = peek_stdin_bgzf(stdin)?;
+            let buffered = BufReader::with_capacity(64 * 1024, stdin);
+            if is_bgzf {
+                warn!(
+                    "BAM input detected on stdin. For best performance, pipe SAM directly \
+                     from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
+                );
+                let bgzf = noodles::bgzf::io::Reader::new(buffered);
+                let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
+                let header = bam_reader.read_header()?;
+                (MappedReader::StdinBam(bam_reader), header)
+            } else {
+                info!(
+                    "Reading SAM from stdin with adaptive buffer (bwa -K {})",
+                    self.bwa_chunk_size
+                );
+                let reader: Box<dyn BufRead + Send> =
+                    Box::new(BatchedSamReader::new(buffered, self.bwa_chunk_size));
+                let mut sam_reader = noodles::sam::io::Reader::new(reader);
+                let header = sam_reader.read_header()?;
+                (MappedReader::Sam(sam_reader), header)
+            }
         } else if self.input.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("bam")) {
             // BAM file input — functional but discouraged
             warn!(
@@ -1433,6 +1498,17 @@ impl Command for Zipper {
                         }
                     }
                 }
+                MappedReader::StdinBam(mut r) => {
+                    let mapped_iter = TemplateIterator::new(
+                        r.record_bufs(&mapped_header_for_reader)
+                            .map(|rec| rec.map_err(anyhow::Error::from)),
+                    );
+                    for template in mapped_iter {
+                        if mapped_tx.send(template).is_err() {
+                            break;
+                        }
+                    }
+                }
             }
         });
         let mapped_iter = std::iter::from_fn(move || mapped_rx.recv().ok());
@@ -1465,7 +1541,83 @@ mod tests {
     use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
     use rstest::rstest;
     use std::collections::HashMap;
+    use std::io::Read;
     use tempfile::TempDir;
+
+    /// A `Read` implementation that returns at most one byte per `read` call,
+    /// mimicking the behavior of a slow pipe or small kernel buffer. Used to
+    /// regression-test `peek_stdin_bgzf`, which must tolerate short reads.
+    struct TrickleReader(std::collections::VecDeque<u8>);
+
+    impl Read for TrickleReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            match self.0.pop_front() {
+                Some(b) => {
+                    buf[0] = b;
+                    Ok(1)
+                }
+                None => Ok(0),
+            }
+        }
+    }
+
+    fn trickle(bytes: &[u8]) -> Box<dyn Read + Send> {
+        Box::new(TrickleReader(bytes.iter().copied().collect()))
+    }
+
+    /// Regression: `BufReader::fill_buf` can return fewer than `BGZF_MAGIC.len()`
+    /// bytes on a pipe even when more data is coming. Before the fix, that caused
+    /// BAM-on-stdin to be misclassified as SAM. Simulate it with a reader that
+    /// returns one byte per `read` call and confirm classification + stream
+    /// reconstruction both work.
+    #[test]
+    fn test_peek_stdin_bgzf_classifies_bam_under_short_reads() -> Result<()> {
+        let mut stream = BGZF_MAGIC.to_vec();
+        stream.extend_from_slice(b"rest-of-bgzf-stream");
+        let (is_bgzf, mut restored) = peek_stdin_bgzf(trickle(&stream))?;
+        assert!(is_bgzf);
+        let mut round_trip = Vec::new();
+        restored.read_to_end(&mut round_trip)?;
+        assert_eq!(round_trip, stream);
+        Ok(())
+    }
+
+    #[test]
+    fn test_peek_stdin_bgzf_classifies_sam_text() -> Result<()> {
+        let stream = b"@HD\tVN:1.6\tSO:queryname\n".to_vec();
+        let (is_bgzf, mut restored) = peek_stdin_bgzf(trickle(&stream))?;
+        assert!(!is_bgzf);
+        let mut round_trip = Vec::new();
+        restored.read_to_end(&mut round_trip)?;
+        assert_eq!(round_trip, stream);
+        Ok(())
+    }
+
+    #[test]
+    fn test_peek_stdin_bgzf_handles_stream_shorter_than_magic() -> Result<()> {
+        // Fewer bytes than BGZF_MAGIC.len() — must not be misclassified as BAM,
+        // and the short prefix must still be recoverable from the returned reader.
+        let stream = b"@H".to_vec();
+        let (is_bgzf, mut restored) = peek_stdin_bgzf(trickle(&stream))?;
+        assert!(!is_bgzf);
+        let mut round_trip = Vec::new();
+        restored.read_to_end(&mut round_trip)?;
+        assert_eq!(round_trip, stream);
+        Ok(())
+    }
+
+    #[test]
+    fn test_peek_stdin_bgzf_handles_empty_stream() -> Result<()> {
+        let (is_bgzf, mut restored) = peek_stdin_bgzf(Box::new(std::io::empty()))?;
+        assert!(!is_bgzf);
+        let mut round_trip = Vec::new();
+        restored.read_to_end(&mut round_trip)?;
+        assert!(round_trip.is_empty());
+        Ok(())
+    }
 
     /// Runs `zipper-bams` and returns the output records
     ///

--- a/tests/integration/test_zipper_command.rs
+++ b/tests/integration/test_zipper_command.rs
@@ -5,6 +5,7 @@
 //! 2. Tag removal via `--tags-to-remove`
 //! 3. Error on missing input files
 
+use fgumi_lib::sam::SamTag;
 use fgumi_lib::sam::builder::RecordBuilder;
 use noodles::bam;
 use noodles::sam;
@@ -12,8 +13,9 @@ use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
@@ -131,7 +133,7 @@ fn test_zipper_basic_merge() {
     let records: Vec<RecordBuf> = reader.record_bufs(&header).map(|r| r.unwrap()).collect();
     assert_eq!(records.len(), 2, "Should have 2 records in output");
 
-    let rx_tag = Tag::from([b'R', b'X']);
+    let rx_tag = Tag::from(SamTag::RX);
     for record in &records {
         assert!(record.data().get(&rx_tag).is_some(), "Output record should have RX tag");
     }
@@ -200,8 +202,8 @@ fn test_zipper_tag_removal() {
     let records: Vec<RecordBuf> = reader.record_bufs(&header).map(|r| r.unwrap()).collect();
     assert_eq!(records.len(), 1);
 
-    let rx_tag = Tag::from([b'R', b'X']);
-    let xy_tag = Tag::from([b'X', b'Y']);
+    let rx_tag = Tag::from(SamTag::RX);
+    let xy_tag = Tag::from(SamTag::new(b'X', b'Y'));
     assert!(records[0].data().get(&rx_tag).is_some(), "RX tag should be present");
     assert!(records[0].data().get(&xy_tag).is_none(), "XY tag should have been removed");
 }
@@ -316,7 +318,7 @@ fn test_zipper_bam_mapped_input() {
     let records: Vec<RecordBuf> = reader.record_bufs(&header).map(|r| r.unwrap()).collect();
     assert_eq!(records.len(), 2, "Should have 2 records in output");
 
-    let rx_tag = Tag::from([b'R', b'X']);
+    let rx_tag = Tag::from(SamTag::RX);
     for record in &records {
         assert!(record.data().get(&rx_tag).is_some(), "Output record should have RX tag");
     }
@@ -324,4 +326,111 @@ fn test_zipper_bam_mapped_input() {
     // Verify warning about BAM input was emitted
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("BAM input detected"), "Should warn about BAM input. stderr: {stderr}");
+}
+
+/// Test zipper accepts BAM piped to stdin (auto-detected via BGZF magic bytes).
+///
+/// Common in nf-core / Galaxy pipelines that produce BAM from intermediate steps
+/// (e.g. `bwameth.py | samtools view -b | fgumi zipper`). Without auto-detection,
+/// fgumi treats stdin as SAM text and crashes with a confusing
+/// "invalid flags / lexical parse error" error from the SAM parser misreading
+/// BGZF binary bytes.
+#[test]
+fn test_zipper_bam_stdin_input() {
+    let temp_dir = TempDir::new().unwrap();
+    let unmapped_bam = temp_dir.path().join("unmapped.bam");
+    let mapped_bam = temp_dir.path().join("mapped.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+
+    let unmapped_records = vec![
+        RecordBuilder::new()
+            .name("read1")
+            .sequence("ACGTACGT")
+            .qualities(&[30; 8])
+            .unmapped(true)
+            .tag("RX", "AACCGGTT")
+            .tag("QX", "IIIIIIII")
+            .build(),
+        RecordBuilder::new()
+            .name("read2")
+            .sequence("TGCATGCA")
+            .qualities(&[30; 8])
+            .unmapped(true)
+            .tag("RX", "GGTTCCAA")
+            .tag("QX", "IIIIIIII")
+            .build(),
+    ];
+    create_unmapped_bam(&unmapped_bam, &unmapped_records);
+
+    let mapped_header = create_minimal_header("chr1", 10000);
+    let mapped_records = vec![
+        RecordBuilder::new()
+            .name("read1")
+            .sequence("ACGTACGT")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(100)
+            .mapping_quality(60)
+            .cigar("8M")
+            .build(),
+        RecordBuilder::new()
+            .name("read2")
+            .sequence("TGCATGCA")
+            .qualities(&[30; 8])
+            .reference_sequence_id(0)
+            .alignment_start(200)
+            .mapping_quality(60)
+            .cigar("8M")
+            .build(),
+    ];
+    create_mapped_bam(&mapped_bam, &mapped_header, &mapped_records);
+
+    // Pipe the BAM bytes into the child's stdin; do NOT pass --input so that
+    // the default ("-") triggers the stdin code path.
+    let bam_bytes = fs::read(&mapped_bam).expect("read mapped BAM bytes");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "zipper",
+            "--unmapped",
+            unmapped_bam.to_str().unwrap(),
+            "--reference",
+            ref_path.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn zipper command");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("Failed to open child stdin")
+        .write_all(&bam_bytes)
+        .expect("Failed to write BAM bytes to stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for zipper");
+
+    assert!(
+        output.status.success(),
+        "Zipper command failed with BAM on stdin: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_bam.exists(), "Output BAM not created");
+
+    // Verify output records have UMI tags transferred
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let header = reader.read_header().unwrap();
+    let records: Vec<RecordBuf> = reader.record_bufs(&header).map(|r| r.unwrap()).collect();
+    assert_eq!(records.len(), 2, "Should have 2 records in output");
+
+    let rx_tag = Tag::from(SamTag::RX);
+    for record in &records {
+        assert!(record.data().get(&rx_tag).is_some(), "Output record should have RX tag");
+    }
 }


### PR DESCRIPTION
## Summary

- Extend BAM-vs-SAM auto-detection from #183 to stdin: peek the first four bytes via a `BufReader`, route to a BGZF + BAM reader on `\x1f\x8b\x08\x04`, otherwise the existing SAM path.
- New integration test `test_zipper_bam_stdin_input` reproduces the production failure mode (`bwameth.py | samtools view -b | fgumi zipper`) and asserts tag-transfer success.
- Drive-by: migrate the four remaining `Tag::from([..])` sites in `test_zipper_command.rs` to the SamTag newtype style for consistency with the other integration test files.

## Why

#183 added BAM file support behind a doc note that "stdin remains SAM-only." In practice, methylation pipelines (nf-core, fgumi-benchmarks EM-Seq realignment) emit BAM via `samtools view -b` on stdin. fgumi treated the BGZF bytes as SAM text and crashed with a misleading

```
Error: invalid flags
Caused by: lexical parse error: 'the string to parse was empty' at index 0
```

— fully reproducible in one second locally with a 2-record toy BAM. This PR closes that gap with the same detection-and-warn pattern #183 used for file inputs.

The SAM-on-stdin fast path (the streaming aligner workflow) is unchanged; the only behavioral change is that BGZF-magic stdin is now accepted with a warning rather than crashing.

## Test plan

- [x] New `test_zipper_bam_stdin_input` integration test fails before the fix (same `invalid flags` error as production), passes after.
- [x] All 71 zipper tests pass (\`cargo ci-test commands::zipper\`).
- [x] Full workspace \`cargo ci-test\`: 2494 passed, 19 skipped.
- [x] \`cargo ci-fmt\` clean.
- [x] \`cargo ci-lint\` (clippy pedantic + \`-D warnings\`) clean.