### PR TITLE
refactor(consensus): migrate internals to RawRecord; drop RecordBuf variants

### DIFF
--- a/benches/core_functions.rs
+++ b/benches/core_functions.rs
@@ -25,6 +25,7 @@ use fgumi_lib::phred::{
 use fgumi_lib::sam::record_utils::parse_cigar_string;
 use fgumi_lib::umi::assigner::{Strategy, count_mismatches, matches_within_threshold};
 use fgumi_lib::vendored::bam_codec::encode_record_buf;
+use fgumi_raw_bam::RawRecord;
 use noodles::core::Position;
 use noodles::sam::alignment::record::Flags;
 use noodles::sam::alignment::record::cigar::op::Kind;
@@ -347,12 +348,12 @@ fn bench_vanilla_consensus_caller(c: &mut Criterion) {
             .collect();
 
         let header = noodles::sam::Header::default();
-        let raw_reads: Vec<Vec<u8>> = reads
+        let raw_reads: Vec<RawRecord> = reads
             .iter()
             .map(|rec| {
                 let mut buf = Vec::new();
                 encode_record_buf(&mut buf, &header, rec).unwrap();
-                buf
+                RawRecord::from(buf)
             })
             .collect();
 
@@ -378,12 +379,12 @@ fn bench_vanilla_consensus_caller(c: &mut Criterion) {
         let reads: Vec<RecordBuf> =
             (0..5).map(|i| create_test_read(&format!("read{i}"), &seq, 35, 1, "1")).collect();
         let header = noodles::sam::Header::default();
-        let raw_reads: Vec<Vec<u8>> = reads
+        let raw_reads: Vec<RawRecord> = reads
             .iter()
             .map(|rec| {
                 let mut buf = Vec::new();
                 encode_record_buf(&mut buf, &header, rec).unwrap();
-                buf
+                RawRecord::from(buf)
             })
             .collect();
 

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -88,6 +88,7 @@
 //!
 //! ```rust,ignore
 //! use fgumi_lib::consensus::caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
+//! use fgumi_raw_bam::RawRecord;
 //! use anyhow::Result;
 //!
 //! pub struct MyConsensusCaller {
@@ -96,8 +97,8 @@
 //! }
 //!
 //! impl ConsensusCaller for MyConsensusCaller {
-//!     fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
-//!         // Each Vec<u8> is a raw BAM record (without block_size prefix)
+//!     fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
+//!         // Each RawRecord is a raw BAM record (without block_size prefix)
 //!         self.stats.record_input(records.len());
 //!
 //!         // ... filter reads, call consensus, write into output ...
@@ -121,6 +122,7 @@
 //! ```rust,ignore
 //! use fgumi_lib::consensus::vanilla_consensus_caller::VanillaUmiConsensusCaller;
 //! use fgumi_lib::consensus::caller::ConsensusCaller;
+//! use fgumi_raw_bam::RawRecord;
 //!
 //! // Create consensus caller
 //! let mut caller = VanillaUmiConsensusCaller::new(
@@ -129,8 +131,8 @@
 //!     options,                   // configuration options
 //! );
 //!
-//! // Process a group of raw-byte BAM records with the same UMI
-//! let records: Vec<Vec<u8>> = vec![raw_record1, raw_record2, raw_record3];
+//! // Process a group of raw BAM records with the same UMI
+//! let records: Vec<RawRecord> = vec![raw_record1, raw_record2, raw_record3];
 //! let consensus = caller.consensus_reads(records)?;
 //!
 //! // Check statistics
@@ -159,6 +161,7 @@
 //! - `base_builder`: Core likelihood-based consensus base calling logic
 
 use anyhow::Result;
+use fgumi_raw_bam::RawRecord;
 use noodles::sam::Header;
 use std::collections::HashMap;
 
@@ -196,14 +199,14 @@ impl ConsensusOutput {
 
 /// The main trait for consensus callers that generate consensus reads from groups of raw reads.
 ///
-/// All consensus callers operate on raw BAM byte records (`Vec<u8>`) to avoid the overhead
-/// of noodles `RecordBuf` parsing. Each `Vec<u8>` is a complete BAM record without the
-/// 4-byte `block_size` prefix.
+/// All consensus callers operate on [`RawRecord`] values to avoid the overhead of noodles
+/// `RecordBuf` parsing. Each record is a complete BAM record without the 4-byte `block_size`
+/// prefix.
 pub trait ConsensusCaller: Send + Sync {
     /// Takes a group of raw-byte BAM records with the same UMI and generates consensus reads.
     ///
     /// # Arguments
-    /// * `records` - Raw BAM byte records from the same source molecule (same MI tag)
+    /// * `records` - Raw BAM records from the same source molecule (same MI tag)
     ///
     /// # Returns
     /// Pre-serialized consensus output (may be empty if the group doesn't meet minimum requirements)
@@ -212,7 +215,7 @@ pub trait ConsensusCaller: Send + Sync {
     ///
     /// Returns an error if BAM record parsing fails or consensus calling encounters an
     /// unrecoverable issue (e.g., malformed tags, invalid CIGAR).
-    fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput>;
+    fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput>;
 
     /// Returns the total number of input reads examined by the consensus caller
     fn total_reads(&self) -> usize;

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -84,7 +84,7 @@ use crate::vanilla_caller::{
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
 use anyhow::Result;
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedSamBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use noodles::sam::alignment::record::data::field::Tag;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -526,7 +526,7 @@ impl CodecConsensusCaller {
         clippy::too_many_lines,
         reason = "consensus pipeline has many sequential steps that are clearest in one function"
     )]
-    fn consensus_reads_raw(&mut self, records: &[Vec<u8>]) -> Result<ConsensusOutput> {
+    fn consensus_reads_raw(&mut self, records: &[RawRecord]) -> Result<ConsensusOutput> {
         self.stats.total_input_reads += records.len() as u64;
 
         if records.is_empty() {
@@ -793,7 +793,7 @@ impl CodecConsensusCaller {
         let all_paired_raws: Vec<&[u8]> = r1_infos
             .iter()
             .chain(r2_infos.iter())
-            .map(|info| records[info.raw_idx].as_slice())
+            .map(|info| records[info.raw_idx].as_ref())
             .collect();
 
         let mut output = ConsensusOutput::default();
@@ -1229,7 +1229,7 @@ impl CodecConsensusCaller {
         ss_b: &SingleStrandConsensus,
         umi: Option<&str>,
         source_raws: &[&[u8]],
-        all_records: &[Vec<u8>],
+        all_records: &[RawRecord],
     ) -> Result<()> {
         // Generate read name - use ':' delimiter to match fgbio format
         self.consensus_counter += 1;
@@ -1377,11 +1377,11 @@ impl CodecConsensusCaller {
 /// This allows `CodecConsensusCaller` to be used polymorphically with other
 /// consensus callers (e.g., `VanillaUmiConsensusCaller`, `DuplexConsensusCaller`).
 impl ConsensusCaller for CodecConsensusCaller {
-    fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
+    fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
         let result = self.consensus_reads_raw(&records)?;
         // When a group fails to produce consensus, all its records are rejected
         if self.track_rejects && result.count == 0 && !records.is_empty() {
-            self.rejected_reads.extend(records);
+            self.rejected_reads.extend(records.into_iter().map(RawRecord::into_inner));
         }
         Ok(result)
     }
@@ -1477,7 +1477,8 @@ impl CodecConsensusCaller {
         &mut self,
         recs: Vec<noodles::sam::alignment::RecordBuf>,
     ) -> Result<ConsensusOutput> {
-        let raw_records: Vec<Vec<u8>> = recs.iter().map(Self::record_buf_to_raw).collect();
+        let raw_records: Vec<RawRecord> =
+            recs.iter().map(|r| RawRecord::from(Self::record_buf_to_raw(r))).collect();
         self.consensus_reads(raw_records)
     }
 }
@@ -1501,7 +1502,8 @@ impl CodecConsensusCaller {
         &mut self,
         recs: Vec<noodles::sam::alignment::RecordBuf>,
     ) -> Vec<noodles::sam::alignment::RecordBuf> {
-        let raws: Vec<Vec<u8>> = recs.iter().map(Self::record_buf_to_raw).collect();
+        let raws: Vec<RawRecord> =
+            recs.iter().map(|r| RawRecord::from(Self::record_buf_to_raw(r))).collect();
         let infos: Vec<ClippedRecordInfo> =
             raws.iter().enumerate().map(|(i, raw)| Self::build_clipped_info(raw, i, 0)).collect();
         let filtered = self.filter_to_most_common_alignment_raw(infos);

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -210,7 +210,7 @@ use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{ReadType, SourceRead};
-use fgumi_raw_bam::{self as bam_fields, RawRecordView, UnmappedSamBuilder, flags};
+use fgumi_raw_bam::{self as bam_fields, RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 
 /// Duplex consensus read - matches fgbio's `DuplexConsensusRead`
 ///
@@ -494,13 +494,13 @@ impl DuplexConsensusCaller {
                 ),
             )
             .build();
-        let raw: Vec<Vec<u8>> = records
+        let raw: Vec<RawRecord> = records
             .iter()
             .map(|rec| {
                 let mut buf = Vec::new();
                 crate::vendored::bam_codec::encode_record_buf(&mut buf, &header, rec)
                     .map_err(|e| anyhow::anyhow!("Failed to encode RecordBuf: {e}"))?;
-                Ok(buf)
+                Ok(RawRecord::from(buf))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         self.consensus_reads(raw)
@@ -609,13 +609,9 @@ impl DuplexConsensusCaller {
     ///
     /// IMPORTANT: This function requires that all reads have MI tags with /A or /B suffixes.
     /// The duplex command MUST be used with reads grouped using the "paired" strategy.
-    #[expect(
-        clippy::type_complexity,
-        reason = "tuple return type is clearer than a one-off struct for strand partitioning"
-    )]
     fn partition_records_by_strand(
-        records: Vec<Vec<u8>>,
-    ) -> Result<(Option<String>, Vec<Vec<u8>>, Vec<Vec<u8>>)> {
+        records: Vec<RawRecord>,
+    ) -> Result<(Option<String>, Vec<RawRecord>, Vec<RawRecord>)> {
         if records.is_empty() {
             return Ok((None, Vec::new(), Vec::new()));
         }
@@ -748,34 +744,39 @@ impl DuplexConsensusCaller {
         }
     }
 
+    /// Returns true if the record is a paired first-of-pair read.
+    ///
+    /// An unpaired/fragment read is never treated as R1.
+    fn is_paired_r1(record: &RawRecord) -> bool {
+        let flg = RawRecordView::new(record).flags();
+        (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
+    }
+
+    /// Returns true if the record is a paired second-of-pair read.
+    ///
+    /// An unpaired/fragment read is never treated as R2. `FIRST_SEGMENT == 0`
+    /// alone is insufficient since unpaired reads have both segment bits clear.
+    fn is_paired_r2(record: &RawRecord) -> bool {
+        let flg = RawRecordView::new(record).flags();
+        (flg & flags::PAIRED != 0) && (flg & flags::LAST_SEGMENT != 0)
+    }
+
     /// Checks if there are enough input reads according to the `min_reads` thresholds.
     /// This matches fgbio's `hasMinimumNumberOfReads` logic.
     ///
     /// Counts only R1 reads (first of pair) for each strand, sorts them so XY >= YX,
     /// then checks: `total >= min_total AND xy >= min_xy AND yx >= min_yx`
     fn has_minimum_number_of_reads(
-        a_records: &[Vec<u8>],
-        b_records: &[Vec<u8>],
+        a_records: &[RawRecord],
+        b_records: &[RawRecord],
         min_total_reads: usize,
         min_xy_reads: usize,
         min_yx_reads: usize,
     ) -> bool {
         // Count R1s only (first of pair) for each strand
         // Match fgbio: x.count(r => r.paired && r.firstOfPair)
-        let num_a = a_records
-            .iter()
-            .filter(|r| {
-                let flg = RawRecordView::new(r).flags();
-                (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
-            })
-            .count();
-        let num_b = b_records
-            .iter()
-            .filter(|r| {
-                let flg = RawRecordView::new(r).flags();
-                (flg & flags::PAIRED != 0) && (flg & flags::FIRST_SEGMENT != 0)
-            })
-            .count();
+        let num_a = a_records.iter().filter(|r| Self::is_paired_r1(r)).count();
+        let num_b = b_records.iter().filter(|r| Self::is_paired_r1(r)).count();
 
         // Sort so xy is the larger count, yx is the smaller
         let (num_xy, num_yx) = if num_a >= num_b { (num_a, num_b) } else { (num_b, num_a) };
@@ -808,7 +809,7 @@ impl DuplexConsensusCaller {
     /// Check if all reads in an iterator are on the same strand.
     /// Returns true if all reads have the same orientation (all forward or all reverse).
     /// Also returns true for empty iterators.
-    fn are_all_same_strand<'a>(mut reads: impl Iterator<Item = &'a Vec<u8>>) -> bool {
+    fn are_all_same_strand<'a>(mut reads: impl Iterator<Item = &'a RawRecord>) -> bool {
         let Some(first) = reads.next() else {
             return true;
         };
@@ -1088,8 +1089,8 @@ impl DuplexConsensusCaller {
         consensus: &DuplexConsensusRead,
         read_type: ReadType,
         umi: &str,
-        source_reads_a: &[&[u8]],
-        source_reads_b: &[&[u8]],
+        source_reads_a: &[&RawRecord],
+        source_reads_b: &[&RawRecord],
         produce_per_base_tags: bool,
         read_name_prefix: &str,
         read_group_id: &str,
@@ -1221,11 +1222,23 @@ impl DuplexConsensusCaller {
         // 9. Build RX consensus from source reads
         let mut all_umis = Vec::new();
 
-        for raw in source_reads_a.iter().chain(source_reads_b.iter()) {
-            let view = RawRecordView::new(raw);
-            if let Some(rx_bytes) = view.tags().find_string(b"RX") {
+        for raw in source_reads_a {
+            if let Some(rx_bytes) = raw.tags().find_string(b"RX") {
                 let rx = String::from_utf8_lossy(rx_bytes).to_string();
-                let is_first = view.flags() & flags::FIRST_SEGMENT != 0;
+                let is_first = raw.flags() & flags::FIRST_SEGMENT != 0;
+                if is_first == first_of_pair {
+                    all_umis.push(rx);
+                } else {
+                    let reversed: Vec<&str> = rx.split('-').rev().collect();
+                    all_umis.push(reversed.join("-"));
+                }
+            }
+        }
+
+        for raw in source_reads_b {
+            if let Some(rx_bytes) = raw.tags().find_string(b"RX") {
+                let rx = String::from_utf8_lossy(rx_bytes).to_string();
+                let is_first = raw.flags() & flags::FIRST_SEGMENT != 0;
                 if is_first == first_of_pair {
                     all_umis.push(rx);
                 } else {
@@ -1728,8 +1741,8 @@ impl DuplexConsensusCaller {
     )]
     fn process_group(
         base_mi: String,
-        a_records: Vec<Vec<u8>>,
-        b_records: Vec<Vec<u8>>,
+        a_records: Vec<RawRecord>,
+        b_records: Vec<RawRecord>,
         ss_caller: &mut VanillaUmiConsensusCaller,
         produce_per_base_tags: bool,
         min_total_reads: usize,
@@ -1776,34 +1789,12 @@ impl DuplexConsensusCaller {
         });
 
         // Split reads into R1/R2 groups for AB and BA strands (done once, reused below).
-        // Only properly paired records are classified; unpaired/malformed records are skipped
-        // so they cannot leak into orientation checks, SS consensus, or RX aggregation.
-        let mut ab_r1s = Vec::new();
-        let mut ab_r2s = Vec::new();
-        for r in &a_records {
-            let flg = RawRecordView::new(r).flags();
-            if flg & flags::PAIRED == 0 {
-                continue;
-            }
-            if flg & flags::FIRST_SEGMENT != 0 {
-                ab_r1s.push(r);
-            } else if flg & flags::LAST_SEGMENT != 0 {
-                ab_r2s.push(r);
-            }
-        }
-        let mut ba_r1s = Vec::new();
-        let mut ba_r2s = Vec::new();
-        for r in &b_records {
-            let flg = RawRecordView::new(r).flags();
-            if flg & flags::PAIRED == 0 {
-                continue;
-            }
-            if flg & flags::FIRST_SEGMENT != 0 {
-                ba_r1s.push(r);
-            } else if flg & flags::LAST_SEGMENT != 0 {
-                ba_r2s.push(r);
-            }
-        }
+        // Require PAIRED for both: otherwise unpaired/fragment reads (which have both
+        // segment bits clear) would be misclassified as R2.
+        let ab_r1s: Vec<&RawRecord> = a_records.iter().filter(|r| Self::is_paired_r1(r)).collect();
+        let ab_r2s: Vec<&RawRecord> = a_records.iter().filter(|r| Self::is_paired_r2(r)).collect();
+        let ba_r1s: Vec<&RawRecord> = b_records.iter().filter(|r| Self::is_paired_r1(r)).collect();
+        let ba_r2s: Vec<&RawRecord> = b_records.iter().filter(|r| Self::is_paired_r2(r)).collect();
 
         // Validate strand orientations before processing
         // The expected orientations are:
@@ -1851,8 +1842,8 @@ impl DuplexConsensusCaller {
             ab_r2s.len() + ba_r1s.len()
         );
 
-        // Keep references to original raw bytes for later tag extraction
-        let x_raws: Vec<&[u8]> = ab_r1s.iter().chain(ba_r2s.iter()).map(|r| r.as_slice()).collect();
+        // Keep references to original raw records for later tag extraction
+        let x_raws: Vec<&RawRecord> = ab_r1s.iter().chain(ba_r2s.iter()).copied().collect();
         let x_sources: Vec<SourceRead> = x_raws
             .iter()
             .enumerate()
@@ -1862,7 +1853,7 @@ impl DuplexConsensusCaller {
             })
             .collect();
 
-        let y_raws: Vec<&[u8]> = ab_r2s.iter().chain(ba_r1s.iter()).map(|r| r.as_slice()).collect();
+        let y_raws: Vec<&RawRecord> = ab_r2s.iter().chain(ba_r1s.iter()).copied().collect();
         let y_sources: Vec<SourceRead> = y_raws
             .iter()
             .enumerate()
@@ -1912,28 +1903,28 @@ impl DuplexConsensusCaller {
         );
 
         // Extract raw records for tag extraction using original_idx to map back
-        let filtered_ab_r1_raws: Vec<&[u8]> = filtered_ab_r1s
+        let filtered_ab_r1_raws: Vec<&RawRecord> = filtered_ab_r1s
             .iter()
             .map(|sr| {
                 debug_assert!(sr.original_idx < x_raws.len());
                 x_raws[sr.original_idx]
             })
             .collect();
-        let filtered_ba_r2_raws: Vec<&[u8]> = filtered_ba_r2s
+        let filtered_ba_r2_raws: Vec<&RawRecord> = filtered_ba_r2s
             .iter()
             .map(|sr| {
                 debug_assert!(sr.original_idx < x_raws.len());
                 x_raws[sr.original_idx]
             })
             .collect();
-        let filtered_ab_r2_raws: Vec<&[u8]> = filtered_ab_r2s
+        let filtered_ab_r2_raws: Vec<&RawRecord> = filtered_ab_r2s
             .iter()
             .map(|sr| {
                 debug_assert!(sr.original_idx < y_raws.len());
                 y_raws[sr.original_idx]
             })
             .collect();
-        let filtered_ba_r1_raws: Vec<&[u8]> = filtered_ba_r1s
+        let filtered_ba_r1_raws: Vec<&RawRecord> = filtered_ba_r1s
             .iter()
             .map(|sr| {
                 debug_assert!(sr.original_idx < y_raws.len());
@@ -2103,7 +2094,7 @@ impl DuplexConsensusCaller {
                     let duplex_r2 = Self::duplex_consensus(Some(r2_a), None, None);
 
                     if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2) {
-                        let empty: &[&[u8]] = &[];
+                        let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
                             &mut output,
@@ -2150,7 +2141,7 @@ impl DuplexConsensusCaller {
                     let duplex_r2 = Self::duplex_consensus(Some(r2_b), None, None);
 
                     if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2) {
-                        let empty: &[&[u8]] = &[];
+                        let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
                             &mut output,
@@ -2204,7 +2195,7 @@ impl DuplexConsensusCaller {
 }
 
 impl ConsensusCaller for DuplexConsensusCaller {
-    fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
+    fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
         self.stats.record_input(records.len());
 
         // Partition records by strand using raw byte-level operations.
@@ -2285,12 +2276,12 @@ mod tests {
     use fgumi_sam::builder::RecordBuilder;
     use noodles::sam::alignment::record_buf::data::field::Value;
 
-    fn encode_to_raw(rec: &noodles::sam::alignment::RecordBuf) -> Vec<u8> {
+    fn encode_to_raw(rec: &noodles::sam::alignment::RecordBuf) -> RawRecord {
         let header = noodles::sam::Header::default();
         let mut buf = Vec::new();
         crate::vendored::bam_codec::encode_record_buf(&mut buf, &header, rec)
             .expect("encode_record_buf should succeed");
-        buf
+        RawRecord::from(buf)
     }
 
     #[test]
@@ -4724,7 +4715,7 @@ mod tests {
         // has_minimum_number_of_reads only counts R1s (first segment of paired reads)
 
         // Create 3 AB R1 reads
-        let a_reads: Vec<Vec<u8>> = (0..3)
+        let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
                 encode_to_raw(
                     &RecordBuilder::new()
@@ -4737,7 +4728,7 @@ mod tests {
             .collect();
 
         // Create 2 BA R1 reads
-        let b_reads: Vec<Vec<u8>> = (0..2)
+        let b_reads: Vec<RawRecord> = (0..2)
             .map(|_| {
                 encode_to_raw(
                     &RecordBuilder::new()
@@ -4767,7 +4758,7 @@ mod tests {
         // Test asymmetric min_reads [D, M_AB, M_BA] configuration
 
         // Create 3 AB R1 reads
-        let a_reads: Vec<Vec<u8>> = (0..3)
+        let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
                 encode_to_raw(
                     &RecordBuilder::new()
@@ -4824,7 +4815,7 @@ mod tests {
             encode_to_raw(&RecordBuilder::new().sequence("ACGT").reverse_complement(true).build());
 
         // Empty collection
-        assert!(DuplexConsensusCaller::are_all_same_strand(std::iter::empty::<&Vec<u8>>()));
+        assert!(DuplexConsensusCaller::are_all_same_strand(std::iter::empty::<&RawRecord>()));
 
         // All forward
         assert!(DuplexConsensusCaller::are_all_same_strand([&fwd_raw, &fwd_raw].into_iter()));
@@ -5166,7 +5157,7 @@ mod tests {
         assert!(!DuplexConsensusCaller::are_all_same_strand([&fwd_raw, &rev_raw].into_iter()));
 
         // Empty - should return true
-        assert!(DuplexConsensusCaller::are_all_same_strand(std::iter::empty::<&Vec<u8>>()));
+        assert!(DuplexConsensusCaller::are_all_same_strand(std::iter::empty::<&RawRecord>()));
 
         // Single record
         assert!(DuplexConsensusCaller::are_all_same_strand([&fwd_raw].into_iter()));
@@ -5476,13 +5467,13 @@ mod tests {
     #[test]
     fn test_has_minimum_number_of_reads_basic() {
         // Create mock reads with paired + first segment flags for R1 counting
-        let a_reads: Vec<Vec<u8>> = (0..3)
+        let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
                 encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
             })
             .collect();
 
-        let b_reads: Vec<Vec<u8>> = (0..3)
+        let b_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
                 encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
             })
@@ -5507,14 +5498,14 @@ mod tests {
     #[test]
     fn test_has_minimum_number_of_reads_empty_strand() {
         // Create 3 A reads
-        let a_reads: Vec<Vec<u8>> = (0..3)
+        let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
                 encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
             })
             .collect();
 
         // Empty B reads
-        let b_reads: Vec<Vec<u8>> = vec![];
+        let b_reads: Vec<RawRecord> = vec![];
 
         // XY = 3, YX = 0, total = 3
 
@@ -5530,6 +5521,60 @@ mod tests {
             &a_reads, &b_reads, 1, // min_total
             1, // min_xy
             1, // min_yx - requires at least 1
+        ));
+    }
+
+    #[test]
+    fn test_is_paired_r1_and_r2_predicates() {
+        // Paired R1: PAIRED | FIRST_SEGMENT.
+        let paired_r1 =
+            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build());
+        assert!(DuplexConsensusCaller::is_paired_r1(&paired_r1));
+        assert!(!DuplexConsensusCaller::is_paired_r2(&paired_r1));
+
+        // Paired R2: PAIRED | LAST_SEGMENT.
+        let paired_r2 =
+            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(false).build());
+        assert!(!DuplexConsensusCaller::is_paired_r1(&paired_r2));
+        assert!(DuplexConsensusCaller::is_paired_r2(&paired_r2));
+
+        // Unpaired fragment: neither PAIRED nor any segment bit. Must not be
+        // classified as R1 or R2 — this is the regression guarded by fix.
+        let fragment = encode_to_raw(&RecordBuilder::new().sequence("ACGT").build());
+        assert!(!DuplexConsensusCaller::is_paired_r1(&fragment));
+        assert!(!DuplexConsensusCaller::is_paired_r2(&fragment));
+    }
+
+    #[test]
+    fn test_has_minimum_number_of_reads_ignores_unpaired_fragments() {
+        // Three R1s plus two unpaired fragments on the A strand: fragments
+        // must not contribute to the R1 count.
+        let a_r1s: Vec<RawRecord> = (0..3)
+            .map(|_| {
+                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
+            })
+            .collect();
+        let a_fragments: Vec<RawRecord> =
+            (0..2).map(|_| encode_to_raw(&RecordBuilder::new().sequence("ACGT").build())).collect();
+        let a_reads: Vec<RawRecord> = a_r1s.into_iter().chain(a_fragments).collect();
+
+        let b_reads: Vec<RawRecord> = (0..3)
+            .map(|_| {
+                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
+            })
+            .collect();
+
+        // With fragments excluded: total R1s = 3 + 3 = 6 -> passes min_total=6.
+        assert!(DuplexConsensusCaller::has_minimum_number_of_reads(
+            &a_reads, &b_reads, 6, // min_total
+            3, // min_xy
+            3, // min_yx
+        ));
+        // min_total=7 would only pass if fragments were counted -> must fail.
+        assert!(!DuplexConsensusCaller::has_minimum_number_of_reads(
+            &a_reads, &b_reads, 7, // min_total
+            3, // min_xy
+            3, // min_yx
         ));
     }
 

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -5,13 +5,12 @@
 
 use ahash::AHashMap;
 use anyhow::Result;
-use noodles::sam::alignment::record::Sequence as SequenceTrait;
-use noodles::sam::alignment::record_buf::data::field::Value;
-use noodles::sam::alignment::record_buf::{QualityScores, RecordBuf, Sequence};
+use noodles::sam::alignment::record::cigar::op::Kind;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE};
-use crate::tags::{per_base, per_read};
 use fgumi_metrics::rejection::RejectionReason;
+use fgumi_raw_bam as bam_fields;
+use fgumi_raw_bam::RawRecordView;
 
 /// Expands a 1-3 element slice to a 3-element array, filling missing values from the last.
 ///
@@ -364,488 +363,11 @@ impl FilterResult {
         }
     }
 }
-
-/// Helper function to extract integer value from SAM tag, handling different integer types
-fn extract_int_tag(data: &noodles::sam::alignment::record_buf::Data, tag_str: &str) -> Option<i32> {
-    let tag = per_read::tag(tag_str);
-    match data.get(&tag)? {
-        Value::Int8(v) => Some(i32::from(*v)),
-        Value::UInt8(v) => Some(i32::from(*v)),
-        Value::Int16(v) => Some(i32::from(*v)),
-        Value::UInt16(v) => Some(i32::from(*v)),
-        Value::Int32(v) => Some(*v),
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "BAM tag values in practice never exceed i32::MAX"
-        )]
-        Value::UInt32(v) => Some(*v as i32),
-        _ => None,
-    }
-}
-
-/// Helper function to extract float value from SAM tag
-fn extract_float_tag(
-    data: &noodles::sam::alignment::record_buf::Data,
-    tag_str: &str,
-) -> Option<f32> {
-    let tag = per_read::tag(tag_str);
-    match data.get(&tag)? {
-        Value::Float(v) => Some(*v),
-        _ => None,
-    }
-}
-
-/// Filters a consensus read based on per-read tags
-///
-/// For duplex reads, also checks AB and BA strand tags independently.
-///
-/// # Arguments
-/// * `record` - The consensus read to filter
-/// * `thresholds` - The filter thresholds to apply
-/// * `ab_thresholds` - Optional thresholds for AB strand (duplex only)
-/// * `ba_thresholds` - Optional thresholds for BA strand (duplex only)
-///
-/// # Returns
-/// `FilterResult` indicating whether the read passed or why it failed
-///
-/// # Errors
-///
-/// Returns an error if the record data cannot be read.
-pub fn filter_read(record: &RecordBuf, thresholds: &FilterThresholds) -> Result<FilterResult> {
-    // Check minimum reads (cD tag)
-    let depth_tag = per_read::tag("cD");
-    if let Some(Value::UInt8(depth)) = record.data().get(&depth_tag) {
-        if (*depth as usize) < thresholds.min_reads {
-            return Ok(FilterResult::InsufficientReads);
-        }
-    }
-
-    // Check maximum error rate (cE tag)
-    // Note: Promote f32 to f64 for comparison (matching fgbio's Float->Double promotion)
-    let error_tag = per_read::tag("cE");
-    if let Some(Value::Float(error_rate)) = record.data().get(&error_tag) {
-        if f64::from(*error_rate) > thresholds.max_read_error_rate {
-            return Ok(FilterResult::ExcessiveErrorRate);
-        }
-    }
-
-    Ok(FilterResult::Pass)
-}
-
-/// Filters a duplex consensus read based on per-read tags, checking both AB and BA strands
-///
-/// # Arguments
-/// * `record` - The consensus read to filter
-/// * `cc_thresholds` - Thresholds for final consensus
-/// * `ab_thresholds` - Thresholds for AB strand
-/// * `ba_thresholds` - Thresholds for BA strand
-///
-/// # Returns
-/// `FilterResult` indicating whether the read passed or why it failed
-///
-/// # Errors
-///
-/// Returns an error if the record data cannot be read.
-pub fn filter_duplex_read(
-    record: &RecordBuf,
-    cc_thresholds: &FilterThresholds,
-    ab_thresholds: &FilterThresholds,
-    ba_thresholds: &FilterThresholds,
-) -> Result<FilterResult> {
-    let data = record.data();
-
-    // First check final consensus thresholds
-    let result = filter_read(record, cc_thresholds)?;
-    if result != FilterResult::Pass {
-        return Ok(result);
-    }
-
-    // Extract AB and BA depths and error rates
-    let ab_depth = extract_int_tag(data, "aD").or_else(|| extract_int_tag(data, "aM"));
-    let ba_depth = extract_int_tag(data, "bD").or_else(|| extract_int_tag(data, "bM"));
-    let ab_error = extract_float_tag(data, "aE");
-    let ba_error = extract_float_tag(data, "bE");
-
-    // Sort depths and errors to identify which is AB (higher) and BA (lower)
-    // Following Scala: val Seq(baMaxDepth, abMaxDepth) = Seq(...).sorted
-    let (min_depth, max_depth) = match (ab_depth, ba_depth) {
-        (Some(a), Some(b)) => {
-            if a < b {
-                (a, b)
-            } else {
-                (b, a)
-            }
-        }
-        (Some(a), None) => (0, a),
-        (None, Some(b)) => (0, b),
-        (None, None) => return Ok(FilterResult::Pass), // No AB/BA tags, not duplex
-    };
-
-    let (min_error, max_error) = match (ab_error, ba_error) {
-        (Some(a), Some(b)) => {
-            if a < b {
-                (a, b)
-            } else {
-                (b, a)
-            }
-        }
-        (Some(a), None) => (a, a),
-        (None, Some(b)) => (b, b),
-        (None, None) => (0.0, 0.0),
-    };
-
-    // Check AB strand (max depth, min error) against AB thresholds
-    // Note: Promote f32 to f64 for comparison (matching fgbio's Float->Double promotion)
-    #[expect(clippy::cast_sign_loss, reason = "depth values are non-negative in BAM tags")]
-    if (max_depth as usize) < ab_thresholds.min_reads {
-        return Ok(FilterResult::InsufficientReads);
-    }
-    if f64::from(min_error) > ab_thresholds.max_read_error_rate {
-        return Ok(FilterResult::ExcessiveErrorRate);
-    }
-
-    // Check BA strand (min depth, max error) against BA thresholds
-    #[expect(clippy::cast_sign_loss, reason = "depth values are non-negative in BAM tags")]
-    if (min_depth as usize) < ba_thresholds.min_reads {
-        return Ok(FilterResult::InsufficientReads);
-    }
-    if f64::from(max_error) > ba_thresholds.max_read_error_rate {
-        return Ok(FilterResult::ExcessiveErrorRate);
-    }
-
-    Ok(FilterResult::Pass)
-}
-
-/// Helper to extract per-base array tag
-fn extract_per_base_array(
-    data: &noodles::sam::alignment::record_buf::Data,
-    tag_str: &str,
-    len: usize,
-) -> Vec<u16> {
-    let tag = per_base::tag(tag_str);
-    if let Some(Value::Array(arr)) = data.get(&tag) {
-        use noodles::sam::alignment::record_buf::data::field::value::Array;
-        match arr {
-            #[expect(clippy::cast_sign_loss, reason = "clamped to non-negative via .max(0)")]
-            Array::Int16(values) => values.iter().map(|&v| v.max(0) as u16).collect(),
-            Array::UInt16(values) => values.clone(),
-            Array::UInt8(values) => values.iter().map(|&v| u16::from(v)).collect(),
-            _ => vec![0; len],
-        }
-    } else {
-        vec![0; len]
-    }
-}
-
-/// Helper to extract consensus base string tag (ac/bc) for single-strand agreement checking
-fn extract_consensus_bases(
-    data: &noodles::sam::alignment::record_buf::Data,
-    tag_str: &str,
-    len: usize,
-) -> Vec<u8> {
-    let tag = per_base::tag(tag_str);
-    if let Some(value) = data.get(&tag) {
-        match value {
-            Value::String(s) => {
-                let bytes: &[u8] = s.as_ref();
-                bytes.to_vec()
-            }
-            Value::Array(arr) => {
-                use noodles::sam::alignment::record_buf::data::field::value::Array;
-                match arr {
-                    Array::UInt8(bytes) => bytes.clone(),
-                    _ => vec![NO_CALL_BASE; len],
-                }
-            }
-            _ => vec![NO_CALL_BASE; len],
-        }
-    } else {
-        vec![NO_CALL_BASE; len]
-    }
-}
-
-/// Masks bases in a consensus read based on per-base tags and thresholds
-///
-/// # Arguments
-/// * `record` - The consensus read to mask (will be modified in place)
-/// * `thresholds` - The filter thresholds to apply
-/// * `min_base_quality` - Minimum base quality to keep (None means no quality masking)
-///
-/// # Returns
-/// Number of bases masked
-///
-/// # Errors
-///
-/// Returns an error if the record data cannot be read or modified.
-pub fn mask_bases(
-    record: &mut RecordBuf,
-    thresholds: &FilterThresholds,
-    min_base_quality: Option<u8>,
-) -> Result<usize> {
-    // Collect sequence and quality scores directly into mutable vectors (no clone needed)
-    let mut new_seq: Vec<u8> = record.sequence().iter().collect();
-    let mut new_quals: Vec<u8> = record.quality_scores().iter().collect();
-    let mut masked_count = 0;
-    let len = new_seq.len();
-
-    // Get per-base depth and error counts using helper
-    let data = record.data();
-    let depths = extract_per_base_array(data, "cd", len);
-    let errors = extract_per_base_array(data, "ce", len);
-
-    // Mask bases that don't meet thresholds
-    for i in 0..len {
-        let should_mask =
-            // Quality too low (only check if min_base_quality is specified)
-            min_base_quality.is_some_and(|min_qual| new_quals[i] < min_qual) ||
-            // Depth too low
-            (depths[i] as usize) < thresholds.min_reads ||
-            // Error rate too high
-            (depths[i] > 0 && (f64::from(errors[i]) / f64::from(depths[i])) > thresholds.max_base_error_rate);
-
-        if should_mask {
-            // Only count as newly masked if not already N
-            if new_seq[i] != NO_CALL_BASE {
-                masked_count += 1;
-            }
-            new_seq[i] = NO_CALL_BASE;
-            new_quals[i] = MIN_PHRED;
-        }
-    }
-
-    // Update the record with masked bases
-    *record.sequence_mut() = Sequence::from(new_seq);
-    *record.quality_scores_mut() = QualityScores::from(new_quals);
-
-    Ok(masked_count)
-}
-
-/// Masks bases in a duplex consensus read based on per-base AB/BA tags and thresholds
-///
-/// This function implements the duplex per-base filtering logic from FilterConsensusReads.scala
-/// (DuplexConsensusPerBaseValues.maskBaseAt, lines 422-435).
-///
-/// For each base position, checks:
-/// - Total depth (AB + BA) against `cc_thresholds`
-/// - Total error rate against `cc_thresholds`
-/// - AB depth (max of two strands) against `ab_thresholds`
-/// - AB error rate (min of two strands) against `ab_thresholds`
-/// - BA depth (min of two strands) against `ba_thresholds`
-/// - BA error rate (max of two strands) against `ba_thresholds`
-/// - Optionally, single-strand agreement
-///
-/// # Arguments
-/// * `record` - The consensus read to mask (will be modified in place)
-/// * `cc_thresholds` - Filter thresholds for final consensus
-/// * `ab_thresholds` - Filter thresholds for AB strand
-/// * `ba_thresholds` - Filter thresholds for BA strand
-/// * `min_base_quality` - Minimum base quality to keep (None means no quality masking)
-/// * `require_ss_agreement` - If true, mask bases where AB and BA disagree
-///
-/// # Returns
-/// Number of bases masked
-///
-/// # Errors
-///
-/// Returns an error if the record data cannot be read or modified.
-pub fn mask_duplex_bases(
-    record: &mut RecordBuf,
-    cc_thresholds: &FilterThresholds,
-    ab_thresholds: &FilterThresholds,
-    ba_thresholds: &FilterThresholds,
-    min_base_quality: Option<u8>,
-    require_ss_agreement: bool,
-) -> Result<usize> {
-    // Collect sequence and quality scores directly into mutable vectors (no clone needed)
-    let mut new_seq: Vec<u8> = record.sequence().iter().collect();
-    let mut new_quals: Vec<u8> = record.quality_scores().iter().collect();
-    let len = new_seq.len();
-    let mut masked_count = 0;
-
-    let data = record.data();
-
-    // Extract AB per-base tags (ad, ae)
-    let ab_depths = extract_per_base_array(data, "ad", len);
-    let ab_errors = extract_per_base_array(data, "ae", len);
-
-    // Extract BA per-base tags (bd, be)
-    let ba_depths = extract_per_base_array(data, "bd", len);
-    let ba_errors = extract_per_base_array(data, "be", len);
-
-    // Extract consensus bases for single-strand agreement checking (ac, bc)
-    let ab_bases = if require_ss_agreement {
-        extract_consensus_bases(data, "ac", len)
-    } else {
-        vec![NO_CALL_BASE; len]
-    };
-    let ba_bases = if require_ss_agreement {
-        extract_consensus_bases(data, "bc", len)
-    } else {
-        vec![NO_CALL_BASE; len]
-    };
-
-    // Mask bases that don't meet thresholds
-    for i in 0..len {
-        if new_seq[i] == NO_CALL_BASE {
-            continue;
-        }
-
-        // Following Scala's maskBaseAt logic (lines 422-435)
-        let ab_depth_i = ab_depths[i];
-        let ba_depth_i = ba_depths[i];
-        let ab_error_i = ab_errors[i];
-        let ba_error_i = ba_errors[i];
-
-        // Sort to get max/min depths and errors
-        let max_depth = std::cmp::max(ab_depth_i, ba_depth_i);
-        let min_depth = std::cmp::min(ab_depth_i, ba_depth_i);
-
-        // For error rates, we need to calculate them first, then sort
-        let ab_error_rate =
-            if ab_depth_i > 0 { f64::from(ab_error_i) / f64::from(ab_depth_i) } else { 0.0 };
-        let ba_error_rate =
-            if ba_depth_i > 0 { f64::from(ba_error_i) / f64::from(ba_depth_i) } else { 0.0 };
-
-        let min_error_rate = ab_error_rate.min(ba_error_rate);
-        let max_error_rate = ab_error_rate.max(ba_error_rate);
-
-        // Total depth and error for final consensus check
-        let total_depth = ab_depth_i + ba_depth_i;
-        let total_error_rate = if total_depth > 0 {
-            f64::from(ab_error_i + ba_error_i) / f64::from(total_depth)
-        } else {
-            0.0
-        };
-
-        // Check if base should be masked
-        let should_mask = min_base_quality.is_some_and(|min_qual| new_quals[i] < min_qual)
-            || (total_depth as usize) < cc_thresholds.min_reads
-            || total_error_rate > cc_thresholds.max_base_error_rate
-            || (max_depth as usize) < ab_thresholds.min_reads
-            || min_error_rate > ab_thresholds.max_base_error_rate
-            || (min_depth as usize) < ba_thresholds.min_reads
-            || max_error_rate > ba_thresholds.max_base_error_rate;
-
-        // Check single-strand agreement if requested
-        let ss_disagree =
-            require_ss_agreement && ab_depth_i > 0 && ba_depth_i > 0 && ab_bases[i] != ba_bases[i];
-
-        if should_mask || ss_disagree {
-            // Only count as newly masked if not already N
-            if new_seq[i] != NO_CALL_BASE {
-                masked_count += 1;
-            }
-            new_seq[i] = NO_CALL_BASE;
-            new_quals[i] = MIN_PHRED;
-        }
-    }
-
-    // Update the record with masked bases
-    *record.sequence_mut() = Sequence::from(new_seq);
-    *record.quality_scores_mut() = QualityScores::from(new_quals);
-
-    Ok(masked_count)
-}
-
-/// Counts the number of N bases in a read
-#[must_use]
-pub fn count_no_calls(record: &RecordBuf) -> usize {
-    record.sequence().iter().filter(|b| *b == NO_CALL_BASE).count()
-}
-
-/// Calculates the mean base quality of non-N bases
-#[must_use]
-pub fn mean_base_quality(record: &RecordBuf) -> f64 {
-    // Use iterators directly to avoid allocating vectors
-    let (sum, count) = record
-        .sequence()
-        .iter()
-        .zip(record.quality_scores().iter())
-        .filter(|&(base, _)| base != NO_CALL_BASE)
-        .fold((0u64, 0usize), |(sum, count), (_, qual)| (sum + u64::from(qual), count + 1));
-
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "precision loss is acceptable for quality averaging"
-    )]
-    if count == 0 { 0.0 } else { sum as f64 / count as f64 }
-}
-
-/// Computes both no-call count and mean base quality in a single pass.
-///
-/// This is more efficient than calling `count_no_calls()` and `mean_base_quality()`
-/// separately when both values are needed, as it only iterates over the sequence once.
-///
-/// # Returns
-/// A tuple of (`no_call_count`, `mean_base_quality`)
-#[must_use]
-pub fn compute_read_stats(record: &RecordBuf) -> (usize, f64) {
-    let (qual_sum, non_n_count, n_count) = record
-        .sequence()
-        .iter()
-        .zip(record.quality_scores().iter())
-        .fold((0u64, 0usize, 0usize), |(sum, non_n, n), (base, qual)| {
-            if base == NO_CALL_BASE {
-                (sum, non_n, n + 1)
-            } else {
-                (sum + u64::from(qual), non_n + 1, n)
-            }
-        });
-
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "precision loss is acceptable for quality averaging"
-    )]
-    let mean_qual = if non_n_count == 0 { 0.0 } else { qual_sum as f64 / non_n_count as f64 };
-    (n_count, mean_qual)
-}
-
-/// Checks if all reads in a template pass filtering
-///
-/// For template-aware filtering, all primary reads (R1/R2) must pass for the template to pass.
-/// Secondary and supplementary alignments are allowed to fail independently.
-///
-/// # Arguments
-/// * `template_records` - All records with the same read name
-/// * `pass_map` - Map of record index to pass/fail status
-///
-/// # Returns
-/// true if all primary reads pass, false otherwise
-#[must_use]
-pub fn template_passes(template_records: &[RecordBuf], pass_map: &AHashMap<usize, bool>) -> bool {
-    // Find primary reads (non-secondary, non-supplementary)
-    let mut has_primary = false;
-    let mut all_primary_pass = true;
-
-    for (idx, record) in template_records.iter().enumerate() {
-        let flags = record.flags();
-        let is_primary = !flags.is_secondary() && !flags.is_supplementary();
-
-        if is_primary {
-            has_primary = true;
-            if let Some(&passes) = pass_map.get(&idx) {
-                if !passes {
-                    all_primary_pass = false;
-                    break;
-                }
-            } else {
-                // If not in map, assume it failed
-                all_primary_pass = false;
-                break;
-            }
-        }
-    }
-
-    // If no primary reads found, template fails
-    // If all primary reads pass, template passes
-    has_primary && all_primary_pass
-}
-
 /// Checks whether all primary raw records in a template pass their filters.
 ///
 /// A template passes if it has at least one primary read and all primary reads pass.
 #[must_use]
-pub fn template_passes_raw(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, bool>) -> bool {
+pub fn template_passes(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, bool>) -> bool {
     let mut has_primary = false;
     let mut all_primary_pass = true;
 
@@ -870,31 +392,6 @@ pub fn template_passes_raw(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, b
 
     has_primary && all_primary_pass
 }
-
-/// Detects if a record is part of a duplex consensus
-///
-/// Checks for presence of AB/BA specific tags (aD, bD)
-///
-/// # Arguments
-/// * `record` - The record to check
-///
-/// # Returns
-/// true if duplex tags are present, false otherwise
-#[must_use]
-pub fn is_duplex_consensus(record: &RecordBuf) -> bool {
-    let ad_tag = per_read::tag("aD");
-    let bd_tag = per_read::tag("bD");
-
-    record.data().get(&ad_tag).is_some() || record.data().get(&bd_tag).is_some()
-}
-
-// ============================================================================
-// Raw-byte equivalents (operate on &[u8] / &mut Vec<u8>)
-// ============================================================================
-
-use fgumi_raw_bam::{self as bam_fields, RawRecordView};
-use noodles::sam::alignment::record::cigar::op::Kind;
-
 /// Pre-parsed methylation aux tags from a raw BAM record.
 ///
 /// Avoids repeated linear scans of the aux block when multiple filters
@@ -943,7 +440,7 @@ impl MethylationTags {
 ///
 /// Checks for presence of `aD` or `bD` tags in the aux data.
 #[must_use]
-pub fn is_duplex_consensus_raw(aux_data: &[u8]) -> bool {
+pub fn is_duplex_consensus(aux_data: &[u8]) -> bool {
     bam_fields::find_tag_type(aux_data, b"aD").is_some()
         || bam_fields::find_tag_type(aux_data, b"bD").is_some()
 }
@@ -953,10 +450,11 @@ pub fn is_duplex_consensus_raw(aux_data: &[u8]) -> bool {
 /// # Errors
 ///
 /// Returns an error if the aux data cannot be parsed.
-pub fn filter_read_raw(aux_data: &[u8], thresholds: &FilterThresholds) -> Result<FilterResult> {
-    // Check minimum reads (cD tag — UInt8)
-    if let Some(depth) = bam_fields::find_uint8_tag(aux_data, b"cD") {
-        if (depth as usize) < thresholds.min_reads {
+pub fn filter_read(aux_data: &[u8], thresholds: &FilterThresholds) -> Result<FilterResult> {
+    // Check minimum reads (cD tag — any integer type)
+    if let Some(depth) = bam_fields::find_int_tag(aux_data, b"cD") {
+        let min_reads = i64::try_from(thresholds.min_reads).unwrap_or(i64::MAX);
+        if depth < min_reads {
             return Ok(FilterResult::InsufficientReads);
         }
     }
@@ -976,14 +474,14 @@ pub fn filter_read_raw(aux_data: &[u8], thresholds: &FilterThresholds) -> Result
 /// # Errors
 ///
 /// Returns an error if the aux data cannot be parsed.
-pub fn filter_duplex_read_raw(
+pub fn filter_duplex_read(
     aux_data: &[u8],
     cc_thresholds: &FilterThresholds,
     ab_thresholds: &FilterThresholds,
     ba_thresholds: &FilterThresholds,
 ) -> Result<FilterResult> {
     // First check final consensus thresholds
-    let result = filter_read_raw(aux_data, cc_thresholds)?;
+    let result = filter_read(aux_data, cc_thresholds)?;
     if result != FilterResult::Pass {
         return Ok(result);
     }
@@ -1059,7 +557,7 @@ pub fn filter_duplex_read_raw(
 /// # Panics
 /// Panics if the record is shorter than `MIN_BAM_RECORD_LEN` (36 bytes).
 #[must_use]
-pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
+pub fn compute_read_stats(bam: &[u8]) -> (usize, f64) {
     assert!(bam.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
     let seq_off = bam_fields::seq_offset(bam);
     let qual_off = bam_fields::qual_offset(bam);
@@ -1084,6 +582,32 @@ pub fn compute_read_stats_raw(bam: &[u8]) -> (usize, f64) {
     )]
     let mean_qual = if non_n_count == 0 { 0.0 } else { qual_sum as f64 / non_n_count as f64 };
     (n_count, mean_qual)
+}
+
+/// Counts the number of N bases in a raw BAM record.
+///
+/// This is a thin wrapper around [`compute_read_stats`] for callers that only need the
+/// no-call count.  When both the count and mean quality are needed, prefer calling
+/// [`compute_read_stats`] directly to avoid a second pass.
+///
+/// # Panics
+/// Panics if the record is shorter than `MIN_BAM_RECORD_LEN` (36 bytes).
+#[must_use]
+pub fn count_no_calls(bam: &[u8]) -> usize {
+    compute_read_stats(bam).0
+}
+
+/// Calculates the mean base quality of non-N bases in a raw BAM record.
+///
+/// This is a thin wrapper around [`compute_read_stats`] for callers that only need the
+/// mean quality.  When both values are needed, prefer calling [`compute_read_stats`]
+/// directly to avoid a second pass.
+///
+/// # Panics
+/// Panics if the record is shorter than `MIN_BAM_RECORD_LEN` (36 bytes).
+#[must_use]
+pub fn mean_base_quality(bam: &[u8]) -> f64 {
+    compute_read_stats(bam).1
 }
 
 /// Reads a tag value as either a Z-type string or a B-type `UInt8` array.
@@ -1118,7 +642,7 @@ fn find_string_or_uint8_array(aux_data: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> 
     clippy::similar_names,
     reason = "threshold variable names mirror the consensus tag names they check"
 )]
-pub fn mask_bases_raw(
+pub fn mask_bases(
     record: &mut [u8],
     thresholds: &FilterThresholds,
     min_base_quality: Option<u8>,
@@ -1170,7 +694,7 @@ pub fn mask_bases_raw(
     clippy::similar_names,
     reason = "threshold variable names mirror the duplex strand tag names"
 )]
-pub fn mask_duplex_bases_raw(
+pub fn mask_duplex_bases(
     record: &mut [u8],
     cc_thresholds: &FilterThresholds,
     ab_thresholds: &FilterThresholds,
@@ -1685,12 +1209,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
 mod tests {
     use super::*;
     use fgumi_sam::builder::RecordBuilder;
-    use noodles::sam::alignment::record::data::field::Tag;
-
-    fn create_test_record() -> RecordBuf {
-        // Uses RecordBuilder which auto-generates Q30 qualities
-        RecordBuilder::new().sequence("ACGTACGT").build()
-    }
+    use noodles::sam::alignment::record_buf::RecordBuf;
 
     #[test]
     fn test_filter_result_to_rejection_reason() {
@@ -1885,867 +1404,6 @@ mod tests {
     }
 
     #[test]
-    fn test_count_no_calls() {
-        let mut record = create_test_record();
-        *record.sequence_mut() = Sequence::from(b"ACNNGCNN".to_vec());
-
-        assert_eq!(count_no_calls(&record), 4);
-    }
-
-    #[test]
-    fn test_mean_base_quality() {
-        let mut record = create_test_record();
-        *record.quality_scores_mut() = QualityScores::from(vec![10, 20, 30, 40, 10, 20, 30, 40]);
-
-        let mean = mean_base_quality(&record);
-        assert!((mean - 25.0).abs() < f64::EPSILON); // (10+20+30+40+10+20+30+40) / 8 = 200/8 = 25
-    }
-
-    #[test]
-    fn test_mean_base_quality_with_n() {
-        let mut record = create_test_record();
-        *record.sequence_mut() = Sequence::from(b"ACNNACGT".to_vec());
-        *record.quality_scores_mut() = QualityScores::from(vec![10, 20, 0, 0, 30, 40, 10, 20]);
-
-        let mean = mean_base_quality(&record);
-        // Only non-N bases: 10+20+30+40+10+20 = 130 / 6 = 21.666...
-        assert!((mean - 21.666).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_compute_read_stats() {
-        let mut record = create_test_record();
-        *record.sequence_mut() = Sequence::from(b"ACNNACGT".to_vec());
-        *record.quality_scores_mut() = QualityScores::from(vec![10, 20, 0, 0, 30, 40, 10, 20]);
-
-        let (n_count, mean_qual) = compute_read_stats(&record);
-
-        // Should match individual functions
-        assert_eq!(n_count, count_no_calls(&record));
-        assert!((mean_qual - mean_base_quality(&record)).abs() < f64::EPSILON);
-
-        // Verify expected values: 2 Ns, mean of non-N quals = 130/6 = 21.666...
-        assert_eq!(n_count, 2);
-        assert!((mean_qual - 21.666).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_compute_read_stats_all_n() {
-        let mut record = create_test_record();
-        *record.sequence_mut() = Sequence::from(b"NNNNNNNN".to_vec());
-        *record.quality_scores_mut() = QualityScores::from(vec![0; 8]);
-
-        let (n_count, mean_qual) = compute_read_stats(&record);
-
-        assert_eq!(n_count, 8);
-        assert!((mean_qual - 0.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_compute_read_stats_no_n() {
-        let mut record = create_test_record();
-        *record.quality_scores_mut() = QualityScores::from(vec![30, 30, 30, 30, 30, 30, 30, 30]);
-
-        let (n_count, mean_qual) = compute_read_stats(&record);
-
-        assert_eq!(n_count, 0);
-        assert!((mean_qual - 30.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_filter_result() {
-        let thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-
-        let mut record = create_test_record();
-
-        // Add cD tag with sufficient depth
-        let tag = Tag::from([b'c', b'D']);
-        record.data_mut().insert(tag, Value::UInt8(5));
-
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
-        assert_eq!(result, FilterResult::Pass);
-    }
-
-    #[test]
-    fn test_filter_insufficient_reads() {
-        let thresholds =
-            FilterThresholds { min_reads: 10, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-
-        let mut record = create_test_record();
-
-        // Add cD tag with insufficient depth
-        let tag = Tag::from([b'c', b'D']);
-        record.data_mut().insert(tag, Value::UInt8(5));
-
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
-        assert_eq!(result, FilterResult::InsufficientReads);
-    }
-
-    #[test]
-    fn test_template_passes_all_pass() {
-        use noodles::sam::alignment::record::Flags;
-
-        let mut rec1 = create_test_record();
-        *rec1.flags_mut() = Flags::SEGMENTED | Flags::FIRST_SEGMENT;
-
-        let mut rec2 = create_test_record();
-        *rec2.flags_mut() = Flags::SEGMENTED | Flags::LAST_SEGMENT;
-
-        let records = vec![rec1, rec2];
-        let mut pass_map = AHashMap::new();
-        pass_map.insert(0, true);
-        pass_map.insert(1, true);
-
-        assert!(template_passes(&records, &pass_map));
-    }
-
-    #[test]
-    fn test_template_passes_one_fails() {
-        use noodles::sam::alignment::record::Flags;
-
-        let mut rec1 = create_test_record();
-        *rec1.flags_mut() = Flags::SEGMENTED | Flags::FIRST_SEGMENT;
-
-        let mut rec2 = create_test_record();
-        *rec2.flags_mut() = Flags::SEGMENTED | Flags::LAST_SEGMENT;
-
-        let records = vec![rec1, rec2];
-        let mut pass_map = AHashMap::new();
-        pass_map.insert(0, true);
-        pass_map.insert(1, false); // R2 fails
-
-        assert!(!template_passes(&records, &pass_map));
-    }
-
-    #[test]
-    fn test_template_passes_secondary_ignored() {
-        use noodles::sam::alignment::record::Flags;
-
-        let mut rec1 = create_test_record();
-        *rec1.flags_mut() = Flags::SEGMENTED | Flags::FIRST_SEGMENT;
-
-        let mut rec2 = create_test_record();
-        *rec2.flags_mut() = Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY;
-
-        let records = vec![rec1, rec2];
-        let mut pass_map = AHashMap::new();
-        pass_map.insert(0, true); // Primary passes
-        pass_map.insert(1, false); // Secondary fails (but should be ignored)
-
-        assert!(template_passes(&records, &pass_map));
-    }
-
-    #[test]
-    fn test_is_duplex_consensus() {
-        let mut record = create_test_record();
-
-        // Not duplex initially
-        assert!(!is_duplex_consensus(&record));
-
-        // Add aD tag
-        let ad_tag = Tag::from([b'a', b'D']);
-        record.data_mut().insert(ad_tag, Value::UInt8(3));
-
-        // Now it's duplex
-        assert!(is_duplex_consensus(&record));
-    }
-
-    // ========== Tests for filter_duplex_read() ==========
-
-    #[test]
-    fn test_filter_duplex_read_pass() {
-        let mut record = create_test_record();
-
-        // Add final consensus tags (passing)
-        record.data_mut().insert(Tag::from([b'c', b'D']), Value::UInt8(10));
-        record.data_mut().insert(Tag::from([b'c', b'E']), Value::Float(0.01));
-
-        // Add AB/BA tags (both passing)
-        record.data_mut().insert(Tag::from([b'a', b'D']), Value::UInt8(6));
-        record.data_mut().insert(Tag::from([b'b', b'D']), Value::UInt8(4));
-        record.data_mut().insert(Tag::from([b'a', b'E']), Value::Float(0.01));
-        record.data_mut().insert(Tag::from([b'b', b'E']), Value::Float(0.02));
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.25 };
-
-        let result = filter_duplex_read(&record, &cc_thresholds, &ab_thresholds, &ba_thresholds)
-            .expect("filter_duplex_read should succeed");
-        assert_eq!(result, FilterResult::Pass);
-    }
-
-    #[test]
-    fn test_filter_duplex_read_insufficient_ab_reads() {
-        let mut record = create_test_record();
-
-        // Add final consensus tags (passing)
-        record.data_mut().insert(Tag::from([b'c', b'D']), Value::UInt8(10));
-        record.data_mut().insert(Tag::from([b'c', b'E']), Value::Float(0.01));
-
-        // Add AB/BA tags - AB has insufficient reads (max depth = 2 < ab_min_reads = 3)
-        record.data_mut().insert(Tag::from([b'a', b'D']), Value::UInt8(2));
-        record.data_mut().insert(Tag::from([b'b', b'D']), Value::UInt8(2));
-        record.data_mut().insert(Tag::from([b'a', b'E']), Value::Float(0.01));
-        record.data_mut().insert(Tag::from([b'b', b'E']), Value::Float(0.02));
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.25 };
-
-        let result = filter_duplex_read(&record, &cc_thresholds, &ab_thresholds, &ba_thresholds)
-            .expect("filter_duplex_read should succeed");
-        assert_eq!(result, FilterResult::InsufficientReads);
-    }
-
-    #[test]
-    fn test_filter_duplex_read_insufficient_ba_reads() {
-        let mut record = create_test_record();
-
-        // Add final consensus tags (passing)
-        record.data_mut().insert(Tag::from([b'c', b'D']), Value::UInt8(10));
-        record.data_mut().insert(Tag::from([b'c', b'E']), Value::Float(0.01));
-
-        // Add AB/BA tags - BA has insufficient reads (min depth = 1 < ba_min_reads = 2)
-        record.data_mut().insert(Tag::from([b'a', b'D']), Value::UInt8(5));
-        record.data_mut().insert(Tag::from([b'b', b'D']), Value::UInt8(1));
-        record.data_mut().insert(Tag::from([b'a', b'E']), Value::Float(0.01));
-        record.data_mut().insert(Tag::from([b'b', b'E']), Value::Float(0.02));
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.25 };
-
-        let result = filter_duplex_read(&record, &cc_thresholds, &ab_thresholds, &ba_thresholds)
-            .expect("filter_duplex_read should succeed");
-        assert_eq!(result, FilterResult::InsufficientReads);
-    }
-
-    #[test]
-    fn test_filter_duplex_read_consensus_fails_first() {
-        let mut record = create_test_record();
-
-        // Add final consensus tags (failing - insufficient reads)
-        record.data_mut().insert(Tag::from([b'c', b'D']), Value::UInt8(3));
-        record.data_mut().insert(Tag::from([b'c', b'E']), Value::Float(0.01));
-
-        // Add AB/BA tags (both would pass if checked)
-        record.data_mut().insert(Tag::from([b'a', b'D']), Value::UInt8(6));
-        record.data_mut().insert(Tag::from([b'b', b'D']), Value::UInt8(4));
-        record.data_mut().insert(Tag::from([b'a', b'E']), Value::Float(0.01));
-        record.data_mut().insert(Tag::from([b'b', b'E']), Value::Float(0.02));
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.25 };
-
-        let result = filter_duplex_read(&record, &cc_thresholds, &ab_thresholds, &ba_thresholds)
-            .expect("filter_duplex_read should succeed");
-        // Should fail on consensus check, not get to AB/BA checks
-        assert_eq!(result, FilterResult::InsufficientReads);
-    }
-
-    #[test]
-    fn test_filter_duplex_read_with_only_one_strand() {
-        let mut record = create_test_record();
-
-        // Add final consensus tags (passing)
-        record.data_mut().insert(Tag::from([b'c', b'D']), Value::UInt8(10));
-        record.data_mut().insert(Tag::from([b'c', b'E']), Value::Float(0.01));
-
-        // Add only AB tags (no BA)
-        record.data_mut().insert(Tag::from([b'a', b'D']), Value::UInt8(6));
-        record.data_mut().insert(Tag::from([b'a', b'E']), Value::Float(0.01));
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.25 };
-
-        let result = filter_duplex_read(&record, &cc_thresholds, &ab_thresholds, &ba_thresholds)
-            .expect("filter_duplex_read should succeed");
-        // Should fail because BA has 0 reads (< ba_min_reads = 2)
-        assert_eq!(result, FilterResult::InsufficientReads);
-    }
-
-    // ========== Tests for mask_duplex_bases() ==========
-
-    fn create_duplex_record_with_per_base_tags() -> RecordBuf {
-        let mut record = create_test_record();
-
-        // Add final consensus per-base tags (all bases have good depth and low error)
-        // Total depth = 10, total errors = 1, error rate = 1/10 = 0.1
-        record.data_mut().insert(
-            Tag::from([b'c', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![10, 10, 10, 10, 10, 10, 10, 10],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'c', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![1, 1, 1, 1, 1, 1, 1, 1], // 1 error out of 10 = 0.1 error rate
-            )),
-        );
-
-        // Add AB per-base tags (higher depth, lower error rate)
-        // AB depth = 6, AB errors = 0, error rate = 0/6 = 0.0
-        record.data_mut().insert(
-            Tag::from([b'a', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![6, 6, 6, 6, 6, 6, 6, 6],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'a', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![0, 0, 0, 0, 0, 0, 0, 0], // 0 errors out of 6 = 0.0 error rate
-            )),
-        );
-
-        // Add BA per-base tags (lower depth, higher error rate)
-        // BA depth = 4, BA errors = 1, error rate = 1/4 = 0.25
-        record.data_mut().insert(
-            Tag::from([b'b', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![4, 4, 4, 4, 4, 4, 4, 4],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![1, 1, 1, 1, 1, 1, 1, 1], // 1 error out of 4 = 0.25 error rate
-            )),
-        );
-
-        record
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_all_pass() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // All bases should pass - no Ns
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_low_ab_depth() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify AB depth at position 2 to be too low
-        record.data_mut().insert(
-            Tag::from([b'a', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![6, 6, 2, 6, 6, 6, 6, 6], // Position 2 has low AB depth
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Position 2 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACNTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_low_ba_depth() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify BA depth at positions 3 and 4 to be too low
-        record.data_mut().insert(
-            Tag::from([b'b', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![4, 4, 4, 1, 1, 4, 4, 4], // Positions 3,4 have low BA depth
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Positions 3,4 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGNNCGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_high_ab_error() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify AB error at position 5 to be too high
-        // AB depth = 6, set error = 2, error rate = 2/6 = 0.33 > 0.25 threshold
-        record.data_mut().insert(
-            Tag::from([b'a', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![0, 0, 0, 0, 0, 2, 0, 0], // Position 5 has 2 errors: 2/6 = 0.33 > 0.25
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Position 5 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGTANGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_high_ba_error() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify BA error at positions 6 and 7 to be too high
-        // BA depth = 4, set error = 2, error rate = 2/4 = 0.5 > 0.3 threshold
-        record.data_mut().insert(
-            Tag::from([b'b', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![1, 1, 1, 1, 1, 1, 2, 2], // Positions 6,7 have 2 errors: 2/4 = 0.5 > 0.3
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Positions 6,7 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGTACNN");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_low_total_depth() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify AB and BA depth at position 1 to make total depth too low
-        // AB depth = 2, BA depth = 1, total = 3 < 5 threshold
-        record.data_mut().insert(
-            Tag::from([b'a', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![6, 2, 6, 6, 6, 6, 6, 6],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![4, 1, 4, 4, 4, 4, 4, 4],
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Position 1 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ANGTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_high_total_error() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Modify AB and BA errors at position 0 to make total error rate too high
-        // Total depth = 10 (AB=6, BA=4), total errors = 2 (AB=1, BA=1), rate = 2/10 = 0.2 > 0.15
-        record.data_mut().insert(
-            Tag::from([b'a', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![1, 0, 0, 0, 0, 0, 0, 0],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![1, 1, 1, 1, 1, 1, 1, 1],
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Position 0 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"NCGTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_multiple_failures() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Create multiple failure conditions
-        // Position 0: low AB depth (2 < 3)
-        record.data_mut().insert(
-            Tag::from([b'a', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![2, 6, 6, 6, 6, 6, 6, 6],
-            )),
-        );
-        // Position 1: low BA depth (1 < 2)
-        record.data_mut().insert(
-            Tag::from([b'b', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![4, 1, 4, 4, 4, 4, 4, 4],
-            )),
-        );
-        // Position 2: high AB error (2/6 = 0.33 > 0.25)
-        record.data_mut().insert(
-            Tag::from([b'a', b'e']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![0, 0, 2, 0, 0, 0, 0, 0],
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Positions 0,1,2 should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"NNNTACGT");
-    }
-
-    // ========== Tests for single-strand agreement ==========
-
-    #[test]
-    fn test_mask_duplex_bases_single_strand_agreement_pass() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Add consensus base tags - all agree
-        record.data_mut().insert(
-            Tag::from([b'a', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'],
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            true,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // All bases agree - no masking
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_single_strand_agreement_fail() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Add consensus base tags - positions 2, 5, 7 disagree
-        record.data_mut().insert(
-            Tag::from([b'a', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'T', b'T', b'A', b'G', b'G', b'A'], // Disagree at 2,5,7
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            true,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Positions 2,5,7 should be masked due to disagreement
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACNTANGN");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_single_strand_agreement_disabled() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Add consensus base tags - positions 2, 5, 7 disagree
-        record.data_mut().insert(
-            Tag::from([b'a', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'T', b'T', b'A', b'G', b'G', b'A'], // Disagree at 2,5,7
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        // Call with require_ss_agreement = false
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            false,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // No masking due to disagreement when disabled
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"ACGTACGT");
-    }
-
-    #[test]
-    fn test_mask_duplex_bases_combined_failures_with_agreement() {
-        let mut record = create_duplex_record_with_per_base_tags();
-
-        // Create depth failure at position 0 (low AB depth: 2 < 3)
-        record.data_mut().insert(
-            Tag::from([b'a', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![2, 6, 6, 6, 6, 6, 6, 6],
-            )),
-        );
-
-        // Create disagreement at positions 3 and 5
-        record.data_mut().insert(
-            Tag::from([b'a', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'],
-            )),
-        );
-        record.data_mut().insert(
-            Tag::from([b'b', b'c']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt8(
-                vec![b'A', b'C', b'G', b'A', b'A', b'G', b'G', b'T'], // Disagree at 3,5
-            )),
-        );
-
-        let cc_thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.15 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 3, max_read_error_rate: 0.1, max_base_error_rate: 0.25 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 2, max_read_error_rate: 0.15, max_base_error_rate: 0.3 };
-
-        mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(13),
-            true,
-        )
-        .expect("mask_duplex_bases should succeed");
-
-        // Positions 0 (depth), 3 (disagreement), 5 (disagreement) should be masked
-        let seq = record.sequence();
-        assert_eq!(seq.as_ref(), b"NCGNANGT");
-    }
-
-    #[test]
-    fn test_extract_per_base_array_int16() {
-        // Test that Int16 arrays are handled correctly (negative values clamped to 0)
-        use noodles::sam::alignment::record_buf::data::field::value::Array;
-
-        let mut data = noodles::sam::alignment::record_buf::Data::default();
-        let tag = Tag::from([b'c', b'D']);
-        data.insert(tag, Value::Array(Array::Int16(vec![5, 10, -1, 15, 0])));
-
-        let result = extract_per_base_array(&data, "cD", 5);
-        // Negative values should be clamped to 0
-        assert_eq!(result, vec![5, 10, 0, 15, 0]);
-    }
-
-    #[test]
-    fn test_masked_base_quality_phred_2() {
-        // Test that masked bases get quality=2 (Phred MIN_VALUE), not 0
-        let mut record = RecordBuilder::new().sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
-
-        // Set up low depth at position 0 and 2 (array tags need direct insertion)
-        record.data_mut().insert(
-            Tag::from([b'c', b'd']),
-            Value::Array(noodles::sam::alignment::record_buf::data::field::value::Array::UInt16(
-                vec![1, 10, 1, 10],
-            )),
-        );
-
-        let thresholds =
-            FilterThresholds { min_reads: 5, max_read_error_rate: 1.0, max_base_error_rate: 1.0 };
-
-        mask_bases(&mut record, &thresholds, Some(10)).expect("mask_bases should succeed");
-
-        // Positions 0 and 2 should be masked to N with quality=2
-        let seq: Vec<u8> = record.sequence().iter().collect();
-        let quals: Vec<u8> = record.quality_scores().iter().collect();
-        assert_eq!(seq, b"NCNT");
-        assert_eq!(
-            quals,
-            vec![2, 30, 2, 30],
-            "Masked bases should have quality=2 (Phred MIN_VALUE)"
-        );
-    }
-
-    #[test]
     fn test_error_rate_f64_comparison() {
         // Test that error rates are properly compared using f64
         // This ensures the f32 -> f64 promotion works correctly
@@ -2768,38 +1426,6 @@ mod tests {
             f64::from(error_rate_high) > thresholds.max_read_error_rate,
             "f32 -> f64 comparison should catch values over threshold"
         );
-    }
-
-    #[test]
-    fn test_ac_bc_string_tag_handling() {
-        // Test that ac/bc tags can be handled as String type (not just Array)
-        // This is important for CODEC consensus reads where these may be stored differently
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .tag("ac", "ACGT")
-            .tag("bc", "ACGT")
-            .build();
-
-        // These should be handled gracefully even if not array format
-        // The function should not panic
-        let cc_thresholds =
-            FilterThresholds { min_reads: 1, max_read_error_rate: 1.0, max_base_error_rate: 1.0 };
-        let ab_thresholds =
-            FilterThresholds { min_reads: 1, max_read_error_rate: 1.0, max_base_error_rate: 1.0 };
-        let ba_thresholds =
-            FilterThresholds { min_reads: 1, max_read_error_rate: 1.0, max_base_error_rate: 1.0 };
-
-        // Should not panic even with String tags
-        let result = mask_duplex_bases(
-            &mut record,
-            &cc_thresholds,
-            &ab_thresholds,
-            &ba_thresholds,
-            Some(10),
-            true,
-        );
-        assert!(result.is_ok());
     }
 
     // ========== Tests for find_string_or_uint8_array ==========
@@ -2861,17 +1487,24 @@ mod tests {
         header: &noodles::sam::Header,
         record: &RecordBuf,
     ) -> Vec<u8> {
-        let mut raw = Vec::new();
-        crate::vendored::bam_codec::encoder::encode_record_buf(&mut raw, header, record)
-            .expect("encoding should succeed");
-        raw
+        fgumi_raw_bam::encode_record_buf_to_raw(record, header)
+            .expect("encode_record_buf_to_raw should succeed")
+            .into_inner()
     }
 
-    /// Helper: create a `SamBuilder` for mapped record tests.
-    fn sam_builder_for_methylation() -> fgumi_sam::builder::SamBuilder {
+    /// Helper: create a SAM header with a single reference sequence for mapped record tests.
+    fn header_for_methylation_tests() -> noodles::sam::Header {
         //                  0123456789
         // Reference:       ACGTCGATCG
-        fgumi_sam::builder::SamBuilder::with_single_ref("chr1", 1000)
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+        noodles::sam::Header::builder()
+            .add_reference_sequence(
+                "chr1",
+                Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("1000 is non-zero")),
+            )
+            .build()
     }
 
     /// Helper: add an i16 array tag to a `RecordBuf`.
@@ -2913,7 +1546,7 @@ mod tests {
 
     #[test]
     fn test_mask_methylation_depth_simplex_all_pass() {
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -2926,14 +1559,14 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[5, 5, 5, 5]);
         add_i16_array_tag(&mut record, "ct", &[3, 3, 3, 3]);
 
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 0);
     }
 
     #[test]
     fn test_mask_methylation_depth_simplex_some_fail() {
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -2949,14 +1582,14 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[5, 1, 0, 10]);
         add_i16_array_tag(&mut record, "ct", &[3, 1, 0, 0]);
 
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 2, "Positions 1 and 2 should be masked");
     }
 
     #[test]
     fn test_mask_methylation_depth_simplex_no_tags_no_masking() {
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -2966,7 +1599,7 @@ mod tests {
             .cigar("4M")
             .build();
         // No cu/ct tags
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 0, "No methylation tags should mean no masking");
     }
@@ -2975,7 +1608,7 @@ mod tests {
 
     #[test]
     fn test_mask_methylation_depth_duplex_all_pass() {
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -2992,14 +1625,14 @@ mod tests {
         add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
 
         let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
         assert_eq!(masked, 0);
     }
 
     #[test]
     fn test_mask_methylation_depth_duplex_ab_fails() {
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -3017,7 +1650,7 @@ mod tests {
         add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
 
         let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
         assert_eq!(masked, 1, "Position 1 should be masked (AB depth too low)");
     }
@@ -3033,7 +1666,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("AAAAACGAAAA")
             .qualities(&[30; 11])
@@ -3049,7 +1682,7 @@ mod tests {
         add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
         add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
 
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 0, "Concordant CpG should not be masked");
@@ -3064,7 +1697,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("AAAAACGAAAA")
             .qualities(&[30; 11])
@@ -3080,7 +1713,7 @@ mod tests {
         add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
         add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
 
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 2, "Both CpG positions should be masked when strands disagree");
@@ -3094,7 +1727,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACAGTGCATGA")
             .qualities(&[30; 11])
@@ -3108,7 +1741,7 @@ mod tests {
         add_i16_array_tag(&mut record, "bu", &[0; 11]);
         add_i16_array_tag(&mut record, "bt", &[0; 11]);
 
-        let mut raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 0, "Non-CpG sites should not be masked");
@@ -3125,7 +1758,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3139,7 +1772,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // 18 converted out of 20 = 90% conversion (positions 1 and 5)
         assert!(
             check_conversion_fraction_raw(
@@ -3160,7 +1793,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3173,7 +1806,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // 2 converted out of 20 = 10% conversion (positions 1 and 5)
         assert!(
             !check_conversion_fraction_raw(
@@ -3195,7 +1828,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("AAAACGAAA")
             .qualities(&[30; 9])
@@ -3209,7 +1842,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 0, 0, 0, 10, 0, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         assert!(
             check_conversion_fraction_raw(
                 &raw,
@@ -3229,7 +1862,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3239,7 +1872,7 @@ mod tests {
             .cigar("9M")
             .build();
         // No cu/ct tags
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         assert!(
             check_conversion_fraction_raw(
                 &raw,
@@ -3283,7 +1916,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3296,7 +1929,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // TAPs numerator = cu: 18 out of 20 = 90%
         assert!(
             check_conversion_fraction_raw(
@@ -3317,7 +1950,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3330,7 +1963,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // TAPs numerator = cu: 2 out of 20 = 10%
         assert!(
             !check_conversion_fraction_raw(
@@ -3351,7 +1984,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3365,7 +1998,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // EM-Seq should fail (10% < 80%), TAPs should pass (90% >= 80%)
         assert!(
             !check_conversion_fraction_raw(
@@ -3398,7 +2031,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let mut record = RecordBuilder::new()
             .sequence("ACATACATA")
             .qualities(&[30; 9])
@@ -3411,7 +2044,7 @@ mod tests {
         add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
         add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
 
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         // Disabled mode should always pass regardless of data
         assert!(
             check_conversion_fraction_raw(
@@ -3434,7 +2067,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let record = RecordBuilder::new()
             .sequence("ACGT")
             .qualities(&[30; 4])
@@ -3443,7 +2076,7 @@ mod tests {
             .mapping_quality(60)
             .cigar("4M")
             .build();
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')]);
     }
@@ -3455,7 +2088,7 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let sam = sam_builder_for_methylation();
+        let header = header_for_methylation_tests();
         let record = RecordBuilder::new()
             .sequence("ACNNGT") // 2M2I2M -> positions 2,3 are insertions
             .qualities(&[30; 6])
@@ -3464,7 +2097,7 @@ mod tests {
             .mapping_quality(60)
             .cigar("2M2I2M")
             .build();
-        let raw = build_raw_with_methylation_tags(&sam.header, &record);
+        let raw = build_raw_with_methylation_tags(&header, &record);
         let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, None, Some(b'G'), Some(b'T')]);
     }

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -5,9 +5,6 @@
 //! UMI consensus calling. This prevents treating them as independent observations.
 
 use anyhow::{Context, Result};
-use noodles::sam::alignment::record::Cigar;
-use noodles::sam::alignment::record::cigar::op::Kind;
-use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER};
 use fgumi_raw_bam::{self, RawRecordView};
@@ -108,121 +105,6 @@ impl OverlappingBasesConsensusCaller {
     /// Reset statistics
     pub fn reset_stats(&mut self) {
         self.stats.reset();
-    }
-
-    /// Process overlapping bases in a read pair
-    ///
-    /// This method modifies the reads in-place, updating bases and qualities
-    /// in the overlapping region according to the configured strategies.
-    ///
-    /// This implementation matches fgbio's `OverlappingBasesConsensusCaller`:
-    /// - Uses merge iteration to properly handle different CIGAR structures
-    /// - Only considers aligned bases (M/X/=), not soft clips or insertions
-    /// - Properly synchronizes by reference position, not read position
-    ///
-    /// # Arguments
-    /// * `r1` - First read in the pair (will be modified)
-    /// * `r2` - Second read in the pair (will be modified)
-    ///
-    /// # Returns
-    /// * `true` if overlapping bases were processed, `false` if reads don't overlap
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if CIGAR parsing or alignment position extraction fails.
-    pub fn call(&mut self, r1: &mut RecordBuf, r2: &mut RecordBuf) -> Result<bool> {
-        // Only process paired reads where both are mapped
-        if r1.flags().is_unmapped() || r2.flags().is_unmapped() {
-            return Ok(false);
-        }
-
-        // Must be on the same reference sequence (chromosome)
-        if r1.reference_sequence_id() != r2.reference_sequence_id() {
-            return Ok(false);
-        }
-
-        // Verify both have alignment positions
-        if r1.alignment_start().is_none()
-            || r1.alignment_end().is_none()
-            || r2.alignment_start().is_none()
-            || r2.alignment_end().is_none()
-        {
-            return Ok(false);
-        }
-
-        // Create merge iterator that yields positions where both reads have aligned bases
-        let Ok(overlap_iter) = ReadMateAndRefPosIterator::new(r1, r2) else { return Ok(false) };
-
-        // Collect overlapping positions
-        let overlapping_positions: Vec<_> = overlap_iter.collect();
-
-        if overlapping_positions.is_empty() {
-            return Ok(false);
-        }
-
-        // Clone sequences and qualities ONCE at the start (avoids O(n²) allocations)
-        let mut r1_seq: Vec<u8> = r1.sequence().as_ref().to_vec();
-        let mut r2_seq: Vec<u8> = r2.sequence().as_ref().to_vec();
-        let mut r1_quals: Vec<u8> = r1.quality_scores().as_ref().to_vec();
-        let mut r2_quals: Vec<u8> = r2.quality_scores().as_ref().to_vec();
-        let mut modified = false;
-
-        // Process each overlapping position
-        for pos in overlapping_positions {
-            let r1_base = r1_seq[pos.read_offset];
-            let r2_base = r2_seq[pos.mate_offset];
-
-            // Skip if either base is a no-call (N) - matches fgbio behavior
-            if is_no_call(r1_base) || is_no_call(r2_base) {
-                continue;
-            }
-
-            self.stats.overlapping_bases += 1;
-
-            let r1_qual = r1_quals[pos.read_offset];
-            let r2_qual = r2_quals[pos.mate_offset];
-
-            if r1_base == r2_base {
-                // Bases agree
-                self.stats.bases_agreeing += 1;
-                if self.process_agreement(
-                    pos.read_offset,
-                    pos.mate_offset,
-                    r1_qual,
-                    r2_qual,
-                    &mut r1_quals,
-                    &mut r2_quals,
-                ) {
-                    modified = true;
-                }
-            } else {
-                // Bases disagree
-                self.stats.bases_disagreeing += 1;
-                self.process_disagreement(
-                    pos.read_offset,
-                    pos.mate_offset,
-                    r1_base,
-                    r2_base,
-                    r1_qual,
-                    r2_qual,
-                    &mut r1_seq,
-                    &mut r2_seq,
-                    &mut r1_quals,
-                    &mut r2_quals,
-                );
-                modified = true;
-            }
-        }
-
-        // Write back modified sequences and qualities ONCE at the end
-        if modified {
-            *r1.sequence_mut() = r1_seq.into();
-            *r2.sequence_mut() = r2_seq.into();
-            *r1.quality_scores_mut() = r1_quals.into();
-            *r2.quality_scores_mut() = r2_quals.into();
-        }
-
-        Ok(true)
     }
 
     /// Process agreeing bases. Returns true if any modification was made.
@@ -340,6 +222,118 @@ impl OverlappingBasesConsensusCaller {
             }
         }
     }
+
+    /// Process overlapping bases in a read pair using raw BAM bytes.
+    ///
+    /// Modifies the raw byte records in-place.
+    ///
+    /// # Returns
+    /// * `true` if overlapping bases were processed, `false` if reads don't overlap
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if raw BAM field extraction or CIGAR parsing fails.
+    pub fn call(&mut self, r1: &mut [u8], r2: &mut [u8]) -> Result<bool> {
+        // Only process paired reads where both are mapped
+        if RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
+            || RawRecordView::new(r2).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
+        {
+            return Ok(false);
+        }
+
+        // Must be on the same reference sequence
+        if RawRecordView::new(r1).ref_id() != RawRecordView::new(r2).ref_id() {
+            return Ok(false);
+        }
+
+        // Verify both have alignment positions and ends
+        let Some(r1_start) = fgumi_raw_bam::alignment_start_from_raw(r1) else {
+            return Ok(false);
+        };
+        let Some(r1_end) = fgumi_raw_bam::alignment_end_from_raw(r1) else { return Ok(false) };
+        let Some(r2_start) = fgumi_raw_bam::alignment_start_from_raw(r2) else {
+            return Ok(false);
+        };
+        let Some(r2_end) = fgumi_raw_bam::alignment_end_from_raw(r2) else { return Ok(false) };
+
+        // Create merge iterator that yields positions where both reads have aligned bases
+        let overlap_iter =
+            ReadMateAndRefPosIterator::new_raw(r1, r2, r1_start, r1_end, r2_start, r2_end);
+
+        let overlapping_positions: Vec<_> = overlap_iter.collect();
+
+        if overlapping_positions.is_empty() {
+            return Ok(false);
+        }
+
+        // Extract sequences and qualities for modification
+        let mut r1_seq = RawRecordView::new(r1).sequence_vec();
+        let mut r2_seq = RawRecordView::new(r2).sequence_vec();
+        let mut r1_quals: Vec<u8> = RawRecordView::new(r1).quality_scores().to_vec();
+        let mut r2_quals: Vec<u8> = RawRecordView::new(r2).quality_scores().to_vec();
+        let mut modified = false;
+
+        for pos in overlapping_positions {
+            let r1_base = r1_seq[pos.read_offset];
+            let r2_base = r2_seq[pos.mate_offset];
+
+            if is_no_call(r1_base) || is_no_call(r2_base) {
+                continue;
+            }
+
+            self.stats.overlapping_bases += 1;
+
+            let r1_qual = r1_quals[pos.read_offset];
+            let r2_qual = r2_quals[pos.mate_offset];
+
+            if r1_base == r2_base {
+                self.stats.bases_agreeing += 1;
+                if self.process_agreement(
+                    pos.read_offset,
+                    pos.mate_offset,
+                    r1_qual,
+                    r2_qual,
+                    &mut r1_quals,
+                    &mut r2_quals,
+                ) {
+                    modified = true;
+                }
+            } else {
+                self.stats.bases_disagreeing += 1;
+                self.process_disagreement(
+                    pos.read_offset,
+                    pos.mate_offset,
+                    r1_base,
+                    r2_base,
+                    r1_qual,
+                    r2_qual,
+                    &mut r1_seq,
+                    &mut r2_seq,
+                    &mut r1_quals,
+                    &mut r2_quals,
+                );
+                modified = true;
+            }
+        }
+
+        // Write back modified sequences and qualities into the raw BAM records
+        if modified {
+            let r1_seq_off = fgumi_raw_bam::seq_offset(r1);
+            let r2_seq_off = fgumi_raw_bam::seq_offset(r2);
+            for (i, &base) in r1_seq.iter().enumerate() {
+                fgumi_raw_bam::set_base(r1, r1_seq_off, i, base);
+            }
+            for (i, &base) in r2_seq.iter().enumerate() {
+                fgumi_raw_bam::set_base(r2, r2_seq_off, i, base);
+            }
+            let r1_qual_off = fgumi_raw_bam::qual_offset(r1);
+            let r2_qual_off = fgumi_raw_bam::qual_offset(r2);
+            r1[r1_qual_off..r1_qual_off + r1_quals.len()].copy_from_slice(&r1_quals);
+            r2[r2_qual_off..r2_qual_off + r2_quals.len()].copy_from_slice(&r2_quals);
+        }
+
+        Ok(true)
+    }
 }
 
 /// A position in a read with both read offset and reference position
@@ -361,7 +355,9 @@ struct ReadMateAndRefPos {
 }
 
 /// Converts a noodles CIGAR `Kind` to the BAM integer op code.
-fn kind_to_bam_op(kind: Kind) -> u8 {
+#[cfg(test)]
+fn kind_to_bam_op(kind: noodles::sam::alignment::record::cigar::op::Kind) -> u8 {
+    use noodles::sam::alignment::record::cigar::op::Kind;
     match kind {
         Kind::Match => 0,
         Kind::Insertion => 1,
@@ -382,8 +378,7 @@ fn kind_to_bam_op(kind: Kind) -> u8 {
 /// - Skips soft clips, insertions, deletions, etc.
 /// - Can be limited to a reference position range
 ///
-/// Works with both noodles `RecordBuf` and raw BAM byte records by storing
-/// CIGAR ops as BAM integer codes internally.
+/// Works with raw BAM byte records by storing CIGAR ops as BAM integer codes internally.
 struct ReadAndRefPosIterator {
     /// 1-based current read position (fgbio uses 1-based)
     cur_read_pos: i32,
@@ -412,58 +407,6 @@ struct ReadAndRefPosIterator {
     reason = "position arithmetic requires casts between BAM integer types"
 )]
 impl ReadAndRefPosIterator {
-    /// Create iterator for aligned positions overlapping with mate (noodles `RecordBuf`)
-    fn new_with_mate(record: &RecordBuf, mate: &RecordBuf) -> Result<Self> {
-        let rec_start = match record.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
-            None => return Err(anyhow::anyhow!("Record has no alignment start")),
-        };
-        let rec_end = match record.alignment_end() {
-            Some(pos) => usize::from(pos) as i32,
-            None => return Err(anyhow::anyhow!("Record has no alignment end")),
-        };
-
-        let mate_start = match mate.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
-            None => return Err(anyhow::anyhow!("Mate has no alignment start")),
-        };
-        let mate_end = match mate.alignment_end() {
-            Some(pos) => usize::from(pos) as i32,
-            None => return Err(anyhow::anyhow!("Mate has no alignment end")),
-        };
-
-        let min_ref_pos = rec_start.max(mate_start);
-        let max_ref_pos = rec_end.min(mate_end);
-        let rec_len = record.sequence().len() as i32;
-
-        let cigar = record.cigar();
-        let cigar_ops: Vec<_> = cigar
-            .iter()
-            .filter_map(std::result::Result::ok)
-            .map(|op| (kind_to_bam_op(op.kind()), op.len()))
-            .collect();
-
-        let start_read_pos = 1i32;
-        let end_read_pos = rec_len;
-        let start_ref_pos = rec_start.max(min_ref_pos);
-        let end_ref_pos = rec_end.min(max_ref_pos);
-
-        let mut iter = Self {
-            cur_read_pos: 1,
-            cur_ref_pos: rec_start,
-            cigar_ops,
-            element_index: 0,
-            in_elem_offset: 0,
-            start_ref_pos,
-            end_ref_pos,
-            start_read_pos,
-            end_read_pos,
-        };
-
-        iter.skip_to_start();
-        Ok(iter)
-    }
-
     /// Create iterator for aligned positions overlapping with mate (raw BAM bytes)
     fn new_raw_with_mate(
         bam: &[u8],
@@ -623,14 +566,6 @@ struct ReadMateAndRefPosIterator {
 }
 
 impl ReadMateAndRefPosIterator {
-    /// Create a new iterator for overlapping positions between read and mate (noodles)
-    fn new(record: &RecordBuf, mate: &RecordBuf) -> Result<Self> {
-        let rec_iter = ReadAndRefPosIterator::new_with_mate(record, mate)?.peekable();
-        let mate_iter = ReadAndRefPosIterator::new_with_mate(mate, record)?.peekable();
-
-        Ok(Self { rec_iter, mate_iter })
-    }
-
     /// Create a new iterator for overlapping positions between read and mate (raw BAM)
     fn new_raw(
         r1: &[u8],
@@ -682,189 +617,12 @@ impl Iterator for ReadMateAndRefPosIterator {
     }
 }
 
-/// Applies overlapping consensus calling to pairs of reads within a group.
-///
-/// For paired-end reads, this function:
-/// 1. Groups reads by name to find R1/R2 pairs
-/// 2. Calls overlapping consensus on each pair using the provided caller
-/// 3. Modifies reads in-place (no copying)
-///
-/// Single-end reads pass through unchanged.
-///
-/// # Arguments
-///
-/// * `reads` - Mutable slice of reads to process (modified in-place)
-/// * `caller` - The overlapping consensus caller to use
-///
-/// # Errors
-///
-/// Returns an error if consensus calling fails for any pair
-pub fn apply_overlapping_consensus(
-    reads: &mut [RecordBuf],
-    caller: &mut OverlappingBasesConsensusCaller,
-) -> Result<()> {
-    use ahash::AHashMap;
-
-    // Group reads by name for pairing
-    let mut read_pairs: AHashMap<String, (Option<usize>, Option<usize>)> = AHashMap::new();
-
-    for (idx, record) in reads.iter().enumerate() {
-        let read_name = record.name().map(std::string::ToString::to_string).unwrap_or_default();
-
-        if record.flags().is_first_segment() {
-            read_pairs.entry(read_name).or_insert((None, None)).0 = Some(idx);
-        } else if record.flags().is_last_segment() {
-            read_pairs.entry(read_name).or_insert((None, None)).1 = Some(idx);
-        }
-        // Single-end reads are not paired, they pass through unchanged
-    }
-
-    // Process pairs
-    for (r1_idx, r2_idx) in read_pairs.values() {
-        if let (Some(idx1), Some(idx2)) = (r1_idx, r2_idx) {
-            // Use split_at_mut to get two mutable references
-            let (r1, r2) = if idx1 < idx2 {
-                let (left, right) = reads.split_at_mut(*idx2);
-                (&mut left[*idx1], &mut right[0])
-            } else {
-                let (left, right) = reads.split_at_mut(*idx1);
-                (&mut right[0], &mut left[*idx2])
-            };
-
-            caller.call(r1, r2).context("Failed to call overlapping consensus")?;
-        }
-    }
-
-    Ok(())
-}
-
-// ============================================================================
-// Raw-byte overlapping consensus
-// ============================================================================
-
-impl OverlappingBasesConsensusCaller {
-    /// Process overlapping bases in a read pair using raw BAM bytes.
-    ///
-    /// Same logic as `call()` but extracts fields from raw bytes directly.
-    /// Modifies the raw byte records in-place.
-    ///
-    /// # Returns
-    /// * `true` if overlapping bases were processed, `false` if reads don't overlap
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if raw BAM field extraction or CIGAR parsing fails.
-    pub fn call_raw(&mut self, r1: &mut [u8], r2: &mut [u8]) -> Result<bool> {
-        // Only process paired reads where both are mapped
-        if RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
-            || RawRecordView::new(r2).flags() & fgumi_raw_bam::flags::UNMAPPED != 0
-        {
-            return Ok(false);
-        }
-
-        // Must be on the same reference sequence
-        if RawRecordView::new(r1).ref_id() != RawRecordView::new(r2).ref_id() {
-            return Ok(false);
-        }
-
-        // Verify both have alignment positions and ends
-        let Some(r1_start) = fgumi_raw_bam::alignment_start_from_raw(r1) else {
-            return Ok(false);
-        };
-        let Some(r1_end) = fgumi_raw_bam::alignment_end_from_raw(r1) else { return Ok(false) };
-        let Some(r2_start) = fgumi_raw_bam::alignment_start_from_raw(r2) else {
-            return Ok(false);
-        };
-        let Some(r2_end) = fgumi_raw_bam::alignment_end_from_raw(r2) else { return Ok(false) };
-
-        // Create merge iterator that yields positions where both reads have aligned bases
-        let overlap_iter =
-            ReadMateAndRefPosIterator::new_raw(r1, r2, r1_start, r1_end, r2_start, r2_end);
-
-        let overlapping_positions: Vec<_> = overlap_iter.collect();
-
-        if overlapping_positions.is_empty() {
-            return Ok(false);
-        }
-
-        // Extract sequences and qualities for modification
-        let mut r1_seq = RawRecordView::new(r1).sequence_vec();
-        let mut r2_seq = RawRecordView::new(r2).sequence_vec();
-        let mut r1_quals: Vec<u8> = RawRecordView::new(r1).quality_scores().to_vec();
-        let mut r2_quals: Vec<u8> = RawRecordView::new(r2).quality_scores().to_vec();
-        let mut modified = false;
-
-        for pos in overlapping_positions {
-            let r1_base = r1_seq[pos.read_offset];
-            let r2_base = r2_seq[pos.mate_offset];
-
-            if is_no_call(r1_base) || is_no_call(r2_base) {
-                continue;
-            }
-
-            self.stats.overlapping_bases += 1;
-
-            let r1_qual = r1_quals[pos.read_offset];
-            let r2_qual = r2_quals[pos.mate_offset];
-
-            if r1_base == r2_base {
-                self.stats.bases_agreeing += 1;
-                if self.process_agreement(
-                    pos.read_offset,
-                    pos.mate_offset,
-                    r1_qual,
-                    r2_qual,
-                    &mut r1_quals,
-                    &mut r2_quals,
-                ) {
-                    modified = true;
-                }
-            } else {
-                self.stats.bases_disagreeing += 1;
-                self.process_disagreement(
-                    pos.read_offset,
-                    pos.mate_offset,
-                    r1_base,
-                    r2_base,
-                    r1_qual,
-                    r2_qual,
-                    &mut r1_seq,
-                    &mut r2_seq,
-                    &mut r1_quals,
-                    &mut r2_quals,
-                );
-                modified = true;
-            }
-        }
-
-        // Write back modified sequences and qualities into the raw BAM records
-        if modified {
-            let r1_seq_off = fgumi_raw_bam::seq_offset(r1);
-            let r2_seq_off = fgumi_raw_bam::seq_offset(r2);
-            for (i, &base) in r1_seq.iter().enumerate() {
-                fgumi_raw_bam::set_base(r1, r1_seq_off, i, base);
-            }
-            for (i, &base) in r2_seq.iter().enumerate() {
-                fgumi_raw_bam::set_base(r2, r2_seq_off, i, base);
-            }
-            let r1_qual_off = fgumi_raw_bam::qual_offset(r1);
-            let r2_qual_off = fgumi_raw_bam::qual_offset(r2);
-            r1[r1_qual_off..r1_qual_off + r1_quals.len()].copy_from_slice(&r1_quals);
-            r2[r2_qual_off..r2_qual_off + r2_quals.len()].copy_from_slice(&r2_quals);
-        }
-
-        Ok(true)
-    }
-}
-
 /// Applies overlapping consensus calling to pairs of raw-byte reads within a group.
-///
-/// This is the raw-byte equivalent of `apply_overlapping_consensus`.
 ///
 /// # Errors
 ///
 /// Returns an error if overlapping consensus calling fails for any read pair.
-pub fn apply_overlapping_consensus_raw(
+pub fn apply_overlapping_consensus(
     records: &mut [Vec<u8>],
     caller: &mut OverlappingBasesConsensusCaller,
 ) -> Result<()> {
@@ -874,9 +632,16 @@ pub fn apply_overlapping_consensus_raw(
     let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> = AHashMap::new();
 
     for (idx, record) in records.iter().enumerate() {
-        let name = RawRecordView::new(record).read_name().to_vec();
-        let flg = RawRecordView::new(record).flags();
+        let view = RawRecordView::new(record);
+        let flg = view.flags();
 
+        // Only register primary alignments; secondary/supplementary records
+        // share the read name and would otherwise overwrite the primary index.
+        if flg & (fgumi_raw_bam::flags::SECONDARY | fgumi_raw_bam::flags::SUPPLEMENTARY) != 0 {
+            continue;
+        }
+
+        let name = view.read_name().to_vec();
         if flg & fgumi_raw_bam::flags::FIRST_SEGMENT != 0 {
             read_pairs.entry(name).or_insert((None, None)).0 = Some(idx);
         } else if flg & fgumi_raw_bam::flags::LAST_SEGMENT != 0 {
@@ -895,7 +660,7 @@ pub fn apply_overlapping_consensus_raw(
                 (&mut right[0], &mut left[*idx2])
             };
 
-            caller.call_raw(r1, r2).context("Failed to call overlapping consensus on raw bytes")?;
+            caller.call(r1, r2).context("Failed to call overlapping consensus on raw bytes")?;
         }
     }
 
@@ -911,354 +676,6 @@ pub fn apply_overlapping_consensus_raw(
 )]
 mod tests {
     use super::*;
-    use fgumi_sam::builder::RecordBuilder;
-    use noodles::sam::alignment::record::Flags;
-
-    /// Creates a test record with explicit sequence, qualities, position, and CIGAR.
-    fn create_test_record(seq: &[u8], qual: &[u8], start: usize, cigar: &str) -> RecordBuf {
-        RecordBuilder::mapped_read()
-            .sequence(&String::from_utf8_lossy(seq))
-            .qualities(qual)
-            .alignment_start(start)
-            .cigar(cigar)
-            .build()
-    }
-
-    #[test]
-    fn test_agreement_strategy_consensus() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        assert_eq!(caller.agreement_strategy, AgreementStrategy::Consensus);
-
-        // Test with overlapping reads
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Check that qualities were summed (30 + 20 = 50)
-        assert_eq!(r1.quality_scores().as_ref()[0], 50);
-        assert_eq!(r2.quality_scores().as_ref()[0], 50);
-    }
-
-    #[test]
-    fn test_agreement_strategy_max_qual() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::MaxQual,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Check that max quality was used (max(30, 20) = 30)
-        assert_eq!(r1.quality_scores().as_ref()[0], 30);
-        assert_eq!(r2.quality_scores().as_ref()[0], 30);
-    }
-
-    #[test]
-    fn test_agreement_strategy_pass_through() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Check that qualities were unchanged
-        assert_eq!(r1.quality_scores().as_ref()[0], 30);
-        assert_eq!(r2.quality_scores().as_ref()[0], 20);
-    }
-
-    #[test]
-    fn test_disagreement_strategy_consensus() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Higher quality base (A from r1) should be chosen, qual = 30 - 20 = 10
-        assert_eq!(r1.sequence().as_ref()[0], b'A');
-        assert_eq!(r2.sequence().as_ref()[0], b'A');
-        assert_eq!(r1.quality_scores().as_ref()[0], 10);
-        assert_eq!(r2.quality_scores().as_ref()[0], 10);
-    }
-
-    #[test]
-    fn test_disagreement_strategy_mask_both() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskBoth,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Both bases should be masked to N with quality 2
-        assert_eq!(r1.sequence().as_ref()[0], b'N');
-        assert_eq!(r2.sequence().as_ref()[0], b'N');
-        assert_eq!(r1.quality_scores().as_ref()[0], 2);
-        assert_eq!(r2.quality_scores().as_ref()[0], 2);
-    }
-
-    #[test]
-    fn test_disagreement_strategy_mask_lower_qual() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskLowerQual,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Only lower quality base (r2) should be masked
-        assert_eq!(r1.sequence().as_ref()[0], b'A'); // Unchanged
-        assert_eq!(r2.sequence().as_ref()[0], b'N'); // Masked
-        assert_eq!(r1.quality_scores().as_ref()[0], 30); // Unchanged
-        assert_eq!(r2.quality_scores().as_ref()[0], 2); // Masked
-    }
-
-    #[test]
-    fn test_disagreement_mask_lower_qual_r1_lower() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskLowerQual,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[30, 30, 30, 30], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Only lower quality base (r1) should be masked
-        assert_eq!(r1.sequence().as_ref()[0], b'N'); // Masked
-        assert_eq!(r2.sequence().as_ref()[0], b'G'); // Unchanged
-    }
-
-    #[test]
-    fn test_disagreement_mask_lower_qual_equal_quality() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskLowerQual,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[30, 30, 30, 30], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Both should be masked when qualities are equal (matches fgbio)
-        assert_eq!(r1.sequence().as_ref()[0], b'N');
-        assert_eq!(r2.sequence().as_ref()[0], b'N');
-        assert_eq!(r1.quality_scores().as_ref()[0], 2);
-        assert_eq!(r2.quality_scores().as_ref()[0], 2);
-    }
-
-    #[test]
-    fn test_disagreement_consensus_equal_quality() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[30, 30, 30, 30], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Both should be masked when qualities are equal (matches fgbio)
-        assert_eq!(r1.sequence().as_ref()[0], b'N');
-        assert_eq!(r2.sequence().as_ref()[0], b'N');
-        assert_eq!(r1.quality_scores().as_ref()[0], 2);
-        assert_eq!(r2.quality_scores().as_ref()[0], 2);
-    }
-
-    #[test]
-    fn test_no_overlap() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Reads don't overlap
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 200, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(!result); // No overlap processed
-    }
-
-    #[test]
-    fn test_unmapped_reads() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-        *r1.flags_mut() = Flags::UNMAPPED;
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(!result); // Unmapped reads not processed
-    }
-
-    #[test]
-    fn test_quality_capping_at_93() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // High qualities that would sum > 93
-        let mut r1 = create_test_record(b"ACGT", &[50, 50, 50, 50], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[50, 50, 50, 50], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Quality should be capped at 93 (not 100)
-        assert_eq!(r1.quality_scores().as_ref()[0], 93);
-    }
-
-    #[test]
-    fn test_stats_tracking() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Create reads where all bases agree - both have "ACGT"
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // NOTE: The overlap calculation uses alignment_end() which returns the position
-        // after the last base. With exclusive end comparison (ref_pos < overlap_end),
-        // the last base may be excluded depending on exact position values.
-        // We verify that overlapping bases are tracked, without requiring an exact count.
-        assert!(caller.stats().overlapping_bases > 0);
-        assert_eq!(caller.stats().bases_agreeing, caller.stats().overlapping_bases);
-        assert_eq!(caller.stats().bases_disagreeing, 0);
-        // With Consensus strategy, agreeing bases get quality summed (corrected)
-        assert_eq!(caller.stats().bases_corrected, caller.stats().overlapping_bases);
-    }
-
-    #[test]
-    fn test_stats_tracking_with_disagreements() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Create reads where bases disagree: ACGT vs TGCA (all different)
-        // Note: N bases are skipped (fgbio behavior), so we use real bases
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"TGCA", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // All overlapping bases disagree
-        assert!(caller.stats().overlapping_bases > 0);
-        assert_eq!(caller.stats().bases_agreeing, 0);
-        assert_eq!(caller.stats().bases_disagreeing, caller.stats().overlapping_bases);
-    }
-
-    #[test]
-    fn test_stats_reset() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(caller.stats().overlapping_bases > 0);
-
-        caller.reset_stats();
-        assert_eq!(caller.stats().overlapping_bases, 0);
-        assert_eq!(caller.stats().bases_agreeing, 0);
-        assert_eq!(caller.stats().bases_disagreeing, 0);
-        assert_eq!(caller.stats().bases_corrected, 0);
-    }
-
-    #[test]
-    fn test_overlap_different_start_positions() {
-        // The merge iteration properly handles reads at different start positions
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // R1: positions 100-103 (ACGT)
-        // R2: positions 102-105 (GTAC)
-        // Overlap: positions 102-103 (GT matches GT)
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GTAC", &[20, 20, 20, 20], 102, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-
-        // Overlap should be detected at positions 102-103 (2 bases)
-        assert!(result);
-        assert_eq!(caller.stats().overlapping_bases, 2);
-        assert_eq!(caller.stats().bases_agreeing, 2); // GT == GT
-
-        // Check quality sums at overlapping positions
-        // R1[2] (pos 102) = 'G' should be summed: 30 + 20 = 50
-        // R1[3] (pos 103) = 'T' should be summed: 30 + 20 = 50
-        assert_eq!(r1.quality_scores().as_ref()[2], 50);
-        assert_eq!(r1.quality_scores().as_ref()[3], 50);
-    }
-
-    #[test]
-    fn test_full_overlap_same_position() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Both reads start at position 100 and fully overlap
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Overlapping bases should be detected (may not be exactly 4 due to boundary handling)
-        assert!(caller.stats().overlapping_bases > 0);
-        assert_eq!(caller.stats().bases_agreeing, caller.stats().overlapping_bases);
-    }
 
     #[test]
     fn test_correction_stats() {
@@ -1277,134 +694,6 @@ mod tests {
         assert_eq!(stats.overlapping_bases, 0);
     }
 
-    #[test]
-    fn test_cigar_with_insertions() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // CIGAR with insertion: 2M2I2M
-        let mut r1 = create_test_record(b"ACTTGG", &[30, 30, 30, 30, 30, 30], 100, "2M2I2M");
-        let mut r2 = create_test_record(b"ACGG", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        // Should process the matching regions
-        assert!(result);
-    }
-
-    #[test]
-    fn test_cigar_with_deletions() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // CIGAR with deletion: 2M2D2M (read has 4 bases but spans 6 ref positions)
-        let mut r1 = create_test_record(b"ACGG", &[30, 30, 30, 30], 100, "2M2D2M");
-        let mut r2 = create_test_record(b"ACTTGG", &[20, 20, 20, 20, 20, 20], 100, "6M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        // Should process overlapping matches
-        assert!(result);
-    }
-
-    #[test]
-    fn test_cigar_with_soft_clips_different_structure() {
-        // The merge iteration properly handles different soft clip structures
-        // by only iterating aligned (M/X/=) bases and synchronizing by ref position
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // R1: 2S4M (6 bases, first 2 soft-clipped, aligned at ref 100-103)
-        // R2: 4M (4 bases, no soft clips, aligned at ref 100-103)
-        // Both have 4 aligned bases at ref 100-103, sequences ACGT match
-        let mut r1 = create_test_record(b"NNACGT", &[2, 2, 30, 30, 30, 30], 100, "2S4M");
-        let mut r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-
-        // The merge iteration properly handles this case:
-        // R1 iterator yields: (2, 100), (3, 101), (4, 102), (5, 103) - skips soft clips
-        // R2 iterator yields: (0, 100), (1, 101), (2, 102), (3, 103)
-        // All 4 positions match by ref_pos
-        assert!(result);
-        assert_eq!(caller.stats().overlapping_bases, 4);
-        assert_eq!(caller.stats().bases_agreeing, 4); // ACGT == ACGT
-
-        // Check quality sums - R1 positions 2-5 and R2 positions 0-3
-        assert_eq!(r1.quality_scores().as_ref()[2], 50); // 30 + 20
-        assert_eq!(r1.quality_scores().as_ref()[3], 50);
-        assert_eq!(r1.quality_scores().as_ref()[4], 50);
-        assert_eq!(r1.quality_scores().as_ref()[5], 50);
-    }
-
-    #[test]
-    fn test_cigar_soft_clips_both_reads_different_lengths() {
-        // Test where both reads have soft clips but different lengths
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // R1: 3S3M (6 bases, 3 soft-clipped, aligned at ref 100-102)
-        // R2: 1S3M (4 bases, 1 soft-clipped, aligned at ref 100-102)
-        let mut r1 = create_test_record(b"NNNACG", &[2, 2, 2, 30, 30, 30], 100, "3S3M");
-        let mut r2 = create_test_record(b"NACG", &[2, 20, 20, 20], 100, "1S3M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // R1 yields: (3, 100), (4, 101), (5, 102)
-        // R2 yields: (1, 100), (2, 101), (3, 102)
-        // 3 overlapping aligned positions
-        assert_eq!(caller.stats().overlapping_bases, 3);
-        assert_eq!(caller.stats().bases_agreeing, 3); // ACG == ACG
-    }
-
-    #[test]
-    fn test_cigar_soft_clips_both_reads_same_structure() {
-        // Test where both reads have the same structure including soft clips
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Both reads have identical CIGAR structure: 1S3M
-        let mut r1 = create_test_record(b"NACG", &[2, 30, 30, 30], 100, "1S3M");
-        let mut r2 = create_test_record(b"NACG", &[2, 20, 20, 20], 100, "1S3M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Both have 3 aligned bases at ref 100-102
-        assert_eq!(caller.stats().overlapping_bases, 3);
-        assert_eq!(caller.stats().bases_agreeing, 3);
-    }
-
-    #[test]
-    fn test_disagreement_consensus_min_quality() {
-        let mut caller = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::Consensus,
-        );
-
-        // Very similar qualities - difference should be at least 2
-        let mut r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut r2 = create_test_record(b"GCTA", &[29, 29, 29, 29], 100, "4M");
-
-        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
-        assert!(result);
-
-        // Quality difference is 1, but should be at least 2
-        assert_eq!(r1.quality_scores().as_ref()[0], 2);
-        assert_eq!(r2.quality_scores().as_ref()[0], 2);
-    }
-
-    // ========================================================================
-    // Raw-byte tests
     // ========================================================================
 
     /// SAM spec 4-bit encoding for A=1, C=2, G=4, T=8, N=15.
@@ -1496,7 +785,7 @@ mod tests {
 
     /// Create a raw BAM record mirroring `create_test_record`.
     ///
-    /// `start_1based` is a 1-based alignment start (matching the `RecordBuf` tests).
+    /// `start_1based` is a 1-based alignment start.
     fn create_raw_test_record(
         seq: &[u8],
         qual: &[u8],
@@ -1519,7 +808,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Check that qualities were summed (30 + 20 = 50)
@@ -1538,7 +827,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Max quality used (max(30, 20) = 30)
@@ -1557,7 +846,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Qualities unchanged
@@ -1576,7 +865,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Higher quality base (A from r1) chosen, qual = 30 - 20 = 10
@@ -1599,7 +888,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Both bases masked to N with quality 2
@@ -1622,7 +911,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Only lower quality base (r2) masked
@@ -1645,7 +934,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Only lower quality base (r1) masked
@@ -1666,7 +955,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Both masked when qualities are equal
@@ -1689,7 +978,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[30, 30, 30, 30], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Both masked when qualities are equal
@@ -1713,7 +1002,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 200, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(!result);
     }
 
@@ -1737,7 +1026,7 @@ mod tests {
         );
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(!result);
     }
 
@@ -1753,7 +1042,7 @@ mod tests {
         let mut r1 = make_raw_bam(b"rea", 0, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
         let mut r2 = make_raw_bam(b"rea", 0, 1, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(!result);
     }
 
@@ -1768,7 +1057,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[50, 50, 50, 50], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[50, 50, 50, 50], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Quality capped at 93
@@ -1786,7 +1075,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         assert!(caller.stats().overlapping_bases > 0);
@@ -1806,7 +1095,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"TGCA", &[20, 20, 20, 20], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         assert!(caller.stats().overlapping_bases > 0);
@@ -1827,7 +1116,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GTAC", &[20, 20, 20, 20], 102, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
         assert_eq!(caller.stats().overlapping_bases, 2);
         assert_eq!(caller.stats().bases_agreeing, 2); // GT == GT
@@ -1850,7 +1139,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"NNACGT", &[2, 2, 30, 30, 30, 30], 100, &r1_cigar);
         let mut r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &r2_cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
         assert_eq!(caller.stats().overlapping_bases, 4);
         assert_eq!(caller.stats().bases_agreeing, 4); // ACGT == ACGT
@@ -1875,7 +1164,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACTTGG", &[30, 30, 30, 30, 30, 30], 100, &r1_cigar);
         let mut r2 = create_raw_test_record(b"ACGG", &[20, 20, 20, 20], 100, &r2_cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
     }
 
@@ -1892,7 +1181,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGG", &[30, 30, 30, 30], 100, &r1_cigar);
         let mut r2 = create_raw_test_record(b"ACTTGG", &[20, 20, 20, 20, 20, 20], 100, &r2_cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
     }
 
@@ -1907,7 +1196,7 @@ mod tests {
         let mut r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
         let mut r2 = create_raw_test_record(b"GCTA", &[29, 29, 29, 29], 100, &cigar);
 
-        let result = caller.call_raw(&mut r1, &mut r2).expect("call_raw should succeed");
+        let result = caller.call(&mut r1, &mut r2).expect("call should succeed");
         assert!(result);
 
         // Quality difference is 1, but minimum is 2
@@ -1915,84 +1204,8 @@ mod tests {
         assert_eq!(RawRecordView::new(&r2).quality_scores()[0], 2);
     }
 
-    /// Verify that `call_raw` produces the same results as `call` for agreement.
     #[test]
-    fn test_raw_matches_recordbuf_agreement() {
-        let mut caller_buf = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-        let mut caller_raw = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::Consensus,
-            DisagreementStrategy::Consensus,
-        );
-
-        // RecordBuf path
-        let mut rb_r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut rb_r2 = create_test_record(b"ACGT", &[20, 20, 20, 20], 100, "4M");
-        caller_buf.call(&mut rb_r1, &mut rb_r2).expect("call should succeed");
-
-        // Raw path
-        let cigar = [cigar_op(4, 0)];
-        let mut raw_r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
-        let mut raw_r2 = create_raw_test_record(b"ACGT", &[20, 20, 20, 20], 100, &cigar);
-        caller_raw.call_raw(&mut raw_r1, &mut raw_r2).expect("call_raw should succeed");
-
-        // Compare results
-        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
-        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
-        assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
-        assert_eq!(caller_buf.stats().bases_agreeing, caller_raw.stats().bases_agreeing);
-        assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
-    }
-
-    /// Verify that `call_raw` produces the same results as `call` for disagreement.
-    #[test]
-    fn test_raw_matches_recordbuf_disagreement() {
-        let mut caller_buf = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskBoth,
-        );
-        let mut caller_raw = OverlappingBasesConsensusCaller::new(
-            AgreementStrategy::PassThrough,
-            DisagreementStrategy::MaskBoth,
-        );
-
-        // RecordBuf path
-        let mut rb_r1 = create_test_record(b"ACGT", &[30, 30, 30, 30], 100, "4M");
-        let mut rb_r2 = create_test_record(b"GCTA", &[20, 20, 20, 20], 100, "4M");
-        caller_buf.call(&mut rb_r1, &mut rb_r2).expect("call should succeed");
-
-        // Raw path
-        let cigar = [cigar_op(4, 0)];
-        let mut raw_r1 = create_raw_test_record(b"ACGT", &[30, 30, 30, 30], 100, &cigar);
-        let mut raw_r2 = create_raw_test_record(b"GCTA", &[20, 20, 20, 20], 100, &cigar);
-        caller_raw.call_raw(&mut raw_r1, &mut raw_r2).expect("call_raw should succeed");
-
-        // Compare sequences
-        let buf_r1_seq: Vec<u8> = rb_r1.sequence().as_ref().to_vec();
-        let buf_r2_seq: Vec<u8> = rb_r2.sequence().as_ref().to_vec();
-        let raw_r1_seq = RawRecordView::new(&raw_r1).sequence_vec();
-        let raw_r2_seq = RawRecordView::new(&raw_r2).sequence_vec();
-        assert_eq!(buf_r1_seq, raw_r1_seq);
-        assert_eq!(buf_r2_seq, raw_r2_seq);
-
-        // Compare qualities
-        assert_eq!(rb_r1.quality_scores().as_ref(), RawRecordView::new(&raw_r1).quality_scores());
-        assert_eq!(rb_r2.quality_scores().as_ref(), RawRecordView::new(&raw_r2).quality_scores());
-
-        // Compare stats
-        assert_eq!(caller_buf.stats().overlapping_bases, caller_raw.stats().overlapping_bases);
-        assert_eq!(caller_buf.stats().bases_disagreeing, caller_raw.stats().bases_disagreeing);
-        assert_eq!(caller_buf.stats().bases_corrected, caller_raw.stats().bases_corrected);
-    }
-
-    // ========================================================================
-    // apply_overlapping_consensus_raw tests
-    // ========================================================================
-
-    #[test]
-    fn test_apply_overlapping_consensus_raw_pair() {
+    fn test_apply_overlapping_consensus_pair() {
         let mut caller = OverlappingBasesConsensusCaller::new(
             AgreementStrategy::Consensus,
             DisagreementStrategy::Consensus,
@@ -2007,8 +1220,8 @@ mod tests {
         let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
 
         let mut records = vec![r1, r2];
-        apply_overlapping_consensus_raw(&mut records, &mut caller)
-            .expect("apply_overlapping_consensus_raw should succeed");
+        apply_overlapping_consensus(&mut records, &mut caller)
+            .expect("apply_overlapping_consensus should succeed");
 
         // Check that qualities were summed (30 + 20 = 50)
         assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 50);
@@ -2017,7 +1230,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_overlapping_consensus_raw_no_pair() {
+    fn test_apply_overlapping_consensus_no_pair() {
         let mut caller = OverlappingBasesConsensusCaller::new(
             AgreementStrategy::Consensus,
             DisagreementStrategy::Consensus,
@@ -2032,8 +1245,8 @@ mod tests {
         let r2 = make_raw_bam(b"reb", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
 
         let mut records = vec![r1, r2];
-        apply_overlapping_consensus_raw(&mut records, &mut caller)
-            .expect("apply_overlapping_consensus_raw should succeed");
+        apply_overlapping_consensus(&mut records, &mut caller)
+            .expect("apply_overlapping_consensus should succeed");
 
         // Qualities unchanged because no matching pair
         assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 30);
@@ -2042,7 +1255,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_overlapping_consensus_raw_reversed_indices() {
+    fn test_apply_overlapping_consensus_reversed_indices() {
         // Test when R2 appears before R1 in the slice (exercises the idx1 > idx2 branch)
         let mut caller = OverlappingBasesConsensusCaller::new(
             AgreementStrategy::Consensus,
@@ -2057,8 +1270,8 @@ mod tests {
 
         // R2 at index 0, R1 at index 1
         let mut records = vec![r2, r1];
-        apply_overlapping_consensus_raw(&mut records, &mut caller)
-            .expect("apply_overlapping_consensus_raw should succeed");
+        apply_overlapping_consensus(&mut records, &mut caller)
+            .expect("apply_overlapping_consensus should succeed");
 
         // Both should have been consensus-called
         assert!(caller.stats().overlapping_bases > 0);
@@ -2066,6 +1279,69 @@ mod tests {
             RawRecordView::new(&records[0]).quality_scores()[0],
             RawRecordView::new(&records[1]).quality_scores()[0]
         );
+    }
+
+    #[test]
+    fn test_apply_overlapping_consensus_skips_supplementary() {
+        // A supplementary R1 with the same name as the primary R1 must not
+        // overwrite the primary pair in read_pairs and get consensus-called.
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+
+        // Primary R1
+        let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
+        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        // Primary R2
+        let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
+        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        // Supplementary R1 (same name, placed AFTER the primary so it would
+        // overwrite the primary index if the loop did not skip non-primary records).
+        let supp_flag = fgumi_raw_bam::flags::PAIRED
+            | fgumi_raw_bam::flags::FIRST_SEGMENT
+            | fgumi_raw_bam::flags::SUPPLEMENTARY;
+        let supp = make_raw_bam(b"rea", supp_flag, 0, 99, &cigar, b"ACGT", &[10, 10, 10, 10]);
+
+        let mut records = vec![r1, r2, supp];
+        apply_overlapping_consensus(&mut records, &mut caller)
+            .expect("apply_overlapping_consensus should succeed");
+
+        // Primary R1 and R2 were consensus-called: qualities sum to 30 + 20 = 50.
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 50);
+        // Supplementary was skipped: its qualities remain unchanged.
+        assert_eq!(RawRecordView::new(&records[2]).quality_scores()[0], 10);
+    }
+
+    #[test]
+    fn test_apply_overlapping_consensus_skips_secondary() {
+        // Same invariant for secondary alignments.
+        let mut caller = OverlappingBasesConsensusCaller::new(
+            AgreementStrategy::Consensus,
+            DisagreementStrategy::Consensus,
+        );
+
+        let cigar = [cigar_op(4, 0)]; // 4M
+
+        let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
+        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
+        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let sec_flag = fgumi_raw_bam::flags::PAIRED
+            | fgumi_raw_bam::flags::FIRST_SEGMENT
+            | fgumi_raw_bam::flags::SECONDARY;
+        let sec = make_raw_bam(b"rea", sec_flag, 0, 99, &cigar, b"ACGT", &[10, 10, 10, 10]);
+
+        let mut records = vec![r1, r2, sec];
+        apply_overlapping_consensus(&mut records, &mut caller)
+            .expect("apply_overlapping_consensus should succeed");
+
+        assert_eq!(RawRecordView::new(&records[0]).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&records[1]).quality_scores()[0], 50);
+        assert_eq!(RawRecordView::new(&records[2]).quality_scores()[0], 10);
     }
 
     // ========================================================================
@@ -2169,6 +1445,7 @@ mod tests {
 
     #[test]
     fn test_kind_to_bam_op() {
+        use noodles::sam::alignment::record::cigar::op::Kind;
         assert_eq!(kind_to_bam_op(Kind::Match), 0);
         assert_eq!(kind_to_bam_op(Kind::Insertion), 1);
         assert_eq!(kind_to_bam_op(Kind::Deletion), 2);
@@ -2178,60 +1455,5 @@ mod tests {
         assert_eq!(kind_to_bam_op(Kind::Pad), 6);
         assert_eq!(kind_to_bam_op(Kind::SequenceMatch), 7);
         assert_eq!(kind_to_bam_op(Kind::SequenceMismatch), 8);
-    }
-
-    #[test]
-    fn test_unified_iterator_noodles_and_raw_agree() {
-        // Create two overlapping records via noodles RecordBuf
-        let r1 = create_test_record(b"ACGTACGT", &[30; 8], 100, "8M");
-        let r2 = create_test_record(b"ACGTACGT", &[20; 8], 104, "8M");
-
-        // Collect positions from the noodles-based iterator
-        let noodles_iter = ReadMateAndRefPosIterator::new(&r1, &r2)
-            .expect("ReadMateAndRefPosIterator::new should succeed");
-        let noodles_positions: Vec<_> = noodles_iter.collect();
-
-        // Build raw BAM bytes for the same records
-        let cigar_8m = [cigar_op(8, 0)]; // 8M
-        let r1_raw = create_raw_test_record(b"ACGTACGT", &[30; 8], 100, &cigar_8m);
-        let r2_raw = create_raw_test_record(b"ACGTACGT", &[20; 8], 104, &cigar_8m);
-
-        // r1: 100-107, r2: 104-111, overlap: 104-107
-        let raw_iter = ReadMateAndRefPosIterator::new_raw(
-            &r1_raw, &r2_raw, 100, 107, // r1 start/end
-            104, 111, // r2 start/end
-        );
-        let raw_positions: Vec<_> = raw_iter.collect();
-
-        assert_eq!(noodles_positions.len(), raw_positions.len());
-        for (n, r) in noodles_positions.iter().zip(raw_positions.iter()) {
-            assert_eq!(n.read_offset, r.read_offset);
-            assert_eq!(n.mate_offset, r.mate_offset);
-        }
-        // Overlap is 4 bases (positions 104-107)
-        assert_eq!(noodles_positions.len(), 4);
-    }
-
-    #[test]
-    fn test_unified_iterator_with_deletion() {
-        // R1: 8bp seq, CIGAR 4M2D4M = 10bp ref span, positions 100-109
-        // R2: 4bp seq, CIGAR 4M, positions 106-109
-        let r1 = create_test_record(b"ACGTACGT", &[30; 8], 100, "4M2D4M");
-        let r2 = create_test_record(b"TTTT", &[20; 4], 106, "4M");
-
-        let iter = ReadMateAndRefPosIterator::new(&r1, &r2)
-            .expect("ReadMateAndRefPosIterator::new should succeed");
-        let positions: Vec<_> = iter.collect();
-
-        // Overlap region: 106-109 (4 ref positions)
-        // R1 deletion at 104-105 means read positions 0-3 map to ref 100-103,
-        // read positions 4-7 map to ref 106-109
-        assert_eq!(positions.len(), 4);
-        // R1 read offsets should be 4,5,6,7 (after the deletion gap)
-        assert_eq!(positions[0].read_offset, 4);
-        assert_eq!(positions[3].read_offset, 7);
-        // R2 read offsets should be 0,1,2,3
-        assert_eq!(positions[0].mate_offset, 0);
-        assert_eq!(positions[3].mate_offset, 3);
     }
 }

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -13,7 +13,7 @@ use crate::phred::{
 use crate::simple_umi::consensus_umis;
 use anyhow::{Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
-use fgumi_raw_bam::{RawRecordView, UnmappedSamBuilder, flags};
+use fgumi_raw_bam::{RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
 #[cfg(test)]
@@ -364,7 +364,11 @@ pub struct VanillaUmiConsensusCaller {
     /// Random number generator for downsampling (seeded or thread-local)
     rng: StdRng,
 
-    /// Rejected reads as raw bytes (if tracking is enabled)
+    /// Rejected reads as raw bytes (if tracking is enabled).
+    ///
+    /// Retained as `Vec<Vec<u8>>` (not `Vec<RawRecord>`) because callers aggregate into
+    /// `all_rejects: Vec<Vec<u8>>` for deferred BAM writing; that rejects path is a
+    /// separate migration from the input path changed here.
     rejected_reads: Vec<Vec<u8>>,
 
     /// Whether to track rejected reads
@@ -740,21 +744,21 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Filters reads to remove secondary/supplementary alignments.
-    fn filter_reads(&mut self, reads: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+    fn filter_reads(&mut self, reads: Vec<RawRecord>) -> Vec<RawRecord> {
         let (accepted, rejected): (Vec<_>, Vec<_>) = reads.into_iter().partition(|raw| {
-            let flg = RawRecordView::new(raw).flags();
+            let flg = RawRecordView::new(raw.as_ref()).flags();
             flg & flags::SECONDARY == 0 && flg & flags::SUPPLEMENTARY == 0
         });
 
         if self.track_rejects {
-            self.rejected_reads.extend(rejected);
+            self.rejected_reads.extend(rejected.into_iter().map(RawRecord::into_inner));
         }
 
         accepted
     }
 
     /// Downsamples reads if there are more than `max_reads`
-    fn downsample_reads(&mut self, mut reads: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+    fn downsample_reads(&mut self, mut reads: Vec<RawRecord>) -> Vec<RawRecord> {
         if let Some(max_reads) = self.options.max_reads {
             if reads.len() > max_reads {
                 reads.shuffle(&mut self.rng);
@@ -1003,20 +1007,19 @@ impl VanillaUmiConsensusCaller {
 
     /// Sub-groups reads by read type (fragment, R1, R2)
     #[expect(
-        clippy::type_complexity,
-        reason = "tuple return type is clearer than a one-off struct for internal grouping"
-    )]
-    #[expect(
         clippy::unused_self,
         reason = "method signature kept for consistency with other caller trait methods"
     )]
-    fn subgroup_reads(&self, reads: Vec<Vec<u8>>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    fn subgroup_reads(
+        &self,
+        reads: Vec<RawRecord>,
+    ) -> (Vec<RawRecord>, Vec<RawRecord>, Vec<RawRecord>) {
         let mut fragment_reads = Vec::new();
         let mut r1_reads = Vec::new();
         let mut r2_reads = Vec::new();
 
         for raw in reads {
-            let flg = RawRecordView::new(&raw).flags();
+            let flg = RawRecordView::new(raw.as_ref()).flags();
             if flg & flags::PAIRED == 0 {
                 fragment_reads.push(raw);
             } else if flg & flags::FIRST_SEGMENT != 0 {
@@ -1030,7 +1033,7 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Processes a single UMI group to produce consensus reads
-    fn process_group(&mut self, umi: &str, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
+    fn process_group(&mut self, umi: &str, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
         let input_count = records.len();
         self.stats.record_input(input_count);
 
@@ -1050,7 +1053,7 @@ impl VanillaUmiConsensusCaller {
         if reads.len() < self.options.min_reads {
             self.stats.record_rejection(RejectionReason::InsufficientReads, reads.len());
             if self.track_rejects {
-                self.rejected_reads.extend(reads);
+                self.rejected_reads.extend(reads.into_iter().map(RawRecord::into_inner));
             }
             return Ok(ConsensusOutput::default());
         }
@@ -1107,13 +1110,17 @@ impl VanillaUmiConsensusCaller {
     /// Returns a tuple of:
     /// - `bool` — whether a consensus was produced
     /// - `usize` — count of reads that survived all internal filtering (not rejected)
-    /// - `Vec<Vec<u8>>` — the surviving raw reads (only populated when `self.track_rejects`)
+    /// - `Vec<Vec<u8>>` — the surviving raw reads as bytes (only populated when `self.track_rejects`)
+    ///
+    /// The return type's third element is `Vec<Vec<u8>>` (not `Vec<RawRecord>`) because
+    /// orphan-consensus rejections are forwarded to `rejected_reads: Vec<Vec<u8>>`; that
+    /// rejects path is a separate migration from the input migration done here.
     fn process_subgroup(
         &mut self,
         output: &mut ConsensusOutput,
         umi: &str,
         read_type: ReadType,
-        group_reads: Vec<Vec<u8>>,
+        group_reads: Vec<RawRecord>,
     ) -> Result<(bool, usize, Vec<Vec<u8>>)> {
         use fgumi_raw_bam as bam_fields;
 
@@ -1124,7 +1131,7 @@ impl VanillaUmiConsensusCaller {
         if group_reads.len() < self.options.min_reads {
             self.stats.record_rejection(RejectionReason::InsufficientReads, group_reads.len());
             if self.track_rejects {
-                self.rejected_reads.extend(group_reads);
+                self.rejected_reads.extend(group_reads.into_iter().map(RawRecord::into_inner));
             }
             return Ok((false, 0, Vec::new()));
         }
@@ -1132,7 +1139,7 @@ impl VanillaUmiConsensusCaller {
         // Calculate mate overlap clips from raw bytes
         let mate_overlap_clips: Vec<usize> = group_reads
             .iter()
-            .map(|raw| bam_fields::num_bases_extending_past_mate_raw(raw))
+            .map(|raw| bam_fields::num_bases_extending_past_mate_raw(raw.as_ref()))
             .collect();
 
         // Create SourceReads from raw bytes
@@ -1142,7 +1149,7 @@ impl VanillaUmiConsensusCaller {
         for (idx, (raw, &mate_clip)) in
             group_reads.iter().zip(mate_overlap_clips.iter()).enumerate()
         {
-            if let Some(sr) = self.create_source_read(raw, idx, mate_clip) {
+            if let Some(sr) = self.create_source_read(raw.as_ref(), idx, mate_clip) {
                 source_reads.push(sr);
             } else {
                 zero_length_indices.push(idx);
@@ -1156,7 +1163,7 @@ impl VanillaUmiConsensusCaller {
             );
             if self.track_rejects {
                 for &idx in &zero_length_indices {
-                    self.rejected_reads.push(group_reads[idx].clone());
+                    self.rejected_reads.push(group_reads[idx].to_vec());
                 }
             }
         }
@@ -1166,7 +1173,7 @@ impl VanillaUmiConsensusCaller {
                 self.stats.record_rejection(RejectionReason::InsufficientReads, source_reads.len());
                 if self.track_rejects {
                     for sr in &source_reads {
-                        self.rejected_reads.push(group_reads[sr.original_idx].clone());
+                        self.rejected_reads.push(group_reads[sr.original_idx].to_vec());
                     }
                 }
             }
@@ -1179,7 +1186,7 @@ impl VanillaUmiConsensusCaller {
 
         if self.track_rejects {
             for idx in rejected_indices {
-                self.rejected_reads.push(group_reads[idx].clone());
+                self.rejected_reads.push(group_reads[idx].to_vec());
             }
         }
 
@@ -1191,7 +1198,7 @@ impl VanillaUmiConsensusCaller {
                 );
                 if self.track_rejects {
                     for sr in &filtered_source_reads {
-                        self.rejected_reads.push(group_reads[sr.original_idx].clone());
+                        self.rejected_reads.push(group_reads[sr.original_idx].to_vec());
                     }
                 }
             }
@@ -1201,7 +1208,7 @@ impl VanillaUmiConsensusCaller {
         // Capture surviving count and reads before building consensus
         let surviving_count = filtered_source_reads.len();
         let surviving_reads = if self.track_rejects {
-            filtered_source_reads.iter().map(|sr| group_reads[sr.original_idx].clone()).collect()
+            filtered_source_reads.iter().map(|sr| group_reads[sr.original_idx].to_vec()).collect()
         } else {
             Vec::new()
         };
@@ -1222,10 +1229,8 @@ impl VanillaUmiConsensusCaller {
         let methylation = methylation.map(|m| m.truncate(bases.len()));
 
         // Get raw records for tag extraction
-        let original_raws: Vec<&[u8]> = filtered_source_reads
-            .iter()
-            .map(|sr| group_reads[sr.original_idx].as_slice())
-            .collect();
+        let original_raws: Vec<&[u8]> =
+            filtered_source_reads.iter().map(|sr| group_reads[sr.original_idx].as_ref()).collect();
 
         self.build_consensus_record_into(
             output,
@@ -1463,7 +1468,7 @@ impl VanillaUmiConsensusCaller {
 }
 
 impl ConsensusCaller for VanillaUmiConsensusCaller {
-    fn consensus_reads(&mut self, records: Vec<Vec<u8>>) -> Result<ConsensusOutput> {
+    fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
         if records.is_empty() {
             return Ok(ConsensusOutput::default());
         }
@@ -1476,13 +1481,13 @@ impl ConsensusCaller for VanillaUmiConsensusCaller {
         let tag_key = [tag_bytes[0], tag_bytes[1]];
 
         let first_raw = records.first().expect("records is non-empty (checked above)");
-        let read_name_bytes = RawRecordView::new(first_raw).read_name();
+        let read_name_bytes = RawRecordView::new(first_raw.as_ref()).read_name();
         let read_name = String::from_utf8_lossy(read_name_bytes);
 
         let tag_value =
-            RawRecordView::new(first_raw).tags().find_string(&tag_key).ok_or_else(|| {
-                anyhow!("Missing UMI tag '{}' for read '{}'", self.options.tag, read_name)
-            })?;
+            RawRecordView::new(first_raw.as_ref()).tags().find_string(&tag_key).ok_or_else(
+                || anyhow!("Missing UMI tag '{}' for read '{}'", self.options.tag, read_name),
+            )?;
 
         let umi = String::from_utf8_lossy(tag_value).into_owned();
 
@@ -1575,7 +1580,8 @@ mod tests {
         caller: &mut VanillaUmiConsensusCaller,
         records: Vec<RecordBuf>,
     ) -> anyhow::Result<ConsensusOutput> {
-        let raw: Vec<Vec<u8>> = records.iter().map(encode_to_raw).collect();
+        let raw: Vec<RawRecord> =
+            records.iter().map(|r| RawRecord::from(encode_to_raw(r))).collect();
         caller.consensus_reads(raw)
     }
 
@@ -1729,7 +1735,8 @@ mod tests {
         // Mark read2 as secondary
         *read2.flags_mut() = NoodlesFlags::SECONDARY;
 
-        let filtered = caller.filter_reads(vec![encode_to_raw(&read1), encode_to_raw(&read2)]);
+        let filtered =
+            caller.filter_reads(vec![encode_to_raw(&read1).into(), encode_to_raw(&read2).into()]);
         assert_eq!(filtered.len(), 1);
     }
 
@@ -1744,9 +1751,9 @@ mod tests {
         let r2 = create_test_read("r2", b"ACGT", b"####", true, false);
 
         let (frag_reads, r1_reads, r2_reads) = caller.subgroup_reads(vec![
-            encode_to_raw(&fragment),
-            encode_to_raw(&r1),
-            encode_to_raw(&r2),
+            encode_to_raw(&fragment).into(),
+            encode_to_raw(&r1).into(),
+            encode_to_raw(&r2).into(),
         ]);
 
         // Should have one read in each subgroup
@@ -1807,11 +1814,11 @@ mod tests {
         };
 
         // Create 10 reads with different names
-        let mut reads = Vec::new();
+        let mut reads: Vec<RawRecord> = Vec::new();
         for i in 0..10 {
             let name = format!("read{i}");
             let read = create_test_read(&name, b"ACGT", b"####", false, false);
-            reads.push(encode_to_raw(&read));
+            reads.push(encode_to_raw(&read).into());
         }
 
         // Create two callers with the same seed
@@ -1851,11 +1858,11 @@ mod tests {
         };
 
         // Create 10 reads
-        let mut reads = Vec::new();
+        let mut reads: Vec<RawRecord> = Vec::new();
         for i in 0..10 {
             let name = format!("read{i}");
             let read = create_test_read(&name, b"ACGT", b"####", false, false);
-            reads.push(encode_to_raw(&read));
+            reads.push(encode_to_raw(&read).into());
         }
 
         let mut caller =

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -380,8 +380,11 @@ impl Command for Codec {
         for result in mi_group_iter {
             let (umi, records) = result.context("Failed to read MI group")?;
 
-            // Call consensus directly — records are already raw bytes!
-            let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
+            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+            let raw: Vec<fgumi_raw_bam::RawRecord> =
+                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+            let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(raw);
             match result {
                 Ok(output) => {
                     let batch_size = output.count;
@@ -572,8 +575,11 @@ impl Codec {
                 for RawMiGroup { mi, records } in batch.groups {
                     caller.clear();
 
-                    // Call CODEC consensus directly — records are already raw bytes!
-                    let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
+                    // Call CODEC consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+                    let raw: Vec<fgumi_raw_bam::RawRecord> =
+                        records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+                    let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(raw);
                     match result {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -27,7 +27,7 @@ use crate::logging::{OperationTimer, log_consensus_summary};
 use crate::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
 use crate::overlapping_consensus::{
     AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
-    apply_overlapping_consensus_raw,
+    apply_overlapping_consensus,
 };
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::progress::ProgressTracker;
@@ -471,12 +471,15 @@ impl Command for Duplex {
             // Skip if group doesn't have both strands - no duplex possible anyway
             if let Some(ref mut oc) = overlapping_caller {
                 if has_both_strands_raw(&records) {
-                    apply_overlapping_consensus_raw(&mut records, oc)?;
+                    apply_overlapping_consensus(&mut records, oc)?;
                 }
             }
 
-            // Call consensus directly -- records are already raw bytes!
-            let output = consensus_caller.consensus_reads(records)?;
+            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+            let raw: Vec<fgumi_raw_bam::RawRecord> =
+                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+            let output = consensus_caller.consensus_reads(raw)?;
 
             // Write pre-serialized consensus reads
             let batch_size = output.count;
@@ -693,15 +696,18 @@ impl Duplex {
                     if let Some(ref mut oc) = overlapping_caller {
                         if has_both_strands_raw(&group_reads) {
                             oc.reset_stats();
-                            if apply_overlapping_consensus_raw(&mut group_reads, oc).is_err() {
+                            if apply_overlapping_consensus(&mut group_reads, oc).is_err() {
                                 continue;
                             }
                             batch_overlapping.merge(oc.stats());
                         }
                     }
 
-                    // Call duplex consensus directly -- records are already raw bytes!
-                    match caller.consensus_reads(group_reads) {
+                    // Call duplex consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+                    let group_raw: Vec<fgumi_raw_bam::RawRecord> =
+                        group_reads.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+                    match caller.consensus_reads(group_raw) {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);
                             batch_stats.merge(&caller.statistics());

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -12,12 +12,11 @@ use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::bam_io::create_bam_reader_for_pipeline_with_opts;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
-    check_conversion_fraction_raw_with_ref_bases_and_tags, compute_read_stats_raw,
-    filter_duplex_read_raw, filter_read_raw, is_duplex_consensus_raw, mask_bases_raw,
-    mask_duplex_bases_raw, mask_methylation_depth_duplex_raw_with_tags,
-    mask_methylation_depth_simplex_raw_with_tags,
+    check_conversion_fraction_raw_with_ref_bases_and_tags, compute_read_stats, filter_duplex_read,
+    filter_read, is_duplex_consensus, mask_bases, mask_duplex_bases,
+    mask_methylation_depth_duplex_raw_with_tags, mask_methylation_depth_simplex_raw_with_tags,
     mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, resolve_ref_bases_for_record,
-    template_passes_raw,
+    template_passes,
 };
 use crate::grouper::{SingleRawRecordGrouper, TemplateGrouper};
 use crate::logging::OperationTimer;
@@ -668,7 +667,7 @@ impl Filter {
                     pass_map.insert(idx, pass);
                 }
 
-                let template_pass = template_passes_raw(&template_records, &pass_map);
+                let template_pass = template_passes(&template_records, &pass_map);
 
                 for (idx, record) in template_records.into_iter().enumerate() {
                     let flags = RawRecordView::new(&record).flags();
@@ -771,14 +770,14 @@ impl Filter {
 
         let is_duplex = {
             let aux = bam_fields::aux_data_slice(record);
-            is_duplex_consensus_raw(aux)
+            is_duplex_consensus(aux)
         };
 
         let mut masked_count = if is_duplex {
             let (cc_thresh, ab_thresh, ba_thresh) = config
                 .duplex_thresholds()
                 .ok_or_else(|| anyhow::anyhow!("No duplex thresholds configured"))?;
-            mask_duplex_bases_raw(
+            mask_duplex_bases(
                 record,
                 cc_thresh,
                 ab_thresh,
@@ -790,7 +789,7 @@ impl Filter {
             let thresholds = config
                 .effective_single_strand_thresholds()
                 .ok_or_else(|| anyhow::anyhow!("No thresholds configured"))?;
-            mask_bases_raw(record, thresholds, min_base_quality)?
+            mask_bases(record, thresholds, min_base_quality)?
         };
 
         // Parse methylation tags once for all EM-Seq filters
@@ -892,7 +891,7 @@ impl Filter {
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> bool {
-        let (no_calls, mean_qual) = compute_read_stats_raw(bam);
+        let (no_calls, mean_qual) = compute_read_stats(bam);
         if let Some(min_qual) = min_mean_qual {
             if mean_qual < min_qual {
                 return false;
@@ -920,7 +919,7 @@ impl Filter {
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> Result<bool> {
-        let filter_result = filter_read_raw(aux_data, thresholds)?;
+        let filter_result = filter_read(aux_data, thresholds)?;
         if filter_result != FilterResult::Pass {
             return Ok(false);
         }
@@ -941,7 +940,7 @@ impl Filter {
         max_no_call_frac: f64,
     ) -> Result<bool> {
         let filter_result =
-            filter_duplex_read_raw(aux_data, cc_thresholds, ab_thresholds, ba_thresholds)?;
+            filter_duplex_read(aux_data, cc_thresholds, ab_thresholds, ba_thresholds)?;
         if filter_result != FilterResult::Pass {
             return Ok(false);
         }
@@ -1096,6 +1095,7 @@ impl Filter {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+    use crate::sam::builder::RecordBuilder;
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use noodles::sam::alignment::record_buf::RecordBuf;
     use rstest::rstest;
@@ -1389,112 +1389,125 @@ mod tests {
 
     // Integration tests for filtering logic
 
-    use crate::sam::builder::RecordBuilder;
-    use noodles::sam::alignment::record_buf::data::field::Value;
-    use noodles::sam::alignment::record_buf::data::field::value::Array;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, aux_data_slice, flags};
 
-    /// Creates a test record with specified properties for filtering tests.
+    /// Creates a raw BAM test record for filtering tests.
     ///
-    /// Generates a minimal BAM record with the provided sequence, quality scores,
-    /// and optional consensus depth and error tags for testing filtering logic.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Read name for the record
-    /// * `sequence` - DNA sequence string (e.g., "ACGT")
-    /// * `qualities` - Quality scores (Phred scale) for each base
-    /// * `read_depth` - Optional read depth for per-read cD tag (use for read-level filtering)
-    /// * `read_error` - Optional error rate for per-read cE tag (use for read-level filtering)
-    /// * `base_depths` - Optional per-base depths for cd tag (use for base-level masking)
-    /// * `base_errors` - Optional per-base error counts for ce tag (use for base-level masking)
-    ///
-    /// # Returns
-    ///
-    /// A `RecordBuf` configured for testing with default mapping properties
+    /// Returns a `RawRecord` with the provided sequence, quality scores,
+    /// and optional consensus depth and error tags.
     fn create_filter_test_record(
-        name: &str,
-        sequence: &str,
+        _name: &str,
+        sequence: &[u8],
         qualities: &[u8],
         read_depth: Option<u8>,
         read_error: Option<f32>,
         base_depths: Option<Vec<u16>>,
         base_errors: Option<Vec<u16>>,
-    ) -> RecordBuf {
-        let mut builder = RecordBuilder::new()
-            .name(name)
-            .sequence(sequence)
-            .qualities(qualities)
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60);
+    ) -> RawRecord {
+        let seq_len = sequence.len();
+        let cigar_op = if seq_len > 0 { (seq_len as u32) << 4 } else { 0 }; // nM
 
-        // Add per-read depth tag (cD) if provided
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0).pos(0).mapq(60).flags(0);
+        if seq_len > 0 {
+            b.cigar_ops(&[cigar_op]).sequence(sequence).qualities(qualities);
+        }
         if let Some(depth) = read_depth {
-            builder = builder.tag("cD", Value::UInt8(depth));
+            b.add_int_tag(b"cD", i32::from(depth));
         }
-
-        // Add per-read error tag (cE) if provided
         if let Some(error) = read_error {
-            builder = builder.tag("cE", Value::Float(error));
+            b.add_float_tag(b"cE", error);
         }
-
-        // Add per-base depth tag (cd) if provided
         if let Some(depths) = base_depths {
-            builder = builder.tag("cd", Value::Array(Array::UInt16(depths)));
+            b.add_array_u16(b"cd", &depths);
         }
-
-        // Add per-base error tag (ce) if provided
         if let Some(errors) = base_errors {
-            builder = builder.tag("ce", Value::Array(Array::UInt16(errors)));
+            b.add_array_u16(b"ce", &errors);
         }
+        b.build()
+    }
 
-        builder.build()
+    /// Creates a raw BAM test record with `PAIRED+FIRST_SEGMENT` flags.
+    fn create_r1_record(sequence: &[u8], qualities: &[u8]) -> RawRecord {
+        let seq_len = sequence.len();
+        let cigar_op = (seq_len as u32) << 4;
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0)
+            .pos(0)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .cigar_ops(&[cigar_op])
+            .sequence(sequence)
+            .qualities(qualities);
+        b.build()
+    }
+
+    /// Creates a raw BAM test record with `PAIRED+LAST_SEGMENT` flags.
+    fn create_r2_record(sequence: &[u8], qualities: &[u8]) -> RawRecord {
+        let seq_len = sequence.len();
+        let cigar_op = (seq_len as u32) << 4;
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0)
+            .pos(0)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .cigar_ops(&[cigar_op])
+            .sequence(sequence)
+            .qualities(qualities);
+        b.build()
     }
 
     #[test]
     fn test_count_no_calls_empty_sequence() {
-        let record = create_filter_test_record("test", "", &[], None, None, None, None);
+        let record = create_filter_test_record("test", b"", &[], None, None, None, None);
         assert_eq!(crate::consensus_filter::count_no_calls(&record), 0);
     }
 
     #[test]
     fn test_count_no_calls_no_ns() {
         let record =
-            create_filter_test_record("test", "ACGT", &[30, 30, 30, 30], None, None, None, None);
+            create_filter_test_record("test", b"ACGT", &[30, 30, 30, 30], None, None, None, None);
         assert_eq!(crate::consensus_filter::count_no_calls(&record), 0);
     }
 
     #[test]
     fn test_count_no_calls_with_ns() {
-        let record =
-            create_filter_test_record("test", "ACNTN", &[30, 30, 0, 30, 0], None, None, None, None);
+        let record = create_filter_test_record(
+            "test",
+            b"ACNTN",
+            &[30, 30, 0, 30, 0],
+            None,
+            None,
+            None,
+            None,
+        );
         assert_eq!(crate::consensus_filter::count_no_calls(&record), 2);
     }
 
     #[test]
     fn test_count_no_calls_all_ns() {
         let record =
-            create_filter_test_record("test", "NNNN", &[0, 0, 0, 0], None, None, None, None);
+            create_filter_test_record("test", b"NNNN", &[0, 0, 0, 0], None, None, None, None);
         assert_eq!(crate::consensus_filter::count_no_calls(&record), 4);
     }
 
     #[test]
     fn test_mean_base_quality_empty() {
-        let record = create_filter_test_record("test", "", &[], None, None, None, None);
+        let record = create_filter_test_record("test", b"", &[], None, None, None, None);
         assert!((crate::consensus_filter::mean_base_quality(&record) - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_mean_base_quality_uniform() {
         let record =
-            create_filter_test_record("test", "ACGT", &[30, 30, 30, 30], None, None, None, None);
+            create_filter_test_record("test", b"ACGT", &[30, 30, 30, 30], None, None, None, None);
         assert!((crate::consensus_filter::mean_base_quality(&record) - 30.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_mean_base_quality_mixed() {
         let record =
-            create_filter_test_record("test", "ACGT", &[10, 20, 30, 40], None, None, None, None);
+            create_filter_test_record("test", b"ACGT", &[10, 20, 30, 40], None, None, None, None);
         assert!((crate::consensus_filter::mean_base_quality(&record) - 25.0).abs() < f64::EPSILON);
     }
 
@@ -1506,7 +1519,7 @@ mod tests {
         // Qualities: A=10 (<20, mask), C=30 (ok), G=5 (<20, mask), T=30 (ok)
         let mut record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[10, 30, 5, 30],
             None,
             None,
@@ -1520,13 +1533,12 @@ mod tests {
         mask_bases(&mut record, &thresholds, Some(20)).expect("mask_bases should succeed");
 
         // Bases 0 and 2 have quality < 20, should be masked to N
-        let seq = std::str::from_utf8(record.sequence().as_ref())
-            .expect("sequence should be valid UTF-8");
-        assert_eq!(seq, "NCNT");
+        let seq = fgumi_raw_bam::RawRecordView::new(&record).sequence_vec();
+        assert_eq!(&seq, b"NCNT");
 
         // Quality scores for masked bases should be 2 (Phred MIN_VALUE, matching fgbio)
-        let quals = record.quality_scores();
-        assert_eq!(quals.as_ref(), &[2, 30, 2, 30]);
+        let quals = fgumi_raw_bam::RawRecordView::new(&record).quality_scores().to_vec();
+        assert_eq!(quals, vec![2u8, 30, 2, 30]);
     }
 
     #[test]
@@ -1535,7 +1547,7 @@ mod tests {
 
         let mut record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[30, 30, 30, 30],
             None,
             None,
@@ -1549,9 +1561,8 @@ mod tests {
         mask_bases(&mut record, &thresholds, Some(10)).expect("mask_bases should succeed");
 
         // Bases with depth < 5 should be masked to N
-        let seq = std::str::from_utf8(record.sequence().as_ref())
-            .expect("sequence should be valid UTF-8");
-        assert_eq!(seq, "NCNT");
+        let seq = fgumi_raw_bam::RawRecordView::new(&record).sequence_vec();
+        assert_eq!(&seq, b"NCNT");
     }
 
     #[test]
@@ -1560,7 +1571,7 @@ mod tests {
 
         let mut record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[30, 30, 30, 30],
             None,
             None,
@@ -1578,9 +1589,8 @@ mod tests {
 
         // Base 1 has 3/10 = 30% > 20%, should be masked
         // Base 2 has 2/10 = 20% = 20%, NOT masked (needs to be strictly greater)
-        let seq = std::str::from_utf8(record.sequence().as_ref())
-            .expect("sequence should be valid UTF-8");
-        assert_eq!(seq, "ANGT");
+        let seq = fgumi_raw_bam::RawRecordView::new(&record).sequence_vec();
+        assert_eq!(&seq, b"ANGT");
     }
 
     #[test]
@@ -1589,7 +1599,7 @@ mod tests {
 
         let record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[30, 30, 30, 30],
             Some(10),   // Per-read depth
             Some(0.05), // Per-read error rate
@@ -1600,7 +1610,8 @@ mod tests {
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
 
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
+        let result =
+            filter_read(aux_data_slice(&record), &thresholds).expect("filter_read should succeed");
         assert_eq!(result, FilterResult::Pass);
     }
 
@@ -1610,7 +1621,7 @@ mod tests {
 
         let record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[30, 30, 30, 30],
             Some(3), // Below threshold
             Some(0.05),
@@ -1621,7 +1632,8 @@ mod tests {
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
 
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
+        let result =
+            filter_read(aux_data_slice(&record), &thresholds).expect("filter_read should succeed");
         assert_eq!(result, FilterResult::InsufficientReads);
     }
 
@@ -1631,7 +1643,7 @@ mod tests {
 
         let record = create_filter_test_record(
             "test",
-            "ACGT",
+            b"ACGT",
             &[30, 30, 30, 30],
             Some(10),
             Some(0.3), // High error rate
@@ -1642,7 +1654,8 @@ mod tests {
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
 
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
+        let result =
+            filter_read(aux_data_slice(&record), &thresholds).expect("filter_read should succeed");
         assert_eq!(result, FilterResult::ExcessiveErrorRate);
     }
 
@@ -1652,12 +1665,13 @@ mod tests {
 
         // Record without depth/error tags should pass (tags are optional)
         let record =
-            create_filter_test_record("test", "ACGT", &[30, 30, 30, 30], None, None, None, None);
+            create_filter_test_record("test", b"ACGT", &[30, 30, 30, 30], None, None, None, None);
 
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
 
-        let result = filter_read(&record, &thresholds).expect("filter_read should succeed");
+        let result =
+            filter_read(aux_data_slice(&record), &thresholds).expect("filter_read should succeed");
         assert_eq!(result, FilterResult::Pass);
     }
 
@@ -1666,12 +1680,10 @@ mod tests {
         use crate::consensus_filter::template_passes;
         use ahash::AHashMap;
 
-        let r1 =
-            create_filter_test_record("read1", "ACGT", &[30, 30, 30, 30], None, None, None, None);
-        let r2 =
-            create_filter_test_record("read1", "GGGG", &[30, 30, 30, 30], None, None, None, None);
+        let r1 = create_r1_record(b"ACGT", &[30, 30, 30, 30]);
+        let r2 = create_r2_record(b"GGGG", &[30, 30, 30, 30]);
 
-        let records = vec![r1, r2];
+        let records: Vec<Vec<u8>> = vec![r1.into_inner(), r2.into_inner()];
         let mut pass_map = AHashMap::new();
         pass_map.insert(0, true);
         pass_map.insert(1, true);
@@ -1684,12 +1696,10 @@ mod tests {
         use crate::consensus_filter::template_passes;
         use ahash::AHashMap;
 
-        let r1 =
-            create_filter_test_record("read1", "ACGT", &[30, 30, 30, 30], None, None, None, None);
-        let r2 =
-            create_filter_test_record("read1", "GGGG", &[30, 30, 30, 30], None, None, None, None);
+        let r1 = create_r1_record(b"ACGT", &[30, 30, 30, 30]);
+        let r2 = create_r2_record(b"GGGG", &[30, 30, 30, 30]);
 
-        let records = vec![r1, r2];
+        let records: Vec<Vec<u8>> = vec![r1.into_inner(), r2.into_inner()];
         let mut pass_map = AHashMap::new();
         pass_map.insert(0, true);
         pass_map.insert(1, false); // One fails
@@ -1702,21 +1712,27 @@ mod tests {
         use crate::consensus_filter::is_duplex_consensus;
 
         let record =
-            create_filter_test_record("test", "ACGT", &[30, 30, 30, 30], None, None, None, None);
-        assert!(!is_duplex_consensus(&record));
+            create_filter_test_record("test", b"ACGT", &[30, 30, 30, 30], None, None, None, None);
+        assert!(!is_duplex_consensus(aux_data_slice(&record)));
     }
 
     #[test]
     fn test_is_duplex_consensus_with_tag() {
         use crate::consensus_filter::is_duplex_consensus;
 
-        let mut record =
-            create_filter_test_record("test", "ACGT", &[30, 30, 30, 30], None, None, None, None);
+        // Build a record with the aD tag included directly
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0)
+            .pos(0)
+            .mapq(60)
+            .flags(0)
+            .cigar_ops(&[4 << 4]) // 4M
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        b.add_int_tag(b"aD", 10);
+        let record = b.build();
 
-        // Add duplex consensus tags (aD per-read tag is key indicator)
-        record.data_mut().insert(crate::consensus_tags::per_read::tag("aD"), Value::UInt8(10));
-
-        assert!(is_duplex_consensus(&record));
+        assert!(is_duplex_consensus(aux_data_slice(&record)));
     }
 
     #[test]
@@ -4041,7 +4057,7 @@ mod tests {
             .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
             .build();
 
-        // Add required cD and cE tags for filter_read_raw to pass
+        // Add required cD and cE tags for filter_read to pass
         record.data_mut().insert(
             noodles::sam::alignment::record::data::field::Tag::from([b'c', b'D']),
             noodles::sam::alignment::record_buf::data::field::Value::from(10u8),

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -15,7 +15,7 @@ use crate::logging::{OperationTimer, log_consensus_summary};
 use crate::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
 use crate::overlapping_consensus::{
     AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
-    apply_overlapping_consensus_raw,
+    apply_overlapping_consensus,
 };
 use crate::progress::ProgressTracker;
 use crate::read_info::LibraryIndex;
@@ -399,12 +399,15 @@ impl Command for Simplex {
 
             // Apply overlapping consensus if enabled (modifies raw bytes in-place)
             if let Some(ref mut oc) = overlapping_caller {
-                apply_overlapping_consensus_raw(&mut records, oc)?;
+                apply_overlapping_consensus(&mut records, oc)?;
             }
 
-            // Call consensus directly — records are already raw bytes!
+            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+            let raw: Vec<fgumi_raw_bam::RawRecord> =
+                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
             let output = caller
-                .consensus_reads(records)
+                .consensus_reads(raw)
                 .with_context(|| format!("Failed to call consensus for UMI: {umi}"))?;
 
             let batch_size = output.count;
@@ -602,7 +605,7 @@ impl Simplex {
                     // Apply overlapping consensus if enabled (modifies raw bytes in-place)
                     if let Some(ref mut oc) = overlapping_caller {
                         oc.reset_stats();
-                        if apply_overlapping_consensus_raw(&mut raw_records, oc).is_err() {
+                        if apply_overlapping_consensus(&mut raw_records, oc).is_err() {
                             batch_overlapping.merge(oc.stats());
                             batch_stats.record_input(raw_records.len());
                             batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
@@ -614,8 +617,11 @@ impl Simplex {
                         batch_overlapping.merge(oc.stats());
                     }
 
-                    // Call consensus directly — records are already raw bytes!
-                    match caller.consensus_reads(raw_records) {
+                    // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
+                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
+                    let raw: Vec<fgumi_raw_bam::RawRecord> =
+                        raw_records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+                    match caller.consensus_reads(raw) {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);
                             batch_stats.merge(&caller.statistics());


### PR DESCRIPTION
## Summary

Migrates the `fgumi-consensus` crate's internals from `RecordBuf` to
`RawRecord` and drops the `RecordBuf` variants of the filter, overlapping,
and caller APIs. The raw-byte variants become the canonical API (the
`_raw` suffix is dropped).

## Stack position

Part 4 of 7 in the follow-up series closing #272. Stacks on
`nh/raw-bam-api-8-sam-raw-helpers` (PR 8 / raw-byte record_utils + RawRecordClipper).

## Scope

**fgumi-consensus crate:**

- `filter.rs` — remove `RecordBuf` variants (`filter_read`, `filter_duplex_read`,
  `mask_bases`, `mask_duplex_bases`, `count_no_calls`, `mean_base_quality`,
  `compute_read_stats`, `template_passes`, `is_duplex_consensus`). Raw variants
  are renamed to the canonical (non-`_raw`-suffixed) names. `filter_read` switched
  to `find_int_tag` (accepts c/C/s/S/i/I) instead of `find_uint8_tag` for the
  `cD` depth tag.
- `overlapping.rs` — remove `RecordBuf` variants (`call`, `apply_overlapping_consensus`)
  and parity tests. Raw variants renamed to canonical names.
- `caller.rs` — change `ConsensusCaller::consensus_reads` trait signature from
  `Vec<Vec<u8>>` to `Vec<RawRecord>`.
- `vanilla_caller.rs` — migrate internal pipeline end-to-end to `Vec<RawRecord>`
  (filter_reads, downsample_reads, subgroup_reads, process_group, process_subgroup).
- `duplex_caller.rs` — migrate internals to `RawRecord` (partition_records_by_strand,
  has_minimum_number_of_reads, are_all_same_strand, process_group, duplex_read_into).
- `codec_caller.rs` — `consensus_reads_raw` takes `&[RawRecord]`;
  `build_output_record_into` accepts `&[RawRecord]`.
- `rejected_reads: Vec<Vec<u8>>` is retained as out-of-scope (bridged to the
  future follow-up PR).

**Command-layer callers** (`src/lib/commands/{simplex,duplex,codec,filter}.rs`):

- Bridge `Vec<Vec<u8>>` from `RawMiGroupIterator` to `Vec<RawRecord>` via
  `RawRecord::from` at `consensus_reads` call sites. The iterator itself is
  migrated to yield `Vec<RawRecord>` directly in a separate PR (mi-group raw
  storage migration).
- Migrate `commands/filter.rs` test fixtures that exercised the dropped
  `RecordBuf` variants to use the raw-byte API + `fgumi_raw_bam::SamBuilder`.

## Size

- 12 files changed, 620 insertions(+), 2801 deletions(-) — well under the
  2-3K-line budget (net decrease).

## Test plan

- [x] `cargo ci-test` — 2541 passed, 23 skipped
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`