### PR TITLE
feat(raw-bam): unified view/editor API + close all gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
- "wide 1.2.0",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -717,7 +717,7 @@ dependencies = [
  "log",
  "noodles",
  "rand 0.10.1",
- "wide 1.2.0",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -744,9 +744,11 @@ name = "fgumi-raw-bam"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "noodles",
  "proptest",
  "rstest",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -2733,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198f6abc41fab83526d10880fa5c17e2b4ee44e763949b4bb34e2fd1e8ca48e4"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
 dependencies = [
  "bytemuck",
  "safe_arch 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,18 @@ fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 name = "core_functions"
 harness = false
 
+[[bench]]
+name = "raw_bam_accessors"
+harness = false
+
+[[bench]]
+name = "raw_bam_tags_editor"
+harness = false
+
+[[bench]]
+name = "raw_bam_length_changing"
+harness = false
+
 [build-dependencies]
 built = { version = "0", features = ["git2"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ fgumi-raw-bam = { version = "0.1.3", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.1.3", path = "crates/fgumi-sam" }
 fgumi-simd-fastq = { version = "0.1.3", path = "crates/fgumi-simd-fastq" }
 fgumi-umi = { version = "0.1.3", path = "crates/fgumi-umi" }
+bytemuck = { version = "1.14", features = ["derive"] }
+wide = "1.3"
 
 [package]
 name = "fgumi"
@@ -71,10 +73,10 @@ num_cpus = "1.16"
 rayon = "1.10"
 approx = "0.5.1"
 ahash = "0.8"
-bytemuck = { version = "1.14", features = ["derive"] }
+bytemuck = { workspace = true }
 noodles-csi = "0.54.0"
 bgzf = "0.3.0"
-wide = "1.1"
+wide = { workspace = true }
 rand_distr = "0.6"
 flate2 = "1.1"
 dhat = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,8 @@ stress-tests = []
 rstest = "0"
 proptest = "1.10"
 criterion = { version = "0.8", features = ["html_reports"] }
-fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+fgumi-raw-bam = { workspace = true, features = ["test-utils", "noodles"] }
+noodles = { version = "0.106.0", features = ["bam", "sam"] }
 
 [[bench]]
 name = "core_functions"
@@ -127,6 +128,10 @@ harness = false
 
 [[bench]]
 name = "raw_bam_length_changing"
+harness = false
+
+[[bench]]
+name = "raw_bam_vs_recordbuf"
 harness = false
 
 [build-dependencies]

--- a/benches/raw_bam_accessors.rs
+++ b/benches/raw_bam_accessors.rs
@@ -1,0 +1,64 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+
+fn bench_view_accessors(c: &mut Criterion) {
+    let bytes = make_bam_bytes(
+        3,
+        100_000,
+        0x42,
+        b"read_name_example",
+        &[encode_op(0, 150)],
+        150,
+        5,
+        100_300,
+        b"NMc\x05MDZ150\0",
+    );
+
+    c.bench_function("view::flags", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.flags())
+        });
+    });
+    c.bench_function("view::pos", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.pos())
+        });
+    });
+    c.bench_function("view::read_name", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.read_name())
+        });
+    });
+    c.bench_function("view::cigar_ops_iter_sum", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            let mut s = 0u32;
+            for op in v.cigar_ops_iter() {
+                s = s.wrapping_add(op);
+            }
+            black_box(s)
+        });
+    });
+    c.bench_function("view::quality_scores_sum", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            let s: u32 = v.quality_scores().iter().map(|&q| u32::from(q)).sum();
+            black_box(s)
+        });
+    });
+    c.bench_function("view::tags_find_int", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.tags().find_int(b"NM"))
+        });
+    });
+}
+
+criterion_group!(benches, bench_view_accessors);
+criterion_main!(benches);

--- a/benches/raw_bam_accessors.rs
+++ b/benches/raw_bam_accessors.rs
@@ -58,6 +58,33 @@ fn bench_view_accessors(c: &mut Criterion) {
             black_box(v.tags().find_int(b"NM"))
         });
     });
+
+    // Shorter seq (below SIMD threshold)
+    let bytes_short = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 16)], 16, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_16bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_short));
+            black_box(v.sequence_vec());
+        });
+    });
+
+    // 150 bp read (typical Illumina short read; SIMD active)
+    let bytes_150 = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 150)], 150, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_150bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_150));
+            black_box(v.sequence_vec());
+        });
+    });
+
+    // 300 bp read (2× typical; SIMD loop iterations dominate)
+    let bytes_300 = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 300)], 300, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_300bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_300));
+            black_box(v.sequence_vec());
+        });
+    });
 }
 
 criterion_group!(benches, bench_view_accessors);

--- a/benches/raw_bam_length_changing.rs
+++ b/benches/raw_bam_length_changing.rs
@@ -1,0 +1,58 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+
+fn bench_length_changing(c: &mut Criterion) {
+    let baseline = || {
+        let bytes = make_bam_bytes(
+            0,
+            0,
+            0,
+            b"my_long_read_name_typical_size",
+            &[encode_op(0, 150)],
+            150,
+            -1,
+            -1,
+            b"NMi\x05\x00\x00\x00",
+        );
+        RawRecord::from(bytes)
+    };
+
+    c.bench_function("set_read_name_grow_then_shrink", |b| {
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_read_name(black_box(b"a_completely_different_longer_name_xxx"));
+            rec.set_read_name(black_box(b"x"));
+        });
+    });
+
+    c.bench_function("set_cigar_ops_replace_with_3_ops", |b| {
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_cigar_ops(black_box(&[encode_op(0, 50), encode_op(2, 1), encode_op(0, 100)]));
+        });
+    });
+
+    c.bench_function("set_sequence_and_qualities_grow", |b| {
+        let seq = vec![b'A'; 200];
+        let qual = vec![30u8; 200];
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+        });
+    });
+
+    c.bench_function("set_sequence_and_qualities_same_length", |b| {
+        let seq = vec![b'C'; 150];
+        let qual = vec![25u8; 150];
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+        });
+    });
+}
+
+criterion_group!(benches, bench_length_changing);
+criterion_main!(benches);

--- a/benches/raw_bam_tags_editor.rs
+++ b/benches/raw_bam_tags_editor.rs
@@ -1,0 +1,51 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+
+fn bench_editor(c: &mut Criterion) {
+    c.bench_function("editor::update_int_same_type", |b| {
+        let bytes =
+            make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMi\x05\x00\x00\x00");
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            let mut ed = rec.tags_editor();
+            ed.update_int(b"NM", black_box(7));
+        });
+    });
+
+    c.bench_function("editor::update_int_resize", |b| {
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            let mut ed = rec.tags_editor();
+            ed.update_int(b"NM", black_box(100_000));
+            ed.update_int(b"NM", 5);
+        });
+    });
+
+    c.bench_function("editor::append_then_remove", |b| {
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            let mut ed = rec.tags_editor();
+            ed.append_string(b"XX", black_box(b"hello"));
+            ed.remove(b"XX");
+        });
+    });
+
+    c.bench_function("editor::update_float_in_place", |b| {
+        let mut aux = b"ASf".to_vec();
+        aux.extend_from_slice(&1.0f32.to_le_bytes());
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            let mut ed = rec.tags_editor();
+            ed.update_float(b"AS", black_box(99.25));
+        });
+    });
+}
+
+criterion_group!(benches, bench_editor);
+criterion_main!(benches);

--- a/benches/raw_bam_vs_recordbuf.rs
+++ b/benches/raw_bam_vs_recordbuf.rs
@@ -1,0 +1,252 @@
+/// Side-by-side benchmarks: raw-byte API vs noodles `RecordBuf` decode-mutate-reencode.
+///
+/// Each `BenchmarkGroup` contains two members:
+///   - `raw_bytes` — our new zero-copy / in-place API
+///   - `recordbuf` — noodles `RecordBuf` round-trip (decode → mutate → re-encode to bytes)
+///
+/// Re-encoding uses `noodles::bam::io::Writer` against an in-memory `Vec<u8>` so both
+/// paths start and end at raw bytes, giving an apples-to-apples comparison.
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use noodles::sam::alignment::record::cigar::op::{Kind, Op};
+use noodles::sam::alignment::record_buf::Cigar as CigarBuf;
+
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::raw_records_to_record_bufs;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Build the canonical benchmark record bytes.
+///
+/// 150 bp unmapped read (tid=-1, pos=-1), one 150M CIGAR op, NM:i:5 aux tag.
+/// Using unmapped coordinates so the record can be re-encoded by noodles using
+/// an empty `Header` (no reference sequences required).
+fn baseline_bytes() -> Vec<u8> {
+    make_bam_bytes(
+        -1,
+        -1,
+        0x42,
+        b"read_name_example",
+        &[encode_op(0, 150)],
+        150,
+        -1,
+        -1,
+        b"NMi\x05\x00\x00\x00",
+    )
+}
+
+/// Decode raw bytes to a noodles `RecordBuf`.
+fn decode_one(bytes: &[u8]) -> noodles::sam::alignment::RecordBuf {
+    let mut bufs = raw_records_to_record_bufs(&[bytes.to_vec()]).expect("decode should succeed");
+    bufs.pop().expect("should have one record")
+}
+
+/// Re-encode a mutated `RecordBuf` back to raw BAM bytes (without `block_size` prefix).
+///
+/// Uses `noodles::bam::io::Writer` → an in-memory `Vec<u8>` then strips the
+/// BAM file header prefix (magic + header text + `n_ref`) that the Writer emits
+/// before the first record.  The returned `Vec<u8>` contains only the
+/// `block_size`-prefixed record bytes so it is equivalent to the raw bytes
+/// produced by `make_bam_bytes`.
+fn encode_one(buf: &noodles::sam::alignment::RecordBuf) -> Vec<u8> {
+    use noodles::sam::alignment::io::Write as AlignmentWrite;
+
+    let header = noodles::sam::Header::default();
+    let mut out: Vec<u8> = Vec::with_capacity(512);
+    // Writer::from(&mut Vec<u8>) writes uncompressed BAM.
+    let mut writer = noodles::bam::io::Writer::from(&mut out);
+    writer.write_header(&header).expect("write_header should succeed");
+    writer.write_alignment_record(&header, buf).expect("write_alignment_record should succeed");
+    // Strip the BAM file header prefix.  The prefix is:
+    //   4 bytes magic
+    //   4 bytes header text length (= 0 for empty header)
+    //   4 bytes n_ref (= 0 for empty header)
+    // Total: 12 bytes.
+    out[12..].to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark groups
+// ---------------------------------------------------------------------------
+
+/// 1. Header field read: `flags()`
+///
+/// Both paths start from raw bytes.  The raw path does two array reads
+/// (construct view + 2-byte read).  The `RecordBuf` path decodes the full record.
+fn bench_flags_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flags_read");
+    let bytes = baseline_bytes();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.flags())
+        });
+    });
+
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let buf = decode_one(black_box(&bytes));
+            // Read the flags and convert to bits so the value is actually used.
+            black_box(buf.flags().bits())
+        });
+    });
+
+    group.finish();
+}
+
+/// 2. Tag update (in-place, same size): `NM:i:7`
+///
+/// Both paths start from raw bytes and end with a mutated record in memory.
+/// The raw path updates the integer tag in-place without any allocation.
+/// The `RecordBuf` path decodes, inserts into the tag map, then re-encodes.
+fn bench_update_int_tag(c: &mut Criterion) {
+    let mut group = c.benchmark_group("update_int_tag");
+    let bytes = baseline_bytes();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.tags_editor().update_int(b"NM", 7);
+            black_box(rec)
+        });
+    });
+
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            {
+                use noodles::sam::alignment::record_buf::data::field::Value;
+                let tag = noodles::sam::alignment::record::data::field::Tag::from(*b"NM");
+                buf.data_mut().insert(tag, Value::Int32(7));
+            }
+            black_box(encode_one(&buf))
+        });
+    });
+
+    group.finish();
+}
+
+/// 3. Length-changing edit: `set_read_name`
+///
+/// Both paths start from a fresh record and replace the read name with a
+/// longer string, requiring a memmove of the variable-length data that follows.
+fn bench_set_read_name(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_read_name");
+    let bytes = baseline_bytes();
+    let new_name = b"a_completely_different_longer_name_for_this_read";
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_read_name(black_box(new_name));
+            black_box(rec)
+        });
+    });
+
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            // name_mut() returns &mut Option<BString>; BString is bstr's growable byte string.
+            *buf.name_mut() = Some(bstr::BString::from(new_name.as_ref()));
+            black_box(encode_one(&buf))
+        });
+    });
+
+    group.finish();
+}
+
+/// 4. Length-changing edit: `set_cigar_ops`
+///
+/// Replace a single 150M CIGAR with three operations (50M 1D 99M).
+fn bench_set_cigar_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_cigar_ops");
+    let bytes = baseline_bytes();
+
+    // Raw: three raw u32 CIGAR ops — 50M + 1D + 100M = 150 query bases (matches l_seq=150).
+    let raw_ops = [encode_op(0, 50), encode_op(2, 1), encode_op(0, 100)];
+
+    // RecordBuf: noodles Op values — same 50M + 1D + 100M.
+    let noodles_ops: CigarBuf =
+        [Op::new(Kind::Match, 50), Op::new(Kind::Deletion, 1), Op::new(Kind::Match, 100)]
+            .into_iter()
+            .collect();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_cigar_ops(black_box(&raw_ops));
+            black_box(rec)
+        });
+    });
+
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            *buf.cigar_mut() = noodles_ops.clone();
+            black_box(encode_one(&buf))
+        });
+    });
+
+    group.finish();
+}
+
+/// 5. Length-changing edit: `set_sequence_and_qualities`
+///
+/// Grow the sequence from 150 bp to 200 bp with fresh bases and quality scores.
+/// The raw path replaces seq+qual only (CIGAR is not re-validated at the byte
+/// level).  The `RecordBuf` path must also update the CIGAR to 200M so that
+/// noodles' re-encoder does not reject the record for a length mismatch;
+/// this extra CIGAR update is part of the `RecordBuf` overhead included in the
+/// measurement.
+fn bench_set_sequence_and_qualities(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_sequence_and_qualities");
+    let bytes = baseline_bytes();
+
+    let seq = vec![b'A'; 200];
+    let qual = vec![30u8; 200];
+
+    // RecordBuf: Sequence and QualityScores both wrap Vec<u8> and implement From<Vec<u8>>.
+    let noodles_seq = noodles::sam::alignment::record_buf::Sequence::from(seq.clone());
+    let noodles_qual = noodles::sam::alignment::record_buf::QualityScores::from(qual.clone());
+    // Updated CIGAR to match new 200 bp read length so noodles re-encoder does
+    // not reject the record.
+    let noodles_cigar_200m: CigarBuf = [Op::new(Kind::Match, 200)].into_iter().collect();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+            black_box(rec)
+        });
+    });
+
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            *buf.sequence_mut() = noodles_seq.clone();
+            *buf.quality_scores_mut() = noodles_qual.clone();
+            // CIGAR must be updated to match new sequence length or noodles
+            // will reject re-encoding with "read length-sequence length mismatch".
+            *buf.cigar_mut() = noodles_cigar_200m.clone();
+            black_box(encode_one(&buf))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_flags_read,
+    bench_update_int_tag,
+    bench_set_read_name,
+    bench_set_cigar_ops,
+    bench_set_sequence_and_qualities,
+);
+criterion_main!(benches);

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -84,7 +84,7 @@ use crate::vanilla_caller::{
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
 use anyhow::Result;
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
 use noodles::sam::alignment::record::data::field::Tag;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -416,9 +416,9 @@ impl CodecConsensusCaller {
         clip_from_start: bool,
         clipped_cigar: Option<&[u32]>,
     ) -> SourceRead {
-        let mut bases = bam_fields::extract_sequence(raw);
-        let mut quals = bam_fields::quality_scores_slice(raw).to_vec();
-        let flg = bam_fields::flags(raw);
+        let mut bases = RawRecordView::new(raw).sequence_vec();
+        let mut quals = RawRecordView::new(raw).quality_scores().to_vec();
+        let flg = RawRecordView::new(raw).flags();
 
         // Apply clipping: truncate bases and quals
         // Clamp clip_amount to avoid panic on malformed input (e.g., CIGAR/MC mismatch)
@@ -451,8 +451,8 @@ impl CodecConsensusCaller {
             quals.reverse();
         }
 
-        let rid = bam_fields::ref_id(raw);
-        let astart = i64::from(bam_fields::pos(raw));
+        let rid = RawRecordView::new(raw).ref_id();
+        let astart = i64::from(RawRecordView::new(raw).pos());
         let original_cigar = {
             let ops = bam_fields::get_cigar_ops(raw);
             bam_fields::simplify_cigar_from_raw(&ops)
@@ -533,14 +533,16 @@ impl CodecConsensusCaller {
         }
 
         // Extract MI tag from first record for naming
-        let umi: Option<String> = bam_fields::find_string_tag_in_record(&records[0], b"MI")
+        let umi: Option<String> = RawRecordView::new(&records[0])
+            .tags()
+            .find_string(b"MI")
             .map(|b| String::from_utf8_lossy(b).to_string());
 
         // Phase 1: Filter on raw bytes — keep paired, primary, mapped, FR-pair reads
         let mut paired_indices: Vec<usize> = Vec::new();
         let mut frag_count = 0usize;
         for (i, raw) in records.iter().enumerate() {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             if flg & flags::PAIRED == 0 {
                 frag_count += 1;
                 continue;
@@ -567,7 +569,7 @@ impl CodecConsensusCaller {
         let mut by_name: HashMap<&[u8], Vec<usize>> = HashMap::new();
         let mut name_order: Vec<&[u8]> = Vec::new();
         for &idx in &paired_indices {
-            let name = bam_fields::read_name(&records[idx]);
+            let name = RawRecordView::new(&records[idx]).read_name();
             if !by_name.contains_key(name) {
                 name_order.push(name);
             }
@@ -584,7 +586,7 @@ impl CodecConsensusCaller {
             }
 
             let (i1, i2) = {
-                let flg0 = bam_fields::flags(&records[indices[0]]);
+                let flg0 = RawRecordView::new(&records[indices[0]]).flags();
                 if flg0 & flags::FIRST_SEGMENT != 0 {
                     (indices[0], indices[1])
                 } else {
@@ -810,7 +812,7 @@ impl CodecConsensusCaller {
 
     /// Build `ClippedRecordInfo` for a single raw record.
     fn build_clipped_info(raw: &[u8], raw_idx: usize, clip_amount: usize) -> ClippedRecordInfo {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let is_reverse = flg & flags::REVERSE != 0;
         let clip_from_start = is_reverse; // negative strand ⟹ clip from start
 
@@ -818,11 +820,11 @@ impl CodecConsensusCaller {
         let (clipped_cigar, ref_bases_consumed) =
             bam_fields::clip_cigar_ops_raw(&original_ops, clip_amount, clip_from_start);
 
-        let original_seq_len = bam_fields::l_seq(raw) as usize;
+        let original_seq_len = RawRecordView::new(raw).l_seq() as usize;
         let clipped_seq_len = original_seq_len.saturating_sub(clip_amount);
 
         // 1-based alignment start, adjusted for start-clipping
-        let pos_0based = bam_fields::pos(raw);
+        let pos_0based = RawRecordView::new(raw).pos();
         debug_assert!(
             pos_0based >= 0,
             "build_clipped_info called on unmapped record (pos={pos_0based})"
@@ -1324,7 +1326,7 @@ impl CodecConsensusCaller {
         if let Some(cell_tag) = &self.options.cell_tag {
             let cell_tag_bytes: [u8; 2] = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
             for raw in source_raws {
-                if let Some(cell_bc) = bam_fields::find_string_tag_in_record(raw, &cell_tag_bytes) {
+                if let Some(cell_bc) = RawRecordView::new(raw).tags().find_string(&cell_tag_bytes) {
                     if !cell_bc.is_empty() {
                         self.bam_builder.append_string_tag(&cell_tag_bytes, cell_bc);
                         break;
@@ -1340,7 +1342,9 @@ impl CodecConsensusCaller {
         let umis: Vec<String> = all_records
             .iter()
             .filter_map(|raw| {
-                bam_fields::find_string_tag_in_record(raw, b"RX")
+                RawRecordView::new(raw)
+                    .tags()
+                    .find_string(b"RX")
                     .and_then(|b| String::from_utf8(b.to_vec()).ok())
             })
             .collect();
@@ -1510,7 +1514,7 @@ impl CodecConsensusCaller {
     ) -> Option<usize> {
         let raw = Self::record_buf_to_raw(rec);
         let cigar_ops = bam_fields::get_cigar_ops(&raw);
-        let alignment_start = (bam_fields::pos(&raw) + 1) as usize; // 1-based
+        let alignment_start = (RawRecordView::new(&raw).pos() + 1) as usize; // 1-based
         bam_fields::read_pos_at_ref_pos_raw(
             &cigar_ops,
             alignment_start,

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -210,7 +210,7 @@ use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{ReadType, SourceRead};
-use fgumi_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
 
 /// Duplex consensus read - matches fgbio's `DuplexConsensusRead`
 ///
@@ -630,8 +630,9 @@ impl DuplexConsensusCaller {
         for record in records {
             // Extract strand info before moving the record (drop borrow before push)
             let is_a_strand = {
-                let Some(mi_bytes) = bam_fields::find_string_tag_in_record(&record, b"MI") else {
-                    let read_name = String::from_utf8_lossy(bam_fields::read_name(&record));
+                let Some(mi_bytes) = RawRecordView::new(&record).tags().find_string(b"MI") else {
+                    let read_name =
+                        String::from_utf8_lossy(RawRecordView::new(&record).read_name());
                     bail!(
                         "Read '{read_name}' is missing MI tag. \
                         The duplex command requires all reads to have MI tags. \
@@ -764,14 +765,14 @@ impl DuplexConsensusCaller {
         let num_a = a_records
             .iter()
             .filter(|r| {
-                let flg = bam_fields::flags(r);
+                let flg = RawRecordView::new(r).flags();
                 (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
             })
             .count();
         let num_b = b_records
             .iter()
             .filter(|r| {
-                let flg = bam_fields::flags(r);
+                let flg = RawRecordView::new(r).flags();
                 (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
             })
             .count();
@@ -811,8 +812,8 @@ impl DuplexConsensusCaller {
         let Some(first) = reads.next() else {
             return true;
         };
-        let first_is_reverse = bam_fields::flags(first) & flags::REVERSE != 0;
-        reads.all(|r| (bam_fields::flags(r) & flags::REVERSE != 0) == first_is_reverse)
+        let first_is_reverse = RawRecordView::new(first).flags() & flags::REVERSE != 0;
+        reads.all(|r| (RawRecordView::new(r).flags() & flags::REVERSE != 0) == first_is_reverse)
     }
 
     // Helper function to cap quality scores to valid range [2, 93]
@@ -1221,9 +1222,9 @@ impl DuplexConsensusCaller {
         let mut all_umis = Vec::new();
 
         for raw in source_reads_a {
-            if let Some(rx_bytes) = bam_fields::find_string_tag_in_record(raw, b"RX") {
+            if let Some(rx_bytes) = RawRecordView::new(raw).tags().find_string(b"RX") {
                 let rx = String::from_utf8_lossy(rx_bytes).to_string();
-                let is_first = bam_fields::flags(raw) & flags::FIRST_SEGMENT != 0;
+                let is_first = RawRecordView::new(raw).flags() & flags::FIRST_SEGMENT != 0;
                 if is_first == first_of_pair {
                     all_umis.push(rx);
                 } else {
@@ -1234,9 +1235,9 @@ impl DuplexConsensusCaller {
         }
 
         for raw in source_reads_b {
-            if let Some(rx_bytes) = bam_fields::find_string_tag_in_record(raw, b"RX") {
+            if let Some(rx_bytes) = RawRecordView::new(raw).tags().find_string(b"RX") {
                 let rx = String::from_utf8_lossy(rx_bytes).to_string();
-                let is_first = bam_fields::flags(raw) & flags::FIRST_SEGMENT != 0;
+                let is_first = RawRecordView::new(raw).flags() & flags::FIRST_SEGMENT != 0;
                 if is_first == first_of_pair {
                     all_umis.push(rx);
                 } else {
@@ -1779,20 +1780,30 @@ impl DuplexConsensusCaller {
         let cell_barcode: Option<String> = cell_tag.and_then(|tag| {
             let tag_bytes: [u8; 2] = <[u8; 2]>::from(tag);
             a_records.first().or_else(|| b_records.first()).and_then(|r| {
-                bam_fields::find_string_tag_in_record(r, &tag_bytes)
+                RawRecordView::new(r)
+                    .tags()
+                    .find_string(&tag_bytes)
                     .map(|v| String::from_utf8_lossy(v).into_owned())
             })
         });
 
         // Split reads into R1/R2 groups for AB and BA strands (done once, reused below)
-        let ab_r1s: Vec<&Vec<u8>> =
-            a_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT != 0).collect();
-        let ab_r2s: Vec<&Vec<u8>> =
-            a_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT == 0).collect();
-        let ba_r1s: Vec<&Vec<u8>> =
-            b_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT != 0).collect();
-        let ba_r2s: Vec<&Vec<u8>> =
-            b_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT == 0).collect();
+        let ab_r1s: Vec<&Vec<u8>> = a_records
+            .iter()
+            .filter(|r| RawRecordView::new(r).flags() & flags::FIRST_SEGMENT != 0)
+            .collect();
+        let ab_r2s: Vec<&Vec<u8>> = a_records
+            .iter()
+            .filter(|r| RawRecordView::new(r).flags() & flags::FIRST_SEGMENT == 0)
+            .collect();
+        let ba_r1s: Vec<&Vec<u8>> = b_records
+            .iter()
+            .filter(|r| RawRecordView::new(r).flags() & flags::FIRST_SEGMENT != 0)
+            .collect();
+        let ba_r2s: Vec<&Vec<u8>> = b_records
+            .iter()
+            .filter(|r| RawRecordView::new(r).flags() & flags::FIRST_SEGMENT == 0)
+            .collect();
 
         // Validate strand orientations before processing
         // The expected orientations are:

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -850,7 +850,7 @@ pub fn template_passes_raw(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, b
     let mut all_primary_pass = true;
 
     for (idx, record) in raw_records.iter().enumerate() {
-        let flags = bam_fields::flags(record);
+        let flags = RawRecordView::new(record).flags();
         let is_primary = (flags & bam_fields::flags::SECONDARY) == 0
             && (flags & bam_fields::flags::SUPPLEMENTARY) == 0;
 
@@ -892,7 +892,7 @@ pub fn is_duplex_consensus(record: &RecordBuf) -> bool {
 // Raw-byte equivalents (operate on &[u8] / &mut Vec<u8>)
 // ============================================================================
 
-use fgumi_raw_bam as bam_fields;
+use fgumi_raw_bam::{self as bam_fields, RawRecordView};
 use noodles::sam::alignment::record::cigar::op::Kind;
 
 /// Pre-parsed methylation aux tags from a raw BAM record.
@@ -1063,7 +1063,7 @@ pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
     assert!(bam.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(bam);
     let qual_off = bam_fields::qual_offset(bam);
-    let len = bam_fields::l_seq(bam) as usize;
+    let len = RawRecordView::new(bam).l_seq() as usize;
 
     let mut n_count = 0usize;
     let mut qual_sum = 0u64;
@@ -1126,7 +1126,7 @@ pub fn mask_bases_raw(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
 
     // Pre-read per-base arrays into owned Vecs to release the immutable borrow on record
@@ -1181,7 +1181,7 @@ pub fn mask_duplex_bases_raw(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
 
     // Pre-read per-base arrays and strings into owned data to release the immutable borrow
@@ -1322,7 +1322,7 @@ pub fn mask_methylation_depth_simplex_raw_with_tags(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags present, nothing to filter
     if tags.cu.is_none() && tags.ct.is_none() {
@@ -1374,7 +1374,7 @@ pub fn mask_methylation_depth_duplex_raw_with_tags(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags present, nothing to filter
     if tags.cu.is_none() && tags.ct.is_none() {
@@ -1420,24 +1420,24 @@ pub fn resolve_ref_bases_for_record(
     reference: &dyn crate::methylation::RefBaseProvider,
     ref_names: &[String],
 ) -> Option<Vec<Option<u8>>> {
-    let flags = bam_fields::flags(record);
+    let flags = RawRecordView::new(record).flags();
     if flags & bam_fields::flags::UNMAPPED != 0 {
         return None;
     }
 
-    let tid = bam_fields::ref_id(record);
+    let tid = RawRecordView::new(record).ref_id();
     if tid < 0 {
         return None;
     }
     let ref_name = ref_names.get(tid as usize)?;
-    let alignment_start = bam_fields::pos(record) as u64; // 0-based
+    let alignment_start = RawRecordView::new(record).pos() as u64; // 0-based
 
     // Try to get the full sequence slice for O(1) indexed access per base,
     // avoiding a HashMap lookup per position.
     let ref_seq = reference.sequence_for(ref_name);
 
     let cigar_ops = bam_fields::get_cigar_ops(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let mut result = Vec::with_capacity(len);
     let mut ref_pos = alignment_start;
 
@@ -1525,7 +1525,7 @@ pub fn mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
 
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no per-strand methylation tags, nothing to check
     if tags.au.is_none() && tags.bu.is_none() {
@@ -1629,7 +1629,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
         return true; // unmapped reads pass
     };
 
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags, pass
     if methylation_tags.cu.is_none() && methylation_tags.ct.is_none() {

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -10,7 +10,7 @@ use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER};
-use fgumi_raw_bam;
+use fgumi_raw_bam::{self, RawRecordView};
 
 /// Check if a base is a no-call (N, n, or .)
 /// Matches htsjdk's SequenceUtil.isNoCall behavior
@@ -474,7 +474,7 @@ impl ReadAndRefPosIterator {
     ) -> Self {
         let rec_start_i32 = rec_start as i32;
         let rec_end_i32 = rec_end as i32;
-        let rec_len = fgumi_raw_bam::l_seq(bam) as i32;
+        let rec_len = RawRecordView::new(bam).l_seq() as i32;
 
         let min_ref_pos = rec_start_i32.max(mate_start as i32);
         let max_ref_pos = rec_end_i32.min(mate_end as i32);
@@ -756,14 +756,14 @@ impl OverlappingBasesConsensusCaller {
     /// Returns an error if raw BAM field extraction or CIGAR parsing fails.
     pub fn call_raw(&mut self, r1: &mut [u8], r2: &mut [u8]) -> Result<bool> {
         // Only process paired reads where both are mapped
-        if fgumi_raw_bam::flags(r1) & fgumi_raw_bam::flags::UNMAPPED != 0
-            || fgumi_raw_bam::flags(r2) & fgumi_raw_bam::flags::UNMAPPED != 0
+        if RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
+            || RawRecordView::new(r2).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
         {
             return Ok(false);
         }
 
         // Must be on the same reference sequence
-        if fgumi_raw_bam::ref_id(r1) != fgumi_raw_bam::ref_id(r2) {
+        if RawRecordView::new(r1).ref_id() != RawRecordView::new(r2).ref_id() {
             return Ok(false);
         }
 
@@ -788,10 +788,10 @@ impl OverlappingBasesConsensusCaller {
         }
 
         // Extract sequences and qualities for modification
-        let mut r1_seq = fgumi_raw_bam::extract_sequence(r1);
-        let mut r2_seq = fgumi_raw_bam::extract_sequence(r2);
-        let mut r1_quals: Vec<u8> = fgumi_raw_bam::quality_scores_slice(r1).to_vec();
-        let mut r2_quals: Vec<u8> = fgumi_raw_bam::quality_scores_slice(r2).to_vec();
+        let mut r1_seq = RawRecordView::new(r1).sequence_vec();
+        let mut r2_seq = RawRecordView::new(r2).sequence_vec();
+        let mut r1_quals: Vec<u8> = RawRecordView::new(r1).quality_scores().to_vec();
+        let mut r2_quals: Vec<u8> = RawRecordView::new(r2).quality_scores().to_vec();
         let mut modified = false;
 
         for pos in overlapping_positions {
@@ -874,8 +874,8 @@ pub fn apply_overlapping_consensus_raw(
     let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> = AHashMap::new();
 
     for (idx, record) in records.iter().enumerate() {
-        let name = fgumi_raw_bam::read_name(record).to_vec();
-        let flg = fgumi_raw_bam::flags(record);
+        let name = RawRecordView::new(record).read_name().to_vec();
+        let flg = RawRecordView::new(record).flags();
 
         if flg & fgumi_raw_bam::flags::FIRST_SEGMENT != 0 {
             read_pairs.entry(name).or_insert((None, None)).0 = Some(idx);
@@ -1523,8 +1523,8 @@ mod tests {
         assert!(result);
 
         // Check that qualities were summed (30 + 20 = 50)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 50);
     }
 
     #[test]
@@ -1542,8 +1542,8 @@ mod tests {
         assert!(result);
 
         // Max quality used (max(30, 20) = 30)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 30);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 30);
     }
 
     #[test]
@@ -1561,8 +1561,8 @@ mod tests {
         assert!(result);
 
         // Qualities unchanged
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 20);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 20);
     }
 
     #[test]
@@ -1580,12 +1580,12 @@ mod tests {
         assert!(result);
 
         // Higher quality base (A from r1) chosen, qual = 30 - 20 = 10
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'A');
         assert_eq!(r2_seq[0], b'A');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 10);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 10);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 10);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 10);
     }
 
     #[test]
@@ -1603,12 +1603,12 @@ mod tests {
         assert!(result);
 
         // Both bases masked to N with quality 2
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1626,12 +1626,12 @@ mod tests {
         assert!(result);
 
         // Only lower quality base (r2) masked
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'A'); // Unchanged
         assert_eq!(r2_seq[0], b'N'); // Masked
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30); // Unchanged
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2); // Masked
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30); // Unchanged
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2); // Masked
     }
 
     #[test]
@@ -1649,8 +1649,8 @@ mod tests {
         assert!(result);
 
         // Only lower quality base (r1) masked
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N'); // Masked
         assert_eq!(r2_seq[0], b'G'); // Unchanged
     }
@@ -1670,12 +1670,12 @@ mod tests {
         assert!(result);
 
         // Both masked when qualities are equal
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1693,12 +1693,12 @@ mod tests {
         assert!(result);
 
         // Both masked when qualities are equal
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1772,7 +1772,7 @@ mod tests {
         assert!(result);
 
         // Quality capped at 93
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 93);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 93);
     }
 
     #[test]
@@ -1833,8 +1833,8 @@ mod tests {
         assert_eq!(caller.stats().bases_agreeing, 2); // GT == GT
 
         // Check quality sums at overlapping positions
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[2], 50); // 30 + 20
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[3], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[2], 50); // 30 + 20
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[3], 50);
     }
 
     #[test]
@@ -1856,10 +1856,10 @@ mod tests {
         assert_eq!(caller.stats().bases_agreeing, 4); // ACGT == ACGT
 
         // Check quality sums at overlapping positions
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[2], 50); // 30 + 20
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[3], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[4], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[5], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[2], 50); // 30 + 20
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[3], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[4], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[5], 50);
     }
 
     #[test]
@@ -1911,8 +1911,8 @@ mod tests {
         assert!(result);
 
         // Quality difference is 1, but minimum is 2
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     /// Verify that `call_raw` produces the same results as `call` for agreement.
@@ -1939,8 +1939,8 @@ mod tests {
         caller_raw.call_raw(&mut raw_r1, &mut raw_r2).expect("call_raw should succeed");
 
         // Compare results
-        assert_eq!(rb_r1.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r1));
-        assert_eq!(rb_r2.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r2));
+        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
+        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
         assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
         assert_eq!(caller_buf.stats().bases_agreeing, caller_raw.stats().bases_agreeing);
         assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
@@ -1972,14 +1972,14 @@ mod tests {
         // Compare sequences
         let buf_r1_seq: Vec<u8> = rb_r1.sequence().as_ref().to_vec();
         let buf_r2_seq: Vec<u8> = rb_r2.sequence().as_ref().to_vec();
-        let raw_r1_seq = fgumi_raw_bam::extract_sequence(&raw_r1);
-        let raw_r2_seq = fgumi_raw_bam::extract_sequence(&raw_r2);
+        let raw_r1_seq = RawRecordView::new(&raw_r1).sequence_vec();
+        let raw_r2_seq = RawRecordView::new(&raw_r2).sequence_vec();
         assert_eq!(buf_r1_seq, raw_r1_seq);
         assert_eq!(buf_r2_seq, raw_r2_seq);
 
         // Compare qualities
-        assert_eq!(rb_r1.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r1));
-        assert_eq!(rb_r2.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r2));
+        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
+        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
 
         // Compare stats
         assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
@@ -2011,8 +2011,8 @@ mod tests {
             .expect("apply_overlapping_consensus_raw should succeed");
 
         // Check that qualities were summed (30 + 20 = 50)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[0])[0], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[1])[0], 50);
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 50);
         assert!(caller.stats().overlapping_bases > 0);
     }
 
@@ -2036,8 +2036,8 @@ mod tests {
             .expect("apply_overlapping_consensus_raw should succeed");
 
         // Qualities unchanged because no matching pair
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[0])[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[1])[0], 20);
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 20);
         assert_eq!(caller.stats().overlapping_bases, 0);
     }
 
@@ -2063,8 +2063,8 @@ mod tests {
         // Both should have been consensus-called
         assert!(caller.stats().overlapping_bases > 0);
         assert_eq!(
-            fgumi_raw_bam::quality_scores_slice(&records[0])[0],
-            fgumi_raw_bam::quality_scores_slice(&records[1])[0]
+            RawRecordView::new(&records[0]).quality_scores()[0],
+            RawRecordView::new(&records[1]).quality_scores()[0]
         );
     }
 

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -13,7 +13,7 @@ use crate::phred::{
 use crate::simple_umi::consensus_umis;
 use anyhow::{Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{RawRecordView, UnmappedBamRecordBuilder, flags};
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
 #[cfg(test)]
@@ -707,7 +707,7 @@ impl VanillaUmiConsensusCaller {
         let ref_positions = methylation::query_to_ref_positions(
             &anchor.simplified_cigar,
             anchor.alignment_start,
-            anchor.flags & fgumi_raw_bam::flags::REVERSE != 0,
+            anchor.flags & flags::REVERSE != 0,
             &anchor.original_cigar,
         );
 
@@ -741,10 +741,8 @@ impl VanillaUmiConsensusCaller {
 
     /// Filters reads to remove secondary/supplementary alignments.
     fn filter_reads(&mut self, reads: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
-        use fgumi_raw_bam as bam_fields;
-
         let (accepted, rejected): (Vec<_>, Vec<_>) = reads.into_iter().partition(|raw| {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             flg & flags::SECONDARY == 0 && flg & flags::SUPPLEMENTARY == 0
         });
 
@@ -867,13 +865,13 @@ impl VanillaUmiConsensusCaller {
     ) -> Option<SourceRead> {
         use fgumi_raw_bam as bam_fields;
 
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let is_negative_strand = flg & flags::REVERSE != 0;
         let min_bq = self.options.min_input_base_quality;
 
         // Get bases and quals from raw bytes
-        let mut bases = bam_fields::extract_sequence(raw);
-        let mut quals = bam_fields::quality_scores_slice(raw).to_vec();
+        let mut bases = RawRecordView::new(raw).sequence_vec();
+        let mut quals = RawRecordView::new(raw).quality_scores().to_vec();
         let read_len = bases.len();
 
         if quals.is_empty() || quals.len() != read_len {
@@ -930,8 +928,8 @@ impl VanillaUmiConsensusCaller {
 
         simplified_cigar = Self::truncate_simplified_cigar(&simplified_cigar, final_len);
 
-        let rid = bam_fields::ref_id(raw);
-        let astart = i64::from(bam_fields::pos(raw));
+        let rid = RawRecordView::new(raw).ref_id();
+        let astart = i64::from(RawRecordView::new(raw).pos());
 
         Some(SourceRead {
             original_idx,
@@ -1012,14 +1010,12 @@ impl VanillaUmiConsensusCaller {
         reason = "method signature kept for consistency with other caller trait methods"
     )]
     fn subgroup_reads(&self, reads: Vec<Vec<u8>>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
-        use fgumi_raw_bam as bam_fields;
-
         let mut fragment_reads = Vec::new();
         let mut r1_reads = Vec::new();
         let mut r2_reads = Vec::new();
 
         for raw in reads {
-            let flg = bam_fields::flags(&raw);
+            let flg = RawRecordView::new(&raw).flags();
             if flg & flags::PAIRED == 0 {
                 fragment_reads.push(raw);
             } else if flg & flags::FIRST_SEGMENT != 0 {
@@ -1366,8 +1362,6 @@ impl VanillaUmiConsensusCaller {
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
     ) {
-        use fgumi_raw_bam as bam_fields;
-
         let read_name = format!("{}:{}", self.read_name_prefix, umi);
 
         let mut flag = flags::UNMAPPED;
@@ -1415,7 +1409,7 @@ impl VanillaUmiConsensusCaller {
         if let Some(cell_tag) = self.options.cell_tag {
             if let Some(first_raw) = original_raws.first() {
                 let tag_bytes = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
-                if let Some(value) = bam_fields::find_string_tag_in_record(first_raw, &tag_bytes) {
+                if let Some(value) = RawRecordView::new(first_raw).tags().find_string(&tag_bytes) {
                     self.bam_builder.append_string_tag(&tag_bytes, value);
                 }
             }
@@ -1425,7 +1419,9 @@ impl VanillaUmiConsensusCaller {
         let umis: Vec<String> = original_raws
             .iter()
             .filter_map(|raw| {
-                bam_fields::find_string_tag_in_record(raw, b"RX")
+                RawRecordView::new(raw)
+                    .tags()
+                    .find_string(b"RX")
                     .map(|v| String::from_utf8_lossy(v).into_owned())
             })
             .collect();
@@ -1438,9 +1434,9 @@ impl VanillaUmiConsensusCaller {
         // Methylation tags (EM-Seq/TAPs)
         if let Some(annot) = methylation {
             // Determine strand for MM tag format
-            let is_top = original_raws
-                .first()
-                .is_none_or(|raw| crate::methylation::is_top_strand(fgumi_raw_bam::flags(raw)));
+            let is_top = original_raws.first().is_none_or(|raw| {
+                crate::methylation::is_top_strand(RawRecordView::new(raw).flags())
+            });
 
             if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(
                 bases,
@@ -1467,8 +1463,6 @@ impl VanillaUmiConsensusCaller {
 
 impl ConsensusCaller for VanillaUmiConsensusCaller {
     fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
-        use fgumi_raw_bam as bam_fields;
-
         if records.is_empty() {
             return Ok(ConsensusOutput::default());
         }
@@ -1481,11 +1475,11 @@ impl ConsensusCaller for VanillaUmiConsensusCaller {
         let tag_key = [tag_bytes[0], tag_bytes[1]];
 
         let first_raw = records.first().expect("records is non-empty (checked above)");
-        let read_name_bytes = bam_fields::read_name(first_raw);
+        let read_name_bytes = RawRecordView::new(first_raw).read_name();
         let read_name = String::from_utf8_lossy(read_name_bytes);
 
         let tag_value =
-            bam_fields::find_string_tag_in_record(first_raw, &tag_key).ok_or_else(|| {
+            RawRecordView::new(first_raw).tags().find_string(&tag_key).ok_or_else(|| {
                 anyhow!("Missing UMI tag '{}' for read '{}'", self.options.tag, read_name)
             })?;
 
@@ -1802,8 +1796,6 @@ mod tests {
 
     #[test]
     fn test_deterministic_downsampling() {
-        use fgumi_raw_bam as bam_fields;
-
         // Test that downsampling with a seed produces deterministic results
         let seed = 42u64;
         let options = VanillaUmiConsensusOptions {
@@ -1841,8 +1833,8 @@ mod tests {
         // Both should select the same reads in the same order
         for i in 0..3 {
             assert_eq!(
-                bam_fields::read_name(&downsampled1[i]),
-                bam_fields::read_name(&downsampled2[i])
+                RawRecordView::new(&downsampled1[i]).read_name(),
+                RawRecordView::new(&downsampled2[i]).read_name()
             );
         }
     }

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 [dependencies]
 noodles = { version = "0.106.0", features = ["bam", "sam"], optional = true }
 anyhow = { version = "1.0.102", optional = true }
+bytemuck = { workspace = true }
+wide = { workspace = true }
 
 [features]
 default = []

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::raw_bam_record::RawRecord;
 use crate::sequence::pack_sequence_into;
 use crate::tags::{
     append_float_tag, append_i16_array_tag, append_int_tag, append_phred33_string_tag,
@@ -27,6 +28,11 @@ use crate::tags::{
 /// builder.append_int_tag(b"cD", max_depth);
 /// builder.append_float_tag(b"cE", error_rate);
 /// builder.append_i16_array_tag(b"cd", &depth_array);
+///
+/// // Return the record as a RawRecord (moves the buffer out).
+/// let record: RawRecord = builder.build();
+///
+/// // -- or write directly without taking ownership --
 /// builder.write_with_block_size(&mut output);
 ///
 /// builder.clear();
@@ -173,6 +179,21 @@ impl UnmappedBamRecordBuilder {
     pub fn append_phred33_string_tag(&mut self, tag: &[u8; 2], quals: &[u8]) {
         debug_assert!(self.sealed, "must call build_record before appending tags");
         append_phred33_string_tag(&mut self.buf, tag, quals);
+    }
+
+    /// Consume the completed record bytes and return them as a [`RawRecord`].
+    ///
+    /// This moves the internal buffer out of the builder. After calling
+    /// `build()`, the builder's buffer is empty; call [`Self::build_record`]
+    /// again before appending tags or writing.
+    ///
+    /// Callers that need the raw bytes can use [`RawRecord::into_inner`].
+    #[inline]
+    #[must_use]
+    pub fn build(&mut self) -> RawRecord {
+        debug_assert!(self.sealed, "must call build_record first");
+        self.sealed = false;
+        RawRecord::from(std::mem::take(&mut self.buf))
     }
 
     /// Get the completed record bytes (**without** the 4-byte `block_size` prefix).
@@ -449,6 +470,41 @@ mod tests {
     // ========================================================================
     // UnmappedBamRecordBuilder additional tests
     // ========================================================================
+
+    #[test]
+    fn test_builder_build_returns_raw_record() {
+        let mut builder = UnmappedBamRecordBuilder::new();
+        builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
+        builder.append_string_tag(b"MI", b"7");
+
+        let record = builder.build();
+
+        // Should be a valid RawRecord with the expected fields.
+        assert_eq!(l_seq(record.as_ref()), 4);
+        assert_eq!(read_name(record.as_ref()), b"r1");
+        assert_eq!(find_string_tag(aux_data_slice(record.as_ref()), b"MI"), Some(b"7" as &[u8]));
+
+        // After build(), the builder's internal buffer should be empty (moved out).
+        assert!(builder.buf.is_empty());
+        assert!(!builder.sealed);
+
+        // The builder can be reused.
+        builder.build_record(b"r2", flags::UNMAPPED, b"AC", &[20, 25]);
+        assert_eq!(l_seq(builder.as_bytes()), 2);
+        assert_eq!(read_name(builder.as_bytes()), b"r2");
+    }
+
+    #[test]
+    fn test_builder_build_into_inner() {
+        let mut builder = UnmappedBamRecordBuilder::new();
+        builder.build_record(b"r3", flags::UNMAPPED, b"ACGT", &[10, 20, 30, 40]);
+
+        let bytes_before = builder.as_bytes().to_vec();
+        let record = builder.build();
+
+        // into_inner() should yield the same bytes.
+        assert_eq!(record.into_inner(), bytes_before);
+    }
 
     #[test]
     fn test_builder_default() {

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -167,104 +167,6 @@ pub fn query_length_from_cigar(cigar_ops: &[u32]) -> usize {
     len
 }
 
-/// Calculate unclipped start position from BAM record.
-///
-/// For forward strand reads, this is the 5' position.
-/// Returns: `pos - leading_clips` (0-based like the input position).
-#[inline]
-#[must_use]
-pub fn unclipped_start_from_cigar(pos: i32, cigar_ops: &[u32]) -> i32 {
-    let mut clipped = 0i32;
-
-    for &op in cigar_ops {
-        let op_len = (op >> 4).cast_signed();
-        let op_type = op & 0xF;
-
-        match op_type {
-            4 | 5 => clipped += op_len, // S (4) or H (5)
-            _ => break,                 // Non-clip operation
-        }
-    }
-
-    pos - clipped
-}
-
-/// Calculate unclipped end position from BAM record.
-///
-/// For reverse strand reads, this is the 5' position.
-/// Returns: `pos + ref_length + trailing_clips - 1` (0-based).
-#[inline]
-#[must_use]
-pub fn unclipped_end_from_cigar(pos: i32, cigar_ops: &[u32]) -> i32 {
-    let mut ref_len = 0i32;
-    let mut trailing_clips = 0i32;
-    let mut saw_ref_op = false;
-
-    for &op in cigar_ops {
-        let op_len = (op >> 4).cast_signed();
-        let op_type = op & 0xF;
-
-        match op_type {
-            _ if consumes_ref(op_type) => {
-                ref_len += op_len;
-                trailing_clips = 0;
-                saw_ref_op = true;
-            }
-            4 | 5 if saw_ref_op => {
-                // S (4) or H (5) after ref-consuming ops
-                trailing_clips += op_len;
-            }
-            _ => {}
-        }
-    }
-
-    pos + ref_len + trailing_clips - 1
-}
-
-/// Calculate unclipped 5' coordinate for this read.
-///
-/// For forward strand: `unclipped_start` (leftmost including clips)
-/// For reverse strand: `unclipped_end` (rightmost including clips)
-#[inline]
-#[must_use]
-pub fn unclipped_5prime(pos: i32, reverse: bool, cigar_ops: &[u32]) -> i32 {
-    if reverse {
-        unclipped_end_from_cigar(pos, cigar_ops)
-    } else {
-        unclipped_start_from_cigar(pos, cigar_ops)
-    }
-}
-
-/// Calculate unclipped 5' coordinate using 1-based positions (matching noodles).
-///
-/// Adds 1 to the 0-based BAM position before applying clip adjustment,
-/// producing values identical to `record_utils::unclipped_five_prime_position()`.
-///
-/// Returns 0 for unmapped reads (matching `get_unclipped_position_for_groupkey`).
-/// Returns `i32::MAX` for mapped reads with no CIGAR operations.
-#[inline]
-#[must_use]
-pub fn unclipped_5prime_1based(
-    pos_0based: i32,
-    reverse: bool,
-    unmapped: bool,
-    cigar_ops: &[u32],
-) -> i32 {
-    if unmapped {
-        return 0;
-    }
-    if cigar_ops.is_empty() {
-        return i32::MAX;
-    }
-    // Convert to 1-based, then apply clip adjustment
-    let pos_1based = pos_0based + 1;
-    if reverse {
-        unclipped_end_from_cigar(pos_1based, cigar_ops)
-    } else {
-        unclipped_start_from_cigar(pos_1based, cigar_ops)
-    }
-}
-
 /// Compute unclipped 5' position directly from raw BAM bytes (zero allocation).
 ///
 /// This is the primary entry point for raw-byte callers, replacing the pattern:
@@ -364,7 +266,7 @@ pub fn mate_unclipped_5prime_1based(
 /// For forward strand mates, this is the 5' position.
 #[inline]
 #[must_use]
-pub fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
+pub(crate) fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
     mate_pos - parse_leading_clips(mc_cigar)
 }
 
@@ -373,7 +275,7 @@ pub fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
 /// For reverse strand mates, this is the 5' position.
 #[inline]
 #[must_use]
-pub fn unclipped_other_end(mate_pos: i32, mc_cigar: &str) -> i32 {
+pub(crate) fn unclipped_other_end(mate_pos: i32, mc_cigar: &str) -> i32 {
     let (ref_len, trailing_clips) = parse_ref_len_and_trailing_clips(mc_cigar);
     mate_pos + ref_len + trailing_clips - 1
 }
@@ -1133,87 +1035,6 @@ mod tests {
         let cigar = &[encode_op(2, 2), encode_op(0, 5)];
         // Position 100 is in the deletion with no prior query bases
         assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, true), Some(1));
-    }
-
-    // ========================================================================
-    // unclipped_start_from_cigar / unclipped_end_from_cigar tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_start_from_cigar_no_clips() {
-        // 10M = (10 << 4)
-        let cigar = &[(10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 100);
-    }
-
-    #[test]
-    fn test_unclipped_start_from_cigar_soft_clip() {
-        // 5S10M: soft clip (op type 4), then match
-        let cigar = &[(5 << 4) | 4, (10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 95);
-    }
-
-    #[test]
-    fn test_unclipped_start_from_cigar_hard_clip() {
-        // 3H10M: hard clip (op type 5), then match
-        let cigar = &[(3 << 4) | 5, (10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 97);
-    }
-
-    #[test]
-    fn test_unclipped_end_from_cigar_no_clips() {
-        // 10M: end = pos + 10 - 1 = 109
-        let cigar = &[(10 << 4)];
-        assert_eq!(unclipped_end_from_cigar(100, cigar), 109);
-    }
-
-    #[test]
-    fn test_unclipped_end_from_cigar_trailing_clips() {
-        // 10M5S3H: end = 100 + 10 + 5 + 3 - 1 = 117
-        let cigar = &[(10 << 4), (5 << 4) | 4, (3 << 4) | 5];
-        assert_eq!(unclipped_end_from_cigar(100, cigar), 117);
-    }
-
-    // ========================================================================
-    // unclipped_5prime tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_5prime_forward_vs_reverse() {
-        // 5S10M3S: forward uses start, reverse uses end
-        let cigar = &[(5 << 4) | 4, (10 << 4), (3 << 4) | 4];
-        // Forward: unclipped_start = 100 - 5 = 95
-        assert_eq!(unclipped_5prime(100, false, cigar), 95);
-        // Reverse: unclipped_end = 100 + 10 + 3 - 1 = 112
-        assert_eq!(unclipped_5prime(100, true, cigar), 112);
-    }
-
-    // ========================================================================
-    // unclipped_5prime_1based tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_5prime_1based_unmapped() {
-        assert_eq!(unclipped_5prime_1based(100, false, true, &[(10 << 4)]), 0);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_no_cigar() {
-        assert_eq!(unclipped_5prime_1based(100, false, false, &[]), i32::MAX);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_forward() {
-        // 5S10M: forward 5' = pos+1 - 5 = 96
-        let cigar = &[(5 << 4) | 4, (10 << 4)];
-        assert_eq!(unclipped_5prime_1based(100, false, false, cigar), 96);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_reverse() {
-        // 10M5S: reverse 5' = pos+1 + 10 + 5 - 1 = 115
-        let cigar = &[(10 << 4), (5 << 4) | 4];
-        assert_eq!(unclipped_5prime_1based(100, true, false, cigar), 115);
     }
 
     // ========================================================================

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -30,18 +30,38 @@ pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op:
     }
 }
 
+/// BAM CIGAR op-type -> (`consume_query`, `consume_ref`) packed bitmask.
+///
+/// Encodes both properties for every op type (0..8) in a single u32. Bit
+/// `(op << 1)` is `consume_query`; bit `(op << 1 | 1)` is `consume_ref`. Bits
+/// for op values >= 9 are zero. Matches htslib's `BAM_CIGAR_TYPE` in
+/// `sam.h`, giving branchless `consumes_*` queries.
+///
+/// | op | mnemonic | consume_query | consume_ref |
+/// |----|----------|---------------|-------------|
+/// | 0  | M        | yes           | yes         |
+/// | 1  | I        | yes           | no          |
+/// | 2  | D        | no            | yes         |
+/// | 3  | N        | no            | yes         |
+/// | 4  | S        | yes           | no          |
+/// | 5  | H        | no            | no          |
+/// | 6  | P        | no            | no          |
+/// | 7  | =        | yes           | yes         |
+/// | 8  | X        | yes           | yes         |
+const BAM_CIGAR_TYPE: u32 = 0x3C1A7;
+
 /// Returns true if the CIGAR op type consumes the reference (M, D, N, =, X).
 #[inline]
 #[must_use]
 pub const fn consumes_ref(op_type: u32) -> bool {
-    matches!(op_type, 0 | 2 | 3 | 7 | 8)
+    (BAM_CIGAR_TYPE >> (op_type << 1)) & 2 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the query including soft clips (M, I, S, =, X).
 #[inline]
 #[must_use]
 pub const fn consumes_query(op_type: u32) -> bool {
-    matches!(op_type, 0 | 1 | 4 | 7 | 8)
+    (BAM_CIGAR_TYPE >> (op_type << 1)) & 1 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the read/query excluding soft clips (M, I, =, X).
@@ -880,6 +900,31 @@ impl<'a> RawRecordView<'a> {
             .sum()
     }
 
+    /// Compute reference-consuming and query-consuming lengths in one pass.
+    ///
+    /// Equivalent to `(self.reference_length(), self.query_length())` but
+    /// walks the CIGAR only once. Use this when both values are needed
+    /// (e.g. record validation, alignment-end computation).
+    ///
+    /// Returns `(ref_length, query_length)`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_lengths(&self) -> (i32, usize) {
+        let mut ref_len = 0i32;
+        let mut q_len = 0usize;
+        for op in self.cigar_ops_iter() {
+            let ty = op & 0xF;
+            let len_u32 = op >> 4;
+            if consumes_ref(ty) {
+                ref_len += len_u32.cast_signed();
+            }
+            if consumes_query(ty) {
+                q_len += len_u32 as usize;
+            }
+        }
+        (ref_len, q_len)
+    }
+
     /// Compute 1-based alignment end position.
     #[inline]
     #[must_use]
@@ -913,6 +958,36 @@ impl<'a> RawRecordView<'a> {
 mod tests {
     use super::*;
     use crate::testutil::*;
+
+    // ========================================================================
+    // BAM_CIGAR_TYPE bitmask tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_type_bitmask_matches_spec() {
+        // Spec: (consumes_query, consumes_ref) for each op type 0..8
+        let expected = [
+            (true, true),   // 0: M
+            (true, false),  // 1: I
+            (false, true),  // 2: D
+            (false, true),  // 3: N
+            (true, false),  // 4: S
+            (false, false), // 5: H
+            (false, false), // 6: P
+            (true, true),   // 7: =
+            (true, true),   // 8: X
+        ];
+        for (op, &(eq, er)) in expected.iter().enumerate() {
+            let op = u32::try_from(op).unwrap();
+            assert_eq!(consumes_query(op), eq, "consumes_query({op})");
+            assert_eq!(consumes_ref(op), er, "consumes_ref({op})");
+        }
+        // Op values >= 9 should return false for both
+        for op in 9u32..=15 {
+            assert!(!consumes_query(op), "consumes_query({op}) should be false");
+            assert!(!consumes_ref(op), "consumes_ref({op}) should be false");
+        }
+    }
 
     // ========================================================================
     // unclipped_start_from_cigar / unclipped_end_from_cigar tests
@@ -1965,5 +2040,47 @@ mod tests {
         assert_eq!(v.query_length(), 100);
         assert_eq!(v.cigar_raw_bytes().len(), 12);
         assert_eq!(v.cigar_ops_iter().count(), 3);
+    }
+
+    // ========================================================================
+    // cigar_lengths tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_lengths_matches_separate_calls() {
+        use crate::fields::RawRecordView;
+
+        // Record with mixed CIGAR: 50M 5D 10I 35M = ref 90, query 95
+        let rec = make_bam_bytes(
+            0,
+            100,
+            0,
+            b"r",
+            &[
+                encode_op(0, 50), // 50M
+                encode_op(2, 5),  // 5D (ref only)
+                encode_op(1, 10), // 10I (query only)
+                encode_op(0, 35), // 35M
+            ],
+            95,
+            -1,
+            -1,
+            &[],
+        );
+        let v = RawRecordView::new(&rec);
+        let (ref_len, q_len) = v.cigar_lengths();
+        assert_eq!(ref_len, 90);
+        assert_eq!(q_len, 95);
+        // Agree with the single-purpose methods
+        assert_eq!(ref_len, v.reference_length());
+        assert_eq!(q_len, v.query_length());
+    }
+
+    #[test]
+    fn test_cigar_lengths_empty_cigar() {
+        use crate::fields::RawRecordView;
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.cigar_lengths(), (0, 0));
     }
 }

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -926,6 +926,87 @@ fn clip_cigar_end_raw(
     (result, 0) // ref_bases_consumed is 0 for end clipping (no position adjustment)
 }
 
+use crate::fields::RawRecordView;
+
+impl<'a> RawRecordView<'a> {
+    /// Raw CIGAR bytes (4 bytes per op), zero-allocation.
+    #[inline]
+    #[must_use]
+    pub fn cigar_raw_bytes(&self) -> &'a [u8] {
+        let bam = self.as_bytes();
+        let lrn = l_read_name(bam) as usize;
+        let n = n_cigar_op(bam) as usize;
+        let start = 32 + lrn;
+        let end = start + n * 4;
+        if end <= bam.len() { &bam[start..end] } else { &[] }
+    }
+
+    /// Zero-allocation iterator yielding decoded CIGAR ops as raw `u32`.
+    #[inline]
+    pub fn cigar_ops_iter(&self) -> impl Iterator<Item = u32> + 'a {
+        self.cigar_raw_bytes().chunks_exact(4).map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    }
+
+    /// Convenience: collect CIGAR ops into a `Vec<u32>`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_ops_vec(&self) -> Vec<u32> {
+        get_cigar_ops(self.as_bytes())
+    }
+
+    /// Format CIGAR as a SAM-style string.
+    #[inline]
+    #[must_use]
+    pub fn cigar_to_string(&self) -> String {
+        cigar_to_string_from_raw(self.as_bytes())
+    }
+
+    /// Sum of M/D/N/=/X op lengths (reference-consuming).
+    #[inline]
+    #[must_use]
+    pub fn reference_length(&self) -> i32 {
+        reference_length_from_raw_bam(self.as_bytes())
+    }
+
+    /// Sum of M/I/S/=/X op lengths (query-consuming).
+    #[inline]
+    #[must_use]
+    pub fn query_length(&self) -> usize {
+        self.cigar_ops_iter()
+            .filter(|&op| consumes_query(op & 0xF))
+            .map(|op| (op >> 4) as usize)
+            .sum()
+    }
+
+    /// Compute 1-based alignment end position.
+    #[inline]
+    #[must_use]
+    pub fn alignment_end_1based(&self) -> Option<usize> {
+        alignment_end_from_raw(self.as_bytes())
+    }
+
+    /// Compute 1-based alignment start position.
+    #[inline]
+    #[must_use]
+    pub fn alignment_start_1based(&self) -> Option<usize> {
+        alignment_start_from_raw(self.as_bytes())
+    }
+
+    /// Computes the unclipped 5' coordinate (1-based) for grouping keys.
+    #[inline]
+    #[must_use]
+    pub fn unclipped_5prime_1based(&self) -> i32 {
+        unclipped_5prime_from_raw_bam(self.as_bytes())
+    }
+
+    /// Virtual clipping — see [`clip_cigar_ops_raw`].
+    #[inline]
+    #[must_use]
+    pub fn clip_cigar_ops(&self, clip_amount: usize, from_start: bool) -> (Vec<u32>, usize) {
+        clip_cigar_ops_raw(&self.cigar_ops_vec(), clip_amount, from_start)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2039,5 +2120,29 @@ mod tests {
         assert_eq!(cigar_op_kind(10 << 4 | 1), Kind::Insertion);
         // 5D = (5 << 4) | 2
         assert_eq!(cigar_op_kind(5 << 4 | 2), Kind::Deletion);
+    }
+
+    #[test]
+    fn test_view_cigar_methods() {
+        use crate::fields::RawRecordView;
+        use crate::testutil::*;
+        let rec = make_bam_bytes(
+            0,
+            100,
+            0,
+            b"r",
+            &[encode_op(0, 50), encode_op(2, 5), encode_op(0, 50)],
+            100,
+            -1,
+            -1,
+            &[],
+        );
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.cigar_ops_vec(), vec![encode_op(0, 50), encode_op(2, 5), encode_op(0, 50)]);
+        assert_eq!(v.cigar_to_string(), "50M5D50M");
+        assert_eq!(v.reference_length(), 105);
+        assert_eq!(v.query_length(), 100);
+        assert_eq!(v.cigar_raw_bytes().len(), 12);
+        assert_eq!(v.cigar_ops_iter().count(), 3);
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -342,14 +342,14 @@ pub fn pos(bam: &[u8]) -> i32 {
 /// Extract `l_read_name` (length of read name + NUL) from a BAM record.
 #[inline]
 #[must_use]
-pub fn l_read_name(bam: &[u8]) -> u8 {
+pub(crate) fn l_read_name(bam: &[u8]) -> u8 {
     bam[8]
 }
 
 /// Extract number of CIGAR operations from a BAM record.
 #[inline]
 #[must_use]
-pub fn n_cigar_op(bam: &[u8]) -> u16 {
+pub(crate) fn n_cigar_op(bam: &[u8]) -> u16 {
     u16::from_le_bytes([bam[12], bam[13]])
 }
 
@@ -401,7 +401,7 @@ pub fn set_flags(bam: &mut [u8], new_flags: u16) {
 
 /// Set the mapping quality in a BAM record.
 #[inline]
-pub fn set_mapq(bam: &mut [u8], new_mapq: u8) {
+pub(crate) fn set_mapq(bam: &mut [u8], new_mapq: u8) {
     bam[9] = new_mapq;
 }
 
@@ -496,7 +496,7 @@ pub fn qual_offset(bam: &[u8]) -> usize {
 /// Returns (tid, pos, reverse, name).
 #[inline]
 #[must_use]
-pub fn extract_coordinate_fields(bam_bytes: &[u8]) -> (i32, i32, bool, &[u8]) {
+pub(crate) fn extract_coordinate_fields(bam_bytes: &[u8]) -> (i32, i32, bool, &[u8]) {
     debug_assert!(
         bam_bytes.len() >= MIN_BAM_RECORD_LEN,
         "BAM record too short ({} < {MIN_BAM_RECORD_LEN})",
@@ -601,7 +601,7 @@ pub struct TemplateCoordFields<'a> {
 /// Extract template-coordinate key fields directly from BAM bytes.
 #[inline]
 #[must_use]
-pub fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFields<'_> {
+pub(crate) fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFields<'_> {
     debug_assert!(
         bam_bytes.len() >= MIN_BAM_RECORD_LEN,
         "BAM record too short ({} < {MIN_BAM_RECORD_LEN})",

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -30,6 +30,45 @@ pub const BAM_MAGIC: &[u8; 4] = b"BAM\x01";
 /// `ref_id`, `pos`, etc.) require at least this many bytes.
 pub const MIN_BAM_RECORD_LEN: usize = 32;
 
+/// Borrowed read-only view over a complete BAM record's bytes.
+///
+/// Wraps `&'a [u8]`. All BAM-spec accessors (`flags`, `pos`, `cigar`, `sequence`,
+/// `tags`, …) are inherent methods on this type.
+///
+/// All accessors assume `bytes.len() >= MIN_BAM_RECORD_LEN`. Use [`RawRecordView::new`]
+/// when the caller can vouch for that (hot path); use [`RawRecordView::try_new`] for
+/// untrusted input.
+#[derive(Copy, Clone, Debug)]
+pub struct RawRecordView<'a>(&'a [u8]);
+
+impl<'a> RawRecordView<'a> {
+    /// Wrap raw BAM bytes without validation.
+    ///
+    /// In debug builds, asserts `bytes.len() >= MIN_BAM_RECORD_LEN`. In release
+    /// builds, accessor methods on a too-short slice will panic on out-of-bounds
+    /// indexing.
+    #[inline]
+    #[must_use]
+    pub const fn new(bytes: &'a [u8]) -> Self {
+        debug_assert!(bytes.len() >= MIN_BAM_RECORD_LEN);
+        Self(bytes)
+    }
+
+    /// Wrap raw BAM bytes, returning `None` if too short for the fixed header.
+    #[inline]
+    #[must_use]
+    pub const fn try_new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() >= MIN_BAM_RECORD_LEN { Some(Self(bytes)) } else { None }
+    }
+
+    /// Returns the underlying byte slice.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
 /// BAM flag bits.
 pub mod flags {
     /// Read is paired in sequencing.
@@ -930,5 +969,24 @@ mod tests {
         assert_eq!(pos(&rec), 0);
         set_pos(&mut rec, 9999);
         assert_eq!(pos(&rec), 9999);
+    }
+
+    #[test]
+    fn test_raw_record_view_new_and_as_bytes() {
+        let bytes = vec![0u8; 32];
+        let view = RawRecordView::new(&bytes);
+        assert_eq!(view.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_raw_record_view_try_new_too_short_returns_none() {
+        let bytes = vec![0u8; 31];
+        assert!(RawRecordView::try_new(&bytes).is_none());
+    }
+
+    #[test]
+    fn test_raw_record_view_try_new_min_length_succeeds() {
+        let bytes = vec![0u8; MIN_BAM_RECORD_LEN];
+        assert!(RawRecordView::try_new(&bytes).is_some());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -632,6 +632,23 @@ pub fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFiel
     }
 }
 
+impl<'a> RawRecordView<'a> {
+    /// Extract `(tid, pos, reverse, name)` for coordinate-key sorting.
+    /// Unmapped reads return `(i32::MAX, i32::MAX, false, name)`.
+    #[inline]
+    #[must_use]
+    pub fn coordinate_fields(&self) -> (i32, i32, bool, &'a [u8]) {
+        extract_coordinate_fields(self.0)
+    }
+
+    /// Extract template-coordinate sort fields in a single pass.
+    #[inline]
+    #[must_use]
+    pub fn template_coordinate_fields(&self) -> TemplateCoordFields<'a> {
+        extract_template_coordinate_fields(self.0)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -1190,5 +1207,19 @@ mod tests {
         assert!(v.is_paired());
         assert!(v.is_reverse());
         assert!(!v.is_unmapped());
+    }
+
+    #[test]
+    fn test_view_batched_coord_helpers() {
+        use crate::testutil::*;
+        let rec = make_bam_bytes(3, 200, flags::REVERSE, b"r", &[], 0, -1, -1, &[]);
+        let v = RawRecordView::new(&rec);
+        let (tid, pos, reverse, name) = v.coordinate_fields();
+        assert_eq!((tid, pos, reverse), (3, 200, true));
+        assert_eq!(name, b"r");
+
+        let f = v.template_coordinate_fields();
+        assert_eq!(f.tid, 3);
+        assert!(f.flags.reverse());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -278,7 +278,11 @@ pub(crate) const TAG_FIXED_SIZES: [u8; 256] = {
 };
 
 /// Calculate the size of a tag value based on its type.
-#[inline]
+// Inlining always is justified here: `tag_value_size` is the inner dispatch of
+// the hot `find_tag_position` loop and is tiny (a table lookup + match).
+// Forcing inline eliminates one call boundary per tag-scan iteration.
+#[allow(clippy::inline_always)]
+#[inline(always)]
 #[must_use]
 pub fn tag_value_size(val_type: u8, data: &[u8]) -> Option<usize> {
     let fixed = TAG_FIXED_SIZES[val_type as usize];
@@ -455,8 +459,12 @@ pub fn aux_data_offset_from_record(bam: &[u8]) -> Option<usize> {
         return None;
     }
     let l_rn = bam[8] as usize;
-    let n_co = u16::from_le_bytes([bam[12], bam[13]]) as usize;
-    let l_s = u32::from_le_bytes([bam[16], bam[17], bam[18], bam[19]]) as usize;
+    // Single 8-byte load over offsets 12..20 covers n_cigar_op (u16 at 12),
+    // flag (u16 at 14, discarded), and l_seq (u32 at 16). Avoids three
+    // separate loads in a frequently-called header-decode path.
+    let packed = u64::from_le_bytes(bam[12..20].try_into().ok()?);
+    let n_co = (packed & 0xFFFF) as usize;
+    let l_s = ((packed >> 32) & 0xFFFF_FFFF) as usize;
     Some(aux_data_offset(l_rn, n_co, l_s))
 }
 

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -69,6 +69,173 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+impl<'a> RawRecordView<'a> {
+    // -- header (fixed-offset) --
+
+    /// Extract reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn ref_id(&self) -> i32 {
+        ref_id(self.0)
+    }
+
+    /// Extract 0-based leftmost position from this record.
+    #[inline]
+    #[must_use]
+    pub fn pos(&self) -> i32 {
+        pos(self.0)
+    }
+
+    /// Extract mapping quality from this record.
+    #[inline]
+    #[must_use]
+    pub fn mapq(&self) -> u8 {
+        mapq(self.0)
+    }
+
+    /// Extract bitwise flags from this record.
+    #[inline]
+    #[must_use]
+    pub fn flags(&self) -> u16 {
+        flags(self.0)
+    }
+
+    /// Extract `l_read_name` (read-name length including NUL) from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_read_name(&self) -> u8 {
+        l_read_name(self.0)
+    }
+
+    /// Extract number of CIGAR operations from this record.
+    #[inline]
+    #[must_use]
+    pub fn n_cigar_op(&self) -> u16 {
+        n_cigar_op(self.0)
+    }
+
+    /// Extract sequence length from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_seq(&self) -> u32 {
+        l_seq(self.0)
+    }
+
+    /// Extract mate reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_ref_id(&self) -> i32 {
+        mate_ref_id(self.0)
+    }
+
+    /// Extract mate 0-based position from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_pos(&self) -> i32 {
+        mate_pos(self.0)
+    }
+
+    /// Extract template length (tlen) from this record.
+    #[inline]
+    #[must_use]
+    pub fn template_length(&self) -> i32 {
+        template_length(self.0)
+    }
+
+    /// Extract read name (without null terminator) from this record.
+    #[inline]
+    #[must_use]
+    pub fn read_name(&self) -> &'a [u8] {
+        read_name(self.0)
+    }
+
+    /// Extract the BAM bin field (computed by the upstream encoder from `pos` and CIGAR).
+    #[inline]
+    #[must_use]
+    pub fn bin(&self) -> u16 {
+        u16::from_le_bytes([self.0[10], self.0[11]])
+    }
+
+    // -- flag-bit convenience --
+
+    /// Returns `true` if the read is paired in sequencing.
+    #[inline]
+    #[must_use]
+    pub fn is_paired(&self) -> bool {
+        self.flags() & flags::PAIRED != 0
+    }
+
+    /// Returns `true` if the read is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_unmapped(&self) -> bool {
+        self.flags() & flags::UNMAPPED != 0
+    }
+
+    /// Returns `true` if the mate is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_unmapped(&self) -> bool {
+        self.flags() & flags::MATE_UNMAPPED != 0
+    }
+
+    /// Returns `true` if the read is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_reverse(&self) -> bool {
+        self.flags() & flags::REVERSE != 0
+    }
+
+    /// Returns `true` if the mate is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_reverse(&self) -> bool {
+        self.flags() & flags::MATE_REVERSE != 0
+    }
+
+    /// Returns `true` if the read is the first segment (R1).
+    #[inline]
+    #[must_use]
+    pub fn is_first_segment(&self) -> bool {
+        self.flags() & flags::FIRST_SEGMENT != 0
+    }
+
+    /// Returns `true` if the read is the last segment (R2).
+    #[inline]
+    #[must_use]
+    pub fn is_last_segment(&self) -> bool {
+        self.flags() & flags::LAST_SEGMENT != 0
+    }
+
+    /// Returns `true` if the read is a secondary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_secondary(&self) -> bool {
+        self.flags() & flags::SECONDARY != 0
+    }
+
+    /// Returns `true` if the read fails quality controls.
+    #[inline]
+    #[must_use]
+    pub fn is_qc_fail(&self) -> bool {
+        self.flags() & flags::QC_FAIL != 0
+    }
+
+    /// Returns `true` if the read is a PCR or optical duplicate.
+    #[inline]
+    #[must_use]
+    pub fn is_duplicate(&self) -> bool {
+        self.flags() & flags::DUPLICATE != 0
+    }
+
+    /// Returns `true` if the read is a supplementary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_supplementary(&self) -> bool {
+        self.flags() & flags::SUPPLEMENTARY != 0
+    }
+}
+
 /// BAM flag bits.
 pub mod flags {
     /// Read is paired in sequencing.
@@ -988,5 +1155,40 @@ mod tests {
     fn test_raw_record_view_try_new_min_length_succeeds() {
         let bytes = vec![0u8; MIN_BAM_RECORD_LEN];
         assert!(RawRecordView::try_new(&bytes).is_some());
+    }
+
+    #[test]
+    fn test_raw_record_view_header_accessors() {
+        use crate::testutil::*;
+        let mut rec = make_bam_bytes(
+            3,
+            200,
+            flags::PAIRED | flags::REVERSE,
+            b"read1",
+            &[encode_op(0, 10)],
+            6,
+            5,
+            400,
+            &[],
+        );
+        rec[9] = 42; // mapq
+        // bin
+        rec[10..12].copy_from_slice(&4680u16.to_le_bytes());
+
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.ref_id(), 3);
+        assert_eq!(v.pos(), 200);
+        assert_eq!(v.mapq(), 42);
+        assert_eq!(v.flags(), flags::PAIRED | flags::REVERSE);
+        assert_eq!(v.bin(), 4680);
+        assert_eq!(v.l_read_name(), 6);
+        assert_eq!(v.n_cigar_op(), 1);
+        assert_eq!(v.l_seq(), 6);
+        assert_eq!(v.mate_ref_id(), 5);
+        assert_eq!(v.mate_pos(), 400);
+        assert_eq!(v.read_name(), b"read1");
+        assert!(v.is_paired());
+        assert!(v.is_reverse());
+        assert!(!v.is_unmapped());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -314,7 +314,7 @@ pub fn tag_value_size(val_type: u8, data: &[u8]) -> Option<usize> {
 /// Extract flags (u16) from a BAM record.
 #[inline]
 #[must_use]
-pub fn flags(bam: &[u8]) -> u16 {
+pub(crate) fn flags(bam: &[u8]) -> u16 {
     u16::from_le_bytes([bam[14], bam[15]])
 }
 

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -649,6 +649,107 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+/// Borrowed fixed-length mutable view over a complete BAM record's bytes.
+///
+/// Wraps `&'a mut [u8]`. Provides every fixed-offset setter plus per-base /
+/// per-quality writes, but cannot change the record's byte length.
+///
+/// Read methods are accessed via [`RawRecordMut::view`].
+#[derive(Debug)]
+pub struct RawRecordMut<'a>(&'a mut [u8]);
+
+impl<'a> RawRecordMut<'a> {
+    /// Wrap raw BAM bytes mutably without validation.
+    ///
+    /// In debug builds, asserts `bytes.len() >= MIN_BAM_RECORD_LEN`. In release
+    /// builds, setter methods on a too-short slice will panic on out-of-bounds
+    /// indexing.
+    #[inline]
+    #[must_use]
+    pub fn new(bytes: &'a mut [u8]) -> Self {
+        debug_assert!(bytes.len() >= MIN_BAM_RECORD_LEN);
+        Self(bytes)
+    }
+
+    /// Wrap raw BAM bytes mutably, returning `None` if too short for the fixed header.
+    #[inline]
+    #[must_use]
+    pub fn try_new(bytes: &'a mut [u8]) -> Option<Self> {
+        if bytes.len() >= MIN_BAM_RECORD_LEN { Some(Self(bytes)) } else { None }
+    }
+
+    /// Borrow as a read-only view (lifetime tied to `&self`).
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawRecordView<'_> {
+        RawRecordView(self.0)
+    }
+
+    /// Returns the underlying byte slice as a shared reference.
+    #[inline]
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+
+    /// Returns the underlying byte slice as a mutable reference.
+    #[inline]
+    #[must_use]
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+
+    // -- header (fixed-offset) setters --
+
+    /// Set the reference sequence ID.
+    #[inline]
+    pub fn set_ref_id(&mut self, v: i32) {
+        set_ref_id(self.0, v);
+    }
+
+    /// Set the 0-based leftmost position.
+    #[inline]
+    pub fn set_pos(&mut self, v: i32) {
+        set_pos(self.0, v);
+    }
+
+    /// Set the mapping quality.
+    #[inline]
+    pub fn set_mapq(&mut self, v: u8) {
+        set_mapq(self.0, v);
+    }
+
+    /// Set the bitwise flags.
+    #[inline]
+    pub fn set_flags(&mut self, v: u16) {
+        set_flags(self.0, v);
+    }
+
+    /// Set the mate reference sequence ID.
+    #[inline]
+    pub fn set_mate_ref_id(&mut self, v: i32) {
+        set_mate_ref_id(self.0, v);
+    }
+
+    /// Set the mate 0-based position.
+    #[inline]
+    pub fn set_mate_pos(&mut self, v: i32) {
+        set_mate_pos(self.0, v);
+    }
+
+    /// Set the template length (TLEN).
+    #[inline]
+    pub fn set_template_length(&mut self, v: i32) {
+        set_template_length(self.0, v);
+    }
+
+    /// Set the BAM bin field (bytes 10–11, little-endian u16).
+    #[inline]
+    pub fn set_bin(&mut self, v: u16) {
+        self.0[10..12].copy_from_slice(&v.to_le_bytes());
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -1221,5 +1322,40 @@ mod tests {
         let f = v.template_coordinate_fields();
         assert_eq!(f.tid, 3);
         assert!(f.flags.reverse());
+    }
+
+    // ========================================================================
+    // RawRecordMut tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_record_mut_constructors_and_view() {
+        let mut bytes = vec![0u8; 32];
+        let m = RawRecordMut::new(&mut bytes);
+        assert_eq!(m.view().as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_raw_record_mut_setters() {
+        use crate::testutil::*;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let mut m = RawRecordMut::new(&mut rec);
+        m.set_ref_id(7);
+        m.set_pos(123);
+        m.set_mapq(40);
+        m.set_flags(flags::PAIRED | flags::REVERSE);
+        m.set_bin(4680);
+        m.set_mate_ref_id(8);
+        m.set_mate_pos(456);
+        m.set_template_length(300);
+        let v = m.view();
+        assert_eq!(v.ref_id(), 7);
+        assert_eq!(v.pos(), 123);
+        assert_eq!(v.mapq(), 40);
+        assert_eq!(v.flags(), flags::PAIRED | flags::REVERSE);
+        assert_eq!(v.bin(), 4680);
+        assert_eq!(v.mate_ref_id(), 8);
+        assert_eq!(v.mate_pos(), 456);
+        assert_eq!(v.template_length(), 300);
     }
 }

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -15,15 +15,51 @@ pub mod testutil;
 #[cfg(feature = "noodles")]
 pub mod noodles_compat;
 
-// Flat re-exports — callers use fgumi_raw_bam::flags() etc.
-pub use builder::*;
-pub use cigar::*;
+// Re-exports — callers use fgumi_raw_bam::FooBar etc.
+//
+// fields uses a wildcard because it defines both a `flags` free-function and a
+// `flags` module (flag-bit constants); explicit re-export of the same name is
+// ambiguous, so the wildcard is the cleanest option for that module. Items
+// demoted to pub(crate) are not re-exported by the wildcard.
 pub use fields::*;
-pub use overlap::*;
-pub use raw_bam_record::*;
-pub use sequence::*;
-pub use sort::*;
-pub use tags::*;
+
+// -- builder --
+pub use builder::UnmappedBamRecordBuilder;
+
+// -- cigar --
+pub use cigar::{
+    alignment_end_from_raw, alignment_start_from_raw, cigar_op_kind, cigar_to_string_from_raw,
+    clip_cigar_ops_raw, consumes_query, consumes_read, consumes_ref, get_cigar_ops,
+    mate_unclipped_5prime, mate_unclipped_5prime_1based, query_length_from_cigar,
+    read_pos_at_ref_pos_raw, reference_length_from_cigar, reference_length_from_raw_bam,
+    unclipped_5prime_from_raw_bam, unclipped_5prime_raw,
+};
+
+// -- overlap --
+pub use overlap::{is_fr_pair_raw, num_bases_extending_past_mate_raw};
+
+// -- raw_bam_record --
+pub use raw_bam_record::{RawBamReader, RawRecord, read_raw_record};
+
+// -- sequence --
+pub use sequence::{
+    BAM_BASE_TO_ASCII, extract_sequence, get_base, get_qual, is_base_n, mask_base,
+    pack_sequence_into, quality_scores_slice, quality_scores_slice_mut, set_base, set_qual,
+};
+
+// -- sort --
+pub use sort::{compare_coordinate_raw, compare_names_raw, compare_queryname_raw, natural_compare};
+
+// -- tags --
+pub use tags::{
+    ArrayTagRef, AuxStringTags, AuxTagsIter, RawTagsEditor, RawTagsMut, RawTagsView, TagEntry,
+    TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
+    array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
+    find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
+    find_string_tag_in_record, find_tag_type, find_uint8_tag, normalize_int_tag_to_smallest_signed,
+    remove_tag, reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
+    reverse_string_tag_in_place, update_int_tag, update_string_tag,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use testutil::*;

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -17,11 +17,42 @@ pub mod noodles_compat;
 
 // Re-exports — callers use fgumi_raw_bam::FooBar etc.
 //
-// fields uses a wildcard because it defines both a `flags` free-function and a
-// `flags` module (flag-bit constants); explicit re-export of the same name is
-// ambiguous, so the wildcard is the cleanest option for that module. Items
-// demoted to pub(crate) are not re-exported by the wildcard.
-pub use fields::*;
+// Explicit named list now that fn flags() has been demoted to pub(crate).
+// The `flags` entry below re-exports the pub mod (flag-bit constants).
+pub use fields::{
+    // -- constants --
+    BAM_MAGIC,
+    MIN_BAM_RECORD_LEN,
+    // -- types --
+    RawRecordMut,
+    RawRecordView,
+    TemplateCoordFields,
+    TemplateCoordFlags,
+    // -- field accessors (free functions) --
+    aux_data_offset,
+    aux_data_offset_from_record,
+    aux_data_slice,
+    // -- flag-bit constants module (pub mod, not fn) --
+    flags,
+    l_seq,
+    mapq,
+    mate_pos,
+    mate_ref_id,
+    pos,
+    qual_offset,
+    read_name,
+    ref_id,
+    seq_offset,
+    // -- field mutators (free functions) --
+    set_flags,
+    set_mate_pos,
+    set_mate_ref_id,
+    set_pos,
+    set_ref_id,
+    set_template_length,
+    tag_value_size,
+    template_length,
+};
 
 // -- builder --
 pub use builder::UnmappedBamRecordBuilder;

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -2,8 +2,8 @@ use crate::cigar::{
     consumes_query, get_cigar_ops, reference_length_from_cigar, reference_length_from_raw_bam,
     unclipped_other_end, unclipped_other_start,
 };
-use crate::fields::{aux_data_slice, flags, mate_pos, mate_ref_id, pos, ref_id, template_length};
-use crate::tags::find_string_tag;
+use crate::fields::{RawRecordView, aux_data_slice, flags, mate_pos, mate_ref_id, template_length};
+use crate::tags::RawTagsView;
 
 /// Check if a single read is part of an FR (forward-reverse) pair using raw BAM bytes.
 ///
@@ -12,7 +12,8 @@ use crate::tags::find_string_tag;
 /// on the same reference, and in FR orientation (positive strand 5' < negative strand 5').
 #[must_use]
 pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
-    let flg = flags(bam);
+    let v = RawRecordView::new(bam);
+    let flg = v.flags();
 
     // Must be paired
     if flg & flags::PAIRED == 0 {
@@ -25,7 +26,7 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
     }
 
     // Must be on the same reference
-    let this_ref_id = ref_id(bam);
+    let this_ref_id = v.ref_id();
     let m_ref_id = mate_ref_id(bam);
     if this_ref_id != m_ref_id {
         return false;
@@ -41,7 +42,7 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
     // Determine if FR or RF using htsjdk's logic:
     // positiveStrandFivePrimePos = readIsOnReverseStrand ? mateStart : alignmentStart
     // negativeStrandFivePrimePos = readIsOnReverseStrand ? alignmentEnd : alignmentStart + insertSize
-    let alignment_start = pos(bam) + 1; // 1-based
+    let alignment_start = v.pos() + 1; // 1-based
     let m_start = mate_pos(bam) + 1; // 1-based
     let insert_size = template_length(bam);
 
@@ -66,19 +67,20 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
         return 0;
     }
 
-    let flg = flags(bam);
+    let v = RawRecordView::new(bam);
+    let flg = v.flags();
     let is_reverse = flg & flags::REVERSE != 0;
 
     // Need MC tag for mate CIGAR information
     let aux = aux_data_slice(bam);
-    let Some(mc_bytes) = find_string_tag(aux, b"MC") else {
+    let Some(mc_bytes) = RawTagsView::new(aux).find_string(b"MC") else {
         return 0;
     };
     let Ok(mc_cigar) = std::str::from_utf8(mc_bytes) else {
         return 0;
     };
 
-    let this_pos_0based = pos(bam);
+    let this_pos_0based = v.pos();
     let m_pos_0based = mate_pos(bam);
     // Convert to 1-based for coordinate calculations
     let this_pos = this_pos_0based + 1;

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -552,6 +552,30 @@ impl RawRecord {
 
     // -- Length-changing edits --
 
+    /// Replace the CIGAR operation array.
+    ///
+    /// Updates `n_cigar_op` and splices the new ops in. Each op is a `u32` in
+    /// the standard BAM packing (`(op_len << 4) | op_type`).
+    ///
+    /// All other fields (sequence, quality, aux tags) are preserved.
+    ///
+    /// # Panics
+    /// Panics if `new_ops.len() > u16::MAX as usize`.
+    pub fn set_cigar_ops(&mut self, new_ops: &[u32]) {
+        let new_n = u16::try_from(new_ops.len())
+            .unwrap_or_else(|_| panic!("CIGAR op count {} overflows u16", new_ops.len()));
+        let l_rn = self.0[8] as usize;
+        let old_n = u16::from_le_bytes([self.0[12], self.0[13]]) as usize;
+        let start = 32 + l_rn;
+        let end = start + old_n * 4;
+        let mut bytes = Vec::with_capacity(new_ops.len() * 4);
+        for &op in new_ops {
+            bytes.extend_from_slice(&op.to_le_bytes());
+        }
+        self.0.splice(start..end, bytes);
+        self.0[12..14].copy_from_slice(&new_n.to_le_bytes());
+    }
+
     /// Replace the read name. Updates `l_read_name` and splices the name +
     /// NUL terminator into the record.
     ///
@@ -752,6 +776,27 @@ mod tests {
         rec.set_read_name(b"");
         assert_eq!(rec.read_name(), b"");
         assert_eq!(rec.l_read_name(), 1);
+    }
+
+    #[test]
+    fn test_set_cigar_ops_resize() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 10)], 10, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_name = rec.read_name().to_vec();
+        let pre_seq = rec.sequence_vec();
+        let pre_qual = rec.quality_scores().to_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        let new_ops = vec![encode_op(0, 4), encode_op(2, 1), encode_op(0, 6)];
+        rec.set_cigar_ops(&new_ops);
+        assert_eq!(rec.cigar_ops_vec(), new_ops);
+        assert_eq!(rec.n_cigar_op() as usize, new_ops.len());
+
+        assert_eq!(rec.read_name(), pre_name.as_slice());
+        assert_eq!(rec.sequence_vec(), pre_seq);
+        assert_eq!(rec.quality_scores(), pre_qual.as_slice());
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -549,6 +549,34 @@ impl RawRecord {
     pub fn set_template_length(&mut self, v: i32) {
         RawRecordMut::new(&mut self.0).set_template_length(v);
     }
+
+    // -- Length-changing edits --
+
+    /// Replace the read name. Updates `l_read_name` and splices the name +
+    /// NUL terminator into the record.
+    ///
+    /// All other fields (CIGAR, sequence, quality, aux tags) are preserved
+    /// because they live after the name and shift accordingly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_name.len() + 1 > u8::MAX as usize` (the BAM spec encodes
+    /// `l_read_name` as a single byte).
+    pub fn set_read_name(&mut self, new_name: &[u8]) {
+        let new_l = new_name.len() + 1; // include NUL
+        let new_l_u8 = u8::try_from(new_l)
+            .unwrap_or_else(|_| panic!("read name too long: {} bytes", new_name.len()));
+        let old_l = self.0[8] as usize;
+        let start = 32;
+        let end = start + old_l;
+        // Splice: replace old name+NUL with new name+NUL
+        let mut replacement = Vec::with_capacity(new_l);
+        replacement.extend_from_slice(new_name);
+        replacement.push(0);
+        self.0.splice(start..end, replacement);
+        // Update l_read_name byte at offset 8
+        self.0[8] = new_l_u8;
+    }
 }
 
 /// A reader for raw BAM records.
@@ -699,6 +727,31 @@ mod tests {
 
         let result = read_raw_record(&mut reader, &mut record);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_read_name_resize() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"oldname", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_cigar = rec.cigar_ops_vec();
+        let pre_seq = rec.sequence_vec();
+        let pre_qual = rec.quality_scores().to_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_read_name(b"new");
+        assert_eq!(rec.read_name(), b"new");
+        assert_eq!(rec.l_read_name(), 4); // 3 bytes + NUL
+        // All other fields preserved
+        assert_eq!(rec.cigar_ops_vec(), pre_cigar);
+        assert_eq!(rec.sequence_vec(), pre_seq);
+        assert_eq!(rec.quality_scores(), pre_qual.as_slice());
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+
+        // Empty name (still NUL-terminated)
+        rec.set_read_name(b"");
+        assert_eq!(rec.read_name(), b"");
+        assert_eq!(rec.l_read_name(), 1);
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -576,6 +576,53 @@ impl RawRecord {
         self.0[12..14].copy_from_slice(&new_n.to_le_bytes());
     }
 
+    /// Replace both the sequence and the quality scores.
+    ///
+    /// `seq` is ASCII (`A`/`C`/`G`/`T`/`N`/IUPAC); `qual` is raw Phred (not +33).
+    /// `seq.len()` and `qual.len()` must match (BAM spec).
+    ///
+    /// Updates `l_seq`; read name, CIGAR, and aux tags are preserved.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `seq.len() != qual.len()` or if `seq.len() > u32::MAX as usize`.
+    pub fn set_sequence_and_qualities(&mut self, seq: &[u8], qual: &[u8]) {
+        assert_eq!(seq.len(), qual.len(), "sequence and quality must have equal length");
+        let new_l = u32::try_from(seq.len()).expect("seq length overflows u32");
+        let l_rn = self.0[8] as usize;
+        let n_co = u16::from_le_bytes([self.0[12], self.0[13]]) as usize;
+        let old_l = u32::from_le_bytes([self.0[16], self.0[17], self.0[18], self.0[19]]) as usize;
+
+        let body_start = 32 + l_rn + n_co * 4;
+        let old_packed = old_l.div_ceil(2);
+        let body_end = body_start + old_packed + old_l;
+
+        let new_packed_len = seq.len().div_ceil(2);
+        let mut new_body = Vec::with_capacity(new_packed_len + qual.len());
+        crate::sequence::pack_sequence_into(&mut new_body, seq);
+        new_body.extend_from_slice(qual);
+
+        self.0.splice(body_start..body_end, new_body);
+        self.0[16..20].copy_from_slice(&new_l.to_le_bytes());
+    }
+
+    /// Convenience: replace quality scores when their length matches `l_seq`.
+    ///
+    /// For length-changing replacement, use [`RawRecord::set_sequence_and_qualities`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `qual.len() != l_seq`.
+    pub fn set_qualities(&mut self, qual: &[u8]) {
+        let l = self.l_seq() as usize;
+        assert_eq!(
+            l,
+            qual.len(),
+            "qualities length must match l_seq; use set_sequence_and_qualities to resize"
+        );
+        self.quality_scores_mut().copy_from_slice(qual);
+    }
+
     /// Replace the read name. Updates `l_read_name` and splices the name +
     /// NUL terminator into the record.
     ///
@@ -797,6 +844,64 @@ mod tests {
         assert_eq!(rec.sequence_vec(), pre_seq);
         assert_eq!(rec.quality_scores(), pre_qual.as_slice());
         assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    #[test]
+    fn test_set_sequence_and_qualities_grow() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_name = rec.read_name().to_vec();
+        let pre_cigar = rec.cigar_ops_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        let new_seq = b"ACGTACGTACGT";
+        let new_qual = vec![30u8; 12];
+        rec.set_sequence_and_qualities(new_seq, &new_qual);
+
+        assert_eq!(rec.l_seq() as usize, 12);
+        assert_eq!(rec.sequence_vec(), new_seq.to_vec());
+        assert_eq!(rec.quality_scores(), new_qual.as_slice());
+        assert_eq!(rec.read_name(), pre_name.as_slice());
+        assert_eq!(rec.cigar_ops_vec(), pre_cigar);
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    #[test]
+    fn test_set_sequence_and_qualities_shrink_with_odd_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_sequence_and_qualities(b"ACG", &[20, 21, 22]);
+        assert_eq!(rec.l_seq(), 3);
+        assert_eq!(rec.sequence_vec(), b"ACG".to_vec());
+        assert_eq!(rec.quality_scores(), &[20u8, 21, 22]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must have equal length")]
+    fn test_set_sequence_and_qualities_mismatch_panics() {
+        use crate::testutil::*;
+        let mut rec = RawRecord::from(make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]));
+        rec.set_sequence_and_qualities(b"AC", &[20]);
+    }
+
+    #[test]
+    fn test_set_qualities_fixed_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_qualities(&[10, 20, 30, 40]);
+        assert_eq!(rec.quality_scores(), &[10u8, 20, 30, 40]);
+    }
+
+    #[test]
+    #[should_panic(expected = "qualities length must match l_seq")]
+    fn test_set_qualities_wrong_length_panics() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_qualities(&[10, 20]);
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -596,13 +596,30 @@ impl RawRecord {
         let body_start = 32 + l_rn + n_co * 4;
         let old_packed = old_l.div_ceil(2);
         let body_end = body_start + old_packed + old_l;
-
         let new_packed_len = seq.len().div_ceil(2);
-        let mut new_body = Vec::with_capacity(new_packed_len + qual.len());
-        crate::sequence::pack_sequence_into(&mut new_body, seq);
-        new_body.extend_from_slice(qual);
+        let new_body_len = new_packed_len + qual.len();
+        let old_body_len = body_end - body_start;
 
-        self.0.splice(body_start..body_end, new_body);
+        // Resize in place by shifting aux data to its new position, then write
+        // packed seq and qual directly into the record buffer. This avoids the
+        // intermediate Vec allocation and extra memcpy that the splice approach
+        // required.
+        if new_body_len > old_body_len {
+            let grow = new_body_len - old_body_len;
+            let old_len = self.0.len();
+            self.0.resize(old_len + grow, 0);
+            self.0.copy_within(body_end..old_len, body_end + grow);
+        } else if new_body_len < old_body_len {
+            let shrink = old_body_len - new_body_len;
+            self.0.copy_within(body_end.., body_end - shrink);
+            self.0.truncate(self.0.len() - shrink);
+        }
+
+        let (seq_slot, qual_slot) =
+            self.0[body_start..body_start + new_body_len].split_at_mut(new_packed_len);
+        crate::sequence::pack_sequence_into_slice(seq_slot, seq);
+        qual_slot.copy_from_slice(qual);
+
         self.0[16..20].copy_from_slice(&new_l.to_le_bytes());
     }
 

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -379,6 +379,15 @@ impl RawRecord {
         RawRecordView::new(&self.0).query_length()
     }
 
+    /// Compute reference-consuming and query-consuming lengths in one pass.
+    ///
+    /// Returns `(ref_length, query_length)`. See [`RawRecordView::cigar_lengths`].
+    #[inline]
+    #[must_use]
+    pub fn cigar_lengths(&self) -> (i32, usize) {
+        self.view().cigar_lengths()
+    }
+
     /// Return the 1-based alignment end position, or `None` if unmapped.
     #[inline]
     #[must_use]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -929,4 +929,147 @@ mod tests {
             read_raw_record(&mut reader, &mut record).expect("reading at EOF should return Ok(0)");
         assert_eq!(n, 0); // EOF
     }
+
+    // ── Edge-case tests for length-changing edits ──────────────────────────
+
+    /// A 254-byte name (+ NUL = 255 = `u8::MAX`) is the longest name the BAM
+    /// spec allows; `set_read_name` must accept it without panic.
+    #[test]
+    fn test_set_read_name_max_length_254_bytes_succeeds() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        let max_name = vec![b'A'; 254]; // + NUL = 255 = u8::MAX
+        rec.set_read_name(&max_name);
+        assert_eq!(rec.l_read_name(), 255);
+        assert_eq!(rec.read_name().len(), 254);
+        assert_eq!(rec.read_name(), max_name.as_slice());
+    }
+
+    /// A 255-byte name (+ NUL = 256) overflows `u8`; `set_read_name` must panic.
+    #[test]
+    #[should_panic(expected = "read name too long")]
+    fn test_set_read_name_over_limit_panics() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        let too_long = vec![b'A'; 255]; // + NUL = 256 > u8::MAX
+        rec.set_read_name(&too_long);
+    }
+
+    /// An empty name is valid: `l_read_name` should be 1 (just the NUL
+    /// terminator) and `read_name()` should return an empty slice.
+    #[test]
+    fn test_set_read_name_empty() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"somename", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_read_name(b"");
+        assert_eq!(rec.l_read_name(), 1); // just the NUL
+        assert_eq!(rec.read_name(), b"");
+    }
+
+    /// `set_cigar_ops(&[])` clears the CIGAR entirely: `n_cigar_op` must be 0
+    /// and aux tags must survive the splice unchanged.
+    #[test]
+    fn test_set_cigar_ops_empty_clears_cigar() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(
+            0,
+            0,
+            0,
+            b"r",
+            &[encode_op(0, 10), encode_op(2, 1), encode_op(0, 5)],
+            15,
+            -1,
+            -1,
+            b"NMc\x05",
+        );
+        let mut rec = RawRecord::from(bytes);
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_cigar_ops(&[]);
+
+        assert_eq!(rec.n_cigar_op(), 0);
+        assert_eq!(rec.cigar_ops_vec(), Vec::<u32>::new());
+        // Aux tags survive the clear.
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    /// `set_sequence_and_qualities(b"", &[])` is legal: `l_seq` becomes 0, the
+    /// packed-sequence and quality slices are empty, and aux tags are preserved.
+    #[test]
+    fn test_set_sequence_and_qualities_zero_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_sequence_and_qualities(b"", &[]);
+
+        assert_eq!(rec.l_seq(), 0);
+        assert_eq!(rec.sequence_vec(), Vec::<u8>::new());
+        assert_eq!(rec.quality_scores(), &[] as &[u8]);
+        // Aux tags survive the removal of all seq+qual bytes.
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    /// A `B:S` (u16) array tag followed by an int tag must be byte-for-byte
+    /// identical after a seq+qual resize (grow from 10 to 16 bases).
+    #[test]
+    fn test_set_sequence_and_qualities_preserves_array_aux_tags() {
+        use crate::testutil::*;
+        // Build aux: B:S array of 4 u16 values, then NM:i:7
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBS");
+        aux.extend_from_slice(&4u32.to_le_bytes());
+        for v in [100u16, 200, 300, 400] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+        aux.extend_from_slice(b"NMc\x07");
+
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 10)], 10, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        let pre_aux = rec.tags().as_bytes().to_vec();
+
+        // Grow seq from 10 to 16 bases.
+        rec.set_sequence_and_qualities(b"ACGTACGTACGTACGT", &[30u8; 16]);
+
+        // Array tag must decode identically.
+        let post_arr = rec.tags().find_array(b"bq").expect("B:S array tag should be preserved");
+        assert_eq!(post_arr.count, 4);
+        let decoded: Vec<u16> = (0..4)
+            .map(|i| u16::from_le_bytes([post_arr.data[i * 2], post_arr.data[i * 2 + 1]]))
+            .collect();
+        assert_eq!(decoded, vec![100u16, 200, 300, 400]);
+
+        assert_eq!(rec.tags().find_int(b"NM"), Some(7));
+        // Byte-for-byte preservation of the entire aux section.
+        assert_eq!(rec.tags().as_bytes(), pre_aux.as_slice());
+    }
+
+    /// A `B:i` (i32) array tag must survive a read-name grow (length-changing
+    /// edit in the variable-length section before seq/qual/aux).
+    #[test]
+    fn test_set_read_name_with_array_aux_tags() {
+        use crate::testutil::*;
+        // Build aux: B:i array of 3 i32 values.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBi");
+        aux.extend_from_slice(&3u32.to_le_bytes());
+        for v in [1_000_000i32, -2_000_000, 3_000_000] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+
+        let bytes = make_bam_bytes(0, 0, 0, b"oldname", &[encode_op(0, 4)], 4, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        let pre_aux = rec.tags().as_bytes().to_vec();
+
+        // Grow the read name so the splice shifts aux.
+        rec.set_read_name(b"new_longer_name_xyz");
+
+        assert_eq!(rec.read_name(), b"new_longer_name_xyz");
+        // Aux bytes must be byte-for-byte identical after the shift.
+        assert_eq!(rec.tags().as_bytes(), pre_aux.as_slice());
+    }
 }

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -164,6 +164,393 @@ where
     usize::try_from(n).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
+use crate::fields::{RawRecordMut, RawRecordView};
+use crate::tags::{RawTagsEditor, RawTagsMut, RawTagsView};
+
+impl RawRecord {
+    /// Borrow as a read-only view.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawRecordView<'_> {
+        RawRecordView::new(&self.0)
+    }
+
+    /// Borrow as a fixed-length mutable view.
+    #[inline]
+    #[must_use]
+    pub fn view_mut(&mut self) -> RawRecordMut<'_> {
+        RawRecordMut::new(&mut self.0)
+    }
+
+    /// Read-only view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags(&self) -> RawTagsView<'_> {
+        self.view().tags()
+    }
+
+    /// Fixed-length mutable view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags_mut(&mut self) -> RawTagsMut<'_> {
+        let len = self.0.len();
+        let off = crate::fields::aux_data_offset_from_record(&self.0).unwrap_or(len);
+        RawTagsMut::new(&mut self.0[off..])
+    }
+
+    /// Length-changing tag editor with cached aux offset.
+    #[inline]
+    #[must_use]
+    pub fn tags_editor(&mut self) -> RawTagsEditor<'_> {
+        RawTagsEditor::from_vec(&mut self.0)
+    }
+
+    // -- Header reads (return primitives — no lifetime borrow from self) --
+
+    /// Extract reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn ref_id(&self) -> i32 {
+        RawRecordView::new(&self.0).ref_id()
+    }
+
+    /// Extract 0-based leftmost position from this record.
+    #[inline]
+    #[must_use]
+    pub fn pos(&self) -> i32 {
+        RawRecordView::new(&self.0).pos()
+    }
+
+    /// Extract mapping quality from this record.
+    #[inline]
+    #[must_use]
+    pub fn mapq(&self) -> u8 {
+        RawRecordView::new(&self.0).mapq()
+    }
+
+    /// Extract bitwise flags from this record.
+    #[inline]
+    #[must_use]
+    pub fn flags(&self) -> u16 {
+        RawRecordView::new(&self.0).flags()
+    }
+
+    /// Extract BAM bin field from this record.
+    #[inline]
+    #[must_use]
+    pub fn bin(&self) -> u16 {
+        RawRecordView::new(&self.0).bin()
+    }
+
+    /// Extract `l_read_name` (read-name length including NUL) from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_read_name(&self) -> u8 {
+        RawRecordView::new(&self.0).l_read_name()
+    }
+
+    /// Extract number of CIGAR operations from this record.
+    #[inline]
+    #[must_use]
+    pub fn n_cigar_op(&self) -> u16 {
+        RawRecordView::new(&self.0).n_cigar_op()
+    }
+
+    /// Extract sequence length from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_seq(&self) -> u32 {
+        RawRecordView::new(&self.0).l_seq()
+    }
+
+    /// Extract mate reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_ref_id(&self) -> i32 {
+        RawRecordView::new(&self.0).mate_ref_id()
+    }
+
+    /// Extract mate 0-based position from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_pos(&self) -> i32 {
+        RawRecordView::new(&self.0).mate_pos()
+    }
+
+    /// Extract template length from this record.
+    #[inline]
+    #[must_use]
+    pub fn template_length(&self) -> i32 {
+        RawRecordView::new(&self.0).template_length()
+    }
+
+    // -- Flag-bit convenience reads --
+
+    /// Returns `true` if the read is paired in sequencing.
+    #[inline]
+    #[must_use]
+    pub fn is_paired(&self) -> bool {
+        RawRecordView::new(&self.0).is_paired()
+    }
+
+    /// Returns `true` if the read is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_unmapped(&self) -> bool {
+        RawRecordView::new(&self.0).is_unmapped()
+    }
+
+    /// Returns `true` if the mate is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_unmapped(&self) -> bool {
+        RawRecordView::new(&self.0).is_mate_unmapped()
+    }
+
+    /// Returns `true` if the read is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_reverse(&self) -> bool {
+        RawRecordView::new(&self.0).is_reverse()
+    }
+
+    /// Returns `true` if the mate is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_reverse(&self) -> bool {
+        RawRecordView::new(&self.0).is_mate_reverse()
+    }
+
+    /// Returns `true` if the read is the first segment (R1).
+    #[inline]
+    #[must_use]
+    pub fn is_first_segment(&self) -> bool {
+        RawRecordView::new(&self.0).is_first_segment()
+    }
+
+    /// Returns `true` if the read is the last segment (R2).
+    #[inline]
+    #[must_use]
+    pub fn is_last_segment(&self) -> bool {
+        RawRecordView::new(&self.0).is_last_segment()
+    }
+
+    /// Returns `true` if the read is a secondary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_secondary(&self) -> bool {
+        RawRecordView::new(&self.0).is_secondary()
+    }
+
+    /// Returns `true` if the read fails quality controls.
+    #[inline]
+    #[must_use]
+    pub fn is_qc_fail(&self) -> bool {
+        RawRecordView::new(&self.0).is_qc_fail()
+    }
+
+    /// Returns `true` if the read is a PCR or optical duplicate.
+    #[inline]
+    #[must_use]
+    pub fn is_duplicate(&self) -> bool {
+        RawRecordView::new(&self.0).is_duplicate()
+    }
+
+    /// Returns `true` if the read is a supplementary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_supplementary(&self) -> bool {
+        RawRecordView::new(&self.0).is_supplementary()
+    }
+
+    // -- CIGAR reads --
+
+    /// Compute the reference length consumed by this record's CIGAR.
+    #[inline]
+    #[must_use]
+    pub fn reference_length(&self) -> i32 {
+        RawRecordView::new(&self.0).reference_length()
+    }
+
+    /// Compute the query (read) length from this record's CIGAR.
+    #[inline]
+    #[must_use]
+    pub fn query_length(&self) -> usize {
+        RawRecordView::new(&self.0).query_length()
+    }
+
+    /// Return the 1-based alignment end position, or `None` if unmapped.
+    #[inline]
+    #[must_use]
+    pub fn alignment_end_1based(&self) -> Option<usize> {
+        RawRecordView::new(&self.0).alignment_end_1based()
+    }
+
+    /// Return the 1-based alignment start position, or `None` if unmapped.
+    #[inline]
+    #[must_use]
+    pub fn alignment_start_1based(&self) -> Option<usize> {
+        RawRecordView::new(&self.0).alignment_start_1based()
+    }
+
+    /// Return the 1-based unclipped 5′ position.
+    #[inline]
+    #[must_use]
+    pub fn unclipped_5prime_1based(&self) -> i32 {
+        RawRecordView::new(&self.0).unclipped_5prime_1based()
+    }
+
+    /// Convert this record's CIGAR to a human-readable string.
+    #[inline]
+    #[must_use]
+    pub fn cigar_to_string(&self) -> String {
+        RawRecordView::new(&self.0).cigar_to_string()
+    }
+
+    /// Return the raw CIGAR ops as a `Vec<u32>`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_ops_vec(&self) -> Vec<u32> {
+        RawRecordView::new(&self.0).cigar_ops_vec()
+    }
+
+    /// Decode the sequence bases to ASCII.
+    #[inline]
+    #[must_use]
+    pub fn sequence_vec(&self) -> Vec<u8> {
+        RawRecordView::new(&self.0).sequence_vec()
+    }
+
+    // -- Methods that return references borrowed from self --
+    //    Hand-written so lifetime elision pins the returned reference to &self.
+
+    /// Return the read name (without null terminator).
+    #[inline]
+    #[must_use]
+    pub fn read_name(&self) -> &[u8] {
+        self.view().read_name()
+    }
+
+    /// Return the raw CIGAR bytes.
+    #[inline]
+    #[must_use]
+    pub fn cigar_raw_bytes(&self) -> &[u8] {
+        self.view().cigar_raw_bytes()
+    }
+
+    /// Return the quality score bytes.
+    #[inline]
+    #[must_use]
+    pub fn quality_scores(&self) -> &[u8] {
+        self.view().quality_scores()
+    }
+
+    /// Return the packed (2-bit-encoded) sequence bytes.
+    #[inline]
+    #[must_use]
+    pub fn sequence_packed(&self) -> &[u8] {
+        self.view().sequence_packed()
+    }
+
+    /// Return the ASCII base at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_base(&self, position: usize) -> u8 {
+        self.view().get_base(position)
+    }
+
+    /// Return `true` if the base at `position` is N (missing/unknown).
+    #[inline]
+    #[must_use]
+    pub fn is_base_n(&self, position: usize) -> bool {
+        self.view().is_base_n(position)
+    }
+
+    /// Return the quality score at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_qual(&self, position: usize) -> u8 {
+        self.view().get_qual(position)
+    }
+
+    /// Return a mutable slice of quality scores.
+    #[inline]
+    pub fn quality_scores_mut(&mut self) -> &mut [u8] {
+        crate::sequence::quality_scores_slice_mut(&mut self.0)
+    }
+
+    /// Set the ASCII base at `position`.
+    #[inline]
+    pub fn set_base(&mut self, position: usize, base: u8) {
+        let seq_off = crate::fields::seq_offset(&self.0);
+        crate::sequence::set_base(&mut self.0, seq_off, position, base);
+    }
+
+    /// Mask the base at `position` to N.
+    #[inline]
+    pub fn mask_base(&mut self, position: usize) {
+        let seq_off = crate::fields::seq_offset(&self.0);
+        crate::sequence::mask_base(&mut self.0, seq_off, position);
+    }
+
+    /// Set the quality score at `position`.
+    #[inline]
+    pub fn set_qual(&mut self, position: usize, value: u8) {
+        let qual_off = crate::fields::qual_offset(&self.0);
+        crate::sequence::set_qual(&mut self.0, qual_off, position, value);
+    }
+
+    // -- Header writes (fixed-length, no return) --
+
+    /// Set the reference sequence ID.
+    #[inline]
+    pub fn set_ref_id(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_ref_id(v);
+    }
+
+    /// Set the 0-based leftmost position.
+    #[inline]
+    pub fn set_pos(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_pos(v);
+    }
+
+    /// Set the mapping quality.
+    #[inline]
+    pub fn set_mapq(&mut self, v: u8) {
+        RawRecordMut::new(&mut self.0).set_mapq(v);
+    }
+
+    /// Set the bitwise flags.
+    #[inline]
+    pub fn set_flags(&mut self, v: u16) {
+        RawRecordMut::new(&mut self.0).set_flags(v);
+    }
+
+    /// Set the BAM bin field.
+    #[inline]
+    pub fn set_bin(&mut self, v: u16) {
+        RawRecordMut::new(&mut self.0).set_bin(v);
+    }
+
+    /// Set the mate reference sequence ID.
+    #[inline]
+    pub fn set_mate_ref_id(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_mate_ref_id(v);
+    }
+
+    /// Set the mate 0-based position.
+    #[inline]
+    pub fn set_mate_pos(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_mate_pos(v);
+    }
+
+    /// Set the template length (TLEN).
+    #[inline]
+    pub fn set_template_length(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_template_length(v);
+    }
+}
+
 /// A reader for raw BAM records.
 ///
 /// This wraps any `Read` type (typically a BGZF reader) and provides
@@ -217,6 +604,33 @@ impl<R: Read> RawBamReader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_raw_record_inherent_delegators() {
+        use crate::flags;
+        use crate::testutil::*;
+        let bytes =
+            make_bam_bytes(3, 200, flags::PAIRED, b"rd", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        // Reads via inherent delegators
+        assert_eq!(rec.ref_id(), 3);
+        assert_eq!(rec.pos(), 200);
+        assert!(rec.is_paired());
+        assert_eq!(rec.tags().find_int(b"NM"), Some(5));
+
+        // Fixed-length writes via inherent delegators
+        rec.set_pos(999);
+        rec.set_mapq(40);
+        assert_eq!(rec.pos(), 999);
+        assert_eq!(rec.mapq(), 40);
+
+        // Length-changing edits via tags_editor
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_int(b"NM", 8);
+        }
+        assert_eq!(rec.tags().find_int(b"NM"), Some(8));
+    }
 
     #[test]
     fn test_raw_record_new() {

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -221,6 +221,38 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+use crate::fields::RawRecordMut;
+
+impl RawRecordMut<'_> {
+    /// Set the base at `position` (ASCII input -> 4-bit BAM encoding).
+    /// Unknown bases encode as `N` (0xF).
+    #[inline]
+    pub fn set_base(&mut self, position: usize, base: u8) {
+        let off = seq_offset(self.as_bytes());
+        set_base(self.as_bytes_mut(), off, position, base);
+    }
+
+    /// Set the base at `position` to `N`.
+    #[inline]
+    pub fn mask_base(&mut self, position: usize) {
+        let off = seq_offset(self.as_bytes());
+        mask_base(self.as_bytes_mut(), off, position);
+    }
+
+    /// Set the raw Phred quality score at `position`.
+    #[inline]
+    pub fn set_qual(&mut self, position: usize, value: u8) {
+        let off = qual_offset(self.as_bytes());
+        set_qual(self.as_bytes_mut(), off, position, value);
+    }
+
+    /// Mutable zero-allocation slice over raw Phred quality scores.
+    #[inline]
+    pub fn quality_scores_mut(&mut self) -> &mut [u8] {
+        quality_scores_slice_mut(self.as_bytes_mut())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -580,6 +612,30 @@ mod tests {
     // ========================================================================
     // RawRecordView sequence/quality method tests
     // ========================================================================
+
+    #[test]
+    fn test_raw_record_mut_seq_qual_writes() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 4, -1, -1, &[]);
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.set_base(0, b'A');
+            m.set_base(1, b'C');
+            m.set_base(2, b'G');
+            m.set_base(3, b'T');
+            m.set_qual(0, 25);
+            m.set_qual(3, 99);
+            m.mask_base(2);
+            for q in m.quality_scores_mut() {
+                if *q == 0 {
+                    *q = 10;
+                }
+            }
+        }
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.sequence_vec(), b"ACNT".to_vec());
+        assert_eq!(v.quality_scores(), &[25, 10, 10, 99]);
+    }
 
     #[test]
     fn test_view_sequence_quality_methods() {

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -126,6 +126,46 @@ pub fn pack_sequence_into(dst: &mut Vec<u8>, bases: &[u8]) {
     }
 }
 
+/// Pack ASCII bases into BAM 4-bit-per-base format, writing into a mutable slice.
+///
+/// `dst` must have length `>= bases.len().div_ceil(2)`. Writes exactly
+/// `bases.len().div_ceil(2)` bytes, zero-padding the last nibble when
+/// `bases.len()` is odd.
+///
+/// Mirrors [`pack_sequence_into`] but targets an existing `&mut [u8]` slot
+/// instead of appending to a `Vec`, avoiding an intermediate allocation when
+/// the destination buffer is already sized.
+#[inline]
+pub fn pack_sequence_into_slice(dst: &mut [u8], bases: &[u8]) {
+    if bases.is_empty() {
+        return;
+    }
+    let packed_len = bases.len().div_ceil(2);
+    debug_assert!(dst.len() >= packed_len);
+    let mut i = 0usize;
+    let mut chunks = bases.chunks_exact(PACK_CHUNK);
+    for chunk in chunks.by_ref() {
+        dst[i] = (SEQ_CODES[chunk[0] as usize] << 4) | SEQ_CODES[chunk[1] as usize];
+        dst[i + 1] = (SEQ_CODES[chunk[2] as usize] << 4) | SEQ_CODES[chunk[3] as usize];
+        dst[i + 2] = (SEQ_CODES[chunk[4] as usize] << 4) | SEQ_CODES[chunk[5] as usize];
+        dst[i + 3] = (SEQ_CODES[chunk[6] as usize] << 4) | SEQ_CODES[chunk[7] as usize];
+        dst[i + 4] = (SEQ_CODES[chunk[8] as usize] << 4) | SEQ_CODES[chunk[9] as usize];
+        dst[i + 5] = (SEQ_CODES[chunk[10] as usize] << 4) | SEQ_CODES[chunk[11] as usize];
+        dst[i + 6] = (SEQ_CODES[chunk[12] as usize] << 4) | SEQ_CODES[chunk[13] as usize];
+        dst[i + 7] = (SEQ_CODES[chunk[14] as usize] << 4) | SEQ_CODES[chunk[15] as usize];
+        i += 8;
+    }
+    let remainder = chunks.remainder();
+    let mut pairs = remainder.chunks_exact(2);
+    for pair in pairs.by_ref() {
+        dst[i] = (SEQ_CODES[pair[0] as usize] << 4) | SEQ_CODES[pair[1] as usize];
+        i += 1;
+    }
+    if let Some(&last) = pairs.remainder().first() {
+        dst[i] = SEQ_CODES[last as usize] << 4;
+    }
+}
+
 /// Extract a quality score at a given position.
 #[inline]
 #[must_use]

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -158,6 +158,69 @@ pub fn quality_scores_slice_mut(bam: &mut [u8]) -> &mut [u8] {
     &mut bam[off..off + l]
 }
 
+use crate::fields::RawRecordView;
+
+impl<'a> RawRecordView<'a> {
+    /// Raw 4-bit packed sequence bytes (`(l_seq + 1) / 2` bytes).
+    #[inline]
+    #[must_use]
+    pub fn sequence_packed(&self) -> &'a [u8] {
+        let bam = self.as_bytes();
+        let l = l_seq(bam) as usize;
+        let off = seq_offset(bam);
+        let bytes = l.div_ceil(2);
+        &bam[off..off + bytes]
+    }
+
+    /// Zero-allocation iterator yielding decoded ASCII bases (A/C/G/T/N/…).
+    #[inline]
+    pub fn sequence_iter(&self) -> impl Iterator<Item = u8> + 'a {
+        let bam = self.as_bytes();
+        let l = l_seq(bam) as usize;
+        let off = seq_offset(bam);
+        (0..l).map(move |i| BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize])
+    }
+
+    /// Convenience: collect the sequence into a `Vec<u8>` of ASCII bases.
+    #[inline]
+    #[must_use]
+    pub fn sequence_vec(&self) -> Vec<u8> {
+        extract_sequence(self.as_bytes())
+    }
+
+    /// Returns the 4-bit encoded base code at `position`
+    /// (1=A, 2=C, 4=G, 8=T, 15=N).
+    #[inline]
+    #[must_use]
+    pub fn get_base(&self, position: usize) -> u8 {
+        let bam = self.as_bytes();
+        get_base(bam, seq_offset(bam), position)
+    }
+
+    /// Returns `true` if the 4-bit encoded base at `position` is `N` (0xF).
+    #[inline]
+    #[must_use]
+    pub fn is_base_n(&self, position: usize) -> bool {
+        let bam = self.as_bytes();
+        is_base_n(bam, seq_offset(bam), position)
+    }
+
+    /// Zero-allocation slice over raw Phred quality scores (not Phred+33).
+    #[inline]
+    #[must_use]
+    pub fn quality_scores(&self) -> &'a [u8] {
+        quality_scores_slice(self.as_bytes())
+    }
+
+    /// Returns the raw Phred quality score at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_qual(&self, position: usize) -> u8 {
+        let bam = self.as_bytes();
+        get_qual(bam, qual_offset(bam), position)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +575,34 @@ mod tests {
         let mut dst = Vec::new();
         pack_sequence_into(&mut dst, b"NN");
         assert_eq!(dst, [0xFF]); // N=15, N=15
+    }
+
+    // ========================================================================
+    // RawRecordView sequence/quality method tests
+    // ========================================================================
+
+    #[test]
+    fn test_view_sequence_quality_methods() {
+        use crate::fields::RawRecordView;
+        // Build a record with seq "ACGT" and quals 30,30,30,30
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 4, -1, -1, &[]);
+        let so = seq_offset(&rec);
+        let qo = qual_offset(&rec);
+        rec[so] = 0x12; // A=1, C=2
+        rec[so + 1] = 0x48; // G=4, T=8
+        for i in 0..4 {
+            rec[qo + i] = 30;
+        }
+
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.l_seq(), 4);
+        assert_eq!(v.sequence_vec(), b"ACGT".to_vec());
+        assert_eq!(v.sequence_iter().collect::<Vec<u8>>(), b"ACGT".to_vec());
+        assert_eq!(v.sequence_packed(), &[0x12, 0x48]);
+        assert_eq!(v.quality_scores(), &[30, 30, 30, 30]);
+        assert_eq!(v.get_qual(0), 30);
+        assert_eq!(v.get_base(0), 1); // A
+        assert_eq!(v.get_base(3), 8); // T
+        assert!(!v.is_base_n(0));
     }
 }

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -1,3 +1,6 @@
+use bytemuck::cast;
+use wide::{u8x16, u16x8};
+
 use crate::fields::{l_seq, qual_offset, seq_offset};
 
 /// BAM 4-bit base encoding -> ASCII lookup table.
@@ -75,12 +78,93 @@ pub fn is_base_n(bam: &[u8], seq_off: usize, position: usize) -> bool {
     get_base(bam, seq_off, position) == 0xF
 }
 
+/// BAM nibble (0–15) → ASCII base, as a SIMD lookup table.
+///
+/// Used by `decode_chunk_32` via `swizzle_relaxed` (portable `pshufb`).
+const NIBBLE_ASCII_LUT: u8x16 = u8x16::new([
+    b'=', b'A', b'C', b'M', b'G', b'R', b'S', b'V', b'T', b'W', b'Y', b'H', b'K', b'D', b'B', b'N',
+]);
+
+/// Decode 16 packed bytes (= 32 bases) into ASCII, using SIMD.
+///
+/// Writes 32 bytes starting at `out[out_off]`. The caller guarantees the
+/// buffers are large enough.
+#[inline]
+fn decode_chunk_32(packed: &[u8], packed_off: usize, out: &mut [u8], out_off: usize) {
+    debug_assert!(packed.len() >= packed_off + 16);
+    debug_assert!(out.len() >= out_off + 32);
+
+    // Load 16 packed bytes.
+    let bytes_arr: [u8; 16] = packed[packed_off..packed_off + 16].try_into().unwrap();
+    let bytes = u8x16::new(bytes_arr);
+
+    // Low nibbles: direct per-lane mask.
+    let lo_nibbles = bytes & u8x16::new([0x0F; 16]);
+
+    // High nibbles via u16 shift + mask trick.
+    //
+    // For packed byte pair [b0, b1] viewed as u16 LE = (b1 << 8) | b0,
+    // (u16 >> 4) produces:
+    //   low byte  = (lo_nibble(b1) << 4) | hi_nibble(b0)
+    //   high byte = hi_nibble(b1)
+    // After &0x0F per byte:
+    //   low byte  = hi_nibble(b0)   ← wanted at even byte index
+    //   high byte = hi_nibble(b1)   ← wanted at odd byte index
+    let as_u16: u16x8 = cast(bytes);
+    let shifted: u16x8 = as_u16 >> 4u32;
+    let hi_nibbles: u8x16 = cast::<u16x8, u8x16>(shifted) & u8x16::new([0x0F; 16]);
+
+    // Parallel table lookup: nibble (0..15) → ASCII base.
+    let hi_ascii = NIBBLE_ASCII_LUT.swizzle_relaxed(hi_nibbles);
+    let lo_ascii = NIBBLE_ASCII_LUT.swizzle_relaxed(lo_nibbles);
+
+    // Output order: [hi(b0), lo(b0), hi(b1), lo(b1), ..., hi(b15), lo(b15)].
+    // u8x16::unpack_low(a, b)  → [a[0], b[0], a[1], b[1], ..., a[7], b[7]]
+    // u8x16::unpack_high(a, b) → [a[8], b[8], a[9], b[9], ..., a[15], b[15]]
+    let first_16 = u8x16::unpack_low(hi_ascii, lo_ascii);
+    let last_16 = u8x16::unpack_high(hi_ascii, lo_ascii);
+
+    out[out_off..out_off + 16].copy_from_slice(first_16.as_array());
+    out[out_off + 16..out_off + 32].copy_from_slice(last_16.as_array());
+}
+
+/// SIMD-accelerated sequence extraction.
+///
+/// Kept `pub(crate)` for benchmarking; external callers go through
+/// `extract_sequence`, which dispatches based on read length.
+#[inline]
+#[must_use]
+pub(crate) fn extract_sequence_simd(bam: &[u8]) -> Vec<u8> {
+    let l = l_seq(bam) as usize;
+    let off = seq_offset(bam);
+    let mut bases = vec![0u8; l];
+
+    // Process 16 packed bytes = 32 bases at a time.
+    let full_chunks = l / 32;
+    for c in 0..full_chunks {
+        decode_chunk_32(bam, off + c * 16, &mut bases, c * 32);
+    }
+
+    // Scalar tail for the remaining (l % 32) bases.
+    let processed = full_chunks * 32;
+    for (slot, i) in bases[processed..].iter_mut().zip(processed..l) {
+        *slot = BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize];
+    }
+    bases
+}
+
 /// Bulk-extract the full sequence from a BAM record as ASCII bases.
 ///
 /// Decodes the packed 4-bit sequence data into a `Vec<u8>` of ASCII bases.
+/// Uses SIMD for reads of 32 bp or longer; falls back to scalar for shorter
+/// reads where SIMD startup cost dominates.
 #[must_use]
 pub fn extract_sequence(bam: &[u8]) -> Vec<u8> {
     let l = l_seq(bam) as usize;
+    if l >= 32 {
+        return extract_sequence_simd(bam);
+    }
+    // Scalar path for short sequences.
     let off = seq_offset(bam);
     let mut bases = Vec::with_capacity(l);
     for i in 0..l {
@@ -675,6 +759,30 @@ mod tests {
         let v = RawRecordView::new(&rec);
         assert_eq!(v.sequence_vec(), b"ACNT".to_vec());
         assert_eq!(v.quality_scores(), &[25, 10, 10, 99]);
+    }
+
+    // ========================================================================
+    // SIMD / scalar equivalence tests
+    // ========================================================================
+
+    #[test]
+    fn test_extract_sequence_simd_matches_scalar_over_lengths() {
+        // Test a range of lengths that exercise the SIMD path (>=32) and the
+        // scalar tail (length % 32 != 0).
+        for l in [0usize, 1, 15, 31, 32, 33, 63, 64, 150, 200, 255] {
+            // Build a record with a deterministic sequence pattern.
+            let seq: Vec<u8> = (0..l).map(|i| b"ACGTN"[i % 5]).collect();
+            let mut packed = Vec::new();
+            pack_sequence_into(&mut packed, &seq);
+            // Build a BAM record with the packed sequence in place.
+            let mut bam = make_bam_bytes(0, 0, 0, b"r", &[], l, -1, -1, &[]);
+            let so = seq_offset(&bam);
+            let packed_len = l.div_ceil(2);
+            bam[so..so + packed_len].copy_from_slice(&packed);
+
+            let got = extract_sequence(&bam);
+            assert_eq!(got, seq, "mismatch at l={l}");
+        }
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/sort.rs
+++ b/crates/fgumi-raw-bam/src/sort.rs
@@ -1,17 +1,20 @@
 use std::cmp::Ordering;
 
-use crate::fields::{self, flags, pos, read_name, ref_id};
+use crate::fields::{RawRecordView, flags};
 
 #[must_use]
 pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
-    let a_tid = ref_id(a);
-    let b_tid = ref_id(b);
+    let av = RawRecordView::new(a);
+    let bv = RawRecordView::new(b);
 
-    let a_pos = pos(a);
-    let b_pos = pos(b);
+    let a_tid = av.ref_id();
+    let b_tid = bv.ref_id();
 
-    let a_flag = fields::flags(a);
-    let b_flag = fields::flags(b);
+    let a_pos = av.pos();
+    let b_pos = bv.pos();
+
+    let a_flag = av.flags();
+    let b_flag = bv.flags();
 
     // Handle reads with no reference (tid = -1) - sort last
     // Unmapped reads with a valid tid (mate's position) sort by that position
@@ -41,14 +44,15 @@ pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
 #[inline]
 #[must_use]
 pub fn compare_names_raw(a: &[u8], b: &[u8]) -> Ordering {
-    read_name(a).cmp(read_name(b))
+    RawRecordView::new(a).read_name().cmp(RawRecordView::new(b).read_name())
 }
 
 /// Compare for queryname ordering using raw bytes.
 #[inline]
 #[must_use]
 pub fn compare_queryname_raw(a: &[u8], b: &[u8]) -> Ordering {
-    compare_names_raw(a, b).then_with(|| fields::flags(a).cmp(&fields::flags(b)))
+    compare_names_raw(a, b)
+        .then_with(|| RawRecordView::new(a).flags().cmp(&RawRecordView::new(b).flags()))
 }
 
 // ============================================================================

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1188,6 +1188,44 @@ impl RawRecordMut<'_> {
     }
 }
 
+/// Length-changing tag editor.
+///
+/// Borrows a full BAM record byte buffer plus the cached aux offset (so update/
+/// append/remove ops don't repeat the header scan). Splices the aux section
+/// in place via `Vec::splice` for length-changing operations.
+pub struct RawTagsEditor<'a> {
+    record: &'a mut Vec<u8>,
+    aux_offset: usize,
+}
+
+impl<'a> RawTagsEditor<'a> {
+    /// Borrow a full BAM record byte buffer.
+    ///
+    /// Computes and caches `aux_offset` once. If the record is too short for
+    /// a valid header, `aux_offset` falls back to `record.len()` so all tag
+    /// ops behave as if the aux section is empty.
+    #[inline]
+    pub fn from_vec(record: &'a mut Vec<u8>) -> Self {
+        let aux_offset = aux_data_offset_from_record(record).unwrap_or(record.len());
+        Self { record, aux_offset }
+    }
+
+    /// Returns the cached aux offset (start of tag section).
+    #[inline]
+    #[must_use]
+    pub fn aux_offset(&self) -> usize {
+        self.aux_offset
+    }
+
+    /// Borrow the aux section as a read-only view.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawTagsView<'_> {
+        let off = self.aux_offset.min(self.record.len());
+        RawTagsView::new(&self.record[off..])
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -3008,5 +3046,19 @@ mod tests {
         assert!(ok);
         let got = RawRecordView::new(&rec).tags().find_float(b"AS").unwrap();
         assert!((got - 99.25).abs() < 1e-6);
+    }
+
+    // ========================================================================
+    // RawTagsEditor tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_tags_editor_from_vec_caches_aux_offset() {
+        let aux = b"RGZmygrp\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let expected_off = aux_data_offset_from_record(&rec).unwrap();
+        let editor = RawTagsEditor::from_vec(&mut rec);
+        assert_eq!(editor.aux_offset(), expected_off);
+        assert_eq!(editor.view().find_string(b"RG"), Some(b"mygrp".as_slice()));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -63,7 +63,8 @@ pub fn find_string_tag_in_record<'a>(bam: &'a [u8], tag: &[u8; 2]) -> Option<&'a
 /// Returns offsets relative to the start of `aux_data`.
 /// Returns `None` if the tag is not found.
 #[must_use]
-pub fn find_tag_bounds(aux_data: &[u8], tag: &[u8; 2]) -> Option<(usize, usize)> {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn find_tag_bounds(aux_data: &[u8], tag: &[u8; 2]) -> Option<(usize, usize)> {
     let (p, val_type) = find_tag_position(aux_data, *tag)?;
     let size = tag_value_size(val_type, &aux_data[p + 3..])?;
     Some((p, p + 3 + size))
@@ -137,7 +138,7 @@ fn extract_int_value(aux_data: &[u8], p: usize, val_type: u8) -> Option<i64> {
 /// - For integer values, returns `(value, true)`
 /// - Returns `None` if MI tag not found.
 #[must_use]
-pub fn find_mi_tag(aux_data: &[u8]) -> Option<(u64, bool)> {
+pub(crate) fn find_mi_tag(aux_data: &[u8]) -> Option<(u64, bool)> {
     let (pos, val_type) = find_tag_position(aux_data, *b"MI")?;
     if val_type == b'Z' {
         // String type - parse "12345" or "12345/A" or "12345/B"
@@ -191,19 +192,11 @@ fn parse_mi_bytes(s: &[u8]) -> Option<(u64, bool)> {
     Some((value, is_a))
 }
 
-/// Find MI tag in a complete BAM record.
-///
-/// Returns `(integer_value, is_A_suffix)` or `(0, true)` if not found.
-#[must_use]
-pub fn find_mi_tag_in_record(bam: &[u8]) -> (u64, bool) {
-    find_mi_tag(aux_data_slice(bam)).unwrap_or((0, true))
-}
-
 /// Find the MC (mate CIGAR) tag in auxiliary data.
 ///
 /// Returns the CIGAR string, or None if not found.
 #[must_use]
-pub fn find_mc_tag(aux_data: &[u8]) -> Option<&str> {
+pub(crate) fn find_mc_tag(aux_data: &[u8]) -> Option<&str> {
     find_string_tag(aux_data, b"MC").and_then(|v| std::str::from_utf8(v).ok())
 }
 
@@ -454,7 +447,8 @@ pub fn array_tag_to_vec_u16(tag_ref: &ArrayTagRef) -> Vec<u16> {
 /// Append a string (Z-type) tag to a BAM record.
 ///
 /// The tag is appended at the end of the record: `[tag_byte_1, tag_byte_2, 'Z', value..., NUL]`.
-pub fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'Z');
@@ -473,7 +467,8 @@ pub fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
 /// - `i16` (type `'s'`): if value in `[-32768, -129]`
 /// - `u16` (type `'S'`): if value in `[256, 65535]`
 /// - `i32` (type `'i'`): otherwise
-pub fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
     record.push(tag[0]);
     record.push(tag[1]);
     if let Ok(v) = i8::try_from(value) {
@@ -495,7 +490,8 @@ pub fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
 }
 
 /// Append a float (`f`-type) tag to a BAM record.
-pub fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'f');
@@ -509,7 +505,8 @@ pub fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -529,7 +526,8 @@ pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -544,7 +542,8 @@ pub fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
 ///
 /// Converts raw Phred scores (0-93) to ASCII (Phred+33) and writes
 /// directly as a null-terminated string tag. Avoids intermediate String allocation.
-pub fn append_phred33_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], quals: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_phred33_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], quals: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'Z');
@@ -736,7 +735,8 @@ pub fn append_i32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i32])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -756,7 +756,8 @@ pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -818,7 +819,7 @@ pub fn append_signed_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
 ///
 /// Iterates all tags in `src_aux` and appends each tag entry (tag + type + value bytes)
 /// to `dest`, unless the tag's two-byte key is in `skip_tags`.
-pub fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]]) {
+pub(crate) fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]]) {
     let mut offset = 0;
     while offset + 3 <= src_aux.len() {
         let tag_key = [src_aux[offset], src_aux[offset + 1]];
@@ -1629,16 +1630,6 @@ mod tests {
         // MI:Z:/B -> num_part is empty after stripping suffix, should return None
         let aux = b"MIZ/B\x00";
         assert_eq!(find_mi_tag(aux), None);
-    }
-
-    // ========================================================================
-    // find_mi_tag_in_record tests
-    // ========================================================================
-
-    #[test]
-    fn test_find_mi_tag_in_record_no_aux() {
-        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
-        assert_eq!(find_mi_tag_in_record(&rec), (0, true));
     }
 
     // ========================================================================

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1,5 +1,6 @@
 use crate::fields::{
-    RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+    RawRecordMut, RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice,
+    tag_value_size,
 };
 
 /// Find a tag's position and type byte in auxiliary data.
@@ -982,6 +983,112 @@ impl<'a> RawRecordView<'a> {
     #[must_use]
     pub fn template_aux_tags(&self, cell_tag: Option<&[u8; 2]>) -> TemplateAuxTags<'a> {
         extract_template_aux_tags(self.as_bytes(), cell_tag)
+    }
+}
+
+/// Borrowed fixed-length mutable view over a BAM record's aux section.
+///
+/// Cannot change the byte count of the aux section. Hosts in-place writers
+/// for B-array elements, Z-tag byte flips, and same-type tag overwrites.
+pub struct RawTagsMut<'a>(&'a mut [u8]);
+
+impl<'a> RawTagsMut<'a> {
+    /// Wraps a raw auxiliary-data slice mutably.
+    #[inline]
+    #[must_use]
+    pub fn new(aux: &'a mut [u8]) -> Self {
+        Self(aux)
+    }
+
+    /// Returns a read-only view over the aux section.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawTagsView<'_> {
+        RawTagsView::new(self.0)
+    }
+
+    /// Overwrite a single u8 element of a B:C array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `C`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_u8(&mut self, tag: &[u8; 2], index: usize, value: u8) {
+        Self::set_array_element_le(self.0, *tag, b'C', 1, index, &[value]);
+    }
+
+    /// Overwrite a single u16 element of a B:S array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `S`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_u16(&mut self, tag: &[u8; 2], index: usize, value: u16) {
+        Self::set_array_element_le(self.0, *tag, b'S', 2, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single i16 element of a B:s array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `s`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_i16(&mut self, tag: &[u8; 2], index: usize, value: i16) {
+        Self::set_array_element_le(self.0, *tag, b's', 2, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single i32 element of a B:i array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `i`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_i32(&mut self, tag: &[u8; 2], index: usize, value: i32) {
+        Self::set_array_element_le(self.0, *tag, b'i', 4, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single f32 element of a B:f array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `f`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_f32(&mut self, tag: &[u8; 2], index: usize, value: f32) {
+        Self::set_array_element_le(self.0, *tag, b'f', 4, index, &value.to_le_bytes());
+    }
+
+    /// Internal helper: locate a B-type array of the expected sub-type and overwrite
+    /// element `index` with the provided little-endian bytes.
+    ///
+    /// The layout of a B-type tag entry in the aux section is:
+    /// `[tag0, tag1, 'B', sub_type, count(4 bytes LE), elem0..elemN]`
+    fn set_array_element_le(
+        aux: &mut [u8],
+        tag: [u8; 2],
+        expected_sub: u8,
+        elem_size: usize,
+        index: usize,
+        le_bytes: &[u8],
+    ) {
+        let Some((p, val_type)) = find_tag_position(aux, tag) else { return };
+        if val_type != b'B' || p + 8 > aux.len() {
+            return;
+        }
+        if aux[p + 3] != expected_sub {
+            return;
+        }
+        let count = u32::from_le_bytes([aux[p + 4], aux[p + 5], aux[p + 6], aux[p + 7]]) as usize;
+        if index >= count {
+            return;
+        }
+        let off = p + 8 + index * elem_size;
+        if off + elem_size > aux.len() {
+            return;
+        }
+        aux[off..off + elem_size].copy_from_slice(le_bytes);
+    }
+}
+
+impl RawRecordMut<'_> {
+    /// Borrow a fixed-length mutable view over this record's aux section.
+    #[inline]
+    #[must_use]
+    pub fn tags_mut(&mut self) -> RawTagsMut<'_> {
+        // Compute offset and length via immutable borrow; both immutable borrows end
+        // before the mutable borrow on the last line (NLL two-phase borrows).
+        let len = self.as_bytes().len();
+        let off = aux_data_offset_from_record(self.as_bytes()).unwrap_or(len);
+        RawTagsMut::new(&mut self.as_bytes_mut()[off..])
     }
 }
 
@@ -2698,5 +2805,28 @@ mod tests {
         assert_eq!(s.rg, Some(b"mygrp".as_slice()));
         assert_eq!(s.cell, Some(b"ACGT".as_slice()));
         assert_eq!(s.mc, Some("50M"));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_array_element() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        // Build a record with B:S array tag "bq" of [10, 20, 30, 40]
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBS");
+        aux.extend_from_slice(&4u32.to_le_bytes());
+        for v in [10u16, 20, 30, 40] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            let mut tm = m.tags_mut();
+            tm.set_array_element_u16(b"bq", 2, 99);
+        }
+        let v = RawRecordView::new(&rec);
+        let arr = v.tags().find_array(b"bq").expect("array tag");
+        assert_eq!(arr.count, 4);
+        assert_eq!(array_tag_element_u16(&arr, 2), 99);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1224,6 +1224,94 @@ impl<'a> RawTagsEditor<'a> {
         let off = self.aux_offset.min(self.record.len());
         RawTagsView::new(&self.record[off..])
     }
+
+    // -- append (always grow) --
+
+    /// Append a string (Z-type) tag to the record.
+    #[inline]
+    pub fn append_string(&mut self, tag: &[u8; 2], value: &[u8]) {
+        append_string_tag(self.record, tag, value);
+    }
+
+    /// Append an integer tag, choosing the smallest fitting unsigned/signed type.
+    #[inline]
+    pub fn append_int(&mut self, tag: &[u8; 2], value: i32) {
+        append_int_tag(self.record, tag, value);
+    }
+
+    /// Append a signed integer tag, choosing the smallest fitting signed type.
+    #[inline]
+    pub fn append_signed_int(&mut self, tag: &[u8; 2], value: i32) {
+        append_signed_int_tag(self.record, tag, value);
+    }
+
+    /// Append a float (`f`-type) tag to the record.
+    #[inline]
+    pub fn append_float(&mut self, tag: &[u8; 2], value: f32) {
+        append_float_tag(self.record, tag, value);
+    }
+
+    /// Append a Phred+33-encoded quality string tag.
+    ///
+    /// Converts raw Phred scores (0–93) to ASCII (Phred+33) and writes as a Z-type tag.
+    #[inline]
+    pub fn append_phred33_string(&mut self, tag: &[u8; 2], quals: &[u8]) {
+        append_phred33_string_tag(self.record, tag, quals);
+    }
+
+    /// Append a `B:C` (u8 array) tag to the record.
+    #[inline]
+    pub fn append_array_u8(&mut self, tag: &[u8; 2], values: &[u8]) {
+        append_u8_array_tag(self.record, tag, values);
+    }
+
+    /// Append a `B:s` (i16 array) tag to the record.
+    #[inline]
+    pub fn append_array_i16(&mut self, tag: &[u8; 2], values: &[i16]) {
+        append_i16_array_tag(self.record, tag, values);
+    }
+
+    /// Append a `B:i` (i32 array) tag to the record.
+    #[inline]
+    pub fn append_array_i32(&mut self, tag: &[u8; 2], values: &[i32]) {
+        append_i32_array_tag(self.record, tag, values);
+    }
+
+    // -- update / remove / normalize --
+
+    /// Update an existing integer tag in place, or append it if absent.
+    #[inline]
+    pub fn update_int(&mut self, tag: &[u8; 2], value: i32) {
+        update_int_tag(self.record, tag, value);
+    }
+
+    /// Update an existing string tag in place, or append it if absent.
+    #[inline]
+    pub fn update_string(&mut self, tag: &[u8; 2], value: &[u8]) {
+        update_string_tag(self.record, tag, value);
+    }
+
+    /// Remove a tag from the record. No-op if the tag is not found.
+    #[inline]
+    pub fn remove(&mut self, tag: &[u8; 2]) {
+        remove_tag(self.record, tag);
+    }
+
+    /// Re-encode an existing integer tag using the smallest fitting signed type.
+    ///
+    /// No-op if the tag is not found or is not an integer type.
+    #[inline]
+    pub fn normalize_int_to_smallest_signed(&mut self, tag: &[u8; 2]) {
+        normalize_int_tag_to_smallest_signed(self.record, tag);
+    }
+
+    /// Copy entries from a source aux view to this record, optionally skipping tags by key.
+    ///
+    /// All tags in `src` are appended to the record unless their two-byte key appears in `skip`.
+    #[inline]
+    pub fn copy_from(&mut self, src: RawTagsView<'_>, skip: &[&[u8; 2]]) {
+        copy_aux_tags(src.as_bytes(), self.record, skip);
+    }
 }
 
 #[cfg(test)]
@@ -3060,5 +3148,83 @@ mod tests {
         let editor = RawTagsEditor::from_vec(&mut rec);
         assert_eq!(editor.aux_offset(), expected_off);
         assert_eq!(editor.view().find_string(b"RG"), Some(b"mygrp".as_slice()));
+    }
+
+    #[test]
+    fn test_editor_append_remove_update_int_string_roundtrip() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_string(b"RG", b"mygrp");
+            ed.append_int(b"NM", 5);
+            ed.update_int(b"NM", 7);
+            ed.update_string(b"RG", b"newgrp");
+        }
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.tags().find_string(b"RG"), Some(b"newgrp".as_slice()));
+        assert_eq!(v.tags().find_int(b"NM"), Some(7));
+
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.remove(b"NM");
+        }
+        assert_eq!(RawRecordView::new(&rec).tags().find_int(b"NM"), None);
+    }
+
+    #[test]
+    fn test_editor_normalize_int_to_smallest_signed() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_int(b"NM", 100_000); // Will encode as 'i' (i32) — fits 100,000
+            ed.normalize_int_to_smallest_signed(b"NM");
+        }
+        let aux = aux_data_slice(&rec);
+        let (p, t) = find_tag_position(aux, *b"NM").unwrap();
+        assert_eq!(t, b'i');
+        assert_eq!(i32::from_le_bytes([aux[p + 3], aux[p + 4], aux[p + 5], aux[p + 6]]), 100_000);
+    }
+
+    #[test]
+    fn test_editor_append_phred33_string() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_phred33_string(b"OQ", &[30, 31, 32, 33]);
+        }
+        // Phred+33: 30 -> '?', 31 -> '@', 32 -> 'A', 33 -> 'B'
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"OQ"), Some(b"?@AB".as_slice()));
+    }
+
+    #[test]
+    fn test_editor_append_array_i16() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_array_i16(b"sq", &[-100, 0, 100]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sq").expect("present");
+        assert_eq!(arr.count, 3);
+        assert_eq!(arr.elem_type, b's');
+    }
+
+    #[test]
+    fn test_editor_copy_from_skip() {
+        use crate::fields::RawRecordView;
+        let src_aux = b"RGZmygrp\0NMc\x05ASc\x0a";
+        let src_rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, src_aux);
+        let mut dst_rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let src_view = RawRecordView::new(&src_rec);
+            let mut ed = RawTagsEditor::from_vec(&mut dst_rec);
+            ed.copy_from(src_view.tags(), &[b"NM"]);
+        }
+        let dst = RawRecordView::new(&dst_rec);
+        assert_eq!(dst.tags().find_string(b"RG"), Some(b"mygrp".as_slice()));
+        assert_eq!(dst.tags().find_int(b"NM"), None); // skipped
+        assert_eq!(dst.tags().find_int(b"AS"), Some(10));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -960,12 +960,28 @@ impl<'a> IntoIterator for &RawTagsView<'a> {
     }
 }
 
+impl<'a> RawTagsView<'a> {
+    /// Single-pass extraction of (RG, cell, MC) string tags from this aux section.
+    #[inline]
+    #[must_use]
+    pub fn extract_string_batch(&self, cell_tag: &[u8; 2]) -> AuxStringTags<'a> {
+        extract_aux_string_tags(self.0, cell_tag)
+    }
+}
+
 impl<'a> RawRecordView<'a> {
     /// Returns a read-only view over this record's auxiliary tag section.
     #[inline]
     #[must_use]
     pub fn tags(&self) -> RawTagsView<'a> {
         RawTagsView::new(aux_data_slice(self.as_bytes()))
+    }
+
+    /// Single-pass extraction of (MI, RG, cell, MC) from this record's aux data.
+    #[inline]
+    #[must_use]
+    pub fn template_aux_tags(&self, cell_tag: Option<&[u8; 2]>) -> TemplateAuxTags<'a> {
+        extract_template_aux_tags(self.as_bytes(), cell_tag)
     }
 }
 
@@ -2671,5 +2687,16 @@ mod tests {
                 ("RG".into(), b'Z', b"rg1\0".to_vec()),
             ]
         );
+    }
+
+    #[test]
+    fn test_raw_tags_extract_string_batch() {
+        use crate::fields::RawRecordView;
+        let aux = b"RGZmygrp\0BCZACGT\0MCZ50M\0";
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let s = RawRecordView::new(&rec).tags().extract_string_batch(b"BC");
+        assert_eq!(s.rg, Some(b"mygrp".as_slice()));
+        assert_eq!(s.cell, Some(b"ACGT".as_slice()));
+        assert_eq!(s.mc, Some("50M"));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1077,6 +1077,102 @@ impl<'a> RawTagsMut<'a> {
         }
         aux[off..off + elem_size].copy_from_slice(le_bytes);
     }
+
+    /// Reverse element bytes of a B-type array tag in place.
+    #[inline]
+    pub fn reverse_array(&mut self, tag: &[u8; 2]) {
+        reverse_array_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Reverse the bytes of a Z-type string tag value in place.
+    #[inline]
+    pub fn reverse_string(&mut self, tag: &[u8; 2]) {
+        reverse_string_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Reverse-complement a Z-type string tag value (A<->T, C<->G).
+    #[inline]
+    pub fn reverse_complement_string(&mut self, tag: &[u8; 2]) {
+        reverse_complement_string_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Overwrite an existing Z-type tag if the new value matches its current length.
+    ///
+    /// Returns `false` (no-op) if absent, wrong type, or different length.
+    pub fn set_string_in_place(&mut self, tag: &[u8; 2], value: &[u8]) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        if val_type != b'Z' {
+            return false;
+        }
+        let start = p + 3;
+        let Some(nul_off) = self.0[start..].iter().position(|&b| b == 0) else {
+            return false;
+        };
+        if nul_off != value.len() {
+            return false;
+        }
+        self.0[start..start + value.len()].copy_from_slice(value);
+        true
+    }
+
+    /// Overwrite an existing integer tag if the new value fits its current type byte.
+    ///
+    /// Returns `false` if absent or value doesn't fit the existing type.
+    pub fn set_int_in_place(&mut self, tag: &[u8; 2], value: i64) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        match val_type {
+            b'c' => i8::try_from(value)
+                .map(|v| {
+                    self.0[p + 3] = v.cast_unsigned();
+                })
+                .is_ok(),
+            b'C' => u8::try_from(value)
+                .map(|v| {
+                    self.0[p + 3] = v;
+                })
+                .is_ok(),
+            b's' => i16::try_from(value)
+                .map(|v| {
+                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_ok(),
+            b'S' => u16::try_from(value)
+                .map(|v| {
+                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_ok(),
+            b'i' => i32::try_from(value)
+                .map(|v| {
+                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_ok(),
+            b'I' => u32::try_from(value)
+                .map(|v| {
+                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_ok(),
+            _ => false,
+        }
+    }
+
+    /// Overwrite an existing `f`-type tag in place.
+    ///
+    /// Returns `false` if absent or wrong type.
+    #[inline]
+    pub fn set_float_in_place(&mut self, tag: &[u8; 2], value: f32) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        if val_type != b'f' {
+            return false;
+        }
+        self.0[p + 3..p + 7].copy_from_slice(&value.to_le_bytes());
+        true
+    }
 }
 
 impl RawRecordMut<'_> {
@@ -2828,5 +2924,89 @@ mod tests {
         let arr = v.tags().find_array(b"bq").expect("array tag");
         assert_eq!(arr.count, 4);
         assert_eq!(array_tag_element_u16(&arr, 2), 99);
+    }
+
+    // ========================================================================
+    // RawTagsMut reverse + in-place setter tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_tags_mut_reverse_string_in_place() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().reverse_string(b"BC");
+        }
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"BC"), Some(b"TGCA".as_slice()));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_string_in_place_same_length() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_string_in_place(b"BC", b"TTTT")
+        };
+        assert!(ok);
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"BC"), Some(b"TTTT".as_slice()));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_string_in_place_different_length_returns_false() {
+        use crate::fields::RawRecordMut;
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_string_in_place(b"BC", b"AC")
+        };
+        assert!(!ok);
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_int_in_place_fits() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        // NM:i:5 (4-byte signed int)
+        let mut aux = Vec::from(b"NMi".as_slice());
+        aux.extend_from_slice(&5i32.to_le_bytes());
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_int_in_place(b"NM", 100_000)
+        };
+        assert!(ok);
+        assert_eq!(RawRecordView::new(&rec).tags().find_int(b"NM"), Some(100_000));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_int_in_place_doesnt_fit_returns_false() {
+        use crate::fields::RawRecordMut;
+        // NM:c:5 (1-byte signed)
+        let aux = b"NMc\x05";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_int_in_place(b"NM", 100_000)
+        };
+        assert!(!ok);
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_float_in_place() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let mut aux = Vec::from(b"ASf".as_slice());
+        aux.extend_from_slice(&12.5f32.to_le_bytes());
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_float_in_place(b"AS", 99.25)
+        };
+        assert!(ok);
+        let got = RawRecordView::new(&rec).tags().find_float(b"AS").unwrap();
+        assert!((got - 99.25).abs() < 1e-6);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -9,12 +9,16 @@ use crate::fields::{
 /// (the first byte of the 2-byte tag identifier). Returns `None` if not found.
 #[must_use]
 fn find_tag_position(aux_data: &[u8], tag: [u8; 2]) -> Option<(usize, u8)> {
+    // Compare as u16 — a single integer compare instead of a slice compare.
+    // LE byte order is preserved: both values are built from the same two bytes
+    // in the same order, so equality is equivalent to the byte-slice compare.
+    let tag_u16 = u16::from_le_bytes(tag);
     let mut p = 0;
     while p + 3 <= aux_data.len() {
-        let t = &aux_data[p..p + 2];
+        let entry_u16 = u16::from_le_bytes([aux_data[p], aux_data[p + 1]]);
         let val_type = aux_data[p + 2];
 
-        if t == tag {
+        if entry_u16 == tag_u16 {
             return Some((p, val_type));
         }
 

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -913,6 +913,53 @@ impl<'a> RawTagsView<'a> {
     }
 }
 
+/// Forward-only iterator over aux tag entries.
+///
+/// Yields `TagEntry` values containing the 2-byte tag, the type byte, and
+/// the raw value bytes (whose length is determined by the type per BAM spec).
+/// Stops at the first malformed entry.
+pub struct AuxTagsIter<'a> {
+    aux: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Iterator for AuxTagsIter<'a> {
+    type Item = TagEntry<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos + 3 > self.aux.len() {
+            return None;
+        }
+        let tag = [self.aux[self.pos], self.aux[self.pos + 1]];
+        let type_byte = self.aux[self.pos + 2];
+        let value_start = self.pos + 3;
+        let size = tag_value_size(type_byte, &self.aux[value_start..])?;
+        let end = value_start.checked_add(size)?;
+        if end > self.aux.len() {
+            return None;
+        }
+        let entry = TagEntry { tag, type_byte, value_bytes: &self.aux[value_start..end] };
+        self.pos = end;
+        Some(entry)
+    }
+}
+
+impl<'a> RawTagsView<'a> {
+    /// Iterate over aux tag entries without allocating.
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> AuxTagsIter<'a> {
+        AuxTagsIter { aux: self.0, pos: 0 }
+    }
+}
+
+impl<'a> IntoIterator for &RawTagsView<'a> {
+    type Item = TagEntry<'a>;
+    type IntoIter = AuxTagsIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<'a> RawRecordView<'a> {
     /// Returns a read-only view over this record's auxiliary tag section.
     #[inline]
@@ -2597,5 +2644,32 @@ mod tests {
         assert!(!tags.is_empty());
         assert!(tags.contains(b"RG"));
         assert!(!tags.contains(b"NM"));
+    }
+
+    #[test]
+    fn test_raw_tags_iter_basic() {
+        use crate::fields::RawRecordView;
+        // RG:Z:rg1\0 NM:i:5 (4 bytes LE)
+        let mut aux: Vec<u8> = b"RGZrg1\0".to_vec();
+        aux.extend_from_slice(b"NMi");
+        aux.extend_from_slice(&5i32.to_le_bytes());
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+
+        let v = RawRecordView::new(&rec);
+        let mut entries: Vec<(String, u8, Vec<u8>)> = v
+            .tags()
+            .iter()
+            .map(|e| {
+                (String::from_utf8(e.tag.to_vec()).unwrap(), e.type_byte, e.value_bytes.to_vec())
+            })
+            .collect();
+        entries.sort();
+        assert_eq!(
+            entries,
+            vec![
+                ("NM".into(), b'i', 5i32.to_le_bytes().to_vec()),
+                ("RG".into(), b'Z', b"rg1\0".to_vec()),
+            ]
+        );
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -729,6 +729,46 @@ pub fn append_i32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i32])
     }
 }
 
+/// Append a `u16` array (`B:S`-type) tag to a BAM record.
+///
+/// Format: `[tag0, tag1, 'B', 'S', count_u32_le, values_u16_le...]`
+///
+/// # Panics
+///
+/// Panics if `values.len()` exceeds `u32::MAX`.
+pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
+    record.push(tag[0]);
+    record.push(tag[1]);
+    record.push(b'B');
+    record.push(b'S');
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
+    for &v in values {
+        record.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+/// Append an `f32` array (`B:f`-type) tag to a BAM record.
+///
+/// Format: `[tag0, tag1, 'B', 'f', count_u32_le, values_f32_le...]`
+///
+/// # Panics
+///
+/// Panics if `values.len()` exceeds `u32::MAX`.
+pub fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
+    record.push(tag[0]);
+    record.push(tag[1]);
+    record.push(b'B');
+    record.push(b'f');
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
+    for &v in values {
+        record.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
 /// Normalize an integer tag to the smallest signed type that fits its value.
 ///
 /// If the tag exists and is an integer type, it is re-encoded using
@@ -1289,6 +1329,165 @@ impl<'a> RawTagsEditor<'a> {
     #[inline]
     pub fn update_string(&mut self, tag: &[u8; 2], value: &[u8]) {
         update_string_tag(self.record, tag, value);
+    }
+
+    /// Update an existing `f`-type tag in place, or remove + append if the existing tag has a
+    /// different type or is absent.
+    pub fn update_float(&mut self, tag: &[u8; 2], value: f32) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'f' && abs + 7 <= self.record.len() {
+                self.record[abs + 3..abs + 7].copy_from_slice(&value.to_le_bytes());
+                return;
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_float_tag(self.record, tag, value);
+    }
+
+    /// Update an existing `B:C` (u8 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_u8(&mut self, tag: &[u8; 2], values: &[u8]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'C' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    self.record[body..body + values.len()].copy_from_slice(values);
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_u8_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:S` (u16 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_u16(&mut self, tag: &[u8; 2], values: &[u16]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'S' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 2;
+                        self.record[dst..dst + 2].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_u16_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:s` (i16 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_i16(&mut self, tag: &[u8; 2], values: &[i16]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b's' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 2;
+                        self.record[dst..dst + 2].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_i16_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:i` (i32 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_i32(&mut self, tag: &[u8; 2], values: &[i32]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'i' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 4;
+                        self.record[dst..dst + 4].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_i32_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:f` (f32 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_f32(&mut self, tag: &[u8; 2], values: &[f32]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'f' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 4;
+                        self.record[dst..dst + 4].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_f32_array_tag(self.record, tag, values);
     }
 
     /// Remove a tag from the record. No-op if the tag is not found.
@@ -3226,5 +3425,114 @@ mod tests {
         assert_eq!(dst.tags().find_string(b"RG"), Some(b"mygrp".as_slice()));
         assert_eq!(dst.tags().find_int(b"NM"), None); // skipped
         assert_eq!(dst.tags().find_int(b"AS"), Some(10));
+    }
+
+    // ========================================================================
+    // update_float + update_array_* tests
+    // ========================================================================
+
+    #[test]
+    fn test_editor_update_float() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_float(b"AS", 12.5);
+            ed.update_float(b"AS", 99.25);
+        }
+        assert!((RawRecordView::new(&rec).tags().find_float(b"AS").unwrap() - 99.25).abs() < 1e-6);
+
+        // Updating a non-existent float tag inserts it
+        let mut rec2 = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec2);
+            ed.update_float(b"BB", 1.5);
+        }
+        assert!((RawRecordView::new(&rec2).tags().find_float(b"BB").unwrap() - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_editor_update_array_u16_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u16(b"bq", &[0u16, 1, 2, 3]); // not present -> append
+            ed.update_array_u16(b"bq", &[10, 20, 30, 40]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"bq").expect("present");
+        let vals = array_tag_to_vec_u16(&arr);
+        assert_eq!(vals, vec![10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_editor_update_array_u16_different_length_splices() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u16(b"bq", &[1u16, 2, 3]); // not present -> append
+            ed.update_array_u16(b"bq", &[7u16, 8, 9, 10, 11]); // grows
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"bq").expect("present");
+        let vals = array_tag_to_vec_u16(&arr);
+        assert_eq!(vals, vec![7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn test_editor_update_array_i32_grow_then_in_place() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_i32(b"sc", &[100, 200, 300]);
+            // Same-length in-place
+            ed.update_array_i32(b"sc", &[-1, -2, -3]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sc").expect("present");
+        assert_eq!(arr.elem_type, b'i');
+        assert_eq!(arr.count, 3);
+    }
+
+    #[test]
+    fn test_editor_update_array_f32() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_f32(b"fa", &[1.0, 2.0, 3.0]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"fa").expect("present");
+        assert_eq!(arr.elem_type, b'f');
+        assert_eq!(arr.count, 3);
+    }
+
+    #[test]
+    fn test_editor_update_array_u8_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u8(b"ML", &[10u8, 20, 30]); // not present -> append
+            ed.update_array_u8(b"ML", &[40u8, 50, 60]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"ML").expect("present");
+        assert_eq!(arr.elem_type, b'C');
+        assert_eq!(arr.count, 3);
+        assert_eq!(arr.data, &[40u8, 50, 60]);
+    }
+
+    #[test]
+    fn test_editor_update_array_i16_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_i16(b"sq", &[-100i16, 0, 100]); // not present -> append
+            ed.update_array_i16(b"sq", &[-200i16, 0, 200]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sq").expect("present");
+        assert_eq!(arr.elem_type, b's');
+        assert_eq!(arr.count, 3);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1,4 +1,6 @@
-use crate::fields::{TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size};
+use crate::fields::{
+    RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+};
 
 /// Find a tag's position and type byte in auxiliary data.
 ///
@@ -796,6 +798,127 @@ pub fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]])
         }
 
         offset = entry_end;
+    }
+}
+
+/// Zero-allocation entry yielded by tag iterators.
+#[derive(Copy, Clone, Debug)]
+pub struct TagEntry<'a> {
+    pub tag: [u8; 2],
+    pub type_byte: u8,
+    pub value_bytes: &'a [u8],
+}
+
+/// Borrowed read-only view over a BAM record's auxiliary tag section.
+#[derive(Copy, Clone, Debug)]
+pub struct RawTagsView<'a>(&'a [u8]);
+
+impl<'a> RawTagsView<'a> {
+    /// Wraps a raw auxiliary-data slice.
+    #[inline]
+    #[must_use]
+    pub const fn new(aux: &'a [u8]) -> Self {
+        Self(aux)
+    }
+
+    /// Returns the underlying aux-data bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.0
+    }
+
+    /// Returns the number of bytes in the aux section.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the aux section is empty (no tags present).
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns `true` if the named tag is present in the aux section.
+    #[inline]
+    #[must_use]
+    pub fn contains(&self, tag: &[u8; 2]) -> bool {
+        find_tag_type(self.0, tag).is_some()
+    }
+
+    /// Returns the value of a `Z`-type (string) tag, without the null terminator.
+    ///
+    /// Returns `None` if the tag is absent or is not `Z`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_string(&self, tag: &[u8; 2]) -> Option<&'a [u8]> {
+        find_string_tag(self.0, tag)
+    }
+
+    /// Returns the value of any integer tag (`c/C/s/S/i/I`) widened to `i64`.
+    ///
+    /// Returns `None` if the tag is absent or is not an integer type.
+    #[inline]
+    #[must_use]
+    pub fn find_int(&self, tag: &[u8; 2]) -> Option<i64> {
+        find_int_tag(self.0, tag)
+    }
+
+    /// Returns the value of a `C`-type (unsigned byte) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `C`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_uint8(&self, tag: &[u8; 2]) -> Option<u8> {
+        find_uint8_tag(self.0, tag)
+    }
+
+    /// Returns the value of an `f`-type (32-bit float) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `f`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_float(&self, tag: &[u8; 2]) -> Option<f32> {
+        find_float_tag(self.0, tag)
+    }
+
+    /// Returns a zero-allocation reference to a `B`-type (array) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `B`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_array(&self, tag: &[u8; 2]) -> Option<ArrayTagRef<'a>> {
+        find_array_tag(self.0, tag)
+    }
+
+    /// Returns the MI (Molecular Identifier) tag as `(value, is_A_suffix)`.
+    ///
+    /// Returns `None` if the tag is absent or cannot be parsed.
+    #[inline]
+    #[must_use]
+    pub fn find_mi(&self) -> Option<(u64, bool)> {
+        find_mi_tag(self.0)
+    }
+
+    /// Returns the MC (mate CIGAR) tag as a `&str`.
+    ///
+    /// Returns `None` if the tag is absent or is not valid UTF-8.
+    #[inline]
+    #[must_use]
+    pub fn find_mc(&self) -> Option<&'a str> {
+        find_mc_tag(self.0)
+    }
+}
+
+impl<'a> RawRecordView<'a> {
+    /// Returns a read-only view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags(&self) -> RawTagsView<'a> {
+        RawTagsView::new(aux_data_slice(self.as_bytes()))
     }
 }
 
@@ -2461,5 +2584,18 @@ mod tests {
         assert_eq!(arr.elem_type, b'C');
         assert_eq!(arr.count, values.len());
         assert_eq!(arr.data, values);
+    }
+
+    #[test]
+    fn test_raw_tags_view_construction_and_find_string() {
+        use crate::fields::RawRecordView;
+        let aux = b"RGZmysample\0";
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let v = RawRecordView::new(&rec);
+        let tags = v.tags();
+        assert_eq!(tags.find_string(b"RG"), Some(b"mysample".as_slice()));
+        assert!(!tags.is_empty());
+        assert!(tags.contains(b"RG"));
+        assert!(!tags.contains(b"NM"));
     }
 }

--- a/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
+++ b/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "noodles")]
+
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+use fgumi_raw_bam::{RawRecord, raw_records_to_record_bufs};
+use noodles::sam::alignment::record::Cigar;
+
+/// Decode a single [`RawRecord`] through noodles and return the parsed record.
+///
+/// Panics if noodles cannot parse the bytes — that failure is the test signal.
+fn decode_with_noodles(rec: &RawRecord) -> noodles::sam::alignment::RecordBuf {
+    let buffers = vec![rec.as_ref().to_vec()];
+    let mut bufs = raw_records_to_record_bufs(&buffers).expect("noodles decode failed");
+    bufs.pop().expect("expected at least one decoded record")
+}
+
+/// Build a minimal valid [`RawRecord`] for use as proptest input.
+///
+/// Constructs a record with the given name, a single Match CIGAR op covering
+/// `l_seq` bases, and no aux data.  The sequence bytes are left as all-zeros
+/// (the BAM encoding for all-N) which is valid.
+fn build_record(name: &[u8], l_seq: usize) -> RawRecord {
+    let cigar = if l_seq > 0 { vec![encode_op(0, l_seq)] } else { vec![] };
+    let bytes = make_bam_bytes(0, 0, 0, name, &cigar, l_seq, -1, -1, b"");
+    RawRecord::from(bytes)
+}
+
+proptest::proptest! {
+    /// Verify that [`RawRecord::set_read_name`] produces bytes that noodles decodes
+    /// to the same name, across many random name strings.
+    #[test]
+    fn set_read_name_roundtrips(name in "[A-Za-z0-9_]{1,200}") {
+        let mut rec = build_record(b"placeholder", 4);
+        rec.set_read_name(name.as_bytes());
+
+        // Internal view must reflect the new name.
+        proptest::prop_assert_eq!(rec.read_name(), name.as_bytes());
+
+        // Noodles must decode the same name.
+        let buf = decode_with_noodles(&rec);
+        let decoded = buf.name().map(std::convert::AsRef::as_ref);
+        proptest::prop_assert_eq!(decoded, Some(name.as_bytes()));
+    }
+
+    /// Verify that [`RawRecord::set_cigar_ops`] produces bytes that noodles decodes
+    /// to the same number of CIGAR operations, across many random op sequences.
+    #[test]
+    fn set_cigar_ops_roundtrips(
+        ops in proptest::collection::vec(1u32..=100u32, 1..=10),
+    ) {
+        // Build all-Match ops so the sequence length equals the sum of op lengths.
+        let total: usize = ops.iter().map(|&l| l as usize).sum();
+        // CIGAR word encodes length in upper bits, op type (M=0) in lower 4 bits.
+        let cigar_ops: Vec<u32> = ops.iter().map(|&len| len << 4).collect();
+
+        let mut rec = build_record(b"r", total);
+        rec.set_cigar_ops(&cigar_ops);
+
+        // Internal view must reflect the new CIGAR.
+        proptest::prop_assert_eq!(rec.cigar_ops_vec(), cigar_ops.clone());
+
+        // Noodles must decode the same number of ops.
+        let buf = decode_with_noodles(&rec);
+        let decoded_n_ops = buf.cigar().iter().count();
+        proptest::prop_assert_eq!(decoded_n_ops, ops.len());
+    }
+
+    /// Verify that [`RawRecord::set_sequence_and_qualities`] produces bytes that
+    /// noodles can parse without error, and that the internal view matches across
+    /// many random sequence lengths.
+    #[test]
+    fn set_sequence_and_qualities_roundtrips(
+        n in 1usize..=200,
+    ) {
+        // Build deterministic bases + quals from the length.
+        let bases: Vec<u8> = (0..n).map(|i| b"ACGTN"[i % 5]).collect();
+        // i % 40 is always 0..=39, so the truncation is safe.
+        #[allow(clippy::cast_possible_truncation)]
+        let quals: Vec<u8> = (0..n).map(|i| (i % 40) as u8).collect();
+
+        let mut rec = build_record(b"r", 1);
+        // Update the CIGAR to match the new sequence length before writing seq+qual.
+        // n <= 200 and u32::MAX >> 4 is well above 200, so the cast is safe.
+        #[allow(clippy::cast_possible_truncation)]
+        rec.set_cigar_ops(&[(n as u32) << 4]);
+        rec.set_sequence_and_qualities(&bases, &quals);
+
+        // Internal view must reflect the new sequence and qualities.
+        proptest::prop_assert_eq!(rec.sequence_vec(), bases.clone());
+        proptest::prop_assert_eq!(rec.quality_scores().to_vec(), quals.clone());
+
+        // Noodles must be able to parse the record without error.
+        decode_with_noodles(&rec);
+    }
+}

--- a/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
+++ b/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
@@ -221,3 +221,287 @@ proptest! {
         }
     }
 }
+
+// =============================================================================
+// Array update / element-write round-trip proptests (Issue #272 Easy gap ops)
+// =============================================================================
+
+/// Decode `count` little-endian `u8` elements from `data`.
+fn decode_u8_array(data: &[u8], count: usize) -> Vec<u8> {
+    (0..count).map(|i| data[i]).collect()
+}
+
+/// Decode `count` little-endian `u16` elements from `data`.
+fn decode_u16_array(data: &[u8], count: usize) -> Vec<u16> {
+    (0..count).map(|i| u16::from_le_bytes([data[i * 2], data[i * 2 + 1]])).collect()
+}
+
+/// Decode `count` little-endian `i16` elements from `data`.
+fn decode_i16_array(data: &[u8], count: usize) -> Vec<i16> {
+    (0..count).map(|i| i16::from_le_bytes([data[i * 2], data[i * 2 + 1]])).collect()
+}
+
+/// Decode `count` little-endian `i32` elements from `data`.
+fn decode_i32_array(data: &[u8], count: usize) -> Vec<i32> {
+    (0..count)
+        .map(|i| {
+            i32::from_le_bytes([data[i * 4], data[i * 4 + 1], data[i * 4 + 2], data[i * 4 + 3]])
+        })
+        .collect()
+}
+
+/// Decode `count` little-endian `f32` elements from `data` as bit patterns.
+fn decode_f32_bits_array(data: &[u8], count: usize) -> Vec<u32> {
+    (0..count)
+        .map(|i| {
+            u32::from_le_bytes([data[i * 4], data[i * 4 + 1], data[i * 4 + 2], data[i * 4 + 3]])
+        })
+        .collect()
+}
+
+proptest! {
+    // =========================================================================
+    // update_array_u8: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_u8_roundtrip(values in proptest::collection::vec(any::<u8>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u8(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_u8");
+        prop_assert_eq!(arr.elem_type, b'C', "elem_type should be 'C' for u8");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_u8_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_u16: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_u16_roundtrip(values in proptest::collection::vec(any::<u16>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u16(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_u16");
+        prop_assert_eq!(arr.elem_type, b'S', "elem_type should be 'S' for u16");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_u16_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_i16: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_i16_roundtrip(values in proptest::collection::vec(any::<i16>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i16(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_i16");
+        prop_assert_eq!(arr.elem_type, b's', "elem_type should be 's' for i16");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_i16_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_i32: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_i32_roundtrip(values in proptest::collection::vec(any::<i32>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i32(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_i32");
+        prop_assert_eq!(arr.elem_type, b'i', "elem_type should be 'i' for i32");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_i32_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_f32: whole-payload round-trip (bit equality — covers NaN)
+    // =========================================================================
+
+    #[test]
+    fn update_array_f32_roundtrip(values in proptest::collection::vec(any::<f32>(), 0..64)) {
+        let bits_in: Vec<u32> = values.iter().map(|f| f.to_bits()).collect();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_f32(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_f32");
+        prop_assert_eq!(arr.elem_type, b'f', "elem_type should be 'f' for f32");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_f32_bits_array(arr.data, arr.count);
+        prop_assert_eq!(got, bits_in);
+    }
+
+    // =========================================================================
+    // set_array_element_u8: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_u8_writes_one_element(
+        initial in proptest::collection::vec(any::<u8>(), 1..32),
+        index in 0usize..32,
+        new_val in any::<u8>(),
+    ) {
+        let index = index % initial.len();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u8(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_u8(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_u8");
+        let got = decode_u8_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_u16: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_u16_writes_one_element(
+        initial in proptest::collection::vec(any::<u16>(), 1..32),
+        index in 0usize..32,
+        new_val in any::<u16>(),
+    ) {
+        let index = index % initial.len();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u16(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_u16(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_u16");
+        let got = decode_u16_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_i16: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_i16_writes_one_element(
+        initial in proptest::collection::vec(any::<i16>(), 1..32),
+        index in 0usize..32,
+        new_val in any::<i16>(),
+    ) {
+        let index = index % initial.len();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i16(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_i16(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_i16");
+        let got = decode_i16_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_i32: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_i32_writes_one_element(
+        initial in proptest::collection::vec(any::<i32>(), 1..32),
+        index in 0usize..32,
+        new_val in any::<i32>(),
+    ) {
+        let index = index % initial.len();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i32(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_i32(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_i32");
+        let got = decode_i32_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_f32: single-element overwrite (bit equality), others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_f32_writes_one_element(
+        initial in proptest::collection::vec(any::<f32>(), 1..32),
+        index in 0usize..32,
+        new_val in any::<f32>(),
+    ) {
+        let index = index % initial.len();
+        let new_bits = new_val.to_bits();
+        let initial_bits: Vec<u32> = initial.iter().map(|f| f.to_bits()).collect();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_f32(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_f32(b"bq", index, new_val);
+        let arr =
+            rec.tags().find_array(b"bq").expect("array tag present after set_array_element_f32");
+        let got = decode_f32_bits_array(arr.data, arr.count);
+        for (i, &bits) in initial_bits.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_bits, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], bits, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_bin / bin: round-trip across the full u16 domain
+    // =========================================================================
+
+    #[test]
+    fn set_bin_roundtrip(v in any::<u16>()) {
+        let mut rec = base_record(&[]);
+        rec.set_bin(v);
+        prop_assert_eq!(rec.bin(), v);
+    }
+}

--- a/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
+++ b/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
@@ -1,0 +1,223 @@
+#![cfg(feature = "test-utils")]
+
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+use proptest::prelude::*;
+
+/// Build a minimal valid [`RawRecord`] with the given aux bytes.
+///
+/// Uses a 4-base Match CIGAR op and a short name whose length + NUL is
+/// word-aligned so the aux section starts at a clean offset.
+fn base_record(aux: &[u8]) -> RawRecord {
+    RawRecord::from(make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, aux))
+}
+
+proptest! {
+    // =========================================================================
+    // INVARIANT 1a: append_string(tag, v); remove(tag) → bytes unchanged
+    // when `tag` was absent before the append.
+    // =========================================================================
+
+    /// A record whose aux section is built exclusively from well-typed integer
+    /// tags is left byte-for-byte identical after appending and then removing
+    /// a "Xz" tag.
+    ///
+    /// We generate valid aux data (zero or more i32 tags with distinct
+    /// two-uppercase-letter names) rather than random bytes, so the scanner
+    /// can always navigate past the existing tags to reach the newly appended
+    /// one.  The invariant requires the aux section to be parseable.
+    #[test]
+    fn append_then_remove_string_is_noop(
+        // 0–4 existing i32 tags under uppercase two-letter names (not "Xz")
+        existing in proptest::collection::vec(
+            ("[A-WY-Z]{2}", any::<i32>()).prop_map(|(t, v)| (t.into_bytes(), v)),
+            0..4,
+        ),
+        val in "[A-Za-z]{0,40}",
+    ) {
+        let tag = b"Xz";
+
+        // Build valid aux bytes from the generated tags (deduplicating names).
+        let mut aux: Vec<u8> = Vec::new();
+        let mut seen: Vec<[u8; 2]> = Vec::new();
+        for (name, val_i) in &existing {
+            let k = [name[0], name[1]];
+            // Skip duplicates and any accidental collision with our test tag.
+            if seen.contains(&k) || &k == tag {
+                continue;
+            }
+            seen.push(k);
+            // Write as i32 (type 'i', 4-byte LE value).
+            aux.push(k[0]);
+            aux.push(k[1]);
+            aux.push(b'i');
+            aux.extend_from_slice(&val_i.to_le_bytes());
+        }
+
+        let mut rec = base_record(&aux);
+        let before = rec.as_ref().to_vec();
+
+        {
+            let mut ed = rec.tags_editor();
+            ed.append_string(tag, val.as_bytes());
+            ed.remove(tag);
+        }
+
+        prop_assert_eq!(rec.as_ref(), before.as_slice());
+    }
+
+    // =========================================================================
+    // INVARIANT 1b: append_int(tag, v); remove(tag) → bytes unchanged
+    // when `tag` was absent before the append.
+    // =========================================================================
+
+    /// Same noop invariant as 1a, exercised over the full i32 domain.
+    #[test]
+    fn append_then_remove_int_is_noop(v in any::<i32>()) {
+        let tag = b"Xz";
+        let mut rec = base_record(&[]);
+        let before = rec.as_ref().to_vec();
+
+        {
+            let mut ed = rec.tags_editor();
+            ed.append_int(tag, v);
+            ed.remove(tag);
+        }
+
+        prop_assert_eq!(rec.as_ref(), before.as_slice());
+    }
+
+    // =========================================================================
+    // INVARIANT 2a: update_int round-trip across i32 domain.
+    // =========================================================================
+
+    /// Writing an integer tag and reading it back must yield the same value
+    /// (widened to i64) on every i32 input.
+    #[test]
+    fn update_int_roundtrip(v in any::<i32>()) {
+        let tag = b"NM";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_int(tag, v);
+        }
+        let found = rec.tags().find_int(tag);
+        prop_assert_eq!(found, Some(i64::from(v)));
+    }
+
+    // =========================================================================
+    // INVARIANT 2b: update_string round-trip.
+    // =========================================================================
+
+    /// Writing a string tag and reading it back must yield the identical bytes.
+    #[test]
+    fn update_string_roundtrip(s in "[A-Za-z0-9 _-]{0,200}") {
+        let tag = b"Zz";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_string(tag, s.as_bytes());
+        }
+        let found = rec.tags().find_string(tag);
+        prop_assert_eq!(found, Some(s.as_bytes()));
+    }
+
+    // =========================================================================
+    // INVARIANT 2c: update_float round-trip across finite f32 domain.
+    // =========================================================================
+
+    /// A float is stored as 4 LE bytes and read back verbatim; the bit pattern
+    /// must be identical (NaN is excluded because NaN != NaN).
+    #[test]
+    fn update_float_roundtrip(
+        v in any::<f32>().prop_filter("finite only", |x| x.is_finite()),
+    ) {
+        let tag = b"As";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_float(tag, v);
+        }
+        let found = rec.tags().find_float(tag);
+        prop_assert!(found.is_some(), "tag not found after update_float");
+        prop_assert_eq!(
+            found.unwrap().to_bits(),
+            v.to_bits(),
+            "float round-trip bit mismatch: wrote {:?}, read back {:?}",
+            v,
+            found
+        );
+    }
+
+    // =========================================================================
+    // INVARIANT 3: aux_offset stays valid across N mixed ops.
+    //
+    // After every mutation, tags().iter() must terminate without panic, and
+    // every tag entry must have value_bytes within the aux section bounds.
+    // =========================================================================
+
+    /// Any sequence of up to 20 update_int / update_string / remove operations
+    /// must leave the record in a state where aux-tag iteration terminates and
+    /// every reported entry is within bounds.
+    #[test]
+    fn mixed_ops_preserve_iterability(
+        ops in proptest::collection::vec(
+            prop_oneof![
+                // update_int: kind='I', tag, int_val, str_val unused
+                ("[A-Z]{2}", any::<i32>()).prop_map(|(t, v)| {
+                    let tb = t.into_bytes();
+                    (b'I', [tb[0], tb[1]], v, Vec::<u8>::new())
+                }),
+                // update_string: kind='S', tag, str_val, int_val unused
+                ("[A-Z]{2}", "[a-z]{0,20}").prop_map(|(t, s)| {
+                    let tb = t.into_bytes();
+                    (b'S', [tb[0], tb[1]], 0i32, s.into_bytes())
+                }),
+                // remove: kind='R', tag, both values unused
+                "[A-Z]{2}".prop_map(|t| {
+                    let tb = t.into_bytes();
+                    (b'R', [tb[0], tb[1]], 0i32, Vec::<u8>::new())
+                }),
+            ],
+            1..20,
+        ),
+    ) {
+        let mut rec = base_record(&[]);
+        let aux_len = rec.as_ref().len();
+
+        for (kind, tag, int_val, str_val) in &ops {
+            {
+                let mut ed = rec.tags_editor();
+                match kind {
+                    b'I' => ed.update_int(tag, *int_val),
+                    b'S' => ed.update_string(tag, str_val),
+                    b'R' => ed.remove(tag),
+                    _ => unreachable!(),
+                }
+            }
+
+            // After the mutation, iteration must terminate and stay in-bounds.
+            let tags = rec.tags();
+            let total_aux = tags.as_bytes().len();
+            let mut count = 0usize;
+            for entry in &tags {
+                prop_assert!(
+                    entry.value_bytes.len() <= total_aux,
+                    "entry value_bytes.len() {} exceeds aux section length {}",
+                    entry.value_bytes.len(),
+                    total_aux
+                );
+                count += 1;
+                prop_assert!(count < 1000, "iter produced >1000 entries — likely infinite loop");
+            }
+
+            // The record must not be shorter than it was at the start (header + fixed fields).
+            prop_assert!(
+                rec.as_ref().len() >= aux_len,
+                "record shrank below initial size: {} < {}",
+                rec.as_ref().len(),
+                aux_len
+            );
+        }
+    }
+}

--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -230,7 +230,7 @@ pub fn regenerate_alignment_tags(
 // Raw-byte alignment tag regeneration
 // ============================================================================
 
-use fgumi_raw_bam;
+use fgumi_raw_bam::{self, RawRecordView, RawTagsEditor};
 
 /// Regenerates NM, UQ, and MD tags for a raw BAM record after base masking.
 ///
@@ -262,18 +262,17 @@ pub fn regenerate_alignment_tags_raw(
             fgumi_raw_bam::MIN_BAM_RECORD_LEN
         );
     }
-    let flg = fgumi_raw_bam::flags(record);
-
     // For unmapped reads, remove alignment tags
-    if (flg & fgumi_raw_bam::flags::UNMAPPED) != 0 {
-        fgumi_raw_bam::remove_tag(record, b"NM");
-        fgumi_raw_bam::remove_tag(record, b"UQ");
-        fgumi_raw_bam::remove_tag(record, b"MD");
+    if RawRecordView::new(record).is_unmapped() {
+        let mut editor = RawTagsEditor::from_vec(record);
+        editor.remove(b"NM");
+        editor.remove(b"UQ");
+        editor.remove(b"MD");
         return Ok(false);
     }
 
     // Get reference sequence ID and look up name in header
-    let ref_seq_id = fgumi_raw_bam::ref_id(record);
+    let ref_seq_id = RawRecordView::new(record).ref_id();
     if ref_seq_id < 0 {
         return Ok(false);
     }
@@ -283,7 +282,7 @@ pub fn regenerate_alignment_tags_raw(
         .context("Reference sequence ID not found in header")?;
     let ref_name = std::str::from_utf8(ref_name_bytes.as_ref())?;
 
-    let alignment_start_0based = fgumi_raw_bam::pos(record);
+    let alignment_start_0based = RawRecordView::new(record).pos();
     if alignment_start_0based < 0 {
         anyhow::bail!("Invalid alignment start position: {alignment_start_0based}");
     }
@@ -299,9 +298,10 @@ pub fn regenerate_alignment_tags_raw(
 
     // Handle edge case: CIGAR with no reference-consuming operations
     if ref_span == 0 {
-        fgumi_raw_bam::update_int_tag(record, b"NM", 0);
-        fgumi_raw_bam::update_int_tag(record, b"UQ", 0);
-        fgumi_raw_bam::update_string_tag(record, b"MD", b"0");
+        let mut editor = RawTagsEditor::from_vec(record);
+        editor.update_int(b"NM", 0);
+        editor.update_int(b"UQ", 0);
+        editor.update_string(b"MD", b"0");
         return Ok(false);
     }
 
@@ -410,9 +410,10 @@ pub fn regenerate_alignment_tags_raw(
     write!(md_string, "{match_count}").expect("write to String is infallible");
 
     // Update tags
-    fgumi_raw_bam::update_int_tag(record, b"NM", nm);
-    fgumi_raw_bam::update_int_tag(record, b"UQ", uq.min(i32::MAX as u32) as i32);
-    fgumi_raw_bam::update_string_tag(record, b"MD", md_string.as_bytes());
+    let mut editor = RawTagsEditor::from_vec(record);
+    editor.update_int(b"NM", nm);
+    editor.update_int(b"UQ", uq.min(i32::MAX as u32) as i32);
+    editor.update_string(b"MD", md_string.as_bytes());
 
     Ok(true)
 }

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -517,9 +517,10 @@ impl IndexingBamWriter {
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
     fn extract_alignment_context(bam: &[u8]) -> Option<(usize, Position, Position, bool)> {
         // Extract fields from BAM record
-        let tid = fgumi_raw_bam::ref_id(bam);
-        let pos = fgumi_raw_bam::pos(bam);
-        let flags = fgumi_raw_bam::flags(bam);
+        let v = fgumi_raw_bam::RawRecordView::new(bam);
+        let tid = v.ref_id();
+        let pos = v.pos();
+        let flags = v.flags();
 
         let is_unmapped = (flags & fgumi_raw_bam::flags::UNMAPPED) != 0;
 

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -370,7 +370,7 @@ fn record_name_to_string(record: &RecordBuf) -> String {
 
 /// Check if the first-in-template (R1) flag is set in raw BAM record bytes.
 fn is_first_segment_raw(raw: &RawRecord) -> bool {
-    let flags = raw_fields::flags(raw.as_ref());
+    let flags = fgumi_raw_bam::RawRecordView::new(raw.as_ref()).flags();
     flags & raw_fields::flags::FIRST_SEGMENT != 0
 }
 
@@ -465,7 +465,8 @@ fn build_mi_map_parallel(
                 let results: Vec<MiExtractResult> = batch
                     .par_iter()
                     .map(|raw| {
-                        let name_bytes = raw_fields::read_name(raw.as_ref());
+                        let name_bytes =
+                            fgumi_raw_bam::RawRecordView::new(raw.as_ref()).read_name();
                         let is_read1 = is_first_segment_raw(raw);
                         let key_hash = hash_read_key_raw(name_bytes, is_read1);
 
@@ -798,8 +799,8 @@ fn compare_raw_batch_grouping_parallel(
         .enumerate()
         .map(|(i, (r1, r2))| {
             let record_num = start_index + i as u64 + 1;
-            let name1_bytes = raw_fields::read_name(r1.as_ref());
-            let name2_bytes = raw_fields::read_name(r2.as_ref());
+            let name1_bytes = fgumi_raw_bam::RawRecordView::new(r1.as_ref()).read_name();
+            let name2_bytes = fgumi_raw_bam::RawRecordView::new(r2.as_ref()).read_name();
             let is_read1_r1 = is_first_segment_raw(r1);
             let is_read1_r2 = is_first_segment_raw(r2);
 
@@ -819,7 +820,7 @@ fn compare_raw_batch_grouping_parallel(
                     Some(DiffDetail {
                         record_num,
                         qname: qname1,
-                        flags: raw_fields::flags(r1.as_ref()).to_string(),
+                        flags: fgumi_raw_bam::RawRecordView::new(r1.as_ref()).flags().to_string(),
                         diff_type: DiffType::FlagMismatch,
                         diffs: vec![format!(
                             "R1/R2 flags differ: is_read1={} vs is_read1={}",
@@ -831,7 +832,7 @@ fn compare_raw_batch_grouping_parallel(
                     Some(DiffDetail {
                         record_num,
                         qname: qname1,
-                        flags: raw_fields::flags(r1.as_ref()).to_string(),
+                        flags: fgumi_raw_bam::RawRecordView::new(r1.as_ref()).flags().to_string(),
                         diff_type: DiffType::ReadNameMismatch,
                         diffs: vec![format!(
                             "Read names differ: '{}' vs '{}'",
@@ -1222,8 +1223,8 @@ impl CompareBams {
             for (r1, r2) in cmp_batch1.iter().zip(cmp_batch2.iter()) {
                 grouping_stats.total_records += 1;
 
-                let name1_bytes = raw_fields::read_name(r1.as_ref());
-                let name2_bytes = raw_fields::read_name(r2.as_ref());
+                let name1_bytes = fgumi_raw_bam::RawRecordView::new(r1.as_ref()).read_name();
+                let name2_bytes = fgumi_raw_bam::RawRecordView::new(r2.as_ref()).read_name();
                 let is_read1 = is_first_segment_raw(r1);
 
                 if name1_bytes != name2_bytes {

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -59,6 +59,7 @@ use crate::commands::common::{
 };
 use crate::sort::PA_TAG;
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Duplicate flag bit in SAM flags (0x400)
 const DUPLICATE_FLAG: u16 = 0x400;
@@ -301,8 +302,9 @@ fn filter_template_raw(
     }
 
     let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0)
+        && raw_r2
+            .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0);
     if both_unmapped {
         metrics.discarded_poor_alignment += 1;
         return false;
@@ -310,7 +312,7 @@ fn filter_template_raw(
 
     // Phase 1: Flag-based checks
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
 
         if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
             metrics.discarded_non_pf += 1;
@@ -328,7 +330,7 @@ fn filter_template_raw(
 
     // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
         let check_umi = !config.no_umi;
@@ -579,12 +581,14 @@ fn get_pair_orientation(template: &Template) -> (bool, bool) {
     (r1_positive, r2_positive)
 }
 
-/// Raw-byte pair orientation using `bam_fields::flags()`.
+/// Raw-byte pair orientation using `RawRecordView::flags()`.
 fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
+    let r1_positive = template
+        .raw_r1()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
+    let r2_positive = template
+        .raw_r2()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 
@@ -828,7 +832,7 @@ fn mark_duplicates_in_family(templates: &mut [&mut Template], dedup_metrics: &mu
 fn mark_template_as_duplicate(template: &mut Template, dedup_metrics: &mut DedupMetrics) {
     if let Some(raw_records) = template.all_raw_records_mut() {
         for raw in raw_records.iter_mut() {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw.as_slice()).flags();
             bam_fields::set_flags(raw, flg | DUPLICATE_FLAG);
             dedup_metrics.duplicate_reads += 1;
         }
@@ -892,7 +896,7 @@ fn process_position_group(
         .map(|mut t| {
             if let Some(raw_records) = t.all_raw_records_mut() {
                 for raw in raw_records.iter_mut() {
-                    let flg = bam_fields::flags(raw);
+                    let flg = RawRecordView::new(raw.as_slice()).flags();
                     bam_fields::set_flags(raw, flg & !DUPLICATE_FLAG);
                 }
             } else {
@@ -959,7 +963,7 @@ fn process_position_group(
         if let Some(raw_records) = template.all_raw_records() {
             for raw in raw_records {
                 dedup_metrics.total_reads += 1;
-                let flg = bam_fields::flags(raw);
+                let flg = RawRecordView::new(raw.as_slice()).flags();
                 let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
                 let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
 
@@ -1306,7 +1310,7 @@ impl Command for MarkDuplicates {
                             for raw in raw_records {
                                 // Skip duplicates if remove mode
                                 if remove_duplicates
-                                    && (bam_fields::flags(raw) & DUPLICATE_FLAG) != 0
+                                    && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
                                 {
                                     continue;
                                 }
@@ -2857,21 +2861,22 @@ mod tests {
     #[test]
     fn test_set_duplicate_flag_on_raw_record() {
         use crate::sort::bam_fields;
+        use fgumi_raw_bam::RawRecordView;
 
         let raw =
             make_raw_bam_for_dedup(b"rea", bam_fields::flags::PAIRED, 30, 4, &[20; 4], b"ACGT");
         let mut rec = raw;
-        let orig_flags = bam_fields::flags(&rec);
+        let orig_flags = RawRecordView::new(&rec).flags();
         assert_eq!(orig_flags & bam_fields::flags::DUPLICATE, 0);
 
         // Set duplicate flag
         bam_fields::set_flags(&mut rec, orig_flags | bam_fields::flags::DUPLICATE);
-        assert_ne!(bam_fields::flags(&rec) & bam_fields::flags::DUPLICATE, 0);
+        assert_ne!(RawRecordView::new(&rec).flags() & bam_fields::flags::DUPLICATE, 0);
 
         // Clear duplicate flag
-        let flags_with_dup = bam_fields::flags(&rec);
+        let flags_with_dup = RawRecordView::new(&rec).flags();
         bam_fields::set_flags(&mut rec, flags_with_dup & !bam_fields::flags::DUPLICATE);
-        assert_eq!(bam_fields::flags(&rec) & bam_fields::flags::DUPLICATE, 0);
+        assert_eq!(RawRecordView::new(&rec).flags() & bam_fields::flags::DUPLICATE, 0);
     }
 
     #[test]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -39,7 +39,7 @@ use crate::unified_pipeline::{
 };
 use crate::validation::validate_file_exists;
 use crossbeam_queue::SegQueue;
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -421,7 +421,7 @@ impl Command for Duplex {
                     Ok(0) => return None, // EOF
                     Ok(_) => {
                         let raw = record.into_inner();
-                        let flg = bam_fields::flags(&raw);
+                        let flg = RawRecordView::new(&raw).flags();
                         // Skip secondary and supplementary reads
                         if flg & bam_fields::flags::SECONDARY != 0
                             || flg & bam_fields::flags::SUPPLEMENTARY != 0
@@ -589,7 +589,7 @@ impl Duplex {
 
         // Record filter for duplex on raw bytes: skip secondary/supplementary, keep mapped or mate-mapped
         let record_filter = |raw: &[u8]| -> bool {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             // Skip secondary and supplementary reads
             if flg & bam_fields::flags::SECONDARY != 0
                 || flg & bam_fields::flags::SUPPLEMENTARY != 0

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -35,6 +35,7 @@ use ahash::AHashMap;
 use anyhow::{Result, bail};
 use clap::Parser;
 use crossbeam_queue::SegQueue;
+use fgumi_raw_bam::RawRecordView;
 use log::info;
 use noodles::sam::Header;
 use std::io;
@@ -666,7 +667,7 @@ impl Filter {
                 let template_pass = template_passes_raw(&template_records, &pass_map);
 
                 for (idx, record) in template_records.into_iter().enumerate() {
-                    let flags = bam_fields::flags(&record);
+                    let flags = RawRecordView::new(&record).flags();
                     let is_primary = (flags & bam_fields::flags::SECONDARY) == 0
                         && (flags & bam_fields::flags::SUPPLEMENTARY) == 0;
 
@@ -751,7 +752,7 @@ impl Filter {
         // Fail fast if we encounter a mapped read without a reference, since masking
         // can invalidate NM/UQ/MD tags and we have no way to regenerate them.
         if reference.is_none() {
-            let flags = bam_fields::flags(record);
+            let flags = RawRecordView::new(record).flags();
             if (flags & bam_fields::flags::UNMAPPED) == 0 {
                 bail!(
                     "--ref is required when filtering mapped reads \

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -214,6 +214,7 @@ fn filter_template_raw(
     metrics: &mut FilterMetrics,
 ) -> bool {
     use crate::sort::bam_fields;
+    use fgumi_raw_bam::RawRecordView;
 
     let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
     let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
@@ -228,8 +229,9 @@ fn filter_template_raw(
 
     // Check if both reads are unmapped
     let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0)
+        && raw_r2
+            .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0);
     if both_unmapped && !config.allow_unmapped {
         metrics.discarded_poor_alignment += num_primary_reads;
         return false;
@@ -237,7 +239,7 @@ fn filter_template_raw(
 
     // Phase 1: Cheap flag-based checks
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
 
         if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
             metrics.discarded_non_pf += num_primary_reads;
@@ -252,7 +254,7 @@ fn filter_template_raw(
 
     // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
         let check_umi = !config.no_umi;
@@ -377,11 +379,14 @@ fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
 /// Get pair orientation from raw-byte template.
 fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
     use crate::sort::bam_fields;
+    use fgumi_raw_bam::RawRecordView;
 
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
+    let r1_positive = template
+        .raw_r1()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
+    let r2_positive = template
+        .raw_r2()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -346,7 +346,9 @@ fn verify_sort_order<K>(
             if is_violation(&key, prev) {
                 violations += 1;
                 if first_violation.is_none() {
-                    let name = String::from_utf8_lossy(fgumi_raw_bam::read_name(bam)).to_string();
+                    let name =
+                        String::from_utf8_lossy(fgumi_raw_bam::RawRecordView::new(bam).read_name())
+                            .to_string();
                     first_violation = Some((total_records, name));
                 }
             }
@@ -993,7 +995,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 
@@ -1024,7 +1026,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 
@@ -1055,7 +1057,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -65,6 +65,7 @@ use crate::vendored::encode_record_buf;
 use anyhow::{Context, Result};
 use bstr::ByteSlice;
 use clap::Parser;
+use fgumi_raw_bam::RawRecordView;
 use log::{debug, info, warn};
 use noodles::core::Position;
 use noodles::sam::Header;
@@ -676,7 +677,7 @@ fn add_primary_alignment_tags_raw(mapped: &mut Template) {
 
     // Fast path: check if there are any secondary/supplementary reads
     let has_sec_supp = rr.iter().any(|r| {
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0
     });
     if !has_sec_supp {
@@ -686,7 +687,7 @@ fn add_primary_alignment_tags_raw(mapped: &mut Template) {
     // Get R1 primary info
     let r1_info: Option<(i32, i32, bool)> = mapped.r1.and_then(|(i, _)| {
         let r = &rr[i];
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         if (f & bam_fields::flags::UNMAPPED) != 0 {
             return None;
         }
@@ -699,7 +700,7 @@ fn add_primary_alignment_tags_raw(mapped: &mut Template) {
     // Get R2 primary info
     let r2_info: Option<(i32, i32, bool)> = mapped.r2.and_then(|(i, _)| {
         let r = &rr[i];
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         if (f & bam_fields::flags::UNMAPPED) != 0 {
             return None;
         }
@@ -739,7 +740,7 @@ fn add_primary_alignment_tags_raw(mapped: &mut Template) {
 
     let rr = mapped.raw_records.as_mut().unwrap();
     for record in rr.iter_mut() {
-        let f = bam_fields::flags(record);
+        let f = RawRecordView::new(record.as_slice()).flags();
         if (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0 {
             bam_fields::remove_tag(record, pa_tag);
             bam_fields::append_i32_array_tag(record, pa_tag, &pa_values);
@@ -851,7 +852,7 @@ pub fn merge_raw(
             let mut pos = false;
             let mut neg = false;
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) == 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) == 0 {
                     pos = true;
                 } else {
                     neg = true;
@@ -867,7 +868,7 @@ pub fn merge_raw(
         if has_pos {
             let rr = mapped.raw_records.as_mut().unwrap();
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) != 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) != 0 {
                     continue;
                 }
                 let aux = bam_fields::aux_data_slice(&rr[i]);
@@ -893,7 +894,7 @@ pub fn merge_raw(
         if has_neg {
             let rr = mapped.raw_records.as_mut().unwrap();
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) == 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) == 0 {
                     continue;
                 }
                 let aux = bam_fields::aux_data_slice(&rr[i]);
@@ -930,7 +931,7 @@ pub fn merge_raw(
         let is_qc_fail = u.flags().is_qc_fail();
         let rr = mapped.raw_records.as_mut().unwrap();
         for &i in &mapped_indices {
-            let mut f = bam_fields::flags(&rr[i]);
+            let mut f = RawRecordView::new(&rr[i]).flags();
             if is_qc_fail {
                 f |= bam_fields::flags::QC_FAIL;
             } else {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -472,6 +472,7 @@ impl RecordPositionGrouper {
     fn validate_mc_tag(&mut self, decoded: &DecodedRecord) -> io::Result<()> {
         use crate::sort::bam_fields;
         use crate::unified_pipeline::DecodedRecordData;
+        use fgumi_raw_bam::RawRecordView;
 
         if self.mc_validated {
             return Ok(());
@@ -479,7 +480,7 @@ impl RecordPositionGrouper {
 
         match &decoded.data {
             DecodedRecordData::Raw(raw) => {
-                let flg = bam_fields::flags(raw);
+                let flg = RawRecordView::new(raw).flags();
                 let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
                 let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
                 let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -1993,7 +1993,7 @@ mod tests {
             10,
             |bam: &[u8]| {
                 // Check flag field
-                let flag = fgumi_raw_bam::flags(bam);
+                let flag = fgumi_raw_bam::RawRecordView::new(bam).flags();
                 flag & fgumi_raw_bam::flags::SECONDARY == 0 // keep if NOT secondary
             },
             |raw: &[u8]| {

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -13,6 +13,7 @@ use crate::sort::bam_fields;
 use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::sort::radix::bytes_needed_u64;
 use crate::sort::segmented_buf::SegmentedBuf;
+use fgumi_raw_bam::RawRecordView;
 use std::cmp::Ordering;
 use std::io::{Read, Write};
 
@@ -414,7 +415,7 @@ impl ProbeableBuffer for RecordBuffer {
 pub fn extract_coordinate_key_inline(bam: &[u8], nref: u32) -> u64 {
     let tid = bam_fields::ref_id(bam);
     let pos = bam_fields::pos(bam);
-    let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+    let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
 
     // Pack key based on tid (samtools behavior):
     // - tid >= 0: sort by (tid, pos, reverse) even if unmapped flag is set

--- a/src/lib/sort/keys.rs
+++ b/src/lib/sort/keys.rs
@@ -29,6 +29,7 @@ use std::cmp::Ordering;
 
 use crate::sam::SamTag;
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 use std::io::{Read, Write};
 
 /// The PA (Primary Alignment) tag for secondary/supplementary reads.
@@ -517,7 +518,7 @@ impl RawSortKey for RawCoordinateKey {
     fn extract(bam: &[u8], ctx: &SortContext) -> Self {
         let tid = bam_fields::ref_id(bam);
         let pos = bam_fields::pos(bam);
-        let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+        let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
 
         // Create key based on tid (samtools behavior):
         // - tid >= 0: sort by (tid, pos, reverse) even if unmapped flag is set
@@ -532,7 +533,7 @@ impl RawSortKey for RawCoordinateKey {
             return Self::unmapped();
         }
         let pos = bam_fields::pos(bam);
-        let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+        let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
         // During merge we don't have nref, but for mapped records (tid >= 0)
         // nref is only used for unmapped handling, so any value > tid works.
         // Use tid+1 as a safe nref since tid is non-negative.

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -296,7 +296,9 @@ impl LibraryLookup {
     #[cfg(test)]
     #[must_use]
     pub fn get_ordinal(&self, bam: &[u8]) -> u32 {
-        fgumi_raw_bam::tags::find_string_tag_in_record(bam, &SamTag::RG)
+        fgumi_raw_bam::RawRecordView::new(bam)
+            .tags()
+            .find_string(&SamTag::RG)
             .and_then(|rg| self.rg_to_ordinal.get(rg))
             .copied()
             .unwrap_or(0)
@@ -2857,12 +2859,13 @@ pub fn extract_template_key_inline(
     let cb_hash = aux.cell.map_or(0u64, |cb_bytes| cb_hasher.hash_one(cb_bytes));
 
     // Extract fields from raw bytes
-    let tid = bam_fields::ref_id(bam_bytes);
-    let pos = bam_fields::pos(bam_bytes);
-    let l_read_name = bam_fields::l_read_name(bam_bytes) as usize;
-    let flag = bam_fields::flags(bam_bytes);
-    let mate_tid = bam_fields::mate_ref_id(bam_bytes);
-    let mate_pos = bam_fields::mate_pos(bam_bytes);
+    let v = bam_fields::RawRecordView::new(bam_bytes);
+    let tid = v.ref_id();
+    let pos = v.pos();
+    let l_read_name = v.l_read_name() as usize;
+    let flag = v.flags();
+    let mate_tid = v.mate_ref_id();
+    let mate_pos = v.mate_pos();
 
     // Extract flags
     let is_unmapped = (flag & flags::UNMAPPED) != 0;
@@ -3154,7 +3157,10 @@ mod tests {
     #[case::absent(b"".as_slice(), None)]
     fn test_find_rg_tag(#[case] aux_data: &[u8], #[case] expected: Option<&[u8]>) {
         let bam = build_bam_with_aux(aux_data);
-        assert_eq!(fgumi_raw_bam::tags::find_string_tag_in_record(&bam, &SamTag::RG), expected);
+        assert_eq!(
+            fgumi_raw_bam::RawRecordView::new(&bam).tags().find_string(&SamTag::RG),
+            expected
+        );
     }
 
     #[test]
@@ -3166,7 +3172,7 @@ mod tests {
         aux.extend_from_slice(b"RGZmygroup\0");
         let bam = build_bam_with_aux(&aux);
         assert_eq!(
-            fgumi_raw_bam::tags::find_string_tag_in_record(&bam, &SamTag::RG),
+            fgumi_raw_bam::RawRecordView::new(&bam).tags().find_string(&SamTag::RG),
             Some(b"mygroup".as_slice())
         );
     }
@@ -3576,7 +3582,7 @@ mod tests {
         let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
         RawReadAheadReader::new(reader)
             .map(|rec| {
-                let name_bytes = fgumi_raw_bam::fields::read_name(rec.as_ref());
+                let name_bytes = fgumi_raw_bam::RawRecordView::new(rec.as_ref()).read_name();
                 String::from_utf8(name_bytes.to_vec()).expect("read name should be valid UTF-8")
             })
             .collect()
@@ -3589,7 +3595,10 @@ mod tests {
         RawReadAheadReader::new(reader)
             .map(|rec| {
                 let bytes = rec.as_ref();
-                (fgumi_raw_bam::fields::ref_id(bytes), fgumi_raw_bam::fields::pos(bytes))
+                {
+                    let v = fgumi_raw_bam::RawRecordView::new(bytes);
+                    (v.ref_id(), v.pos())
+                }
             })
             .collect()
     }

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -8,6 +8,7 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::consensus_tags::per_base;
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Reverses per-base tags for a negative-strand read
 ///
@@ -78,7 +79,7 @@ pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
             bam_fields::MIN_BAM_RECORD_LEN
         );
     }
-    let flg = bam_fields::flags(record);
+    let flg = RawRecordView::new(record).flags();
     if (flg & bam_fields::flags::REVERSE) == 0 {
         return Ok(false);
     }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -38,6 +38,7 @@
 use crate::sam::{SamTag, record_utils, to_smallest_signed_int};
 use crate::unified_pipeline::MemoryEstimate;
 use anyhow::{Result, anyhow, bail};
+use fgumi_raw_bam::RawRecordView;
 use noodles::sam::alignment::record::Cigar;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -600,7 +601,7 @@ impl Template {
 
     /// Build a Template from raw BAM byte records, categorizing by flags.
     ///
-    /// The records are categorized using `bam_fields::flags()` to determine
+    /// The records are categorized using `RawRecordView::flags()` to determine
     /// R1/R2/supplementary/secondary status, with the same index-pair scheme
     /// as `Builder::build()`.
     ///
@@ -638,8 +639,8 @@ impl Template {
 
         // Fast path for common 2-record paired-end case (no supplementals/secondaries)
         if raw_records.len() == 2 {
-            let f0 = bam_fields::flags(&raw_records[0]);
-            let f1 = bam_fields::flags(&raw_records[1]);
+            let f0 = RawRecordView::new(&raw_records[0]).flags();
+            let f1 = RawRecordView::new(&raw_records[1]).flags();
             let neither_sec_supp =
                 (f0 | f1) & (bam_fields::flags::SECONDARY | bam_fields::flags::SUPPLEMENTARY) == 0;
             if neither_sec_supp {
@@ -687,7 +688,7 @@ impl Template {
         let mut r2_sec: Vec<usize> = Vec::new();
 
         for (i, rec) in raw_records.iter().enumerate() {
-            let flg = bam_fields::flags(rec);
+            let flg = RawRecordView::new(rec).flags();
             let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
             let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
             let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
@@ -1041,8 +1042,10 @@ impl Template {
 
         // Fix mate info for primary R1/R2 pair
         if let (Some((r1_i, _)), Some((r2_i, _))) = (self.r1, self.r2) {
-            let r1_is_unmapped = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::UNMAPPED) != 0;
-            let r2_is_unmapped = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::UNMAPPED) != 0;
+            let r1_is_unmapped =
+                (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::UNMAPPED) != 0;
+            let r2_is_unmapped =
+                (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::UNMAPPED) != 0;
 
             // Get alignment scores for mate score tags
             let r1_as = bam_fields::find_int_tag(bam_fields::aux_data_slice(&rr[r1_i]), b"AS");
@@ -1080,7 +1083,7 @@ impl Template {
             let rr = self.raw_records.as_ref().unwrap();
             let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
             let r2_pos = bam_fields::pos(&rr[r2_i]);
-            let r2_flags = bam_fields::flags(&rr[r2_i]);
+            let r2_flags = RawRecordView::new(&rr[r2_i]).flags();
             let r2_is_reverse = (r2_flags & bam_fields::flags::REVERSE) != 0;
             let r2_is_unmapped = (r2_flags & bam_fields::flags::UNMAPPED) != 0;
             let r2_tlen = bam_fields::template_length(&rr[r2_i]);
@@ -1120,7 +1123,7 @@ impl Template {
             let rr = self.raw_records.as_ref().unwrap();
             let r1_ref_id = bam_fields::ref_id(&rr[r1_i]);
             let r1_pos = bam_fields::pos(&rr[r1_i]);
-            let r1_flags = bam_fields::flags(&rr[r1_i]);
+            let r1_flags = RawRecordView::new(&rr[r1_i]).flags();
             let r1_is_reverse = (r1_flags & bam_fields::flags::REVERSE) != 0;
             let r1_is_unmapped = (r1_flags & bam_fields::flags::UNMAPPED) != 0;
             let r1_tlen = bam_fields::template_length(&rr[r1_i]);
@@ -1167,14 +1170,16 @@ impl Template {
         // Get R2's info for R1
         let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
         let r2_pos = bam_fields::pos(&rr[r2_i]);
-        let r2_is_reverse = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::REVERSE) != 0;
+        let r2_is_reverse =
+            (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::REVERSE) != 0;
         let r2_mapq = bam_fields::mapq(&rr[r2_i]);
         let r2_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[r2_i]);
 
         // Get R1's info for R2
         let r1_ref_id = bam_fields::ref_id(&rr[r1_i]);
         let r1_pos = bam_fields::pos(&rr[r1_i]);
-        let r1_is_reverse = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::REVERSE) != 0;
+        let r1_is_reverse =
+            (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::REVERSE) != 0;
         let r1_mapq = bam_fields::mapq(&rr[r1_i]);
         let r1_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[r1_i]);
 
@@ -1217,8 +1222,10 @@ impl Template {
         use crate::sort::bam_fields;
 
         let rr = self.raw_records.as_ref().unwrap();
-        let r1_is_reverse = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::REVERSE) != 0;
-        let r2_is_reverse = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::REVERSE) != 0;
+        let r1_is_reverse =
+            (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::REVERSE) != 0;
+        let r2_is_reverse =
+            (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
         let rr = self.raw_records.as_mut().unwrap();
 
@@ -1252,13 +1259,13 @@ impl Template {
         let rr = self.raw_records.as_ref().unwrap();
         let mapped_ref_id = bam_fields::ref_id(&rr[mapped_i]);
         let mapped_pos = bam_fields::pos(&rr[mapped_i]);
-        let mapped_flags = bam_fields::flags(&rr[mapped_i]);
+        let mapped_flags = RawRecordView::new(&rr[mapped_i]).flags();
         let mapped_is_reverse = (mapped_flags & bam_fields::flags::REVERSE) != 0;
         let mapped_mapq = bam_fields::mapq(&rr[mapped_i]);
         let mapped_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[mapped_i]);
 
         let unmapped_is_reverse =
-            (bam_fields::flags(&rr[unmapped_i]) & bam_fields::flags::REVERSE) != 0;
+            (RawRecordView::new(&rr[unmapped_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
         let rr = self.raw_records.as_mut().unwrap();
 
@@ -1489,7 +1496,7 @@ fn alignment_length(cigar: &noodles::sam::alignment::record_buf::Cigar) -> i32 {
 /// Sets mate flags (`MATE_REVERSE`, `MATE_UNMAPPED`) on a raw BAM record.
 fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped: bool) {
     use crate::sort::bam_fields;
-    let mut f = bam_fields::flags(record);
+    let mut f = RawRecordView::new(record).flags();
     f &= !bam_fields::flags::MATE_REVERSE;
     if mate_is_reverse {
         f |= bam_fields::flags::MATE_REVERSE;
@@ -1508,8 +1515,8 @@ fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped
 fn compute_insert_size_raw(rec1: &[u8], rec2: &[u8]) -> i32 {
     use crate::sort::bam_fields;
 
-    let f1 = bam_fields::flags(rec1);
-    let f2 = bam_fields::flags(rec2);
+    let f1 = RawRecordView::new(rec1).flags();
+    let f2 = RawRecordView::new(rec2).flags();
 
     // If either read is unmapped, return 0
     if (f1 & bam_fields::flags::UNMAPPED) != 0 || (f2 & bam_fields::flags::UNMAPPED) != 0 {
@@ -4104,7 +4111,7 @@ mod tests {
         assert!(template.raw_r2().is_some());
         // Verify R1 is at index 0 (has FIRST_SEGMENT flag)
         let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = crate::sort::bam_fields::flags(raw_r1);
+        let r1_flags = RawRecordView::new(raw_r1).flags();
         assert_ne!(r1_flags & FLAG_READ1, 0);
     }
 
@@ -4118,10 +4125,10 @@ mod tests {
         assert!(template.is_raw_byte_mode());
         // After swap, R1 should be at index 0
         let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = crate::sort::bam_fields::flags(raw_r1);
+        let r1_flags = RawRecordView::new(raw_r1).flags();
         assert_ne!(r1_flags & FLAG_READ1, 0);
         let raw_r2 = template.raw_r2().expect("raw_r2 should be present");
-        let r2_flags = crate::sort::bam_fields::flags(raw_r2);
+        let r2_flags = RawRecordView::new(raw_r2).flags();
         assert_ne!(r2_flags & FLAG_READ2, 0);
     }
 

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -41,6 +41,7 @@ use super::deadlock::{
 use super::scheduler::{BackpressureState, SchedulerStrategy};
 use crate::read_info::{LibraryIndex, compute_group_key};
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Buffer size for buffered I/O (8 MB).
 /// This reduces syscalls by batching reads/writes into larger chunks.
@@ -439,7 +440,7 @@ fn compute_group_key_from_raw(
     };
 
     // Check secondary/supplementary
-    let flg = bam_fields::flags(raw);
+    let flg = RawRecordView::new(raw).flags();
     let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
     let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
     if is_secondary || is_supplementary {


### PR DESCRIPTION
## Summary

Closes #272.

Replaces `fgumi-raw-bam`'s flat free-function API with a principled six-type wrapper hierarchy and closes every gap catalogued in the issue. Follow-up perf work landed on top of the core refactor.

### New types

| Type | Backing | Capability |
|---|---|---|
| `RawRecordView<'a>` | `&'a [u8]` | All read accessors |
| `RawRecordMut<'a>` | `&'a mut [u8]` | Fixed-length writes |
| `RawRecord` | `Vec<u8>` | Length-changing edits |
| `RawTagsView<'a>` | `&'a [u8]` | Tag finders + zero-alloc iteration |
| `RawTagsMut<'a>` | `&'a mut [u8]` | Array element writes, in-place flips |
| `RawTagsEditor<'a>` | `&'a mut Vec<u8>` + cached `aux_offset` | Append/remove/update/resize |

### Issue 272 gaps closed (13 new methods)

**Easy:**
- `bin()` / `set_bin()` — header accessor/setter
- `update_float()` — parallel to `update_int`/`update_string`
- `set_array_element_u8/u16/i16/i32/f32()` — per-element B-array writes
- `update_array_u8/u16/i16/i32/f32()` — whole-payload B-array replacement

**Medium (length-changing, previously required RecordBuf round-trip):**
- `set_read_name(&[u8])` — splices name + NUL, updates `l_read_name`
- `set_cigar_ops(&[u32])` — splices CIGAR bytes, updates `n_cigar_op`
- `set_sequence_and_qualities(&[u8], &[u8])` — repacks 4-bit seq + qual, updates `l_seq`

**Nice:**
- `RawTagsView::iter()` — zero-allocation `AuxTagsIter` yielding `TagEntry { tag, type_byte, value_bytes }`

### Performance (Apple M-series, release profile)

#### Raw-byte API vs noodles `RecordBuf` round-trip

| Operation | Raw bytes | RecordBuf | Speedup |
|---|---:|---:|---:|
| `flags_read` | 585 ps | 539 ns | **~922×** |
| `update_int_tag` | ~26 ns | 1.67 µs | **~65×** |
| `set_read_name` | 120 ns | 1.67 µs | **~14×** |
| `set_cigar_ops` | 101 ns | 1.62 µs | **~16×** |
| `set_sequence_and_qualities` | **125 ns** | 1.91 µs | **~15×** |

The RecordBuf baseline includes full decode on every call; the `set_sequence_and_qualities` RecordBuf path also updates the CIGAR to satisfy noodles' re-encoder length-consistency check.

#### Sequence extraction (`sequence_vec`, SIMD nibble2base)

| Length | Scalar (pre-SIMD) | SIMD | Speedup |
|---|---:|---:|---:|
| 16 bp | 23.3 ns | 23.8 ns | ~1× (scalar path, < 32 bp threshold) |
| 150 bp | 117 ns | 30.8 ns | **3.8×** |
| 300 bp | 220 ns | 36.9 ns | **6.0×** |

Validates the issue's ~10× speedup claim for length-changing edits, with even larger gains on reads (`flags_read`) and sequence decode paths.

### Performance optimizations applied

On top of the core API redesign, the following perf wins landed in this PR:

1. `tag_value_size` marked `#[inline(always)]`; `find_tag_position` compares tags as u16; `aux_data_offset_from_record` does a single u64 load over offsets 12..20
2. `set_sequence_and_qualities` splices in place via `Vec::copy_within` instead of allocating an intermediate `Vec` (300 ns → 125 ns, 6× → 13.8× vs RecordBuf)
3. `wide` bumped to 1.3 and exposed as a direct dep for SIMD work
4. SIMD nibble2base in `extract_sequence`: 16 packed bytes / 32 bases per iteration using `u8x16::swizzle_relaxed` (portable `pshufb`) for parallel table lookup
5. Branchless `consumes_query` / `consumes_ref` via `BAM_CIGAR_TYPE = 0x3C1A7` bitmask (matches htslib's `sam.h`)
6. `cigar_lengths()` — dual-return CIGAR walk so callers needing both `reference_length` and `query_length` iterate the ops only once

### Breaking changes

Old free-function API (`flags(bam)`, `update_int_tag(rec, ...)`, etc.) demoted to `pub(crate)`. All external access is now through the six wrapper types. Constants, offset helpers (`seq_offset`, `qual_offset`, `aux_data_slice`), per-base/per-qual free functions, and CIGAR op helpers remain public.

### Migration

All call sites across `fgumi-raw-bam`, `fgumi-sam`, `fgumi-consensus`, and `src/lib` are migrated. Follow-up PRs will make idiomatic use of the new types (e.g., storing `RawRecord` instead of `Vec<u8>` in downstream signatures).

### Test coverage

- Port of all existing unit tests to the new API
- `tests/noodles_roundtrip.rs` — noodles cross-check proptests for all three length-changing edits
- `tests/tags_editor_invariants.rs` — tag editor invariant proptests:
  - `append(tag, v); remove(tag)` is a byte-level no-op when `tag` was absent (string + int)
  - `update_int/string/float` round-trips across full value domains
  - `update_array_{u8,u16,i16,i32,f32}` whole-payload round-trips
  - `set_array_element_{u8,u16,i16,i32,f32}` single-element overwrites preserve all other elements
  - `set_bin` round-trip across the full `u16` domain
  - Mixed update/remove sequences preserve iterability (`aux_offset` stays valid)
- Edge cases: max-length read name (254 bytes + NUL), zero-length sequence, `set_cigar_ops(&[])` clear, length-changing edits preserve B-array aux tags byte-for-byte
- SIMD equivalence test: `extract_sequence_simd_matches_scalar_over_lengths` checks byte-exact parity between scalar and SIMD paths across {0, 1, 15, 31, 32, 33, 63, 64, 150, 200, 255}

### Suggested reading order

1. `crates/fgumi-raw-bam/src/fields.rs` — `RawRecordView` + `RawRecordMut` definitions
2. `crates/fgumi-raw-bam/src/tags.rs` — `RawTagsView` + `RawTagsMut` + `RawTagsEditor`
3. `crates/fgumi-raw-bam/src/raw_bam_record.rs` — `RawRecord` inherent delegators + length-changing edits
4. `crates/fgumi-raw-bam/src/cigar.rs` / `sequence.rs` — view method impls (note: SIMD nibble2base at the bottom of `sequence.rs`)
5. Downstream migrations (`fgumi-sam`, `fgumi-consensus`, `src/lib`)
6. Benchmarks under `benches/` — 4 suites (`raw_bam_accessors`, `raw_bam_tags_editor`, `raw_bam_length_changing`, `raw_bam_vs_recordbuf`)

## Test plan

- [x] `cargo ci-test` — 2076/2076 workspace tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Noodles cross-check proptests validate all three length-changing edits decode correctly
- [x] Tag editor invariant proptests (append/remove, update round-trips, mixed-op iterability)
- [x] Easy-gap round-trip proptests (update_array_*, set_array_element_*, set_bin)
- [x] Edge-case unit tests (max name length, empty seq, cleared CIGAR, array tags across splices)
- [x] Criterion benchmarks run — accessor parity confirmed, length-changing baselines documented
- [x] Side-by-side `RecordBuf` comparison benchmarks — 14×–922× speedups documented
- [x] SIMD scalar-parity test for `extract_sequence` across varied lengths
- [ ] Reviewer confirms API ergonomics and naming conventions