### PR TITLE
feat(raw-bam): unified view/editor API + close #272 gaps

### DIFF
--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -926,6 +926,87 @@ fn clip_cigar_end_raw(
     (result, 0) // ref_bases_consumed is 0 for end clipping (no position adjustment)
 }
 
+use crate::fields::RawRecordView;
+
+impl<'a> RawRecordView<'a> {
+    /// Raw CIGAR bytes (4 bytes per op), zero-allocation.
+    #[inline]
+    #[must_use]
+    pub fn cigar_raw_bytes(&self) -> &'a [u8] {
+        let bam = self.as_bytes();
+        let lrn = l_read_name(bam) as usize;
+        let n = n_cigar_op(bam) as usize;
+        let start = 32 + lrn;
+        let end = start + n * 4;
+        if end <= bam.len() { &bam[start..end] } else { &[] }
+    }
+
+    /// Zero-allocation iterator yielding decoded CIGAR ops as raw `u32`.
+    #[inline]
+    pub fn cigar_ops_iter(&self) -> impl Iterator<Item = u32> + 'a {
+        self.cigar_raw_bytes().chunks_exact(4).map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    }
+
+    /// Convenience: collect CIGAR ops into a `Vec<u32>`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_ops_vec(&self) -> Vec<u32> {
+        get_cigar_ops(self.as_bytes())
+    }
+
+    /// Format CIGAR as a SAM-style string.
+    #[inline]
+    #[must_use]
+    pub fn cigar_to_string(&self) -> String {
+        cigar_to_string_from_raw(self.as_bytes())
+    }
+
+    /// Sum of M/D/N/=/X op lengths (reference-consuming).
+    #[inline]
+    #[must_use]
+    pub fn reference_length(&self) -> i32 {
+        reference_length_from_raw_bam(self.as_bytes())
+    }
+
+    /// Sum of M/I/S/=/X op lengths (query-consuming).
+    #[inline]
+    #[must_use]
+    pub fn query_length(&self) -> usize {
+        self.cigar_ops_iter()
+            .filter(|&op| consumes_query(op & 0xF))
+            .map(|op| (op >> 4) as usize)
+            .sum()
+    }
+
+    /// Compute 1-based alignment end position.
+    #[inline]
+    #[must_use]
+    pub fn alignment_end_1based(&self) -> Option<usize> {
+        alignment_end_from_raw(self.as_bytes())
+    }
+
+    /// Compute 1-based alignment start position.
+    #[inline]
+    #[must_use]
+    pub fn alignment_start_1based(&self) -> Option<usize> {
+        alignment_start_from_raw(self.as_bytes())
+    }
+
+    /// Computes the unclipped 5' coordinate (1-based) for grouping keys.
+    #[inline]
+    #[must_use]
+    pub fn unclipped_5prime_1based(&self) -> i32 {
+        unclipped_5prime_from_raw_bam(self.as_bytes())
+    }
+
+    /// Virtual clipping — see [`clip_cigar_ops_raw`].
+    #[inline]
+    #[must_use]
+    pub fn clip_cigar_ops(&self, clip_amount: usize, from_start: bool) -> (Vec<u32>, usize) {
+        clip_cigar_ops_raw(&self.cigar_ops_vec(), clip_amount, from_start)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2039,5 +2120,29 @@ mod tests {
         assert_eq!(cigar_op_kind(10 << 4 | 1), Kind::Insertion);
         // 5D = (5 << 4) | 2
         assert_eq!(cigar_op_kind(5 << 4 | 2), Kind::Deletion);
+    }
+
+    #[test]
+    fn test_view_cigar_methods() {
+        use crate::fields::RawRecordView;
+        use crate::testutil::*;
+        let rec = make_bam_bytes(
+            0,
+            100,
+            0,
+            b"r",
+            &[encode_op(0, 50), encode_op(2, 5), encode_op(0, 50)],
+            100,
+            -1,
+            -1,
+            &[],
+        );
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.cigar_ops_vec(), vec![encode_op(0, 50), encode_op(2, 5), encode_op(0, 50)]);
+        assert_eq!(v.cigar_to_string(), "50M5D50M");
+        assert_eq!(v.reference_length(), 105);
+        assert_eq!(v.query_length(), 100);
+        assert_eq!(v.cigar_raw_bytes().len(), 12);
+        assert_eq!(v.cigar_ops_iter().count(), 3);
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -30,6 +30,45 @@ pub const BAM_MAGIC: &[u8; 4] = b"BAM\x01";
 /// `ref_id`, `pos`, etc.) require at least this many bytes.
 pub const MIN_BAM_RECORD_LEN: usize = 32;
 
+/// Borrowed read-only view over a complete BAM record's bytes.
+///
+/// Wraps `&'a [u8]`. All BAM-spec accessors (`flags`, `pos`, `cigar`, `sequence`,
+/// `tags`, …) are inherent methods on this type.
+///
+/// All accessors assume `bytes.len() >= MIN_BAM_RECORD_LEN`. Use [`RawRecordView::new`]
+/// when the caller can vouch for that (hot path); use [`RawRecordView::try_new`] for
+/// untrusted input.
+#[derive(Copy, Clone, Debug)]
+pub struct RawRecordView<'a>(&'a [u8]);
+
+impl<'a> RawRecordView<'a> {
+    /// Wrap raw BAM bytes without validation.
+    ///
+    /// In debug builds, asserts `bytes.len() >= MIN_BAM_RECORD_LEN`. In release
+    /// builds, accessor methods on a too-short slice will panic on out-of-bounds
+    /// indexing.
+    #[inline]
+    #[must_use]
+    pub const fn new(bytes: &'a [u8]) -> Self {
+        debug_assert!(bytes.len() >= MIN_BAM_RECORD_LEN);
+        Self(bytes)
+    }
+
+    /// Wrap raw BAM bytes, returning `None` if too short for the fixed header.
+    #[inline]
+    #[must_use]
+    pub const fn try_new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() >= MIN_BAM_RECORD_LEN { Some(Self(bytes)) } else { None }
+    }
+
+    /// Returns the underlying byte slice.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
 /// BAM flag bits.
 pub mod flags {
     /// Read is paired in sequencing.
@@ -930,5 +969,24 @@ mod tests {
         assert_eq!(pos(&rec), 0);
         set_pos(&mut rec, 9999);
         assert_eq!(pos(&rec), 9999);
+    }
+
+    #[test]
+    fn test_raw_record_view_new_and_as_bytes() {
+        let bytes = vec![0u8; 32];
+        let view = RawRecordView::new(&bytes);
+        assert_eq!(view.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_raw_record_view_try_new_too_short_returns_none() {
+        let bytes = vec![0u8; 31];
+        assert!(RawRecordView::try_new(&bytes).is_none());
+    }
+
+    #[test]
+    fn test_raw_record_view_try_new_min_length_succeeds() {
+        let bytes = vec![0u8; MIN_BAM_RECORD_LEN];
+        assert!(RawRecordView::try_new(&bytes).is_some());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -632,6 +632,23 @@ pub fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFiel
     }
 }
 
+impl<'a> RawRecordView<'a> {
+    /// Extract `(tid, pos, reverse, name)` for coordinate-key sorting.
+    /// Unmapped reads return `(i32::MAX, i32::MAX, false, name)`.
+    #[inline]
+    #[must_use]
+    pub fn coordinate_fields(&self) -> (i32, i32, bool, &'a [u8]) {
+        extract_coordinate_fields(self.0)
+    }
+
+    /// Extract template-coordinate sort fields in a single pass.
+    #[inline]
+    #[must_use]
+    pub fn template_coordinate_fields(&self) -> TemplateCoordFields<'a> {
+        extract_template_coordinate_fields(self.0)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -1190,5 +1207,19 @@ mod tests {
         assert!(v.is_paired());
         assert!(v.is_reverse());
         assert!(!v.is_unmapped());
+    }
+
+    #[test]
+    fn test_view_batched_coord_helpers() {
+        use crate::testutil::*;
+        let rec = make_bam_bytes(3, 200, flags::REVERSE, b"r", &[], 0, -1, -1, &[]);
+        let v = RawRecordView::new(&rec);
+        let (tid, pos, reverse, name) = v.coordinate_fields();
+        assert_eq!((tid, pos, reverse), (3, 200, true));
+        assert_eq!(name, b"r");
+
+        let f = v.template_coordinate_fields();
+        assert_eq!(f.tid, 3);
+        assert!(f.flags.reverse());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -69,6 +69,173 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+impl<'a> RawRecordView<'a> {
+    // -- header (fixed-offset) --
+
+    /// Extract reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn ref_id(&self) -> i32 {
+        ref_id(self.0)
+    }
+
+    /// Extract 0-based leftmost position from this record.
+    #[inline]
+    #[must_use]
+    pub fn pos(&self) -> i32 {
+        pos(self.0)
+    }
+
+    /// Extract mapping quality from this record.
+    #[inline]
+    #[must_use]
+    pub fn mapq(&self) -> u8 {
+        mapq(self.0)
+    }
+
+    /// Extract bitwise flags from this record.
+    #[inline]
+    #[must_use]
+    pub fn flags(&self) -> u16 {
+        flags(self.0)
+    }
+
+    /// Extract `l_read_name` (read-name length including NUL) from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_read_name(&self) -> u8 {
+        l_read_name(self.0)
+    }
+
+    /// Extract number of CIGAR operations from this record.
+    #[inline]
+    #[must_use]
+    pub fn n_cigar_op(&self) -> u16 {
+        n_cigar_op(self.0)
+    }
+
+    /// Extract sequence length from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_seq(&self) -> u32 {
+        l_seq(self.0)
+    }
+
+    /// Extract mate reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_ref_id(&self) -> i32 {
+        mate_ref_id(self.0)
+    }
+
+    /// Extract mate 0-based position from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_pos(&self) -> i32 {
+        mate_pos(self.0)
+    }
+
+    /// Extract template length (tlen) from this record.
+    #[inline]
+    #[must_use]
+    pub fn template_length(&self) -> i32 {
+        template_length(self.0)
+    }
+
+    /// Extract read name (without null terminator) from this record.
+    #[inline]
+    #[must_use]
+    pub fn read_name(&self) -> &'a [u8] {
+        read_name(self.0)
+    }
+
+    /// Extract the BAM bin field (computed by the upstream encoder from `pos` and CIGAR).
+    #[inline]
+    #[must_use]
+    pub fn bin(&self) -> u16 {
+        u16::from_le_bytes([self.0[10], self.0[11]])
+    }
+
+    // -- flag-bit convenience --
+
+    /// Returns `true` if the read is paired in sequencing.
+    #[inline]
+    #[must_use]
+    pub fn is_paired(&self) -> bool {
+        self.flags() & flags::PAIRED != 0
+    }
+
+    /// Returns `true` if the read is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_unmapped(&self) -> bool {
+        self.flags() & flags::UNMAPPED != 0
+    }
+
+    /// Returns `true` if the mate is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_unmapped(&self) -> bool {
+        self.flags() & flags::MATE_UNMAPPED != 0
+    }
+
+    /// Returns `true` if the read is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_reverse(&self) -> bool {
+        self.flags() & flags::REVERSE != 0
+    }
+
+    /// Returns `true` if the mate is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_reverse(&self) -> bool {
+        self.flags() & flags::MATE_REVERSE != 0
+    }
+
+    /// Returns `true` if the read is the first segment (R1).
+    #[inline]
+    #[must_use]
+    pub fn is_first_segment(&self) -> bool {
+        self.flags() & flags::FIRST_SEGMENT != 0
+    }
+
+    /// Returns `true` if the read is the last segment (R2).
+    #[inline]
+    #[must_use]
+    pub fn is_last_segment(&self) -> bool {
+        self.flags() & flags::LAST_SEGMENT != 0
+    }
+
+    /// Returns `true` if the read is a secondary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_secondary(&self) -> bool {
+        self.flags() & flags::SECONDARY != 0
+    }
+
+    /// Returns `true` if the read fails quality controls.
+    #[inline]
+    #[must_use]
+    pub fn is_qc_fail(&self) -> bool {
+        self.flags() & flags::QC_FAIL != 0
+    }
+
+    /// Returns `true` if the read is a PCR or optical duplicate.
+    #[inline]
+    #[must_use]
+    pub fn is_duplicate(&self) -> bool {
+        self.flags() & flags::DUPLICATE != 0
+    }
+
+    /// Returns `true` if the read is a supplementary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_supplementary(&self) -> bool {
+        self.flags() & flags::SUPPLEMENTARY != 0
+    }
+}
+
 /// BAM flag bits.
 pub mod flags {
     /// Read is paired in sequencing.
@@ -988,5 +1155,40 @@ mod tests {
     fn test_raw_record_view_try_new_min_length_succeeds() {
         let bytes = vec![0u8; MIN_BAM_RECORD_LEN];
         assert!(RawRecordView::try_new(&bytes).is_some());
+    }
+
+    #[test]
+    fn test_raw_record_view_header_accessors() {
+        use crate::testutil::*;
+        let mut rec = make_bam_bytes(
+            3,
+            200,
+            flags::PAIRED | flags::REVERSE,
+            b"read1",
+            &[encode_op(0, 10)],
+            6,
+            5,
+            400,
+            &[],
+        );
+        rec[9] = 42; // mapq
+        // bin
+        rec[10..12].copy_from_slice(&4680u16.to_le_bytes());
+
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.ref_id(), 3);
+        assert_eq!(v.pos(), 200);
+        assert_eq!(v.mapq(), 42);
+        assert_eq!(v.flags(), flags::PAIRED | flags::REVERSE);
+        assert_eq!(v.bin(), 4680);
+        assert_eq!(v.l_read_name(), 6);
+        assert_eq!(v.n_cigar_op(), 1);
+        assert_eq!(v.l_seq(), 6);
+        assert_eq!(v.mate_ref_id(), 5);
+        assert_eq!(v.mate_pos(), 400);
+        assert_eq!(v.read_name(), b"read1");
+        assert!(v.is_paired());
+        assert!(v.is_reverse());
+        assert!(!v.is_unmapped());
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -649,6 +649,107 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+/// Borrowed fixed-length mutable view over a complete BAM record's bytes.
+///
+/// Wraps `&'a mut [u8]`. Provides every fixed-offset setter plus per-base /
+/// per-quality writes, but cannot change the record's byte length.
+///
+/// Read methods are accessed via [`RawRecordMut::view`].
+#[derive(Debug)]
+pub struct RawRecordMut<'a>(&'a mut [u8]);
+
+impl<'a> RawRecordMut<'a> {
+    /// Wrap raw BAM bytes mutably without validation.
+    ///
+    /// In debug builds, asserts `bytes.len() >= MIN_BAM_RECORD_LEN`. In release
+    /// builds, setter methods on a too-short slice will panic on out-of-bounds
+    /// indexing.
+    #[inline]
+    #[must_use]
+    pub fn new(bytes: &'a mut [u8]) -> Self {
+        debug_assert!(bytes.len() >= MIN_BAM_RECORD_LEN);
+        Self(bytes)
+    }
+
+    /// Wrap raw BAM bytes mutably, returning `None` if too short for the fixed header.
+    #[inline]
+    #[must_use]
+    pub fn try_new(bytes: &'a mut [u8]) -> Option<Self> {
+        if bytes.len() >= MIN_BAM_RECORD_LEN { Some(Self(bytes)) } else { None }
+    }
+
+    /// Borrow as a read-only view (lifetime tied to `&self`).
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawRecordView<'_> {
+        RawRecordView(self.0)
+    }
+
+    /// Returns the underlying byte slice as a shared reference.
+    #[inline]
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+
+    /// Returns the underlying byte slice as a mutable reference.
+    #[inline]
+    #[must_use]
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+
+    // -- header (fixed-offset) setters --
+
+    /// Set the reference sequence ID.
+    #[inline]
+    pub fn set_ref_id(&mut self, v: i32) {
+        set_ref_id(self.0, v);
+    }
+
+    /// Set the 0-based leftmost position.
+    #[inline]
+    pub fn set_pos(&mut self, v: i32) {
+        set_pos(self.0, v);
+    }
+
+    /// Set the mapping quality.
+    #[inline]
+    pub fn set_mapq(&mut self, v: u8) {
+        set_mapq(self.0, v);
+    }
+
+    /// Set the bitwise flags.
+    #[inline]
+    pub fn set_flags(&mut self, v: u16) {
+        set_flags(self.0, v);
+    }
+
+    /// Set the mate reference sequence ID.
+    #[inline]
+    pub fn set_mate_ref_id(&mut self, v: i32) {
+        set_mate_ref_id(self.0, v);
+    }
+
+    /// Set the mate 0-based position.
+    #[inline]
+    pub fn set_mate_pos(&mut self, v: i32) {
+        set_mate_pos(self.0, v);
+    }
+
+    /// Set the template length (TLEN).
+    #[inline]
+    pub fn set_template_length(&mut self, v: i32) {
+        set_template_length(self.0, v);
+    }
+
+    /// Set the BAM bin field (bytes 10–11, little-endian u16).
+    #[inline]
+    pub fn set_bin(&mut self, v: u16) {
+        self.0[10..12].copy_from_slice(&v.to_le_bytes());
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -1221,5 +1322,40 @@ mod tests {
         let f = v.template_coordinate_fields();
         assert_eq!(f.tid, 3);
         assert!(f.flags.reverse());
+    }
+
+    // ========================================================================
+    // RawRecordMut tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_record_mut_constructors_and_view() {
+        let mut bytes = vec![0u8; 32];
+        let m = RawRecordMut::new(&mut bytes);
+        assert_eq!(m.view().as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_raw_record_mut_setters() {
+        use crate::testutil::*;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let mut m = RawRecordMut::new(&mut rec);
+        m.set_ref_id(7);
+        m.set_pos(123);
+        m.set_mapq(40);
+        m.set_flags(flags::PAIRED | flags::REVERSE);
+        m.set_bin(4680);
+        m.set_mate_ref_id(8);
+        m.set_mate_pos(456);
+        m.set_template_length(300);
+        let v = m.view();
+        assert_eq!(v.ref_id(), 7);
+        assert_eq!(v.pos(), 123);
+        assert_eq!(v.mapq(), 40);
+        assert_eq!(v.flags(), flags::PAIRED | flags::REVERSE);
+        assert_eq!(v.bin(), 4680);
+        assert_eq!(v.mate_ref_id(), 8);
+        assert_eq!(v.mate_pos(), 456);
+        assert_eq!(v.template_length(), 300);
     }
 }

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -164,6 +164,397 @@ where
     usize::try_from(n).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
+use crate::fields::{RawRecordMut, RawRecordView};
+use crate::tags::{RawTagsEditor, RawTagsMut, RawTagsView};
+
+impl RawRecord {
+    /// Borrow as a read-only view.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawRecordView<'_> {
+        RawRecordView::new(&self.0)
+    }
+
+    /// Borrow as a fixed-length mutable view.
+    #[inline]
+    #[must_use]
+    pub fn view_mut(&mut self) -> RawRecordMut<'_> {
+        RawRecordMut::new(&mut self.0)
+    }
+
+    /// Read-only view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags(&self) -> RawTagsView<'_> {
+        self.view().tags()
+    }
+
+    /// Fixed-length mutable view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags_mut(&mut self) -> RawTagsMut<'_> {
+        let len = self.0.len();
+        // Clamp against truncated/corrupt records where the parsed offset can
+        // exceed the buffer length; falls back to an empty aux view rather than panicking.
+        let off = crate::fields::aux_data_offset_from_record(&self.0)
+            .filter(|&off| off <= len)
+            .unwrap_or(len);
+        RawTagsMut::new(&mut self.0[off..])
+    }
+
+    /// Length-changing tag editor with cached aux offset.
+    #[inline]
+    #[must_use]
+    pub fn tags_editor(&mut self) -> RawTagsEditor<'_> {
+        RawTagsEditor::from_vec(&mut self.0)
+    }
+
+    // -- Header reads (return primitives — no lifetime borrow from self) --
+
+    /// Extract reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn ref_id(&self) -> i32 {
+        RawRecordView::new(&self.0).ref_id()
+    }
+
+    /// Extract 0-based leftmost position from this record.
+    #[inline]
+    #[must_use]
+    pub fn pos(&self) -> i32 {
+        RawRecordView::new(&self.0).pos()
+    }
+
+    /// Extract mapping quality from this record.
+    #[inline]
+    #[must_use]
+    pub fn mapq(&self) -> u8 {
+        RawRecordView::new(&self.0).mapq()
+    }
+
+    /// Extract bitwise flags from this record.
+    #[inline]
+    #[must_use]
+    pub fn flags(&self) -> u16 {
+        RawRecordView::new(&self.0).flags()
+    }
+
+    /// Extract BAM bin field from this record.
+    #[inline]
+    #[must_use]
+    pub fn bin(&self) -> u16 {
+        RawRecordView::new(&self.0).bin()
+    }
+
+    /// Extract `l_read_name` (read-name length including NUL) from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_read_name(&self) -> u8 {
+        RawRecordView::new(&self.0).l_read_name()
+    }
+
+    /// Extract number of CIGAR operations from this record.
+    #[inline]
+    #[must_use]
+    pub fn n_cigar_op(&self) -> u16 {
+        RawRecordView::new(&self.0).n_cigar_op()
+    }
+
+    /// Extract sequence length from this record.
+    #[inline]
+    #[must_use]
+    pub fn l_seq(&self) -> u32 {
+        RawRecordView::new(&self.0).l_seq()
+    }
+
+    /// Extract mate reference sequence ID from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_ref_id(&self) -> i32 {
+        RawRecordView::new(&self.0).mate_ref_id()
+    }
+
+    /// Extract mate 0-based position from this record.
+    #[inline]
+    #[must_use]
+    pub fn mate_pos(&self) -> i32 {
+        RawRecordView::new(&self.0).mate_pos()
+    }
+
+    /// Extract template length from this record.
+    #[inline]
+    #[must_use]
+    pub fn template_length(&self) -> i32 {
+        RawRecordView::new(&self.0).template_length()
+    }
+
+    // -- Flag-bit convenience reads --
+
+    /// Returns `true` if the read is paired in sequencing.
+    #[inline]
+    #[must_use]
+    pub fn is_paired(&self) -> bool {
+        RawRecordView::new(&self.0).is_paired()
+    }
+
+    /// Returns `true` if the read is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_unmapped(&self) -> bool {
+        RawRecordView::new(&self.0).is_unmapped()
+    }
+
+    /// Returns `true` if the mate is unmapped.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_unmapped(&self) -> bool {
+        RawRecordView::new(&self.0).is_mate_unmapped()
+    }
+
+    /// Returns `true` if the read is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_reverse(&self) -> bool {
+        RawRecordView::new(&self.0).is_reverse()
+    }
+
+    /// Returns `true` if the mate is reverse complemented.
+    #[inline]
+    #[must_use]
+    pub fn is_mate_reverse(&self) -> bool {
+        RawRecordView::new(&self.0).is_mate_reverse()
+    }
+
+    /// Returns `true` if the read is the first segment (R1).
+    #[inline]
+    #[must_use]
+    pub fn is_first_segment(&self) -> bool {
+        RawRecordView::new(&self.0).is_first_segment()
+    }
+
+    /// Returns `true` if the read is the last segment (R2).
+    #[inline]
+    #[must_use]
+    pub fn is_last_segment(&self) -> bool {
+        RawRecordView::new(&self.0).is_last_segment()
+    }
+
+    /// Returns `true` if the read is a secondary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_secondary(&self) -> bool {
+        RawRecordView::new(&self.0).is_secondary()
+    }
+
+    /// Returns `true` if the read fails quality controls.
+    #[inline]
+    #[must_use]
+    pub fn is_qc_fail(&self) -> bool {
+        RawRecordView::new(&self.0).is_qc_fail()
+    }
+
+    /// Returns `true` if the read is a PCR or optical duplicate.
+    #[inline]
+    #[must_use]
+    pub fn is_duplicate(&self) -> bool {
+        RawRecordView::new(&self.0).is_duplicate()
+    }
+
+    /// Returns `true` if the read is a supplementary alignment.
+    #[inline]
+    #[must_use]
+    pub fn is_supplementary(&self) -> bool {
+        RawRecordView::new(&self.0).is_supplementary()
+    }
+
+    // -- CIGAR reads --
+
+    /// Compute the reference length consumed by this record's CIGAR.
+    #[inline]
+    #[must_use]
+    pub fn reference_length(&self) -> i32 {
+        RawRecordView::new(&self.0).reference_length()
+    }
+
+    /// Compute the query (read) length from this record's CIGAR.
+    #[inline]
+    #[must_use]
+    pub fn query_length(&self) -> usize {
+        RawRecordView::new(&self.0).query_length()
+    }
+
+    /// Return the 1-based alignment end position, or `None` if unmapped.
+    #[inline]
+    #[must_use]
+    pub fn alignment_end_1based(&self) -> Option<usize> {
+        RawRecordView::new(&self.0).alignment_end_1based()
+    }
+
+    /// Return the 1-based alignment start position, or `None` if unmapped.
+    #[inline]
+    #[must_use]
+    pub fn alignment_start_1based(&self) -> Option<usize> {
+        RawRecordView::new(&self.0).alignment_start_1based()
+    }
+
+    /// Return the 1-based unclipped 5′ position.
+    #[inline]
+    #[must_use]
+    pub fn unclipped_5prime_1based(&self) -> i32 {
+        RawRecordView::new(&self.0).unclipped_5prime_1based()
+    }
+
+    /// Convert this record's CIGAR to a human-readable string.
+    #[inline]
+    #[must_use]
+    pub fn cigar_to_string(&self) -> String {
+        RawRecordView::new(&self.0).cigar_to_string()
+    }
+
+    /// Return the raw CIGAR ops as a `Vec<u32>`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_ops_vec(&self) -> Vec<u32> {
+        RawRecordView::new(&self.0).cigar_ops_vec()
+    }
+
+    /// Decode the sequence bases to ASCII.
+    #[inline]
+    #[must_use]
+    pub fn sequence_vec(&self) -> Vec<u8> {
+        RawRecordView::new(&self.0).sequence_vec()
+    }
+
+    // -- Methods that return references borrowed from self --
+    //    Hand-written so lifetime elision pins the returned reference to &self.
+
+    /// Return the read name (without null terminator).
+    #[inline]
+    #[must_use]
+    pub fn read_name(&self) -> &[u8] {
+        self.view().read_name()
+    }
+
+    /// Return the raw CIGAR bytes.
+    #[inline]
+    #[must_use]
+    pub fn cigar_raw_bytes(&self) -> &[u8] {
+        self.view().cigar_raw_bytes()
+    }
+
+    /// Return the quality score bytes.
+    #[inline]
+    #[must_use]
+    pub fn quality_scores(&self) -> &[u8] {
+        self.view().quality_scores()
+    }
+
+    /// Return the packed (2-bit-encoded) sequence bytes.
+    #[inline]
+    #[must_use]
+    pub fn sequence_packed(&self) -> &[u8] {
+        self.view().sequence_packed()
+    }
+
+    /// Return the ASCII base at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_base(&self, position: usize) -> u8 {
+        self.view().get_base(position)
+    }
+
+    /// Return `true` if the base at `position` is N (missing/unknown).
+    #[inline]
+    #[must_use]
+    pub fn is_base_n(&self, position: usize) -> bool {
+        self.view().is_base_n(position)
+    }
+
+    /// Return the quality score at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_qual(&self, position: usize) -> u8 {
+        self.view().get_qual(position)
+    }
+
+    /// Return a mutable slice of quality scores.
+    #[inline]
+    pub fn quality_scores_mut(&mut self) -> &mut [u8] {
+        crate::sequence::quality_scores_slice_mut(&mut self.0)
+    }
+
+    /// Set the ASCII base at `position`.
+    #[inline]
+    pub fn set_base(&mut self, position: usize, base: u8) {
+        let seq_off = crate::fields::seq_offset(&self.0);
+        crate::sequence::set_base(&mut self.0, seq_off, position, base);
+    }
+
+    /// Mask the base at `position` to N.
+    #[inline]
+    pub fn mask_base(&mut self, position: usize) {
+        let seq_off = crate::fields::seq_offset(&self.0);
+        crate::sequence::mask_base(&mut self.0, seq_off, position);
+    }
+
+    /// Set the quality score at `position`.
+    #[inline]
+    pub fn set_qual(&mut self, position: usize, value: u8) {
+        let qual_off = crate::fields::qual_offset(&self.0);
+        crate::sequence::set_qual(&mut self.0, qual_off, position, value);
+    }
+
+    // -- Header writes (fixed-length, no return) --
+
+    /// Set the reference sequence ID.
+    #[inline]
+    pub fn set_ref_id(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_ref_id(v);
+    }
+
+    /// Set the 0-based leftmost position.
+    #[inline]
+    pub fn set_pos(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_pos(v);
+    }
+
+    /// Set the mapping quality.
+    #[inline]
+    pub fn set_mapq(&mut self, v: u8) {
+        RawRecordMut::new(&mut self.0).set_mapq(v);
+    }
+
+    /// Set the bitwise flags.
+    #[inline]
+    pub fn set_flags(&mut self, v: u16) {
+        RawRecordMut::new(&mut self.0).set_flags(v);
+    }
+
+    /// Set the BAM bin field.
+    #[inline]
+    pub fn set_bin(&mut self, v: u16) {
+        RawRecordMut::new(&mut self.0).set_bin(v);
+    }
+
+    /// Set the mate reference sequence ID.
+    #[inline]
+    pub fn set_mate_ref_id(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_mate_ref_id(v);
+    }
+
+    /// Set the mate 0-based position.
+    #[inline]
+    pub fn set_mate_pos(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_mate_pos(v);
+    }
+
+    /// Set the template length (TLEN).
+    #[inline]
+    pub fn set_template_length(&mut self, v: i32) {
+        RawRecordMut::new(&mut self.0).set_template_length(v);
+    }
+}
+
 /// A reader for raw BAM records.
 ///
 /// This wraps any `Read` type (typically a BGZF reader) and provides
@@ -217,6 +608,33 @@ impl<R: Read> RawBamReader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_raw_record_inherent_delegators() {
+        use crate::flags;
+        use crate::testutil::*;
+        let bytes =
+            make_bam_bytes(3, 200, flags::PAIRED, b"rd", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        // Reads via inherent delegators
+        assert_eq!(rec.ref_id(), 3);
+        assert_eq!(rec.pos(), 200);
+        assert!(rec.is_paired());
+        assert_eq!(rec.tags().find_int(b"NM"), Some(5));
+
+        // Fixed-length writes via inherent delegators
+        rec.set_pos(999);
+        rec.set_mapq(40);
+        assert_eq!(rec.pos(), 999);
+        assert_eq!(rec.mapq(), 40);
+
+        // Length-changing edits via tags_editor
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_int(b"NM", 8);
+        }
+        assert_eq!(rec.tags().find_int(b"NM"), Some(8));
+    }
 
     #[test]
     fn test_raw_record_new() {
@@ -285,6 +703,22 @@ mod tests {
 
         let result = read_raw_record(&mut reader, &mut record);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tags_mut_clamps_truncated_aux_offset() {
+        // Build a record then truncate below the parsed aux offset. The header
+        // fields still imply aux starts past the buffer end, so tags_mut() must
+        // clamp rather than panic on the out-of-bounds slice.
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut truncated: Vec<u8> = bytes;
+        // Drop the aux bytes plus one byte of the seq/qual region so the parsed
+        // aux offset exceeds the buffer length.
+        truncated.truncate(truncated.len() - 5);
+        let mut rec = RawRecord::from(truncated);
+        let tags = rec.tags_mut(); // must not panic
+        assert!(tags.view().is_empty());
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -556,6 +556,30 @@ impl RawRecord {
 
     // -- Length-changing edits --
 
+    /// Replace the CIGAR operation array.
+    ///
+    /// Updates `n_cigar_op` and splices the new ops in. Each op is a `u32` in
+    /// the standard BAM packing (`(op_len << 4) | op_type`).
+    ///
+    /// All other fields (sequence, quality, aux tags) are preserved.
+    ///
+    /// # Panics
+    /// Panics if `new_ops.len() > u16::MAX as usize`.
+    pub fn set_cigar_ops(&mut self, new_ops: &[u32]) {
+        let new_n = u16::try_from(new_ops.len())
+            .unwrap_or_else(|_| panic!("CIGAR op count {} overflows u16", new_ops.len()));
+        let l_rn = self.0[8] as usize;
+        let old_n = u16::from_le_bytes([self.0[12], self.0[13]]) as usize;
+        let start = 32 + l_rn;
+        let end = start + old_n * 4;
+        let mut bytes = Vec::with_capacity(new_ops.len() * 4);
+        for &op in new_ops {
+            bytes.extend_from_slice(&op.to_le_bytes());
+        }
+        self.0.splice(start..end, bytes);
+        self.0[12..14].copy_from_slice(&new_n.to_le_bytes());
+    }
+
     /// Replace the read name. Updates `l_read_name` and splices the name +
     /// NUL terminator into the record.
     ///
@@ -784,6 +808,27 @@ mod tests {
         let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"");
         let mut rec = RawRecord::from(bytes);
         rec.set_read_name(b"bad\0name");
+    }
+
+    #[test]
+    fn test_set_cigar_ops_resize() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 10)], 10, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_name = rec.read_name().to_vec();
+        let pre_seq = rec.sequence_vec();
+        let pre_qual = rec.quality_scores().to_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        let new_ops = vec![encode_op(0, 4), encode_op(2, 1), encode_op(0, 6)];
+        rec.set_cigar_ops(&new_ops);
+        assert_eq!(rec.cigar_ops_vec(), new_ops);
+        assert_eq!(rec.n_cigar_op() as usize, new_ops.len());
+
+        assert_eq!(rec.read_name(), pre_name.as_slice());
+        assert_eq!(rec.sequence_vec(), pre_seq);
+        assert_eq!(rec.quality_scores(), pre_qual.as_slice());
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -580,6 +580,53 @@ impl RawRecord {
         self.0[12..14].copy_from_slice(&new_n.to_le_bytes());
     }
 
+    /// Replace both the sequence and the quality scores.
+    ///
+    /// `seq` is ASCII (`A`/`C`/`G`/`T`/`N`/IUPAC); `qual` is raw Phred (not +33).
+    /// `seq.len()` and `qual.len()` must match (BAM spec).
+    ///
+    /// Updates `l_seq`; read name, CIGAR, and aux tags are preserved.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `seq.len() != qual.len()` or if `seq.len() > u32::MAX as usize`.
+    pub fn set_sequence_and_qualities(&mut self, seq: &[u8], qual: &[u8]) {
+        assert_eq!(seq.len(), qual.len(), "sequence and quality must have equal length");
+        let new_l = u32::try_from(seq.len()).expect("seq length overflows u32");
+        let l_rn = self.0[8] as usize;
+        let n_co = u16::from_le_bytes([self.0[12], self.0[13]]) as usize;
+        let old_l = u32::from_le_bytes([self.0[16], self.0[17], self.0[18], self.0[19]]) as usize;
+
+        let body_start = 32 + l_rn + n_co * 4;
+        let old_packed = old_l.div_ceil(2);
+        let body_end = body_start + old_packed + old_l;
+
+        let new_packed_len = seq.len().div_ceil(2);
+        let mut new_body = Vec::with_capacity(new_packed_len + qual.len());
+        crate::sequence::pack_sequence_into(&mut new_body, seq);
+        new_body.extend_from_slice(qual);
+
+        self.0.splice(body_start..body_end, new_body);
+        self.0[16..20].copy_from_slice(&new_l.to_le_bytes());
+    }
+
+    /// Convenience: replace quality scores when their length matches `l_seq`.
+    ///
+    /// For length-changing replacement, use [`RawRecord::set_sequence_and_qualities`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `qual.len() != l_seq`.
+    pub fn set_qualities(&mut self, qual: &[u8]) {
+        let l = self.l_seq() as usize;
+        assert_eq!(
+            l,
+            qual.len(),
+            "qualities length must match l_seq; use set_sequence_and_qualities to resize"
+        );
+        self.quality_scores_mut().copy_from_slice(qual);
+    }
+
     /// Replace the read name. Updates `l_read_name` and splices the name +
     /// NUL terminator into the record.
     ///
@@ -829,6 +876,64 @@ mod tests {
         assert_eq!(rec.sequence_vec(), pre_seq);
         assert_eq!(rec.quality_scores(), pre_qual.as_slice());
         assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    #[test]
+    fn test_set_sequence_and_qualities_grow() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_name = rec.read_name().to_vec();
+        let pre_cigar = rec.cigar_ops_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        let new_seq = b"ACGTACGTACGT";
+        let new_qual = vec![30u8; 12];
+        rec.set_sequence_and_qualities(new_seq, &new_qual);
+
+        assert_eq!(rec.l_seq() as usize, 12);
+        assert_eq!(rec.sequence_vec(), new_seq.to_vec());
+        assert_eq!(rec.quality_scores(), new_qual.as_slice());
+        assert_eq!(rec.read_name(), pre_name.as_slice());
+        assert_eq!(rec.cigar_ops_vec(), pre_cigar);
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    #[test]
+    fn test_set_sequence_and_qualities_shrink_with_odd_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_sequence_and_qualities(b"ACG", &[20, 21, 22]);
+        assert_eq!(rec.l_seq(), 3);
+        assert_eq!(rec.sequence_vec(), b"ACG".to_vec());
+        assert_eq!(rec.quality_scores(), &[20u8, 21, 22]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must have equal length")]
+    fn test_set_sequence_and_qualities_mismatch_panics() {
+        use crate::testutil::*;
+        let mut rec = RawRecord::from(make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]));
+        rec.set_sequence_and_qualities(b"AC", &[20]);
+    }
+
+    #[test]
+    fn test_set_qualities_fixed_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_qualities(&[10, 20, 30, 40]);
+        assert_eq!(rec.quality_scores(), &[10u8, 20, 30, 40]);
+    }
+
+    #[test]
+    #[should_panic(expected = "qualities length must match l_seq")]
+    fn test_set_qualities_wrong_length_panics() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_qualities(&[10, 20]);
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -553,6 +553,37 @@ impl RawRecord {
     pub fn set_template_length(&mut self, v: i32) {
         RawRecordMut::new(&mut self.0).set_template_length(v);
     }
+
+    // -- Length-changing edits --
+
+    /// Replace the read name. Updates `l_read_name` and splices the name +
+    /// NUL terminator into the record.
+    ///
+    /// All other fields (CIGAR, sequence, quality, aux tags) are preserved
+    /// because they live after the name and shift accordingly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_name.len() + 1 > u8::MAX as usize` (the BAM spec encodes
+    /// `l_read_name` as a single byte) or if `new_name` contains an embedded NUL
+    /// (BAM read names are NUL-terminated; an interior NUL would produce an
+    /// invalid record that downstream readers misparse).
+    pub fn set_read_name(&mut self, new_name: &[u8]) {
+        assert!(!new_name.contains(&0), "read name must not contain NUL bytes");
+        let new_l = new_name.len() + 1; // include NUL
+        let new_l_u8 = u8::try_from(new_l)
+            .unwrap_or_else(|_| panic!("read name too long: {} bytes", new_name.len()));
+        let old_l = self.0[8] as usize;
+        let start = 32;
+        let end = start + old_l;
+        // Splice: replace old name+NUL with new name+NUL
+        let mut replacement = Vec::with_capacity(new_l);
+        replacement.extend_from_slice(new_name);
+        replacement.push(0);
+        self.0.splice(start..end, replacement);
+        // Update l_read_name byte at offset 8
+        self.0[8] = new_l_u8;
+    }
 }
 
 /// A reader for raw BAM records.
@@ -719,6 +750,40 @@ mod tests {
         let mut rec = RawRecord::from(truncated);
         let tags = rec.tags_mut(); // must not panic
         assert!(tags.view().is_empty());
+    }
+
+    #[test]
+    fn test_set_read_name_resize() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"oldname", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_cigar = rec.cigar_ops_vec();
+        let pre_seq = rec.sequence_vec();
+        let pre_qual = rec.quality_scores().to_vec();
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_read_name(b"new");
+        assert_eq!(rec.read_name(), b"new");
+        assert_eq!(rec.l_read_name(), 4); // 3 bytes + NUL
+        // All other fields preserved
+        assert_eq!(rec.cigar_ops_vec(), pre_cigar);
+        assert_eq!(rec.sequence_vec(), pre_seq);
+        assert_eq!(rec.quality_scores(), pre_qual.as_slice());
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+
+        // Empty name (still NUL-terminated)
+        rec.set_read_name(b"");
+        assert_eq!(rec.read_name(), b"");
+        assert_eq!(rec.l_read_name(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "read name must not contain NUL bytes")]
+    fn test_set_read_name_rejects_embedded_nul() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"");
+        let mut rec = RawRecord::from(bytes);
+        rec.set_read_name(b"bad\0name");
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -221,6 +221,38 @@ impl<'a> RawRecordView<'a> {
     }
 }
 
+use crate::fields::RawRecordMut;
+
+impl RawRecordMut<'_> {
+    /// Set the base at `position` (ASCII input -> 4-bit BAM encoding).
+    /// Unknown bases encode as `N` (0xF).
+    #[inline]
+    pub fn set_base(&mut self, position: usize, base: u8) {
+        let off = seq_offset(self.as_bytes());
+        set_base(self.as_bytes_mut(), off, position, base);
+    }
+
+    /// Set the base at `position` to `N`.
+    #[inline]
+    pub fn mask_base(&mut self, position: usize) {
+        let off = seq_offset(self.as_bytes());
+        mask_base(self.as_bytes_mut(), off, position);
+    }
+
+    /// Set the raw Phred quality score at `position`.
+    #[inline]
+    pub fn set_qual(&mut self, position: usize, value: u8) {
+        let off = qual_offset(self.as_bytes());
+        set_qual(self.as_bytes_mut(), off, position, value);
+    }
+
+    /// Mutable zero-allocation slice over raw Phred quality scores.
+    #[inline]
+    pub fn quality_scores_mut(&mut self) -> &mut [u8] {
+        quality_scores_slice_mut(self.as_bytes_mut())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -580,6 +612,30 @@ mod tests {
     // ========================================================================
     // RawRecordView sequence/quality method tests
     // ========================================================================
+
+    #[test]
+    fn test_raw_record_mut_seq_qual_writes() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 4, -1, -1, &[]);
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.set_base(0, b'A');
+            m.set_base(1, b'C');
+            m.set_base(2, b'G');
+            m.set_base(3, b'T');
+            m.set_qual(0, 25);
+            m.set_qual(3, 99);
+            m.mask_base(2);
+            for q in m.quality_scores_mut() {
+                if *q == 0 {
+                    *q = 10;
+                }
+            }
+        }
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.sequence_vec(), b"ACNT".to_vec());
+        assert_eq!(v.quality_scores(), &[25, 10, 10, 99]);
+    }
 
     #[test]
     fn test_view_sequence_quality_methods() {

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -158,6 +158,69 @@ pub fn quality_scores_slice_mut(bam: &mut [u8]) -> &mut [u8] {
     &mut bam[off..off + l]
 }
 
+use crate::fields::RawRecordView;
+
+impl<'a> RawRecordView<'a> {
+    /// Raw 4-bit packed sequence bytes (`(l_seq + 1) / 2` bytes).
+    #[inline]
+    #[must_use]
+    pub fn sequence_packed(&self) -> &'a [u8] {
+        let bam = self.as_bytes();
+        let l = l_seq(bam) as usize;
+        let off = seq_offset(bam);
+        let bytes = l.div_ceil(2);
+        &bam[off..off + bytes]
+    }
+
+    /// Zero-allocation iterator yielding decoded ASCII bases (A/C/G/T/N/…).
+    #[inline]
+    pub fn sequence_iter(&self) -> impl Iterator<Item = u8> + 'a {
+        let bam = self.as_bytes();
+        let l = l_seq(bam) as usize;
+        let off = seq_offset(bam);
+        (0..l).map(move |i| BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize])
+    }
+
+    /// Convenience: collect the sequence into a `Vec<u8>` of ASCII bases.
+    #[inline]
+    #[must_use]
+    pub fn sequence_vec(&self) -> Vec<u8> {
+        extract_sequence(self.as_bytes())
+    }
+
+    /// Returns the 4-bit encoded base code at `position`
+    /// (1=A, 2=C, 4=G, 8=T, 15=N).
+    #[inline]
+    #[must_use]
+    pub fn get_base(&self, position: usize) -> u8 {
+        let bam = self.as_bytes();
+        get_base(bam, seq_offset(bam), position)
+    }
+
+    /// Returns `true` if the 4-bit encoded base at `position` is `N` (0xF).
+    #[inline]
+    #[must_use]
+    pub fn is_base_n(&self, position: usize) -> bool {
+        let bam = self.as_bytes();
+        is_base_n(bam, seq_offset(bam), position)
+    }
+
+    /// Zero-allocation slice over raw Phred quality scores (not Phred+33).
+    #[inline]
+    #[must_use]
+    pub fn quality_scores(&self) -> &'a [u8] {
+        quality_scores_slice(self.as_bytes())
+    }
+
+    /// Returns the raw Phred quality score at `position`.
+    #[inline]
+    #[must_use]
+    pub fn get_qual(&self, position: usize) -> u8 {
+        let bam = self.as_bytes();
+        get_qual(bam, qual_offset(bam), position)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +575,34 @@ mod tests {
         let mut dst = Vec::new();
         pack_sequence_into(&mut dst, b"NN");
         assert_eq!(dst, [0xFF]); // N=15, N=15
+    }
+
+    // ========================================================================
+    // RawRecordView sequence/quality method tests
+    // ========================================================================
+
+    #[test]
+    fn test_view_sequence_quality_methods() {
+        use crate::fields::RawRecordView;
+        // Build a record with seq "ACGT" and quals 30,30,30,30
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 4, -1, -1, &[]);
+        let so = seq_offset(&rec);
+        let qo = qual_offset(&rec);
+        rec[so] = 0x12; // A=1, C=2
+        rec[so + 1] = 0x48; // G=4, T=8
+        for i in 0..4 {
+            rec[qo + i] = 30;
+        }
+
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.l_seq(), 4);
+        assert_eq!(v.sequence_vec(), b"ACGT".to_vec());
+        assert_eq!(v.sequence_iter().collect::<Vec<u8>>(), b"ACGT".to_vec());
+        assert_eq!(v.sequence_packed(), &[0x12, 0x48]);
+        assert_eq!(v.quality_scores(), &[30, 30, 30, 30]);
+        assert_eq!(v.get_qual(0), 30);
+        assert_eq!(v.get_base(0), 1); // A
+        assert_eq!(v.get_base(3), 8); // T
+        assert!(!v.is_base_n(0));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1077,6 +1077,117 @@ impl<'a> RawTagsMut<'a> {
         }
         aux[off..off + elem_size].copy_from_slice(le_bytes);
     }
+
+    /// Reverse element bytes of a B-type array tag in place.
+    #[inline]
+    pub fn reverse_array(&mut self, tag: &[u8; 2]) {
+        reverse_array_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Reverse the bytes of a Z-type string tag value in place.
+    #[inline]
+    pub fn reverse_string(&mut self, tag: &[u8; 2]) {
+        reverse_string_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Reverse-complement a Z-type string tag value (A<->T, C<->G).
+    #[inline]
+    pub fn reverse_complement_string(&mut self, tag: &[u8; 2]) {
+        reverse_complement_string_tag_in_place(self.0, 0, tag);
+    }
+
+    /// Overwrite an existing Z-type tag if the new value matches its current length.
+    ///
+    /// Returns `false` (no-op) if absent, wrong type, or different length.
+    pub fn set_string_in_place(&mut self, tag: &[u8; 2], value: &[u8]) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        if val_type != b'Z' {
+            return false;
+        }
+        let start = p + 3;
+        let Some(nul_off) = self.0[start..].iter().position(|&b| b == 0) else {
+            return false;
+        };
+        if nul_off != value.len() {
+            return false;
+        }
+        self.0[start..start + value.len()].copy_from_slice(value);
+        true
+    }
+
+    /// Overwrite an existing integer tag if the new value fits its current type byte.
+    ///
+    /// Returns `false` if absent, value doesn't fit the existing type, or the
+    /// aux buffer is truncated and the value bytes lie out of bounds.
+    pub fn set_int_in_place(&mut self, tag: &[u8; 2], value: i64) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        let len = self.0.len();
+        match val_type {
+            b'c' => i8::try_from(value)
+                .ok()
+                .filter(|_| p + 4 <= len)
+                .map(|v| {
+                    self.0[p + 3] = v.cast_unsigned();
+                })
+                .is_some(),
+            b'C' => u8::try_from(value)
+                .ok()
+                .filter(|_| p + 4 <= len)
+                .map(|v| {
+                    self.0[p + 3] = v;
+                })
+                .is_some(),
+            b's' => i16::try_from(value)
+                .ok()
+                .filter(|_| p + 5 <= len)
+                .map(|v| {
+                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_some(),
+            b'S' => u16::try_from(value)
+                .ok()
+                .filter(|_| p + 5 <= len)
+                .map(|v| {
+                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_some(),
+            b'i' => i32::try_from(value)
+                .ok()
+                .filter(|_| p + 7 <= len)
+                .map(|v| {
+                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_some(),
+            b'I' => u32::try_from(value)
+                .ok()
+                .filter(|_| p + 7 <= len)
+                .map(|v| {
+                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
+                })
+                .is_some(),
+            _ => false,
+        }
+    }
+
+    /// Overwrite an existing `f`-type tag in place.
+    ///
+    /// Returns `false` if absent, wrong type, or the aux buffer is truncated
+    /// and the value bytes lie out of bounds.
+    #[inline]
+    pub fn set_float_in_place(&mut self, tag: &[u8; 2], value: f32) -> bool {
+        let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
+            return false;
+        };
+        if val_type != b'f' || p + 7 > self.0.len() {
+            return false;
+        }
+        self.0[p + 3..p + 7].copy_from_slice(&value.to_le_bytes());
+        true
+    }
 }
 
 impl RawRecordMut<'_> {
@@ -2831,5 +2942,124 @@ mod tests {
         let arr = v.tags().find_array(b"bq").expect("array tag");
         assert_eq!(arr.count, 4);
         assert_eq!(array_tag_element_u16(&arr, 2), 99);
+    }
+
+    // ========================================================================
+    // RawTagsMut reverse + in-place setter tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_tags_mut_reverse_string_in_place() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().reverse_string(b"BC");
+        }
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"BC"), Some(b"TGCA".as_slice()));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_string_in_place_same_length() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_string_in_place(b"BC", b"TTTT")
+        };
+        assert!(ok);
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"BC"), Some(b"TTTT".as_slice()));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_string_in_place_different_length_returns_false() {
+        use crate::fields::RawRecordMut;
+        let aux = b"BCZACGT\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_string_in_place(b"BC", b"AC")
+        };
+        assert!(!ok);
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_int_in_place_fits() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        // NM:i:5 (4-byte signed int)
+        let mut aux = Vec::from(b"NMi".as_slice());
+        aux.extend_from_slice(&5i32.to_le_bytes());
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_int_in_place(b"NM", 100_000)
+        };
+        assert!(ok);
+        assert_eq!(RawRecordView::new(&rec).tags().find_int(b"NM"), Some(100_000));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_int_in_place_doesnt_fit_returns_false() {
+        use crate::fields::RawRecordMut;
+        // NM:c:5 (1-byte signed)
+        let aux = b"NMc\x05";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_int_in_place(b"NM", 100_000)
+        };
+        assert!(!ok);
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_int_in_place_truncated_aux_returns_false() {
+        // Slice the tag's value bytes off so set_int_in_place would otherwise
+        // panic on the out-of-bounds write. It must return false instead.
+        // Test every int sub-type since each branch has its own bounds check.
+        for sub in [b'c', b'C'] {
+            let aux = [b'N', b'M', sub]; // header only, no value byte
+            let mut tags = aux;
+            let mut tm = RawTagsMut::new(&mut tags);
+            assert!(!tm.set_int_in_place(b"NM", 1));
+        }
+        for sub in [b's', b'S'] {
+            let aux = [b'N', b'M', sub, 0]; // 1 of 2 value bytes
+            let mut tags = aux;
+            let mut tm = RawTagsMut::new(&mut tags);
+            assert!(!tm.set_int_in_place(b"NM", 1));
+        }
+        for sub in [b'i', b'I'] {
+            let aux = [b'N', b'M', sub, 0, 0, 0]; // 3 of 4 value bytes
+            let mut tags = aux;
+            let mut tm = RawTagsMut::new(&mut tags);
+            assert!(!tm.set_int_in_place(b"NM", 1));
+        }
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_float_in_place_truncated_aux_returns_false() {
+        // Slice off some of the f32 value bytes so set_float_in_place would
+        // otherwise panic on the out-of-bounds write.
+        let aux = [b'A', b'S', b'f', 0, 0, 0]; // 3 of 4 value bytes
+        let mut tags = aux;
+        let mut tm = RawTagsMut::new(&mut tags);
+        assert!(!tm.set_float_in_place(b"AS", 1.0));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_float_in_place() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        let mut aux = Vec::from(b"ASf".as_slice());
+        aux.extend_from_slice(&12.5f32.to_le_bytes());
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_float_in_place(b"AS", 99.25)
+        };
+        assert!(ok);
+        let got = RawRecordView::new(&rec).tags().find_float(b"AS").unwrap();
+        assert!((got - 99.25).abs() < 1e-6);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1,5 +1,6 @@
 use crate::fields::{
-    RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+    RawRecordMut, RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice,
+    tag_value_size,
 };
 
 /// Find a tag's position and type byte in auxiliary data.
@@ -982,6 +983,115 @@ impl<'a> RawRecordView<'a> {
     #[must_use]
     pub fn template_aux_tags(&self, cell_tag: Option<&[u8; 2]>) -> TemplateAuxTags<'a> {
         extract_template_aux_tags(self.as_bytes(), cell_tag)
+    }
+}
+
+/// Borrowed fixed-length mutable view over a BAM record's aux section.
+///
+/// Cannot change the byte count of the aux section. Hosts in-place writers
+/// for B-array elements, Z-tag byte flips, and same-type tag overwrites.
+pub struct RawTagsMut<'a>(&'a mut [u8]);
+
+impl<'a> RawTagsMut<'a> {
+    /// Wraps a raw auxiliary-data slice mutably.
+    #[inline]
+    #[must_use]
+    pub fn new(aux: &'a mut [u8]) -> Self {
+        Self(aux)
+    }
+
+    /// Returns a read-only view over the aux section.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawTagsView<'_> {
+        RawTagsView::new(self.0)
+    }
+
+    /// Overwrite a single u8 element of a B:C array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `C`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_u8(&mut self, tag: &[u8; 2], index: usize, value: u8) {
+        Self::set_array_element_le(self.0, *tag, b'C', 1, index, &[value]);
+    }
+
+    /// Overwrite a single u16 element of a B:S array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `S`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_u16(&mut self, tag: &[u8; 2], index: usize, value: u16) {
+        Self::set_array_element_le(self.0, *tag, b'S', 2, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single i16 element of a B:s array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `s`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_i16(&mut self, tag: &[u8; 2], index: usize, value: i16) {
+        Self::set_array_element_le(self.0, *tag, b's', 2, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single i32 element of a B:i array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `i`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_i32(&mut self, tag: &[u8; 2], index: usize, value: i32) {
+        Self::set_array_element_le(self.0, *tag, b'i', 4, index, &value.to_le_bytes());
+    }
+
+    /// Overwrite a single f32 element of a B:f array tag in place.
+    ///
+    /// No-op on tag absence, type mismatch (must be `B` with sub-type `f`), or out-of-range index.
+    #[inline]
+    pub fn set_array_element_f32(&mut self, tag: &[u8; 2], index: usize, value: f32) {
+        Self::set_array_element_le(self.0, *tag, b'f', 4, index, &value.to_le_bytes());
+    }
+
+    /// Internal helper: locate a B-type array of the expected sub-type and overwrite
+    /// element `index` with the provided little-endian bytes.
+    ///
+    /// The layout of a B-type tag entry in the aux section is:
+    /// `[tag0, tag1, 'B', sub_type, count(4 bytes LE), elem0..elemN]`
+    fn set_array_element_le(
+        aux: &mut [u8],
+        tag: [u8; 2],
+        expected_sub: u8,
+        elem_size: usize,
+        index: usize,
+        le_bytes: &[u8],
+    ) {
+        let Some((p, val_type)) = find_tag_position(aux, tag) else { return };
+        if val_type != b'B' || p + 8 > aux.len() {
+            return;
+        }
+        if aux[p + 3] != expected_sub {
+            return;
+        }
+        let count = u32::from_le_bytes([aux[p + 4], aux[p + 5], aux[p + 6], aux[p + 7]]) as usize;
+        if index >= count {
+            return;
+        }
+        let off = p + 8 + index * elem_size;
+        if off + elem_size > aux.len() {
+            return;
+        }
+        aux[off..off + elem_size].copy_from_slice(le_bytes);
+    }
+}
+
+impl RawRecordMut<'_> {
+    /// Borrow a fixed-length mutable view over this record's aux section.
+    #[inline]
+    #[must_use]
+    pub fn tags_mut(&mut self) -> RawTagsMut<'_> {
+        // Compute offset and length via immutable borrow; both immutable borrows end
+        // before the mutable borrow on the last line (NLL two-phase borrows).
+        let len = self.as_bytes().len();
+        // Clamp against truncated/corrupt records where the parsed offset can
+        // exceed the buffer length; falls back to an empty aux view rather than panicking.
+        let off =
+            aux_data_offset_from_record(self.as_bytes()).filter(|&off| off <= len).unwrap_or(len);
+        RawTagsMut::new(&mut self.as_bytes_mut()[off..])
     }
 }
 
@@ -2698,5 +2808,28 @@ mod tests {
         assert_eq!(s.rg, Some(b"mygrp".as_slice()));
         assert_eq!(s.cell, Some(b"ACGT".as_slice()));
         assert_eq!(s.mc, Some("50M"));
+    }
+
+    #[test]
+    fn test_raw_tags_mut_set_array_element() {
+        use crate::fields::{RawRecordMut, RawRecordView};
+        // Build a record with B:S array tag "bq" of [10, 20, 30, 40]
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBS");
+        aux.extend_from_slice(&4u32.to_le_bytes());
+        for v in [10u16, 20, 30, 40] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+
+        {
+            let mut m = RawRecordMut::new(&mut rec);
+            let mut tm = m.tags_mut();
+            tm.set_array_element_u16(b"bq", 2, 99);
+        }
+        let v = RawRecordView::new(&rec);
+        let arr = v.tags().find_array(b"bq").expect("array tag");
+        assert_eq!(arr.count, 4);
+        assert_eq!(array_tag_element_u16(&arr, 2), 99);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -960,12 +960,28 @@ impl<'a> IntoIterator for &RawTagsView<'a> {
     }
 }
 
+impl<'a> RawTagsView<'a> {
+    /// Single-pass extraction of (RG, cell, MC) string tags from this aux section.
+    #[inline]
+    #[must_use]
+    pub fn extract_string_batch(&self, cell_tag: &[u8; 2]) -> AuxStringTags<'a> {
+        extract_aux_string_tags(self.0, cell_tag)
+    }
+}
+
 impl<'a> RawRecordView<'a> {
     /// Returns a read-only view over this record's auxiliary tag section.
     #[inline]
     #[must_use]
     pub fn tags(&self) -> RawTagsView<'a> {
         RawTagsView::new(aux_data_slice(self.as_bytes()))
+    }
+
+    /// Single-pass extraction of (MI, RG, cell, MC) from this record's aux data.
+    #[inline]
+    #[must_use]
+    pub fn template_aux_tags(&self, cell_tag: Option<&[u8; 2]>) -> TemplateAuxTags<'a> {
+        extract_template_aux_tags(self.as_bytes(), cell_tag)
     }
 }
 
@@ -2671,5 +2687,16 @@ mod tests {
                 ("RG".into(), b'Z', b"rg1\0".to_vec()),
             ]
         );
+    }
+
+    #[test]
+    fn test_raw_tags_extract_string_batch() {
+        use crate::fields::RawRecordView;
+        let aux = b"RGZmygrp\0BCZACGT\0MCZ50M\0";
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let s = RawRecordView::new(&rec).tags().extract_string_batch(b"BC");
+        assert_eq!(s.rg, Some(b"mygrp".as_slice()));
+        assert_eq!(s.cell, Some(b"ACGT".as_slice()));
+        assert_eq!(s.mc, Some("50M"));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -729,6 +729,46 @@ pub fn append_i32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i32])
     }
 }
 
+/// Append a `u16` array (`B:S`-type) tag to a BAM record.
+///
+/// Format: `[tag0, tag1, 'B', 'S', count_u32_le, values_u16_le...]`
+///
+/// # Panics
+///
+/// Panics if `values.len()` exceeds `u32::MAX`.
+pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
+    record.push(tag[0]);
+    record.push(tag[1]);
+    record.push(b'B');
+    record.push(b'S');
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
+    for &v in values {
+        record.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+/// Append an `f32` array (`B:f`-type) tag to a BAM record.
+///
+/// Format: `[tag0, tag1, 'B', 'f', count_u32_le, values_f32_le...]`
+///
+/// # Panics
+///
+/// Panics if `values.len()` exceeds `u32::MAX`.
+pub fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
+    record.push(tag[0]);
+    record.push(tag[1]);
+    record.push(b'B');
+    record.push(b'f');
+    record.extend_from_slice(
+        &u32::try_from(values.len()).expect("array length exceeds u32").to_le_bytes(),
+    );
+    for &v in values {
+        record.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
 /// Normalize an integer tag to the smallest signed type that fits its value.
 ///
 /// If the tag exists and is an integer type, it is re-encoded using
@@ -1307,6 +1347,165 @@ impl<'a> RawTagsEditor<'a> {
     #[inline]
     pub fn update_string(&mut self, tag: &[u8; 2], value: &[u8]) {
         update_string_tag(self.record, tag, value);
+    }
+
+    /// Update an existing `f`-type tag in place, or remove + append if the existing tag has a
+    /// different type or is absent.
+    pub fn update_float(&mut self, tag: &[u8; 2], value: f32) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'f' && abs + 7 <= self.record.len() {
+                self.record[abs + 3..abs + 7].copy_from_slice(&value.to_le_bytes());
+                return;
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_float_tag(self.record, tag, value);
+    }
+
+    /// Update an existing `B:C` (u8 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_u8(&mut self, tag: &[u8; 2], values: &[u8]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'C' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    self.record[body..body + values.len()].copy_from_slice(values);
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_u8_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:S` (u16 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_u16(&mut self, tag: &[u8; 2], values: &[u16]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'S' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 2;
+                        self.record[dst..dst + 2].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_u16_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:s` (i16 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_i16(&mut self, tag: &[u8; 2], values: &[i16]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b's' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 2;
+                        self.record[dst..dst + 2].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_i16_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:i` (i32 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_i32(&mut self, tag: &[u8; 2], values: &[i32]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'i' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 4;
+                        self.record[dst..dst + 4].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_i32_array_tag(self.record, tag, values);
+    }
+
+    /// Update an existing `B:f` (f32 array) tag in place if the length matches, else remove and
+    /// append.
+    pub fn update_array_f32(&mut self, tag: &[u8; 2], values: &[f32]) {
+        let off = self.aux_offset.min(self.record.len());
+        if let Some((p, val_type)) = find_tag_position(&self.record[off..], *tag) {
+            let abs = off + p;
+            if val_type == b'B' && abs + 8 <= self.record.len() && self.record[abs + 3] == b'f' {
+                let count = u32::from_le_bytes([
+                    self.record[abs + 4],
+                    self.record[abs + 5],
+                    self.record[abs + 6],
+                    self.record[abs + 7],
+                ]) as usize;
+                if count == values.len() {
+                    let body = abs + 8;
+                    for (i, &v) in values.iter().enumerate() {
+                        let dst = body + i * 4;
+                        self.record[dst..dst + 4].copy_from_slice(&v.to_le_bytes());
+                    }
+                    return;
+                }
+            }
+            if let Some(size) = tag_value_size(val_type, &self.record[abs + 3..]) {
+                self.record.drain(abs..abs + 3 + size);
+            }
+        }
+        append_f32_array_tag(self.record, tag, values);
     }
 
     /// Remove a tag from the record. No-op if the tag is not found.
@@ -3279,5 +3478,114 @@ mod tests {
         assert_eq!(dst.tags().find_string(b"RG"), Some(b"mygrp".as_slice()));
         assert_eq!(dst.tags().find_int(b"NM"), None); // skipped
         assert_eq!(dst.tags().find_int(b"AS"), Some(10));
+    }
+
+    // ========================================================================
+    // update_float + update_array_* tests
+    // ========================================================================
+
+    #[test]
+    fn test_editor_update_float() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_float(b"AS", 12.5);
+            ed.update_float(b"AS", 99.25);
+        }
+        assert!((RawRecordView::new(&rec).tags().find_float(b"AS").unwrap() - 99.25).abs() < 1e-6);
+
+        // Updating a non-existent float tag inserts it
+        let mut rec2 = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec2);
+            ed.update_float(b"BB", 1.5);
+        }
+        assert!((RawRecordView::new(&rec2).tags().find_float(b"BB").unwrap() - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_editor_update_array_u16_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u16(b"bq", &[0u16, 1, 2, 3]); // not present -> append
+            ed.update_array_u16(b"bq", &[10, 20, 30, 40]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"bq").expect("present");
+        let vals = array_tag_to_vec_u16(&arr);
+        assert_eq!(vals, vec![10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_editor_update_array_u16_different_length_splices() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u16(b"bq", &[1u16, 2, 3]); // not present -> append
+            ed.update_array_u16(b"bq", &[7u16, 8, 9, 10, 11]); // grows
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"bq").expect("present");
+        let vals = array_tag_to_vec_u16(&arr);
+        assert_eq!(vals, vec![7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn test_editor_update_array_i32_grow_then_in_place() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_i32(b"sc", &[100, 200, 300]);
+            // Same-length in-place
+            ed.update_array_i32(b"sc", &[-1, -2, -3]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sc").expect("present");
+        assert_eq!(arr.elem_type, b'i');
+        assert_eq!(arr.count, 3);
+    }
+
+    #[test]
+    fn test_editor_update_array_f32() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_f32(b"fa", &[1.0, 2.0, 3.0]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"fa").expect("present");
+        assert_eq!(arr.elem_type, b'f');
+        assert_eq!(arr.count, 3);
+    }
+
+    #[test]
+    fn test_editor_update_array_u8_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_u8(b"ML", &[10u8, 20, 30]); // not present -> append
+            ed.update_array_u8(b"ML", &[40u8, 50, 60]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"ML").expect("present");
+        assert_eq!(arr.elem_type, b'C');
+        assert_eq!(arr.count, 3);
+        assert_eq!(arr.data, &[40u8, 50, 60]);
+    }
+
+    #[test]
+    fn test_editor_update_array_i16_same_length() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.update_array_i16(b"sq", &[-100i16, 0, 100]); // not present -> append
+            ed.update_array_i16(b"sq", &[-200i16, 0, 200]); // same length -> in-place
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sq").expect("present");
+        assert_eq!(arr.elem_type, b's');
+        assert_eq!(arr.count, 3);
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1206,6 +1206,44 @@ impl RawRecordMut<'_> {
     }
 }
 
+/// Length-changing tag editor.
+///
+/// Borrows a full BAM record byte buffer plus the cached aux offset (so update/
+/// append/remove ops don't repeat the header scan). Splices the aux section
+/// in place via `Vec::splice` for length-changing operations.
+pub struct RawTagsEditor<'a> {
+    record: &'a mut Vec<u8>,
+    aux_offset: usize,
+}
+
+impl<'a> RawTagsEditor<'a> {
+    /// Borrow a full BAM record byte buffer.
+    ///
+    /// Computes and caches `aux_offset` once. If the record is too short for
+    /// a valid header, `aux_offset` falls back to `record.len()` so all tag
+    /// ops behave as if the aux section is empty.
+    #[inline]
+    pub fn from_vec(record: &'a mut Vec<u8>) -> Self {
+        let aux_offset = aux_data_offset_from_record(record).unwrap_or(record.len());
+        Self { record, aux_offset }
+    }
+
+    /// Returns the cached aux offset (start of tag section).
+    #[inline]
+    #[must_use]
+    pub fn aux_offset(&self) -> usize {
+        self.aux_offset
+    }
+
+    /// Borrow the aux section as a read-only view.
+    #[inline]
+    #[must_use]
+    pub fn view(&self) -> RawTagsView<'_> {
+        let off = self.aux_offset.min(self.record.len());
+        RawTagsView::new(&self.record[off..])
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 mod tests {
@@ -3061,5 +3099,19 @@ mod tests {
         assert!(ok);
         let got = RawRecordView::new(&rec).tags().find_float(b"AS").unwrap();
         assert!((got - 99.25).abs() < 1e-6);
+    }
+
+    // ========================================================================
+    // RawTagsEditor tests
+    // ========================================================================
+
+    #[test]
+    fn test_raw_tags_editor_from_vec_caches_aux_offset() {
+        let aux = b"RGZmygrp\0";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let expected_off = aux_data_offset_from_record(&rec).unwrap();
+        let editor = RawTagsEditor::from_vec(&mut rec);
+        assert_eq!(editor.aux_offset(), expected_off);
+        assert_eq!(editor.view().find_string(b"RG"), Some(b"mygrp".as_slice()));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -913,6 +913,53 @@ impl<'a> RawTagsView<'a> {
     }
 }
 
+/// Forward-only iterator over aux tag entries.
+///
+/// Yields `TagEntry` values containing the 2-byte tag, the type byte, and
+/// the raw value bytes (whose length is determined by the type per BAM spec).
+/// Stops at the first malformed entry.
+pub struct AuxTagsIter<'a> {
+    aux: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Iterator for AuxTagsIter<'a> {
+    type Item = TagEntry<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos + 3 > self.aux.len() {
+            return None;
+        }
+        let tag = [self.aux[self.pos], self.aux[self.pos + 1]];
+        let type_byte = self.aux[self.pos + 2];
+        let value_start = self.pos + 3;
+        let size = tag_value_size(type_byte, &self.aux[value_start..])?;
+        let end = value_start.checked_add(size)?;
+        if end > self.aux.len() {
+            return None;
+        }
+        let entry = TagEntry { tag, type_byte, value_bytes: &self.aux[value_start..end] };
+        self.pos = end;
+        Some(entry)
+    }
+}
+
+impl<'a> RawTagsView<'a> {
+    /// Iterate over aux tag entries without allocating.
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> AuxTagsIter<'a> {
+        AuxTagsIter { aux: self.0, pos: 0 }
+    }
+}
+
+impl<'a> IntoIterator for &RawTagsView<'a> {
+    type Item = TagEntry<'a>;
+    type IntoIter = AuxTagsIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<'a> RawRecordView<'a> {
     /// Returns a read-only view over this record's auxiliary tag section.
     #[inline]
@@ -2597,5 +2644,32 @@ mod tests {
         assert!(!tags.is_empty());
         assert!(tags.contains(b"RG"));
         assert!(!tags.contains(b"NM"));
+    }
+
+    #[test]
+    fn test_raw_tags_iter_basic() {
+        use crate::fields::RawRecordView;
+        // RG:Z:rg1\0 NM:i:5 (4 bytes LE)
+        let mut aux: Vec<u8> = b"RGZrg1\0".to_vec();
+        aux.extend_from_slice(b"NMi");
+        aux.extend_from_slice(&5i32.to_le_bytes());
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+
+        let v = RawRecordView::new(&rec);
+        let mut entries: Vec<(String, u8, Vec<u8>)> = v
+            .tags()
+            .iter()
+            .map(|e| {
+                (String::from_utf8(e.tag.to_vec()).unwrap(), e.type_byte, e.value_bytes.to_vec())
+            })
+            .collect();
+        entries.sort();
+        assert_eq!(
+            entries,
+            vec![
+                ("NM".into(), b'i', 5i32.to_le_bytes().to_vec()),
+                ("RG".into(), b'Z', b"rg1\0".to_vec()),
+            ]
+        );
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1242,6 +1242,94 @@ impl<'a> RawTagsEditor<'a> {
         let off = self.aux_offset.min(self.record.len());
         RawTagsView::new(&self.record[off..])
     }
+
+    // -- append (always grow) --
+
+    /// Append a string (Z-type) tag to the record.
+    #[inline]
+    pub fn append_string(&mut self, tag: &[u8; 2], value: &[u8]) {
+        append_string_tag(self.record, tag, value);
+    }
+
+    /// Append an integer tag, choosing the smallest fitting unsigned/signed type.
+    #[inline]
+    pub fn append_int(&mut self, tag: &[u8; 2], value: i32) {
+        append_int_tag(self.record, tag, value);
+    }
+
+    /// Append a signed integer tag, choosing the smallest fitting signed type.
+    #[inline]
+    pub fn append_signed_int(&mut self, tag: &[u8; 2], value: i32) {
+        append_signed_int_tag(self.record, tag, value);
+    }
+
+    /// Append a float (`f`-type) tag to the record.
+    #[inline]
+    pub fn append_float(&mut self, tag: &[u8; 2], value: f32) {
+        append_float_tag(self.record, tag, value);
+    }
+
+    /// Append a Phred+33-encoded quality string tag.
+    ///
+    /// Converts raw Phred scores (0–93) to ASCII (Phred+33) and writes as a Z-type tag.
+    #[inline]
+    pub fn append_phred33_string(&mut self, tag: &[u8; 2], quals: &[u8]) {
+        append_phred33_string_tag(self.record, tag, quals);
+    }
+
+    /// Append a `B:C` (u8 array) tag to the record.
+    #[inline]
+    pub fn append_array_u8(&mut self, tag: &[u8; 2], values: &[u8]) {
+        append_u8_array_tag(self.record, tag, values);
+    }
+
+    /// Append a `B:s` (i16 array) tag to the record.
+    #[inline]
+    pub fn append_array_i16(&mut self, tag: &[u8; 2], values: &[i16]) {
+        append_i16_array_tag(self.record, tag, values);
+    }
+
+    /// Append a `B:i` (i32 array) tag to the record.
+    #[inline]
+    pub fn append_array_i32(&mut self, tag: &[u8; 2], values: &[i32]) {
+        append_i32_array_tag(self.record, tag, values);
+    }
+
+    // -- update / remove / normalize --
+
+    /// Update an existing integer tag in place, or append it if absent.
+    #[inline]
+    pub fn update_int(&mut self, tag: &[u8; 2], value: i32) {
+        update_int_tag(self.record, tag, value);
+    }
+
+    /// Update an existing string tag in place, or append it if absent.
+    #[inline]
+    pub fn update_string(&mut self, tag: &[u8; 2], value: &[u8]) {
+        update_string_tag(self.record, tag, value);
+    }
+
+    /// Remove a tag from the record. No-op if the tag is not found.
+    #[inline]
+    pub fn remove(&mut self, tag: &[u8; 2]) {
+        remove_tag(self.record, tag);
+    }
+
+    /// Re-encode an existing integer tag using the smallest fitting signed type.
+    ///
+    /// No-op if the tag is not found or is not an integer type.
+    #[inline]
+    pub fn normalize_int_to_smallest_signed(&mut self, tag: &[u8; 2]) {
+        normalize_int_tag_to_smallest_signed(self.record, tag);
+    }
+
+    /// Copy entries from a source aux view to this record, optionally skipping tags by key.
+    ///
+    /// All tags in `src` are appended to the record unless their two-byte key appears in `skip`.
+    #[inline]
+    pub fn copy_from(&mut self, src: RawTagsView<'_>, skip: &[&[u8; 2]]) {
+        copy_aux_tags(src.as_bytes(), self.record, skip);
+    }
 }
 
 #[cfg(test)]
@@ -3113,5 +3201,83 @@ mod tests {
         let editor = RawTagsEditor::from_vec(&mut rec);
         assert_eq!(editor.aux_offset(), expected_off);
         assert_eq!(editor.view().find_string(b"RG"), Some(b"mygrp".as_slice()));
+    }
+
+    #[test]
+    fn test_editor_append_remove_update_int_string_roundtrip() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_string(b"RG", b"mygrp");
+            ed.append_int(b"NM", 5);
+            ed.update_int(b"NM", 7);
+            ed.update_string(b"RG", b"newgrp");
+        }
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.tags().find_string(b"RG"), Some(b"newgrp".as_slice()));
+        assert_eq!(v.tags().find_int(b"NM"), Some(7));
+
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.remove(b"NM");
+        }
+        assert_eq!(RawRecordView::new(&rec).tags().find_int(b"NM"), None);
+    }
+
+    #[test]
+    fn test_editor_normalize_int_to_smallest_signed() {
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_int(b"NM", 100_000); // Will encode as 'i' (i32) — fits 100,000
+            ed.normalize_int_to_smallest_signed(b"NM");
+        }
+        let aux = aux_data_slice(&rec);
+        let (p, t) = find_tag_position(aux, *b"NM").unwrap();
+        assert_eq!(t, b'i');
+        assert_eq!(i32::from_le_bytes([aux[p + 3], aux[p + 4], aux[p + 5], aux[p + 6]]), 100_000);
+    }
+
+    #[test]
+    fn test_editor_append_phred33_string() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_phred33_string(b"OQ", &[30, 31, 32, 33]);
+        }
+        // Phred+33: 30 -> '?', 31 -> '@', 32 -> 'A', 33 -> 'B'
+        assert_eq!(RawRecordView::new(&rec).tags().find_string(b"OQ"), Some(b"?@AB".as_slice()));
+    }
+
+    #[test]
+    fn test_editor_append_array_i16() {
+        use crate::fields::RawRecordView;
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let mut ed = RawTagsEditor::from_vec(&mut rec);
+            ed.append_array_i16(b"sq", &[-100, 0, 100]);
+        }
+        let arr = RawRecordView::new(&rec).tags().find_array(b"sq").expect("present");
+        assert_eq!(arr.count, 3);
+        assert_eq!(arr.elem_type, b's');
+    }
+
+    #[test]
+    fn test_editor_copy_from_skip() {
+        use crate::fields::RawRecordView;
+        let src_aux = b"RGZmygrp\0NMc\x05ASc\x0a";
+        let src_rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, src_aux);
+        let mut dst_rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        {
+            let src_view = RawRecordView::new(&src_rec);
+            let mut ed = RawTagsEditor::from_vec(&mut dst_rec);
+            ed.copy_from(src_view.tags(), &[b"NM"]);
+        }
+        let dst = RawRecordView::new(&dst_rec);
+        assert_eq!(dst.tags().find_string(b"RG"), Some(b"mygrp".as_slice()));
+        assert_eq!(dst.tags().find_int(b"NM"), None); // skipped
+        assert_eq!(dst.tags().find_int(b"AS"), Some(10));
     }
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1,4 +1,6 @@
-use crate::fields::{TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size};
+use crate::fields::{
+    RawRecordView, TAG_FIXED_SIZES, aux_data_offset_from_record, aux_data_slice, tag_value_size,
+};
 
 /// Find a tag's position and type byte in auxiliary data.
 ///
@@ -796,6 +798,127 @@ pub fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]])
         }
 
         offset = entry_end;
+    }
+}
+
+/// Zero-allocation entry yielded by tag iterators.
+#[derive(Copy, Clone, Debug)]
+pub struct TagEntry<'a> {
+    pub tag: [u8; 2],
+    pub type_byte: u8,
+    pub value_bytes: &'a [u8],
+}
+
+/// Borrowed read-only view over a BAM record's auxiliary tag section.
+#[derive(Copy, Clone, Debug)]
+pub struct RawTagsView<'a>(&'a [u8]);
+
+impl<'a> RawTagsView<'a> {
+    /// Wraps a raw auxiliary-data slice.
+    #[inline]
+    #[must_use]
+    pub const fn new(aux: &'a [u8]) -> Self {
+        Self(aux)
+    }
+
+    /// Returns the underlying aux-data bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.0
+    }
+
+    /// Returns the number of bytes in the aux section.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the aux section is empty (no tags present).
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns `true` if the named tag is present in the aux section.
+    #[inline]
+    #[must_use]
+    pub fn contains(&self, tag: &[u8; 2]) -> bool {
+        find_tag_type(self.0, tag).is_some()
+    }
+
+    /// Returns the value of a `Z`-type (string) tag, without the null terminator.
+    ///
+    /// Returns `None` if the tag is absent or is not `Z`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_string(&self, tag: &[u8; 2]) -> Option<&'a [u8]> {
+        find_string_tag(self.0, tag)
+    }
+
+    /// Returns the value of any integer tag (`c/C/s/S/i/I`) widened to `i64`.
+    ///
+    /// Returns `None` if the tag is absent or is not an integer type.
+    #[inline]
+    #[must_use]
+    pub fn find_int(&self, tag: &[u8; 2]) -> Option<i64> {
+        find_int_tag(self.0, tag)
+    }
+
+    /// Returns the value of a `C`-type (unsigned byte) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `C`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_uint8(&self, tag: &[u8; 2]) -> Option<u8> {
+        find_uint8_tag(self.0, tag)
+    }
+
+    /// Returns the value of an `f`-type (32-bit float) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `f`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_float(&self, tag: &[u8; 2]) -> Option<f32> {
+        find_float_tag(self.0, tag)
+    }
+
+    /// Returns a zero-allocation reference to a `B`-type (array) tag.
+    ///
+    /// Returns `None` if the tag is absent or is not `B`-typed.
+    #[inline]
+    #[must_use]
+    pub fn find_array(&self, tag: &[u8; 2]) -> Option<ArrayTagRef<'a>> {
+        find_array_tag(self.0, tag)
+    }
+
+    /// Returns the MI (Molecular Identifier) tag as `(value, is_A_suffix)`.
+    ///
+    /// Returns `None` if the tag is absent or cannot be parsed.
+    #[inline]
+    #[must_use]
+    pub fn find_mi(&self) -> Option<(u64, bool)> {
+        find_mi_tag(self.0)
+    }
+
+    /// Returns the MC (mate CIGAR) tag as a `&str`.
+    ///
+    /// Returns `None` if the tag is absent or is not valid UTF-8.
+    #[inline]
+    #[must_use]
+    pub fn find_mc(&self) -> Option<&'a str> {
+        find_mc_tag(self.0)
+    }
+}
+
+impl<'a> RawRecordView<'a> {
+    /// Returns a read-only view over this record's auxiliary tag section.
+    #[inline]
+    #[must_use]
+    pub fn tags(&self) -> RawTagsView<'a> {
+        RawTagsView::new(aux_data_slice(self.as_bytes()))
     }
 }
 
@@ -2461,5 +2584,18 @@ mod tests {
         assert_eq!(arr.elem_type, b'C');
         assert_eq!(arr.count, values.len());
         assert_eq!(arr.data, values);
+    }
+
+    #[test]
+    fn test_raw_tags_view_construction_and_find_string() {
+        use crate::fields::RawRecordView;
+        let aux = b"RGZmysample\0";
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let v = RawRecordView::new(&rec);
+        let tags = v.tags();
+        assert_eq!(tags.find_string(b"RG"), Some(b"mysample".as_slice()));
+        assert!(!tags.is_empty());
+        assert!(tags.contains(b"RG"));
+        assert!(!tags.contains(b"NM"));
     }
 }

--- a/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
+++ b/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "noodles")]
+
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+use fgumi_raw_bam::{RawRecord, raw_records_to_record_bufs};
+use noodles::sam::alignment::record::Cigar;
+
+/// Decode a single [`RawRecord`] through noodles and return the parsed record.
+///
+/// Panics if noodles cannot parse the bytes — that failure is the test signal.
+fn decode_with_noodles(rec: &RawRecord) -> noodles::sam::alignment::RecordBuf {
+    let buffers = vec![rec.as_ref().to_vec()];
+    let mut bufs = raw_records_to_record_bufs(&buffers).expect("noodles decode failed");
+    bufs.pop().expect("expected at least one decoded record")
+}
+
+/// Build a minimal valid [`RawRecord`] for use as proptest input.
+///
+/// Constructs a record with the given name, a single Match CIGAR op covering
+/// `l_seq` bases, and no aux data.  The sequence bytes are left as all-zeros
+/// (the BAM encoding for all-N) which is valid.
+fn build_record(name: &[u8], l_seq: usize) -> RawRecord {
+    let cigar = if l_seq > 0 { vec![encode_op(0, l_seq)] } else { vec![] };
+    let bytes = make_bam_bytes(0, 0, 0, name, &cigar, l_seq, -1, -1, b"");
+    RawRecord::from(bytes)
+}
+
+proptest::proptest! {
+    /// Verify that [`RawRecord::set_read_name`] produces bytes that noodles decodes
+    /// to the same name, across many random name strings.
+    #[test]
+    fn set_read_name_roundtrips(name in "[A-Za-z0-9_]{1,200}") {
+        let mut rec = build_record(b"placeholder", 4);
+        rec.set_read_name(name.as_bytes());
+
+        // Internal view must reflect the new name.
+        proptest::prop_assert_eq!(rec.read_name(), name.as_bytes());
+
+        // Noodles must decode the same name.
+        let buf = decode_with_noodles(&rec);
+        let decoded = buf.name().map(std::convert::AsRef::as_ref);
+        proptest::prop_assert_eq!(decoded, Some(name.as_bytes()));
+    }
+
+    /// Verify that [`RawRecord::set_cigar_ops`] produces bytes that noodles decodes
+    /// to the same CIGAR operations (kind + length), across many random op sequences.
+    #[test]
+    fn set_cigar_ops_roundtrips(
+        ops in proptest::collection::vec(1u32..=100u32, 1..=10),
+    ) {
+        // Build all-Match ops so the sequence length equals the sum of op lengths.
+        let total: usize = ops.iter().map(|&l| l as usize).sum();
+        // CIGAR word encodes length in upper bits, op type (M=0) in lower 4 bits.
+        let cigar_ops: Vec<u32> = ops.iter().map(|&len| len << 4).collect();
+
+        let mut rec = build_record(b"r", total);
+        rec.set_cigar_ops(&cigar_ops);
+
+        // Internal view must reflect the new CIGAR.
+        proptest::prop_assert_eq!(rec.cigar_ops_vec(), cigar_ops.clone());
+
+        // Noodles must decode each op with the same kind and length.
+        let buf = decode_with_noodles(&rec);
+        let decoded: Vec<(noodles::sam::alignment::record::cigar::op::Kind, usize)> = buf
+            .cigar()
+            .iter()
+            .map(|r| r.expect("noodles cigar op decode failed"))
+            .map(|op| (op.kind(), op.len()))
+            .collect();
+        let expected: Vec<(noodles::sam::alignment::record::cigar::op::Kind, usize)> = ops
+            .iter()
+            .map(|&len| (noodles::sam::alignment::record::cigar::op::Kind::Match, len as usize))
+            .collect();
+        proptest::prop_assert_eq!(decoded, expected);
+    }
+
+    /// Verify that [`RawRecord::set_sequence_and_qualities`] produces bytes that
+    /// noodles decodes to the same bases and quality scores, across many random
+    /// sequence lengths.
+    #[test]
+    fn set_sequence_and_qualities_roundtrips(
+        n in 1usize..=200,
+    ) {
+        // Build deterministic bases + quals from the length.
+        let bases: Vec<u8> = (0..n).map(|i| b"ACGTN"[i % 5]).collect();
+        // i % 40 is always 0..=39, so the truncation is safe.
+        #[allow(clippy::cast_possible_truncation)]
+        let quals: Vec<u8> = (0..n).map(|i| (i % 40) as u8).collect();
+
+        let mut rec = build_record(b"r", 1);
+        // Update the CIGAR to match the new sequence length before writing seq+qual.
+        // n <= 200 and u32::MAX >> 4 is well above 200, so the cast is safe.
+        #[allow(clippy::cast_possible_truncation)]
+        rec.set_cigar_ops(&[(n as u32) << 4]);
+        rec.set_sequence_and_qualities(&bases, &quals);
+
+        // Internal view must reflect the new sequence and qualities.
+        proptest::prop_assert_eq!(rec.sequence_vec(), bases.clone());
+        proptest::prop_assert_eq!(rec.quality_scores().to_vec(), quals.clone());
+
+        // Noodles must decode the same bases and quality scores element-wise.
+        let buf = decode_with_noodles(&rec);
+        proptest::prop_assert_eq!(buf.sequence().as_ref(), bases.as_slice());
+        proptest::prop_assert_eq!(buf.quality_scores().as_ref(), quals.as_slice());
+    }
+}


### PR DESCRIPTION
## Summary

Part 1 of 5 in the stacked series closing #272.

Introduces the six-type `fgumi-raw-bam` wrapper hierarchy and closes every gap catalogued in the issue. This PR is **purely additive** — the old free-function API remains `pub` so no downstream caller breaks. Migration to the new types, demotion of the old API, tests/benches, and perf optimizations land in follow-up PRs.

## New types

| Type | Backing | Capability |
|---|---|---|
| `RawRecordView<'a>` | `&'a [u8]` | All read accessors |
| `RawRecordMut<'a>` | `&'a mut [u8]` | Fixed-length writes |
| `RawRecord` | `Vec<u8>` | Length-changing edits |
| `RawTagsView<'a>` | `&'a [u8]` | Tag finders + zero-alloc iteration |
| `RawTagsMut<'a>` | `&'a mut [u8]` | Array element writes, in-place flips |
| `RawTagsEditor<'a>` | `&'a mut Vec<u8>` + cached `aux_offset` | Append/remove/update/resize |

## Issue 272 gaps closed (13 new methods)

**Easy:** `bin()`, `set_bin()`, `update_float()`, `set_array_element_{u8,u16,i16,i32,f32}()`, `update_array_{u8,u16,i16,i32,f32}()`
**Medium (length-changing):** `set_read_name()`, `set_cigar_ops()`, `set_sequence_and_qualities()`
**Nice:** `RawTagsView::iter()` (zero-allocation)

## Test coverage in this PR

- Port of all existing unit tests to the new API (in the same commit that introduces each type)
- `tests/noodles_roundtrip.rs` — proptests cross-checking all three length-changing edits against noodles decode

## Suggested reading order

1. `crates/fgumi-raw-bam/src/fields.rs` — `RawRecordView` + `RawRecordMut`
2. `crates/fgumi-raw-bam/src/tags.rs` — tag sub-types
3. `crates/fgumi-raw-bam/src/raw_bam_record.rs` — `RawRecord` delegators + length-changing edits
4. `crates/fgumi-raw-bam/src/{cigar,sequence}.rs` — view method impls

## Test plan

- [x] `cargo ci-test` — workspace tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean
- [x] Noodles round-trip proptests validate length-changing edits

## Stack

- **PR 1 (this):** Core API + gap closures
- PR 2: Migrate internal + downstream crates to the new API
- PR 3: Demote old free-function API to `pub(crate)` (BREAKING)
- PR 4: Tests + benchmarks
- PR 5: Post-refactor perf optimizations

Closes #272 when the full stack lands.

Supersedes #277.