### PR TITLE
test(raw-bam): benchmarks + proptests + edge cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,8 @@ stress-tests = []
 rstest = "0"
 proptest = "1.10"
 criterion = { version = "0.8", features = ["html_reports"] }
-fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+fgumi-raw-bam = { workspace = true, features = ["test-utils", "noodles"] }
+noodles = { version = "0.106.0", features = ["bam", "sam"] }
 
 [[bench]]
 name = "core_functions"
@@ -122,6 +123,10 @@ harness = false
 
 [[bench]]
 name = "reorder_buffer"
+harness = false
+
+[[bench]]
+name = "raw_bam"
 harness = false
 
 [build-dependencies]

--- a/benches/raw_bam.rs
+++ b/benches/raw_bam.rs
@@ -1,0 +1,557 @@
+//! Consolidated benchmarks for the `fgumi-raw-bam` crate.
+//!
+//! Groups:
+//!   - `view::*` — zero-copy header/CIGAR/seq/qual accessors via `RawRecordView`
+//!   - `tags::*` — tag iteration and batched string extraction via `RawTagsView`
+//!   - `editor::*` — length-changing tag mutations via `RawTagsEditor`
+//!   - `mut::*` — fixed-length tag mutations via `RawTagsMut`
+//!   - `length::*` — length-changing record setters (read name, CIGAR, seq/qual)
+//!   - `seq::*` — per-base / per-qual writes
+//!   - `flags_read`, `update_int_tag`, `set_read_name`, `set_cigar_ops`,
+//!     `set_sequence_and_qualities` — side-by-side raw-byte vs noodles `RecordBuf`
+//!     groups (each containing `raw_bytes` and `recordbuf` members)
+#![deny(unsafe_code)]
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use noodles::sam::alignment::record::cigar::op::{Kind, Op};
+use noodles::sam::alignment::record_buf::Cigar as CigarBuf;
+
+use fgumi_raw_bam::raw_records_to_record_bufs;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+use fgumi_raw_bam::{RawRecord, RawRecordView};
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+fn baseline_bytes_mapped() -> Vec<u8> {
+    make_bam_bytes(
+        3,
+        100_000,
+        0x42,
+        b"read_name_example",
+        &[encode_op(0, 150)],
+        150,
+        5,
+        100_300,
+        b"NMc\x05MDZ150\0",
+    )
+}
+
+/// Seven-tag aux section: NM, MD, RG, CR, MC, MI, AS.
+fn multi_tag_aux() -> Vec<u8> {
+    let mut aux = Vec::new();
+    aux.extend_from_slice(b"NMi\x05\x00\x00\x00");
+    aux.extend_from_slice(b"MDZ150\0");
+    aux.extend_from_slice(b"RGZorg1\0");
+    aux.extend_from_slice(b"CRZcellABC\0");
+    aux.extend_from_slice(b"MCZ150M\0");
+    aux.extend_from_slice(b"MIi\x05\x00\x00\x00");
+    aux.extend_from_slice(b"ASi\x32\x00\x00\x00");
+    aux
+}
+
+fn multi_tag_bytes() -> Vec<u8> {
+    let aux = multi_tag_aux();
+    make_bam_bytes(
+        3,
+        100_000,
+        0x42,
+        b"read_name_example",
+        &[encode_op(0, 150)],
+        150,
+        5,
+        100_300,
+        &aux,
+    )
+}
+
+fn baseline_bytes_unmapped() -> Vec<u8> {
+    make_bam_bytes(
+        -1,
+        -1,
+        0x42,
+        b"read_name_example",
+        &[encode_op(0, 150)],
+        150,
+        -1,
+        -1,
+        b"NMi\x05\x00\x00\x00",
+    )
+}
+
+fn bi_array_aux(values: &[i32]) -> Vec<u8> {
+    let mut aux = b"XYBi".to_vec();
+    let count = u32::try_from(values.len()).expect("array length fits in u32");
+    aux.extend_from_slice(&count.to_le_bytes());
+    for v in values {
+        aux.extend_from_slice(&v.to_le_bytes());
+    }
+    aux
+}
+
+fn decode_one(bytes: &[u8]) -> noodles::sam::alignment::RecordBuf {
+    let mut bufs = raw_records_to_record_bufs(&[bytes.to_vec()]).expect("decode should succeed");
+    bufs.pop().expect("should have one record")
+}
+
+fn encode_one(buf: &noodles::sam::alignment::RecordBuf) -> Vec<u8> {
+    use noodles::sam::alignment::io::Write as AlignmentWrite;
+    let header = noodles::sam::Header::default();
+    let mut out: Vec<u8> = Vec::with_capacity(512);
+    let mut writer = noodles::bam::io::Writer::from(&mut out);
+    writer.write_header(&header).expect("write_header should succeed");
+    writer.write_alignment_record(&header, buf).expect("write_alignment_record should succeed");
+    // Strip 12-byte BAM file header prefix (magic + header text len + n_ref)
+    // so the result matches the block_size-prefixed bytes from `make_bam_bytes`.
+    out[12..].to_vec()
+}
+
+// ============================================================================
+// view::* — zero-copy accessors
+// ============================================================================
+
+fn bench_view_accessors(c: &mut Criterion) {
+    let bytes = baseline_bytes_mapped();
+
+    c.bench_function("view::flags", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.flags())
+        });
+    });
+    c.bench_function("view::pos", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.pos())
+        });
+    });
+    c.bench_function("view::read_name", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.read_name())
+        });
+    });
+    c.bench_function("view::cigar_ops_iter_sum", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            let mut s = 0u32;
+            for op in v.cigar_ops_iter() {
+                s = s.wrapping_add(op);
+            }
+            black_box(s)
+        });
+    });
+    c.bench_function("view::quality_scores_sum", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            let s: u32 = v.quality_scores().iter().map(|&q| u32::from(q)).sum();
+            black_box(s)
+        });
+    });
+    c.bench_function("view::tags_find_int", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.tags().find_int(b"NM"))
+        });
+    });
+}
+
+// ============================================================================
+// tags::* — tag-section reads
+// ============================================================================
+
+fn bench_tags_read(c: &mut Criterion) {
+    let bytes = multi_tag_bytes();
+
+    c.bench_function("tags::iter_all", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            let mut n = 0usize;
+            let tags = v.tags();
+            for entry in &tags {
+                black_box(entry);
+                n += 1;
+            }
+            black_box(n)
+        });
+    });
+
+    c.bench_function("tags::extract_string_batch", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.tags().extract_string_batch(b"CR"))
+        });
+    });
+}
+
+// ============================================================================
+// editor::* — length-changing tag mutations
+// ============================================================================
+
+fn bench_tags_editor_scalar(c: &mut Criterion) {
+    c.bench_function("editor::update_int_same_type", |b| {
+        let bytes =
+            make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMi\x05\x00\x00\x00");
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            rec.tags_editor().update_int(b"NM", black_box(7));
+        });
+    });
+
+    c.bench_function("editor::update_int_resize", |b| {
+        b.iter_batched_ref(
+            || {
+                let bytes =
+                    make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().update_int(b"NM", black_box(100_000));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("editor::append_then_remove", |b| {
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            let mut ed = rec.tags_editor();
+            ed.append_string(b"XX", black_box(b"hello"));
+            ed.remove(b"XX");
+        });
+    });
+
+    c.bench_function("editor::update_float_in_place", |b| {
+        let mut aux = b"ASf".to_vec();
+        aux.extend_from_slice(&1.0f32.to_le_bytes());
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            rec.tags_editor().update_float(b"AS", black_box(99.25));
+        });
+    });
+
+    c.bench_function("editor::normalize_int_to_smallest_signed", |b| {
+        b.iter_batched_ref(
+            || {
+                let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, b"NMi\x05\x00\x00\x00");
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().normalize_int_to_smallest_signed(b"NM");
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn bench_tags_editor_variable(c: &mut Criterion) {
+    c.bench_function("editor::update_string_same_length", |b| {
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, b"XXZabcde\0");
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            rec.tags_editor().update_string(b"XX", black_box(b"ABCDE"));
+        });
+    });
+
+    c.bench_function("editor::update_string_grow", |b| {
+        b.iter_batched_ref(
+            || {
+                let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, b"XXZabc\0");
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().update_string(b"XX", black_box(b"a_much_longer_string"));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("editor::append_string", |b| {
+        b.iter_batched_ref(
+            || {
+                let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().append_string(b"XX", black_box(b"hello"));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("editor::remove", |b| {
+        b.iter_batched_ref(
+            || {
+                let bytes =
+                    make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, b"NMi\x05\x00\x00\x00XXZhello\0");
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().remove(b"XX");
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("editor::copy_from", |b| {
+        let src_bytes = multi_tag_bytes();
+        let src_tags = RawRecordView::new(&src_bytes).tags();
+        b.iter_batched_ref(
+            || {
+                let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+                RawRecord::from(bytes)
+            },
+            |rec| {
+                rec.tags_editor().copy_from(src_tags, black_box(&[b"NM"]));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("editor::update_array_i32_same_len", |b| {
+        let aux = bi_array_aux(&[1, 2, 3, 4]);
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        let replacement: [i32; 4] = [10, 20, 30, 40];
+        b.iter(|| {
+            rec.tags_editor().update_array_i32(b"XY", black_box(&replacement));
+        });
+    });
+}
+
+// ============================================================================
+// mut::* — fixed-length tag mutations
+// ============================================================================
+
+fn bench_tags_mut(c: &mut Criterion) {
+    c.bench_function("mut::set_array_element_i32", |b| {
+        let aux = bi_array_aux(&[1, 2, 3, 4]);
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        b.iter(|| {
+            rec.tags_mut().set_array_element_i32(b"XY", 2, black_box(99));
+        });
+    });
+}
+
+// ============================================================================
+// length::* — length-changing record setters
+// ============================================================================
+
+fn bench_length_changing(c: &mut Criterion) {
+    let baseline = || {
+        let bytes = make_bam_bytes(
+            0,
+            0,
+            0,
+            b"my_long_read_name_typical_size",
+            &[encode_op(0, 150)],
+            150,
+            -1,
+            -1,
+            b"NMi\x05\x00\x00\x00",
+        );
+        RawRecord::from(bytes)
+    };
+
+    c.bench_function("length::set_read_name_grow_then_shrink", |b| {
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_read_name(black_box(b"a_completely_different_longer_name_xxx"));
+            rec.set_read_name(black_box(b"x"));
+        });
+    });
+
+    c.bench_function("length::set_cigar_ops_replace_with_3_ops", |b| {
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_cigar_ops(black_box(&[encode_op(0, 50), encode_op(2, 1), encode_op(0, 100)]));
+        });
+    });
+
+    c.bench_function("length::set_sequence_and_qualities_grow", |b| {
+        let seq = vec![b'A'; 200];
+        let qual = vec![30u8; 200];
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+        });
+    });
+
+    c.bench_function("length::set_sequence_and_qualities_same_length", |b| {
+        let seq = vec![b'C'; 150];
+        let qual = vec![25u8; 150];
+        b.iter(|| {
+            let mut rec = baseline();
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+        });
+    });
+}
+
+// ============================================================================
+// seq::* — per-base / per-qual writes
+// ============================================================================
+
+fn bench_per_base(c: &mut Criterion) {
+    let seq_bytes = baseline_bytes_mapped();
+
+    c.bench_function("seq::set_base", |b| {
+        let mut rec = RawRecord::from(seq_bytes.clone());
+        b.iter(|| {
+            rec.set_base(black_box(75), black_box(b'C'));
+        });
+    });
+
+    c.bench_function("seq::set_qual", |b| {
+        let mut rec = RawRecord::from(seq_bytes.clone());
+        b.iter(|| {
+            rec.set_qual(black_box(75), black_box(40));
+        });
+    });
+}
+
+// ============================================================================
+// vs_recordbuf: side-by-side raw-byte vs noodles `RecordBuf`
+// ============================================================================
+
+fn bench_flags_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flags_read");
+    let bytes = baseline_bytes_unmapped();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes));
+            black_box(v.flags())
+        });
+    });
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let buf = decode_one(black_box(&bytes));
+            black_box(buf.flags().bits())
+        });
+    });
+    group.finish();
+}
+
+fn bench_update_int_tag(c: &mut Criterion) {
+    let mut group = c.benchmark_group("update_int_tag");
+    let bytes = baseline_bytes_unmapped();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.tags_editor().update_int(b"NM", 7);
+            black_box(rec)
+        });
+    });
+    group.bench_function("recordbuf", |b| {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value;
+        let tag = Tag::from(*b"NM");
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            buf.data_mut().insert(tag, Value::Int32(7));
+            black_box(encode_one(&buf))
+        });
+    });
+    group.finish();
+}
+
+fn bench_set_read_name_vs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_read_name");
+    let bytes = baseline_bytes_unmapped();
+    let new_name = b"a_completely_different_longer_name_for_this_read";
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_read_name(black_box(new_name));
+            black_box(rec)
+        });
+    });
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            *buf.name_mut() = Some(bstr::BString::from(new_name.as_ref()));
+            black_box(encode_one(&buf))
+        });
+    });
+    group.finish();
+}
+
+fn bench_set_cigar_ops_vs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_cigar_ops");
+    let bytes = baseline_bytes_unmapped();
+    let raw_ops = [encode_op(0, 50), encode_op(2, 1), encode_op(0, 100)];
+    let noodles_ops: CigarBuf =
+        [Op::new(Kind::Match, 50), Op::new(Kind::Deletion, 1), Op::new(Kind::Match, 100)]
+            .into_iter()
+            .collect();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_cigar_ops(black_box(&raw_ops));
+            black_box(rec)
+        });
+    });
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            *buf.cigar_mut() = noodles_ops.clone();
+            black_box(encode_one(&buf))
+        });
+    });
+    group.finish();
+}
+
+fn bench_set_sequence_and_qualities_vs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_sequence_and_qualities");
+    let bytes = baseline_bytes_unmapped();
+    let seq = vec![b'A'; 200];
+    let qual = vec![30u8; 200];
+    let noodles_seq = noodles::sam::alignment::record_buf::Sequence::from(seq.clone());
+    let noodles_qual = noodles::sam::alignment::record_buf::QualityScores::from(qual.clone());
+    // CIGAR must match new seq length or noodles rejects re-encoding.
+    let noodles_cigar_200m: CigarBuf = [Op::new(Kind::Match, 200)].into_iter().collect();
+
+    group.bench_function("raw_bytes", |b| {
+        b.iter(|| {
+            let mut rec = RawRecord::from(black_box(bytes.clone()));
+            rec.set_sequence_and_qualities(black_box(&seq), black_box(&qual));
+            black_box(rec)
+        });
+    });
+    group.bench_function("recordbuf", |b| {
+        b.iter(|| {
+            let mut buf = decode_one(black_box(&bytes));
+            *buf.sequence_mut() = noodles_seq.clone();
+            *buf.quality_scores_mut() = noodles_qual.clone();
+            *buf.cigar_mut() = noodles_cigar_200m.clone();
+            black_box(encode_one(&buf))
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_view_accessors,
+    bench_tags_read,
+    bench_tags_editor_scalar,
+    bench_tags_editor_variable,
+    bench_tags_mut,
+    bench_length_changing,
+    bench_per_base,
+    bench_flags_read,
+    bench_update_int_tag,
+    bench_set_read_name_vs,
+    bench_set_cigar_ops_vs,
+    bench_set_sequence_and_qualities_vs,
+);
+criterion_main!(benches);

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -961,4 +961,147 @@ mod tests {
             read_raw_record(&mut reader, &mut record).expect("reading at EOF should return Ok(0)");
         assert_eq!(n, 0); // EOF
     }
+
+    // ── Edge-case tests for length-changing edits ──────────────────────────
+
+    /// A 254-byte name (+ NUL = 255 = `u8::MAX`) is the longest name the BAM
+    /// spec allows; `set_read_name` must accept it without panic.
+    #[test]
+    fn test_set_read_name_max_length_254_bytes_succeeds() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        let max_name = vec![b'A'; 254]; // + NUL = 255 = u8::MAX
+        rec.set_read_name(&max_name);
+        assert_eq!(rec.l_read_name(), 255);
+        assert_eq!(rec.read_name().len(), 254);
+        assert_eq!(rec.read_name(), max_name.as_slice());
+    }
+
+    /// A 255-byte name (+ NUL = 256) overflows `u8`; `set_read_name` must panic.
+    #[test]
+    #[should_panic(expected = "read name too long")]
+    fn test_set_read_name_over_limit_panics() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        let too_long = vec![b'A'; 255]; // + NUL = 256 > u8::MAX
+        rec.set_read_name(&too_long);
+    }
+
+    /// An empty name is valid: `l_read_name` should be 1 (just the NUL
+    /// terminator) and `read_name()` should return an empty slice.
+    #[test]
+    fn test_set_read_name_empty() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"somename", &[encode_op(0, 4)], 4, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        rec.set_read_name(b"");
+        assert_eq!(rec.l_read_name(), 1); // just the NUL
+        assert_eq!(rec.read_name(), b"");
+    }
+
+    /// `set_cigar_ops(&[])` clears the CIGAR entirely: `n_cigar_op` must be 0
+    /// and aux tags must survive the splice unchanged.
+    #[test]
+    fn test_set_cigar_ops_empty_clears_cigar() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(
+            0,
+            0,
+            0,
+            b"r",
+            &[encode_op(0, 10), encode_op(2, 1), encode_op(0, 5)],
+            15,
+            -1,
+            -1,
+            b"NMc\x05",
+        );
+        let mut rec = RawRecord::from(bytes);
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_cigar_ops(&[]);
+
+        assert_eq!(rec.n_cigar_op(), 0);
+        assert_eq!(rec.cigar_ops_vec(), Vec::<u32>::new());
+        // Aux tags survive the clear.
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    /// `set_sequence_and_qualities(b"", &[])` is legal: `l_seq` becomes 0, the
+    /// packed-sequence and quality slices are empty, and aux tags are preserved.
+    #[test]
+    fn test_set_sequence_and_qualities_zero_length() {
+        use crate::testutil::*;
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
+        let mut rec = RawRecord::from(bytes);
+        let pre_nm = rec.tags().find_int(b"NM");
+
+        rec.set_sequence_and_qualities(b"", &[]);
+
+        assert_eq!(rec.l_seq(), 0);
+        assert_eq!(rec.sequence_vec(), Vec::<u8>::new());
+        assert_eq!(rec.quality_scores(), &[] as &[u8]);
+        // Aux tags survive the removal of all seq+qual bytes.
+        assert_eq!(rec.tags().find_int(b"NM"), pre_nm);
+    }
+
+    /// A `B:S` (u16) array tag followed by an int tag must be byte-for-byte
+    /// identical after a seq+qual resize (grow from 10 to 16 bases).
+    #[test]
+    fn test_set_sequence_and_qualities_preserves_array_aux_tags() {
+        use crate::testutil::*;
+        // Build aux: B:S array of 4 u16 values, then NM:i:7
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBS");
+        aux.extend_from_slice(&4u32.to_le_bytes());
+        for v in [100u16, 200, 300, 400] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+        aux.extend_from_slice(b"NMc\x07");
+
+        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 10)], 10, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        let pre_aux = rec.tags().as_bytes().to_vec();
+
+        // Grow seq from 10 to 16 bases.
+        rec.set_sequence_and_qualities(b"ACGTACGTACGTACGT", &[30u8; 16]);
+
+        // Array tag must decode identically.
+        let post_arr = rec.tags().find_array(b"bq").expect("B:S array tag should be preserved");
+        assert_eq!(post_arr.count, 4);
+        let decoded: Vec<u16> = (0..4)
+            .map(|i| u16::from_le_bytes([post_arr.data[i * 2], post_arr.data[i * 2 + 1]]))
+            .collect();
+        assert_eq!(decoded, vec![100u16, 200, 300, 400]);
+
+        assert_eq!(rec.tags().find_int(b"NM"), Some(7));
+        // Byte-for-byte preservation of the entire aux section.
+        assert_eq!(rec.tags().as_bytes(), pre_aux.as_slice());
+    }
+
+    /// A `B:i` (i32) array tag must survive a read-name grow (length-changing
+    /// edit in the variable-length section before seq/qual/aux).
+    #[test]
+    fn test_set_read_name_with_array_aux_tags() {
+        use crate::testutil::*;
+        // Build aux: B:i array of 3 i32 values.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"bqBi");
+        aux.extend_from_slice(&3u32.to_le_bytes());
+        for v in [1_000_000i32, -2_000_000, 3_000_000] {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+
+        let bytes = make_bam_bytes(0, 0, 0, b"oldname", &[encode_op(0, 4)], 4, -1, -1, &aux);
+        let mut rec = RawRecord::from(bytes);
+        let pre_aux = rec.tags().as_bytes().to_vec();
+
+        // Grow the read name so the splice shifts aux.
+        rec.set_read_name(b"new_longer_name_xyz");
+
+        assert_eq!(rec.read_name(), b"new_longer_name_xyz");
+        // Aux bytes must be byte-for-byte identical after the shift.
+        assert_eq!(rec.tags().as_bytes(), pre_aux.as_slice());
+    }
 }

--- a/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
+++ b/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
@@ -1,0 +1,514 @@
+#![cfg(feature = "test-utils")]
+#![deny(unsafe_code)]
+
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
+use proptest::prelude::*;
+
+/// Strategy yielding `(Vec<T>, usize)` where the index is uniformly drawn
+/// from `0..vec.len()`. Avoids the low-index bias of `index % vec.len()`
+/// when the index range exceeds the vec length.
+macro_rules! vec_and_valid_index {
+    ($ty:ty) => {
+        proptest::collection::vec(any::<$ty>(), 1..32).prop_flat_map(|v| {
+            let len = v.len();
+            (Just(v), 0..len)
+        })
+    };
+}
+
+/// Build a minimal valid [`RawRecord`] with the given aux bytes.
+///
+/// Uses a 4-base Match CIGAR op and a short name whose length + NUL is
+/// word-aligned so the aux section starts at a clean offset.
+fn base_record(aux: &[u8]) -> RawRecord {
+    RawRecord::from(make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, aux))
+}
+
+proptest! {
+    // =========================================================================
+    // INVARIANT 1a: append_string(tag, v); remove(tag) → bytes unchanged
+    // when `tag` was absent before the append.
+    // =========================================================================
+
+    /// A record whose aux section is built exclusively from well-typed integer
+    /// tags is left byte-for-byte identical after appending and then removing
+    /// a "Xz" tag.
+    ///
+    /// We generate valid aux data (zero or more i32 tags with distinct
+    /// two-uppercase-letter names) rather than random bytes, so the scanner
+    /// can always navigate past the existing tags to reach the newly appended
+    /// one.  The invariant requires the aux section to be parseable.
+    #[test]
+    fn append_then_remove_string_is_noop(
+        // 0–4 existing i32 tags under uppercase two-letter names (not "Xz")
+        existing in proptest::collection::vec(
+            ("[A-WY-Z]{2}", any::<i32>()).prop_map(|(t, v)| (t.into_bytes(), v)),
+            0..4,
+        ),
+        val in "[A-Za-z]{0,40}",
+    ) {
+        let tag = b"Xz";
+
+        // Build valid aux bytes from the generated tags (deduplicating names).
+        let mut aux: Vec<u8> = Vec::new();
+        let mut seen: Vec<[u8; 2]> = Vec::new();
+        for (name, val_i) in &existing {
+            let k = [name[0], name[1]];
+            // Skip duplicates and any accidental collision with our test tag.
+            if seen.contains(&k) || &k == tag {
+                continue;
+            }
+            seen.push(k);
+            // Write as i32 (type 'i', 4-byte LE value).
+            aux.push(k[0]);
+            aux.push(k[1]);
+            aux.push(b'i');
+            aux.extend_from_slice(&val_i.to_le_bytes());
+        }
+
+        let mut rec = base_record(&aux);
+        let before = rec.as_ref().to_vec();
+
+        {
+            let mut ed = rec.tags_editor();
+            ed.append_string(tag, val.as_bytes());
+            ed.remove(tag);
+        }
+
+        prop_assert_eq!(rec.as_ref(), before.as_slice());
+    }
+
+    // =========================================================================
+    // INVARIANT 1b: append_int(tag, v); remove(tag) → bytes unchanged
+    // when `tag` was absent before the append.
+    // =========================================================================
+
+    /// Same noop invariant as 1a, exercised over the full i32 domain.
+    #[test]
+    fn append_then_remove_int_is_noop(v in any::<i32>()) {
+        let tag = b"Xz";
+        let mut rec = base_record(&[]);
+        let before = rec.as_ref().to_vec();
+
+        {
+            let mut ed = rec.tags_editor();
+            ed.append_int(tag, v);
+            ed.remove(tag);
+        }
+
+        prop_assert_eq!(rec.as_ref(), before.as_slice());
+    }
+
+    // =========================================================================
+    // INVARIANT 2a: update_int round-trip across i32 domain.
+    // =========================================================================
+
+    /// Writing an integer tag and reading it back must yield the same value
+    /// (widened to i64) on every i32 input.
+    #[test]
+    fn update_int_roundtrip(v in any::<i32>()) {
+        let tag = b"NM";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_int(tag, v);
+        }
+        let found = rec.tags().find_int(tag);
+        prop_assert_eq!(found, Some(i64::from(v)));
+    }
+
+    // =========================================================================
+    // INVARIANT 2b: update_string round-trip.
+    // =========================================================================
+
+    /// Writing a string tag and reading it back must yield the identical bytes.
+    #[test]
+    fn update_string_roundtrip(s in "[A-Za-z0-9 _-]{0,200}") {
+        let tag = b"Zz";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_string(tag, s.as_bytes());
+        }
+        let found = rec.tags().find_string(tag);
+        prop_assert_eq!(found, Some(s.as_bytes()));
+    }
+
+    // =========================================================================
+    // INVARIANT 2c: update_float round-trip across finite f32 domain.
+    // =========================================================================
+
+    /// A float is stored as 4 LE bytes and read back verbatim; the bit pattern
+    /// must be identical (NaN is excluded because NaN != NaN).
+    #[test]
+    fn update_float_roundtrip(
+        v in any::<f32>().prop_filter("finite only", |x| x.is_finite()),
+    ) {
+        let tag = b"As";
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_float(tag, v);
+        }
+        let found = rec.tags().find_float(tag);
+        prop_assert!(found.is_some(), "tag not found after update_float");
+        prop_assert_eq!(
+            found.unwrap().to_bits(),
+            v.to_bits(),
+            "float round-trip bit mismatch: wrote {:?}, read back {:?}",
+            v,
+            found
+        );
+    }
+
+    // =========================================================================
+    // INVARIANT 3: aux_offset stays valid across N mixed ops.
+    //
+    // After every mutation, tags().iter() must terminate without panic, and
+    // every tag entry must have value_bytes within the aux section bounds.
+    // =========================================================================
+
+    /// Any sequence of up to 20 update_int / update_string / remove operations
+    /// must leave the record in a state where aux-tag iteration terminates and
+    /// every reported entry is within bounds.
+    #[test]
+    fn mixed_ops_preserve_iterability(
+        ops in proptest::collection::vec(
+            prop_oneof![
+                // update_int: kind='I', tag, int_val, str_val unused
+                ("[A-Z]{2}", any::<i32>()).prop_map(|(t, v)| {
+                    let tb = t.into_bytes();
+                    (b'I', [tb[0], tb[1]], v, Vec::<u8>::new())
+                }),
+                // update_string: kind='S', tag, str_val, int_val unused
+                ("[A-Z]{2}", "[a-z]{0,20}").prop_map(|(t, s)| {
+                    let tb = t.into_bytes();
+                    (b'S', [tb[0], tb[1]], 0i32, s.into_bytes())
+                }),
+                // remove: kind='R', tag, both values unused
+                "[A-Z]{2}".prop_map(|t| {
+                    let tb = t.into_bytes();
+                    (b'R', [tb[0], tb[1]], 0i32, Vec::<u8>::new())
+                }),
+            ],
+            1..20,
+        ),
+    ) {
+        let mut rec = base_record(&[]);
+        let initial_record_len = rec.as_ref().len();
+
+        for (kind, tag, int_val, str_val) in &ops {
+            {
+                let mut ed = rec.tags_editor();
+                match kind {
+                    b'I' => ed.update_int(tag, *int_val),
+                    b'S' => ed.update_string(tag, str_val),
+                    b'R' => ed.remove(tag),
+                    _ => unreachable!(),
+                }
+            }
+
+            // After the mutation, iteration must terminate and stay in-bounds.
+            let tags = rec.tags();
+            let total_aux = tags.as_bytes().len();
+            let mut count = 0usize;
+            for entry in &tags {
+                prop_assert!(
+                    entry.value_bytes.len() <= total_aux,
+                    "entry value_bytes.len() {} exceeds aux section length {}",
+                    entry.value_bytes.len(),
+                    total_aux
+                );
+                count += 1;
+                prop_assert!(count < 1000, "iter produced >1000 entries — likely infinite loop");
+            }
+
+            // The record must not be shorter than it was at the start (header + fixed fields).
+            prop_assert!(
+                rec.as_ref().len() >= initial_record_len,
+                "record shrank below initial size: {} < {}",
+                rec.as_ref().len(),
+                initial_record_len
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Array update / element-write round-trip proptests (Issue #272 Easy gap ops)
+// =============================================================================
+
+/// Decode `count` little-endian `u8` elements from `data`.
+fn decode_u8_array(data: &[u8], count: usize) -> Vec<u8> {
+    data[..count].to_vec()
+}
+
+/// Decode `count` little-endian `u16` elements from `data`.
+fn decode_u16_array(data: &[u8], count: usize) -> Vec<u16> {
+    data.chunks_exact(2)
+        .take(count)
+        .map(|c| u16::from_le_bytes(c.try_into().expect("chunks_exact(2) yields 2-byte chunks")))
+        .collect()
+}
+
+/// Decode `count` little-endian `i16` elements from `data`.
+fn decode_i16_array(data: &[u8], count: usize) -> Vec<i16> {
+    data.chunks_exact(2)
+        .take(count)
+        .map(|c| i16::from_le_bytes(c.try_into().expect("chunks_exact(2) yields 2-byte chunks")))
+        .collect()
+}
+
+/// Decode `count` little-endian `i32` elements from `data`.
+fn decode_i32_array(data: &[u8], count: usize) -> Vec<i32> {
+    data.chunks_exact(4)
+        .take(count)
+        .map(|c| i32::from_le_bytes(c.try_into().expect("chunks_exact(4) yields 4-byte chunks")))
+        .collect()
+}
+
+/// Decode `count` little-endian `f32` elements from `data` as bit patterns.
+fn decode_f32_bits_array(data: &[u8], count: usize) -> Vec<u32> {
+    data.chunks_exact(4)
+        .take(count)
+        .map(|c| u32::from_le_bytes(c.try_into().expect("chunks_exact(4) yields 4-byte chunks")))
+        .collect()
+}
+
+proptest! {
+    // =========================================================================
+    // update_array_u8: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_u8_roundtrip(values in proptest::collection::vec(any::<u8>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u8(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_u8");
+        prop_assert_eq!(arr.elem_type, b'C', "elem_type should be 'C' for u8");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_u8_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_u16: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_u16_roundtrip(values in proptest::collection::vec(any::<u16>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u16(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_u16");
+        prop_assert_eq!(arr.elem_type, b'S', "elem_type should be 'S' for u16");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_u16_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_i16: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_i16_roundtrip(values in proptest::collection::vec(any::<i16>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i16(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_i16");
+        prop_assert_eq!(arr.elem_type, b's', "elem_type should be 's' for i16");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_i16_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_i32: whole-payload round-trip
+    // =========================================================================
+
+    #[test]
+    fn update_array_i32_roundtrip(values in proptest::collection::vec(any::<i32>(), 0..64)) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i32(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_i32");
+        prop_assert_eq!(arr.elem_type, b'i', "elem_type should be 'i' for i32");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_i32_array(arr.data, arr.count);
+        prop_assert_eq!(got, values);
+    }
+
+    // =========================================================================
+    // update_array_f32: whole-payload round-trip (bit equality — covers NaN)
+    // =========================================================================
+
+    #[test]
+    fn update_array_f32_roundtrip(values in proptest::collection::vec(any::<f32>(), 0..64)) {
+        let bits_in: Vec<u32> = values.iter().map(|f| f.to_bits()).collect();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_f32(b"bq", &values);
+        }
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after update_array_f32");
+        prop_assert_eq!(arr.elem_type, b'f', "elem_type should be 'f' for f32");
+        prop_assert_eq!(arr.count, values.len());
+        let got = decode_f32_bits_array(arr.data, arr.count);
+        prop_assert_eq!(got, bits_in);
+    }
+
+    // =========================================================================
+    // set_array_element_u8: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_u8_writes_one_element(
+        (initial, index) in vec_and_valid_index!(u8),
+        new_val in any::<u8>(),
+    ) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u8(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_u8(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_u8");
+        let got = decode_u8_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_u16: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_u16_writes_one_element(
+        (initial, index) in vec_and_valid_index!(u16),
+        new_val in any::<u16>(),
+    ) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_u16(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_u16(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_u16");
+        let got = decode_u16_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_i16: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_i16_writes_one_element(
+        (initial, index) in vec_and_valid_index!(i16),
+        new_val in any::<i16>(),
+    ) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i16(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_i16(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_i16");
+        let got = decode_i16_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_i32: single-element overwrite, all others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_i32_writes_one_element(
+        (initial, index) in vec_and_valid_index!(i32),
+        new_val in any::<i32>(),
+    ) {
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_i32(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_i32(b"bq", index, new_val);
+        let arr = rec.tags().find_array(b"bq").expect("array tag present after set_array_element_i32");
+        let got = decode_i32_array(arr.data, arr.count);
+        for (i, &v) in initial.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_val, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], v, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_array_element_f32: single-element overwrite (bit equality), others preserved
+    // =========================================================================
+
+    #[test]
+    fn set_array_element_f32_writes_one_element(
+        (initial, index) in vec_and_valid_index!(f32),
+        new_val in any::<f32>(),
+    ) {
+        let new_bits = new_val.to_bits();
+        let initial_bits: Vec<u32> = initial.iter().map(|f| f.to_bits()).collect();
+        let mut rec = base_record(&[]);
+        {
+            let mut ed = rec.tags_editor();
+            ed.update_array_f32(b"bq", &initial);
+        }
+        rec.tags_mut().set_array_element_f32(b"bq", index, new_val);
+        let arr =
+            rec.tags().find_array(b"bq").expect("array tag present after set_array_element_f32");
+        let got = decode_f32_bits_array(arr.data, arr.count);
+        for (i, &bits) in initial_bits.iter().enumerate() {
+            if i == index {
+                prop_assert_eq!(got[i], new_bits, "overwritten element mismatch at index {}", i);
+            } else {
+                prop_assert_eq!(got[i], bits, "non-overwritten element changed at index {}", i);
+            }
+        }
+    }
+
+    // =========================================================================
+    // set_bin / bin: round-trip across the full u16 domain
+    // =========================================================================
+
+    #[test]
+    fn set_bin_roundtrip(v in any::<u16>()) {
+        let mut rec = base_record(&[]);
+        rec.set_bin(v);
+        prop_assert_eq!(rec.bin(), v);
+    }
+}


### PR DESCRIPTION
## Summary

Part 4 of 5 in the stacked series closing #272. Stacks on #280.

Adds benchmarks, property tests, and edge-case unit tests covering the new API. Pure test/bench additions — no source behavior change.

## Benchmarks (`benches/`)

- `raw_bam_accessors.rs` — hot-path accessor reads (flags, pos, read_name, cigar iter, quality scores, tag find)
- `raw_bam_tags_editor.rs` — tag editor in-place vs resize patterns
- `raw_bam_length_changing.rs` — length-changing edit baselines
- `raw_bam_vs_recordbuf.rs` — side-by-side raw-byte vs noodles `RecordBuf` round-trip (measures actual speedup per op)

## Property tests

- `tests/tags_editor_invariants.rs`:
  - `append(tag, v); remove(tag)` is a byte-level no-op when tag absent (string + int)
  - `update_int/string/float` round-trip across full value domains
  - `update_array_{u8,u16,i16,i32,f32}` whole-payload round-trips
  - `set_array_element_{u8,u16,i16,i32,f32}` preserves other elements
  - `set_bin` round-trip across full `u16` domain
  - Mixed update/remove sequences preserve iterability (`aux_offset` stays valid)

## Edge-case unit tests (in `raw_bam_record.rs`)

- Max-length read name (254 bytes + NUL) succeeds; one over panics
- Zero-length sequence
- `set_cigar_ops(&[])` clears CIGAR without touching aux
- Length-changing edits preserve B-array aux tags byte-for-byte

## Test plan

- [x] `cargo ci-test` — all new tests pass
- [x] `cargo bench --bench raw_bam_vs_recordbuf` — numbers captured in PR 5 description

## Stack

- PR 1: Core API + gap closures
- PR 2: Migration
- PR 3: Demotion (BREAKING)
- **PR 4 (this):** Tests + benchmarks
- PR 5: Post-refactor perf optimizations

Part of #272. Supersedes #277.