### PR TITLE
refactor: migrate fgumi to new raw-bam view/editor API

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -84,7 +84,7 @@ use crate::vanilla_caller::{
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
 use anyhow::Result;
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
 use noodles::sam::alignment::record::data::field::Tag;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -416,9 +416,10 @@ impl CodecConsensusCaller {
         clip_from_start: bool,
         clipped_cigar: Option<&[u32]>,
     ) -> SourceRead {
-        let mut bases = bam_fields::extract_sequence(raw);
-        let mut quals = bam_fields::quality_scores_slice(raw).to_vec();
-        let flg = bam_fields::flags(raw);
+        let view = RawRecordView::new(raw);
+        let mut bases = view.sequence_vec();
+        let mut quals = view.quality_scores().to_vec();
+        let flg = view.flags();
 
         // Apply clipping: truncate bases and quals
         // Clamp clip_amount to avoid panic on malformed input (e.g., CIGAR/MC mismatch)
@@ -451,8 +452,8 @@ impl CodecConsensusCaller {
             quals.reverse();
         }
 
-        let rid = bam_fields::ref_id(raw);
-        let astart = i64::from(bam_fields::pos(raw));
+        let rid = view.ref_id();
+        let astart = i64::from(view.pos());
         let original_cigar = {
             let ops = bam_fields::get_cigar_ops(raw);
             bam_fields::simplify_cigar_from_raw(&ops)
@@ -533,14 +534,16 @@ impl CodecConsensusCaller {
         }
 
         // Extract MI tag from first record for naming
-        let umi: Option<String> = bam_fields::find_string_tag_in_record(&records[0], b"MI")
+        let umi: Option<String> = RawRecordView::new(&records[0])
+            .tags()
+            .find_string(b"MI")
             .map(|b| String::from_utf8_lossy(b).to_string());
 
         // Phase 1: Filter on raw bytes — keep paired, primary, mapped, FR-pair reads
         let mut paired_indices: Vec<usize> = Vec::new();
         let mut frag_count = 0usize;
         for (i, raw) in records.iter().enumerate() {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             if flg & flags::PAIRED == 0 {
                 frag_count += 1;
                 continue;
@@ -567,7 +570,7 @@ impl CodecConsensusCaller {
         let mut by_name: HashMap<&[u8], Vec<usize>> = HashMap::new();
         let mut name_order: Vec<&[u8]> = Vec::new();
         for &idx in &paired_indices {
-            let name = bam_fields::read_name(&records[idx]);
+            let name = RawRecordView::new(&records[idx]).read_name();
             if !by_name.contains_key(name) {
                 name_order.push(name);
             }
@@ -584,7 +587,7 @@ impl CodecConsensusCaller {
             }
 
             let (i1, i2) = {
-                let flg0 = bam_fields::flags(&records[indices[0]]);
+                let flg0 = RawRecordView::new(&records[indices[0]]).flags();
                 if flg0 & flags::FIRST_SEGMENT != 0 {
                     (indices[0], indices[1])
                 } else {
@@ -810,7 +813,8 @@ impl CodecConsensusCaller {
 
     /// Build `ClippedRecordInfo` for a single raw record.
     fn build_clipped_info(raw: &[u8], raw_idx: usize, clip_amount: usize) -> ClippedRecordInfo {
-        let flg = bam_fields::flags(raw);
+        let view = RawRecordView::new(raw);
+        let flg = view.flags();
         let is_reverse = flg & flags::REVERSE != 0;
         let clip_from_start = is_reverse; // negative strand ⟹ clip from start
 
@@ -818,11 +822,11 @@ impl CodecConsensusCaller {
         let (clipped_cigar, ref_bases_consumed) =
             bam_fields::clip_cigar_ops_raw(&original_ops, clip_amount, clip_from_start);
 
-        let original_seq_len = bam_fields::l_seq(raw) as usize;
+        let original_seq_len = view.l_seq() as usize;
         let clipped_seq_len = original_seq_len.saturating_sub(clip_amount);
 
         // 1-based alignment start, adjusted for start-clipping
-        let pos_0based = bam_fields::pos(raw);
+        let pos_0based = view.pos();
         debug_assert!(
             pos_0based >= 0,
             "build_clipped_info called on unmapped record (pos={pos_0based})"
@@ -1324,7 +1328,7 @@ impl CodecConsensusCaller {
         if let Some(cell_tag) = &self.options.cell_tag {
             let cell_tag_bytes: [u8; 2] = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
             for raw in source_raws {
-                if let Some(cell_bc) = bam_fields::find_string_tag_in_record(raw, &cell_tag_bytes) {
+                if let Some(cell_bc) = RawRecordView::new(raw).tags().find_string(&cell_tag_bytes) {
                     if !cell_bc.is_empty() {
                         self.bam_builder.append_string_tag(&cell_tag_bytes, cell_bc);
                         break;
@@ -1340,7 +1344,9 @@ impl CodecConsensusCaller {
         let umis: Vec<String> = all_records
             .iter()
             .filter_map(|raw| {
-                bam_fields::find_string_tag_in_record(raw, b"RX")
+                RawRecordView::new(raw)
+                    .tags()
+                    .find_string(b"RX")
                     .and_then(|b| String::from_utf8(b.to_vec()).ok())
             })
             .collect();
@@ -1510,7 +1516,7 @@ impl CodecConsensusCaller {
     ) -> Option<usize> {
         let raw = Self::record_buf_to_raw(rec);
         let cigar_ops = bam_fields::get_cigar_ops(&raw);
-        let alignment_start = (bam_fields::pos(&raw) + 1) as usize; // 1-based
+        let alignment_start = (RawRecordView::new(&raw).pos() + 1) as usize; // 1-based
         bam_fields::read_pos_at_ref_pos_raw(
             &cigar_ops,
             alignment_start,

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -210,7 +210,7 @@ use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{ReadType, SourceRead};
-use fgumi_raw_bam::{self as bam_fields, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
 
 /// Duplex consensus read - matches fgbio's `DuplexConsensusRead`
 ///
@@ -630,8 +630,9 @@ impl DuplexConsensusCaller {
         for record in records {
             // Extract strand info before moving the record (drop borrow before push)
             let is_a_strand = {
-                let Some(mi_bytes) = bam_fields::find_string_tag_in_record(&record, b"MI") else {
-                    let read_name = String::from_utf8_lossy(bam_fields::read_name(&record));
+                let Some(mi_bytes) = RawRecordView::new(&record).tags().find_string(b"MI") else {
+                    let read_name =
+                        String::from_utf8_lossy(RawRecordView::new(&record).read_name());
                     bail!(
                         "Read '{read_name}' is missing MI tag. \
                         The duplex command requires all reads to have MI tags. \
@@ -764,14 +765,14 @@ impl DuplexConsensusCaller {
         let num_a = a_records
             .iter()
             .filter(|r| {
-                let flg = bam_fields::flags(r);
+                let flg = RawRecordView::new(r).flags();
                 (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
             })
             .count();
         let num_b = b_records
             .iter()
             .filter(|r| {
-                let flg = bam_fields::flags(r);
+                let flg = RawRecordView::new(r).flags();
                 (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
             })
             .count();
@@ -811,8 +812,8 @@ impl DuplexConsensusCaller {
         let Some(first) = reads.next() else {
             return true;
         };
-        let first_is_reverse = bam_fields::flags(first) & flags::REVERSE != 0;
-        reads.all(|r| (bam_fields::flags(r) & flags::REVERSE != 0) == first_is_reverse)
+        let first_is_reverse = RawRecordView::new(first).flags() & flags::REVERSE != 0;
+        reads.all(|r| (RawRecordView::new(r).flags() & flags::REVERSE != 0) == first_is_reverse)
     }
 
     // Helper function to cap quality scores to valid range [2, 93]
@@ -1220,23 +1221,11 @@ impl DuplexConsensusCaller {
         // 9. Build RX consensus from source reads
         let mut all_umis = Vec::new();
 
-        for raw in source_reads_a {
-            if let Some(rx_bytes) = bam_fields::find_string_tag_in_record(raw, b"RX") {
+        for raw in source_reads_a.iter().chain(source_reads_b.iter()) {
+            let view = RawRecordView::new(raw);
+            if let Some(rx_bytes) = view.tags().find_string(b"RX") {
                 let rx = String::from_utf8_lossy(rx_bytes).to_string();
-                let is_first = bam_fields::flags(raw) & flags::FIRST_SEGMENT != 0;
-                if is_first == first_of_pair {
-                    all_umis.push(rx);
-                } else {
-                    let reversed: Vec<&str> = rx.split('-').rev().collect();
-                    all_umis.push(reversed.join("-"));
-                }
-            }
-        }
-
-        for raw in source_reads_b {
-            if let Some(rx_bytes) = bam_fields::find_string_tag_in_record(raw, b"RX") {
-                let rx = String::from_utf8_lossy(rx_bytes).to_string();
-                let is_first = bam_fields::flags(raw) & flags::FIRST_SEGMENT != 0;
+                let is_first = view.flags() & flags::FIRST_SEGMENT != 0;
                 if is_first == first_of_pair {
                     all_umis.push(rx);
                 } else {
@@ -1779,20 +1768,42 @@ impl DuplexConsensusCaller {
         let cell_barcode: Option<String> = cell_tag.and_then(|tag| {
             let tag_bytes: [u8; 2] = <[u8; 2]>::from(tag);
             a_records.first().or_else(|| b_records.first()).and_then(|r| {
-                bam_fields::find_string_tag_in_record(r, &tag_bytes)
+                RawRecordView::new(r)
+                    .tags()
+                    .find_string(&tag_bytes)
                     .map(|v| String::from_utf8_lossy(v).into_owned())
             })
         });
 
-        // Split reads into R1/R2 groups for AB and BA strands (done once, reused below)
-        let ab_r1s: Vec<&Vec<u8>> =
-            a_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT != 0).collect();
-        let ab_r2s: Vec<&Vec<u8>> =
-            a_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT == 0).collect();
-        let ba_r1s: Vec<&Vec<u8>> =
-            b_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT != 0).collect();
-        let ba_r2s: Vec<&Vec<u8>> =
-            b_records.iter().filter(|r| bam_fields::flags(r) & flags::FIRST_SEGMENT == 0).collect();
+        // Split reads into R1/R2 groups for AB and BA strands (done once, reused below).
+        // Only properly paired records are classified; unpaired/malformed records are skipped
+        // so they cannot leak into orientation checks, SS consensus, or RX aggregation.
+        let mut ab_r1s = Vec::new();
+        let mut ab_r2s = Vec::new();
+        for r in &a_records {
+            let flg = RawRecordView::new(r).flags();
+            if flg & flags::PAIRED == 0 {
+                continue;
+            }
+            if flg & flags::FIRST_SEGMENT != 0 {
+                ab_r1s.push(r);
+            } else if flg & flags::LAST_SEGMENT != 0 {
+                ab_r2s.push(r);
+            }
+        }
+        let mut ba_r1s = Vec::new();
+        let mut ba_r2s = Vec::new();
+        for r in &b_records {
+            let flg = RawRecordView::new(r).flags();
+            if flg & flags::PAIRED == 0 {
+                continue;
+            }
+            if flg & flags::FIRST_SEGMENT != 0 {
+                ba_r1s.push(r);
+            } else if flg & flags::LAST_SEGMENT != 0 {
+                ba_r2s.push(r);
+            }
+        }
 
         // Validate strand orientations before processing
         // The expected orientations are:

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -850,7 +850,7 @@ pub fn template_passes_raw(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, b
     let mut all_primary_pass = true;
 
     for (idx, record) in raw_records.iter().enumerate() {
-        let flags = bam_fields::flags(record);
+        let flags = RawRecordView::new(record).flags();
         let is_primary = (flags & bam_fields::flags::SECONDARY) == 0
             && (flags & bam_fields::flags::SUPPLEMENTARY) == 0;
 
@@ -892,7 +892,7 @@ pub fn is_duplex_consensus(record: &RecordBuf) -> bool {
 // Raw-byte equivalents (operate on &[u8] / &mut Vec<u8>)
 // ============================================================================
 
-use fgumi_raw_bam as bam_fields;
+use fgumi_raw_bam::{self as bam_fields, RawRecordView};
 use noodles::sam::alignment::record::cigar::op::Kind;
 
 /// Pre-parsed methylation aux tags from a raw BAM record.
@@ -1063,7 +1063,7 @@ pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
     assert!(bam.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(bam);
     let qual_off = bam_fields::qual_offset(bam);
-    let len = bam_fields::l_seq(bam) as usize;
+    let len = RawRecordView::new(bam).l_seq() as usize;
 
     let mut n_count = 0usize;
     let mut qual_sum = 0u64;
@@ -1126,7 +1126,7 @@ pub fn mask_bases_raw(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
 
     // Pre-read per-base arrays into owned Vecs to release the immutable borrow on record
@@ -1181,7 +1181,7 @@ pub fn mask_duplex_bases_raw(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let aux_off = bam_fields::aux_data_offset_from_record(record).unwrap_or(record.len());
 
     // Pre-read per-base arrays and strings into owned data to release the immutable borrow
@@ -1322,7 +1322,7 @@ pub fn mask_methylation_depth_simplex_raw_with_tags(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags present, nothing to filter
     if tags.cu.is_none() && tags.ct.is_none() {
@@ -1374,7 +1374,7 @@ pub fn mask_methylation_depth_duplex_raw_with_tags(
     anyhow::ensure!(record.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags present, nothing to filter
     if tags.cu.is_none() && tags.ct.is_none() {
@@ -1420,24 +1420,24 @@ pub fn resolve_ref_bases_for_record(
     reference: &dyn crate::methylation::RefBaseProvider,
     ref_names: &[String],
 ) -> Option<Vec<Option<u8>>> {
-    let flags = bam_fields::flags(record);
+    let flags = RawRecordView::new(record).flags();
     if flags & bam_fields::flags::UNMAPPED != 0 {
         return None;
     }
 
-    let tid = bam_fields::ref_id(record);
+    let tid = RawRecordView::new(record).ref_id();
     if tid < 0 {
         return None;
     }
     let ref_name = ref_names.get(tid as usize)?;
-    let alignment_start = bam_fields::pos(record) as u64; // 0-based
+    let alignment_start = RawRecordView::new(record).pos() as u64; // 0-based
 
     // Try to get the full sequence slice for O(1) indexed access per base,
     // avoiding a HashMap lookup per position.
     let ref_seq = reference.sequence_for(ref_name);
 
     let cigar_ops = bam_fields::get_cigar_ops(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
     let mut result = Vec::with_capacity(len);
     let mut ref_pos = alignment_start;
 
@@ -1525,7 +1525,7 @@ pub fn mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
 
     let seq_off = bam_fields::seq_offset(record);
     let qual_off = bam_fields::qual_offset(record);
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no per-strand methylation tags, nothing to check
     if tags.au.is_none() && tags.bu.is_none() {
@@ -1629,7 +1629,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
         return true; // unmapped reads pass
     };
 
-    let len = bam_fields::l_seq(record) as usize;
+    let len = RawRecordView::new(record).l_seq() as usize;
 
     // If no methylation tags, pass
     if methylation_tags.cu.is_none() && methylation_tags.ct.is_none() {

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -10,7 +10,7 @@ use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER};
-use fgumi_raw_bam;
+use fgumi_raw_bam::{self, RawRecordView};
 
 /// Check if a base is a no-call (N, n, or .)
 /// Matches htsjdk's SequenceUtil.isNoCall behavior
@@ -474,7 +474,7 @@ impl ReadAndRefPosIterator {
     ) -> Self {
         let rec_start_i32 = rec_start as i32;
         let rec_end_i32 = rec_end as i32;
-        let rec_len = fgumi_raw_bam::l_seq(bam) as i32;
+        let rec_len = RawRecordView::new(bam).l_seq() as i32;
 
         let min_ref_pos = rec_start_i32.max(mate_start as i32);
         let max_ref_pos = rec_end_i32.min(mate_end as i32);
@@ -756,14 +756,14 @@ impl OverlappingBasesConsensusCaller {
     /// Returns an error if raw BAM field extraction or CIGAR parsing fails.
     pub fn call_raw(&mut self, r1: &mut [u8], r2: &mut [u8]) -> Result<bool> {
         // Only process paired reads where both are mapped
-        if fgumi_raw_bam::flags(r1) & fgumi_raw_bam::flags::UNMAPPED != 0
-            || fgumi_raw_bam::flags(r2) & fgumi_raw_bam::flags::UNMAPPED != 0
+        if RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
+            || RawRecordView::new(r2).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
         {
             return Ok(false);
         }
 
         // Must be on the same reference sequence
-        if fgumi_raw_bam::ref_id(r1) != fgumi_raw_bam::ref_id(r2) {
+        if RawRecordView::new(r1).ref_id() != RawRecordView::new(r2).ref_id() {
             return Ok(false);
         }
 
@@ -788,10 +788,10 @@ impl OverlappingBasesConsensusCaller {
         }
 
         // Extract sequences and qualities for modification
-        let mut r1_seq = fgumi_raw_bam::extract_sequence(r1);
-        let mut r2_seq = fgumi_raw_bam::extract_sequence(r2);
-        let mut r1_quals: Vec<u8> = fgumi_raw_bam::quality_scores_slice(r1).to_vec();
-        let mut r2_quals: Vec<u8> = fgumi_raw_bam::quality_scores_slice(r2).to_vec();
+        let mut r1_seq = RawRecordView::new(r1).sequence_vec();
+        let mut r2_seq = RawRecordView::new(r2).sequence_vec();
+        let mut r1_quals: Vec<u8> = RawRecordView::new(r1).quality_scores().to_vec();
+        let mut r2_quals: Vec<u8> = RawRecordView::new(r2).quality_scores().to_vec();
         let mut modified = false;
 
         for pos in overlapping_positions {
@@ -874,8 +874,8 @@ pub fn apply_overlapping_consensus_raw(
     let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> = AHashMap::new();
 
     for (idx, record) in records.iter().enumerate() {
-        let name = fgumi_raw_bam::read_name(record).to_vec();
-        let flg = fgumi_raw_bam::flags(record);
+        let name = RawRecordView::new(record).read_name().to_vec();
+        let flg = RawRecordView::new(record).flags();
 
         if flg & fgumi_raw_bam::flags::FIRST_SEGMENT != 0 {
             read_pairs.entry(name).or_insert((None, None)).0 = Some(idx);
@@ -1523,8 +1523,8 @@ mod tests {
         assert!(result);
 
         // Check that qualities were summed (30 + 20 = 50)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 50);
     }
 
     #[test]
@@ -1542,8 +1542,8 @@ mod tests {
         assert!(result);
 
         // Max quality used (max(30, 20) = 30)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 30);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 30);
     }
 
     #[test]
@@ -1561,8 +1561,8 @@ mod tests {
         assert!(result);
 
         // Qualities unchanged
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 20);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 20);
     }
 
     #[test]
@@ -1580,12 +1580,12 @@ mod tests {
         assert!(result);
 
         // Higher quality base (A from r1) chosen, qual = 30 - 20 = 10
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'A');
         assert_eq!(r2_seq[0], b'A');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 10);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 10);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 10);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 10);
     }
 
     #[test]
@@ -1603,12 +1603,12 @@ mod tests {
         assert!(result);
 
         // Both bases masked to N with quality 2
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1626,12 +1626,12 @@ mod tests {
         assert!(result);
 
         // Only lower quality base (r2) masked
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'A'); // Unchanged
         assert_eq!(r2_seq[0], b'N'); // Masked
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 30); // Unchanged
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2); // Masked
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 30); // Unchanged
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2); // Masked
     }
 
     #[test]
@@ -1649,8 +1649,8 @@ mod tests {
         assert!(result);
 
         // Only lower quality base (r1) masked
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N'); // Masked
         assert_eq!(r2_seq[0], b'G'); // Unchanged
     }
@@ -1670,12 +1670,12 @@ mod tests {
         assert!(result);
 
         // Both masked when qualities are equal
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1693,12 +1693,12 @@ mod tests {
         assert!(result);
 
         // Both masked when qualities are equal
-        let r1_seq = fgumi_raw_bam::extract_sequence(&r1);
-        let r2_seq = fgumi_raw_bam::extract_sequence(&r2);
+        let r1_seq = RawRecordView::new(&r1).sequence_vec();
+        let r2_seq = RawRecordView::new(&r2).sequence_vec();
         assert_eq!(r1_seq[0], b'N');
         assert_eq!(r2_seq[0], b'N');
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     #[test]
@@ -1772,7 +1772,7 @@ mod tests {
         assert!(result);
 
         // Quality capped at 93
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 93);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 93);
     }
 
     #[test]
@@ -1833,8 +1833,8 @@ mod tests {
         assert_eq!(caller.stats().bases_agreeing, 2); // GT == GT
 
         // Check quality sums at overlapping positions
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[2], 50); // 30 + 20
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[3], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[2], 50); // 30 + 20
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[3], 50);
     }
 
     #[test]
@@ -1856,10 +1856,10 @@ mod tests {
         assert_eq!(caller.stats().bases_agreeing, 4); // ACGT == ACGT
 
         // Check quality sums at overlapping positions
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[2], 50); // 30 + 20
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[3], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[4], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[5], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[2], 50); // 30 + 20
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[3], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[4], 50);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[5], 50);
     }
 
     #[test]
@@ -1911,8 +1911,8 @@ mod tests {
         assert!(result);
 
         // Quality difference is 1, but minimum is 2
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r1)[0], 2);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&r2)[0], 2);
+        assert_eq!(RawRecordView::new(&r1).quality_scores()[0], 2);
+        assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
     /// Verify that `call_raw` produces the same results as `call` for agreement.
@@ -1939,8 +1939,8 @@ mod tests {
         caller_raw.call_raw(&mut raw_r1, &mut raw_r2).expect("call_raw should succeed");
 
         // Compare results
-        assert_eq!(rb_r1.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r1));
-        assert_eq!(rb_r2.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r2));
+        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
+        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
         assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
         assert_eq!(caller_buf.stats().bases_agreeing, caller_raw.stats().bases_agreeing);
         assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
@@ -1972,14 +1972,14 @@ mod tests {
         // Compare sequences
         let buf_r1_seq: Vec<u8> = rb_r1.sequence().as_ref().to_vec();
         let buf_r2_seq: Vec<u8> = rb_r2.sequence().as_ref().to_vec();
-        let raw_r1_seq = fgumi_raw_bam::extract_sequence(&raw_r1);
-        let raw_r2_seq = fgumi_raw_bam::extract_sequence(&raw_r2);
+        let raw_r1_seq = RawRecordView::new(&raw_r1).sequence_vec();
+        let raw_r2_seq = RawRecordView::new(&raw_r2).sequence_vec();
         assert_eq!(buf_r1_seq, raw_r1_seq);
         assert_eq!(buf_r2_seq, raw_r2_seq);
 
         // Compare qualities
-        assert_eq!(rb_r1.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r1));
-        assert_eq!(rb_r2.quality_scores().as_ref(), fgumi_raw_bam::quality_scores_slice(&raw_r2));
+        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
+        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
 
         // Compare stats
         assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
@@ -2011,8 +2011,8 @@ mod tests {
             .expect("apply_overlapping_consensus_raw should succeed");
 
         // Check that qualities were summed (30 + 20 = 50)
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[0])[0], 50);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[1])[0], 50);
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 50);
         assert!(caller.stats().overlapping_bases > 0);
     }
 
@@ -2036,8 +2036,8 @@ mod tests {
             .expect("apply_overlapping_consensus_raw should succeed");
 
         // Qualities unchanged because no matching pair
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[0])[0], 30);
-        assert_eq!(fgumi_raw_bam::quality_scores_slice(&records[1])[0], 20);
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 30);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 20);
         assert_eq!(caller.stats().overlapping_bases, 0);
     }
 
@@ -2063,8 +2063,8 @@ mod tests {
         // Both should have been consensus-called
         assert!(caller.stats().overlapping_bases > 0);
         assert_eq!(
-            fgumi_raw_bam::quality_scores_slice(&records[0])[0],
-            fgumi_raw_bam::quality_scores_slice(&records[1])[0]
+            RawRecordView::new(&records[0]).quality_scores()[0],
+            RawRecordView::new(&records[1]).quality_scores()[0]
         );
     }
 

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -13,7 +13,7 @@ use crate::phred::{
 use crate::simple_umi::consensus_umis;
 use anyhow::{Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{RawRecordView, UnmappedBamRecordBuilder, flags};
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
 #[cfg(test)]
@@ -707,7 +707,7 @@ impl VanillaUmiConsensusCaller {
         let ref_positions = methylation::query_to_ref_positions(
             &anchor.simplified_cigar,
             anchor.alignment_start,
-            anchor.flags & fgumi_raw_bam::flags::REVERSE != 0,
+            anchor.flags & flags::REVERSE != 0,
             &anchor.original_cigar,
         );
 
@@ -741,10 +741,8 @@ impl VanillaUmiConsensusCaller {
 
     /// Filters reads to remove secondary/supplementary alignments.
     fn filter_reads(&mut self, reads: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
-        use fgumi_raw_bam as bam_fields;
-
         let (accepted, rejected): (Vec<_>, Vec<_>) = reads.into_iter().partition(|raw| {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             flg & flags::SECONDARY == 0 && flg & flags::SUPPLEMENTARY == 0
         });
 
@@ -867,13 +865,14 @@ impl VanillaUmiConsensusCaller {
     ) -> Option<SourceRead> {
         use fgumi_raw_bam as bam_fields;
 
-        let flg = bam_fields::flags(raw);
+        let view = RawRecordView::new(raw);
+        let flg = view.flags();
         let is_negative_strand = flg & flags::REVERSE != 0;
         let min_bq = self.options.min_input_base_quality;
 
         // Get bases and quals from raw bytes
-        let mut bases = bam_fields::extract_sequence(raw);
-        let mut quals = bam_fields::quality_scores_slice(raw).to_vec();
+        let mut bases = view.sequence_vec();
+        let mut quals = view.quality_scores().to_vec();
         let read_len = bases.len();
 
         if quals.is_empty() || quals.len() != read_len {
@@ -930,8 +929,8 @@ impl VanillaUmiConsensusCaller {
 
         simplified_cigar = Self::truncate_simplified_cigar(&simplified_cigar, final_len);
 
-        let rid = bam_fields::ref_id(raw);
-        let astart = i64::from(bam_fields::pos(raw));
+        let rid = view.ref_id();
+        let astart = i64::from(view.pos());
 
         Some(SourceRead {
             original_idx,
@@ -1012,14 +1011,12 @@ impl VanillaUmiConsensusCaller {
         reason = "method signature kept for consistency with other caller trait methods"
     )]
     fn subgroup_reads(&self, reads: Vec<Vec<u8>>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
-        use fgumi_raw_bam as bam_fields;
-
         let mut fragment_reads = Vec::new();
         let mut r1_reads = Vec::new();
         let mut r2_reads = Vec::new();
 
         for raw in reads {
-            let flg = bam_fields::flags(&raw);
+            let flg = RawRecordView::new(&raw).flags();
             if flg & flags::PAIRED == 0 {
                 fragment_reads.push(raw);
             } else if flg & flags::FIRST_SEGMENT != 0 {
@@ -1366,8 +1363,6 @@ impl VanillaUmiConsensusCaller {
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
     ) {
-        use fgumi_raw_bam as bam_fields;
-
         let read_name = format!("{}:{}", self.read_name_prefix, umi);
 
         let mut flag = flags::UNMAPPED;
@@ -1415,7 +1410,7 @@ impl VanillaUmiConsensusCaller {
         if let Some(cell_tag) = self.options.cell_tag {
             if let Some(first_raw) = original_raws.first() {
                 let tag_bytes = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
-                if let Some(value) = bam_fields::find_string_tag_in_record(first_raw, &tag_bytes) {
+                if let Some(value) = RawRecordView::new(first_raw).tags().find_string(&tag_bytes) {
                     self.bam_builder.append_string_tag(&tag_bytes, value);
                 }
             }
@@ -1425,7 +1420,9 @@ impl VanillaUmiConsensusCaller {
         let umis: Vec<String> = original_raws
             .iter()
             .filter_map(|raw| {
-                bam_fields::find_string_tag_in_record(raw, b"RX")
+                RawRecordView::new(raw)
+                    .tags()
+                    .find_string(b"RX")
                     .map(|v| String::from_utf8_lossy(v).into_owned())
             })
             .collect();
@@ -1438,9 +1435,9 @@ impl VanillaUmiConsensusCaller {
         // Methylation tags (EM-Seq/TAPs)
         if let Some(annot) = methylation {
             // Determine strand for MM tag format
-            let is_top = original_raws
-                .first()
-                .is_none_or(|raw| crate::methylation::is_top_strand(fgumi_raw_bam::flags(raw)));
+            let is_top = original_raws.first().is_none_or(|raw| {
+                crate::methylation::is_top_strand(RawRecordView::new(raw).flags())
+            });
 
             if let Some((mm, ml)) = crate::methylation::build_mm_ml_tags(
                 bases,
@@ -1467,8 +1464,6 @@ impl VanillaUmiConsensusCaller {
 
 impl ConsensusCaller for VanillaUmiConsensusCaller {
     fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
-        use fgumi_raw_bam as bam_fields;
-
         if records.is_empty() {
             return Ok(ConsensusOutput::default());
         }
@@ -1481,11 +1476,11 @@ impl ConsensusCaller for VanillaUmiConsensusCaller {
         let tag_key = [tag_bytes[0], tag_bytes[1]];
 
         let first_raw = records.first().expect("records is non-empty (checked above)");
-        let read_name_bytes = bam_fields::read_name(first_raw);
+        let read_name_bytes = RawRecordView::new(first_raw).read_name();
         let read_name = String::from_utf8_lossy(read_name_bytes);
 
         let tag_value =
-            bam_fields::find_string_tag_in_record(first_raw, &tag_key).ok_or_else(|| {
+            RawRecordView::new(first_raw).tags().find_string(&tag_key).ok_or_else(|| {
                 anyhow!("Missing UMI tag '{}' for read '{}'", self.options.tag, read_name)
             })?;
 
@@ -1802,8 +1797,6 @@ mod tests {
 
     #[test]
     fn test_deterministic_downsampling() {
-        use fgumi_raw_bam as bam_fields;
-
         // Test that downsampling with a seed produces deterministic results
         let seed = 42u64;
         let options = VanillaUmiConsensusOptions {
@@ -1841,8 +1834,8 @@ mod tests {
         // Both should select the same reads in the same order
         for i in 0..3 {
             assert_eq!(
-                bam_fields::read_name(&downsampled1[i]),
-                bam_fields::read_name(&downsampled2[i])
+                RawRecordView::new(&downsampled1[i]).read_name(),
+                RawRecordView::new(&downsampled2[i]).read_name()
             );
         }
     }

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::raw_bam_record::RawRecord;
 use crate::sequence::pack_sequence_into;
 use crate::tags::{
     append_float_tag, append_i16_array_tag, append_int_tag, append_phred33_string_tag,
@@ -27,9 +28,13 @@ use crate::tags::{
 /// builder.append_int_tag(b"cD", max_depth);
 /// builder.append_float_tag(b"cE", error_rate);
 /// builder.append_i16_array_tag(b"cd", &depth_array);
-/// builder.write_with_block_size(&mut output);
 ///
-/// builder.clear();
+/// // Option A: return the record as a RawRecord (moves the buffer out).
+/// let record: RawRecord = builder.build();
+///
+/// // Option B (alternative): write directly without taking ownership.
+/// // builder.write_with_block_size(&mut output);
+/// // builder.clear();
 /// // ... build next record ...
 /// ```
 pub struct UnmappedBamRecordBuilder {
@@ -173,6 +178,21 @@ impl UnmappedBamRecordBuilder {
     pub fn append_phred33_string_tag(&mut self, tag: &[u8; 2], quals: &[u8]) {
         debug_assert!(self.sealed, "must call build_record before appending tags");
         append_phred33_string_tag(&mut self.buf, tag, quals);
+    }
+
+    /// Consume the completed record bytes and return them as a [`RawRecord`].
+    ///
+    /// This moves the internal buffer out of the builder. After calling
+    /// `build()`, the builder's buffer is empty; call [`Self::build_record`]
+    /// again before appending tags or writing.
+    ///
+    /// Callers that need the raw bytes can use [`RawRecord::into_inner`].
+    #[inline]
+    #[must_use]
+    pub fn build(&mut self) -> RawRecord {
+        debug_assert!(self.sealed, "must call build_record first");
+        self.sealed = false;
+        RawRecord::from(std::mem::take(&mut self.buf))
     }
 
     /// Get the completed record bytes (**without** the 4-byte `block_size` prefix).
@@ -449,6 +469,41 @@ mod tests {
     // ========================================================================
     // UnmappedBamRecordBuilder additional tests
     // ========================================================================
+
+    #[test]
+    fn test_builder_build_returns_raw_record() {
+        let mut builder = UnmappedBamRecordBuilder::new();
+        builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
+        builder.append_string_tag(b"MI", b"7");
+
+        let record = builder.build();
+
+        // Should be a valid RawRecord with the expected fields.
+        assert_eq!(l_seq(record.as_ref()), 4);
+        assert_eq!(read_name(record.as_ref()), b"r1");
+        assert_eq!(find_string_tag(aux_data_slice(record.as_ref()), b"MI"), Some(b"7" as &[u8]));
+
+        // After build(), the builder's internal buffer should be empty (moved out).
+        assert!(builder.buf.is_empty());
+        assert!(!builder.sealed);
+
+        // The builder can be reused.
+        builder.build_record(b"r2", flags::UNMAPPED, b"AC", &[20, 25]);
+        assert_eq!(l_seq(builder.as_bytes()), 2);
+        assert_eq!(read_name(builder.as_bytes()), b"r2");
+    }
+
+    #[test]
+    fn test_builder_build_into_inner() {
+        let mut builder = UnmappedBamRecordBuilder::new();
+        builder.build_record(b"r3", flags::UNMAPPED, b"ACGT", &[10, 20, 30, 40]);
+
+        let bytes_before = builder.as_bytes().to_vec();
+        let record = builder.build();
+
+        // into_inner() should yield the same bytes.
+        assert_eq!(record.into_inner(), bytes_before);
+    }
 
     #[test]
     fn test_builder_default() {

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -2,8 +2,8 @@ use crate::cigar::{
     consumes_query, get_cigar_ops, reference_length_from_cigar, reference_length_from_raw_bam,
     unclipped_other_end, unclipped_other_start,
 };
-use crate::fields::{aux_data_slice, flags, mate_pos, mate_ref_id, pos, ref_id, template_length};
-use crate::tags::find_string_tag;
+use crate::fields::{RawRecordView, aux_data_slice, flags, mate_pos, mate_ref_id, template_length};
+use crate::tags::RawTagsView;
 
 /// Check if a single read is part of an FR (forward-reverse) pair using raw BAM bytes.
 ///
@@ -12,7 +12,8 @@ use crate::tags::find_string_tag;
 /// on the same reference, and in FR orientation (positive strand 5' < negative strand 5').
 #[must_use]
 pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
-    let flg = flags(bam);
+    let v = RawRecordView::new(bam);
+    let flg = v.flags();
 
     // Must be paired
     if flg & flags::PAIRED == 0 {
@@ -25,7 +26,7 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
     }
 
     // Must be on the same reference
-    let this_ref_id = ref_id(bam);
+    let this_ref_id = v.ref_id();
     let m_ref_id = mate_ref_id(bam);
     if this_ref_id != m_ref_id {
         return false;
@@ -41,7 +42,7 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
     // Determine if FR or RF using htsjdk's logic:
     // positiveStrandFivePrimePos = readIsOnReverseStrand ? mateStart : alignmentStart
     // negativeStrandFivePrimePos = readIsOnReverseStrand ? alignmentEnd : alignmentStart + insertSize
-    let alignment_start = pos(bam) + 1; // 1-based
+    let alignment_start = v.pos() + 1; // 1-based
     let m_start = mate_pos(bam) + 1; // 1-based
     let insert_size = template_length(bam);
 
@@ -66,19 +67,20 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
         return 0;
     }
 
-    let flg = flags(bam);
+    let v = RawRecordView::new(bam);
+    let flg = v.flags();
     let is_reverse = flg & flags::REVERSE != 0;
 
     // Need MC tag for mate CIGAR information
     let aux = aux_data_slice(bam);
-    let Some(mc_bytes) = find_string_tag(aux, b"MC") else {
+    let Some(mc_bytes) = RawTagsView::new(aux).find_string(b"MC") else {
         return 0;
     };
     let Ok(mc_cigar) = std::str::from_utf8(mc_bytes) else {
         return 0;
     };
 
-    let this_pos_0based = pos(bam);
+    let this_pos_0based = v.pos();
     let m_pos_0based = mate_pos(bam);
     // Convert to 1-based for coordinate calculations
     let this_pos = this_pos_0based + 1;

--- a/crates/fgumi-raw-bam/src/sort.rs
+++ b/crates/fgumi-raw-bam/src/sort.rs
@@ -1,17 +1,20 @@
 use std::cmp::Ordering;
 
-use crate::fields::{self, flags, pos, read_name, ref_id};
+use crate::fields::{RawRecordView, flags};
 
 #[must_use]
 pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
-    let a_tid = ref_id(a);
-    let b_tid = ref_id(b);
+    let av = RawRecordView::new(a);
+    let bv = RawRecordView::new(b);
 
-    let a_pos = pos(a);
-    let b_pos = pos(b);
+    let a_tid = av.ref_id();
+    let b_tid = bv.ref_id();
 
-    let a_flag = fields::flags(a);
-    let b_flag = fields::flags(b);
+    let a_pos = av.pos();
+    let b_pos = bv.pos();
+
+    let a_flag = av.flags();
+    let b_flag = bv.flags();
 
     // Handle reads with no reference (tid = -1) - sort last
     // Unmapped reads with a valid tid (mate's position) sort by that position
@@ -41,14 +44,15 @@ pub fn compare_coordinate_raw(a: &[u8], b: &[u8]) -> Ordering {
 #[inline]
 #[must_use]
 pub fn compare_names_raw(a: &[u8], b: &[u8]) -> Ordering {
-    read_name(a).cmp(read_name(b))
+    RawRecordView::new(a).read_name().cmp(RawRecordView::new(b).read_name())
 }
 
 /// Compare for queryname ordering using raw bytes.
 #[inline]
 #[must_use]
 pub fn compare_queryname_raw(a: &[u8], b: &[u8]) -> Ordering {
-    compare_names_raw(a, b).then_with(|| fields::flags(a).cmp(&fields::flags(b)))
+    compare_names_raw(a, b)
+        .then_with(|| RawRecordView::new(a).flags().cmp(&RawRecordView::new(b).flags()))
 }
 
 // ============================================================================

--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -101,7 +101,7 @@ pub fn regenerate_alignment_tags(
         record.data_mut().insert(nm_tag(), Value::from(0u32));
         record.data_mut().insert(md_tag(), Value::String("0".to_owned().into()));
         record.data_mut().insert(uq_tag(), Value::from(0u32));
-        return Ok(false);
+        return Ok(true);
     }
 
     // Fetch entire reference span in one call
@@ -230,7 +230,7 @@ pub fn regenerate_alignment_tags(
 // Raw-byte alignment tag regeneration
 // ============================================================================
 
-use fgumi_raw_bam;
+use fgumi_raw_bam::{self, RawRecordView, RawTagsEditor};
 
 /// Regenerates NM, UQ, and MD tags for a raw BAM record after base masking.
 ///
@@ -262,18 +262,17 @@ pub fn regenerate_alignment_tags_raw(
             fgumi_raw_bam::MIN_BAM_RECORD_LEN
         );
     }
-    let flg = fgumi_raw_bam::flags(record);
-
     // For unmapped reads, remove alignment tags
-    if (flg & fgumi_raw_bam::flags::UNMAPPED) != 0 {
-        fgumi_raw_bam::remove_tag(record, b"NM");
-        fgumi_raw_bam::remove_tag(record, b"UQ");
-        fgumi_raw_bam::remove_tag(record, b"MD");
+    if RawRecordView::new(record).is_unmapped() {
+        let mut editor = RawTagsEditor::from_vec(record);
+        editor.remove(b"NM");
+        editor.remove(b"UQ");
+        editor.remove(b"MD");
         return Ok(false);
     }
 
     // Get reference sequence ID and look up name in header
-    let ref_seq_id = fgumi_raw_bam::ref_id(record);
+    let ref_seq_id = RawRecordView::new(record).ref_id();
     if ref_seq_id < 0 {
         return Ok(false);
     }
@@ -283,7 +282,7 @@ pub fn regenerate_alignment_tags_raw(
         .context("Reference sequence ID not found in header")?;
     let ref_name = std::str::from_utf8(ref_name_bytes.as_ref())?;
 
-    let alignment_start_0based = fgumi_raw_bam::pos(record);
+    let alignment_start_0based = RawRecordView::new(record).pos();
     if alignment_start_0based < 0 {
         anyhow::bail!("Invalid alignment start position: {alignment_start_0based}");
     }
@@ -299,10 +298,11 @@ pub fn regenerate_alignment_tags_raw(
 
     // Handle edge case: CIGAR with no reference-consuming operations
     if ref_span == 0 {
-        fgumi_raw_bam::update_int_tag(record, b"NM", 0);
-        fgumi_raw_bam::update_int_tag(record, b"UQ", 0);
-        fgumi_raw_bam::update_string_tag(record, b"MD", b"0");
-        return Ok(false);
+        let mut editor = RawTagsEditor::from_vec(record);
+        editor.update_int(b"NM", 0);
+        editor.update_int(b"UQ", 0);
+        editor.update_string(b"MD", b"0");
+        return Ok(true);
     }
 
     // Fetch entire reference span in one call
@@ -410,9 +410,10 @@ pub fn regenerate_alignment_tags_raw(
     write!(md_string, "{match_count}").expect("write to String is infallible");
 
     // Update tags
-    fgumi_raw_bam::update_int_tag(record, b"NM", nm);
-    fgumi_raw_bam::update_int_tag(record, b"UQ", uq.min(i32::MAX as u32) as i32);
-    fgumi_raw_bam::update_string_tag(record, b"MD", md_string.as_bytes());
+    let mut editor = RawTagsEditor::from_vec(record);
+    editor.update_int(b"NM", nm);
+    editor.update_int(b"UQ", uq.min(i32::MAX as u32) as i32);
+    editor.update_string(b"MD", md_string.as_bytes());
 
     Ok(true)
 }

--- a/src/lib/bam_io.rs
+++ b/src/lib/bam_io.rs
@@ -517,9 +517,10 @@ impl IndexingBamWriter {
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
     fn extract_alignment_context(bam: &[u8]) -> Option<(usize, Position, Position, bool)> {
         // Extract fields from BAM record
-        let tid = fgumi_raw_bam::ref_id(bam);
-        let pos = fgumi_raw_bam::pos(bam);
-        let flags = fgumi_raw_bam::flags(bam);
+        let v = fgumi_raw_bam::RawRecordView::new(bam);
+        let tid = v.ref_id();
+        let pos = v.pos();
+        let flags = v.flags();
 
         let is_unmapped = (flags & fgumi_raw_bam::flags::UNMAPPED) != 0;
 

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -380,7 +380,7 @@ fn record_name_to_string(record: &RecordBuf) -> String {
 
 /// Check if the first-in-template (R1) flag is set in raw BAM record bytes.
 fn is_first_segment_raw(raw: &RawRecord) -> bool {
-    let flags = raw_fields::flags(raw.as_ref());
+    let flags = fgumi_raw_bam::RawRecordView::new(raw.as_ref()).flags();
     flags & raw_fields::flags::FIRST_SEGMENT != 0
 }
 
@@ -461,7 +461,8 @@ fn build_mi_map_parallel(
                 let results: Vec<MiExtractResult> = batch
                     .par_iter()
                     .map(|raw| {
-                        let name_bytes = raw_fields::read_name(raw.as_ref());
+                        let name_bytes =
+                            fgumi_raw_bam::RawRecordView::new(raw.as_ref()).read_name();
                         let is_read1 = is_first_segment_raw(raw);
                         let key_hash = hash_read_key_raw(name_bytes, is_read1);
 
@@ -1164,8 +1165,8 @@ impl CompareBams {
             for (r1, r2) in cmp_batch1.iter().zip(cmp_batch2.iter()) {
                 grouping_stats.total_records += 1;
 
-                let name1_bytes = raw_fields::read_name(r1.as_ref());
-                let name2_bytes = raw_fields::read_name(r2.as_ref());
+                let name1_bytes = fgumi_raw_bam::RawRecordView::new(r1.as_ref()).read_name();
+                let name2_bytes = fgumi_raw_bam::RawRecordView::new(r2.as_ref()).read_name();
                 let is_read1 = is_first_segment_raw(r1);
 
                 if name1_bytes != name2_bytes {

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -59,6 +59,7 @@ use crate::commands::common::{
 };
 use crate::sam::TC_TAG;
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Duplicate flag bit in SAM flags (0x400)
 const DUPLICATE_FLAG: u16 = 0x400;
@@ -305,8 +306,9 @@ fn filter_template_raw(
     }
 
     let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0)
+        && raw_r2
+            .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0);
     if both_unmapped {
         metrics.discarded_poor_alignment += 1;
         return false;
@@ -314,7 +316,7 @@ fn filter_template_raw(
 
     // Phase 1: Flag-based checks
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
 
         if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
             metrics.discarded_non_pf += 1;
@@ -332,7 +334,7 @@ fn filter_template_raw(
 
     // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
         let check_umi = !config.no_umi;
@@ -583,12 +585,14 @@ fn get_pair_orientation(template: &Template) -> (bool, bool) {
     (r1_positive, r2_positive)
 }
 
-/// Raw-byte pair orientation using `bam_fields::flags()`.
+/// Raw-byte pair orientation using `RawRecordView::flags()`.
 fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
+    let r1_positive = template
+        .raw_r1()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
+    let r2_positive = template
+        .raw_r2()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 
@@ -832,7 +836,7 @@ fn mark_duplicates_in_family(templates: &mut [&mut Template], dedup_metrics: &mu
 fn mark_template_as_duplicate(template: &mut Template, dedup_metrics: &mut DedupMetrics) {
     if let Some(raw_records) = template.all_raw_records_mut() {
         for raw in raw_records.iter_mut() {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw.as_slice()).flags();
             bam_fields::set_flags(raw, flg | DUPLICATE_FLAG);
             dedup_metrics.duplicate_reads += 1;
         }
@@ -897,7 +901,7 @@ fn process_position_group(
         .map(|mut t| {
             if let Some(raw_records) = t.all_raw_records_mut() {
                 for raw in raw_records.iter_mut() {
-                    let flg = bam_fields::flags(raw);
+                    let flg = RawRecordView::new(raw.as_slice()).flags();
                     bam_fields::set_flags(raw, flg & !DUPLICATE_FLAG);
                 }
             } else {
@@ -964,7 +968,7 @@ fn process_position_group(
         if let Some(raw_records) = template.all_raw_records() {
             for raw in raw_records {
                 dedup_metrics.total_reads += 1;
-                let flg = bam_fields::flags(raw);
+                let flg = RawRecordView::new(raw.as_slice()).flags();
                 let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
                 let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
 
@@ -1326,7 +1330,7 @@ impl Command for MarkDuplicates {
                             for raw in raw_records {
                                 // Skip duplicates if remove mode
                                 if remove_duplicates
-                                    && (bam_fields::flags(raw) & DUPLICATE_FLAG) != 0
+                                    && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
                                 {
                                     continue;
                                 }
@@ -2877,21 +2881,22 @@ mod tests {
     #[test]
     fn test_set_duplicate_flag_on_raw_record() {
         use crate::sort::bam_fields;
+        use fgumi_raw_bam::RawRecordView;
 
         let raw =
             make_raw_bam_for_dedup(b"rea", bam_fields::flags::PAIRED, 30, 4, &[20; 4], b"ACGT");
         let mut rec = raw;
-        let orig_flags = bam_fields::flags(&rec);
+        let orig_flags = RawRecordView::new(&rec).flags();
         assert_eq!(orig_flags & bam_fields::flags::DUPLICATE, 0);
 
         // Set duplicate flag
         bam_fields::set_flags(&mut rec, orig_flags | bam_fields::flags::DUPLICATE);
-        assert_ne!(bam_fields::flags(&rec) & bam_fields::flags::DUPLICATE, 0);
+        assert_ne!(RawRecordView::new(&rec).flags() & bam_fields::flags::DUPLICATE, 0);
 
         // Clear duplicate flag
-        let flags_with_dup = bam_fields::flags(&rec);
+        let flags_with_dup = RawRecordView::new(&rec).flags();
         bam_fields::set_flags(&mut rec, flags_with_dup & !bam_fields::flags::DUPLICATE);
-        assert_eq!(bam_fields::flags(&rec) & bam_fields::flags::DUPLICATE, 0);
+        assert_eq!(RawRecordView::new(&rec).flags() & bam_fields::flags::DUPLICATE, 0);
     }
 
     #[test]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -39,7 +39,7 @@ use crate::unified_pipeline::{
 };
 use crate::validation::validate_file_exists;
 use crossbeam_queue::SegQueue;
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -425,7 +425,7 @@ impl Command for Duplex {
                     Ok(0) => return None, // EOF
                     Ok(_) => {
                         let raw = record.into_inner();
-                        let flg = bam_fields::flags(&raw);
+                        let flg = RawRecordView::new(&raw).flags();
                         // Skip secondary and supplementary reads
                         if flg & bam_fields::flags::SECONDARY != 0
                             || flg & bam_fields::flags::SUPPLEMENTARY != 0
@@ -593,7 +593,7 @@ impl Duplex {
 
         // Record filter for duplex on raw bytes: skip secondary/supplementary, keep mapped or mate-mapped
         let record_filter = |raw: &[u8]| -> bool {
-            let flg = bam_fields::flags(raw);
+            let flg = RawRecordView::new(raw).flags();
             // Skip secondary and supplementary reads
             if flg & bam_fields::flags::SECONDARY != 0
                 || flg & bam_fields::flags::SUPPLEMENTARY != 0

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -35,6 +35,7 @@ use ahash::AHashMap;
 use anyhow::{Result, bail};
 use clap::Parser;
 use crossbeam_queue::SegQueue;
+use fgumi_raw_bam::RawRecordView;
 use log::info;
 use noodles::sam::Header;
 use std::io;
@@ -669,7 +670,7 @@ impl Filter {
                 let template_pass = template_passes_raw(&template_records, &pass_map);
 
                 for (idx, record) in template_records.into_iter().enumerate() {
-                    let flags = bam_fields::flags(&record);
+                    let flags = RawRecordView::new(&record).flags();
                     let is_primary = (flags & bam_fields::flags::SECONDARY) == 0
                         && (flags & bam_fields::flags::SUPPLEMENTARY) == 0;
 
@@ -754,7 +755,7 @@ impl Filter {
         // Fail fast if we encounter a mapped read without a reference, since masking
         // can invalidate NM/UQ/MD tags and we have no way to regenerate them.
         if reference.is_none() {
-            let flags = bam_fields::flags(record);
+            let flags = RawRecordView::new(record).flags();
             if (flags & bam_fields::flags::UNMAPPED) == 0 {
                 bail!(
                     "--ref is required when filtering mapped reads \

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -214,6 +214,7 @@ fn filter_template_raw(
     metrics: &mut FilterMetrics,
 ) -> bool {
     use crate::sort::bam_fields;
+    use fgumi_raw_bam::RawRecordView;
 
     let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
     let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
@@ -228,8 +229,9 @@ fn filter_template_raw(
 
     // Check if both reads are unmapped
     let both_unmapped = raw_r1
-        .is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0)
-        && raw_r2.is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::UNMAPPED) != 0);
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0)
+        && raw_r2
+            .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0);
     if both_unmapped && !config.allow_unmapped {
         metrics.discarded_poor_alignment += num_primary_reads;
         return false;
@@ -237,7 +239,7 @@ fn filter_template_raw(
 
     // Phase 1: Cheap flag-based checks
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
 
         if !config.include_non_pf && (flg & bam_fields::flags::QC_FAIL) != 0 {
             metrics.discarded_non_pf += num_primary_reads;
@@ -252,7 +254,7 @@ fn filter_template_raw(
 
     // Phase 2: Single-pass tag lookups (MQ + UMI in one aux scan)
     for raw in [raw_r1, raw_r2].into_iter().flatten() {
-        let flg = bam_fields::flags(raw);
+        let flg = RawRecordView::new(raw).flags();
         let aux = bam_fields::aux_data_slice(raw);
         let check_mq = (flg & bam_fields::flags::MATE_UNMAPPED) == 0;
         let check_umi = !config.no_umi;
@@ -377,11 +379,14 @@ fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
 /// Get pair orientation from raw-byte template.
 fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
     use crate::sort::bam_fields;
+    use fgumi_raw_bam::RawRecordView;
 
-    let r1_positive =
-        template.raw_r1().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
-    let r2_positive =
-        template.raw_r2().is_none_or(|r| (bam_fields::flags(r) & bam_fields::flags::REVERSE) == 0);
+    let r1_positive = template
+        .raw_r1()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
+    let r2_positive = template
+        .raw_r2()
+        .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -354,7 +354,9 @@ fn verify_sort_order<K>(
             if is_violation(&key, prev) {
                 violations += 1;
                 if first_violation.is_none() {
-                    let name = String::from_utf8_lossy(fgumi_raw_bam::read_name(bam)).to_string();
+                    let name =
+                        String::from_utf8_lossy(fgumi_raw_bam::RawRecordView::new(bam).read_name())
+                            .to_string();
                     first_violation = Some((total_records, name));
                 }
             }
@@ -1003,7 +1005,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 
@@ -1034,7 +1036,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 
@@ -1065,7 +1067,7 @@ mod tests {
 
         let (total, violations, first_violation) = verify_sort_order(
             reader,
-            |bam| fgumi_raw_bam::read_name(bam).to_vec(),
+            |bam| fgumi_raw_bam::RawRecordView::new(bam).read_name().to_vec(),
             |key, prev| key < prev,
         )?;
 

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -65,6 +65,7 @@ use crate::vendored::encode_record_buf;
 use anyhow::{Context, Result};
 use bstr::ByteSlice;
 use clap::Parser;
+use fgumi_raw_bam::RawRecordView;
 use log::{debug, info, warn};
 use noodles::core::Position;
 use noodles::sam::Header;
@@ -677,7 +678,7 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
 
     // Fast path: check if there are any secondary/supplementary reads
     let has_sec_supp = rr.iter().any(|r| {
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0
     });
     if !has_sec_supp {
@@ -687,7 +688,7 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
     // Get R1 primary info
     let r1_info: Option<(i32, i32, bool)> = mapped.r1.and_then(|(i, _)| {
         let r = &rr[i];
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         if (f & bam_fields::flags::UNMAPPED) != 0 {
             return None;
         }
@@ -700,7 +701,7 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
     // Get R2 primary info
     let r2_info: Option<(i32, i32, bool)> = mapped.r2.and_then(|(i, _)| {
         let r = &rr[i];
-        let f = bam_fields::flags(r);
+        let f = RawRecordView::new(r).flags();
         if (f & bam_fields::flags::UNMAPPED) != 0 {
             return None;
         }
@@ -740,7 +741,7 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
 
     let rr = mapped.raw_records.as_mut().unwrap();
     for record in rr.iter_mut() {
-        let f = bam_fields::flags(record);
+        let f = RawRecordView::new(record.as_slice()).flags();
         if (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0 {
             bam_fields::remove_tag(record, tc_tag);
             bam_fields::append_i32_array_tag(record, tc_tag, &tc_values);
@@ -852,7 +853,7 @@ pub fn merge_raw(
             let mut pos = false;
             let mut neg = false;
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) == 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) == 0 {
                     pos = true;
                 } else {
                     neg = true;
@@ -868,7 +869,7 @@ pub fn merge_raw(
         if has_pos {
             let rr = mapped.raw_records.as_mut().unwrap();
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) != 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) != 0 {
                     continue;
                 }
                 let aux = bam_fields::aux_data_slice(&rr[i]);
@@ -894,7 +895,7 @@ pub fn merge_raw(
         if has_neg {
             let rr = mapped.raw_records.as_mut().unwrap();
             for &i in &mapped_indices {
-                if (bam_fields::flags(&rr[i]) & bam_fields::flags::REVERSE) == 0 {
+                if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) == 0 {
                     continue;
                 }
                 let aux = bam_fields::aux_data_slice(&rr[i]);
@@ -931,7 +932,7 @@ pub fn merge_raw(
         let is_qc_fail = u.flags().is_qc_fail();
         let rr = mapped.raw_records.as_mut().unwrap();
         for &i in &mapped_indices {
-            let mut f = bam_fields::flags(&rr[i]);
+            let mut f = RawRecordView::new(&rr[i]).flags();
             if is_qc_fail {
                 f |= bam_fields::flags::QC_FAIL;
             } else {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -482,6 +482,7 @@ impl RecordPositionGrouper {
     fn validate_mc_tag(&mut self, decoded: &DecodedRecord) -> io::Result<()> {
         use crate::sort::bam_fields;
         use crate::unified_pipeline::DecodedRecordData;
+        use fgumi_raw_bam::RawRecordView;
 
         if self.mc_validated {
             return Ok(());
@@ -489,7 +490,7 @@ impl RecordPositionGrouper {
 
         match &decoded.data {
             DecodedRecordData::Raw(raw) => {
-                let flg = bam_fields::flags(raw);
+                let flg = RawRecordView::new(raw).flags();
                 let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
                 let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
                 let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -1993,7 +1993,7 @@ mod tests {
             10,
             |bam: &[u8]| {
                 // Check flag field
-                let flag = fgumi_raw_bam::flags(bam);
+                let flag = fgumi_raw_bam::RawRecordView::new(bam).flags();
                 flag & fgumi_raw_bam::flags::SECONDARY == 0 // keep if NOT secondary
             },
             |raw: &[u8]| {

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -13,6 +13,7 @@ use crate::sort::bam_fields;
 use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::sort::radix::bytes_needed_u64;
 use crate::sort::segmented_buf::SegmentedBuf;
+use fgumi_raw_bam::RawRecordView;
 use std::cmp::Ordering;
 use std::io::{Read, Write};
 
@@ -237,11 +238,11 @@ impl RecordBuffer {
     /// (256 MiB) or if the record length exceeds `u32::MAX`.
     #[inline]
     pub fn push_coordinate(&mut self, record: &[u8]) -> anyhow::Result<()> {
-        // BAM fixed-length block is 32 bytes; coordinate fields end at offset 15.
-        const MIN_BAM_RECORD_LEN: usize = 16;
+        // Require full BAM core record length to match RawRecordView preconditions.
+        const MIN_BAM_RECORD_LEN: usize = 32;
         anyhow::ensure!(
             record.len() >= MIN_BAM_RECORD_LEN,
-            "BAM record is truncated: need at least {} bytes to extract coordinate fields, got {}",
+            "BAM record is truncated: need at least {} bytes for BAM core fields, got {}",
             MIN_BAM_RECORD_LEN,
             record.len(),
         );
@@ -414,7 +415,7 @@ impl ProbeableBuffer for RecordBuffer {
 pub fn extract_coordinate_key_inline(bam: &[u8], nref: u32) -> u64 {
     let tid = bam_fields::ref_id(bam);
     let pos = bam_fields::pos(bam);
-    let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+    let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
 
     // Pack key based on tid (samtools behavior):
     // - tid >= 0: sort by (tid, pos, reverse) even if unmapped flag is set

--- a/src/lib/sort/keys.rs
+++ b/src/lib/sort/keys.rs
@@ -27,6 +27,7 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 use std::cmp::Ordering;
 
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 use std::io::{Read, Write};
 
 // ============================================================================
@@ -381,7 +382,7 @@ impl RawSortKey for RawCoordinateKey {
     fn extract(bam: &[u8], ctx: &SortContext) -> Self {
         let tid = bam_fields::ref_id(bam);
         let pos = bam_fields::pos(bam);
-        let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+        let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
 
         // Create key based on tid (samtools behavior):
         // - tid >= 0: sort by (tid, pos, reverse) even if unmapped flag is set
@@ -396,7 +397,7 @@ impl RawSortKey for RawCoordinateKey {
             return Self::unmapped();
         }
         let pos = bam_fields::pos(bam);
-        let reverse = (bam_fields::flags(bam) & bam_fields::flags::REVERSE) != 0;
+        let reverse = RawRecordView::new(bam).flags() & bam_fields::flags::REVERSE != 0;
         // During merge we don't have nref, but for mapped records (tid >= 0)
         // nref is only used for unmapped handling, so any value > tid works.
         // Use tid+1 as a safe nref since tid is non-negative.

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -296,7 +296,9 @@ impl LibraryLookup {
     #[cfg(test)]
     #[must_use]
     pub fn get_ordinal(&self, bam: &[u8]) -> u32 {
-        fgumi_raw_bam::tags::find_string_tag_in_record(bam, &SamTag::RG)
+        fgumi_raw_bam::RawRecordView::new(bam)
+            .tags()
+            .find_string(&SamTag::RG)
             .and_then(|rg| self.rg_to_ordinal.get(rg))
             .copied()
             .unwrap_or(0)
@@ -2870,12 +2872,13 @@ pub fn extract_template_key_inline(
     let cb_hash = aux.cell.map_or(0u64, |cb_bytes| cb_hasher.hash_one(cb_bytes));
 
     // Extract fields from raw bytes
-    let tid = bam_fields::ref_id(bam_bytes);
-    let pos = bam_fields::pos(bam_bytes);
-    let l_read_name = bam_fields::l_read_name(bam_bytes) as usize;
-    let flag = bam_fields::flags(bam_bytes);
-    let mate_tid = bam_fields::mate_ref_id(bam_bytes);
-    let mate_pos = bam_fields::mate_pos(bam_bytes);
+    let v = bam_fields::RawRecordView::new(bam_bytes);
+    let tid = v.ref_id();
+    let pos = v.pos();
+    let l_read_name = v.l_read_name() as usize;
+    let flag = v.flags();
+    let mate_tid = v.mate_ref_id();
+    let mate_pos = v.mate_pos();
 
     // Extract flags
     let is_unmapped = (flag & flags::UNMAPPED) != 0;
@@ -3167,7 +3170,10 @@ mod tests {
     #[case::absent(b"".as_slice(), None)]
     fn test_find_rg_tag(#[case] aux_data: &[u8], #[case] expected: Option<&[u8]>) {
         let bam = build_bam_with_aux(aux_data);
-        assert_eq!(fgumi_raw_bam::tags::find_string_tag_in_record(&bam, &SamTag::RG), expected);
+        assert_eq!(
+            fgumi_raw_bam::RawRecordView::new(&bam).tags().find_string(&SamTag::RG),
+            expected
+        );
     }
 
     #[test]
@@ -3179,7 +3185,7 @@ mod tests {
         aux.extend_from_slice(b"RGZmygroup\0");
         let bam = build_bam_with_aux(&aux);
         assert_eq!(
-            fgumi_raw_bam::tags::find_string_tag_in_record(&bam, &SamTag::RG),
+            fgumi_raw_bam::RawRecordView::new(&bam).tags().find_string(&SamTag::RG),
             Some(b"mygroup".as_slice())
         );
     }
@@ -3589,7 +3595,7 @@ mod tests {
         let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
         RawReadAheadReader::new(reader)
             .map(|rec| {
-                let name_bytes = fgumi_raw_bam::fields::read_name(rec.as_ref());
+                let name_bytes = fgumi_raw_bam::RawRecordView::new(rec.as_ref()).read_name();
                 String::from_utf8(name_bytes.to_vec()).expect("read name should be valid UTF-8")
             })
             .collect()
@@ -3602,7 +3608,10 @@ mod tests {
         RawReadAheadReader::new(reader)
             .map(|rec| {
                 let bytes = rec.as_ref();
-                (fgumi_raw_bam::fields::ref_id(bytes), fgumi_raw_bam::fields::pos(bytes))
+                {
+                    let v = fgumi_raw_bam::RawRecordView::new(bytes);
+                    (v.ref_id(), v.pos())
+                }
             })
             .collect()
     }

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -8,6 +8,7 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::consensus_tags::per_base;
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Reverses per-base tags for a negative-strand read
 ///
@@ -78,7 +79,7 @@ pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
             bam_fields::MIN_BAM_RECORD_LEN
         );
     }
-    let flg = bam_fields::flags(record);
+    let flg = RawRecordView::new(record).flags();
     if (flg & bam_fields::flags::REVERSE) == 0 {
         return Ok(false);
     }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -38,6 +38,7 @@
 use crate::sam::{SamTag, record_utils, to_smallest_signed_int};
 use crate::unified_pipeline::MemoryEstimate;
 use anyhow::{Result, anyhow, bail};
+use fgumi_raw_bam::RawRecordView;
 use noodles::sam::alignment::record::Cigar;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -600,7 +601,7 @@ impl Template {
 
     /// Build a Template from raw BAM byte records, categorizing by flags.
     ///
-    /// The records are categorized using `bam_fields::flags()` to determine
+    /// The records are categorized using `RawRecordView::flags()` to determine
     /// R1/R2/supplementary/secondary status, with the same index-pair scheme
     /// as `Builder::build()`.
     ///
@@ -638,8 +639,8 @@ impl Template {
 
         // Fast path for common 2-record paired-end case (no supplementals/secondaries)
         if raw_records.len() == 2 {
-            let f0 = bam_fields::flags(&raw_records[0]);
-            let f1 = bam_fields::flags(&raw_records[1]);
+            let f0 = RawRecordView::new(&raw_records[0]).flags();
+            let f1 = RawRecordView::new(&raw_records[1]).flags();
             let neither_sec_supp =
                 (f0 | f1) & (bam_fields::flags::SECONDARY | bam_fields::flags::SUPPLEMENTARY) == 0;
             if neither_sec_supp {
@@ -687,7 +688,7 @@ impl Template {
         let mut r2_sec: Vec<usize> = Vec::new();
 
         for (i, rec) in raw_records.iter().enumerate() {
-            let flg = bam_fields::flags(rec);
+            let flg = RawRecordView::new(rec).flags();
             let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
             let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
             let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
@@ -1041,8 +1042,10 @@ impl Template {
 
         // Fix mate info for primary R1/R2 pair
         if let (Some((r1_i, _)), Some((r2_i, _))) = (self.r1, self.r2) {
-            let r1_is_unmapped = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::UNMAPPED) != 0;
-            let r2_is_unmapped = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::UNMAPPED) != 0;
+            let r1_is_unmapped =
+                (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::UNMAPPED) != 0;
+            let r2_is_unmapped =
+                (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::UNMAPPED) != 0;
 
             // Get alignment scores for mate score tags
             let r1_as = bam_fields::find_int_tag(bam_fields::aux_data_slice(&rr[r1_i]), b"AS");
@@ -1080,7 +1083,7 @@ impl Template {
             let rr = self.raw_records.as_ref().unwrap();
             let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
             let r2_pos = bam_fields::pos(&rr[r2_i]);
-            let r2_flags = bam_fields::flags(&rr[r2_i]);
+            let r2_flags = RawRecordView::new(&rr[r2_i]).flags();
             let r2_is_reverse = (r2_flags & bam_fields::flags::REVERSE) != 0;
             let r2_is_unmapped = (r2_flags & bam_fields::flags::UNMAPPED) != 0;
             let r2_tlen = bam_fields::template_length(&rr[r2_i]);
@@ -1120,7 +1123,7 @@ impl Template {
             let rr = self.raw_records.as_ref().unwrap();
             let r1_ref_id = bam_fields::ref_id(&rr[r1_i]);
             let r1_pos = bam_fields::pos(&rr[r1_i]);
-            let r1_flags = bam_fields::flags(&rr[r1_i]);
+            let r1_flags = RawRecordView::new(&rr[r1_i]).flags();
             let r1_is_reverse = (r1_flags & bam_fields::flags::REVERSE) != 0;
             let r1_is_unmapped = (r1_flags & bam_fields::flags::UNMAPPED) != 0;
             let r1_tlen = bam_fields::template_length(&rr[r1_i]);
@@ -1167,14 +1170,16 @@ impl Template {
         // Get R2's info for R1
         let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
         let r2_pos = bam_fields::pos(&rr[r2_i]);
-        let r2_is_reverse = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::REVERSE) != 0;
+        let r2_is_reverse =
+            (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::REVERSE) != 0;
         let r2_mapq = bam_fields::mapq(&rr[r2_i]);
         let r2_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[r2_i]);
 
         // Get R1's info for R2
         let r1_ref_id = bam_fields::ref_id(&rr[r1_i]);
         let r1_pos = bam_fields::pos(&rr[r1_i]);
-        let r1_is_reverse = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::REVERSE) != 0;
+        let r1_is_reverse =
+            (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::REVERSE) != 0;
         let r1_mapq = bam_fields::mapq(&rr[r1_i]);
         let r1_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[r1_i]);
 
@@ -1217,8 +1222,10 @@ impl Template {
         use crate::sort::bam_fields;
 
         let rr = self.raw_records.as_ref().unwrap();
-        let r1_is_reverse = (bam_fields::flags(&rr[r1_i]) & bam_fields::flags::REVERSE) != 0;
-        let r2_is_reverse = (bam_fields::flags(&rr[r2_i]) & bam_fields::flags::REVERSE) != 0;
+        let r1_is_reverse =
+            (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::REVERSE) != 0;
+        let r2_is_reverse =
+            (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
         let rr = self.raw_records.as_mut().unwrap();
 
@@ -1252,13 +1259,13 @@ impl Template {
         let rr = self.raw_records.as_ref().unwrap();
         let mapped_ref_id = bam_fields::ref_id(&rr[mapped_i]);
         let mapped_pos = bam_fields::pos(&rr[mapped_i]);
-        let mapped_flags = bam_fields::flags(&rr[mapped_i]);
+        let mapped_flags = RawRecordView::new(&rr[mapped_i]).flags();
         let mapped_is_reverse = (mapped_flags & bam_fields::flags::REVERSE) != 0;
         let mapped_mapq = bam_fields::mapq(&rr[mapped_i]);
         let mapped_cigar_str = bam_fields::cigar_to_string_from_raw(&rr[mapped_i]);
 
         let unmapped_is_reverse =
-            (bam_fields::flags(&rr[unmapped_i]) & bam_fields::flags::REVERSE) != 0;
+            (RawRecordView::new(&rr[unmapped_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
         let rr = self.raw_records.as_mut().unwrap();
 
@@ -1489,7 +1496,7 @@ fn alignment_length(cigar: &noodles::sam::alignment::record_buf::Cigar) -> i32 {
 /// Sets mate flags (`MATE_REVERSE`, `MATE_UNMAPPED`) on a raw BAM record.
 fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped: bool) {
     use crate::sort::bam_fields;
-    let mut f = bam_fields::flags(record);
+    let mut f = RawRecordView::new(record).flags();
     f &= !bam_fields::flags::MATE_REVERSE;
     if mate_is_reverse {
         f |= bam_fields::flags::MATE_REVERSE;
@@ -1508,8 +1515,8 @@ fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped
 fn compute_insert_size_raw(rec1: &[u8], rec2: &[u8]) -> i32 {
     use crate::sort::bam_fields;
 
-    let f1 = bam_fields::flags(rec1);
-    let f2 = bam_fields::flags(rec2);
+    let f1 = RawRecordView::new(rec1).flags();
+    let f2 = RawRecordView::new(rec2).flags();
 
     // If either read is unmapped, return 0
     if (f1 & bam_fields::flags::UNMAPPED) != 0 || (f2 & bam_fields::flags::UNMAPPED) != 0 {
@@ -4104,7 +4111,7 @@ mod tests {
         assert!(template.raw_r2().is_some());
         // Verify R1 is at index 0 (has FIRST_SEGMENT flag)
         let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = crate::sort::bam_fields::flags(raw_r1);
+        let r1_flags = RawRecordView::new(raw_r1).flags();
         assert_ne!(r1_flags & FLAG_READ1, 0);
     }
 
@@ -4118,10 +4125,10 @@ mod tests {
         assert!(template.is_raw_byte_mode());
         // After swap, R1 should be at index 0
         let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = crate::sort::bam_fields::flags(raw_r1);
+        let r1_flags = RawRecordView::new(raw_r1).flags();
         assert_ne!(r1_flags & FLAG_READ1, 0);
         let raw_r2 = template.raw_r2().expect("raw_r2 should be present");
-        let r2_flags = crate::sort::bam_fields::flags(raw_r2);
+        let r2_flags = RawRecordView::new(raw_r2).flags();
         assert_ne!(r2_flags & FLAG_READ2, 0);
     }
 

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -41,6 +41,7 @@ use super::deadlock::{
 use super::scheduler::{BackpressureState, SchedulerStrategy};
 use crate::read_info::{LibraryIndex, compute_group_key};
 use crate::sort::bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Buffer size for buffered I/O (8 MB).
 /// This reduces syscalls by batching reads/writes into larger chunks.
@@ -439,7 +440,7 @@ fn compute_group_key_from_raw(
     };
 
     // Check secondary/supplementary
-    let flg = bam_fields::flags(raw);
+    let flg = RawRecordView::new(raw).flags();
     let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
     let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
     if is_secondary || is_supplementary {


### PR DESCRIPTION
## Summary

Part 2 of 5 in the stacked series closing #272. Stacks on #278.

Mechanical call-site migration across the workspace: `fgumi-raw-bam` internals (overlap, sort, builder), `fgumi-sam`, `fgumi-consensus`, and `src/lib`. Every `flags(bam)`, `pos(bam)`, `find_string_tag(...)`, etc. is rewritten to use the new `RawRecordView` / `RawTagsEditor` API introduced in PR 1.

No behavior changes; 2076 workspace tests still pass. The old free-function API remains `pub` throughout this PR — demotion to `pub(crate)` happens in PR 3.

## Scope

- `crates/fgumi-raw-bam/src/{overlap,sort,builder}.rs` — internal ports
- `crates/fgumi-sam/src/alignment_tags.rs` — `RawTagsEditor` in place of per-call free-function tag ops
- `crates/fgumi-consensus/src/{overlapping,filter}.rs` (plus earlier caller migrations)
- `src/lib/` — compare, sort, dedup, duplex, filter, group, zipper, grouper, inline_buffer, keys, tag_reversal, template, unified_pipeline/bam, mi_group, bam_io, sort/raw, plus all `src/lib/commands/*`

## Test plan

- [x] `cargo ci-test` — 2076/2076 pass
- [x] `cargo ci-fmt` / `cargo ci-lint` — clean

## Stack

- PR 1: Core API + gap closures
- **PR 2 (this):** Migration
- PR 3: Demote old free-function API to `pub(crate)` (BREAKING)
- PR 4: Tests + benchmarks
- PR 5: Post-refactor perf optimizations

Part of #272. Supersedes #277.