### PR TITLE
perf(raw-bam): follow-up speedups + SIMD nibble2base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
- "wide 1.2.0",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ dependencies = [
  "log",
  "noodles",
  "rand 0.10.1",
- "wide 1.2.0",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -751,9 +751,11 @@ name = "fgumi-raw-bam"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "noodles",
  "proptest",
  "rstest",
+ "wide 1.3.0",
 ]
 
 [[package]]
@@ -2752,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198f6abc41fab83526d10880fa5c17e2b4ee44e763949b4bb34e2fd1e8ca48e4"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
 dependencies = [
  "bytemuck",
  "safe_arch 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ fgumi-raw-bam = { version = "0.1.3", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.1.3", path = "crates/fgumi-sam" }
 fgumi-simd-fastq = { version = "0.1.3", path = "crates/fgumi-simd-fastq" }
 fgumi-umi = { version = "0.1.3", path = "crates/fgumi-umi" }
+bytemuck = { version = "1.14", features = ["derive"] }
+wide = "1.3"
 
 [package]
 name = "fgumi"
@@ -71,10 +73,10 @@ num_cpus = "1.16"
 rayon = "1.10"
 approx = "0.5.1"
 ahash = "0.8"
-bytemuck = { version = "1.14", features = ["derive"] }
+bytemuck = { workspace = true }
 noodles-csi = "0.54.0"
 bgzf = "0.3.0"
-wide = "1.1"
+wide = { workspace = true }
 rand_distr = "0.6"
 flate2 = "1.1"
 dhat = { version = "0.3", optional = true }

--- a/benches/raw_bam.rs
+++ b/benches/raw_bam.rs
@@ -157,6 +157,33 @@ fn bench_view_accessors(c: &mut Criterion) {
             black_box(v.tags().find_int(b"NM"))
         });
     });
+
+    // Shorter seq (below SIMD threshold)
+    let bytes_short = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 16)], 16, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_16bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_short));
+            black_box(v.sequence_vec());
+        });
+    });
+
+    // 150 bp read (typical Illumina short read; SIMD active)
+    let bytes_150 = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 150)], 150, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_150bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_150));
+            black_box(v.sequence_vec());
+        });
+    });
+
+    // 300 bp read (2× typical; SIMD loop iterations dominate)
+    let bytes_300 = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 300)], 300, -1, -1, &[]);
+    c.bench_function("view::sequence_vec_300bp", |b| {
+        b.iter(|| {
+            let v = RawRecordView::new(black_box(&bytes_300));
+            black_box(v.sequence_vec());
+        });
+    });
 }
 
 // ============================================================================

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 [dependencies]
 noodles = { version = "0.106.0", features = ["bam", "sam"], optional = true }
 anyhow = { version = "1.0.102", optional = true }
+bytemuck = { workspace = true }
+wide = { workspace = true }
 
 [features]
 default = []

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -30,18 +30,42 @@ pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op:
     }
 }
 
+/// BAM CIGAR op-type -> (`consume_query`, `consume_ref`) packed bitmask.
+///
+/// Encodes both properties for every op type (0..8) in a single u32. Bit
+/// `(op << 1)` is `consume_query`; bit `(op << 1 | 1)` is `consume_ref`. Bits
+/// for op values >= 9 are zero. Matches htslib's `BAM_CIGAR_TYPE` in
+/// `sam.h`, giving branchless `consumes_*` queries.
+///
+/// | op | mnemonic | consume_query | consume_ref |
+/// |----|----------|---------------|-------------|
+/// | 0  | M        | yes           | yes         |
+/// | 1  | I        | yes           | no          |
+/// | 2  | D        | no            | yes         |
+/// | 3  | N        | no            | yes         |
+/// | 4  | S        | yes           | no          |
+/// | 5  | H        | no            | no          |
+/// | 6  | P        | no            | no          |
+/// | 7  | =        | yes           | yes         |
+/// | 8  | X        | yes           | yes         |
+const BAM_CIGAR_TYPE: u32 = 0x3C1A7;
+
 /// Returns true if the CIGAR op type consumes the reference (M, D, N, =, X).
 #[inline]
 #[must_use]
 pub const fn consumes_ref(op_type: u32) -> bool {
-    matches!(op_type, 0 | 2 | 3 | 7 | 8)
+    // Guard the shift: `op_type << 1 >= 32` would panic in debug mode. Any
+    // value above the defined range (0..=8) is not a reference-consuming op.
+    op_type < 9 && (BAM_CIGAR_TYPE >> (op_type << 1)) & 2 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the query including soft clips (M, I, S, =, X).
 #[inline]
 #[must_use]
 pub const fn consumes_query(op_type: u32) -> bool {
-    matches!(op_type, 0 | 1 | 4 | 7 | 8)
+    // Guard the shift: `op_type << 1 >= 32` would panic in debug mode. Any
+    // value above the defined range (0..=8) is not a query-consuming op.
+    op_type < 9 && (BAM_CIGAR_TYPE >> (op_type << 1)) & 1 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the read/query excluding soft clips (M, I, =, X).
@@ -880,6 +904,31 @@ impl<'a> RawRecordView<'a> {
             .sum()
     }
 
+    /// Compute reference-consuming and query-consuming lengths in one pass.
+    ///
+    /// Equivalent to `(self.reference_length(), self.query_length())` but
+    /// walks the CIGAR only once. Use this when both values are needed
+    /// (e.g. record validation, alignment-end computation).
+    ///
+    /// Returns `(ref_length, query_length)`.
+    #[inline]
+    #[must_use]
+    pub fn cigar_lengths(&self) -> (i32, usize) {
+        let mut ref_len = 0i32;
+        let mut q_len = 0usize;
+        for op in self.cigar_ops_iter() {
+            let ty = op & 0xF;
+            let len_u32 = op >> 4;
+            if consumes_ref(ty) {
+                ref_len += len_u32.cast_signed();
+            }
+            if consumes_query(ty) {
+                q_len += len_u32 as usize;
+            }
+        }
+        (ref_len, q_len)
+    }
+
     /// Compute 1-based alignment end position.
     #[inline]
     #[must_use]
@@ -913,6 +962,39 @@ impl<'a> RawRecordView<'a> {
 mod tests {
     use super::*;
     use crate::testutil::*;
+
+    // ========================================================================
+    // BAM_CIGAR_TYPE bitmask tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_type_bitmask_matches_spec() {
+        // Spec: (consumes_query, consumes_ref) for each op type 0..8
+        let expected = [
+            (true, true),   // 0: M
+            (true, false),  // 1: I
+            (false, true),  // 2: D
+            (false, true),  // 3: N
+            (true, false),  // 4: S
+            (false, false), // 5: H
+            (false, false), // 6: P
+            (true, true),   // 7: =
+            (true, true),   // 8: X
+        ];
+        for (op, &(eq, er)) in expected.iter().enumerate() {
+            let op = u32::try_from(op).unwrap();
+            assert_eq!(consumes_query(op), eq, "consumes_query({op})");
+            assert_eq!(consumes_ref(op), er, "consumes_ref({op})");
+        }
+        // Op values >= 9 (including out-of-range >= 16) must not panic in
+        // debug mode and must return false. The naked bitmask shift would
+        // overflow for op >= 16 (since op << 1 >= 32), so `consumes_*` must
+        // guard the shift.
+        for op in 9u32..=255 {
+            assert!(!consumes_query(op), "consumes_query({op}) should be false");
+            assert!(!consumes_ref(op), "consumes_ref({op}) should be false");
+        }
+    }
 
     // ========================================================================
     // unclipped_start_from_cigar / unclipped_end_from_cigar tests
@@ -1965,5 +2047,47 @@ mod tests {
         assert_eq!(v.query_length(), 100);
         assert_eq!(v.cigar_raw_bytes().len(), 12);
         assert_eq!(v.cigar_ops_iter().count(), 3);
+    }
+
+    // ========================================================================
+    // cigar_lengths tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_lengths_matches_separate_calls() {
+        use crate::fields::RawRecordView;
+
+        // Record with mixed CIGAR: 50M 5D 10I 35M = ref 90, query 95
+        let rec = make_bam_bytes(
+            0,
+            100,
+            0,
+            b"r",
+            &[
+                encode_op(0, 50), // 50M
+                encode_op(2, 5),  // 5D (ref only)
+                encode_op(1, 10), // 10I (query only)
+                encode_op(0, 35), // 35M
+            ],
+            95,
+            -1,
+            -1,
+            &[],
+        );
+        let v = RawRecordView::new(&rec);
+        let (ref_len, q_len) = v.cigar_lengths();
+        assert_eq!(ref_len, 90);
+        assert_eq!(q_len, 95);
+        // Agree with the single-purpose methods
+        assert_eq!(ref_len, v.reference_length());
+        assert_eq!(q_len, v.query_length());
+    }
+
+    #[test]
+    fn test_cigar_lengths_empty_cigar() {
+        use crate::fields::RawRecordView;
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let v = RawRecordView::new(&rec);
+        assert_eq!(v.cigar_lengths(), (0, 0));
     }
 }

--- a/crates/fgumi-raw-bam/src/fields.rs
+++ b/crates/fgumi-raw-bam/src/fields.rs
@@ -278,7 +278,11 @@ pub(crate) const TAG_FIXED_SIZES: [u8; 256] = {
 };
 
 /// Calculate the size of a tag value based on its type.
-#[inline]
+// Inlining always is justified here: `tag_value_size` is the inner dispatch of
+// the hot `find_tag_position` loop and is tiny (a table lookup + match).
+// Forcing inline eliminates one call boundary per tag-scan iteration.
+#[allow(clippy::inline_always)]
+#[inline(always)]
 #[must_use]
 pub fn tag_value_size(val_type: u8, data: &[u8]) -> Option<usize> {
     let fixed = TAG_FIXED_SIZES[val_type as usize];
@@ -455,8 +459,12 @@ pub fn aux_data_offset_from_record(bam: &[u8]) -> Option<usize> {
         return None;
     }
     let l_rn = bam[8] as usize;
-    let n_co = u16::from_le_bytes([bam[12], bam[13]]) as usize;
-    let l_s = u32::from_le_bytes([bam[16], bam[17], bam[18], bam[19]]) as usize;
+    // Single 8-byte load over offsets 12..20 covers n_cigar_op (u16 at 12),
+    // flag (u16 at 14, discarded), and l_seq (u32 at 16). Avoids three
+    // separate loads in a frequently-called header-decode path.
+    let packed = u64::from_le_bytes(bam[12..20].try_into().ok()?);
+    let n_co = (packed & 0xFFFF) as usize;
+    let l_s = ((packed >> 32) & 0xFFFF_FFFF) as usize;
     Some(aux_data_offset(l_rn, n_co, l_s))
 }
 

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -383,6 +383,15 @@ impl RawRecord {
         RawRecordView::new(&self.0).query_length()
     }
 
+    /// Compute reference-consuming and query-consuming lengths in one pass.
+    ///
+    /// Returns `(ref_length, query_length)`. See [`RawRecordView::cigar_lengths`].
+    #[inline]
+    #[must_use]
+    pub fn cigar_lengths(&self) -> (i32, usize) {
+        self.view().cigar_lengths()
+    }
+
     /// Return the 1-based alignment end position, or `None` if unmapped.
     #[inline]
     #[must_use]
@@ -600,13 +609,30 @@ impl RawRecord {
         let body_start = 32 + l_rn + n_co * 4;
         let old_packed = old_l.div_ceil(2);
         let body_end = body_start + old_packed + old_l;
-
         let new_packed_len = seq.len().div_ceil(2);
-        let mut new_body = Vec::with_capacity(new_packed_len + qual.len());
-        crate::sequence::pack_sequence_into(&mut new_body, seq);
-        new_body.extend_from_slice(qual);
+        let new_body_len = new_packed_len + qual.len();
+        let old_body_len = body_end - body_start;
 
-        self.0.splice(body_start..body_end, new_body);
+        // Resize in place by shifting aux data to its new position, then write
+        // packed seq and qual directly into the record buffer. This avoids the
+        // intermediate Vec allocation and extra memcpy that the splice approach
+        // required.
+        if new_body_len > old_body_len {
+            let grow = new_body_len - old_body_len;
+            let old_len = self.0.len();
+            self.0.resize(old_len + grow, 0);
+            self.0.copy_within(body_end..old_len, body_end + grow);
+        } else if new_body_len < old_body_len {
+            let shrink = old_body_len - new_body_len;
+            self.0.copy_within(body_end.., body_end - shrink);
+            self.0.truncate(self.0.len() - shrink);
+        }
+
+        let (seq_slot, qual_slot) =
+            self.0[body_start..body_start + new_body_len].split_at_mut(new_packed_len);
+        crate::sequence::pack_sequence_into_slice(seq_slot, seq);
+        qual_slot.copy_from_slice(qual);
+
         self.0[16..20].copy_from_slice(&new_l.to_le_bytes());
     }
 

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -1,3 +1,6 @@
+use bytemuck::cast;
+use wide::{u8x16, u16x8};
+
 use crate::fields::{l_seq, qual_offset, seq_offset};
 
 /// BAM 4-bit base encoding -> ASCII lookup table.
@@ -75,12 +78,93 @@ pub fn is_base_n(bam: &[u8], seq_off: usize, position: usize) -> bool {
     get_base(bam, seq_off, position) == 0xF
 }
 
+/// BAM nibble (0–15) → ASCII base, as a SIMD lookup table.
+///
+/// Used by `decode_chunk_32` via `swizzle_relaxed` (portable `pshufb`).
+const NIBBLE_ASCII_LUT: u8x16 = u8x16::new([
+    b'=', b'A', b'C', b'M', b'G', b'R', b'S', b'V', b'T', b'W', b'Y', b'H', b'K', b'D', b'B', b'N',
+]);
+
+/// Decode 16 packed bytes (= 32 bases) into ASCII, using SIMD.
+///
+/// Writes 32 bytes starting at `out[out_off]`. The caller guarantees the
+/// buffers are large enough.
+#[inline]
+fn decode_chunk_32(packed: &[u8], packed_off: usize, out: &mut [u8], out_off: usize) {
+    debug_assert!(packed.len() >= packed_off + 16);
+    debug_assert!(out.len() >= out_off + 32);
+
+    // Load 16 packed bytes.
+    let bytes_arr: [u8; 16] = packed[packed_off..packed_off + 16].try_into().unwrap();
+    let bytes = u8x16::new(bytes_arr);
+
+    // Low nibbles: direct per-lane mask.
+    let lo_nibbles = bytes & u8x16::new([0x0F; 16]);
+
+    // High nibbles via u16 shift + mask trick.
+    //
+    // For packed byte pair [b0, b1] viewed as u16 LE = (b1 << 8) | b0,
+    // (u16 >> 4) produces:
+    //   low byte  = (lo_nibble(b1) << 4) | hi_nibble(b0)
+    //   high byte = hi_nibble(b1)
+    // After &0x0F per byte:
+    //   low byte  = hi_nibble(b0)   ← wanted at even byte index
+    //   high byte = hi_nibble(b1)   ← wanted at odd byte index
+    let as_u16: u16x8 = cast(bytes);
+    let shifted: u16x8 = as_u16 >> 4u32;
+    let hi_nibbles: u8x16 = cast::<u16x8, u8x16>(shifted) & u8x16::new([0x0F; 16]);
+
+    // Parallel table lookup: nibble (0..15) → ASCII base.
+    let hi_ascii = NIBBLE_ASCII_LUT.swizzle_relaxed(hi_nibbles);
+    let lo_ascii = NIBBLE_ASCII_LUT.swizzle_relaxed(lo_nibbles);
+
+    // Output order: [hi(b0), lo(b0), hi(b1), lo(b1), ..., hi(b15), lo(b15)].
+    // u8x16::unpack_low(a, b)  → [a[0], b[0], a[1], b[1], ..., a[7], b[7]]
+    // u8x16::unpack_high(a, b) → [a[8], b[8], a[9], b[9], ..., a[15], b[15]]
+    let first_16 = u8x16::unpack_low(hi_ascii, lo_ascii);
+    let last_16 = u8x16::unpack_high(hi_ascii, lo_ascii);
+
+    out[out_off..out_off + 16].copy_from_slice(first_16.as_array());
+    out[out_off + 16..out_off + 32].copy_from_slice(last_16.as_array());
+}
+
+/// SIMD-accelerated sequence extraction.
+///
+/// Kept `pub(crate)` for benchmarking; external callers go through
+/// `extract_sequence`, which dispatches based on read length.
+#[inline]
+#[must_use]
+pub(crate) fn extract_sequence_simd(bam: &[u8]) -> Vec<u8> {
+    let l = l_seq(bam) as usize;
+    let off = seq_offset(bam);
+    let mut bases = vec![0u8; l];
+
+    // Process 16 packed bytes = 32 bases at a time.
+    let full_chunks = l / 32;
+    for c in 0..full_chunks {
+        decode_chunk_32(bam, off + c * 16, &mut bases, c * 32);
+    }
+
+    // Scalar tail for the remaining (l % 32) bases.
+    let processed = full_chunks * 32;
+    for (slot, i) in bases[processed..].iter_mut().zip(processed..l) {
+        *slot = BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize];
+    }
+    bases
+}
+
 /// Bulk-extract the full sequence from a BAM record as ASCII bases.
 ///
 /// Decodes the packed 4-bit sequence data into a `Vec<u8>` of ASCII bases.
+/// Uses SIMD for reads of 32 bp or longer; falls back to scalar for shorter
+/// reads where SIMD startup cost dominates.
 #[must_use]
 pub fn extract_sequence(bam: &[u8]) -> Vec<u8> {
     let l = l_seq(bam) as usize;
+    if l >= 32 {
+        return extract_sequence_simd(bam);
+    }
+    // Scalar path for short sequences.
     let off = seq_offset(bam);
     let mut bases = Vec::with_capacity(l);
     for i in 0..l {
@@ -123,6 +207,57 @@ pub fn pack_sequence_into(dst: &mut Vec<u8>, bases: &[u8]) {
     }
     if let Some(&last) = pairs.remainder().first() {
         dst.push(SEQ_CODES[last as usize] << 4);
+    }
+}
+
+/// Pack ASCII bases into BAM 4-bit-per-base format, writing into a mutable slice.
+///
+/// `dst` must have length `>= bases.len().div_ceil(2)`. Writes exactly
+/// `bases.len().div_ceil(2)` bytes, zero-padding the last nibble when
+/// `bases.len()` is odd.
+///
+/// Mirrors [`pack_sequence_into`] but targets an existing `&mut [u8]` slot
+/// instead of appending to a `Vec`, avoiding an intermediate allocation when
+/// the destination buffer is already sized.
+///
+/// # Panics
+///
+/// Panics if `dst.len() < bases.len().div_ceil(2)`. This contract is enforced
+/// unconditionally (not just in debug builds) so callers get a clear failure
+/// at the call boundary rather than a later bounds-check panic.
+#[inline]
+pub fn pack_sequence_into_slice(dst: &mut [u8], bases: &[u8]) {
+    if bases.is_empty() {
+        return;
+    }
+    let packed_len = bases.len().div_ceil(2);
+    assert!(
+        dst.len() >= packed_len,
+        "pack_sequence_into_slice: destination slice too small; need {} bytes, got {}",
+        packed_len,
+        dst.len(),
+    );
+    let mut i = 0usize;
+    let mut chunks = bases.chunks_exact(PACK_CHUNK);
+    for chunk in chunks.by_ref() {
+        dst[i] = (SEQ_CODES[chunk[0] as usize] << 4) | SEQ_CODES[chunk[1] as usize];
+        dst[i + 1] = (SEQ_CODES[chunk[2] as usize] << 4) | SEQ_CODES[chunk[3] as usize];
+        dst[i + 2] = (SEQ_CODES[chunk[4] as usize] << 4) | SEQ_CODES[chunk[5] as usize];
+        dst[i + 3] = (SEQ_CODES[chunk[6] as usize] << 4) | SEQ_CODES[chunk[7] as usize];
+        dst[i + 4] = (SEQ_CODES[chunk[8] as usize] << 4) | SEQ_CODES[chunk[9] as usize];
+        dst[i + 5] = (SEQ_CODES[chunk[10] as usize] << 4) | SEQ_CODES[chunk[11] as usize];
+        dst[i + 6] = (SEQ_CODES[chunk[12] as usize] << 4) | SEQ_CODES[chunk[13] as usize];
+        dst[i + 7] = (SEQ_CODES[chunk[14] as usize] << 4) | SEQ_CODES[chunk[15] as usize];
+        i += 8;
+    }
+    let remainder = chunks.remainder();
+    let mut pairs = remainder.chunks_exact(2);
+    for pair in pairs.by_ref() {
+        dst[i] = (SEQ_CODES[pair[0] as usize] << 4) | SEQ_CODES[pair[1] as usize];
+        i += 1;
+    }
+    if let Some(&last) = pairs.remainder().first() {
+        dst[i] = SEQ_CODES[last as usize] << 4;
     }
 }
 
@@ -635,6 +770,52 @@ mod tests {
         let v = RawRecordView::new(&rec);
         assert_eq!(v.sequence_vec(), b"ACNT".to_vec());
         assert_eq!(v.quality_scores(), &[25, 10, 10, 99]);
+    }
+
+    // ========================================================================
+    // SIMD / scalar equivalence tests
+    // ========================================================================
+
+    #[test]
+    #[should_panic(expected = "pack_sequence_into_slice: destination slice too small")]
+    fn test_pack_sequence_into_slice_asserts_on_undersized_dst() {
+        // Contract must be enforced in release builds too: bases=8 needs 4 bytes,
+        // dst has only 3 → unconditional assert.
+        let bases = b"ACGTACGT";
+        let mut dst = [0u8; 3];
+        pack_sequence_into_slice(&mut dst, bases);
+    }
+
+    #[test]
+    fn test_extract_sequence_simd_matches_scalar_over_lengths() {
+        // Test a range of lengths that exercise the SIMD path (>=32) and the
+        // scalar tail (length % 32 != 0). The expected bytes are computed by
+        // the scalar `get_base` / `BAM_BASE_TO_ASCII` decoder on the same
+        // packed record, so this directly verifies the SIMD shuffle order
+        // against the scalar path (not just pack->unpack round-trip).
+        //
+        // Cycling through the full 16-nibble alphabet `=ACMGRSVTWYHKDBN`
+        // exercises every LUT entry at every even/odd (hi/lo) nibble slot.
+        const ALPHABET: &[u8; 16] = b"=ACMGRSVTWYHKDBN";
+        for l in [0usize, 1, 15, 31, 32, 33, 63, 64, 150, 200, 255] {
+            let seq: Vec<u8> = (0..l).map(|i| ALPHABET[i % 16]).collect();
+            let mut packed = Vec::new();
+            pack_sequence_into(&mut packed, &seq);
+            // Build a BAM record with the packed sequence in place.
+            let mut bam = make_bam_bytes(0, 0, 0, b"r", &[], l, -1, -1, &[]);
+            let so = seq_offset(&bam);
+            let packed_len = l.div_ceil(2);
+            bam[so..so + packed_len].copy_from_slice(&packed);
+
+            // Expected: decode the same packed bytes with the scalar decoder.
+            let expected: Vec<u8> =
+                (0..l).map(|i| BAM_BASE_TO_ASCII[get_base(&bam, so, i) as usize]).collect();
+
+            let got = extract_sequence(&bam);
+            assert_eq!(got, expected, "SIMD vs scalar mismatch at l={l}");
+            // And the round-trip against the source bases also holds.
+            assert_eq!(got, seq, "round-trip mismatch at l={l}");
+        }
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -9,12 +9,16 @@ use crate::fields::{
 /// (the first byte of the 2-byte tag identifier). Returns `None` if not found.
 #[must_use]
 fn find_tag_position(aux_data: &[u8], tag: [u8; 2]) -> Option<(usize, u8)> {
+    // Compare as u16 — a single integer compare instead of a slice compare.
+    // LE byte order is preserved: both values are built from the same two bytes
+    // in the same order, so equality is equivalent to the byte-slice compare.
+    let tag_u16 = u16::from_le_bytes(tag);
     let mut p = 0;
     while p + 3 <= aux_data.len() {
-        let t = &aux_data[p..p + 2];
+        let entry_u16 = u16::from_le_bytes([aux_data[p], aux_data[p + 1]]);
         let val_type = aux_data[p + 2];
 
-        if t == tag {
+        if entry_u16 == tag_u16 {
             return Some((p, val_type));
         }
 


### PR DESCRIPTION
## Summary

Part 5 of 5 in the stacked series closing #272. Stacks on #281.

Six perf optimizations on top of the core API, grouped into three commits:

1. **`f0b8b32`** — small tag-lookup/header-decode wins
   - `tag_value_size` marked `#[inline(always)]` (hot inside `find_tag_position`)
   - `find_tag_position` compares tags as `u16` instead of byte slices
   - `aux_data_offset_from_record` does a single u64 load over offsets 12..20

2. **`bea6016`** — `set_sequence_and_qualities` splices in place
   - `Vec::copy_within` + `pack_sequence_into_slice` replace intermediate `Vec` allocation
   - Impact: `set_sequence_and_qualities_grow` 300 ns → 125 ns (**−58%**); vs-RecordBuf speedup **6× → 13.8×**

3. **`df1089c` + `dd8b4fb`** — SIMD nibble2base via `wide::u8x16::swizzle_relaxed` (portable `pshufb`)
   - Port of htslib's `simd.c` nibble2base
   - 16 packed bytes (32 bases) per iteration
   - `sequence_vec` 150 bp: **3.8×**, 300 bp: **6.0×**

4. **`0955cfa`** — branchless `BAM_CIGAR_TYPE = 0x3C1A7` bitmask (matches htslib)
   - `consumes_query` / `consumes_ref` become single shift+mask
   - Adds `RawRecordView::cigar_lengths()` for dual-return walk (ref_len + query_len in one iteration)

## Benchmark summary

See the comparison table in PR description for the raw-byte-vs-`RecordBuf` speedups after all perf work: 14×–922× range, 13.8× on the previously-weakest `set_sequence_and_qualities`.

## Test plan

- [x] `cargo ci-test` — all tests pass
- [x] `cargo bench --bench raw_bam_accessors` — SIMD numbers confirmed
- [x] `cargo bench --bench raw_bam_vs_recordbuf` — post-refactor speedups measured

## Stack

- PR 1: Core API + gap closures
- PR 2: Migration
- PR 3: Demotion (BREAKING)
- PR 4: Tests + benchmarks
- **PR 5 (this):** Post-refactor perf optimizations

Closes #272 (when the full stack lands). Supersedes #277.