### PR TITLE
refactor(raw-bam)!: narrow re-exports + partial free-fn demotion

### DIFF
--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -167,104 +167,6 @@ pub fn query_length_from_cigar(cigar_ops: &[u32]) -> usize {
     len
 }
 
-/// Calculate unclipped start position from BAM record.
-///
-/// For forward strand reads, this is the 5' position.
-/// Returns: `pos - leading_clips` (0-based like the input position).
-#[inline]
-#[must_use]
-pub fn unclipped_start_from_cigar(pos: i32, cigar_ops: &[u32]) -> i32 {
-    let mut clipped = 0i32;
-
-    for &op in cigar_ops {
-        let op_len = (op >> 4).cast_signed();
-        let op_type = op & 0xF;
-
-        match op_type {
-            4 | 5 => clipped += op_len, // S (4) or H (5)
-            _ => break,                 // Non-clip operation
-        }
-    }
-
-    pos - clipped
-}
-
-/// Calculate unclipped end position from BAM record.
-///
-/// For reverse strand reads, this is the 5' position.
-/// Returns: `pos + ref_length + trailing_clips - 1` (0-based).
-#[inline]
-#[must_use]
-pub fn unclipped_end_from_cigar(pos: i32, cigar_ops: &[u32]) -> i32 {
-    let mut ref_len = 0i32;
-    let mut trailing_clips = 0i32;
-    let mut saw_ref_op = false;
-
-    for &op in cigar_ops {
-        let op_len = (op >> 4).cast_signed();
-        let op_type = op & 0xF;
-
-        match op_type {
-            _ if consumes_ref(op_type) => {
-                ref_len += op_len;
-                trailing_clips = 0;
-                saw_ref_op = true;
-            }
-            4 | 5 if saw_ref_op => {
-                // S (4) or H (5) after ref-consuming ops
-                trailing_clips += op_len;
-            }
-            _ => {}
-        }
-    }
-
-    pos + ref_len + trailing_clips - 1
-}
-
-/// Calculate unclipped 5' coordinate for this read.
-///
-/// For forward strand: `unclipped_start` (leftmost including clips)
-/// For reverse strand: `unclipped_end` (rightmost including clips)
-#[inline]
-#[must_use]
-pub fn unclipped_5prime(pos: i32, reverse: bool, cigar_ops: &[u32]) -> i32 {
-    if reverse {
-        unclipped_end_from_cigar(pos, cigar_ops)
-    } else {
-        unclipped_start_from_cigar(pos, cigar_ops)
-    }
-}
-
-/// Calculate unclipped 5' coordinate using 1-based positions (matching noodles).
-///
-/// Adds 1 to the 0-based BAM position before applying clip adjustment,
-/// producing values identical to `record_utils::unclipped_five_prime_position()`.
-///
-/// Returns 0 for unmapped reads (matching `get_unclipped_position_for_groupkey`).
-/// Returns `i32::MAX` for mapped reads with no CIGAR operations.
-#[inline]
-#[must_use]
-pub fn unclipped_5prime_1based(
-    pos_0based: i32,
-    reverse: bool,
-    unmapped: bool,
-    cigar_ops: &[u32],
-) -> i32 {
-    if unmapped {
-        return 0;
-    }
-    if cigar_ops.is_empty() {
-        return i32::MAX;
-    }
-    // Convert to 1-based, then apply clip adjustment
-    let pos_1based = pos_0based + 1;
-    if reverse {
-        unclipped_end_from_cigar(pos_1based, cigar_ops)
-    } else {
-        unclipped_start_from_cigar(pos_1based, cigar_ops)
-    }
-}
-
 /// Compute unclipped 5' position directly from raw BAM bytes (zero allocation).
 ///
 /// This is the primary entry point for raw-byte callers, replacing the pattern:
@@ -364,7 +266,7 @@ pub fn mate_unclipped_5prime_1based(
 /// For forward strand mates, this is the 5' position.
 #[inline]
 #[must_use]
-pub fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
+pub(crate) fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
     mate_pos - parse_leading_clips(mc_cigar)
 }
 
@@ -373,7 +275,7 @@ pub fn unclipped_other_start(mate_pos: i32, mc_cigar: &str) -> i32 {
 /// For reverse strand mates, this is the 5' position.
 #[inline]
 #[must_use]
-pub fn unclipped_other_end(mate_pos: i32, mc_cigar: &str) -> i32 {
+pub(crate) fn unclipped_other_end(mate_pos: i32, mc_cigar: &str) -> i32 {
     let (ref_len, trailing_clips) = parse_ref_len_and_trailing_clips(mc_cigar);
     mate_pos + ref_len + trailing_clips - 1
 }
@@ -1133,87 +1035,6 @@ mod tests {
         let cigar = &[encode_op(2, 2), encode_op(0, 5)];
         // Position 100 is in the deletion with no prior query bases
         assert_eq!(read_pos_at_ref_pos_raw(cigar, 100, 100, true), Some(1));
-    }
-
-    // ========================================================================
-    // unclipped_start_from_cigar / unclipped_end_from_cigar tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_start_from_cigar_no_clips() {
-        // 10M = (10 << 4)
-        let cigar = &[(10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 100);
-    }
-
-    #[test]
-    fn test_unclipped_start_from_cigar_soft_clip() {
-        // 5S10M: soft clip (op type 4), then match
-        let cigar = &[(5 << 4) | 4, (10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 95);
-    }
-
-    #[test]
-    fn test_unclipped_start_from_cigar_hard_clip() {
-        // 3H10M: hard clip (op type 5), then match
-        let cigar = &[(3 << 4) | 5, (10 << 4)];
-        assert_eq!(unclipped_start_from_cigar(100, cigar), 97);
-    }
-
-    #[test]
-    fn test_unclipped_end_from_cigar_no_clips() {
-        // 10M: end = pos + 10 - 1 = 109
-        let cigar = &[(10 << 4)];
-        assert_eq!(unclipped_end_from_cigar(100, cigar), 109);
-    }
-
-    #[test]
-    fn test_unclipped_end_from_cigar_trailing_clips() {
-        // 10M5S3H: end = 100 + 10 + 5 + 3 - 1 = 117
-        let cigar = &[(10 << 4), (5 << 4) | 4, (3 << 4) | 5];
-        assert_eq!(unclipped_end_from_cigar(100, cigar), 117);
-    }
-
-    // ========================================================================
-    // unclipped_5prime tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_5prime_forward_vs_reverse() {
-        // 5S10M3S: forward uses start, reverse uses end
-        let cigar = &[(5 << 4) | 4, (10 << 4), (3 << 4) | 4];
-        // Forward: unclipped_start = 100 - 5 = 95
-        assert_eq!(unclipped_5prime(100, false, cigar), 95);
-        // Reverse: unclipped_end = 100 + 10 + 3 - 1 = 112
-        assert_eq!(unclipped_5prime(100, true, cigar), 112);
-    }
-
-    // ========================================================================
-    // unclipped_5prime_1based tests
-    // ========================================================================
-
-    #[test]
-    fn test_unclipped_5prime_1based_unmapped() {
-        assert_eq!(unclipped_5prime_1based(100, false, true, &[(10 << 4)]), 0);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_no_cigar() {
-        assert_eq!(unclipped_5prime_1based(100, false, false, &[]), i32::MAX);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_forward() {
-        // 5S10M: forward 5' = pos+1 - 5 = 96
-        let cigar = &[(5 << 4) | 4, (10 << 4)];
-        assert_eq!(unclipped_5prime_1based(100, false, false, cigar), 96);
-    }
-
-    #[test]
-    fn test_unclipped_5prime_1based_reverse() {
-        // 10M5S: reverse 5' = pos+1 + 10 + 5 - 1 = 115
-        let cigar = &[(10 << 4), (5 << 4) | 4];
-        assert_eq!(unclipped_5prime_1based(100, true, false, cigar), 115);
     }
 
     // ========================================================================

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -342,14 +342,14 @@ pub fn pos(bam: &[u8]) -> i32 {
 /// Extract `l_read_name` (length of read name + NUL) from a BAM record.
 #[inline]
 #[must_use]
-pub fn l_read_name(bam: &[u8]) -> u8 {
+pub(crate) fn l_read_name(bam: &[u8]) -> u8 {
     bam[8]
 }
 
 /// Extract number of CIGAR operations from a BAM record.
 #[inline]
 #[must_use]
-pub fn n_cigar_op(bam: &[u8]) -> u16 {
+pub(crate) fn n_cigar_op(bam: &[u8]) -> u16 {
     u16::from_le_bytes([bam[12], bam[13]])
 }
 
@@ -401,7 +401,7 @@ pub fn set_flags(bam: &mut [u8], new_flags: u16) {
 
 /// Set the mapping quality in a BAM record.
 #[inline]
-pub fn set_mapq(bam: &mut [u8], new_mapq: u8) {
+pub(crate) fn set_mapq(bam: &mut [u8], new_mapq: u8) {
     bam[9] = new_mapq;
 }
 
@@ -496,7 +496,7 @@ pub fn qual_offset(bam: &[u8]) -> usize {
 /// Returns (tid, pos, reverse, name).
 #[inline]
 #[must_use]
-pub fn extract_coordinate_fields(bam_bytes: &[u8]) -> (i32, i32, bool, &[u8]) {
+pub(crate) fn extract_coordinate_fields(bam_bytes: &[u8]) -> (i32, i32, bool, &[u8]) {
     debug_assert!(
         bam_bytes.len() >= MIN_BAM_RECORD_LEN,
         "BAM record too short ({} < {MIN_BAM_RECORD_LEN})",
@@ -601,7 +601,7 @@ pub struct TemplateCoordFields<'a> {
 /// Extract template-coordinate key fields directly from BAM bytes.
 #[inline]
 #[must_use]
-pub fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFields<'_> {
+pub(crate) fn extract_template_coordinate_fields(bam_bytes: &[u8]) -> TemplateCoordFields<'_> {
     debug_assert!(
         bam_bytes.len() >= MIN_BAM_RECORD_LEN,
         "BAM record too short ({} < {MIN_BAM_RECORD_LEN})",

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -314,7 +314,7 @@ pub fn tag_value_size(val_type: u8, data: &[u8]) -> Option<usize> {
 /// Extract flags (u16) from a BAM record.
 #[inline]
 #[must_use]
-pub fn flags(bam: &[u8]) -> u16 {
+pub(crate) fn flags(bam: &[u8]) -> u16 {
     u16::from_le_bytes([bam[14], bam[15]])
 }
 

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -15,15 +15,51 @@ pub mod testutil;
 #[cfg(feature = "noodles")]
 pub mod noodles_compat;
 
-// Flat re-exports — callers use fgumi_raw_bam::flags() etc.
-pub use builder::*;
-pub use cigar::*;
+// Re-exports — callers use fgumi_raw_bam::FooBar etc.
+//
+// fields uses a wildcard because it defines both a `flags` free-function and a
+// `flags` module (flag-bit constants); explicit re-export of the same name is
+// ambiguous, so the wildcard is the cleanest option for that module. Items
+// demoted to pub(crate) are not re-exported by the wildcard.
 pub use fields::*;
-pub use overlap::*;
-pub use raw_bam_record::*;
-pub use sequence::*;
-pub use sort::*;
-pub use tags::*;
+
+// -- builder --
+pub use builder::UnmappedBamRecordBuilder;
+
+// -- cigar --
+pub use cigar::{
+    alignment_end_from_raw, alignment_start_from_raw, cigar_op_kind, cigar_to_string_from_raw,
+    clip_cigar_ops_raw, consumes_query, consumes_read, consumes_ref, get_cigar_ops,
+    mate_unclipped_5prime, mate_unclipped_5prime_1based, query_length_from_cigar,
+    read_pos_at_ref_pos_raw, reference_length_from_cigar, reference_length_from_raw_bam,
+    unclipped_5prime_from_raw_bam, unclipped_5prime_raw,
+};
+
+// -- overlap --
+pub use overlap::{is_fr_pair_raw, num_bases_extending_past_mate_raw};
+
+// -- raw_bam_record --
+pub use raw_bam_record::{RawBamReader, RawRecord, read_raw_record};
+
+// -- sequence --
+pub use sequence::{
+    BAM_BASE_TO_ASCII, extract_sequence, get_base, get_qual, is_base_n, mask_base,
+    pack_sequence_into, quality_scores_slice, quality_scores_slice_mut, set_base, set_qual,
+};
+
+// -- sort --
+pub use sort::{compare_coordinate_raw, compare_names_raw, compare_queryname_raw, natural_compare};
+
+// -- tags --
+pub use tags::{
+    ArrayTagRef, AuxStringTags, AuxTagsIter, RawTagsEditor, RawTagsMut, RawTagsView, TagEntry,
+    TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
+    array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
+    find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
+    find_string_tag_in_record, find_tag_type, find_uint8_tag, normalize_int_tag_to_smallest_signed,
+    remove_tag, reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
+    reverse_string_tag_in_place, update_int_tag, update_string_tag,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use testutil::*;

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -17,11 +17,42 @@ pub mod noodles_compat;
 
 // Re-exports — callers use fgumi_raw_bam::FooBar etc.
 //
-// fields uses a wildcard because it defines both a `flags` free-function and a
-// `flags` module (flag-bit constants); explicit re-export of the same name is
-// ambiguous, so the wildcard is the cleanest option for that module. Items
-// demoted to pub(crate) are not re-exported by the wildcard.
-pub use fields::*;
+// Explicit named list now that fn flags() has been demoted to pub(crate).
+// The `flags` entry below re-exports the pub mod (flag-bit constants).
+pub use fields::{
+    // -- constants --
+    BAM_MAGIC,
+    MIN_BAM_RECORD_LEN,
+    // -- types --
+    RawRecordMut,
+    RawRecordView,
+    TemplateCoordFields,
+    TemplateCoordFlags,
+    // -- field accessors (free functions) --
+    aux_data_offset,
+    aux_data_offset_from_record,
+    aux_data_slice,
+    // -- flag-bit constants module (pub mod, not fn) --
+    flags,
+    l_seq,
+    mapq,
+    mate_pos,
+    mate_ref_id,
+    pos,
+    qual_offset,
+    read_name,
+    ref_id,
+    seq_offset,
+    // -- field mutators (free functions) --
+    set_flags,
+    set_mate_pos,
+    set_mate_ref_id,
+    set_pos,
+    set_ref_id,
+    set_template_length,
+    tag_value_size,
+    template_length,
+};
 
 // -- builder --
 pub use builder::UnmappedBamRecordBuilder;

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -63,7 +63,8 @@ pub fn find_string_tag_in_record<'a>(bam: &'a [u8], tag: &[u8; 2]) -> Option<&'a
 /// Returns offsets relative to the start of `aux_data`.
 /// Returns `None` if the tag is not found.
 #[must_use]
-pub fn find_tag_bounds(aux_data: &[u8], tag: &[u8; 2]) -> Option<(usize, usize)> {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn find_tag_bounds(aux_data: &[u8], tag: &[u8; 2]) -> Option<(usize, usize)> {
     let (p, val_type) = find_tag_position(aux_data, *tag)?;
     let size = tag_value_size(val_type, &aux_data[p + 3..])?;
     Some((p, p + 3 + size))
@@ -137,7 +138,7 @@ fn extract_int_value(aux_data: &[u8], p: usize, val_type: u8) -> Option<i64> {
 /// - For integer values, returns `(value, true)`
 /// - Returns `None` if MI tag not found.
 #[must_use]
-pub fn find_mi_tag(aux_data: &[u8]) -> Option<(u64, bool)> {
+pub(crate) fn find_mi_tag(aux_data: &[u8]) -> Option<(u64, bool)> {
     let (pos, val_type) = find_tag_position(aux_data, *b"MI")?;
     if val_type == b'Z' {
         // String type - parse "12345" or "12345/A" or "12345/B"
@@ -191,19 +192,11 @@ fn parse_mi_bytes(s: &[u8]) -> Option<(u64, bool)> {
     Some((value, is_a))
 }
 
-/// Find MI tag in a complete BAM record.
-///
-/// Returns `(integer_value, is_A_suffix)` or `(0, true)` if not found.
-#[must_use]
-pub fn find_mi_tag_in_record(bam: &[u8]) -> (u64, bool) {
-    find_mi_tag(aux_data_slice(bam)).unwrap_or((0, true))
-}
-
 /// Find the MC (mate CIGAR) tag in auxiliary data.
 ///
 /// Returns the CIGAR string, or None if not found.
 #[must_use]
-pub fn find_mc_tag(aux_data: &[u8]) -> Option<&str> {
+pub(crate) fn find_mc_tag(aux_data: &[u8]) -> Option<&str> {
     find_string_tag(aux_data, b"MC").and_then(|v| std::str::from_utf8(v).ok())
 }
 
@@ -454,7 +447,8 @@ pub fn array_tag_to_vec_u16(tag_ref: &ArrayTagRef) -> Vec<u16> {
 /// Append a string (Z-type) tag to a BAM record.
 ///
 /// The tag is appended at the end of the record: `[tag_byte_1, tag_byte_2, 'Z', value..., NUL]`.
-pub fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'Z');
@@ -473,7 +467,8 @@ pub fn append_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: &[u8]) {
 /// - `i16` (type `'s'`): if value in `[-32768, -129]`
 /// - `u16` (type `'S'`): if value in `[256, 65535]`
 /// - `i32` (type `'i'`): otherwise
-pub fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
     record.push(tag[0]);
     record.push(tag[1]);
     if let Ok(v) = i8::try_from(value) {
@@ -495,7 +490,8 @@ pub fn append_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
 }
 
 /// Append a float (`f`-type) tag to a BAM record.
-pub fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'f');
@@ -509,7 +505,8 @@ pub fn append_float_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: f32) {
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -529,7 +526,8 @@ pub fn append_i16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i16])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -544,7 +542,8 @@ pub fn append_u8_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u8]) {
 ///
 /// Converts raw Phred scores (0-93) to ASCII (Phred+33) and writes
 /// directly as a null-terminated string tag. Avoids intermediate String allocation.
-pub fn append_phred33_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], quals: &[u8]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_phred33_string_tag(record: &mut Vec<u8>, tag: &[u8; 2], quals: &[u8]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'Z');
@@ -736,7 +735,8 @@ pub fn append_i32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[i32])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -756,7 +756,8 @@ pub fn append_u16_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[u16])
 /// # Panics
 ///
 /// Panics if `values.len()` exceeds `u32::MAX`.
-pub fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn append_f32_array_tag(record: &mut Vec<u8>, tag: &[u8; 2], values: &[f32]) {
     record.push(tag[0]);
     record.push(tag[1]);
     record.push(b'B');
@@ -818,7 +819,7 @@ pub fn append_signed_int_tag(record: &mut Vec<u8>, tag: &[u8; 2], value: i32) {
 ///
 /// Iterates all tags in `src_aux` and appends each tag entry (tag + type + value bytes)
 /// to `dest`, unless the tag's two-byte key is in `skip_tags`.
-pub fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]]) {
+pub(crate) fn copy_aux_tags(src_aux: &[u8], dest: &mut Vec<u8>, skip_tags: &[&[u8; 2]]) {
     let mut offset = 0;
     while offset + 3 <= src_aux.len() {
         let tag_key = [src_aux[offset], src_aux[offset + 1]];
@@ -1647,16 +1648,6 @@ mod tests {
         // MI:Z:/B -> num_part is empty after stripping suffix, should return None
         let aux = b"MIZ/B\x00";
         assert_eq!(find_mi_tag(aux), None);
-    }
-
-    // ========================================================================
-    // find_mi_tag_in_record tests
-    // ========================================================================
-
-    #[test]
-    fn test_find_mi_tag_in_record_no_aux() {
-        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &[]);
-        assert_eq!(find_mi_tag_in_record(&rec), (0, true));
     }
 
     // ========================================================================

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -1206,7 +1206,7 @@ fn restore_unconverted_bases_in_raw_record(
     header: &Header,
 ) -> Result<()> {
     // Skip unmapped reads
-    let flag = bam_fields::flags(record);
+    let flag = RawRecordView::new(record).flags();
     if (flag & bam_fields::flags::UNMAPPED) != 0 {
         return Ok(());
     }
@@ -4336,8 +4336,8 @@ mod tests {
             .build();
         let (raw, _seq) = run_restore_raw(&modified_record, &reference, &header)?;
         let aux = bam_fields::aux_data_slice(&raw);
-        assert!(bam_fields::find_tag_bounds(aux, &SamTag::NM).is_none(), "NM should be removed");
-        assert!(bam_fields::find_tag_bounds(aux, &SamTag::MD).is_none(), "MD should be removed");
+        assert!(bam_fields::find_tag_type(aux, &SamTag::NM).is_none(), "NM should be removed");
+        assert!(bam_fields::find_tag_type(aux, &SamTag::MD).is_none(), "MD should be removed");
 
         // SEQ unchanged case: read already matches ref, NM/MD must be preserved.
         let unchanged_record = RecordBuilder::new()
@@ -4354,8 +4354,8 @@ mod tests {
             .build();
         let (raw, _seq) = run_restore_raw(&unchanged_record, &reference, &header)?;
         let aux = bam_fields::aux_data_slice(&raw);
-        assert!(bam_fields::find_tag_bounds(aux, &SamTag::NM).is_some(), "NM should be kept");
-        assert!(bam_fields::find_tag_bounds(aux, &SamTag::MD).is_some(), "MD should be kept");
+        assert!(bam_fields::find_tag_type(aux, &SamTag::NM).is_some(), "NM should be kept");
+        assert!(bam_fields::find_tag_type(aux, &SamTag::MD).is_some(), "MD should be kept");
 
         Ok(())
     }
@@ -4409,8 +4409,8 @@ mod tests {
         assert_eq!(raw_seq, oracle_seq, "raw SEQ mismatch for CIGAR {cigar}");
 
         let aux = bam_fields::aux_data_slice(&raw);
-        let nm_present = bam_fields::find_tag_bounds(aux, &SamTag::NM).is_some();
-        let md_present = bam_fields::find_tag_bounds(aux, &SamTag::MD).is_some();
+        let nm_present = bam_fields::find_tag_type(aux, &SamTag::NM).is_some();
+        let md_present = bam_fields::find_tag_type(aux, &SamTag::MD).is_some();
         if oracle_modified {
             assert!(!nm_present, "NM should be removed when SEQ modified (CIGAR {cigar})");
             assert!(!md_present, "MD should be removed when SEQ modified (CIGAR {cigar})");


### PR DESCRIPTION
## Summary

Part 3 of a stacked series closing #272. Stacks on #279. **BREAKING** — some
previously-`pub` free functions become `pub(crate)`.

## Changes

- `crates/fgumi-raw-bam/src/lib.rs` switches from `pub use <module>::*;`
  wildcards to explicit named re-export lists so the public surface is
  inspectable at a glance.
- Demotes `pub → pub(crate)` for helpers already fully replaced by inherent
  methods on the wrapper types introduced in earlier PRs:
  - `fields.rs`: `flags` (fn), `l_read_name`, `n_cigar_op`, `set_mapq`,
    `extract_coordinate_fields`, `extract_template_coordinate_fields`
  - `tags.rs`: `find_tag_bounds`, `find_mi_tag`, `find_mc_tag`,
    `append_{string,int,float}_tag`, `append_{i16,u8}_array_tag`,
    `append_phred33_string_tag`, `copy_aux_tags` (and new `pub(crate)`
    `append_{u16,f32}_array_tag`)
  - `cigar.rs`: `unclipped_other_start`, `unclipped_other_end`
- Deletes dead helpers now unreferenced: `unclipped_start_from_cigar`,
  `unclipped_end_from_cigar`, `unclipped_5prime`, `unclipped_5prime_1based`,
  `find_mi_tag_in_record`.

## Not yet demoted

Header getters/setters (`mapq`, `pos`, `ref_id`, `l_seq`, `mate_pos`,
`mate_ref_id`, `template_length`, `read_name`, `set_{flags,pos,ref_id,
mate_pos,mate_ref_id,template_length}`) and several tag helpers
(`find_{string,float,int,array,uint8}_tag`, `update_{string,int}_tag`,
`remove_tag`, `reverse_{array,string,complement_string}_tag_in_place`,
`append_i32_array_tag`, `append_signed_int_tag`) remain `pub` because
~80 in-tree call sites still use them. They'll be demoted in a
follow-up PR once those callers migrate to the `RawRecordView` /
`RawRecordMut` / `RawTagsEditor` inherent methods.

## Public surface retained

- Wrapper types: `RawRecordView`, `RawRecordMut`, `RawRecord`, `RawTagsView`,
  `RawTagsMut`, `RawTagsEditor`
- Constants: `BAM_MAGIC`, `MIN_BAM_RECORD_LEN` (note: `TAG_FIXED_SIZES` is
  `pub(crate)`, not public)
- Structural helpers: `aux_data_offset`, `aux_data_offset_from_record`,
  `aux_data_slice`, `qual_offset`, `seq_offset`, `tag_value_size`,
  `TemplateCoordFields`, `TemplateCoordFlags`, `flags` (constants module)
- Sequence / CIGAR op helpers that callers use with pre-computed offsets
- All header getters/setters and tag helpers listed under "Not yet demoted"

## Test plan

- [x] `cargo ci-test` — workspace green
- [x] `cargo ci-fmt` / `cargo ci-lint` — clean

## Stack

- PR 1: Core API + gap closures (#278)
- PR 2: Migration (#279)
- **PR 3 (this):** Explicit re-exports + partial demotion (BREAKING)
- Follow-ups: Complete demotion after remaining caller migration, plus
  tests, benchmarks, and post-refactor perf work

Part of #272. Supersedes #277.
