### PR TITLE
feat(sort): distribute spill files across multiple temp dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -615,7 +615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -670,6 +670,7 @@ dependencies = [
  "fgumi-simd-fastq",
  "fgumi-umi",
  "flate2",
+ "fs4",
  "indexmap",
  "itertools 0.14.0",
  "libdeflater",
@@ -836,6 +837,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2161,7 +2172,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2449,7 +2460,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2782,7 +2793,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2894,11 +2905,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2909,6 +2945,54 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ murmur3 = "0.5"
 statrs = "0.18"
 bytesize = "2.3"
 sysinfo = { version = "0.38", default-features = false, features = ["system"] } # unconditionally used by validate_against_system_memory
+fs4 = { version = "0.13", default-features = false, features = ["sync"] } # cross-platform filesystem free-space queries
 num_cpus = "1.16"
 rayon = "1.10"
 approx = "0.5.1"

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -165,6 +165,12 @@ EXAMPLES:
 
   # Verify a BAM file is correctly sorted
   fgumi sort -i sorted.bam --verify --order template-coordinate
+
+  # Spread spill chunks across multiple temp dirs (round-robin, free-space aware)
+  fgumi sort -i in.bam -o out.bam -T /mnt/ssd1 -T /mnt/ssd2
+
+  # Same via FGUMI_TMP_DIRS env var (PATH-style list)
+  FGUMI_TMP_DIRS=/mnt/ssd1:/mnt/ssd2 fgumi sort -i in.bam -o out.bam
 "#
 )]
 #[allow(clippy::struct_excessive_bools)]
@@ -224,12 +230,20 @@ pub struct Sort {
     #[arg(long = "memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub memory_per_thread: bool,
 
-    /// Temporary directory for intermediate files.
+    /// Temporary directory for intermediate files. Repeatable.
     ///
-    /// If not specified, uses the system default temp directory.
-    /// For best performance, use a fast SSD.
-    #[arg(short = 'T', long = "tmp-dir")]
-    pub tmp_dir: Option<PathBuf>,
+    /// Pass `-T <path>` one or more times to spread spill chunks across multiple
+    /// directories in free-space-aware round-robin order. Useful when one
+    /// filesystem is too small or slower than the aggregate of several.
+    ///
+    /// If no flags are given and the `FGUMI_TMP_DIRS` environment variable is
+    /// set, its value is parsed as a `PATH`-style list (colon-separated on
+    /// Unix, semicolon-separated on Windows) and used instead.
+    ///
+    /// If neither is provided, the system default temp directory is used.
+    /// For best performance, use fast SSDs.
+    #[arg(short = 'T', long = "tmp-dir", action = clap::ArgAction::Append)]
+    pub tmp_dirs: Vec<PathBuf>,
 
     /// Number of threads for parallel operations.
     ///
@@ -306,6 +320,32 @@ pub(crate) fn parse_memory(s: &str) -> Result<MemoryLimit, String> {
     }
 
     Ok(MemoryLimit::Fixed(parse_memory_bytes(s, "Memory size")?))
+}
+
+/// Environment variable name for the fallback temp-dir list, parsed as a
+/// `PATH`-style list when no `-T/--tmp-dir` flags are passed.
+const TMP_DIRS_ENV: &str = "FGUMI_TMP_DIRS";
+
+/// Resolve the final list of temp directories for a sort run.
+///
+/// Precedence: CLI flags (if non-empty) > `FGUMI_TMP_DIRS` env var > empty.
+/// Empty strings and whitespace-only entries are filtered out of the env-var
+/// value so that `FGUMI_TMP_DIRS=:` or trailing separators don't produce bogus
+/// paths.
+pub(crate) fn resolve_tmp_dirs(cli: &[PathBuf], env_value: Option<&str>) -> Vec<PathBuf> {
+    if !cli.is_empty() {
+        return cli.to_vec();
+    }
+
+    let Some(value) = env_value else { return Vec::new() };
+    if value.is_empty() {
+        return Vec::new();
+    }
+
+    std::env::split_paths(value)
+        .filter(|p| !p.as_os_str().is_empty())
+        .filter(|p| !p.to_string_lossy().trim().is_empty())
+        .collect()
 }
 
 /// Parse memory reserve string (e.g., "10G", "auto").
@@ -553,8 +593,15 @@ impl Sort {
         if self.write_index {
             info!("Write index: enabled");
         }
-        if let Some(ref tmp) = self.tmp_dir {
-            info!("Temp directory: {}", tmp.display());
+        let env_value = std::env::var(TMP_DIRS_ENV).ok();
+        let resolved_tmp_dirs = resolve_tmp_dirs(&self.tmp_dirs, env_value.as_deref());
+        if !resolved_tmp_dirs.is_empty() {
+            let joined = resolved_tmp_dirs
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            info!("Temp directories: {joined}");
         }
 
         // Sort using raw-bytes sorter for optimal memory efficiency and speed
@@ -582,8 +629,8 @@ impl Sort {
             sorter = sorter.cell_tag(ct);
         }
 
-        if let Some(ref tmp) = self.tmp_dir {
-            sorter = sorter.temp_dir(tmp.clone());
+        if !resolved_tmp_dirs.is_empty() {
+            sorter = sorter.temp_dirs(resolved_tmp_dirs);
         }
 
         let stats = sorter.sort(&self.input, output)?;
@@ -694,7 +741,84 @@ impl Sort {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use rstest::rstest;
+
+    // ========================================================================
+    // Temp-dir resolution tests
+    // ========================================================================
+
+    #[test]
+    fn test_resolve_tmp_dirs_empty() {
+        assert!(resolve_tmp_dirs(&[], None).is_empty());
+        assert!(resolve_tmp_dirs(&[], Some("")).is_empty());
+    }
+
+    #[test]
+    fn test_resolve_tmp_dirs_cli_only() {
+        let cli = vec![PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")];
+        let got = resolve_tmp_dirs(&cli, None);
+        assert_eq!(got, cli);
+    }
+
+    #[test]
+    fn test_resolve_tmp_dirs_env_only() {
+        #[cfg(unix)]
+        let env = "/tmp/x:/tmp/y";
+        #[cfg(windows)]
+        let env = "C:/tmp/x;C:/tmp/y";
+
+        let got = resolve_tmp_dirs(&[], Some(env));
+        assert_eq!(got.len(), 2);
+        assert!(got[0].to_string_lossy().ends_with('x'));
+        assert!(got[1].to_string_lossy().ends_with('y'));
+    }
+
+    #[test]
+    fn test_resolve_tmp_dirs_cli_overrides_env() {
+        let cli = vec![PathBuf::from("/tmp/cli")];
+        #[cfg(unix)]
+        let env = "/tmp/env1:/tmp/env2";
+        #[cfg(windows)]
+        let env = "C:/tmp/env1;C:/tmp/env2";
+
+        let got = resolve_tmp_dirs(&cli, Some(env));
+        assert_eq!(got, cli, "CLI flags must take precedence over env var");
+    }
+
+    #[test]
+    fn test_resolve_tmp_dirs_skips_empty_segments() {
+        // Trailing separator / empty segment must not produce a bogus empty PathBuf.
+        #[cfg(unix)]
+        let env = "/tmp/a::/tmp/b:";
+        #[cfg(windows)]
+        let env = "C:/tmp/a;;C:/tmp/b;";
+
+        let got = resolve_tmp_dirs(&[], Some(env));
+        assert_eq!(got.len(), 2, "empty path segments must be filtered: {got:?}");
+    }
+
+    // ========================================================================
+    // Clap parsing tests for repeatable -T flag
+    // ========================================================================
+
+    #[rstest]
+    #[case::zero(&[], vec![])]
+    #[case::single_short(&["-T", "/tmp/a"], vec![PathBuf::from("/tmp/a")])]
+    #[case::multiple_short(
+        &["-T", "/tmp/a", "-T", "/tmp/b", "-T", "/tmp/c"],
+        vec![PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b"), PathBuf::from("/tmp/c")],
+    )]
+    #[case::multiple_long(
+        &["--tmp-dir", "/tmp/a", "--tmp-dir", "/tmp/b"],
+        vec![PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")],
+    )]
+    fn test_clap_tmp_dir_repeatable(#[case] extra: &[&str], #[case] expected: Vec<PathBuf>) {
+        let base = ["sort", "-i", "in.bam", "-o", "out.bam", "--order", "coordinate"];
+        let args: Vec<&str> = base.iter().copied().chain(extra.iter().copied()).collect();
+        let sort = Sort::try_parse_from(args).expect("parse should succeed");
+        assert_eq!(sort.tmp_dirs, expected);
+    }
 
     /// Helper to construct a `Sort` struct with a given order.
     fn make_sort(order: SortOrderArg) -> Sort {
@@ -706,7 +830,7 @@ mod tests {
             max_memory: MemoryLimit::Fixed(512 * 1024 * 1024),
             memory_reserve: MemoryReserve::Auto,
             memory_per_thread: true,
-            tmp_dir: None,
+            tmp_dirs: Vec::new(),
             threads: 1,
             compression: CompressionOptions::default(),
             temp_compression: 1,

--- a/src/lib/sort/mod.rs
+++ b/src/lib/sort/mod.rs
@@ -47,6 +47,7 @@ pub mod raw;
 pub mod raw_bam_reader;
 pub mod read_ahead;
 pub(crate) mod segmented_buf;
+pub mod tmp_dir_alloc;
 pub mod worker_pool;
 
 /// Buffer size for `BufReader` during merge phase.

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -30,6 +30,7 @@ use crate::sort::memory_probe::{
 };
 use crate::sort::pooled_chunk_writer::PooledChunkWriter;
 use crate::sort::read_ahead::{RawReadAheadReader, RecordSource};
+use crate::sort::tmp_dir_alloc::TmpDirAllocator;
 use crate::sort::worker_pool::SortWorkerPool;
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, bounded};
@@ -1082,29 +1083,34 @@ impl<K: RawSortKey + 'static> Read for SourceReadAdapter<'_, K> {
 /// Maintains monotonic counters for both chunk files (`chunk_0000.keyed`, ...)
 /// and merged files (`merged_0000.keyed`, ...) to prevent naming collisions
 /// after consolidation drains entries from the chunk file list.
+///
+/// When multiple temp directories are supplied via [`TmpDirAllocator`], chunk
+/// and merged files are distributed across them in round-robin order.
 struct ChunkNamer<'a> {
-    temp_path: &'a Path,
+    alloc: &'a mut TmpDirAllocator,
     chunk_count: usize,
     merge_count: usize,
 }
 
 impl<'a> ChunkNamer<'a> {
-    fn new(temp_path: &'a Path) -> Self {
-        Self { temp_path, chunk_count: 0, merge_count: 0 }
+    fn new(alloc: &'a mut TmpDirAllocator) -> Self {
+        Self { alloc, chunk_count: 0, merge_count: 0 }
     }
 
-    /// Returns the next unique chunk file path.
-    fn next_chunk_path(&mut self) -> PathBuf {
-        let path = self.temp_path.join(format!("chunk_{:04}.keyed", self.chunk_count));
+    /// Returns the next unique chunk file path, drawing from the allocator.
+    fn next_chunk_path(&mut self) -> Result<PathBuf> {
+        let base = self.alloc.next()?;
+        let path = base.join(format!("chunk_{:04}.keyed", self.chunk_count));
         self.chunk_count += 1;
-        path
+        Ok(path)
     }
 
-    /// Returns the next unique merged file path.
-    fn next_merged_path(&mut self) -> PathBuf {
-        let path = self.temp_path.join(format!("merged_{:04}.keyed", self.merge_count));
+    /// Returns the next unique merged file path, drawing from the allocator.
+    fn next_merged_path(&mut self) -> Result<PathBuf> {
+        let base = self.alloc.next()?;
+        let path = base.join(format!("merged_{:04}.keyed", self.merge_count));
         self.merge_count += 1;
-        path
+        Ok(path)
     }
 }
 
@@ -1139,8 +1145,13 @@ pub struct RawExternalSorter {
     sort_order: SortOrder,
     /// Maximum memory to use for in-memory sorting.
     memory_limit: usize,
-    /// Temporary directory for spill files.
-    temp_dir: Option<PathBuf>,
+    /// Temporary directories for spill files.
+    ///
+    /// When empty, a single directory is created under the system default
+    /// temp location. When one or more paths are given, spill files are
+    /// distributed across them in free-space-aware round-robin order via
+    /// [`TmpDirAllocator`].
+    temp_dirs: Vec<PathBuf>,
     /// Number of threads for parallel operations.
     threads: usize,
     /// Compression level for output.
@@ -1206,7 +1217,7 @@ impl RawExternalSorter {
         Self {
             sort_order,
             memory_limit: 512 * 1024 * 1024, // 512 MB default
-            temp_dir: None,
+            temp_dirs: Vec::new(),
             threads: 1,
             output_compression: 6,
             temp_compression: 1, // Default: fast compression
@@ -1226,10 +1237,23 @@ impl RawExternalSorter {
         self
     }
 
-    /// Set the temporary directory for spill files.
+    /// Set a single temporary directory for spill files.
+    ///
+    /// Equivalent to calling [`Self::temp_dirs`] with a single-element vector.
     #[must_use]
     pub fn temp_dir(mut self, path: PathBuf) -> Self {
-        self.temp_dir = Some(path);
+        self.temp_dirs = vec![path];
+        self
+    }
+
+    /// Set multiple temporary directories for spill files.
+    ///
+    /// Spill files are distributed across the supplied directories in
+    /// free-space-aware round-robin order. Passing an empty vector falls
+    /// back to a single directory under the system temp location.
+    #[must_use]
+    pub fn temp_dirs(mut self, paths: Vec<PathBuf>) -> Self {
+        self.temp_dirs = paths;
         self
     }
 
@@ -1401,7 +1425,7 @@ impl RawExternalSorter {
         );
 
         // Create merged output file
-        let merged_path = namer.next_merged_path();
+        let merged_path = namer.next_merged_path()?;
 
         // Open readers with semaphore to cap concurrent I/O.
         let sem = make_reader_semaphore(self.threads);
@@ -1505,20 +1529,19 @@ impl RawExternalSorter {
             header
         };
 
-        // Create temp directory
-        let temp_dir = self.create_temp_dir()?;
-        let temp_path = temp_dir.path();
+        // _temp_dirs: RAII handles; kept alive until sort returns.
+        let (_temp_dirs, mut alloc) = self.create_temp_dirs()?;
 
         // Sort based on order
         match self.sort_order {
             SortOrder::Coordinate => {
-                self.sort_coordinate(record_source, pool, &header, output, temp_path)
+                self.sort_coordinate(record_source, pool, &header, output, &mut alloc)
             }
             SortOrder::Queryname(comparator) => {
-                self.sort_queryname(record_source, pool, &header, output, temp_path, comparator)
+                self.sort_queryname(record_source, pool, &header, output, &mut alloc, comparator)
             }
             SortOrder::TemplateCoordinate => {
-                self.sort_template_coordinate(record_source, pool, &header, output, temp_path)
+                self.sort_template_coordinate(record_source, pool, &header, output, &mut alloc)
             }
         }
     }
@@ -1670,12 +1693,12 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         if self.write_index {
-            self.sort_coordinate_with_index(record_source, pool, header, output, temp_path)
+            self.sort_coordinate_with_index(record_source, pool, header, output, alloc)
         } else {
-            self.sort_coordinate_optimized(record_source, pool, header, output, temp_path)
+            self.sort_coordinate_optimized(record_source, pool, header, output, alloc)
         }
     }
 
@@ -1690,7 +1713,7 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         use crate::sort::keys::RawCoordinateKey;
 
@@ -1710,7 +1733,7 @@ impl RawExternalSorter {
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
-        let mut namer = ChunkNamer::new(temp_path);
+        let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
@@ -1747,7 +1770,7 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path();
+                let chunk_path = namer.next_chunk_path()?;
 
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -1876,7 +1899,7 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         use crate::bam_io::{create_indexing_bam_writer, write_bai_index};
         use crate::sort::keys::RawCoordinateKey;
@@ -1894,7 +1917,7 @@ impl RawExternalSorter {
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
-        let mut namer = ChunkNamer::new(temp_path);
+        let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
@@ -1926,7 +1949,7 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path();
+                let chunk_path = namer.next_chunk_path()?;
 
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -2063,7 +2086,7 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
         comparator: QuerynameComparator,
     ) -> Result<RawSortStats> {
         use crate::sort::keys::{RawQuerynameKey, RawQuerynameLexKey};
@@ -2074,14 +2097,14 @@ impl RawExternalSorter {
                 pool,
                 header,
                 output,
-                temp_path,
+                alloc,
             ),
             QuerynameComparator::Natural => self.sort_queryname_keyed::<RawQuerynameKey>(
                 record_source,
                 pool,
                 header,
                 output,
-                temp_path,
+                alloc,
             ),
         }
     }
@@ -2094,7 +2117,7 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         use crate::sort::keys::SortContext;
 
@@ -2110,7 +2133,7 @@ impl RawExternalSorter {
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut entries: Vec<(K, Vec<u8>)> = Vec::with_capacity(estimated_records);
         let mut memory_used = 0usize;
-        let mut namer = ChunkNamer::new(temp_path);
+        let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
@@ -2155,7 +2178,7 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(bstats, Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path();
+                let chunk_path = namer.next_chunk_path()?;
 
                 timer.time_sort(|| {
                     use rayon::prelude::*;
@@ -2300,7 +2323,7 @@ impl RawExternalSorter {
         pool: Arc<SortWorkerPool>,
         header: &Header,
         output: &Path,
-        temp_path: &Path,
+        alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         let mut stats = RawSortStats::default();
         let mut timer = SortPhaseTimer::new();
@@ -2323,7 +2346,7 @@ impl RawExternalSorter {
         let mut chunk_files: Vec<PathBuf> = Vec::new();
         let mut buffer =
             TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
-        let mut namer = ChunkNamer::new(temp_path);
+        let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
@@ -2367,7 +2390,7 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path();
+                let chunk_path = namer.next_chunk_path()?;
 
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -2842,9 +2865,34 @@ impl RawExternalSorter {
         super::create_output_header(self.sort_order, header)
     }
 
-    /// Create temporary directory for spill files.
-    fn create_temp_dir(&self) -> Result<TempDir> {
-        super::create_temp_dir(self.temp_dir.as_deref())
+    /// Create per-base temp directories and an allocator over their subdirs.
+    ///
+    /// For each user-supplied base directory, a fresh sort-run subdirectory is
+    /// created (via `tempfile::TempDir`). The returned [`Vec<TempDir>`] owns
+    /// those handles so subdirs are removed on drop; the allocator hands out
+    /// the corresponding subdir paths for chunk/merged file placement.
+    ///
+    /// When `temp_dirs` is empty, a single subdirectory is created under the
+    /// system default temp location.
+    fn create_temp_dirs(&self) -> Result<(Vec<TempDir>, TmpDirAllocator)> {
+        use super::create_temp_dir;
+
+        if self.temp_dirs.is_empty() {
+            let td = create_temp_dir(None)?;
+            let base = td.path().to_path_buf();
+            let alloc = TmpDirAllocator::new(vec![base])?;
+            return Ok((vec![td], alloc));
+        }
+
+        let mut handles = Vec::with_capacity(self.temp_dirs.len());
+        let mut subdirs = Vec::with_capacity(self.temp_dirs.len());
+        for base in &self.temp_dirs {
+            let td = create_temp_dir(Some(base))?;
+            subdirs.push(td.path().to_path_buf());
+            handles.push(td);
+        }
+        let alloc = TmpDirAllocator::new(subdirs)?;
+        Ok((handles, alloc))
     }
 }
 
@@ -3051,7 +3099,7 @@ mod tests {
     fn test_raw_sorter_defaults() {
         let sorter = RawExternalSorter::new(SortOrder::Coordinate);
         assert_eq!(sorter.memory_limit, 512 * 1024 * 1024);
-        assert!(sorter.temp_dir.is_none());
+        assert!(sorter.temp_dirs.is_empty());
         assert_eq!(sorter.threads, 1);
         assert_eq!(sorter.output_compression, 6);
         assert_eq!(sorter.temp_compression, 1);
@@ -3073,7 +3121,7 @@ mod tests {
             .max_temp_files(128);
 
         assert_eq!(sorter.memory_limit, 1024);
-        assert_eq!(sorter.temp_dir, Some(PathBuf::from("/tmp/test")));
+        assert_eq!(sorter.temp_dirs, vec![PathBuf::from("/tmp/test")]);
         assert_eq!(sorter.threads, 8);
         assert_eq!(sorter.output_compression, 9);
         assert_eq!(sorter.temp_compression, 3);
@@ -3943,5 +3991,64 @@ mod tests {
             let total: usize = chunks.iter().map(Vec::len).sum();
             assert_eq!(total, n, "n={n} threads={threads}: total mismatch");
         }
+    }
+
+    /// End-to-end sort across two temp directories. Forces multiple spill
+    /// chunks and verifies the output is still correct. The round-robin
+    /// distribution itself is covered by `TmpDirAllocator`'s unit tests; this
+    /// test proves the plumbing from `temp_dirs(...)` through to the sort
+    /// fns works and that multi-dir mode produces byte-identical output to
+    /// single-dir mode.
+    #[test]
+    fn test_sort_with_two_temp_dirs_matches_single_dir() {
+        use crate::sam::builder::SamBuilder;
+
+        let num_pairs = 200;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(i * 200 + 1)
+                .start2(i * 200 + 101)
+                .build();
+        }
+
+        let workdir = tempfile::tempdir().expect("workdir");
+        let input = workdir.path().join("input.bam");
+        let output_multi = workdir.path().join("output_multi.bam");
+        let output_single = workdir.path().join("output_single.bam");
+        builder.write_bam(&input).expect("write bam");
+
+        let tmp_a = tempfile::tempdir().expect("tmp a");
+        let tmp_b = tempfile::tempdir().expect("tmp b");
+
+        // 8 KiB memory limit forces several spills across the dir rotation.
+        let stats_multi = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .threads(1)
+            .temp_compression(0)
+            .output_compression(0)
+            .temp_dirs(vec![tmp_a.path().to_path_buf(), tmp_b.path().to_path_buf()])
+            .sort(&input, &output_multi)
+            .expect("multi-dir sort should succeed");
+
+        assert!(stats_multi.chunks_written >= 2, "expected multiple spill chunks");
+
+        RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .threads(1)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output_single)
+            .expect("single-dir sort should succeed");
+
+        let names_multi = collect_read_names(&output_multi);
+        let names_single = collect_read_names(&output_single);
+        assert_eq!(names_multi.len(), num_pairs * 2, "record count mismatch");
+        assert_eq!(
+            names_multi, names_single,
+            "multi-dir and single-dir sort produced different record orders"
+        );
     }
 }

--- a/src/lib/sort/tmp_dir_alloc.rs
+++ b/src/lib/sort/tmp_dir_alloc.rs
@@ -1,0 +1,468 @@
+//! Allocator for distributing sort spill files across multiple temporary directories.
+//!
+//! `TmpDirAllocator` hands out base directory paths for spill/merged files in a
+//! round-robin fashion across one or more user-supplied temp directories. It
+//! also supports:
+//!
+//! - Dropping a directory from the rotation when it runs out of space
+//!   (e.g. `ENOSPC` during chunk creation).
+//! - Periodic re-checking of free space; directories whose free space falls
+//!   below a minimum threshold are dropped from rotation automatically.
+
+use anyhow::{Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+
+/// Minimum free bytes a directory must have to remain in rotation.
+pub const DEFAULT_MIN_FREE_BYTES: u64 = 1 << 30; // 1 GiB
+
+/// Number of `next()` calls between periodic free-space re-checks.
+pub const DEFAULT_RECHECK_INTERVAL: usize = 8;
+
+/// Function that reports free bytes available on a filesystem for writes.
+///
+/// The default implementation uses [`fs4::available_space`]. Tests inject a
+/// closure so they can simulate a filesystem filling up.
+pub type FreeSpaceProbe = Box<dyn FnMut(&Path) -> Result<u64> + Send>;
+
+/// Allocator that distributes spill directory assignments across one or more
+/// base directories using free-space-aware round-robin.
+pub struct TmpDirAllocator {
+    /// Directories currently eligible for allocation. Shrinks as dirs are
+    /// dropped via `mark_full` or the periodic free-space recheck.
+    active: Vec<PathBuf>,
+    cursor: usize,
+    min_free_bytes: u64,
+    recheck_interval: usize,
+    calls_since_recheck: usize,
+    probe: FreeSpaceProbe,
+}
+
+impl TmpDirAllocator {
+    /// Create an allocator over the given base directories.
+    ///
+    /// At least one directory must be supplied. Directories whose initial free
+    /// space is below `DEFAULT_MIN_FREE_BYTES` are dropped immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `dirs` is empty or if no directory has sufficient
+    /// free space.
+    pub fn new(dirs: Vec<PathBuf>) -> Result<Self> {
+        Self::with_probe(dirs, Box::new(default_free_space_probe), DEFAULT_MIN_FREE_BYTES)
+    }
+
+    /// Create an allocator with a custom free-space probe and threshold
+    /// (primarily for testing).
+    ///
+    /// `min_free_bytes` is the single threshold used both for the startup
+    /// filter and the periodic recheck.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `dirs` is empty or if every supplied directory
+    /// either fails to probe or has insufficient free space.
+    pub fn with_probe(
+        dirs: Vec<PathBuf>,
+        mut probe: FreeSpaceProbe,
+        min_free_bytes: u64,
+    ) -> Result<Self> {
+        if dirs.is_empty() {
+            bail!("TmpDirAllocator requires at least one directory");
+        }
+
+        let mut active = Vec::with_capacity(dirs.len());
+        for dir in dirs {
+            match probe(&dir) {
+                Ok(free) if free >= min_free_bytes => active.push(dir),
+                Ok(free) => log::warn!(
+                    "Temp dir {} dropped: only {} free (need {})",
+                    dir.display(),
+                    free,
+                    min_free_bytes
+                ),
+                Err(e) => log::warn!("Temp dir {} dropped: probe failed: {}", dir.display(), e),
+            }
+        }
+
+        if active.is_empty() {
+            bail!("No temp directory has sufficient free space (need {min_free_bytes} bytes)");
+        }
+
+        Ok(Self {
+            active,
+            cursor: 0,
+            min_free_bytes,
+            recheck_interval: DEFAULT_RECHECK_INTERVAL,
+            calls_since_recheck: 0,
+            probe,
+        })
+    }
+
+    /// Override the periodic recheck interval (primarily for testing).
+    #[must_use]
+    pub fn with_recheck_interval(mut self, interval: usize) -> Self {
+        self.recheck_interval = interval.max(1);
+        self
+    }
+
+    /// Number of directories currently eligible for allocation.
+    #[cfg(test)]
+    #[must_use]
+    pub fn active_count(&self) -> usize {
+        self.active.len()
+    }
+
+    /// Return the next base directory in round-robin order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if all directories have been marked full or dropped
+    /// by free-space checks.
+    #[allow(clippy::should_implement_trait)] // This is not Iterator::next — it is fallible.
+    pub fn next(&mut self) -> Result<PathBuf> {
+        self.maybe_recheck();
+
+        if self.active.is_empty() {
+            return Err(anyhow!(
+                "All temp directories have been exhausted (marked full or below min free space)"
+            ));
+        }
+
+        // `cursor` is maintained in `[0, active.len())` by every mutation of
+        // `active`, so indexing is safe without a modulo.
+        let dir = self.active[self.cursor].clone();
+        self.cursor = (self.cursor + 1) % self.active.len();
+        self.calls_since_recheck = self.calls_since_recheck.saturating_add(1);
+        Ok(dir)
+    }
+
+    /// Drop a directory from rotation (e.g. after `ENOSPC` during a spill write).
+    ///
+    /// Matches by path equality. A no-op if the path isn't currently active.
+    pub fn mark_full(&mut self, dir: &Path) {
+        if let Some(pos) = self.active.iter().position(|d| d == dir) {
+            self.active.remove(pos);
+            self.rebase_cursor_after_remove(pos);
+            log::warn!("Temp dir {} removed from rotation", dir.display());
+        }
+    }
+
+    /// Shift `cursor` to compensate for an element removed at `removed_pos`,
+    /// preserving round-robin order.
+    ///
+    /// If the removed index was strictly before the cursor, everything after
+    /// it shifted down by one so the cursor must follow. If the cursor now
+    /// sits past the end of `active`, wrap it back to the front. When
+    /// `active` becomes empty the cursor is reset to zero so the next
+    /// `next()` call fails cleanly on the length check rather than
+    /// mis-indexing.
+    fn rebase_cursor_after_remove(&mut self, removed_pos: usize) {
+        if self.active.is_empty() {
+            self.cursor = 0;
+            return;
+        }
+        if removed_pos < self.cursor {
+            self.cursor -= 1;
+        }
+        if self.cursor >= self.active.len() {
+            self.cursor = 0;
+        }
+    }
+
+    fn maybe_recheck(&mut self) {
+        if self.calls_since_recheck < self.recheck_interval {
+            return;
+        }
+        self.calls_since_recheck = 0;
+
+        let min = self.min_free_bytes;
+        let mut idx = 0;
+        while idx < self.active.len() {
+            let drop_dir = match (self.probe)(&self.active[idx]) {
+                Ok(free) if free >= min => false,
+                Ok(free) => {
+                    log::warn!(
+                        "Temp dir {} dropped mid-sort: {} free (need {})",
+                        self.active[idx].display(),
+                        free,
+                        min
+                    );
+                    true
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Temp dir {} dropped mid-sort: probe failed: {}",
+                        self.active[idx].display(),
+                        e
+                    );
+                    true
+                }
+            };
+            if drop_dir {
+                self.active.remove(idx);
+                self.rebase_cursor_after_remove(idx);
+                // Do not advance `idx`: what was at `idx+1` is now at `idx`.
+            } else {
+                idx += 1;
+            }
+        }
+    }
+}
+
+/// Default probe: number of bytes free on the filesystem backing `path`.
+fn default_free_space_probe(path: &Path) -> Result<u64> {
+    fs4::available_space(path).map_err(anyhow::Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Probe that always returns a fixed free-space value.
+    fn always_free(bytes: u64) -> FreeSpaceProbe {
+        Box::new(move |_| Ok(bytes))
+    }
+
+    /// Probe backed by a shared map of path -> free-bytes.
+    ///
+    /// Used to simulate individual directories filling up between calls.
+    fn map_probe(state: Arc<Mutex<std::collections::HashMap<PathBuf, u64>>>) -> FreeSpaceProbe {
+        Box::new(move |p: &Path| {
+            let guard = state.lock().expect("probe map lock");
+            Ok(*guard.get(p).unwrap_or(&u64::MAX))
+        })
+    }
+
+    #[test]
+    fn test_new_empty_errors() {
+        let result = TmpDirAllocator::new(vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_single_dir_always_returns_same() {
+        let dir = PathBuf::from("/tmp/a");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![dir.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("allocator should be constructable with one dir");
+        for _ in 0..5 {
+            assert_eq!(alloc.next().expect("next should succeed"), dir);
+        }
+    }
+
+    #[test]
+    fn test_two_dirs_round_robin() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("two-dir alloc should build");
+
+        let seq: Vec<_> = (0..4).map(|_| alloc.next().expect("next")).collect();
+        assert_eq!(seq, vec![a.clone(), b.clone(), a.clone(), b]);
+    }
+
+    #[test]
+    fn test_mark_full_skips_dir() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("two-dir alloc should build");
+
+        assert_eq!(alloc.next().expect("next"), a);
+        alloc.mark_full(&b);
+        // After dropping b, every subsequent next() must be a.
+        for _ in 0..5 {
+            assert_eq!(alloc.next().expect("next"), a);
+        }
+        assert_eq!(alloc.active_count(), 1);
+    }
+
+    #[test]
+    fn test_mark_full_all_exhausts() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("two-dir alloc should build");
+
+        alloc.mark_full(&a);
+        alloc.mark_full(&b);
+        assert!(alloc.next().is_err(), "exhausted allocator must error");
+    }
+
+    /// Regression: removing a dir at a position strictly before the cursor
+    /// must shift the cursor down so round-robin order is preserved.
+    #[test]
+    fn test_mark_full_preserves_round_robin_order() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let c = PathBuf::from("/tmp/c");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone(), c.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("three-dir alloc should build");
+
+        // After handing out `a`, the next-in-rotation is `b`.
+        assert_eq!(alloc.next().expect("1"), a);
+        // Pruning `a` (pos=0, strictly before cursor=1) must leave `b` next,
+        // not `c`.
+        alloc.mark_full(&a);
+        assert_eq!(alloc.next().expect("2"), b);
+        assert_eq!(alloc.next().expect("3"), c);
+        assert_eq!(alloc.next().expect("4"), b);
+    }
+
+    /// Regression: pruning the dir the cursor points at lets the cursor
+    /// naturally move to what was the next element, and wrapping still
+    /// works cleanly when that was the tail.
+    #[test]
+    fn test_mark_full_at_cursor_wraps_cleanly() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let c = PathBuf::from("/tmp/c");
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone(), c.clone()],
+            always_free(u64::MAX),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("three-dir alloc should build");
+
+        // Hand out a, then b; cursor now points to c (pos=2).
+        assert_eq!(alloc.next().expect("1"), a);
+        assert_eq!(alloc.next().expect("2"), b);
+        // Prune c at pos=2 == cursor. active=[a,b]; cursor=2 is now past the
+        // end and must wrap to 0.
+        alloc.mark_full(&c);
+        assert_eq!(alloc.next().expect("3"), a);
+        assert_eq!(alloc.next().expect("4"), b);
+    }
+
+    #[test]
+    fn test_initial_free_space_filter() {
+        // Dir b has insufficient free space at startup → dropped immediately.
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(a.clone(), u64::MAX);
+        map.insert(b.clone(), 1024); // tiny
+        let state = Arc::new(Mutex::new(map));
+
+        let alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone()],
+            map_probe(state),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("should accept at least one valid dir");
+        assert_eq!(alloc.active_count(), 1);
+    }
+
+    /// The startup filter must honor the `min_free_bytes` argument rather
+    /// than the `DEFAULT_MIN_FREE_BYTES` constant.
+    #[test]
+    fn test_startup_filter_honors_threshold_argument() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+
+        // Both dirs report 2048 free, well below the 1 GiB default. A low
+        // threshold of 1024 must still admit them.
+        let alloc =
+            TmpDirAllocator::with_probe(vec![a.clone(), b.clone()], always_free(2048), 1024)
+                .expect("low threshold should admit both dirs");
+        assert_eq!(alloc.active_count(), 2);
+    }
+
+    #[test]
+    fn test_periodic_recheck_drops_dir() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(a.clone(), u64::MAX);
+        map.insert(b.clone(), u64::MAX);
+        let state = Arc::new(Mutex::new(map));
+
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone()],
+            map_probe(Arc::clone(&state)),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("two-dir alloc should build")
+        .with_recheck_interval(2);
+
+        // First two calls round-robin between a and b.
+        assert_eq!(alloc.next().expect("1"), a);
+        assert_eq!(alloc.next().expect("2"), b);
+
+        // Now b runs out of space. Recheck fires on next call.
+        state.lock().expect("lock").insert(b.clone(), 1024);
+
+        // After recheck, only a should remain.
+        let next = alloc.next().expect("3");
+        assert_eq!(next, a);
+        // And subsequent calls stay on a.
+        for _ in 0..4 {
+            assert_eq!(alloc.next().expect("more"), a);
+        }
+        assert_eq!(alloc.active_count(), 1);
+    }
+
+    /// Regression: when `maybe_recheck` drops a dir at a position strictly
+    /// before the cursor, the cursor must shift with it.
+    #[test]
+    fn test_periodic_recheck_preserves_round_robin_order() {
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let c = PathBuf::from("/tmp/c");
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(a.clone(), u64::MAX);
+        map.insert(b.clone(), u64::MAX);
+        map.insert(c.clone(), u64::MAX);
+        let state = Arc::new(Mutex::new(map));
+
+        let mut alloc = TmpDirAllocator::with_probe(
+            vec![a.clone(), b.clone(), c.clone()],
+            map_probe(Arc::clone(&state)),
+            DEFAULT_MIN_FREE_BYTES,
+        )
+        .expect("three-dir alloc should build")
+        .with_recheck_interval(1);
+
+        // Hand out a; cursor is now 1 pointing at b.
+        assert_eq!(alloc.next().expect("1"), a);
+        // a runs out of space before the next call.
+        state.lock().expect("lock").insert(a.clone(), 1024);
+
+        // Recheck drops a at pos=0 (< cursor=1). Cursor must follow so the
+        // next allocation stays on b, not c.
+        assert_eq!(alloc.next().expect("2"), b);
+        assert_eq!(alloc.next().expect("3"), c);
+        assert_eq!(alloc.next().expect("4"), b);
+    }
+
+    #[test]
+    fn test_all_dirs_below_threshold_errors() {
+        let a = PathBuf::from("/tmp/a");
+        let result =
+            TmpDirAllocator::with_probe(vec![a], always_free(1024), DEFAULT_MIN_FREE_BYTES);
+        assert!(result.is_err(), "no dirs with enough free space → error");
+    }
+}


### PR DESCRIPTION
## Summary

- `fgumi sort -T/--tmp-dir` is now repeatable; pass more than one path to spread spill chunks across multiple filesystems in free-space-aware round-robin order.
- `FGUMI_TMP_DIRS` (PATH-style list) is honoured as a fallback when no `-T` flags are passed on the command line. CLI flags take precedence.
- New `TmpDirAllocator` owns the rotation and re-checks free space every 8 spills; dirs below 1 GiB free are dropped from rotation automatically.
- Behaviour with zero or one `-T` flag is unchanged.

## Usage

```bash
# Spread spill across multiple dirs
fgumi sort -i in.bam -o out.bam -T /mnt/ssd1 -T /mnt/ssd2

# Same via env var (useful for site defaults on HPC)
FGUMI_TMP_DIRS=/mnt/ssd1:/mnt/ssd2 fgumi sort -i in.bam -o out.bam
```

## Design notes

- **Distribution policy**: free-space-aware round-robin. At startup, each supplied dir is probed for free space; dirs below the 1 GiB threshold are dropped. In-rotation dirs receive chunks in strict round-robin order. Every 8 calls, the allocator re-probes and prunes dirs whose free space has fallen below the threshold.
- **Hot path**: allocator work happens only at spill boundaries (typically 10s-100s of times per sort), never per-record. Per-record loops in the four `sort_*` fns are untouched.
- **Scope**: only `fgumi sort` spills today, so the option lives in `src/lib/commands/sort.rs` rather than in `CompressionOptions`-style shared common-options.

## Known limitation

Mid-write `ENOSPC` is not auto-recovered — the startup filter and periodic recheck catch most cases *before* a write begins, but if a pooled spill writer hits `ENOSPC` mid-flight the sort fails with a clean error. `TmpDirAllocator::mark_full()` is wired and ready for a follow-up that intercepts the async `PendingSpill` error path.

## New dependency

- `fs4 = "0.13"` (default-features off) — cross-platform `available_space()` query. Pulls in rustix + libc + errno + bitflags only; no async runtime.

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test` all green (2559/2559)
- [x] 18 new tests: 7 `TmpDirAllocator` unit tests (round-robin, `mark_full`, startup filter, periodic recheck, exhaustion), 4 env-var resolver tests, 1 rstest-parameterized clap parse test (4 cases), 1 e2e multi-tmpdir sort test (byte-equal to single-dir)
- [x] `fgumi sort --help` renders new `-T` doc and `EXAMPLES` entries cleanly