### PR TITLE
feat(raw-bam): additive API surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,10 +752,12 @@ name = "fgumi-raw-bam"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "bstr 1.12.1",
  "bytemuck",
  "noodles",
  "proptest",
  "rstest",
+ "tempfile",
  "wide 1.3.0",
 ]
 
@@ -1496,6 +1498,7 @@ dependencies = [
  "noodles-bam",
  "noodles-bgzf",
  "noodles-core",
+ "noodles-csi",
  "noodles-fasta",
  "noodles-sam",
  "noodles-vcf",

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -84,7 +84,7 @@ use crate::vanilla_caller::{
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
 use anyhow::Result;
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedSamBuilder, flags};
 use noodles::sam::alignment::record::data::field::Tag;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -284,7 +284,7 @@ pub struct CodecConsensusCaller {
     ss_caller: VanillaUmiConsensusCaller,
 
     /// Reusable builder for raw-byte BAM record output
-    bam_builder: UnmappedBamRecordBuilder,
+    bam_builder: UnmappedSamBuilder,
 
     /// Whether to store rejected reads (raw bytes) for output
     track_rejects: bool,
@@ -350,7 +350,7 @@ impl CodecConsensusCaller {
             rng,
             consensus_counter: 0,
             ss_caller,
-            bam_builder: UnmappedBamRecordBuilder::new(),
+            bam_builder: UnmappedSamBuilder::new(),
             track_rejects: false,
             rejected_reads: Vec::new(),
         }

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -210,7 +210,7 @@ use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{ReadType, SourceRead};
-use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedSamBuilder, flags};
 
 /// Duplex consensus read - matches fgbio's `DuplexConsensusRead`
 ///
@@ -1083,7 +1083,7 @@ impl DuplexConsensusCaller {
         reason = "Result return type kept for API consistency with other consensus record builders"
     )]
     pub(crate) fn duplex_read_into(
-        builder: &mut UnmappedBamRecordBuilder,
+        builder: &mut UnmappedSamBuilder,
         output: &mut ConsensusOutput,
         consensus: &DuplexConsensusRead,
         read_type: ReadType,
@@ -1740,7 +1740,7 @@ impl DuplexConsensusCaller {
         cell_tag: Option<Tag>,
     ) -> Result<(ConsensusOutput, ConsensusCallingStats)> {
         let mut stats = ConsensusCallingStats::new();
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         let methylation_mode = ss_caller.options.methylation_mode;
 
@@ -4534,7 +4534,7 @@ mod tests {
             is_ba_only: false,
         };
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
@@ -4930,7 +4930,7 @@ mod tests {
         let cell_tag = Tag::from(fgumi_sam::SamTag::CB);
         let cell_barcode = "ACGTACGT-1";
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
@@ -4981,7 +4981,7 @@ mod tests {
             is_ba_only: false,
         };
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
@@ -5112,7 +5112,7 @@ mod tests {
             is_ba_only: false,
         };
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
@@ -5206,7 +5206,7 @@ mod tests {
             is_ba_only: false,
         };
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
@@ -5267,7 +5267,7 @@ mod tests {
 
         // Helper to build and parse a single record
         let build_and_parse = |read_type: ReadType| -> ParsedBamRecord {
-            let mut builder = UnmappedBamRecordBuilder::new();
+            let mut builder = UnmappedSamBuilder::new();
             let mut output = ConsensusOutput::default();
             DuplexConsensusCaller::duplex_read_into(
                 &mut builder,
@@ -6031,7 +6031,7 @@ mod tests {
         let duplex_result = DuplexConsensusCaller::duplex_consensus(Some(&ab), Some(&ba), None);
         let duplex = duplex_result.expect("Should produce duplex consensus");
 
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -13,7 +13,7 @@ use crate::phred::{
 use crate::simple_umi::consensus_umis;
 use anyhow::{Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{RawRecordView, UnmappedBamRecordBuilder, flags};
+use fgumi_raw_bam::{RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
 #[cfg(test)]
@@ -376,7 +376,7 @@ pub struct VanillaUmiConsensusCaller {
     single_input_consensus_quals: Vec<u8>,
 
     /// Reusable builder for raw-byte BAM record construction.
-    bam_builder: UnmappedBamRecordBuilder,
+    bam_builder: UnmappedSamBuilder,
 
     /// Optional reference genome for EM-Seq methylation annotation.
     reference: Option<std::sync::Arc<dyn crate::methylation::RefBaseProvider + Send + Sync>>,
@@ -444,7 +444,7 @@ impl VanillaUmiConsensusCaller {
             rejected_reads: Vec::new(),
             track_rejects,
             single_input_consensus_quals,
-            bam_builder: UnmappedBamRecordBuilder::new(),
+            bam_builder: UnmappedSamBuilder::new(),
             reference: None,
             ref_names: None,
         }

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-noodles = { version = "0.106.0", features = ["bam", "sam"], optional = true }
+noodles = { version = "0.106.0", features = ["bam", "bgzf", "core", "csi", "sam"], optional = true }
 anyhow = { version = "1.0.102", optional = true }
 bytemuck = { workspace = true }
 wide = { workspace = true }
@@ -19,5 +19,7 @@ noodles = ["dep:noodles", "dep:anyhow"]
 test-utils = []
 
 [dev-dependencies]
+bstr = "1.12.1"
 proptest = "1.10"
 rstest = "0"
+tempfile = "3"

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -1,8 +1,9 @@
 use crate::raw_bam_record::RawRecord;
 use crate::sequence::pack_sequence_into;
 use crate::tags::{
-    append_float_tag, append_i16_array_tag, append_int_tag, append_phred33_string_tag,
-    append_string_tag, append_u8_array_tag,
+    append_f32_array_tag, append_float_tag, append_i16_array_tag, append_i32_array_tag,
+    append_int_tag, append_phred33_string_tag, append_string_tag, append_u8_array_tag,
+    append_u16_array_tag,
 };
 
 // ============================================================================
@@ -21,7 +22,7 @@ use crate::tags::{
 /// # Usage
 ///
 /// ```rust,ignore
-/// let mut builder = UnmappedBamRecordBuilder::new();
+/// let mut builder = UnmappedSamBuilder::new();
 ///
 /// builder.build_record(b"cons:1:ACG-TCG", my_flags, &bases, &quals);
 /// builder.append_string_tag(b"RG", b"sample1");
@@ -29,15 +30,16 @@ use crate::tags::{
 /// builder.append_float_tag(b"cE", error_rate);
 /// builder.append_i16_array_tag(b"cd", &depth_array);
 ///
-/// // Option A: return the record as a RawRecord (moves the buffer out).
+/// // Return the record as a RawRecord (moves the buffer out).
 /// let record: RawRecord = builder.build();
 ///
-/// // Option B (alternative): write directly without taking ownership.
-/// // builder.write_with_block_size(&mut output);
-/// // builder.clear();
+/// // -- or write directly without taking ownership --
+/// builder.write_with_block_size(&mut output);
+///
+/// builder.clear();
 /// // ... build next record ...
 /// ```
-pub struct UnmappedBamRecordBuilder {
+pub struct UnmappedSamBuilder {
     buf: Vec<u8>,
     sealed: bool,
 }
@@ -45,7 +47,7 @@ pub struct UnmappedBamRecordBuilder {
 /// Unmapped BAM bin (SAM spec §4.2.1: `reg2bin(-1, 0)` = 4680).
 const UNMAPPED_BIN: u16 = 4680;
 
-impl UnmappedBamRecordBuilder {
+impl UnmappedSamBuilder {
     /// Create a new builder with default capacity (512 bytes).
     #[must_use]
     pub fn new() -> Self {
@@ -221,7 +223,348 @@ impl UnmappedBamRecordBuilder {
     }
 }
 
-impl Default for UnmappedBamRecordBuilder {
+impl Default for UnmappedSamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Mapped BAM Record Builder
+// ============================================================================
+
+/// Builder for constructing mapped (or unmapped) BAM records as raw bytes.
+///
+/// Unlike [`UnmappedSamBuilder`], this builder supports any combination
+/// of `ref_id`, `pos`, CIGAR operations, `mapq`, flags, mate fields, sequence,
+/// quality scores, and auxiliary tags. It uses a fluent setter API; call
+/// [`Self::build`] to assemble the final [`RawRecord`].
+///
+/// The internal state is reused across calls via [`Self::clear`] to avoid
+/// repeated allocations.
+///
+/// # Default field values
+///
+/// | Field           | Default  |
+/// |-----------------|----------|
+/// | `ref_id`        | `-1`     |
+/// | `pos`           | `-1`     |
+/// | `mapq`          | `0`      |
+/// | `flags`         | `0`      |
+/// | `mate_ref_id`   | `-1`     |
+/// | `mate_pos`      | `-1`     |
+/// | `template_length` | `0`  |
+/// | `bin`           | `0`      |
+/// | `read_name`     | `b"*"`   |
+/// | `cigar_ops`     | empty    |
+/// | `sequence`      | empty    |
+/// | `qualities`     | empty    |
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// let mut b = SamBuilder::new();
+/// b.ref_id(0)
+///  .pos(999)
+///  .mapq(60)
+///  .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+///  .read_name(b"read1")
+///  .cigar_ops(&[/* 100M */ (100u32 << 4) | 0])
+///  .sequence(b"ACGT")
+///  .qualities(&[30, 25, 35, 40]);
+/// b.add_string_tag(b"RG", b"sample1");
+/// let record: RawRecord = b.build();
+/// ```
+pub struct SamBuilder {
+    ref_id: i32,
+    pos: i32,
+    mapq: u8,
+    flags: u16,
+    mate_ref_id: i32,
+    mate_pos: i32,
+    tlen: i32,
+    bin: u16,
+    read_name: Vec<u8>,
+    cigar_ops: Vec<u32>,
+    sequence: Vec<u8>,
+    qualities: Vec<u8>,
+    aux: Vec<u8>,
+}
+
+impl SamBuilder {
+    /// Create a new builder with default field values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            ref_id: -1,
+            pos: -1,
+            mapq: 0,
+            flags: 0,
+            mate_ref_id: -1,
+            mate_pos: -1,
+            tlen: 0,
+            bin: 0,
+            read_name: b"*".to_vec(),
+            cigar_ops: Vec::new(),
+            sequence: Vec::new(),
+            qualities: Vec::new(),
+            aux: Vec::new(),
+        }
+    }
+
+    /// Reset all fields to their defaults, retaining allocated capacity.
+    pub fn clear(&mut self) {
+        self.ref_id = -1;
+        self.pos = -1;
+        self.mapq = 0;
+        self.flags = 0;
+        self.mate_ref_id = -1;
+        self.mate_pos = -1;
+        self.tlen = 0;
+        self.bin = 0;
+        self.read_name.clear();
+        self.read_name.extend_from_slice(b"*");
+        self.cigar_ops.clear();
+        self.sequence.clear();
+        self.qualities.clear();
+        self.aux.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Fluent setters
+    // -------------------------------------------------------------------------
+
+    /// Set the reference sequence ID (`ref_id`). Use `-1` for unmapped.
+    pub fn ref_id(&mut self, v: i32) -> &mut Self {
+        self.ref_id = v;
+        self
+    }
+
+    /// Set the 0-based leftmost alignment position. Use `-1` for unmapped.
+    pub fn pos(&mut self, v: i32) -> &mut Self {
+        self.pos = v;
+        self
+    }
+
+    /// Set the mapping quality.
+    pub fn mapq(&mut self, v: u8) -> &mut Self {
+        self.mapq = v;
+        self
+    }
+
+    /// Set the bitwise flags.
+    pub fn flags(&mut self, v: u16) -> &mut Self {
+        self.flags = v;
+        self
+    }
+
+    /// Set the mate reference sequence ID. Use `-1` for unmapped mate.
+    pub fn mate_ref_id(&mut self, v: i32) -> &mut Self {
+        self.mate_ref_id = v;
+        self
+    }
+
+    /// Set the mate 0-based alignment position. Use `-1` for unmapped mate.
+    pub fn mate_pos(&mut self, v: i32) -> &mut Self {
+        self.mate_pos = v;
+        self
+    }
+
+    /// Set the template length (`tlen`).
+    pub fn template_length(&mut self, v: i32) -> &mut Self {
+        self.tlen = v;
+        self
+    }
+
+    /// Set the BAM bin (SAM spec §4.2.1). Defaults to `0`; callers may compute
+    /// with `reg2bin` or leave as-is for unmapped records.
+    pub fn bin(&mut self, v: u16) -> &mut Self {
+        self.bin = v;
+        self
+    }
+
+    /// Set the read name (without null terminator). Maximum 254 bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics in [`Self::build`] if `name.len() >= 255`.
+    pub fn read_name(&mut self, name: &[u8]) -> &mut Self {
+        self.read_name.clear();
+        self.read_name.extend_from_slice(name);
+        self
+    }
+
+    /// Set the CIGAR operations as BAM-encoded `u32` words
+    /// (`(len << 4) | op_code`).
+    pub fn cigar_ops(&mut self, ops: &[u32]) -> &mut Self {
+        self.cigar_ops.clear();
+        self.cigar_ops.extend_from_slice(ops);
+        self
+    }
+
+    /// Set the ASCII sequence (e.g. `b"ACGT"`).
+    pub fn sequence(&mut self, seq: &[u8]) -> &mut Self {
+        self.sequence.clear();
+        self.sequence.extend_from_slice(seq);
+        self
+    }
+
+    /// Set the raw Phred quality scores (0–93, not Phred+33 ASCII).
+    pub fn qualities(&mut self, quals: &[u8]) -> &mut Self {
+        self.qualities.clear();
+        self.qualities.extend_from_slice(quals);
+        self
+    }
+
+    // -------------------------------------------------------------------------
+    // Aux tag helpers
+    // -------------------------------------------------------------------------
+
+    /// Append a string (`Z`-type) aux tag.
+    pub fn add_string_tag(&mut self, tag: &[u8; 2], value: &[u8]) -> &mut Self {
+        append_string_tag(&mut self.aux, tag, value);
+        self
+    }
+
+    /// Append an integer aux tag (smallest type that fits).
+    pub fn add_int_tag(&mut self, tag: &[u8; 2], value: i32) -> &mut Self {
+        append_int_tag(&mut self.aux, tag, value);
+        self
+    }
+
+    /// Append a float (`f`-type) aux tag.
+    pub fn add_float_tag(&mut self, tag: &[u8; 2], value: f32) -> &mut Self {
+        append_float_tag(&mut self.aux, tag, value);
+        self
+    }
+
+    /// Append a `u8` array (`B:C`-type) aux tag.
+    pub fn add_array_u8(&mut self, tag: &[u8; 2], values: &[u8]) -> &mut Self {
+        append_u8_array_tag(&mut self.aux, tag, values);
+        self
+    }
+
+    /// Append a `u16` array (`B:S`-type) aux tag.
+    pub fn add_array_u16(&mut self, tag: &[u8; 2], values: &[u16]) -> &mut Self {
+        append_u16_array_tag(&mut self.aux, tag, values);
+        self
+    }
+
+    /// Append an `i16` array (`B:s`-type) aux tag.
+    pub fn add_array_i16(&mut self, tag: &[u8; 2], values: &[i16]) -> &mut Self {
+        append_i16_array_tag(&mut self.aux, tag, values);
+        self
+    }
+
+    /// Append an `i32` array (`B:i`-type) aux tag.
+    pub fn add_array_i32(&mut self, tag: &[u8; 2], values: &[i32]) -> &mut Self {
+        append_i32_array_tag(&mut self.aux, tag, values);
+        self
+    }
+
+    /// Append an `f32` array (`B:f`-type) aux tag.
+    pub fn add_array_f32(&mut self, tag: &[u8; 2], values: &[f32]) -> &mut Self {
+        append_f32_array_tag(&mut self.aux, tag, values);
+        self
+    }
+
+    // -------------------------------------------------------------------------
+    // Finalize
+    // -------------------------------------------------------------------------
+
+    /// Assemble all fields into a [`RawRecord`] and return it.
+    ///
+    /// The builder's state is **not** cleared after calling `build()`. Call
+    /// [`Self::clear`] explicitly before reusing for a different record.
+    ///
+    /// # Panics
+    ///
+    /// - If `read_name.len() >= 255` (BAM spec limit is 254 characters + NUL).
+    /// - If `sequence` and `qualities` are both non-empty and their lengths differ.
+    /// - If `sequence.len()` overflows `u32`.
+    /// - If `cigar_ops.len()` overflows `u16`.
+    #[must_use]
+    pub fn build(&mut self) -> RawRecord {
+        assert!(
+            self.read_name.len() < 255,
+            "read name too long ({} bytes, max 254)",
+            self.read_name.len(),
+        );
+        assert!(
+            self.qualities.is_empty() || self.sequence.len() == self.qualities.len(),
+            "sequence length ({}) != qualities length ({})",
+            self.sequence.len(),
+            self.qualities.len(),
+        );
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "assert above guarantees read_name.len() < 255"
+        )]
+        let l_read_name = (self.read_name.len() + 1) as u8; // +1 for NUL
+
+        let n_cigar_op =
+            u16::try_from(self.cigar_ops.len()).expect("too many CIGAR operations (max 65535)");
+
+        let l_seq = u32::try_from(self.sequence.len()).expect("sequence length overflow");
+
+        let packed_seq_len = self.sequence.len().div_ceil(2);
+        let record_len = 32
+            + l_read_name as usize
+            + self.cigar_ops.len() * 4
+            + packed_seq_len
+            + self.sequence.len() // qual bytes (same length as seq)
+            + self.aux.len();
+
+        let mut buf = Vec::with_capacity(record_len);
+
+        // Unmapped records (ref_id<0 or pos<0) emit UNMAPPED_BIN (4680) per
+        // SAM spec §4.2.1 reg2bin(-1, 0), matching UnmappedSamBuilder behavior.
+        let bin = if self.ref_id < 0 || self.pos < 0 { UNMAPPED_BIN } else { self.bin };
+
+        // === Fixed 32-byte header ===
+        buf.extend_from_slice(&self.ref_id.to_le_bytes());
+        buf.extend_from_slice(&self.pos.to_le_bytes());
+        buf.push(l_read_name);
+        buf.push(self.mapq);
+        buf.extend_from_slice(&bin.to_le_bytes());
+        buf.extend_from_slice(&n_cigar_op.to_le_bytes());
+        buf.extend_from_slice(&self.flags.to_le_bytes());
+        buf.extend_from_slice(&l_seq.to_le_bytes());
+        buf.extend_from_slice(&self.mate_ref_id.to_le_bytes());
+        buf.extend_from_slice(&self.mate_pos.to_le_bytes());
+        buf.extend_from_slice(&self.tlen.to_le_bytes());
+
+        // === Read name + NUL ===
+        buf.extend_from_slice(&self.read_name);
+        buf.push(0);
+
+        // === CIGAR ops (4 bytes each) ===
+        for &op in &self.cigar_ops {
+            buf.extend_from_slice(&op.to_le_bytes());
+        }
+
+        // === Packed sequence (4 bits per base) ===
+        if !self.sequence.is_empty() {
+            pack_sequence_into(&mut buf, &self.sequence);
+
+            // === Quality scores ===
+            if self.qualities.is_empty() {
+                // Absent quality: 0xFF per SAM spec
+                buf.resize(buf.len() + self.sequence.len(), 0xFF);
+            } else {
+                buf.extend_from_slice(&self.qualities);
+            }
+        }
+
+        // === Aux tags ===
+        buf.extend_from_slice(&self.aux);
+
+        RawRecord::from(buf)
+    }
+}
+
+impl Default for SamBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -238,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_builder_basic_unmapped_record() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"read1", flags::UNMAPPED, b"ACGT", &[30, 25, 35, 40]);
 
         let bam = builder.as_bytes();
@@ -275,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_builder_with_tags() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"cons:1:ACG", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
         builder.append_string_tag(b"RG", b"sample1");
         builder.append_string_tag(b"MI", b"42");
@@ -302,7 +645,7 @@ mod tests {
 
     #[test]
     fn test_builder_reuse() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
 
         // Build first record
         builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
@@ -325,7 +668,7 @@ mod tests {
 
     #[test]
     fn test_builder_write_with_block_size() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
 
         let mut output = Vec::new();
@@ -339,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_builder_paired_consensus_flags() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
 
         // R1
         let r1_flags =
@@ -356,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_builder_empty_sequence() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"empty", flags::UNMAPPED, b"", &[]);
         builder.append_string_tag(b"RG", b"rg0");
 
@@ -367,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_builder_missing_quality() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         // Empty quals with non-empty bases -> fills with 0xFF
         builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[]);
 
@@ -387,7 +730,7 @@ mod tests {
         //
         // Verify shared unmapped constants: ref_id=-1, pos=-1, bin=4680,
         // n_cigar_op=0, next_ref_id=-1, next_pos=-1, tlen=0
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"*", flags::UNMAPPED, b"", &[]);
 
         let bam = builder.as_bytes();
@@ -419,7 +762,7 @@ mod tests {
 
     #[test]
     fn test_builder_phred33_string_tag() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"test", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
         builder.append_phred33_string_tag(b"aq", &[0, 10, 30, 40]);
         let bytes = builder.as_bytes();
@@ -431,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_parsed_bam_record_roundtrip() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(
             b"myread",
             flags::UNMAPPED | flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED,
@@ -467,12 +810,12 @@ mod tests {
     }
 
     // ========================================================================
-    // UnmappedBamRecordBuilder additional tests
+    // UnmappedSamBuilder additional tests
     // ========================================================================
 
     #[test]
     fn test_builder_build_returns_raw_record() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
         builder.append_string_tag(b"MI", b"7");
 
@@ -495,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_builder_build_into_inner() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"r3", flags::UNMAPPED, b"ACGT", &[10, 20, 30, 40]);
 
         let bytes_before = builder.as_bytes().to_vec();
@@ -507,7 +850,7 @@ mod tests {
 
     #[test]
     fn test_builder_default() {
-        let builder = UnmappedBamRecordBuilder::default();
+        let builder = UnmappedSamBuilder::default();
         // Default builder has empty buffer and is not sealed
         assert!(builder.buf.is_empty());
         assert!(!builder.sealed);
@@ -515,14 +858,14 @@ mod tests {
 
     #[test]
     fn test_builder_with_capacity() {
-        let builder = UnmappedBamRecordBuilder::with_capacity(1024);
+        let builder = UnmappedSamBuilder::with_capacity(1024);
         assert!(builder.buf.capacity() >= 1024);
     }
 
     #[test]
     fn test_builder_odd_length_sequence() {
         // Odd-length sequence to exercise the packing edge case
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"read1", flags::UNMAPPED, b"ACG", &[30, 25, 20]);
 
         let bam = builder.as_bytes();
@@ -536,7 +879,7 @@ mod tests {
     #[test]
     fn test_builder_long_sequence() {
         // Longer sequence to exercise multi-byte packing
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let bases = b"ACGTACGTACGTACGT"; // 16 bases
         let quals = vec![30u8; 16];
         builder.build_record(b"r1", flags::UNMAPPED, bases, &quals);
@@ -559,7 +902,7 @@ mod tests {
     #[test]
     fn test_builder_multiple_records_via_write_with_block_size() {
         // Build two records into the same output buffer
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         let mut output = Vec::new();
 
         builder.build_record(b"r1", flags::UNMAPPED, b"ACGT", &[30, 30, 30, 30]);
@@ -585,5 +928,276 @@ mod tests {
             records[1].get_string_tag(b"MI").expect("MI tag should be present on record 1"),
             b"2"
         );
+    }
+
+    // ========================================================================
+    // SamBuilder tests
+    // ========================================================================
+
+    /// Encode a BAM CIGAR operation: `(len << 4) | op_code`.
+    /// Op codes: 0=M, 1=I, 2=D, 3=N, 4=S, 5=H, 6=P, 7==, 8=X
+    const fn cigar_op(len: u32, op: u32) -> u32 {
+        (len << 4) | op
+    }
+
+    #[test]
+    fn test_mapped_builder_default_values() {
+        // Default build should produce a valid minimal record.
+        let mut b = SamBuilder::new();
+        let rec = b.build();
+        let bam = rec.as_ref();
+
+        assert_eq!(ref_id(bam), -1);
+        assert_eq!(pos(bam), -1);
+        assert_eq!(mapq(bam), 0);
+        assert_eq!(flags(bam), 0);
+        assert_eq!(mate_ref_id(bam), -1);
+        assert_eq!(mate_pos(bam), -1);
+        assert_eq!(template_length(bam), 0);
+        assert_eq!(l_seq(bam), 0);
+        assert_eq!(read_name(bam), b"*");
+        assert_eq!(n_cigar_op(bam), 0);
+        assert!(aux_data_slice(bam).is_empty());
+        // Unmapped defaults must emit UNMAPPED_BIN (4680), matching UnmappedSamBuilder.
+        assert_eq!(u16::from_le_bytes([bam[10], bam[11]]), UNMAPPED_BIN);
+    }
+
+    #[test]
+    fn test_mapped_builder_emits_unmapped_bin_when_ref_or_pos_missing() {
+        // ref_id < 0 alone (with explicit pos) must still produce UNMAPPED_BIN.
+        let mut b = SamBuilder::new();
+        b.pos(0).bin(1234);
+        let rec = b.build();
+        let bam = rec.as_ref();
+        assert_eq!(u16::from_le_bytes([bam[10], bam[11]]), UNMAPPED_BIN);
+
+        // pos < 0 alone must also produce UNMAPPED_BIN.
+        let mut b = SamBuilder::new();
+        b.ref_id(0).bin(1234);
+        let rec = b.build();
+        let bam = rec.as_ref();
+        assert_eq!(u16::from_le_bytes([bam[10], bam[11]]), UNMAPPED_BIN);
+
+        // Both ref_id >= 0 and pos >= 0: self.bin is preserved.
+        let mut b = SamBuilder::new();
+        b.ref_id(0).pos(0).bin(1234);
+        let rec = b.build();
+        let bam = rec.as_ref();
+        assert_eq!(u16::from_le_bytes([bam[10], bam[11]]), 1234u16);
+    }
+
+    #[test]
+    fn test_mapped_builder_all_header_fields() {
+        // Set every header field and verify round-trip.
+        let mut b = SamBuilder::new();
+        b.ref_id(3)
+            .pos(999)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::REVERSE)
+            .mate_ref_id(3)
+            .mate_pos(1499)
+            .template_length(500)
+            .bin(4681)
+            .read_name(b"myread")
+            .cigar_ops(&[cigar_op(100, 0)]) // 100M
+            .sequence(b"ACGTACGT")
+            .qualities(&[30, 25, 35, 40, 30, 25, 35, 40]);
+        let rec = b.build();
+        let bam = rec.as_ref();
+
+        assert_eq!(ref_id(bam), 3);
+        assert_eq!(pos(bam), 999);
+        assert_eq!(mapq(bam), 60);
+        assert_eq!(flags(bam), flags::PAIRED | flags::REVERSE);
+        assert_eq!(mate_ref_id(bam), 3);
+        assert_eq!(mate_pos(bam), 1499);
+        assert_eq!(template_length(bam), 500);
+        // bin
+        assert_eq!(u16::from_le_bytes([bam[10], bam[11]]), 4681u16);
+        assert_eq!(read_name(bam), b"myread");
+        assert_eq!(n_cigar_op(bam), 1);
+        assert_eq!(l_seq(bam), 8);
+
+        // Verify packed sequence
+        let so = seq_offset(bam);
+        let expected = [1u8, 2, 4, 8, 1, 2, 4, 8]; // A C G T A C G T
+        for (i, &exp) in expected.iter().enumerate() {
+            assert_eq!(get_base(bam, so, i), exp, "base mismatch at position {i}");
+        }
+
+        // Verify quality scores
+        let qo = qual_offset(bam);
+        let expected_quals = [30u8, 25, 35, 40, 30, 25, 35, 40];
+        for (i, &exp) in expected_quals.iter().enumerate() {
+            assert_eq!(get_qual(bam, qo, i), exp, "qual mismatch at position {i}");
+        }
+
+        assert!(aux_data_slice(bam).is_empty());
+    }
+
+    #[test]
+    fn test_mapped_builder_with_all_tag_types() {
+        // Verify every add_*_tag method appends bytes that can be read back.
+        let mut b = SamBuilder::new();
+        b.read_name(b"tagged").sequence(b"ACGT").qualities(&[30, 30, 30, 30]);
+        b.add_string_tag(b"RG", b"lane1");
+        b.add_int_tag(b"NM", 2);
+        b.add_float_tag(b"AS", 98.5);
+        b.add_array_u8(b"BC", &[10, 20, 30]);
+        b.add_array_u16(b"QT", &[100, 200, 300]);
+        b.add_array_i16(b"cd", &[-1, 0, 1]);
+        b.add_array_i32(b"id", &[-100_000, 0, 100_000]);
+        b.add_array_f32(b"fd", &[1.0_f32, 2.5, -3.0]);
+        let rec = b.build();
+        let bam = rec.as_ref();
+        let aux = aux_data_slice(bam);
+
+        assert_eq!(find_string_tag(aux, b"RG"), Some(b"lane1" as &[u8]));
+        assert_eq!(find_int_tag(aux, b"NM"), Some(2));
+        let as_val = find_float_tag(aux, b"AS").expect("AS float tag present");
+        assert!((as_val - 98.5).abs() < 1e-4);
+
+        // Verify array tags exist (type byte check)
+        assert_eq!(find_tag_type(aux, b"BC"), Some(b'B'));
+        assert_eq!(find_tag_type(aux, b"QT"), Some(b'B'));
+        assert_eq!(find_tag_type(aux, b"cd"), Some(b'B'));
+        assert_eq!(find_tag_type(aux, b"id"), Some(b'B'));
+        assert_eq!(find_tag_type(aux, b"fd"), Some(b'B'));
+    }
+
+    #[test]
+    fn test_mapped_builder_cigar_multple_ops() {
+        // Build a record with a multi-op CIGAR: 10S 80M 10S
+        let cigar = [cigar_op(10, 4), cigar_op(80, 0), cigar_op(10, 4)];
+        let mut b = SamBuilder::new();
+        b.ref_id(0).pos(100).mapq(30).read_name(b"clip").cigar_ops(&cigar);
+        let rec = b.build();
+        let bam = rec.as_ref();
+
+        assert_eq!(n_cigar_op(bam), 3);
+        // Verify raw CIGAR words stored in order at the cigar offset
+        let cigar_off = 32 + l_read_name(bam) as usize;
+        for (i, &op) in cigar.iter().enumerate() {
+            let stored = u32::from_le_bytes([
+                bam[cigar_off + i * 4],
+                bam[cigar_off + i * 4 + 1],
+                bam[cigar_off + i * 4 + 2],
+                bam[cigar_off + i * 4 + 3],
+            ]);
+            assert_eq!(stored, op, "CIGAR op mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_mapped_builder_empty_cigar_unmapped_like() {
+        // A record with ref_id=-1, pos=-1, no cigar is valid (unmapped-like).
+        let mut b = SamBuilder::new();
+        b.flags(flags::UNMAPPED).read_name(b"unmap").sequence(b"ACGT").qualities(&[30; 4]);
+        let rec = b.build();
+        let bam = rec.as_ref();
+
+        assert_eq!(ref_id(bam), -1);
+        assert_eq!(pos(bam), -1);
+        assert_eq!(n_cigar_op(bam), 0);
+        assert_eq!(l_seq(bam), 4);
+    }
+
+    #[test]
+    fn test_mapped_builder_absent_qualities_filled_with_ff() {
+        // When sequence is set but qualities are omitted, emit 0xFF per SAM spec.
+        let mut b = SamBuilder::new();
+        b.read_name(b"r1").sequence(b"ACGT"); // no qualities()
+        let rec = b.build();
+        let bam = rec.as_ref();
+
+        assert_eq!(l_seq(bam), 4);
+        let qo = qual_offset(bam);
+        for i in 0..4 {
+            assert_eq!(get_qual(bam, qo, i), 0xFF, "expected 0xFF sentinel at pos {i}");
+        }
+    }
+
+    #[test]
+    fn test_mapped_builder_empty_seq_and_qual() {
+        // Both empty: l_seq == 0, no seq/qual bytes emitted.
+        let mut b = SamBuilder::new();
+        b.read_name(b"noSeq");
+        let rec = b.build();
+        let bam = rec.as_ref();
+        assert_eq!(l_seq(bam), 0);
+        // The record length should be exactly: 32 (header) + 6 (name+NUL) + 0 (CIGAR) + 0 (seq/qual)
+        assert_eq!(bam.len(), 32 + 6);
+    }
+
+    #[test]
+    fn test_mapped_builder_clear_and_reuse() {
+        let mut b = SamBuilder::new();
+
+        // First record
+        b.ref_id(1).pos(100).read_name(b"r1").sequence(b"ACGT").qualities(&[30; 4]);
+        b.add_string_tag(b"RG", b"sample1");
+        let rec1 = b.build();
+        let bam1 = rec1.as_ref();
+        assert_eq!(ref_id(bam1), 1);
+        assert_eq!(pos(bam1), 100);
+        assert_eq!(read_name(bam1), b"r1");
+        assert_eq!(find_string_tag(aux_data_slice(bam1), b"RG"), Some(b"sample1" as &[u8]));
+
+        // Clear and build a second, different record
+        b.clear();
+        b.ref_id(2).pos(500).read_name(b"r2").sequence(b"TTTT").qualities(&[25; 4]);
+        b.add_int_tag(b"NM", 0);
+        let rec2 = b.build();
+        let bam2 = rec2.as_ref();
+
+        assert_eq!(ref_id(bam2), 2);
+        assert_eq!(pos(bam2), 500);
+        assert_eq!(read_name(bam2), b"r2");
+        // Old tag should be gone
+        assert!(find_string_tag(aux_data_slice(bam2), b"RG").is_none());
+        assert_eq!(find_int_tag(aux_data_slice(bam2), b"NM"), Some(0));
+    }
+
+    #[test]
+    fn test_mapped_builder_default_impl() {
+        let b = SamBuilder::default();
+        assert_eq!(b.ref_id, -1);
+        assert_eq!(b.pos, -1);
+        assert_eq!(b.read_name, b"*");
+    }
+
+    #[cfg(feature = "noodles")]
+    #[test]
+    fn test_mapped_builder_noodles_roundtrip() {
+        use crate::noodles_compat::raw_record_to_record_buf;
+        use noodles::sam::Header;
+        use noodles::sam::alignment::record::Flags;
+        use noodles::sam::alignment::record::Sequence as _;
+
+        // Build a mapped record and decode it via noodles to cross-validate.
+        let header = Header::default();
+        let mut b = SamBuilder::new();
+        b.flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .read_name(b"noodles_read")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30, 25, 35, 40, 30, 25, 35, 40]);
+        b.add_string_tag(b"RG", b"sg1");
+        b.add_int_tag(b"NM", 1);
+        let rec = b.build();
+
+        let record_buf = raw_record_to_record_buf(&rec, &header)
+            .expect("noodles should decode the record without error");
+
+        assert_eq!(
+            record_buf.flags(),
+            Flags::SEGMENTED | Flags::FIRST_SEGMENT,
+            "flags round-trip mismatch"
+        );
+        // Sequence
+        let seq_bytes: Vec<u8> = record_buf.sequence().iter().collect();
+        assert_eq!(seq_bytes, b"ACGTACGT");
+        // Quality scores
+        let qual_bytes: Vec<u8> = record_buf.quality_scores().as_ref().to_vec();
+        assert_eq!(qual_bytes, [30, 25, 35, 40, 30, 25, 35, 40]);
     }
 }

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -20,13 +20,11 @@ pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op:
         3 => Kind::Skip,
         4 => Kind::SoftClip,
         5 => Kind::HardClip,
-        6 => Kind::Pad,
         7 => Kind::SequenceMatch,
         8 => Kind::SequenceMismatch,
-        _ => {
-            debug_assert!(false, "invalid BAM CIGAR op code: {op}");
-            Kind::Pad
-        }
+        // 6 => Pad; 9..=15 are reserved/invalid per the BAM spec and fall back
+        // to Pad as the documented default so callers don't need to branch.
+        _ => Kind::Pad,
     }
 }
 
@@ -51,21 +49,23 @@ pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op:
 const BAM_CIGAR_TYPE: u32 = 0x3C1A7;
 
 /// Returns true if the CIGAR op type consumes the reference (M, D, N, =, X).
+///
+/// Values outside the 0..=15 spec range are masked with `& 0xF` — keeps the
+/// shift amount bounded in case a caller passes a raw CIGAR word or a noodles
+/// conversion bug leaks a larger value.
 #[inline]
 #[must_use]
 pub const fn consumes_ref(op_type: u32) -> bool {
-    // Guard the shift: `op_type << 1 >= 32` would panic in debug mode. Any
-    // value above the defined range (0..=8) is not a reference-consuming op.
-    op_type < 9 && (BAM_CIGAR_TYPE >> (op_type << 1)) & 2 != 0
+    (BAM_CIGAR_TYPE >> ((op_type & 0xF) << 1)) & 2 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the query including soft clips (M, I, S, =, X).
+///
+/// See [`consumes_ref`] for the `& 0xF` rationale.
 #[inline]
 #[must_use]
 pub const fn consumes_query(op_type: u32) -> bool {
-    // Guard the shift: `op_type << 1 >= 32` would panic in debug mode. Any
-    // value above the defined range (0..=8) is not a query-consuming op.
-    op_type < 9 && (BAM_CIGAR_TYPE >> (op_type << 1)) & 1 != 0
+    (BAM_CIGAR_TYPE >> ((op_type & 0xF) << 1)) & 1 != 0
 }
 
 /// Returns true if the CIGAR op type consumes the read/query excluding soft clips (M, I, =, X).
@@ -852,6 +852,200 @@ fn clip_cigar_end_raw(
     (result, 0) // ref_bases_consumed is 0 for end clipping (no position adjustment)
 }
 
+// ============================================================================
+// CigarKind and CigarOp — typed, zero-cost CIGAR iteration
+// ============================================================================
+
+/// BAM CIGAR operation kind. Matches the wire-format op-type low 4 bits.
+///
+/// Variant ordering is intentionally identical to the BAM spec so that
+/// `as u8` gives the correct op-type byte (useful in low-level code).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CigarKind {
+    /// Alignment match (M, op-type 0). Consumes both query and reference.
+    Match = 0,
+    /// Insertion to reference (I, op-type 1). Consumes query only.
+    Insertion = 1,
+    /// Deletion from reference (D, op-type 2). Consumes reference only.
+    Deletion = 2,
+    /// Skipped region from reference (N, op-type 3). Consumes reference only.
+    Skip = 3,
+    /// Soft clip (S, op-type 4). Consumes query only.
+    SoftClip = 4,
+    /// Hard clip (H, op-type 5). Consumes neither.
+    HardClip = 5,
+    /// Padding (P, op-type 6). Consumes neither.
+    Pad = 6,
+    /// Sequence match (=, op-type 7). Consumes both query and reference.
+    SequenceMatch = 7,
+    /// Sequence mismatch (X, op-type 8). Consumes both query and reference.
+    SequenceMismatch = 8,
+}
+
+impl CigarKind {
+    /// Single-char SAM representation (M/I/D/N/S/H/P/=/X).
+    #[inline]
+    #[must_use]
+    pub const fn as_char(self) -> char {
+        match self {
+            Self::Match => 'M',
+            Self::Insertion => 'I',
+            Self::Deletion => 'D',
+            Self::Skip => 'N',
+            Self::SoftClip => 'S',
+            Self::HardClip => 'H',
+            Self::Pad => 'P',
+            Self::SequenceMatch => '=',
+            Self::SequenceMismatch => 'X',
+        }
+    }
+
+    /// Parse from the wire-format 4-bit op-type value.
+    ///
+    /// Returns `None` for values >= 9 (reserved/invalid in the BAM spec).
+    #[inline]
+    #[must_use]
+    pub const fn from_op_type(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(Self::Match),
+            1 => Some(Self::Insertion),
+            2 => Some(Self::Deletion),
+            3 => Some(Self::Skip),
+            4 => Some(Self::SoftClip),
+            5 => Some(Self::HardClip),
+            6 => Some(Self::Pad),
+            7 => Some(Self::SequenceMatch),
+            8 => Some(Self::SequenceMismatch),
+            _ => None,
+        }
+    }
+}
+
+/// A single typed BAM CIGAR operation — `Copy` newtype over the raw u32 packing.
+///
+/// Provides the same ergonomic shape as noodles `record::cigar::op::Op` but
+/// backed by a single `u32` (no allocation, no trait dispatch, inline methods).
+///
+/// # Wire format
+///
+/// BAM encodes each CIGAR op as a u32 where:
+/// - low 4 bits (bits 0–3) encode the op type (0 = M, 1 = I, …, 8 = X)
+/// - high 28 bits (bits 4–31) encode the op length
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CigarOp(u32);
+
+impl CigarOp {
+    /// Construct from the raw 4-bit-op-type + 28-bit-length packing.
+    #[inline]
+    #[must_use]
+    pub const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Construct from a (kind, len) pair.
+    ///
+    /// Rejects zero-length ops: the BAM spec treats them as invalid (see
+    /// [`CigarOp::len`]), and the typed constructor should not mint what the
+    /// type claims to forbid. Use [`CigarOp::from_raw`] on a raw `u32` word if
+    /// you must preserve malformed wire data.
+    ///
+    /// # Panics
+    ///
+    /// - `len == 0`
+    /// - `len > 0x0FFF_FFFF` (28-bit limit)
+    #[inline]
+    #[must_use]
+    pub fn new(kind: CigarKind, len: u32) -> Self {
+        assert!(len > 0, "CIGAR op length must be non-zero");
+        assert!(len <= 0x0FFF_FFFF, "CIGAR op length exceeds 28-bit limit");
+        Self((len << 4) | (kind as u32))
+    }
+
+    /// The raw u32 packing, for byte-level code paths.
+    #[inline]
+    #[must_use]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Op kind (M, I, D, N, S, H, P, =, X).
+    ///
+    /// Decodes the low 4 bits of the raw u32 and returns the corresponding
+    /// [`CigarKind`] variant. Returns [`CigarKind::Pad`] for reserved/invalid
+    /// op-type values (>= 9) — same fallback used by [`cigar_op_kind`].
+    #[inline]
+    #[must_use]
+    pub fn kind(self) -> CigarKind {
+        CigarKind::from_op_type(self.0 & 0xF).unwrap_or(CigarKind::Pad)
+    }
+
+    /// Op length (number of bases).
+    ///
+    /// Note: zero-length CIGAR ops are invalid per the BAM spec, so there is
+    /// intentionally no companion `is_empty` method.
+    #[allow(clippy::len_without_is_empty)]
+    #[inline]
+    #[must_use]
+    pub const fn len(self) -> u32 {
+        self.0 >> 4
+    }
+
+    /// True if this op type consumes query bases (M, I, S, =, X).
+    ///
+    /// Uses the [`BAM_CIGAR_TYPE`] bitmask for a branchless test.
+    #[inline]
+    #[must_use]
+    pub fn consumes_query(self) -> bool {
+        consumes_query(self.0 & 0xF)
+    }
+
+    /// True if this op type consumes reference bases (M, D, N, =, X).
+    ///
+    /// Uses the [`BAM_CIGAR_TYPE`] bitmask for a branchless test.
+    #[inline]
+    #[must_use]
+    pub fn consumes_ref(self) -> bool {
+        consumes_ref(self.0 & 0xF)
+    }
+}
+
+#[cfg(feature = "noodles")]
+impl From<CigarKind> for noodles::sam::alignment::record::cigar::op::Kind {
+    fn from(k: CigarKind) -> Self {
+        use noodles::sam::alignment::record::cigar::op::Kind;
+        match k {
+            CigarKind::Match => Kind::Match,
+            CigarKind::Insertion => Kind::Insertion,
+            CigarKind::Deletion => Kind::Deletion,
+            CigarKind::Skip => Kind::Skip,
+            CigarKind::SoftClip => Kind::SoftClip,
+            CigarKind::HardClip => Kind::HardClip,
+            CigarKind::Pad => Kind::Pad,
+            CigarKind::SequenceMatch => Kind::SequenceMatch,
+            CigarKind::SequenceMismatch => Kind::SequenceMismatch,
+        }
+    }
+}
+
+#[cfg(feature = "noodles")]
+impl From<noodles::sam::alignment::record::cigar::op::Kind> for CigarKind {
+    fn from(k: noodles::sam::alignment::record::cigar::op::Kind) -> Self {
+        use noodles::sam::alignment::record::cigar::op::Kind;
+        match k {
+            Kind::Match => CigarKind::Match,
+            Kind::Insertion => CigarKind::Insertion,
+            Kind::Deletion => CigarKind::Deletion,
+            Kind::Skip => CigarKind::Skip,
+            Kind::SoftClip => CigarKind::SoftClip,
+            Kind::HardClip => CigarKind::HardClip,
+            Kind::Pad => CigarKind::Pad,
+            Kind::SequenceMatch => CigarKind::SequenceMatch,
+            Kind::SequenceMismatch => CigarKind::SequenceMismatch,
+        }
+    }
+}
+
 use crate::fields::RawRecordView;
 
 impl<'a> RawRecordView<'a> {
@@ -871,6 +1065,17 @@ impl<'a> RawRecordView<'a> {
     #[inline]
     pub fn cigar_ops_iter(&self) -> impl Iterator<Item = u32> + 'a {
         self.cigar_raw_bytes().chunks_exact(4).map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    }
+
+    /// Typed iteration over CIGAR ops. Ergonomically equivalent to
+    /// noodles `cigar().iter()` but zero-cost: each [`CigarOp`] is a `Copy`
+    /// newtype over the raw u32.
+    ///
+    /// The returned iterator has lifetime `'a` (tied to the underlying byte
+    /// slice, not to `&self`), so it can outlive a temporary view.
+    #[inline]
+    pub fn cigar_ops_typed(&self) -> impl Iterator<Item = CigarOp> + 'a {
+        self.cigar_ops_iter().map(CigarOp::from_raw)
     }
 
     /// Convenience: collect CIGAR ops into a `Vec<u32>`.
@@ -986,13 +1191,30 @@ mod tests {
             assert_eq!(consumes_query(op), eq, "consumes_query({op})");
             assert_eq!(consumes_ref(op), er, "consumes_ref({op})");
         }
-        // Op values >= 9 (including out-of-range >= 16) must not panic in
-        // debug mode and must return false. The naked bitmask shift would
-        // overflow for op >= 16 (since op << 1 >= 32), so `consumes_*` must
-        // guard the shift.
-        for op in 9u32..=255 {
+        // Op values >= 9 should return false for both
+        for op in 9u32..=15 {
             assert!(!consumes_query(op), "consumes_query({op}) should be false");
             assert!(!consumes_ref(op), "consumes_ref({op}) should be false");
+        }
+    }
+
+    #[test]
+    fn test_consumes_fns_mask_values_beyond_4_bits() {
+        // Without the `& 0xF` guard, op_type >= 16 overshifts (debug panic /
+        // release wrap). With the guard, the input is normalised to 0..=15 and
+        // the result matches the low-nibble equivalent. For example op=16 aliases
+        // to op=0 (M) and op=22 aliases to op=6 (P).
+        for (bad, good) in [(16u32, 0u32), (22u32, 6u32), (257u32, 1u32), (u32::MAX, 15u32)] {
+            assert_eq!(
+                consumes_query(bad),
+                consumes_query(good),
+                "consumes_query({bad}) should equal consumes_query({good})",
+            );
+            assert_eq!(
+                consumes_ref(bad),
+                consumes_ref(good),
+                "consumes_ref({bad}) should equal consumes_ref({good})",
+            );
         }
     }
 
@@ -2089,5 +2311,259 @@ mod tests {
         let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
         let v = RawRecordView::new(&rec);
         assert_eq!(v.cigar_lengths(), (0, 0));
+    }
+
+    // ========================================================================
+    // CigarKind tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_kind_as_char_all_variants() {
+        assert_eq!(CigarKind::Match.as_char(), 'M');
+        assert_eq!(CigarKind::Insertion.as_char(), 'I');
+        assert_eq!(CigarKind::Deletion.as_char(), 'D');
+        assert_eq!(CigarKind::Skip.as_char(), 'N');
+        assert_eq!(CigarKind::SoftClip.as_char(), 'S');
+        assert_eq!(CigarKind::HardClip.as_char(), 'H');
+        assert_eq!(CigarKind::Pad.as_char(), 'P');
+        assert_eq!(CigarKind::SequenceMatch.as_char(), '=');
+        assert_eq!(CigarKind::SequenceMismatch.as_char(), 'X');
+    }
+
+    #[test]
+    fn test_cigar_kind_from_op_type_all_valid() {
+        assert_eq!(CigarKind::from_op_type(0), Some(CigarKind::Match));
+        assert_eq!(CigarKind::from_op_type(1), Some(CigarKind::Insertion));
+        assert_eq!(CigarKind::from_op_type(2), Some(CigarKind::Deletion));
+        assert_eq!(CigarKind::from_op_type(3), Some(CigarKind::Skip));
+        assert_eq!(CigarKind::from_op_type(4), Some(CigarKind::SoftClip));
+        assert_eq!(CigarKind::from_op_type(5), Some(CigarKind::HardClip));
+        assert_eq!(CigarKind::from_op_type(6), Some(CigarKind::Pad));
+        assert_eq!(CigarKind::from_op_type(7), Some(CigarKind::SequenceMatch));
+        assert_eq!(CigarKind::from_op_type(8), Some(CigarKind::SequenceMismatch));
+    }
+
+    #[test]
+    fn test_cigar_kind_from_op_type_reserved_returns_none() {
+        for v in 9u32..=15 {
+            assert_eq!(CigarKind::from_op_type(v), None, "op_type {v} should be None");
+        }
+    }
+
+    // ========================================================================
+    // CigarOp tests
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_op_round_trip_from_raw() {
+        // All 9 op types with a representative length each.
+        let cases: &[(u32, u32)] = &[
+            (0, 50), // 50M
+            (1, 5),  // 5I
+            (2, 3),  // 3D
+            (3, 10), // 10N
+            (4, 4),  // 4S
+            (5, 2),  // 2H
+            (6, 1),  // 1P
+            (7, 20), // 20=
+            (8, 7),  // 7X
+        ];
+        for &(op_type, op_len) in cases {
+            let raw = (op_len << 4) | op_type;
+            let cigar_op = CigarOp::from_raw(raw);
+            assert_eq!(cigar_op.raw(), raw, "raw round-trip for op_type {op_type}");
+            assert_eq!(cigar_op.len(), op_len, "len for op_type {op_type}");
+            let expected_kind = CigarKind::from_op_type(op_type).unwrap();
+            assert_eq!(cigar_op.kind(), expected_kind, "kind for op_type {op_type}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "CIGAR op length must be non-zero")]
+    fn test_cigar_op_new_rejects_zero_length() {
+        let _ = CigarOp::new(CigarKind::Match, 0);
+    }
+
+    #[test]
+    fn test_cigar_op_from_raw_allows_zero_length_for_malformed_data() {
+        // from_raw intentionally preserves malformed wire data, so zero-length
+        // must still be constructable via the raw path even though CigarOp::new
+        // rejects it.
+        let op = CigarOp::from_raw(CigarKind::Match as u32); // len = 0
+        assert_eq!(op.len(), 0);
+    }
+
+    #[test]
+    fn test_cigar_op_new_round_trip() {
+        // Construct via CigarOp::new and verify kind/len match.
+        let cases: &[(CigarKind, u32)] = &[
+            (CigarKind::Match, 100),
+            (CigarKind::Insertion, 3),
+            (CigarKind::Deletion, 8),
+            (CigarKind::Skip, 1000),
+            (CigarKind::SoftClip, 5),
+            (CigarKind::HardClip, 2),
+            (CigarKind::Pad, 1),
+            (CigarKind::SequenceMatch, 42),
+            (CigarKind::SequenceMismatch, 7),
+        ];
+        for &(kind, len) in cases {
+            let op = CigarOp::new(kind, len);
+            assert_eq!(op.kind(), kind, "kind mismatch for {kind:?}");
+            assert_eq!(op.len(), len, "len mismatch for {kind:?}");
+        }
+    }
+
+    #[test]
+    fn test_cigar_op_consumes_query_matches_free_fn() {
+        // For all 9 op types, CigarOp::consumes_query should match consumes_query(op_type).
+        for op_type in 0u32..9 {
+            let raw = (10 << 4) | op_type; // length=10, arbitrary
+            let cigar_op = CigarOp::from_raw(raw);
+            assert_eq!(
+                cigar_op.consumes_query(),
+                consumes_query(op_type),
+                "consumes_query mismatch for op_type {op_type}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cigar_op_consumes_ref_matches_free_fn() {
+        // For all 9 op types, CigarOp::consumes_ref should match consumes_ref(op_type).
+        for op_type in 0u32..9 {
+            let raw = (10 << 4) | op_type;
+            let cigar_op = CigarOp::from_raw(raw);
+            assert_eq!(
+                cigar_op.consumes_ref(),
+                consumes_ref(op_type),
+                "consumes_ref mismatch for op_type {op_type}"
+            );
+        }
+    }
+
+    // ========================================================================
+    // cigar_ops_typed on RawRecordView
+    // ========================================================================
+
+    #[test]
+    fn test_cigar_ops_typed_known_cigar() {
+        // 5S10M3I2D4= 2X 1H => 8 ops
+        let raw_cigar = &[
+            encode_op(4, 5),  // 5S
+            encode_op(0, 10), // 10M
+            encode_op(1, 3),  // 3I
+            encode_op(2, 2),  // 2D
+            encode_op(7, 4),  // 4=
+            encode_op(8, 2),  // 2X
+            encode_op(5, 1),  // 1H
+        ];
+        let seq_len = 5 + 10 + 3 + 4 + 2; // query-consuming ops
+        let rec = make_bam_bytes(0, 100, 0, b"rd", raw_cigar, seq_len, -1, -1, &[]);
+        let view = RawRecordView::new(&rec);
+
+        let typed: Vec<CigarOp> = view.cigar_ops_typed().collect();
+        assert_eq!(typed.len(), 7);
+        assert_eq!(typed[0].kind(), CigarKind::SoftClip);
+        assert_eq!(typed[0].len(), 5);
+        assert_eq!(typed[1].kind(), CigarKind::Match);
+        assert_eq!(typed[1].len(), 10);
+        assert_eq!(typed[2].kind(), CigarKind::Insertion);
+        assert_eq!(typed[2].len(), 3);
+        assert_eq!(typed[3].kind(), CigarKind::Deletion);
+        assert_eq!(typed[3].len(), 2);
+        assert_eq!(typed[4].kind(), CigarKind::SequenceMatch);
+        assert_eq!(typed[4].len(), 4);
+        assert_eq!(typed[5].kind(), CigarKind::SequenceMismatch);
+        assert_eq!(typed[5].len(), 2);
+        assert_eq!(typed[6].kind(), CigarKind::HardClip);
+        assert_eq!(typed[6].len(), 1);
+    }
+
+    #[test]
+    fn test_cigar_ops_typed_empty_cigar() {
+        let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, &[]);
+        let view = RawRecordView::new(&rec);
+        let typed: Vec<CigarOp> = view.cigar_ops_typed().collect();
+        assert!(typed.is_empty());
+    }
+
+    #[test]
+    fn test_cigar_ops_typed_matches_cigar_ops_iter() {
+        // cigar_ops_typed().map(|op| op.raw()) should equal cigar_ops_iter()
+        let raw_cigar = &[
+            encode_op(0, 30), // 30M
+            encode_op(1, 2),  // 2I
+            encode_op(0, 20), // 20M
+            encode_op(4, 5),  // 5S
+        ];
+        let rec = make_bam_bytes(0, 50, 0, b"rd", raw_cigar, 57, -1, -1, &[]);
+        let view = RawRecordView::new(&rec);
+
+        let from_raw: Vec<u32> = view.cigar_ops_iter().collect();
+        let from_typed: Vec<u32> = view.cigar_ops_typed().map(CigarOp::raw).collect();
+        assert_eq!(from_raw, from_typed);
+    }
+
+    #[cfg(feature = "noodles")]
+    mod noodles_roundtrip {
+        use super::*;
+
+        #[test]
+        fn test_cigar_kind_noodles_roundtrip_all_variants() {
+            use noodles::sam::alignment::record::cigar::op::Kind;
+
+            let kinds = [
+                CigarKind::Match,
+                CigarKind::Insertion,
+                CigarKind::Deletion,
+                CigarKind::Skip,
+                CigarKind::SoftClip,
+                CigarKind::HardClip,
+                CigarKind::Pad,
+                CigarKind::SequenceMatch,
+                CigarKind::SequenceMismatch,
+            ];
+
+            for original in kinds {
+                // CigarKind -> noodles Kind -> CigarKind
+                let noodles_kind: Kind = original.into();
+                let round_tripped: CigarKind = noodles_kind.into();
+                assert_eq!(round_tripped, original, "round-trip failed for {original:?}");
+            }
+        }
+
+        #[test]
+        fn test_noodles_kind_to_cigar_kind_all_variants() {
+            use noodles::sam::alignment::record::cigar::op::Kind;
+
+            let noodles_kinds = [
+                Kind::Match,
+                Kind::Insertion,
+                Kind::Deletion,
+                Kind::Skip,
+                Kind::SoftClip,
+                Kind::HardClip,
+                Kind::Pad,
+                Kind::SequenceMatch,
+                Kind::SequenceMismatch,
+            ];
+            let expected = [
+                CigarKind::Match,
+                CigarKind::Insertion,
+                CigarKind::Deletion,
+                CigarKind::Skip,
+                CigarKind::SoftClip,
+                CigarKind::HardClip,
+                CigarKind::Pad,
+                CigarKind::SequenceMatch,
+                CigarKind::SequenceMismatch,
+            ];
+
+            for (nk, ck) in noodles_kinds.iter().zip(expected.iter()) {
+                let converted: CigarKind = (*nk).into();
+                assert_eq!(converted, *ck, "noodles->CigarKind failed for {nk:?}");
+            }
+        }
     }
 }

--- a/crates/fgumi-raw-bam/src/indexed_reader.rs
+++ b/crates/fgumi-raw-bam/src/indexed_reader.rs
@@ -1,0 +1,592 @@
+//! Indexed BAM reader that yields raw bytes without decoding to `RecordBuf`.
+//!
+//! [`IndexedRawBamReader`] delegates index parsing and BGZF seek to noodles,
+//! then yields [`RawRecord`] directly — bypassing the noodles `Record` type
+//! whose inner bytes are not publicly accessible (noodles#373).
+//!
+//! # Feature gate
+//!
+//! This module is only compiled when the `noodles` feature is enabled, because
+//! it depends on noodles for BGZF seek, BAI index parsing, and SAM header
+//! decoding.
+
+use std::io::{self, Read, Seek};
+
+use anyhow::Context as _;
+use noodles::bam::bai;
+use noodles::bgzf;
+use noodles::bgzf::io::Seek as BgzfSeek;
+use noodles::core::region::Interval;
+use noodles::csi::BinningIndex as _;
+use noodles::sam;
+
+use crate::raw_bam_record::{RawRecord, read_raw_record};
+
+// ─── public type ────────────────────────────────────────────────────────────
+
+/// An indexed BAM reader that yields [`RawRecord`] bytes.
+///
+/// Uses a BAI index to compute the BGZF virtual-offset chunks that overlap a
+/// query region, then seeks the BGZF stream and reads raw BAM records from
+/// those chunks.  Per-record overlap is verified via a cheap raw-byte
+/// intersection test before yielding.
+///
+/// # Constructing
+///
+/// ```rust,ignore
+/// use fgumi_raw_bam::IndexedRawBamReader;
+/// use noodles::bam::bai;
+///
+/// let index = bai::fs::read("sample.bam.bai")?;
+/// let mut reader = IndexedRawBamReader::from_path("sample.bam", index)?;
+/// let header = reader.read_header()?;
+/// let region = "chr1:100-200".parse()?;
+/// for result in reader.query(&header, &region)? {
+///     let raw = result?;
+///     // use raw bytes …
+/// }
+/// ```
+pub struct IndexedRawBamReader<R> {
+    /// Noodles BAM reader wrapping the BGZF decompressor.
+    inner: noodles::bam::io::Reader<bgzf::io::Reader<R>>,
+    /// BAI (or CSI) index held as a boxed `BinningIndex`.
+    index: Box<dyn noodles::csi::BinningIndex>,
+    /// BGZF virtual position of the first record (captured after `read_header`).
+    /// Used as the `query_unmapped` fallback when the index lacks a
+    /// `last_first_record_start_position` marker, so the iterator rewinds to
+    /// the first record rather than resuming at a mid-stream cursor.
+    first_record_position: Option<bgzf::VirtualPosition>,
+}
+
+// ─── convenience constructors ───────────────────────────────────────────────
+
+impl IndexedRawBamReader<std::fs::File> {
+    /// Open a BAM file from a path and pair it with a BAI index.
+    ///
+    /// The BGZF layer is created automatically from the file handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened.
+    pub fn from_path(path: impl AsRef<std::path::Path>, index: bai::Index) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        Ok(Self::new(file, index))
+    }
+}
+
+// ─── generic impl ───────────────────────────────────────────────────────────
+
+impl<R: Read + Seek> IndexedRawBamReader<R> {
+    /// Create from any seekable readable stream and a BAI index.
+    #[must_use]
+    pub fn new(reader: R, index: bai::Index) -> Self {
+        Self {
+            inner: noodles::bam::io::Reader::new(reader),
+            index: Box::new(index),
+            first_record_position: None,
+        }
+    }
+}
+
+impl<R: Read> IndexedRawBamReader<R> {
+    /// Read (and consume) the BAM header.
+    ///
+    /// Must be called exactly once before [`query`], because the header
+    /// encodes the reference-sequence dictionary needed to resolve region
+    /// names to reference-sequence IDs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the header cannot be read or parsed.
+    pub fn read_header(&mut self) -> anyhow::Result<sam::Header> {
+        let header = self.inner.read_header().context("reading BAM header")?;
+        // Remember the post-header BGZF position so `query_unmapped` can rewind
+        // to the first record when the index lacks a location marker.
+        self.first_record_position = Some(self.inner.get_ref().virtual_position());
+        Ok(header)
+    }
+}
+
+impl<R: Read + Seek> IndexedRawBamReader<R> {
+    /// Return an iterator over unmapped [`RawRecord`]s.
+    ///
+    /// Seeks to the position of the last placed read's start (or the first
+    /// record if the index has no such marker), then yields only records
+    /// flagged as unmapped (`FLAG & 4`).
+    ///
+    /// # Errors
+    ///
+    /// - Seek or read failures.
+    /// - The index has no `last_first_record_start_position` AND
+    ///   [`read_header`](Self::read_header) has not been called — without
+    ///   either, the first-record position is unknown and falling back to
+    ///   BGZF offset 0 would attempt to parse the BAM header as a record.
+    pub fn query_unmapped(&mut self) -> anyhow::Result<UnmappedIter<'_, R>> {
+        // Prefer the index marker; otherwise use the first-record position
+        // captured during `read_header`. Refusing to guess prevents
+        // UnmappedIter from parsing header bytes as a record.
+        let virtual_pos = self
+            .index
+            .last_first_record_start_position()
+            .or(self.first_record_position)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "query_unmapped: index has no unmapped start marker and \
+                     read_header() has not been called",
+                )
+            })?;
+        self.inner
+            .get_mut()
+            .seek_to_virtual_position(virtual_pos)
+            .context("seeking to unmapped position")?;
+        Ok(UnmappedIter { inner: &mut self.inner, record: RawRecord::new() })
+    }
+
+    /// Return an iterator over [`RawRecord`]s that overlap `region`.
+    ///
+    /// The iterator yields only records whose alignment interval intersects
+    /// the query region; records that fall entirely outside the region (but
+    /// in the same BGZF chunk) are silently skipped.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` — SAM header obtained from [`read_header`]; used to
+    ///   resolve the region name to a reference-sequence ID.
+    /// * `region` — Genomic region to query (e.g. `"chr1:100-200".parse()`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the region name is not found in the header or if
+    /// the index cannot be queried.
+    pub fn query<'a>(
+        &'a mut self,
+        header: &'a sam::Header,
+        region: &noodles::core::Region,
+    ) -> anyhow::Result<RawQueryIter<'a, R>> {
+        // Resolve the region name to a 0-based reference-sequence index.
+        let ref_id = header.reference_sequences().get_index_of(region.name()).ok_or_else(|| {
+            anyhow::anyhow!("region reference sequence {:?} not found in BAM header", region.name())
+        })?;
+
+        let interval = region.interval();
+
+        // Ask the index for the BGZF chunks covering this interval.
+        let chunks = self.index.query(ref_id, interval).context("querying BAI index")?;
+
+        // Hand `&mut bgzf_reader` to `csi::io::Query` so it can seek between
+        // chunks and feed us decompressed data in order.
+        let bgzf_reader = self.inner.get_mut();
+        let csi_query = noodles::csi::io::Query::new(bgzf_reader, chunks);
+
+        Ok(RawQueryIter { reader: csi_query, ref_id, interval, record: RawRecord::new() })
+    }
+}
+
+// ─── iterator ───────────────────────────────────────────────────────────────
+
+/// Iterator over raw BAM records overlapping a queried region.
+///
+/// Created by [`IndexedRawBamReader::query`].  Reuses a single
+/// [`RawRecord`] buffer internally; each `next()` call clones the bytes
+/// into a new owned [`RawRecord`] that is yielded to the caller.
+pub struct RawQueryIter<'r, R> {
+    reader: noodles::csi::io::Query<'r, bgzf::io::Reader<R>>,
+    ref_id: usize,
+    interval: Interval,
+    record: RawRecord,
+}
+
+impl<R: Read + Seek> Iterator for RawQueryIter<'_, R> {
+    type Item = anyhow::Result<RawRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match read_raw_record(&mut self.reader, &mut self.record) {
+                Ok(0) => return None, // EOF / all chunks consumed
+                Ok(_) => {
+                    match intersects_region(&self.record, self.ref_id, self.interval) {
+                        Ok(true) => {
+                            // Yield a clone so the caller owns the bytes.
+                            return Some(Ok(self.record.clone()));
+                        }
+                        Ok(false) => {} // record outside query region; skip
+                        Err(e) => return Some(Err(e)),
+                    }
+                }
+                Err(e) => return Some(Err(e.into())),
+            }
+        }
+    }
+}
+
+// ─── unmapped iterator ──────────────────────────────────────────────────────
+
+/// Iterator over unmapped raw BAM records.
+///
+/// Created by [`IndexedRawBamReader::query_unmapped`].
+pub struct UnmappedIter<'r, R> {
+    inner: &'r mut noodles::bam::io::Reader<bgzf::io::Reader<R>>,
+    record: RawRecord,
+}
+
+impl<R: Read> Iterator for UnmappedIter<'_, R> {
+    type Item = anyhow::Result<RawRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match read_raw_record(self.inner.get_mut(), &mut self.record) {
+                Ok(0) => return None,
+                Ok(_) => {
+                    if self.record.is_unmapped() {
+                        return Some(Ok(self.record.clone()));
+                    }
+                    // skip mapped records
+                }
+                Err(e) => return Some(Err(e.into())),
+            }
+        }
+    }
+}
+
+// ─── overlap test ───────────────────────────────────────────────────────────
+
+/// Returns `true` if `record` overlaps `(ref_id, interval)`.
+///
+/// Mirrors noodles' `query::intersects` but operates on raw BAM bytes so
+/// no decoding to `Record` is needed.
+fn intersects_region(
+    record: &RawRecord,
+    ref_id: usize,
+    interval: Interval,
+) -> anyhow::Result<bool> {
+    use crate::cigar::reference_length_from_raw_bam;
+    use crate::fields::{pos, ref_id as raw_ref_id};
+    use noodles::core::Position;
+
+    let bytes: &[u8] = record;
+    if bytes.len() < 8 {
+        return Ok(false);
+    }
+
+    // Reference-sequence ID check.
+    let record_ref_id = raw_ref_id(bytes);
+    if record_ref_id < 0 {
+        return Ok(false); // unmapped
+    }
+    if usize::try_from(record_ref_id).ok() != Some(ref_id) {
+        return Ok(false);
+    }
+
+    // Position: 0-based in BAM, convert to 1-based for noodles Interval.
+    let p = pos(bytes);
+    if p < 0 {
+        return Ok(false);
+    }
+    #[allow(clippy::cast_sign_loss)] // guarded by `p >= 0` check above
+    let start_1based = p as usize + 1;
+
+    // Alignment end: start_1based + ref_length - 1
+    let ref_len_raw = reference_length_from_raw_bam(bytes);
+    #[allow(clippy::cast_sign_loss)] // reference_length_from_raw_bam returns non-negative
+    let ref_len = ref_len_raw as usize;
+    if ref_len == 0 {
+        // Unmapped or no CIGAR; treat as single-position
+        let start_pos =
+            Position::try_from(start_1based).context("converting alignment start to Position")?;
+        let record_interval = Interval::from(start_pos..=start_pos);
+        return Ok(interval.intersects(record_interval));
+    }
+    let end_1based = start_1based + ref_len - 1;
+
+    let start_pos =
+        Position::try_from(start_1based).context("converting alignment start to Position")?;
+    let end_pos = Position::try_from(end_1based).context("converting alignment end to Position")?;
+
+    let record_interval = Interval::from(start_pos..=end_pos);
+    Ok(interval.intersects(record_interval))
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::*;
+    use noodles::bam::{self, bai};
+    use noodles::sam::alignment::io::Write as _;
+    use std::io::Cursor;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// Build a coordinate-sorted SAM header with `ref_names` as reference sequences.
+    ///
+    /// The header includes `SO:coordinate` so that `bam::fs::index` will accept
+    /// the BAM file without error.
+    fn make_header(ref_names: &[(&str, usize)]) -> sam::Header {
+        use bstr::BString;
+        use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+        use std::num::NonZeroUsize;
+
+        // Parse a header line that includes SO:coordinate so that bam::fs::index
+        // does not reject the file with "invalid sort order".
+        let hd_line: sam::Header = "@HD\tVN:1.6\tSO:coordinate\n".parse().expect("parse @HD line");
+
+        let mut builder = sam::Header::builder();
+        if let Some(hd) = hd_line.header() {
+            builder = builder.set_header(hd.clone());
+        }
+        for (name, len) in ref_names {
+            builder = builder.add_reference_sequence(
+                BString::from(*name),
+                Map::<ReferenceSequence>::new(
+                    NonZeroUsize::try_from(*len).expect("non-zero ref len"),
+                ),
+            );
+        }
+        builder.build()
+    }
+
+    /// Encode a `RecordBuf` to a BGZF-compressed BAM `Vec<u8>`, including
+    /// the BAM magic + header preamble.
+    fn encode_bam(header: &sam::Header, records: &[sam::alignment::RecordBuf]) -> Vec<u8> {
+        let mut writer = bam::io::Writer::new(Vec::new());
+        writer.write_header(header).expect("write header");
+        for rec in records {
+            writer.write_alignment_record(header, rec).expect("write record");
+        }
+        writer.into_inner().finish().expect("bgzf finish")
+    }
+
+    /// Build and index a BAM from `records` using noodles' `bam::fs::index`.
+    /// Returns `(bam_bytes, bai_index)`.
+    fn build_and_index(
+        header: &sam::Header,
+        records: &[sam::alignment::RecordBuf],
+    ) -> (Vec<u8>, bai::Index) {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let bam_bytes = encode_bam(header, records);
+
+        // Write to a temp file so noodles can index it.
+        let mut tmp = NamedTempFile::new().expect("tmp file");
+        tmp.write_all(&bam_bytes).expect("write bam");
+        tmp.flush().expect("flush");
+
+        let index = bam::fs::index(tmp.path()).expect("index bam");
+        (bam_bytes, index)
+    }
+
+    /// Create a simple mapped `RecordBuf` at `(ref_id, pos_1based)` with
+    /// `read_len` M bases.  The `RecordBuf` is decoded from a `SamBuilder` raw
+    /// record, which is sufficient for writing into a BAM file.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn mapped_record(
+        ref_id: usize,
+        pos_1based: usize,
+        read_len: usize,
+    ) -> sam::alignment::RecordBuf {
+        use crate::SamBuilder;
+
+        let mut b = SamBuilder::new();
+        b.ref_id(ref_id as i32)
+            .pos((pos_1based as i32) - 1)
+            .mapq(60)
+            .cigar_ops(&[encode_op(0, read_len)])
+            .sequence(&vec![b'A'; read_len])
+            .qualities(&vec![30u8; read_len])
+            .flags(crate::flags::PAIRED | crate::flags::FIRST_SEGMENT);
+        crate::noodles_compat::raw_records_to_record_bufs(&[b.build().as_ref().to_vec()])
+            .expect("decode mapped record")
+            .pop()
+            .expect("one record")
+    }
+
+    /// Create an unmapped `RecordBuf` (`ref_id` = -1, flags UNMAPPED).
+    fn unmapped_record() -> sam::alignment::RecordBuf {
+        use crate::SamBuilder;
+
+        let mut b = SamBuilder::new();
+        b.ref_id(-1)
+            .pos(-1)
+            .mapq(0)
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(crate::flags::UNMAPPED);
+        crate::noodles_compat::raw_records_to_record_bufs(&[b.build().as_ref().to_vec()])
+            .expect("decode unmapped record")
+            .pop()
+            .expect("one record")
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// Query a region; verify the right records are returned.
+    #[test]
+    fn query_returns_overlapping_records() {
+        let header = make_header(&[("chr1", 1000)]);
+
+        // Three records: pos 10-19, pos 50-59, pos 100-109 (all 10bp M).
+        let r1 = mapped_record(0, 10, 10);
+        let r2 = mapped_record(0, 50, 10);
+        let r3 = mapped_record(0, 100, 10);
+
+        let records = [r1, r2, r3];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let hdr = reader.read_header().expect("header");
+
+        // Query chr1:45-55 — should hit r2 (pos 50-59) only.
+        let region = "chr1:45-55".parse().expect("region");
+        let results: Vec<_> = reader.query(&hdr, &region).expect("query").collect();
+        assert_eq!(results.len(), 1, "expected exactly 1 overlapping record");
+        let raw = results[0].as_ref().expect("record ok");
+        // Verify position (0-based pos = 49 → 1-based start = 50).
+        assert_eq!(raw.pos(), 49);
+    }
+
+    /// Query a region with no overlapping records — iterator must be empty.
+    #[test]
+    fn query_empty_region_returns_no_records() {
+        let header = make_header(&[("chr1", 1000)]);
+        let r1 = mapped_record(0, 10, 10);
+        let (bam_bytes, index) = build_and_index(&header, &[r1]);
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let hdr = reader.read_header().expect("header");
+
+        // Query chr1:500-600 — no records there.
+        let region = "chr1:500-600".parse().expect("region");
+        let results: Vec<_> = reader.query(&hdr, &region).expect("query").collect();
+        assert_eq!(results.len(), 0, "expected no records in empty region");
+    }
+
+    /// Multiple records in the same region; verify all are returned in order.
+    #[test]
+    fn query_returns_multiple_overlapping_records() {
+        let header = make_header(&[("chr1", 1000)]);
+        let r1 = mapped_record(0, 100, 50);
+        let r2 = mapped_record(0, 120, 50);
+        let r3 = mapped_record(0, 200, 50); // outside query window
+
+        let records = [r1, r2, r3];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let hdr = reader.read_header().expect("header");
+
+        // Query chr1:100-169 — hits r1 and r2, not r3.
+        let region = "chr1:100-169".parse().expect("region");
+        let results: Vec<_> = reader.query(&hdr, &region).expect("query").collect();
+        assert_eq!(results.len(), 2, "expected 2 overlapping records");
+
+        let pos0 = results[0].as_ref().expect("ok").pos();
+        let pos1 = results[1].as_ref().expect("ok").pos();
+        assert_eq!(pos0, 99); // 1-based 100 → 0-based 99
+        assert_eq!(pos1, 119); // 1-based 120 → 0-based 119
+    }
+
+    /// Two queries on the same reader; verify seeking works correctly.
+    #[test]
+    fn multiple_queries_on_same_reader() {
+        let header = make_header(&[("chr1", 1000)]);
+        let r1 = mapped_record(0, 10, 10);
+        let r2 = mapped_record(0, 200, 10);
+
+        let records = [r1, r2];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let hdr = reader.read_header().expect("header");
+
+        // First query: chr1:1-20 → r1 only.
+        let region1 = "chr1:1-20".parse().expect("region");
+        let res1: Vec<_> = reader.query(&hdr, &region1).expect("query").collect();
+        assert_eq!(res1.len(), 1);
+        assert_eq!(res1[0].as_ref().expect("ok").pos(), 9);
+
+        // Second query: chr1:190-210 → r2 only.
+        let region2 = "chr1:190-210".parse().expect("region");
+        let res2: Vec<_> = reader.query(&hdr, &region2).expect("query").collect();
+        assert_eq!(res2.len(), 1);
+        assert_eq!(res2[0].as_ref().expect("ok").pos(), 199);
+    }
+
+    /// `query_unmapped` returns only unmapped records.
+    #[test]
+    fn query_unmapped_returns_unmapped_records() {
+        let header = make_header(&[("chr1", 1000)]);
+
+        // One mapped record and one unmapped record.
+        let r_mapped = mapped_record(0, 10, 10);
+        let r_unmap = unmapped_record();
+
+        let records = [r_mapped, r_unmap];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let _hdr = reader.read_header().expect("header");
+
+        let results: Vec<_> = reader.query_unmapped().expect("query_unmapped").collect();
+        assert_eq!(results.len(), 1, "expected exactly 1 unmapped record");
+        assert!(results[0].as_ref().expect("ok").is_unmapped());
+    }
+
+    /// If neither the index nor `read_header` provides a first-record
+    /// position, `query_unmapped` must return an explicit error rather than
+    /// silently fall back to BGZF offset 0 (which would parse the BAM header
+    /// as a record).
+    #[test]
+    fn query_unmapped_errors_when_no_marker_and_header_unread() {
+        let header = make_header(&[("chr1", 1000)]);
+
+        // Empty BAM → noodles does not set last_first_record_start_position.
+        let records: [sam::alignment::RecordBuf; 0] = [];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+        assert!(index.last_first_record_start_position().is_none());
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        // Intentionally NOT calling read_header — the error path depends on
+        // first_record_position being None.
+        let Err(err) = reader.query_unmapped() else {
+            panic!("expected query_unmapped to error without a position");
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("read_header"),
+            "error message should mention read_header(); got: {msg}",
+        );
+    }
+
+    /// When the index lacks a `last_first_record_start_position` marker,
+    /// `query_unmapped` must rewind to the first record (captured in
+    /// `read_header`) rather than resume wherever the BGZF cursor was last
+    /// left. Exercises the empty-BAM case where noodles leaves the marker
+    /// unset; verifies the fallback seek succeeds and two consecutive calls
+    /// yield the same (empty) result.
+    #[test]
+    fn query_unmapped_falls_back_to_first_record_when_no_marker() {
+        let header = make_header(&[("chr1", 1000)]);
+
+        // Empty BAM → noodles does not set last_first_record_start_position.
+        let records: [sam::alignment::RecordBuf; 0] = [];
+        let (bam_bytes, index) = build_and_index(&header, &records);
+        assert!(
+            index.last_first_record_start_position().is_none(),
+            "test precondition: no last_first_record_start_position",
+        );
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam_bytes), index);
+        let _hdr = reader.read_header().expect("header");
+
+        // First call consumes the (empty) unmapped section and advances the
+        // BGZF cursor. Second call without the fix would silently return an
+        // iterator rooted at that advanced cursor; with the fix, it rewinds
+        // to the captured first-record position.
+        let a: Vec<_> = reader.query_unmapped().expect("1st query_unmapped").collect();
+        assert_eq!(a.len(), 0);
+        let b: Vec<_> = reader.query_unmapped().expect("2nd query_unmapped").collect();
+        assert_eq!(b.len(), 0);
+    }
+}

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -13,6 +13,9 @@ pub mod tags;
 pub mod testutil;
 
 #[cfg(feature = "noodles")]
+pub mod indexed_reader;
+
+#[cfg(feature = "noodles")]
 pub mod noodles_compat;
 
 // Re-exports — callers use fgumi_raw_bam::FooBar etc.
@@ -55,22 +58,39 @@ pub use fields::{
 };
 
 // -- builder --
-pub use builder::UnmappedBamRecordBuilder;
+pub use builder::{SamBuilder, UnmappedSamBuilder};
 
 // -- cigar --
 pub use cigar::{
-    alignment_end_from_raw, alignment_start_from_raw, cigar_op_kind, cigar_to_string_from_raw,
-    clip_cigar_ops_raw, consumes_query, consumes_read, consumes_ref, get_cigar_ops,
-    mate_unclipped_5prime, mate_unclipped_5prime_1based, query_length_from_cigar,
-    read_pos_at_ref_pos_raw, reference_length_from_cigar, reference_length_from_raw_bam,
-    unclipped_5prime_from_raw_bam, unclipped_5prime_raw,
+    // -- typed CIGAR iteration --
+    CigarKind,
+    CigarOp,
+    alignment_end_from_raw,
+    alignment_start_from_raw,
+    cigar_op_kind,
+    cigar_to_string_from_raw,
+    clip_cigar_ops_raw,
+    consumes_query,
+    consumes_read,
+    consumes_ref,
+    get_cigar_ops,
+    mate_unclipped_5prime,
+    mate_unclipped_5prime_1based,
+    query_length_from_cigar,
+    read_pos_at_ref_pos_raw,
+    reference_length_from_cigar,
+    reference_length_from_raw_bam,
+    unclipped_5prime_from_raw_bam,
+    unclipped_5prime_raw,
 };
 
 // -- overlap --
 pub use overlap::{is_fr_pair_raw, num_bases_extending_past_mate_raw};
 
 // -- raw_bam_record --
-pub use raw_bam_record::{RawBamReader, RawRecord, read_raw_record};
+pub use raw_bam_record::{
+    RawBamReader, RawBamWriter, RawRecord, read_raw_record, write_raw_record, write_raw_records,
+};
 
 // -- sequence --
 pub use sequence::{
@@ -84,7 +104,7 @@ pub use sort::{compare_coordinate_raw, compare_names_raw, compare_queryname_raw,
 // -- tags --
 pub use tags::{
     ArrayTagRef, AuxStringTags, AuxTagsIter, RawTagsEditor, RawTagsMut, RawTagsView, TagEntry,
-    TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
+    TagValue, TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
     array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
     find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
     find_string_tag_in_record, find_tag_type, find_uint8_tag, normalize_int_tag_to_smallest_signed,
@@ -97,3 +117,6 @@ pub use testutil::*;
 
 #[cfg(feature = "noodles")]
 pub use noodles_compat::*;
+
+#[cfg(feature = "noodles")]
+pub use indexed_reader::{IndexedRawBamReader, RawQueryIter, UnmappedIter};

--- a/crates/fgumi-raw-bam/src/noodles_compat.rs
+++ b/crates/fgumi-raw-bam/src/noodles_compat.rs
@@ -54,6 +54,158 @@ pub fn simplify_cigar_from_raw(
     simplified
 }
 
+/// Length of the 4-byte little-endian `block_size` prefix in the BAM framing protocol.
+///
+/// When `noodles::bam::io::Writer<Vec<u8>>` writes a record it prepends a `u32` `block_size`
+/// field before the record payload.  This constant names that prefix so it can be stripped.
+const BLOCK_SIZE_PREFIX_LEN: usize = 4;
+
+/// Encode a single `RecordBuf` to raw BAM bytes and wrap in a [`RawRecord`].
+///
+/// Uses noodles' BAM writer machinery writing to an in-memory buffer to produce
+/// the record's binary representation. The 4-byte `block_size` prefix written
+/// by the BAM framing protocol is stripped so the returned `RawRecord` contains
+/// only the record payload bytes (matching the layout of records produced by
+/// [`raw_records_to_record_bufs`] and consumed by [`RawRecord`] field accessors).
+///
+/// # Errors
+///
+/// Returns an error if encoding fails (e.g., the record contains an invalid
+/// reference-sequence ID or alignment position for the given `header`).
+pub fn encode_record_buf_to_raw(
+    buf: &noodles::sam::alignment::RecordBuf,
+    header: &noodles::sam::Header,
+) -> anyhow::Result<crate::RawRecord> {
+    use noodles::sam::alignment::io::Write as _;
+
+    // Writer<Vec<u8>> is uncompressed — writes 4-byte block_size + record bytes.
+    let mut writer = noodles::bam::io::Writer::from(Vec::new());
+    writer
+        .write_alignment_record(header, buf)
+        .map_err(|e| anyhow::anyhow!("encode_record_buf_to_raw: {e}"))?;
+    let raw = writer.into_inner();
+
+    // Skip the 4-byte little-endian block_size prefix to get the record bytes.
+    anyhow::ensure!(
+        raw.len() >= BLOCK_SIZE_PREFIX_LEN,
+        "encode_record_buf_to_raw: encoded output too short ({} bytes)",
+        raw.len()
+    );
+    Ok(crate::RawRecord::from(raw[BLOCK_SIZE_PREFIX_LEN..].to_vec()))
+}
+
+/// Decode a single raw BAM record to a noodles `RecordBuf`, using the supplied
+/// SAM header for the reference-sequence dictionary.
+///
+/// Delegates to [`raw_records_to_record_bufs_with_header`] for the single-record
+/// case. Passing a non-empty header is required for round-tripping mapped
+/// records — without the matching `@SQ` dictionary, reference IDs do not
+/// resolve back to names on re-encode.
+///
+/// # Errors
+///
+/// Returns an error if the record bytes cannot be decoded (e.g., malformed
+/// binary data) or the header cannot be serialized into the decode stream.
+pub fn raw_record_to_record_buf(
+    rec: &crate::RawRecord,
+    header: &noodles::sam::Header,
+) -> anyhow::Result<noodles::sam::alignment::RecordBuf> {
+    let mut bufs = raw_records_to_record_bufs_with_header(&[rec.as_ref().to_vec()], header)?;
+    bufs.pop().ok_or_else(|| anyhow::anyhow!("raw_record_to_record_buf: no record decoded"))
+}
+
+/// Amortized `RecordBuf` → `RawRecord` encoder.
+///
+/// Holds a reference to the SAM header and an internal scratch `Vec<u8>` so
+/// that per-call allocations for the encoded output are avoided.  The scratch
+/// buffer is reused on every call to [`encode`] and [`encode_into`].
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let mut enc = RecordBufEncoder::new(&header);
+/// for record in records {
+///     let raw = enc.encode(&record)?;
+///     // use raw …
+/// }
+/// ```
+pub struct RecordBufEncoder<'h> {
+    header: &'h noodles::sam::Header,
+    /// Scratch buffer reused across encode calls to amortize allocations.
+    scratch: Vec<u8>,
+}
+
+impl<'h> RecordBufEncoder<'h> {
+    /// Creates a new encoder that encodes against `header`.
+    #[must_use]
+    pub fn new(header: &'h noodles::sam::Header) -> Self {
+        Self { header, scratch: Vec::with_capacity(512) }
+    }
+
+    /// Encode `buf` into a freshly-allocated [`RawRecord`].
+    ///
+    /// The internal scratch buffer is reused for the encoding step, so no
+    /// allocation is needed there.  The returned [`RawRecord`] owns its bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding fails.
+    pub fn encode(
+        &mut self,
+        buf: &noodles::sam::alignment::RecordBuf,
+    ) -> anyhow::Result<crate::RawRecord> {
+        use noodles::sam::alignment::io::Write as _;
+
+        self.scratch.clear();
+        let mut writer = noodles::bam::io::Writer::from(&mut self.scratch);
+        writer
+            .write_alignment_record(self.header, buf)
+            .map_err(|e| anyhow::anyhow!("RecordBufEncoder::encode: {e}"))?;
+
+        // Skip the 4-byte block_size prefix.
+        anyhow::ensure!(
+            self.scratch.len() >= BLOCK_SIZE_PREFIX_LEN,
+            "RecordBufEncoder::encode: encoded output too short ({} bytes)",
+            self.scratch.len()
+        );
+        Ok(crate::RawRecord::from(self.scratch[BLOCK_SIZE_PREFIX_LEN..].to_vec()))
+    }
+
+    /// Encode `buf` into the caller-supplied `out` [`RawRecord`], replacing its
+    /// contents.
+    ///
+    /// Reuses both the internal scratch buffer and the storage inside `out` to
+    /// minimise allocations per call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding fails.
+    pub fn encode_into(
+        &mut self,
+        buf: &noodles::sam::alignment::RecordBuf,
+        out: &mut crate::RawRecord,
+    ) -> anyhow::Result<()> {
+        use noodles::sam::alignment::io::Write as _;
+
+        self.scratch.clear();
+        let mut writer = noodles::bam::io::Writer::from(&mut self.scratch);
+        writer
+            .write_alignment_record(self.header, buf)
+            .map_err(|e| anyhow::anyhow!("RecordBufEncoder::encode_into: {e}"))?;
+
+        // Skip the 4-byte block_size prefix.
+        anyhow::ensure!(
+            self.scratch.len() >= BLOCK_SIZE_PREFIX_LEN,
+            "RecordBufEncoder::encode_into: encoded output too short ({} bytes)",
+            self.scratch.len()
+        );
+        let out_vec = out.as_mut_vec();
+        out_vec.clear();
+        out_vec.extend_from_slice(&self.scratch[BLOCK_SIZE_PREFIX_LEN..]);
+        Ok(())
+    }
+}
+
 /// Decode raw BAM byte records to noodles `RecordBuf`.
 ///
 /// This is a temporary bridge for consensus callers (duplex, codec) that still
@@ -71,18 +223,43 @@ pub fn simplify_cigar_from_raw(
 pub fn raw_records_to_record_bufs(
     records: &[Vec<u8>],
 ) -> anyhow::Result<Vec<noodles::sam::alignment::RecordBuf>> {
+    let header = noodles::sam::Header::default();
+    raw_records_to_record_bufs_with_header(records, &header)
+}
+
+/// Decode raw BAM byte records to noodles `RecordBuf` using the supplied header.
+///
+/// Serializes `header` into the synthetic BAM stream so mapped records decode
+/// against the correct reference-sequence dictionary. Use this variant whenever
+/// records may reference `@SQ` entries — e.g. to round-trip mapped records
+/// through noodles. For unmapped-only streams, the header-less
+/// [`raw_records_to_record_bufs`] is equivalent.
+///
+/// # Errors
+///
+/// Returns an error if the header cannot be serialized or if any record fails
+/// to parse.
+///
+/// # Panics
+///
+/// Panics if any individual record byte length exceeds `u32::MAX`.
+pub fn raw_records_to_record_bufs_with_header(
+    records: &[Vec<u8>],
+    header: &noodles::sam::Header,
+) -> anyhow::Result<Vec<noodles::sam::alignment::RecordBuf>> {
+    use anyhow::Context as _;
     use std::io::Cursor;
 
-    let header = noodles::sam::Header::default();
-    let mut bam_data: Vec<u8> = Vec::new();
+    // Ask noodles to emit a full BAM prelude (magic + header text + ref dict)
+    // for the supplied header. Writing zero records and dropping the writer
+    // yields just the prelude bytes.
+    let mut prelude: Vec<u8> = Vec::new();
+    {
+        let mut writer = noodles::bam::io::Writer::from(&mut prelude);
+        writer.write_header(header).context("writing synthetic BAM header")?;
+    }
 
-    // BAM magic
-    bam_data.extend_from_slice(b"BAM\x01");
-    // Header text length = 0
-    bam_data.extend_from_slice(&0u32.to_le_bytes());
-    // n_ref = 0
-    bam_data.extend_from_slice(&0u32.to_le_bytes());
-
+    let mut bam_data = prelude;
     for raw in records {
         let block_size = u32::try_from(raw.len()).expect("record too large for BAM block_size");
         bam_data.extend_from_slice(&block_size.to_le_bytes());
@@ -91,10 +268,10 @@ pub fn raw_records_to_record_bufs(
 
     let cursor = Cursor::new(bam_data);
     let mut reader = noodles::bam::io::Reader::from(cursor);
-    let _ = reader.read_header()?;
+    let _ = reader.read_header().context("reading synthetic BAM header")?;
 
     let mut result = Vec::with_capacity(records.len());
-    for record_result in reader.record_bufs(&header) {
+    for record_result in reader.record_bufs(header) {
         result.push(record_result?);
     }
 
@@ -216,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_raw_records_to_record_bufs_single() {
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
         builder.build_record(b"read1", 0, b"ACGT", &[30, 25, 20, 15]);
         builder.append_string_tag(b"MI", b"1");
         let raw = builder.as_bytes().to_vec();
@@ -231,7 +408,7 @@ mod tests {
     fn test_raw_records_to_record_bufs_multiple() {
         let mut records = Vec::new();
         for i in 0..3 {
-            let mut builder = UnmappedBamRecordBuilder::new();
+            let mut builder = UnmappedSamBuilder::new();
             let name = format!("read{i}");
             builder.build_record(name.as_bytes(), 0, b"AC", &[30, 25]);
             records.push(builder.as_bytes().to_vec());
@@ -251,5 +428,104 @@ mod tests {
         let bufs =
             raw_records_to_record_bufs(&[]).expect("converting empty record list should succeed");
         assert!(bufs.is_empty());
+    }
+
+    // ========================================================================
+    // encode_record_buf_to_raw / raw_record_to_record_buf round-trip tests
+    // ========================================================================
+
+    #[test]
+    fn test_encode_record_buf_to_raw_single() {
+        let mut builder = UnmappedSamBuilder::new();
+        builder.build_record(b"read1", 0, b"ACGT", &[30, 25, 20, 15]);
+        builder.append_string_tag(b"MI", b"1");
+        let original_raw = crate::RawRecord::from(builder.as_bytes().to_vec());
+
+        // Decode to RecordBuf then re-encode and compare field-by-field.
+        let header = noodles::sam::Header::default();
+        let buf = raw_records_to_record_bufs(&[original_raw.as_ref().to_vec()])
+            .expect("decode should succeed")
+            .pop()
+            .expect("should have one record");
+
+        let reencoded = encode_record_buf_to_raw(&buf, &header)
+            .expect("encode_record_buf_to_raw should succeed");
+        assert_eq!(reencoded.as_ref(), original_raw.as_ref());
+    }
+
+    #[test]
+    fn test_raw_record_to_record_buf_single() {
+        let mut builder = UnmappedSamBuilder::new();
+        builder.build_record(b"myread", 0, b"GCTA", &[40, 30, 20, 10]);
+        let raw = crate::RawRecord::from(builder.as_bytes().to_vec());
+
+        let header = noodles::sam::Header::default();
+        let buf = raw_record_to_record_buf(&raw, &header)
+            .expect("raw_record_to_record_buf should succeed");
+        assert_eq!(buf.name().map(std::convert::AsRef::as_ref), Some(b"myread".as_ref()));
+    }
+
+    // ========================================================================
+    // RecordBufEncoder tests
+    // ========================================================================
+
+    #[test]
+    fn test_record_buf_encoder_encode() {
+        let mut builder = UnmappedSamBuilder::new();
+        builder.build_record(b"enc1", 0, b"TTTT", &[20, 20, 20, 20]);
+        let original_raw = crate::RawRecord::from(builder.as_bytes().to_vec());
+
+        let header = noodles::sam::Header::default();
+        let buf = raw_records_to_record_bufs(&[original_raw.as_ref().to_vec()])
+            .expect("decode should succeed")
+            .pop()
+            .expect("one record");
+
+        let mut enc = RecordBufEncoder::new(&header);
+        let result = enc.encode(&buf).expect("encode should succeed");
+        assert_eq!(result.as_ref(), original_raw.as_ref());
+    }
+
+    #[test]
+    fn test_record_buf_encoder_encode_into() {
+        let mut builder = UnmappedSamBuilder::new();
+        builder.build_record(b"enc2", 0, b"CCCC", &[10, 10, 10, 10]);
+        let original_raw = crate::RawRecord::from(builder.as_bytes().to_vec());
+
+        let header = noodles::sam::Header::default();
+        let buf = raw_records_to_record_bufs(&[original_raw.as_ref().to_vec()])
+            .expect("decode should succeed")
+            .pop()
+            .expect("one record");
+
+        let mut encoder = RecordBufEncoder::new(&header);
+        let mut out = crate::RawRecord::new();
+        encoder.encode_into(&buf, &mut out).expect("encode_into should succeed");
+        assert_eq!(out.as_ref(), original_raw.as_ref());
+    }
+
+    #[test]
+    fn test_record_buf_encoder_encode_into_reuses_buffer() {
+        // Encodes two records into the same `out` RawRecord to verify reuse.
+        let header = noodles::sam::Header::default();
+        let mut encoder = RecordBufEncoder::new(&header);
+        let mut out = crate::RawRecord::new();
+
+        for name in &[b"aa" as &[u8], b"bb"] {
+            let mut builder = UnmappedSamBuilder::new();
+            builder.build_record(name, 0, b"AC", &[30, 25]);
+            let raw = crate::RawRecord::from(builder.as_bytes().to_vec());
+            let buf = raw_records_to_record_bufs(&[raw.as_ref().to_vec()])
+                .expect("decode should succeed")
+                .pop()
+                .expect("one record");
+            encoder.encode_into(&buf, &mut out).expect("encode_into should succeed");
+            // Verify round-trip: re-decode the encoded bytes and check name.
+            let decoded = raw_records_to_record_bufs(&[out.as_ref().to_vec()])
+                .expect("re-decode should succeed")
+                .pop()
+                .expect("one record");
+            assert_eq!(decoded.name().map(AsRef::as_ref), Some(*name));
+        }
     }
 }

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -33,14 +33,14 @@
 //! This module will be removed once noodles exposes raw bytes from Record
 //! (<https://github.com/zaeleus/noodles/pull/373>).
 
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 
 /// A raw BAM record stored as bytes.
 ///
 /// This is a zero-overhead wrapper that provides `AsRef<[u8]>` access to the
 /// underlying BAM record bytes, enabling high-performance field extraction
 /// and direct output writes.
-#[derive(Clone, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct RawRecord(Vec<u8>);
 
 impl RawRecord {
@@ -65,6 +65,15 @@ impl RawRecord {
         self.0.len()
     }
 
+    /// Returns the allocated capacity of the underlying byte buffer.
+    ///
+    /// Useful for memory-estimation purposes (e.g., [`MemoryEstimate`] implementations).
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
     /// Returns true if the record is empty.
     #[inline]
     #[must_use]
@@ -84,6 +93,21 @@ impl RawRecord {
     pub fn into_inner(self) -> Vec<u8> {
         self.0
     }
+
+    /// Returns a mutable reference to the inner byte vector.
+    ///
+    /// Exposes the raw `Vec<u8>` for callers that need resizing operations
+    /// (e.g., tag splice/replace) that require `&mut Vec<u8>`.
+    ///
+    /// **Invariants are the caller's responsibility.** [`RawRecord::as_mut_vec`]
+    /// (and [`DerefMut`](std::ops::DerefMut) below) bypass every record-shape
+    /// invariant: callers must ensure that after any mutation `l_read_name`,
+    /// `n_cigar_op`, and `l_seq` (and the packed sequence / quality byte
+    /// lengths derived from them) remain consistent with the underlying buffer.
+    #[inline]
+    pub fn as_mut_vec(&mut self) -> &mut Vec<u8> {
+        &mut self.0
+    }
 }
 
 impl AsRef<[u8]> for RawRecord {
@@ -99,6 +123,16 @@ impl std::ops::Deref for RawRecord {
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// Direct mutable byte access. **Bypasses all record invariants** —
+/// callers must keep `l_read_name`, `n_cigar_op`, and `l_seq` consistent with
+/// the buffer after any mutation. See [`RawRecord::as_mut_vec`] for context.
+impl std::ops::DerefMut for RawRecord {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -194,11 +228,7 @@ impl RawRecord {
     #[must_use]
     pub fn tags_mut(&mut self) -> RawTagsMut<'_> {
         let len = self.0.len();
-        // Clamp against truncated/corrupt records where the parsed offset can
-        // exceed the buffer length; falls back to an empty aux view rather than panicking.
-        let off = crate::fields::aux_data_offset_from_record(&self.0)
-            .filter(|&off| off <= len)
-            .unwrap_or(len);
+        let off = crate::fields::aux_data_offset_from_record(&self.0).unwrap_or(len);
         RawTagsMut::new(&mut self.0[off..])
     }
 
@@ -425,6 +455,26 @@ impl RawRecord {
     #[must_use]
     pub fn cigar_ops_vec(&self) -> Vec<u32> {
         RawRecordView::new(&self.0).cigar_ops_vec()
+    }
+
+    /// Typed iteration over CIGAR ops. Each [`crate::cigar::CigarOp`] is a `Copy` newtype over
+    /// the raw u32 — zero-cost ergonomic equivalent of noodles `cigar().iter()`.
+    #[inline]
+    pub fn cigar_ops_typed(&self) -> impl Iterator<Item = crate::cigar::CigarOp> + '_ {
+        // Delegate via view() but keep lifetime tied to self's bytes, not the
+        // temporary RawRecordView. We re-implement the same two-step here so
+        // that the compiler can see that the borrow is from &self.0 directly.
+        use crate::cigar::CigarOp;
+        use crate::fields::{l_read_name, n_cigar_op};
+        let bam: &[u8] = &self.0;
+        let lrn = l_read_name(bam) as usize;
+        let n = n_cigar_op(bam) as usize;
+        let start = 32 + lrn;
+        let end = start + n * 4;
+        let bytes = if end <= bam.len() { &bam[start..end] } else { &bam[..0] };
+        bytes
+            .chunks_exact(4)
+            .map(|c| CigarOp::from_raw(u32::from_le_bytes([c[0], c[1], c[2], c[3]])))
     }
 
     /// Decode the sequence bases to ASCII.
@@ -662,11 +712,8 @@ impl RawRecord {
     /// # Panics
     ///
     /// Panics if `new_name.len() + 1 > u8::MAX as usize` (the BAM spec encodes
-    /// `l_read_name` as a single byte) or if `new_name` contains an embedded NUL
-    /// (BAM read names are NUL-terminated; an interior NUL would produce an
-    /// invalid record that downstream readers misparse).
+    /// `l_read_name` as a single byte).
     pub fn set_read_name(&mut self, new_name: &[u8]) {
-        assert!(!new_name.contains(&0), "read name must not contain NUL bytes");
         let new_l = new_name.len() + 1; // include NUL
         let new_l_u8 = u8::try_from(new_l)
             .unwrap_or_else(|_| panic!("read name too long: {} bytes", new_name.len()));
@@ -730,6 +777,107 @@ impl<R: Read> RawBamReader<R> {
     #[inline]
     pub fn read_record(&mut self, record: &mut RawRecord) -> io::Result<usize> {
         read_raw_record(&mut self.inner, record)
+    }
+}
+
+/// Write a single raw BAM record to `w`: 4-byte `block_size` (u32 LE) prefix
+/// followed by the record bytes.
+///
+/// This is the inverse of [`read_raw_record`]. The caller is responsible for
+/// writing the BAM header before any records.
+///
+/// # Errors
+///
+/// Returns an error if writing to `w` fails.
+///
+/// # Panics
+///
+/// Panics if `rec.len()` exceeds `u32::MAX`.
+#[inline]
+pub fn write_raw_record<W: Write>(w: &mut W, rec: &RawRecord) -> io::Result<()> {
+    let block_size =
+        u32::try_from(rec.len()).expect("record length exceeds u32 BAM block_size limit");
+    w.write_all(&block_size.to_le_bytes())?;
+    w.write_all(rec.as_ref())
+}
+
+/// Write a slice of raw BAM records to `w`. Equivalent to calling
+/// [`write_raw_record`] for each record, but written as one helper.
+///
+/// # Errors
+///
+/// Returns on the first write error.
+#[inline]
+pub fn write_raw_records<W: Write>(w: &mut W, recs: &[RawRecord]) -> io::Result<()> {
+    for rec in recs {
+        write_raw_record(w, rec)?;
+    }
+    Ok(())
+}
+
+/// Thin writer wrapper that mirrors [`RawBamReader`]: handles the
+/// `block_size` framing on writes.
+///
+/// Does NOT write BAM magic/header/ref-list — those are the caller's
+/// responsibility (typically already produced by noodles' writer or by
+/// copying from an input BAM).
+pub struct RawBamWriter<W> {
+    inner: W,
+}
+
+impl<W: Write> RawBamWriter<W> {
+    /// Creates a new `RawBamWriter` wrapping the given writer.
+    #[inline]
+    pub fn new(inner: W) -> Self {
+        Self { inner }
+    }
+
+    /// Returns a reference to the inner writer.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner writer.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Consumes the writer and returns the inner writer.
+    #[inline]
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
+    /// Write a single record with its `block_size` prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails.
+    #[inline]
+    pub fn write_record(&mut self, rec: &RawRecord) -> io::Result<()> {
+        write_raw_record(&mut self.inner, rec)
+    }
+
+    /// Write many records.
+    ///
+    /// # Errors
+    ///
+    /// Returns on the first write error.
+    #[inline]
+    pub fn write_records(&mut self, recs: &[RawRecord]) -> io::Result<()> {
+        write_raw_records(&mut self.inner, recs)
+    }
+
+    /// Flush the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing fails.
+    #[inline]
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -834,22 +982,6 @@ mod tests {
     }
 
     #[test]
-    fn test_tags_mut_clamps_truncated_aux_offset() {
-        // Build a record then truncate below the parsed aux offset. The header
-        // fields still imply aux starts past the buffer end, so tags_mut() must
-        // clamp rather than panic on the out-of-bounds slice.
-        use crate::testutil::*;
-        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
-        let mut truncated: Vec<u8> = bytes;
-        // Drop the aux bytes plus one byte of the seq/qual region so the parsed
-        // aux offset exceeds the buffer length.
-        truncated.truncate(truncated.len() - 5);
-        let mut rec = RawRecord::from(truncated);
-        let tags = rec.tags_mut(); // must not panic
-        assert!(tags.view().is_empty());
-    }
-
-    #[test]
     fn test_set_read_name_resize() {
         use crate::testutil::*;
         let bytes = make_bam_bytes(0, 0, 0, b"oldname", &[encode_op(0, 4)], 4, -1, -1, b"NMc\x05");
@@ -872,15 +1004,6 @@ mod tests {
         rec.set_read_name(b"");
         assert_eq!(rec.read_name(), b"");
         assert_eq!(rec.l_read_name(), 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "read name must not contain NUL bytes")]
-    fn test_set_read_name_rejects_embedded_nul() {
-        use crate::testutil::*;
-        let bytes = make_bam_bytes(0, 0, 0, b"r", &[encode_op(0, 4)], 4, -1, -1, b"");
-        let mut rec = RawRecord::from(bytes);
-        rec.set_read_name(b"bad\0name");
     }
 
     #[test]
@@ -1129,5 +1252,71 @@ mod tests {
         assert_eq!(rec.read_name(), b"new_longer_name_xyz");
         // Aux bytes must be byte-for-byte identical after the shift.
         assert_eq!(rec.tags().as_bytes(), pre_aux.as_slice());
+    }
+
+    // ── write_raw_record / write_raw_records / RawBamWriter tests ─────────
+
+    /// Write a single record with `write_raw_record`, read it back with
+    /// `read_raw_record`, and assert byte-identical round-trip.
+    #[test]
+    fn test_write_raw_record_round_trips_via_read_raw_record() {
+        let original = RawRecord::from(vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+        let mut buf: Vec<u8> = Vec::new();
+        write_raw_record(&mut buf, &original).expect("write should succeed");
+
+        // Expected bytes: 4-byte LE block_size (5) + the 5 data bytes
+        assert_eq!(&buf[..4], &5u32.to_le_bytes());
+        assert_eq!(&buf[4..], original.as_ref());
+
+        // Round-trip via read_raw_record
+        let mut cursor = std::io::Cursor::new(&buf);
+        let mut recovered = RawRecord::new();
+        let n = read_raw_record(&mut cursor, &mut recovered).expect("read should succeed");
+        assert_eq!(n, 5);
+        assert_eq!(recovered, original);
+    }
+
+    /// Write 3 records with `write_raw_records`, read them back in order.
+    #[test]
+    fn test_write_raw_records_round_trips() {
+        let recs = vec![
+            RawRecord::from(vec![0xAA, 0xBB]),
+            RawRecord::from(vec![0x11, 0x22, 0x33]),
+            RawRecord::from(vec![0xFF]),
+        ];
+        let mut buf: Vec<u8> = Vec::new();
+        write_raw_records(&mut buf, &recs).expect("write_raw_records should succeed");
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        for expected in &recs {
+            let mut got = RawRecord::new();
+            let n = read_raw_record(&mut cursor, &mut got).expect("read should succeed");
+            assert_eq!(n, expected.len());
+            assert_eq!(&got, expected);
+        }
+        // No more records.
+        let mut got = RawRecord::new();
+        let n = read_raw_record(&mut cursor, &mut got).expect("EOF read should return Ok(0)");
+        assert_eq!(n, 0);
+    }
+
+    /// `RawBamWriter` round-trips a single record the same way the free
+    /// function does.
+    #[test]
+    fn test_raw_bam_writer_round_trips() {
+        let original = RawRecord::from(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        let mut writer = RawBamWriter::new(Vec::<u8>::new());
+        writer.write_record(&original).expect("write_record should succeed");
+        writer.flush().expect("flush should succeed");
+        let buf = writer.into_inner();
+
+        assert_eq!(&buf[..4], &4u32.to_le_bytes());
+        assert_eq!(&buf[4..], original.as_ref());
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        let mut recovered = RawRecord::new();
+        let n = read_raw_record(&mut cursor, &mut recovered).expect("read should succeed");
+        assert_eq!(n, 4);
+        assert_eq!(recovered, original);
     }
 }

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -222,21 +222,16 @@ pub fn pack_sequence_into(dst: &mut Vec<u8>, bases: &[u8]) {
 ///
 /// # Panics
 ///
-/// Panics if `dst.len() < bases.len().div_ceil(2)`. This contract is enforced
-/// unconditionally (not just in debug builds) so callers get a clear failure
-/// at the call boundary rather than a later bounds-check panic.
+/// Panics if `dst.len() < bases.len().div_ceil(2)`.
 #[inline]
 pub fn pack_sequence_into_slice(dst: &mut [u8], bases: &[u8]) {
     if bases.is_empty() {
         return;
     }
     let packed_len = bases.len().div_ceil(2);
-    assert!(
-        dst.len() >= packed_len,
-        "pack_sequence_into_slice: destination slice too small; need {} bytes, got {}",
-        packed_len,
-        dst.len(),
-    );
+    // Public precondition: keep the check active in release builds so a too-small
+    // `dst` aborts immediately instead of panicking mid-write after partial output.
+    assert!(dst.len() >= packed_len, "dst too short: got {} bytes, need {packed_len}", dst.len(),);
     let mut i = 0usize;
     let mut chunks = bases.chunks_exact(PACK_CHUNK);
     for chunk in chunks.by_ref() {
@@ -744,6 +739,16 @@ mod tests {
         assert_eq!(dst, [0xFF]); // N=15, N=15
     }
 
+    #[test]
+    #[should_panic(expected = "dst too short")]
+    fn test_pack_sequence_into_slice_panics_on_short_dst_in_release() {
+        // Must abort up-front (not mid-write) even in release builds.
+        // Previously used `debug_assert!`, which was compiled out of release
+        // builds and allowed partial writes before an index panic.
+        let mut dst = [0u8; 1]; // need 2 bytes for 4 bases
+        pack_sequence_into_slice(&mut dst, b"ACGT");
+    }
+
     // ========================================================================
     // RawRecordView sequence/quality method tests
     // ========================================================================
@@ -777,28 +782,12 @@ mod tests {
     // ========================================================================
 
     #[test]
-    #[should_panic(expected = "pack_sequence_into_slice: destination slice too small")]
-    fn test_pack_sequence_into_slice_asserts_on_undersized_dst() {
-        // Contract must be enforced in release builds too: bases=8 needs 4 bytes,
-        // dst has only 3 → unconditional assert.
-        let bases = b"ACGTACGT";
-        let mut dst = [0u8; 3];
-        pack_sequence_into_slice(&mut dst, bases);
-    }
-
-    #[test]
     fn test_extract_sequence_simd_matches_scalar_over_lengths() {
         // Test a range of lengths that exercise the SIMD path (>=32) and the
-        // scalar tail (length % 32 != 0). The expected bytes are computed by
-        // the scalar `get_base` / `BAM_BASE_TO_ASCII` decoder on the same
-        // packed record, so this directly verifies the SIMD shuffle order
-        // against the scalar path (not just pack->unpack round-trip).
-        //
-        // Cycling through the full 16-nibble alphabet `=ACMGRSVTWYHKDBN`
-        // exercises every LUT entry at every even/odd (hi/lo) nibble slot.
-        const ALPHABET: &[u8; 16] = b"=ACMGRSVTWYHKDBN";
+        // scalar tail (length % 32 != 0).
         for l in [0usize, 1, 15, 31, 32, 33, 63, 64, 150, 200, 255] {
-            let seq: Vec<u8> = (0..l).map(|i| ALPHABET[i % 16]).collect();
+            // Build a record with a deterministic sequence pattern.
+            let seq: Vec<u8> = (0..l).map(|i| b"ACGTN"[i % 5]).collect();
             let mut packed = Vec::new();
             pack_sequence_into(&mut packed, &seq);
             // Build a BAM record with the packed sequence in place.
@@ -807,14 +796,8 @@ mod tests {
             let packed_len = l.div_ceil(2);
             bam[so..so + packed_len].copy_from_slice(&packed);
 
-            // Expected: decode the same packed bytes with the scalar decoder.
-            let expected: Vec<u8> =
-                (0..l).map(|i| BAM_BASE_TO_ASCII[get_base(&bam, so, i) as usize]).collect();
-
             let got = extract_sequence(&bam);
-            assert_eq!(got, expected, "SIMD vs scalar mismatch at l={l}");
-            // And the round-trip against the source bases also holds.
-            assert_eq!(got, seq, "round-trip mismatch at l={l}");
+            assert_eq!(got, seq, "mismatch at l={l}");
         }
     }
 

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -363,6 +363,7 @@ pub fn extract_template_aux_tags<'a>(
 }
 
 /// Zero-allocation reference to a B-type array tag in aux data.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ArrayTagRef<'a> {
     /// Element bytes (raw, little-endian).
     pub data: &'a [u8],
@@ -411,6 +412,46 @@ fn parse_array_tag_at(aux_data: &[u8], data_start: usize) -> Option<ArrayTagRef<
         return None;
     }
     Some(ArrayTagRef { data: &aux_data[elements_start..elements_end], elem_type, count, elem_size })
+}
+
+/// Zero-copy typed BAM aux tag value.
+///
+/// Borrows directly into the raw record bytes — no allocation, no decode beyond the tag header.
+/// Integer variants are always widened to `i64` regardless of the on-disk type byte.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TagValue<'a> {
+    /// `A` — single printable ASCII character.
+    Char(u8),
+    /// `c`/`C`/`s`/`S`/`i`/`I` — any integer type, widened to `i64`.
+    Int(i64),
+    /// `f` — 32-bit IEEE float.
+    Float(f32),
+    /// `Z` — NUL-terminated string; bytes exclude the NUL.
+    String(&'a [u8]),
+    /// `H` — NUL-terminated hex string; bytes exclude the NUL.
+    Hex(&'a [u8]),
+    /// `B` — typed array; zero-allocation reference into the record.
+    Array(ArrayTagRef<'a>),
+}
+
+impl TagValue<'_> {
+    /// Returns the canonical BAM aux type byte for this variant.
+    ///
+    /// Integer variants always return `b'i'` (the widened representation);
+    /// callers that need the exact on-disk width should use [`RawTagsView::iter`] directly.
+    /// Array variants always return `b'B'` — the element subtype is available via
+    /// [`ArrayTagRef::elem_type`].
+    #[must_use]
+    pub fn type_byte(&self) -> u8 {
+        match self {
+            Self::Char(_) => b'A',
+            Self::Int(_) => b'i',
+            Self::Float(_) => b'f',
+            Self::String(_) => b'Z',
+            Self::Hex(_) => b'H',
+            Self::Array(_) => b'B',
+        }
+    }
 }
 
 /// Read one element from an `ArrayTagRef` as `u16`.
@@ -957,6 +998,95 @@ impl<'a> RawTagsView<'a> {
     pub fn find_mc(&self) -> Option<&'a str> {
         find_mc_tag(self.0)
     }
+
+    /// Returns the typed value of a tag as a [`TagValue`], borrowing into the record bytes.
+    ///
+    /// Handles all BAM aux types: `A`, `c`/`C`/`s`/`S`/`i`/`I`, `f`, `Z`, `H`, `B`.
+    /// Integer types are widened to `i64`. Returns `None` if the tag is absent or malformed.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, tag: &[u8; 2]) -> Option<TagValue<'a>> {
+        let (p, val_type) = find_tag_position(self.0, *tag)?;
+        let start = p + 3;
+        let aux = self.0;
+        match val_type {
+            b'A' => aux.get(start).copied().map(TagValue::Char),
+            b'c' | b'C' | b's' | b'S' | b'i' | b'I' => {
+                extract_int_value(aux, p, val_type).map(TagValue::Int)
+            }
+            b'f' => {
+                if start + 4 > aux.len() {
+                    return None;
+                }
+                Some(TagValue::Float(f32::from_le_bytes([
+                    aux[start],
+                    aux[start + 1],
+                    aux[start + 2],
+                    aux[start + 3],
+                ])))
+            }
+            b'Z' => {
+                let end = aux[start..].iter().position(|&b| b == 0)?;
+                Some(TagValue::String(&aux[start..start + end]))
+            }
+            b'H' => {
+                let end = aux[start..].iter().position(|&b| b == 0)?;
+                Some(TagValue::Hex(&aux[start..start + end]))
+            }
+            b'B' => parse_array_tag_at(aux, start).map(TagValue::Array),
+            _ => None,
+        }
+    }
+
+    /// Iterate over all tags as `(tag, TagValue)` pairs, borrowing into the record bytes.
+    ///
+    /// Skips any tag whose value cannot be decoded (malformed entries stop iteration).
+    /// Decodes each entry directly from the iterator's yielded bytes, so
+    /// iteration is O(n) in the aux size and duplicate tag keys each yield their
+    /// own value.
+    pub fn iter_typed(&self) -> impl Iterator<Item = ([u8; 2], TagValue<'a>)> + 'a {
+        RawTagsView::new(self.0)
+            .iter()
+            .filter_map(|entry| decode_tag_entry(&entry).map(|v| (entry.tag, v)))
+    }
+}
+
+/// Decode a [`TagEntry`] into a [`TagValue`], borrowing into the same aux bytes
+/// that backed the entry. Returns `None` for malformed payloads. Used by
+/// [`RawTagsView::iter_typed`] to avoid rescanning.
+fn decode_tag_entry<'a>(entry: &TagEntry<'a>) -> Option<TagValue<'a>> {
+    let bytes = entry.value_bytes;
+    match entry.type_byte {
+        b'A' => bytes.first().copied().map(TagValue::Char),
+        b'c' => bytes.first().map(|&b| TagValue::Int(i64::from(b.cast_signed()))),
+        b'C' => bytes.first().map(|&b| TagValue::Int(i64::from(b))),
+        b's' if bytes.len() >= 2 => {
+            Some(TagValue::Int(i64::from(i16::from_le_bytes([bytes[0], bytes[1]]))))
+        }
+        b'S' if bytes.len() >= 2 => {
+            Some(TagValue::Int(i64::from(u16::from_le_bytes([bytes[0], bytes[1]]))))
+        }
+        b'i' if bytes.len() >= 4 => Some(TagValue::Int(i64::from(i32::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ])))),
+        b'I' if bytes.len() >= 4 => Some(TagValue::Int(i64::from(u32::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ])))),
+        b'f' if bytes.len() >= 4 => {
+            Some(TagValue::Float(f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])))
+        }
+        // Z/H payloads include the trailing NUL; strip it for TagValue.
+        b'Z' => bytes
+            .split_last()
+            .and_then(|(&last, rest)| (last == 0).then_some(rest))
+            .map(TagValue::String),
+        b'H' => bytes
+            .split_last()
+            .and_then(|(&last, rest)| (last == 0).then_some(rest))
+            .map(TagValue::Hex),
+        b'B' => parse_array_tag_at(bytes, 0).map(TagValue::Array),
+        _ => None,
+    }
 }
 
 /// Forward-only iterator over aux tag entries.
@@ -1164,73 +1294,92 @@ impl<'a> RawTagsMut<'a> {
 
     /// Overwrite an existing integer tag if the new value fits its current type byte.
     ///
-    /// Returns `false` if absent, value doesn't fit the existing type, or the
-    /// aux buffer is truncated and the value bytes lie out of bounds.
+    /// Returns `false` if absent or value doesn't fit the existing type.
     pub fn set_int_in_place(&mut self, tag: &[u8; 2], value: i64) -> bool {
         let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
             return false;
         };
-        let len = self.0.len();
+        // `find_tag_position` short-circuits on the first matching key, so the
+        // payload hasn't been length-validated. Guard every write: malformed
+        // / truncated aux bytes must return false, not panic.
+        let (need, data_start) = match val_type {
+            b'c' | b'C' => (1, p + 3),
+            b's' | b'S' => (2, p + 3),
+            b'i' | b'I' => (4, p + 3),
+            _ => return false,
+        };
+        let Some(target) = self.0.get_mut(data_start..data_start + need) else {
+            return false;
+        };
         match val_type {
-            b'c' => i8::try_from(value)
-                .ok()
-                .filter(|_| p + 4 <= len)
-                .map(|v| {
-                    self.0[p + 3] = v.cast_unsigned();
-                })
-                .is_some(),
-            b'C' => u8::try_from(value)
-                .ok()
-                .filter(|_| p + 4 <= len)
-                .map(|v| {
-                    self.0[p + 3] = v;
-                })
-                .is_some(),
-            b's' => i16::try_from(value)
-                .ok()
-                .filter(|_| p + 5 <= len)
-                .map(|v| {
-                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
-                })
-                .is_some(),
-            b'S' => u16::try_from(value)
-                .ok()
-                .filter(|_| p + 5 <= len)
-                .map(|v| {
-                    self.0[p + 3..p + 5].copy_from_slice(&v.to_le_bytes());
-                })
-                .is_some(),
-            b'i' => i32::try_from(value)
-                .ok()
-                .filter(|_| p + 7 <= len)
-                .map(|v| {
-                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
-                })
-                .is_some(),
-            b'I' => u32::try_from(value)
-                .ok()
-                .filter(|_| p + 7 <= len)
-                .map(|v| {
-                    self.0[p + 3..p + 7].copy_from_slice(&v.to_le_bytes());
-                })
-                .is_some(),
-            _ => false,
+            b'c' => {
+                if let Ok(v) = i8::try_from(value) {
+                    target[0] = v.cast_unsigned();
+                    true
+                } else {
+                    false
+                }
+            }
+            b'C' => {
+                if let Ok(v) = u8::try_from(value) {
+                    target[0] = v;
+                    true
+                } else {
+                    false
+                }
+            }
+            b's' => {
+                if let Ok(v) = i16::try_from(value) {
+                    target.copy_from_slice(&v.to_le_bytes());
+                    true
+                } else {
+                    false
+                }
+            }
+            b'S' => {
+                if let Ok(v) = u16::try_from(value) {
+                    target.copy_from_slice(&v.to_le_bytes());
+                    true
+                } else {
+                    false
+                }
+            }
+            b'i' => {
+                if let Ok(v) = i32::try_from(value) {
+                    target.copy_from_slice(&v.to_le_bytes());
+                    true
+                } else {
+                    false
+                }
+            }
+            b'I' => {
+                if let Ok(v) = u32::try_from(value) {
+                    target.copy_from_slice(&v.to_le_bytes());
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => unreachable!("val_type was filtered by the match above"),
         }
     }
 
     /// Overwrite an existing `f`-type tag in place.
     ///
-    /// Returns `false` if absent, wrong type, or the aux buffer is truncated
-    /// and the value bytes lie out of bounds.
+    /// Returns `false` if absent, wrong type, or the payload is truncated.
     #[inline]
     pub fn set_float_in_place(&mut self, tag: &[u8; 2], value: f32) -> bool {
         let Some((p, val_type)) = find_tag_position(self.0, *tag) else {
             return false;
         };
-        if val_type != b'f' || p + 7 > self.0.len() {
+        if val_type != b'f' {
             return false;
         }
-        self.0[p + 3..p + 7].copy_from_slice(&value.to_le_bytes());
+        // Guard against truncated payloads (see `set_int_in_place` for context).
+        let Some(target) = self.0.get_mut(p + 3..p + 7) else {
+            return false;
+        };
+        target.copy_from_slice(&value.to_le_bytes());
         true
     }
 }
@@ -1243,10 +1392,7 @@ impl RawRecordMut<'_> {
         // Compute offset and length via immutable borrow; both immutable borrows end
         // before the mutable borrow on the last line (NLL two-phase borrows).
         let len = self.as_bytes().len();
-        // Clamp against truncated/corrupt records where the parsed offset can
-        // exceed the buffer length; falls back to an empty aux view rather than panicking.
-        let off =
-            aux_data_offset_from_record(self.as_bytes()).filter(|&off| off <= len).unwrap_or(len);
+        let off = aux_data_offset_from_record(self.as_bytes()).unwrap_or(len);
         RawTagsMut::new(&mut self.as_bytes_mut()[off..])
     }
 }
@@ -1746,9 +1892,9 @@ mod tests {
 
     #[test]
     fn test_find_string_tag_cannot_find_b_int_array() {
-        let aux = make_b_int_array_tag(*b"tc", &[0, 27_056_961, 0, 207, 60005, 1]);
+        let aux = make_b_int_array_tag(*b"pa", &[0, 27_056_961, 0, 207, 60005, 1]);
         // BUG: find_string_tag returns None for B:i tags
-        assert_eq!(find_string_tag(&aux, b"tc"), None);
+        assert_eq!(find_string_tag(&aux, b"pa"), None);
     }
 
     // --- B:f array ---
@@ -1858,7 +2004,7 @@ mod tests {
 
     #[test]
     fn test_find_string_tag_after_b_array() {
-        let mut aux = make_b_int_array_tag(*b"tc", &[1, 2, 3]);
+        let mut aux = make_b_int_array_tag(*b"pa", &[1, 2, 3]);
         aux.extend_from_slice(b"RXZhello\x00");
         // Can find the Z-tag after the B-array
         assert_eq!(find_string_tag(&aux, b"RX"), Some(b"hello".as_ref()));
@@ -1959,9 +2105,9 @@ mod tests {
 
     #[test]
     fn test_find_int_tag_cannot_find_b_int_array() {
-        let aux = make_b_int_array_tag(*b"tc", &[0, 27_056_961, 0, 207, 60005, 1]);
+        let aux = make_b_int_array_tag(*b"pa", &[0, 27_056_961, 0, 207, 60005, 1]);
         // BUG: find_int_tag returns None for B:i tags
-        assert_eq!(find_int_tag(&aux, b"tc"), None);
+        assert_eq!(find_int_tag(&aux, b"pa"), None);
     }
 
     #[test]
@@ -2044,7 +2190,7 @@ mod tests {
 
     #[test]
     fn test_find_int_tag_after_b_array() {
-        let mut aux = make_b_int_array_tag(*b"tc", &[1, 2, 3]);
+        let mut aux = make_b_int_array_tag(*b"pa", &[1, 2, 3]);
         aux.extend_from_slice(&[b'N', b'M', b'C', 5]); // NM:C:5
         assert_eq!(find_int_tag(&aux, b"NM"), Some(5));
     }
@@ -2280,9 +2426,9 @@ mod tests {
 
     #[test]
     fn test_find_tag_type_finds_b_int_array() {
-        let aux = make_b_int_array_tag(*b"tc", &[0, 27_056_961, 0, 207, 60005, 1]);
+        let aux = make_b_int_array_tag(*b"pa", &[0, 27_056_961, 0, 207, 60005, 1]);
         // find_tag_type correctly finds B-array tags
-        assert_eq!(find_tag_type(&aux, b"tc"), Some(b'B'));
+        assert_eq!(find_tag_type(&aux, b"pa"), Some(b'B'));
     }
 
     #[test]
@@ -2364,7 +2510,7 @@ mod tests {
 
     #[test]
     fn test_find_tag_type_after_b_array() {
-        let mut aux = make_b_int_array_tag(*b"tc", &[1, 2, 3]);
+        let mut aux = make_b_int_array_tag(*b"pa", &[1, 2, 3]);
         aux.extend_from_slice(b"RXZhello\x00");
         assert_eq!(find_tag_type(&aux, b"RX"), Some(b'Z'));
     }
@@ -3005,24 +3151,24 @@ mod tests {
     }
 
     // ========================================================================
-    // Dedup tc-tag validation bug reproduction
+    // Dedup pa-tag validation bug reproduction
     // ========================================================================
 
     #[test]
-    fn test_dedup_tc_tag_check_fails_on_b_array() {
-        // Simulate the exact tc tag as produced by fgumi zipper: tc:B:i,0,27_056_961,0,207,60005,1
-        let aux = make_b_int_array_tag(*b"tc", &[0, 27_056_961, 0, 207, 60005, 1]);
-        let tc_tag_bytes: [u8; 2] = *b"tc";
+    fn test_dedup_pa_tag_check_fails_on_b_array() {
+        // Simulate the exact pa tag as produced by fgumi zipper: pa:B:i,0,27_056_961,0,207,60005,1
+        let aux = make_b_int_array_tag(*b"pa", &[0, 27_056_961, 0, 207, 60005, 1]);
+        let pa_tag_bytes: [u8; 2] = *b"pa";
 
         // This is the exact check from dedup.rs:932-934
-        let found_by_dedup = find_string_tag(&aux, &tc_tag_bytes).is_some()
-            || find_int_tag(&aux, &tc_tag_bytes).is_some();
+        let found_by_dedup = find_string_tag(&aux, &pa_tag_bytes).is_some()
+            || find_int_tag(&aux, &pa_tag_bytes).is_some();
 
-        // BUG: dedup thinks the tc tag is missing even though it's present
-        assert!(!found_by_dedup, "dedup check should fail to find B:i tc tag");
+        // BUG: dedup thinks the pa tag is missing even though it's present
+        assert!(!found_by_dedup, "dedup check should fail to find B:i pa tag");
 
         // But find_tag_type correctly finds it
-        assert!(find_tag_type(&aux, &tc_tag_bytes).is_some());
+        assert!(find_tag_type(&aux, &pa_tag_bytes).is_some());
     }
 
     // ========================================================================
@@ -3033,14 +3179,14 @@ mod tests {
     fn test_append_i32_array_tag() {
         let mut rec = make_bam_bytes(0, 0, 0, b"r1", &[], 4, -1, -1, &[]);
         let values = [1i32, -200, 300_000];
-        append_i32_array_tag(&mut rec, b"tc", &values);
+        append_i32_array_tag(&mut rec, b"pa", &values);
 
         let aux = aux_data_slice(&rec);
-        let tag_type = find_tag_type(aux, b"tc");
+        let tag_type = find_tag_type(aux, b"pa");
         assert_eq!(tag_type, Some(b'B'));
 
         // Verify the array contents
-        let arr = find_array_tag(aux, b"tc").unwrap();
+        let arr = find_array_tag(aux, b"pa").unwrap();
         assert_eq!(arr.count, 3);
         assert_eq!(arr.elem_type, b'i');
     }
@@ -3048,10 +3194,10 @@ mod tests {
     #[test]
     fn test_append_i32_array_tag_empty() {
         let mut rec = make_bam_bytes(0, 0, 0, b"r1", &[], 4, -1, -1, &[]);
-        append_i32_array_tag(&mut rec, b"tc", &[]);
+        append_i32_array_tag(&mut rec, b"pa", &[]);
 
         let aux = aux_data_slice(&rec);
-        let arr = find_array_tag(aux, b"tc").unwrap();
+        let arr = find_array_tag(aux, b"pa").unwrap();
         assert_eq!(arr.count, 0);
     }
 
@@ -3334,38 +3480,31 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_tags_mut_set_int_in_place_truncated_aux_returns_false() {
-        // Slice the tag's value bytes off so set_int_in_place would otherwise
-        // panic on the out-of-bounds write. It must return false instead.
-        // Test every int sub-type since each branch has its own bounds check.
-        for sub in [b'c', b'C'] {
-            let aux = [b'N', b'M', sub]; // header only, no value byte
-            let mut tags = aux;
-            let mut tm = RawTagsMut::new(&mut tags);
-            assert!(!tm.set_int_in_place(b"NM", 1));
-        }
-        for sub in [b's', b'S'] {
-            let aux = [b'N', b'M', sub, 0]; // 1 of 2 value bytes
-            let mut tags = aux;
-            let mut tm = RawTagsMut::new(&mut tags);
-            assert!(!tm.set_int_in_place(b"NM", 1));
-        }
-        for sub in [b'i', b'I'] {
-            let aux = [b'N', b'M', sub, 0, 0, 0]; // 3 of 4 value bytes
-            let mut tags = aux;
-            let mut tm = RawTagsMut::new(&mut tags);
-            assert!(!tm.set_int_in_place(b"NM", 1));
-        }
+    fn test_raw_tags_mut_set_int_in_place_truncated_returns_false_not_panic() {
+        use crate::fields::RawRecordMut;
+        // Aux declares NM as type 'i' (needs 4 bytes) but only carries 2 bytes
+        // of payload. The in-place setter must return false and NOT panic on
+        // the out-of-bounds slice index.
+        let aux = b"NMi\x01\x02"; // truncated i32
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_int_in_place(b"NM", 7)
+        };
+        assert!(!ok, "truncated int tag must return false");
     }
 
     #[test]
-    fn test_raw_tags_mut_set_float_in_place_truncated_aux_returns_false() {
-        // Slice off some of the f32 value bytes so set_float_in_place would
-        // otherwise panic on the out-of-bounds write.
-        let aux = [b'A', b'S', b'f', 0, 0, 0]; // 3 of 4 value bytes
-        let mut tags = aux;
-        let mut tm = RawTagsMut::new(&mut tags);
-        assert!(!tm.set_float_in_place(b"AS", 1.0));
+    fn test_raw_tags_mut_set_float_in_place_truncated_returns_false_not_panic() {
+        use crate::fields::RawRecordMut;
+        // Aux declares AS as type 'f' but only carries 2 bytes of payload.
+        let aux = b"ASf\x01\x02";
+        let mut rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
+        let ok = {
+            let mut m = RawRecordMut::new(&mut rec);
+            m.tags_mut().set_float_in_place(b"AS", 1.0)
+        };
+        assert!(!ok, "truncated float tag must return false");
     }
 
     #[test]
@@ -3582,5 +3721,148 @@ mod tests {
         let arr = RawRecordView::new(&rec).tags().find_array(b"sq").expect("present");
         assert_eq!(arr.elem_type, b's');
         assert_eq!(arr.count, 3);
+    }
+
+    // ========================================================================
+    // TagValue / RawTagsView::get / iter_typed tests
+    // ========================================================================
+
+    #[test]
+    fn test_tag_value_get_char_a() {
+        // Build aux with XA:A:! (single ASCII char 0x21)
+        let aux = [b'X', b'A', b'A', b'!'];
+        let view = RawTagsView::new(&aux);
+        assert_eq!(view.get(b"XA"), Some(TagValue::Char(b'!')));
+    }
+
+    #[rstest]
+    #[case::signed_byte(b'c', vec![42u8], 42i64)]
+    #[case::unsigned_byte(b'C', vec![200u8], 200i64)]
+    #[case::signed_short(b's', (-300i16).to_le_bytes().to_vec(), -300i64)]
+    #[case::unsigned_short(b'S', 50_000u16.to_le_bytes().to_vec(), 50_000i64)]
+    #[case::signed_int(b'i', (-100_000i32).to_le_bytes().to_vec(), -100_000i64)]
+    #[case::unsigned_int(b'I', 3_000_000_000u32.to_le_bytes().to_vec(), 3_000_000_000i64)]
+    fn test_tag_value_get_int_variants(
+        #[case] type_byte: u8,
+        #[case] value_bytes: Vec<u8>,
+        #[case] expected: i64,
+    ) {
+        let mut aux = vec![b'X', b'Y', type_byte];
+        aux.extend_from_slice(&value_bytes);
+        let view = RawTagsView::new(&aux);
+        assert_eq!(view.get(b"XY"), Some(TagValue::Int(expected)));
+    }
+
+    #[test]
+    fn test_tag_value_get_float() {
+        let value: f32 = 1.5;
+        let mut aux = vec![b'A', b'S', b'f'];
+        aux.extend_from_slice(&value.to_le_bytes());
+        let view = RawTagsView::new(&aux);
+        match view.get(b"AS") {
+            Some(TagValue::Float(got)) => assert_eq!(got.to_bits(), value.to_bits()),
+            other => panic!("expected TagValue::Float, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_tag_value_get_string_z() {
+        // RX:Z:hello\0 — get should return TagValue::String without NUL
+        let aux = b"RXZhello\x00";
+        let view = RawTagsView::new(aux.as_ref());
+        assert_eq!(view.get(b"RX"), Some(TagValue::String(b"hello")));
+    }
+
+    #[test]
+    fn test_tag_value_get_hex_h() {
+        // XH:H:1A2B\0 — H-type is distinct from Z-type
+        let aux = b"XHH1A2B\x00";
+        let view = RawTagsView::new(aux.as_ref());
+        assert_eq!(view.get(b"XH"), Some(TagValue::Hex(b"1A2B")));
+        // Confirm it does NOT return TagValue::String for H tags
+        assert_ne!(view.get(b"XH"), Some(TagValue::String(b"1A2B")));
+    }
+
+    #[test]
+    fn test_tag_value_get_array_b() {
+        // Build B:i array [10, 20, 30]
+        let aux = make_b_int_array_tag(*b"pa", &[10, 20, 30]);
+        let view = RawTagsView::new(&aux);
+        match view.get(b"pa") {
+            Some(TagValue::Array(arr)) => {
+                assert_eq!(arr.elem_type, b'i');
+                assert_eq!(arr.count, 3);
+            }
+            other => panic!("expected TagValue::Array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_tag_value_get_truncated_a_returns_none() {
+        // Aux bytes "XA" + 'A' type byte but NO value byte. `get` must return
+        // None rather than panic on out-of-bounds indexing.
+        let aux = vec![b'X', b'A', b'A'];
+        let view = RawTagsView::new(&aux);
+        assert_eq!(view.get(b"XA"), None);
+    }
+
+    #[test]
+    fn test_tag_value_type_byte() {
+        // Scalar variants return their canonical BAM aux type byte.
+        assert_eq!(TagValue::Char(b'A').type_byte(), b'A');
+        assert_eq!(TagValue::Int(42).type_byte(), b'i');
+        assert_eq!(TagValue::Float(1.0).type_byte(), b'f');
+        assert_eq!(TagValue::String(b"xy").type_byte(), b'Z');
+        assert_eq!(TagValue::Hex(b"AF").type_byte(), b'H');
+
+        // Array variants must return b'B' (the BAM aux type byte), not the
+        // element subtype — otherwise `TagValue::Array(B:i)` would look like
+        // a scalar `i` tag to callers.
+        let aux = make_b_int_array_tag(*b"pa", &[1, 2, 3]);
+        let view = RawTagsView::new(&aux);
+        let Some(TagValue::Array(arr)) = view.get(b"pa") else {
+            panic!("expected Array");
+        };
+        assert_eq!(arr.elem_type, b'i', "element subtype preserved on ArrayTagRef");
+        assert_eq!(TagValue::Array(arr).type_byte(), b'B', "aux type byte for array is B");
+    }
+
+    #[test]
+    fn test_tag_value_iter_typed_yields_duplicate_keys_distinctly() {
+        // Two entries with the same tag but different values. The old
+        // implementation rescanned via `get()` and would yield the first
+        // value twice; the direct-decode path must yield each on its own.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(&[b'X', b'N', b'C', 7u8]); // XN:C:7
+        aux.extend_from_slice(&[b'X', b'N', b'C', 42u8]); // XN:C:42 (duplicate key)
+
+        let view = RawTagsView::new(&aux);
+        let pairs: Vec<([u8; 2], TagValue<'_>)> = view.iter_typed().collect();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], (*b"XN", TagValue::Int(7)));
+        assert_eq!(pairs[1], (*b"XN", TagValue::Int(42)));
+    }
+
+    #[test]
+    fn test_tag_value_iter_typed_roundtrip() {
+        // Record with 3 tags of different types: NM:C:5, RG:Z:lib1, AS:f:1.5
+        let mut aux = Vec::new();
+        aux.extend_from_slice(&[b'N', b'M', b'C', 5u8]); // NM:C:5
+        aux.extend_from_slice(b"RGZlib1\x00"); // RG:Z:lib1
+        aux.extend_from_slice(b"ASf"); // AS:f:1.5
+        aux.extend_from_slice(&1.5f32.to_le_bytes());
+
+        let view = RawTagsView::new(&aux);
+        let pairs: Vec<([u8; 2], TagValue<'_>)> = view.iter_typed().collect();
+
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0], (*b"NM", TagValue::Int(5)));
+        assert_eq!(pairs[1], (*b"RG", TagValue::String(b"lib1")));
+        let (tag2, val2) = pairs[2];
+        assert_eq!(tag2, *b"AS");
+        match val2 {
+            TagValue::Float(f) => assert_eq!(f.to_bits(), 1.5f32.to_bits()),
+            other => panic!("expected TagValue::Float(1.5), got {other:?}"),
+        }
     }
 }

--- a/crates/fgumi-raw-bam/src/testutil.rs
+++ b/crates/fgumi-raw-bam/src/testutil.rs
@@ -1,7 +1,7 @@
 /// Parsed BAM record for test assertions.
 ///
 /// Provides convenient access to fields extracted from raw BAM bytes
-/// produced by `UnmappedBamRecordBuilder`. Used only in tests.
+/// produced by `UnmappedSamBuilder`. Used only in tests.
 pub struct ParsedBamRecord {
     pub name: Vec<u8>,
     pub flag: u16,

--- a/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
+++ b/crates/fgumi-raw-bam/tests/noodles_roundtrip.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "noodles")]
+#![deny(unsafe_code)]
 
 use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
 use fgumi_raw_bam::{RawRecord, raw_records_to_record_bufs};
 use noodles::sam::alignment::record::Cigar;
+use noodles::sam::alignment::record::cigar::op::Kind;
 
 /// Decode a single [`RawRecord`] through noodles and return the parsed record.
 ///
@@ -41,8 +43,9 @@ proptest::proptest! {
         proptest::prop_assert_eq!(decoded, Some(name.as_bytes()));
     }
 
-    /// Verify that [`RawRecord::set_cigar_ops`] produces bytes that noodles decodes
-    /// to the same CIGAR operations (kind + length), across many random op sequences.
+    /// Verify that [`RawRecord::set_cigar_ops`] produces bytes that noodles
+    /// decodes to the exact same CIGAR: every op's kind (Match, here) and
+    /// length must match the original, not just the op count.
     #[test]
     fn set_cigar_ops_roundtrips(
         ops in proptest::collection::vec(1u32..=100u32, 1..=10),
@@ -58,24 +61,22 @@ proptest::proptest! {
         // Internal view must reflect the new CIGAR.
         proptest::prop_assert_eq!(rec.cigar_ops_vec(), cigar_ops.clone());
 
-        // Noodles must decode each op with the same kind and length.
+        // Noodles must decode the same ops with matching kinds and lengths.
         let buf = decode_with_noodles(&rec);
-        let decoded: Vec<(noodles::sam::alignment::record::cigar::op::Kind, usize)> = buf
+        let decoded: Vec<(Kind, usize)> = buf
             .cigar()
             .iter()
-            .map(|r| r.expect("noodles cigar op decode failed"))
-            .map(|op| (op.kind(), op.len()))
-            .collect();
-        let expected: Vec<(noodles::sam::alignment::record::cigar::op::Kind, usize)> = ops
-            .iter()
-            .map(|&len| (noodles::sam::alignment::record::cigar::op::Kind::Match, len as usize))
-            .collect();
+            .map(|r| r.map(|o| (o.kind(), o.len())))
+            .collect::<Result<_, _>>()
+            .expect("cigar iter");
+        let expected: Vec<(Kind, usize)> =
+            ops.iter().map(|&len| (Kind::Match, len as usize)).collect();
         proptest::prop_assert_eq!(decoded, expected);
     }
 
-    /// Verify that [`RawRecord::set_sequence_and_qualities`] produces bytes that
-    /// noodles decodes to the same bases and quality scores, across many random
-    /// sequence lengths.
+    /// Verify that [`RawRecord::set_sequence_and_qualities`] produces bytes
+    /// that noodles decodes to the exact same sequence and quality scores,
+    /// byte for byte — not just parseable output.
     #[test]
     fn set_sequence_and_qualities_roundtrips(
         n in 1usize..=200,
@@ -97,7 +98,7 @@ proptest::proptest! {
         proptest::prop_assert_eq!(rec.sequence_vec(), bases.clone());
         proptest::prop_assert_eq!(rec.quality_scores().to_vec(), quals.clone());
 
-        // Noodles must decode the same bases and quality scores element-wise.
+        // Noodles must decode the same sequence + quality scores.
         let buf = decode_with_noodles(&rec);
         proptest::prop_assert_eq!(buf.sequence().as_ref(), bases.as_slice());
         proptest::prop_assert_eq!(buf.quality_scores().as_ref(), quals.as_slice());

--- a/crates/fgumi-raw-bam/tests/noodles_roundtrip_comprehensive.rs
+++ b/crates/fgumi-raw-bam/tests/noodles_roundtrip_comprehensive.rs
@@ -1,0 +1,632 @@
+//! Comprehensive noodles round-trip validation tests.
+//!
+//! Ensures every major raw-byte API path produces BAM-spec-compliant bytes
+//! by verifying that noodles can read back what we write, field by field.
+//!
+//! Each test section is labelled with what it exercises:
+//!
+//! 1. [`SamBuilder`] (all fields + all tag types) → noodles `RecordBuf` decode
+//! 2. [`UnmappedSamBuilder`] → noodles decode
+//! 3. `write_raw_record` framing → noodles BAM reader
+//! 4. Tag editor mutations → noodles tag verification
+//! 5. SIMD sequence extraction vs noodles sequence decode
+//! 6. Proptest random complete records → noodles full field verification
+#![cfg(feature = "noodles")]
+#![deny(unsafe_code)]
+#![allow(clippy::too_many_lines)] // test functions are intentionally exhaustive
+#![allow(clippy::cast_possible_truncation)] // test values are always in range
+#![allow(clippy::cast_sign_loss)] // pos() as usize in assertions is safe for test data
+
+use noodles::sam::alignment::record::Cigar;
+use noodles::sam::alignment::record::data::field::Tag as NoodlesTag;
+use noodles::sam::alignment::record_buf::data::field::Value as NoodlesValue;
+use noodles::sam::alignment::record_buf::data::field::value::Array as NoodlesArray;
+
+use fgumi_raw_bam::testutil::encode_op;
+use fgumi_raw_bam::{
+    RawRecord, SamBuilder, UnmappedSamBuilder, raw_record_to_record_buf,
+    raw_records_to_record_bufs, raw_records_to_record_bufs_with_header, write_raw_record,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn decode(rec: &RawRecord) -> noodles::sam::alignment::RecordBuf {
+    let header = noodles::sam::Header::default();
+    raw_record_to_record_buf(rec, &header).expect("noodles decode failed")
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn tag(s: &[u8; 2]) -> NoodlesTag {
+    NoodlesTag::from(*s)
+}
+
+fn make_bam_stream(records: &[RawRecord]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"BAM\x01");
+    out.extend_from_slice(&0u32.to_le_bytes()); // header text len
+    out.extend_from_slice(&0u32.to_le_bytes()); // n_ref = 0
+    for rec in records {
+        write_raw_record(&mut out, rec).expect("write_raw_record failed");
+    }
+    out
+}
+
+// ============================================================================
+// 1. SamBuilder → noodles decode: verify every field and every tag type
+// ============================================================================
+
+#[test]
+fn sam_builder_all_fields_roundtrip() {
+    use noodles::sam::alignment::record::cigar::op::Kind;
+
+    let seq = b"ACGTACGTACGTACGT";
+    let quals: Vec<u8> = (0..16u8).map(|i| (i * 3) % 40).collect();
+    // 10M + 2I + 4M = 16 query-consuming bases
+    let cigar_ops = &[encode_op(0, 10), encode_op(1, 2), encode_op(0, 4)];
+
+    let mut b = SamBuilder::new();
+    b.ref_id(3)
+        .pos(999)
+        .mapq(60)
+        .flags(0x0001 | 0x0040) // PAIRED | READ1
+        .mate_ref_id(3)
+        .mate_pos(1500)
+        .template_length(200)
+        .bin(4681)
+        .read_name(b"read/roundtrip")
+        .cigar_ops(cigar_ops)
+        .sequence(seq)
+        .qualities(&quals);
+
+    b.add_string_tag(b"RG", b"sample_rg"); // Z
+    b.add_int_tag(b"NM", 1); // smallest signed int
+    b.add_float_tag(b"AS", 42.5_f32); // f
+    b.add_array_u8(
+        b"BD",
+        &[10u8, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
+    ); // B:C
+    b.add_array_u16(
+        b"XU",
+        &[100u16, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+    ); // B:S
+    b.add_array_i16(b"cd", &[-1i16, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16]); // B:s
+    b.add_array_i32(b"YI", &[-100_000i32, 200_000, -300_000, 400_000]); // B:i
+    b.add_array_f32(b"YF", &[1.1_f32, 2.2, 3.3, 4.4]); // B:f
+    b.add_int_tag(b"X0", 70_000); // forces S or i encoding
+
+    let rec = b.build();
+    let buf = decode(&rec);
+
+    // -- header fields --
+    assert_eq!(rec.ref_id(), 3);
+    assert_eq!(rec.pos(), 999);
+    assert_eq!(rec.mapq(), 60);
+    assert_eq!(buf.alignment_start().map(usize::from), Some(rec.pos() as usize + 1));
+    assert_eq!(buf.mapping_quality().map(u8::from), Some(60u8));
+    assert_eq!(u16::from(buf.flags()), rec.flags());
+
+    // -- name --
+    assert_eq!(buf.name().map(std::convert::AsRef::as_ref), Some(b"read/roundtrip" as &[u8]));
+
+    // -- CIGAR --
+    let ops: Vec<_> = buf
+        .cigar()
+        .iter()
+        .map(|op| op.map(|o| (o.kind(), o.len())))
+        .collect::<Result<_, _>>()
+        .expect("cigar iter");
+    assert_eq!(ops, &[(Kind::Match, 10), (Kind::Insertion, 2), (Kind::Match, 4)]);
+
+    // -- sequence and quality scores --
+    assert_eq!(buf.sequence().as_ref(), seq.as_ref());
+    assert_eq!(rec.sequence_vec(), seq.to_vec());
+    assert_eq!(buf.quality_scores().as_ref(), quals.as_slice());
+
+    // -- tags --
+    let data = buf.data();
+
+    let rg = data.get(&tag(b"RG")).expect("RG absent");
+    assert!(matches!(rg, NoodlesValue::String(s) if AsRef::<[u8]>::as_ref(s) == b"sample_rg"));
+
+    let as_ = data.get(&tag(b"AS")).expect("AS absent");
+    assert!(matches!(as_, NoodlesValue::Float(f) if (f - 42.5).abs() < 1e-5));
+
+    let bd = data.get(&tag(b"BD")).expect("BD absent");
+    if let NoodlesValue::Array(NoodlesArray::UInt8(vals)) = bd {
+        assert_eq!(
+            vals.as_slice(),
+            &[10u8, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
+        );
+    } else {
+        panic!("BD not UInt8 array: {bd:?}");
+    }
+
+    let yi = data.get(&tag(b"YI")).expect("YI absent");
+    if let NoodlesValue::Array(NoodlesArray::Int32(vals)) = yi {
+        assert_eq!(vals.as_slice(), &[-100_000i32, 200_000, -300_000, 400_000]);
+    } else {
+        panic!("YI not Int32 array: {yi:?}");
+    }
+
+    let yf = data.get(&tag(b"YF")).expect("YF absent");
+    if let NoodlesValue::Array(NoodlesArray::Float(vals)) = yf {
+        for (a, b) in vals.iter().zip([1.1_f32, 2.2, 3.3, 4.4].iter()) {
+            assert!((a - b).abs() < 1e-5, "float mismatch: {a} != {b}");
+        }
+    } else {
+        panic!("YF not Float array: {yf:?}");
+    }
+}
+
+#[test]
+fn sam_builder_i16_array_tag_roundtrip() {
+    let seq = b"ACGTACGT";
+    let quals = &[30u8, 31, 32, 33, 34, 35, 36, 37];
+
+    let mut b = SamBuilder::new();
+    b.read_name(b"i16test").cigar_ops(&[encode_op(0, 8)]).sequence(seq).qualities(quals);
+    b.add_array_i16(b"cd", &[-100i16, 200, -300, 400, -500, 600, -700, 800]);
+
+    let buf = decode(&b.build());
+    let cd = buf.data().get(&tag(b"cd")).expect("cd absent");
+    if let NoodlesValue::Array(NoodlesArray::Int16(vals)) = cd {
+        assert_eq!(vals.as_slice(), &[-100i16, 200, -300, 400, -500, 600, -700, 800]);
+    } else {
+        panic!("cd not Int16 array: {cd:?}");
+    }
+}
+
+#[test]
+fn sam_builder_u16_array_tag_roundtrip() {
+    let seq = b"ACGT";
+    let quals = &[30u8, 31, 32, 33];
+
+    let mut b = SamBuilder::new();
+    b.read_name(b"u16test").cigar_ops(&[encode_op(0, 4)]).sequence(seq).qualities(quals);
+    b.add_array_u16(b"XU", &[1000u16, 2000, 3000, 65535]);
+
+    let buf = decode(&b.build());
+    let xu = buf.data().get(&tag(b"XU")).expect("XU absent");
+    if let NoodlesValue::Array(NoodlesArray::UInt16(vals)) = xu {
+        assert_eq!(vals.as_slice(), &[1000u16, 2000, 3000, 65535]);
+    } else {
+        panic!("XU not UInt16 array: {xu:?}");
+    }
+}
+
+/// Verify integer tags with various values encode to the expected BAM type and
+/// that noodles decodes each to the correct numeric value.
+#[test]
+fn sam_builder_int_tag_types_roundtrip() {
+    let mut b = SamBuilder::new();
+    b.read_name(b"inttypes")
+        .cigar_ops(&[encode_op(0, 4)])
+        .sequence(b"ACGT")
+        .qualities(&[30u8, 31, 32, 33]);
+    b.add_int_tag(b"X1", -100); // i8 range → 'c'
+    b.add_int_tag(b"X2", 200); // u8 range (>127) → 'C'
+    b.add_int_tag(b"X3", -1000); // i16 range → 's'
+    b.add_int_tag(b"X4", 40000); // u16 range (>32767) → 'S'
+    b.add_int_tag(b"X5", 100_000); // i32 range → 'i'
+
+    let buf = decode(&b.build());
+    let data = buf.data();
+
+    let get_int = |t: &[u8; 2]| -> i64 {
+        data.get(&tag(t)).and_then(NoodlesValue::as_int).unwrap_or_else(|| {
+            panic!("missing or non-integer tag {}", std::str::from_utf8(t).unwrap())
+        })
+    };
+
+    assert_eq!(get_int(b"X1"), -100);
+    assert_eq!(get_int(b"X2"), 200);
+    assert_eq!(get_int(b"X3"), -1000);
+    assert_eq!(get_int(b"X4"), 40000);
+    assert_eq!(get_int(b"X5"), 100_000);
+}
+
+// ============================================================================
+// 2. UnmappedSamBuilder → noodles decode
+// ============================================================================
+
+#[test]
+fn unmapped_sam_builder_roundtrip() {
+    use fgumi_raw_bam::fields::flags;
+
+    let seq = b"ACGTNACGTN";
+    let quals = &[10u8, 20, 30, 40, 0, 10, 20, 30, 40, 0];
+
+    let mut ub = UnmappedSamBuilder::new();
+    ub.build_record(b"unmapped/1", flags::UNMAPPED | flags::PAIRED, seq, quals);
+    ub.append_string_tag(b"RG", b"sample1");
+    ub.append_int_tag(b"NM", 0);
+    ub.append_float_tag(b"XF", 9.75_f32);
+    ub.append_i16_array_tag(b"cd", &[5i16, 10, 15]);
+    ub.append_u8_array_tag(b"BD", &[1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    let raw = RawRecord::from(ub.as_bytes().to_vec());
+    let buf = decode(&raw);
+
+    // unmapped → ref_id = -1 → noodles reference_sequence_id is None
+    assert_eq!(buf.reference_sequence_id(), None);
+    assert_eq!(buf.alignment_start(), None);
+
+    assert!(buf.flags().is_unmapped());
+    assert!(buf.flags().is_segmented());
+
+    assert_eq!(buf.name().map(std::convert::AsRef::as_ref), Some(b"unmapped/1" as &[u8]));
+    assert_eq!(buf.sequence().as_ref(), seq.as_ref());
+    assert_eq!(buf.quality_scores().as_ref(), quals.as_ref());
+    assert_eq!(buf.cigar().as_ref().len(), 0);
+
+    let data = buf.data();
+
+    let rg = data.get(&tag(b"RG")).expect("RG absent");
+    assert!(matches!(rg, NoodlesValue::String(s) if AsRef::<[u8]>::as_ref(s) == b"sample1"));
+
+    let xf = data.get(&tag(b"XF")).expect("XF absent");
+    assert!(matches!(xf, NoodlesValue::Float(f) if (f - 9.75_f32).abs() < 1e-5));
+
+    let cd = data.get(&tag(b"cd")).expect("cd absent");
+    if let NoodlesValue::Array(NoodlesArray::Int16(vals)) = cd {
+        assert_eq!(vals.as_slice(), &[5i16, 10, 15]);
+    } else {
+        panic!("cd not Int16 array: {cd:?}");
+    }
+
+    let bd = data.get(&tag(b"BD")).expect("BD absent");
+    if let NoodlesValue::Array(NoodlesArray::UInt8(vals)) = bd {
+        assert_eq!(vals.as_slice(), &[1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    } else {
+        panic!("BD not UInt8 array: {bd:?}");
+    }
+}
+
+// ============================================================================
+// 3. write_raw_record framing → noodles BAM reader
+// ============================================================================
+
+#[test]
+fn write_raw_record_framing_roundtrip() {
+    let n = 5usize;
+    let mut records: Vec<RawRecord> = Vec::new();
+
+    for i in 0..n {
+        let name = format!("read{i:04}");
+        let seq: Vec<u8> = (0..10).map(|j| b"ACGTN"[(i + j) % 5]).collect();
+        let quals: Vec<u8> = (0..10u8).map(|j| j + 20).collect();
+
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .cigar_ops(&[encode_op(0, 10)])
+            .sequence(&seq)
+            .qualities(&quals);
+        records.push(b.build());
+    }
+
+    let bam_bytes = make_bam_stream(&records);
+    let cursor = std::io::Cursor::new(bam_bytes);
+    let mut reader = noodles::bam::io::Reader::from(cursor);
+    let header = reader.read_header().expect("read BAM header");
+
+    let decoded: Vec<_> =
+        reader.record_bufs(&header).collect::<Result<_, _>>().expect("read BAM records");
+
+    assert_eq!(decoded.len(), n, "record count mismatch");
+
+    for (i, buf) in decoded.iter().enumerate() {
+        let expected_name = format!("read{i:04}");
+        let got_name = buf.name().map(std::convert::AsRef::as_ref);
+        assert_eq!(got_name, Some(expected_name.as_bytes()), "name mismatch at record {i}");
+
+        let expected_seq: Vec<u8> = (0..10).map(|j| b"ACGTN"[(i + j) % 5]).collect();
+        assert_eq!(buf.sequence().as_ref(), expected_seq.as_slice(), "seq mismatch at {i}");
+    }
+}
+
+#[test]
+fn write_raw_record_single_framing_roundtrip() {
+    let mut b = SamBuilder::new();
+    b.read_name(b"singleton")
+        .cigar_ops(&[encode_op(0, 4)])
+        .sequence(b"TGCA")
+        .qualities(&[40u8, 39, 38, 37])
+        .ref_id(0)
+        .pos(42);
+
+    let bam_bytes = make_bam_stream(&[b.build()]);
+    let cursor = std::io::Cursor::new(bam_bytes);
+    let mut reader = noodles::bam::io::Reader::from(cursor);
+    let header = reader.read_header().expect("read BAM header");
+
+    let decoded: Vec<_> =
+        reader.record_bufs(&header).collect::<Result<_, _>>().expect("read BAM records");
+    assert_eq!(decoded.len(), 1);
+    assert_eq!(decoded[0].name().map(std::convert::AsRef::as_ref), Some(b"singleton" as &[u8]));
+    assert_eq!(decoded[0].sequence().as_ref(), b"TGCA");
+    // pos()=42 (0-based) → alignment_start=43 (1-based)
+    assert_eq!(decoded[0].alignment_start().map(usize::from), Some(43));
+}
+
+// ============================================================================
+// 4. Tag editor mutations → noodles tag verification
+// ============================================================================
+
+#[test]
+fn tags_editor_mutations_roundtrip() {
+    let mut b = SamBuilder::new();
+    b.read_name(b"tageditor")
+        .cigar_ops(&[encode_op(0, 4)])
+        .sequence(b"ACGT")
+        .qualities(&[30u8, 31, 32, 33]);
+    b.add_int_tag(b"NM", 5);
+    b.add_string_tag(b"RG", b"old_value");
+    let mut rec = b.build();
+
+    {
+        let mut ed = rec.tags_editor();
+        ed.update_int(b"NM", 99);
+        ed.update_string(b"RG", b"new_longer_value");
+        ed.append_float(b"AS", 7.5_f32);
+        ed.append_array_u8(b"BD", &[1u8, 2, 3, 4]);
+        ed.append_array_i16(b"cd", &[-10i16, 20, -30]);
+        ed.append_array_i32(b"XA", &[1000i32, -2000, 3000]);
+    }
+
+    let buf = decode(&rec);
+    let data = buf.data();
+
+    let nm = data.get(&tag(b"NM")).expect("NM absent");
+    assert_eq!(nm.as_int(), Some(99));
+
+    let rg = data.get(&tag(b"RG")).expect("RG absent");
+    assert!(
+        matches!(rg, NoodlesValue::String(s) if AsRef::<[u8]>::as_ref(s) == b"new_longer_value")
+    );
+
+    let as_ = data.get(&tag(b"AS")).expect("AS absent");
+    assert!(matches!(as_, NoodlesValue::Float(f) if (f - 7.5_f32).abs() < 1e-5));
+
+    let bd = data.get(&tag(b"BD")).expect("BD absent");
+    if let NoodlesValue::Array(NoodlesArray::UInt8(vals)) = bd {
+        assert_eq!(vals.as_slice(), &[1u8, 2, 3, 4]);
+    } else {
+        panic!("BD not UInt8 array: {bd:?}");
+    }
+
+    let cd = data.get(&tag(b"cd")).expect("cd absent");
+    if let NoodlesValue::Array(NoodlesArray::Int16(vals)) = cd {
+        assert_eq!(vals.as_slice(), &[-10i16, 20, -30]);
+    } else {
+        panic!("cd not Int16 array: {cd:?}");
+    }
+
+    let xa = data.get(&tag(b"XA")).expect("XA absent");
+    if let NoodlesValue::Array(NoodlesArray::Int32(vals)) = xa {
+        assert_eq!(vals.as_slice(), &[1000i32, -2000, 3000]);
+    } else {
+        panic!("XA not Int32 array: {xa:?}");
+    }
+}
+
+#[test]
+fn tags_editor_remove_tag_roundtrip() {
+    let mut b = SamBuilder::new();
+    b.read_name(b"rmtest")
+        .cigar_ops(&[encode_op(0, 4)])
+        .sequence(b"TTTT")
+        .qualities(&[20u8, 20, 20, 20]);
+    b.add_string_tag(b"MI", b"42");
+    b.add_int_tag(b"NM", 2);
+    let mut rec = b.build();
+
+    rec.tags_editor().remove(b"MI");
+
+    let buf = decode(&rec);
+    let data = buf.data();
+    assert!(data.get(&tag(b"MI")).is_none(), "MI should have been removed");
+    assert!(data.get(&tag(b"NM")).is_some(), "NM should still be present");
+}
+
+// ============================================================================
+// 5. SIMD sequence extraction vs noodles sequence decode
+// ============================================================================
+
+/// For a range of sequence lengths, build a record with a known sequence, decode
+/// with noodles, and compare our `sequence_vec()` output byte-for-byte with what
+/// noodles decodes.  This exercises the SIMD nibble2base path.
+#[test]
+fn simd_sequence_extraction_vs_noodles() {
+    const LENGTHS: &[usize] = &[1, 31, 32, 33, 64, 65, 127, 150, 255];
+    const BASES: &[u8] = b"ACGTN";
+
+    for &n in LENGTHS {
+        let seq: Vec<u8> = (0..n).map(|i| BASES[i % 5]).collect();
+        let quals: Vec<u8> = (0..n).map(|i| (i % 40) as u8).collect();
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"simdtest").cigar_ops(&[encode_op(0, n)]).sequence(&seq).qualities(&quals);
+        let rec = b.build();
+
+        let buf = decode(&rec);
+
+        assert_eq!(rec.sequence_vec().as_slice(), buf.sequence().as_ref(), "seq mismatch n={n}");
+        assert_eq!(
+            rec.quality_scores().to_vec().as_slice(),
+            buf.quality_scores().as_ref(),
+            "qual mismatch n={n}"
+        );
+    }
+}
+
+// ============================================================================
+// 6. Proptest random complete records → noodles full field verification
+// ============================================================================
+
+proptest::proptest! {
+    /// Generate random but valid mapped records via `SamBuilder` and verify that
+    /// noodles decodes every field correctly: name, CIGAR, sequence, quality scores,
+    /// and tags.
+    #[test]
+    fn proptest_random_complete_record_roundtrip(
+        name in "[A-Za-z0-9]{1,30}",
+        op_lengths in proptest::collection::vec(1usize..=50usize, 1..=6),
+        mapq in 0u8..=255u8,
+        ref_id in 0i32..=10i32,
+        pos in 0i32..=9999i32,
+        nm in 0i32..=100i32,
+        as_score in -1000.0f32..=1000.0f32,
+    ) {
+        let cigar_ops: Vec<u32> = op_lengths.iter().map(|&l| encode_op(0, l)).collect();
+        let l_seq: usize = op_lengths.iter().sum();
+
+        let seq: Vec<u8> = (0..l_seq).map(|i| b"ACGTN"[i % 5]).collect();
+        let quals: Vec<u8> = (0..l_seq).map(|i| (i % 40) as u8).collect();
+
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+         .cigar_ops(&cigar_ops)
+         .sequence(&seq)
+         .qualities(&quals)
+         .mapq(mapq)
+         .ref_id(ref_id)
+         .pos(pos);
+        b.add_int_tag(b"NM", nm);
+        b.add_float_tag(b"AS", as_score);
+        let rec = b.build();
+
+        let header = noodles::sam::Header::default();
+        let buf = raw_record_to_record_buf(&rec, &header)
+            .expect("noodles decode failed");
+
+        // name
+        proptest::prop_assert_eq!(
+            buf.name().map(std::convert::AsRef::as_ref),
+            Some(name.as_bytes())
+        );
+
+        // mapq — noodles treats 255 as "missing" per BAM spec
+        let expected_mapq = if mapq == 255 { None } else { Some(mapq) };
+        proptest::prop_assert_eq!(buf.mapping_quality().map(u8::from), expected_mapq);
+
+        // CIGAR op count
+        proptest::prop_assert_eq!(buf.cigar().iter().count(), op_lengths.len());
+
+        // sequence and quality scores
+        proptest::prop_assert_eq!(buf.sequence().as_ref(), seq.as_slice());
+        proptest::prop_assert_eq!(buf.quality_scores().as_ref(), quals.as_slice());
+
+        // NM integer tag
+        let nm_val = buf.data().get(&NoodlesTag::from(*b"NM")).and_then(NoodlesValue::as_int);
+        proptest::prop_assert_eq!(nm_val, Some(i64::from(nm)));
+
+        // AS float tag
+        let as_val = buf.data().get(&NoodlesTag::from(*b"AS"));
+        proptest::prop_assert!(as_val.is_some(), "AS tag absent");
+        if let Some(NoodlesValue::Float(decoded_f)) = as_val {
+            proptest::prop_assert!(
+                (decoded_f - as_score).abs() < 1e-3_f32,
+                "AS float mismatch: {decoded_f} != {as_score}"
+            );
+        }
+    }
+
+    /// Verify `raw_records_to_record_bufs` handles random batches of unmapped records
+    /// and that every record's name and sequence survive the round-trip.
+    #[test]
+    fn proptest_batch_unmapped_roundtrip(
+        names in proptest::collection::vec("[A-Za-z0-9]{1,20}", 1..=8),
+    ) {
+        let mut raw_vecs: Vec<Vec<u8>> = Vec::new();
+        let mut expected_names: Vec<Vec<u8>> = Vec::new();
+        let mut expected_seqs: Vec<Vec<u8>> = Vec::new();
+
+        for (i, name) in names.iter().enumerate() {
+            let seq: Vec<u8> = (0..8).map(|j| b"ACGTN"[(i + j) % 5]).collect();
+            let quals = vec![20u8; 8];
+
+            let mut ub = UnmappedSamBuilder::new();
+            ub.build_record(name.as_bytes(), 4u16 /* UNMAPPED */, &seq, &quals);
+            raw_vecs.push(ub.as_bytes().to_vec());
+            expected_names.push(name.as_bytes().to_vec());
+            expected_seqs.push(seq);
+        }
+
+        let bufs = raw_records_to_record_bufs(&raw_vecs).expect("batch decode failed");
+        proptest::prop_assert_eq!(bufs.len(), names.len());
+
+        for (i, buf) in bufs.iter().enumerate() {
+            proptest::prop_assert_eq!(
+                buf.name().map(std::convert::AsRef::as_ref),
+                Some(expected_names[i].as_slice())
+            );
+            proptest::prop_assert_eq!(buf.sequence().as_ref(), expected_seqs[i].as_slice());
+        }
+    }
+}
+
+/// Mapped record round-trip through `raw_record_to_record_buf` with a non-empty
+/// SAM header: the supplied `@SQ` dictionary must actually be used during
+/// decoding, and encoding back through a noodles writer must produce the same
+/// reference name for the mapped reference ID.
+#[test]
+fn mapped_record_roundtrip_with_non_empty_header() {
+    use bstr::BString;
+    use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+    use std::num::NonZeroUsize;
+
+    // Build a header with a non-default reference dictionary so the decode
+    // path must honor it. `@HD SO:coordinate` is required for reference IDs
+    // to be meaningful in mapped records.
+    let hd: noodles::sam::Header = "@HD\tVN:1.6\tSO:coordinate\n".parse().expect("parse @HD");
+    let mut hb = noodles::sam::Header::builder();
+    if let Some(h) = hd.header() {
+        hb = hb.set_header(h.clone());
+    }
+    let header = hb
+        .add_reference_sequence(
+            BString::from("chrA"),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        )
+        .add_reference_sequence(
+            BString::from("chrB"),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(20_000).unwrap()),
+        )
+        .build();
+
+    // Build a mapped record against the second reference (index 1 → "chrB").
+    let mut b = SamBuilder::new();
+    b.ref_id(1)
+        .pos(499) // 500 in 1-based
+        .mapq(42)
+        .read_name(b"mapped/1")
+        .cigar_ops(&[encode_op(0, 10)])
+        .sequence(b"ACGTACGTAC")
+        .qualities(&[30u8; 10]);
+    let rec = b.build();
+
+    // Decode with the real header.
+    let buf = raw_record_to_record_buf(&rec, &header).expect("decode with header");
+    assert_eq!(buf.alignment_start().map(usize::from), Some(500));
+    assert_eq!(buf.reference_sequence_id(), Some(1));
+
+    // Re-encode through a noodles writer to verify the header genuinely drives
+    // the decode path: writing requires the header to resolve the reference id
+    // and will error if the decoded record is inconsistent with the header.
+    let mut out: Vec<u8> = Vec::new();
+    {
+        use noodles::sam::alignment::io::Write as _;
+        let mut writer = noodles::bam::io::Writer::from(&mut out);
+        writer.write_header(&header).expect("write header");
+        writer.write_alignment_record(&header, &buf).expect("write record");
+    }
+    assert!(!out.is_empty(), "re-encode should produce bytes");
+
+    // Sanity: `raw_records_to_record_bufs_with_header` is the plural counterpart.
+    let bufs =
+        raw_records_to_record_bufs_with_header(&[rec.as_ref().to_vec()], &header).expect("batch");
+    assert_eq!(bufs.len(), 1);
+    assert_eq!(bufs[0].reference_sequence_id(), Some(1));
+}

--- a/crates/fgumi-raw-bam/tests/tags_editor_invariants.proptest-regressions
+++ b/crates/fgumi-raw-bam/tests/tags_editor_invariants.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc aeab97a23a453e9fb828606212f8a0b62fa5e24feb724bf24157f809cf2ac074 # shrinks to aux = [0], val = ""

--- a/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
+++ b/crates/fgumi-raw-bam/tests/tags_editor_invariants.rs
@@ -5,18 +5,6 @@ use fgumi_raw_bam::RawRecord;
 use fgumi_raw_bam::testutil::{encode_op, make_bam_bytes};
 use proptest::prelude::*;
 
-/// Strategy yielding `(Vec<T>, usize)` where the index is uniformly drawn
-/// from `0..vec.len()`. Avoids the low-index bias of `index % vec.len()`
-/// when the index range exceeds the vec length.
-macro_rules! vec_and_valid_index {
-    ($ty:ty) => {
-        proptest::collection::vec(any::<$ty>(), 1..32).prop_flat_map(|v| {
-            let len = v.len();
-            (Just(v), 0..len)
-        })
-    };
-}
-
 /// Build a minimal valid [`RawRecord`] with the given aux bytes.
 ///
 /// Uses a 4-base Match CIGAR op and a short name whose length + NUL is
@@ -196,7 +184,7 @@ proptest! {
         ),
     ) {
         let mut rec = base_record(&[]);
-        let initial_record_len = rec.as_ref().len();
+        let aux_len = rec.as_ref().len();
 
         for (kind, tag, int_val, str_val) in &ops {
             {
@@ -226,10 +214,10 @@ proptest! {
 
             // The record must not be shorter than it was at the start (header + fixed fields).
             prop_assert!(
-                rec.as_ref().len() >= initial_record_len,
+                rec.as_ref().len() >= aux_len,
                 "record shrank below initial size: {} < {}",
                 rec.as_ref().len(),
-                initial_record_len
+                aux_len
             );
         }
     }
@@ -241,38 +229,34 @@ proptest! {
 
 /// Decode `count` little-endian `u8` elements from `data`.
 fn decode_u8_array(data: &[u8], count: usize) -> Vec<u8> {
-    data[..count].to_vec()
+    (0..count).map(|i| data[i]).collect()
 }
 
 /// Decode `count` little-endian `u16` elements from `data`.
 fn decode_u16_array(data: &[u8], count: usize) -> Vec<u16> {
-    data.chunks_exact(2)
-        .take(count)
-        .map(|c| u16::from_le_bytes(c.try_into().expect("chunks_exact(2) yields 2-byte chunks")))
-        .collect()
+    (0..count).map(|i| u16::from_le_bytes([data[i * 2], data[i * 2 + 1]])).collect()
 }
 
 /// Decode `count` little-endian `i16` elements from `data`.
 fn decode_i16_array(data: &[u8], count: usize) -> Vec<i16> {
-    data.chunks_exact(2)
-        .take(count)
-        .map(|c| i16::from_le_bytes(c.try_into().expect("chunks_exact(2) yields 2-byte chunks")))
-        .collect()
+    (0..count).map(|i| i16::from_le_bytes([data[i * 2], data[i * 2 + 1]])).collect()
 }
 
 /// Decode `count` little-endian `i32` elements from `data`.
 fn decode_i32_array(data: &[u8], count: usize) -> Vec<i32> {
-    data.chunks_exact(4)
-        .take(count)
-        .map(|c| i32::from_le_bytes(c.try_into().expect("chunks_exact(4) yields 4-byte chunks")))
+    (0..count)
+        .map(|i| {
+            i32::from_le_bytes([data[i * 4], data[i * 4 + 1], data[i * 4 + 2], data[i * 4 + 3]])
+        })
         .collect()
 }
 
 /// Decode `count` little-endian `f32` elements from `data` as bit patterns.
 fn decode_f32_bits_array(data: &[u8], count: usize) -> Vec<u32> {
-    data.chunks_exact(4)
-        .take(count)
-        .map(|c| u32::from_le_bytes(c.try_into().expect("chunks_exact(4) yields 4-byte chunks")))
+    (0..count)
+        .map(|i| {
+            u32::from_le_bytes([data[i * 4], data[i * 4 + 1], data[i * 4 + 2], data[i * 4 + 3]])
+        })
         .collect()
 }
 
@@ -374,9 +358,11 @@ proptest! {
 
     #[test]
     fn set_array_element_u8_writes_one_element(
-        (initial, index) in vec_and_valid_index!(u8),
+        initial in proptest::collection::vec(any::<u8>(), 1..32),
+        index in 0usize..32,
         new_val in any::<u8>(),
     ) {
+        let index = index % initial.len();
         let mut rec = base_record(&[]);
         {
             let mut ed = rec.tags_editor();
@@ -400,9 +386,11 @@ proptest! {
 
     #[test]
     fn set_array_element_u16_writes_one_element(
-        (initial, index) in vec_and_valid_index!(u16),
+        initial in proptest::collection::vec(any::<u16>(), 1..32),
+        index in 0usize..32,
         new_val in any::<u16>(),
     ) {
+        let index = index % initial.len();
         let mut rec = base_record(&[]);
         {
             let mut ed = rec.tags_editor();
@@ -426,9 +414,11 @@ proptest! {
 
     #[test]
     fn set_array_element_i16_writes_one_element(
-        (initial, index) in vec_and_valid_index!(i16),
+        initial in proptest::collection::vec(any::<i16>(), 1..32),
+        index in 0usize..32,
         new_val in any::<i16>(),
     ) {
+        let index = index % initial.len();
         let mut rec = base_record(&[]);
         {
             let mut ed = rec.tags_editor();
@@ -452,9 +442,11 @@ proptest! {
 
     #[test]
     fn set_array_element_i32_writes_one_element(
-        (initial, index) in vec_and_valid_index!(i32),
+        initial in proptest::collection::vec(any::<i32>(), 1..32),
+        index in 0usize..32,
         new_val in any::<i32>(),
     ) {
+        let index = index % initial.len();
         let mut rec = base_record(&[]);
         {
             let mut ed = rec.tags_editor();
@@ -478,9 +470,11 @@ proptest! {
 
     #[test]
     fn set_array_element_f32_writes_one_element(
-        (initial, index) in vec_and_valid_index!(f32),
+        initial in proptest::collection::vec(any::<f32>(), 1..32),
+        index in 0usize..32,
         new_val in any::<f32>(),
     ) {
+        let index = index % initial.len();
         let new_bits = new_val.to_bits();
         let initial_bits: Vec<u32> = initial.iter().map(|f| f.to_bits()).collect();
         let mut rec = base_record(&[]);

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -31,7 +31,7 @@ use crate::validation::validate_file_exists;
 use anyhow::{Result, bail, ensure};
 use bstr::{BString, ByteSlice};
 use clap::Parser;
-use fgumi_raw_bam::UnmappedBamRecordBuilder;
+use fgumi_raw_bam::UnmappedSamBuilder;
 use fgumi_raw_bam::fields::flags;
 use log::{debug, info};
 use noodles_bgzf::io::MultithreadedReader;
@@ -769,7 +769,7 @@ impl Extract {
 
     /// Write raw BAM records from a read set directly to a writer.
     ///
-    /// Uses `UnmappedBamRecordBuilder` to construct records as raw bytes,
+    /// Uses `UnmappedSamBuilder` to construct records as raw bytes,
     /// bypassing `RecordBuf` allocation and encoding overhead.
     ///
     /// Returns the number of records written.
@@ -778,7 +778,7 @@ impl Extract {
         &self,
         read_set: &FastqSet,
         encoding: QualityEncoding,
-        builder: &mut UnmappedBamRecordBuilder,
+        builder: &mut UnmappedSamBuilder,
         writer: &mut RawBamWriter,
     ) -> Result<u64> {
         let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
@@ -924,7 +924,7 @@ impl Extract {
     ) -> Result<u64> {
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
         let mut read_pair_count: u64 = 0;
-        let mut builder = UnmappedBamRecordBuilder::new();
+        let mut builder = UnmappedSamBuilder::new();
 
         loop {
             let mut next_read_sets = Vec::with_capacity(fq_iterators.len());
@@ -1170,7 +1170,7 @@ fn make_raw_records_static(
     };
 
     let num_templates = templates.len();
-    let mut builder = UnmappedBamRecordBuilder::new();
+    let mut builder = UnmappedSamBuilder::new();
     let mut data = Vec::new();
 
     for (index, template) in templates.iter().enumerate() {


### PR DESCRIPTION
## Summary

Additive additions to \`fgumi-raw-bam\` that later stack-series PRs consume:

- \`RawBamWriter\`, \`write_raw_record\`, \`write_raw_records\`
- \`CigarOp\` / \`CigarKind\` typed CIGAR iteration
- \`TagValue\` zero-copy typed tag dispatch
- Symmetric \`RawRecord\` ↔ \`RecordBuf\` converters + \`RecordBufEncoder\`
- \`SamBuilder\` (general-purpose record construction, renamed from \`MappedBamRecordBuilder\`)
- \`UnmappedSamBuilder\` (renamed from \`UnmappedBamRecordBuilder\`)
- \`IndexedRawBamReader\`, \`RawQueryIter\`, \`UnmappedIter\` (new \`indexed_reader.rs\`)
- Matching re-exports in \`lib.rs\`

Also updates three consensus callers (\`codec_caller\`, \`duplex_caller\`, \`vanilla_caller\`) and \`commands/extract.rs\` to use the renamed \`UnmappedSamBuilder\`.

Adds comprehensive \`noodles\` round-trip tests and widens the tag-editor invariant proptests to match the expanded API.

Part 2 of 7 in the follow-up series closing #272. Stacks on #286.

## Test plan

- [x] \`cargo ci-test\` — 2541/2541 pass (incl. expanded proptest + round-trip coverage)
- [x] \`cargo ci-fmt\` clean
- [x] \`cargo ci-lint\` clean

## Stack

- PR 1: zipper \`restore_unconverted_bases_in_raw_record\` → RawRecord methods (#286)
- **PR 2 (this):** fgumi-raw-bam additive API
- PR 3: fgumi-sam raw helpers + RawRecordClipper
- PR 4: consensus internals → RawRecord + drop RecordBuf variants
- PR 5: commands + storage + pipeline collapses
- PR 6: workspace test migrations to SamBuilder
- PR 7: delete vendored bam_codec + simulate → SamBuilder