### PR TITLE
refactor(lib): migrate commands, storage, and pipeline to raw-byte records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,19 @@ Uses `mimalloc` as global allocator for performance.
 
 `#![deny(unsafe_code)]` - only standard library unsafe is permitted.
 
+### Approved non-stdlib FFI exceptions
+
+The following external FFI calls are approved because they back core infrastructure:
+
+- **`libmimalloc_sys`** (`src/lib/sort/memory_probe.rs`) — mimalloc is the configured
+  global allocator. The FFI wrappers (`force_mi_collect`, `process_rss_bytes`, and the
+  `memory-debug`-gated `print_mi_stats` calling `mi_stats_print_out`) are isolated to
+  a single `#[allow(unsafe_code)]` sub-module. mimalloc synchronizes these calls
+  internally, so they are safe to invoke concurrently.
+- **`mach2`** (`src/lib/sort/memory_probe.rs`, macOS only) — `task_info(TASK_VM_INFO)`
+  is the only way to read `phys_footprint` (the RSS metric mimalloc reports accurately).
+  Isolated to the same sub-module as the mimalloc FFI.
+
 ## Benchmarking Notes
 
 ### samtools sort orders

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -10,7 +10,7 @@ use noodles::sam::alignment::record::cigar::op::Kind;
 use crate::phred::{MIN_PHRED, NO_CALL_BASE};
 use fgumi_metrics::rejection::RejectionReason;
 use fgumi_raw_bam as bam_fields;
-use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 
 /// Expands a 1-3 element slice to a 3-element array, filling missing values from the last.
 ///
@@ -367,7 +367,7 @@ impl FilterResult {
 ///
 /// A template passes if it has at least one primary read and all primary reads pass.
 #[must_use]
-pub fn template_passes(raw_records: &[Vec<u8>], pass_map: &AHashMap<usize, bool>) -> bool {
+pub fn template_passes(raw_records: &[RawRecord], pass_map: &AHashMap<usize, bool>) -> bool {
     let mut has_primary = false;
     let mut all_primary_pass = true;
 

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -623,7 +623,7 @@ impl Iterator for ReadMateAndRefPosIterator {
 ///
 /// Returns an error if overlapping consensus calling fails for any read pair.
 pub fn apply_overlapping_consensus(
-    records: &mut [Vec<u8>],
+    records: &mut [fgumi_raw_bam::RawRecord],
     caller: &mut OverlappingBasesConsensusCaller,
 ) -> Result<()> {
     use ahash::AHashMap;
@@ -660,7 +660,9 @@ pub fn apply_overlapping_consensus(
                 (&mut right[0], &mut left[*idx2])
             };
 
-            caller.call(r1, r2).context("Failed to call overlapping consensus on raw bytes")?;
+            caller
+                .call(r1.as_mut_vec().as_mut_slice(), r2.as_mut_vec().as_mut_slice())
+                .context("Failed to call overlapping consensus on raw bytes")?;
         }
     }
 
@@ -1214,10 +1216,26 @@ mod tests {
         // R1 (first segment): flag = PAIRED | FIRST_SEGMENT
         let cigar = [cigar_op(4, 0)]; // 4M
         let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
-        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r1 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r1_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        ));
         // R2 (last segment): flag = PAIRED | LAST_SEGMENT
         let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
-        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r2 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r2_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[20, 20, 20, 20],
+        ));
 
         let mut records = vec![r1, r2];
         apply_overlapping_consensus(&mut records, &mut caller)
@@ -1239,10 +1257,26 @@ mod tests {
         // Only FIRST_SEGMENT, no matching LAST_SEGMENT for this name
         let cigar = [cigar_op(4, 0)]; // 4M
         let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
-        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r1 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r1_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        ));
         // Different name so no pairing occurs
         let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
-        let r2 = make_raw_bam(b"reb", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r2 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"reb",
+            r2_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[20, 20, 20, 20],
+        ));
 
         let mut records = vec![r1, r2];
         apply_overlapping_consensus(&mut records, &mut caller)
@@ -1264,9 +1298,25 @@ mod tests {
 
         let cigar = [cigar_op(4, 0)]; // 4M
         let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
-        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r2 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r2_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[20, 20, 20, 20],
+        ));
         let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
-        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r1 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r1_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        ));
 
         // R2 at index 0, R1 at index 1
         let mut records = vec![r2, r1];
@@ -1294,16 +1344,40 @@ mod tests {
 
         // Primary R1
         let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
-        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r1 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r1_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        ));
         // Primary R2
         let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
-        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r2 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r2_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[20, 20, 20, 20],
+        ));
         // Supplementary R1 (same name, placed AFTER the primary so it would
         // overwrite the primary index if the loop did not skip non-primary records).
         let supp_flag = fgumi_raw_bam::flags::PAIRED
             | fgumi_raw_bam::flags::FIRST_SEGMENT
             | fgumi_raw_bam::flags::SUPPLEMENTARY;
-        let supp = make_raw_bam(b"rea", supp_flag, 0, 99, &cigar, b"ACGT", &[10, 10, 10, 10]);
+        let supp = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            supp_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[10, 10, 10, 10],
+        ));
 
         let mut records = vec![r1, r2, supp];
         apply_overlapping_consensus(&mut records, &mut caller)
@@ -1327,13 +1401,37 @@ mod tests {
         let cigar = [cigar_op(4, 0)]; // 4M
 
         let r1_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT;
-        let r1 = make_raw_bam(b"rea", r1_flag, 0, 99, &cigar, b"ACGT", &[30, 30, 30, 30]);
+        let r1 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r1_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[30, 30, 30, 30],
+        ));
         let r2_flag = fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::LAST_SEGMENT;
-        let r2 = make_raw_bam(b"rea", r2_flag, 0, 99, &cigar, b"ACGT", &[20, 20, 20, 20]);
+        let r2 = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            r2_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[20, 20, 20, 20],
+        ));
         let sec_flag = fgumi_raw_bam::flags::PAIRED
             | fgumi_raw_bam::flags::FIRST_SEGMENT
             | fgumi_raw_bam::flags::SECONDARY;
-        let sec = make_raw_bam(b"rea", sec_flag, 0, 99, &cigar, b"ACGT", &[10, 10, 10, 10]);
+        let sec = fgumi_raw_bam::RawRecord::from(make_raw_bam(
+            b"rea",
+            sec_flag,
+            0,
+            99,
+            &cigar,
+            b"ACGT",
+            &[10, 10, 10, 10],
+        ));
 
         let mut records = vec![r1, r2, sec];
         apply_overlapping_consensus(&mut records, &mut caller)

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -94,8 +94,9 @@ pub use raw_bam_record::{
 
 // -- sequence --
 pub use sequence::{
-    BAM_BASE_TO_ASCII, extract_sequence, get_base, get_qual, is_base_n, mask_base,
-    pack_sequence_into, quality_scores_slice, quality_scores_slice_mut, set_base, set_qual,
+    BAM_BASE_TO_ASCII, extract_sequence, extract_sequence_into, get_base, get_qual, is_base_n,
+    mask_base, pack_sequence_into, quality_scores_slice, quality_scores_slice_mut, set_base,
+    set_qual,
 };
 
 // -- sort --

--- a/crates/fgumi-raw-bam/src/sequence.rs
+++ b/crates/fgumi-raw-bam/src/sequence.rs
@@ -128,31 +128,6 @@ fn decode_chunk_32(packed: &[u8], packed_off: usize, out: &mut [u8], out_off: us
     out[out_off + 16..out_off + 32].copy_from_slice(last_16.as_array());
 }
 
-/// SIMD-accelerated sequence extraction.
-///
-/// Kept `pub(crate)` for benchmarking; external callers go through
-/// `extract_sequence`, which dispatches based on read length.
-#[inline]
-#[must_use]
-pub(crate) fn extract_sequence_simd(bam: &[u8]) -> Vec<u8> {
-    let l = l_seq(bam) as usize;
-    let off = seq_offset(bam);
-    let mut bases = vec![0u8; l];
-
-    // Process 16 packed bytes = 32 bases at a time.
-    let full_chunks = l / 32;
-    for c in 0..full_chunks {
-        decode_chunk_32(bam, off + c * 16, &mut bases, c * 32);
-    }
-
-    // Scalar tail for the remaining (l % 32) bases.
-    let processed = full_chunks * 32;
-    for (slot, i) in bases[processed..].iter_mut().zip(processed..l) {
-        *slot = BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize];
-    }
-    bases
-}
-
 /// Bulk-extract the full sequence from a BAM record as ASCII bases.
 ///
 /// Decodes the packed 4-bit sequence data into a `Vec<u8>` of ASCII bases.
@@ -160,18 +135,41 @@ pub(crate) fn extract_sequence_simd(bam: &[u8]) -> Vec<u8> {
 /// reads where SIMD startup cost dominates.
 #[must_use]
 pub fn extract_sequence(bam: &[u8]) -> Vec<u8> {
-    let l = l_seq(bam) as usize;
-    if l >= 32 {
-        return extract_sequence_simd(bam);
-    }
-    // Scalar path for short sequences.
-    let off = seq_offset(bam);
-    let mut bases = Vec::with_capacity(l);
-    for i in 0..l {
-        let code = get_base(bam, off, i);
-        bases.push(BAM_BASE_TO_ASCII[code as usize]);
-    }
+    let mut bases = Vec::new();
+    extract_sequence_into(bam, &mut bases);
     bases
+}
+
+/// Decode the full sequence from a BAM record into `dst` as ASCII bases.
+///
+/// Reuses the caller's buffer: clears `dst` and resizes it to the read length
+/// before decoding. Uses SIMD for reads of 32 bp or longer; falls back to
+/// scalar for shorter reads where SIMD startup cost dominates.
+pub fn extract_sequence_into(bam: &[u8], dst: &mut Vec<u8>) {
+    let l = l_seq(bam) as usize;
+    let off = seq_offset(bam);
+
+    dst.clear();
+    dst.resize(l, 0);
+
+    if l >= 32 {
+        // Process 16 packed bytes = 32 bases at a time.
+        let full_chunks = l / 32;
+        for c in 0..full_chunks {
+            decode_chunk_32(bam, off + c * 16, dst, c * 32);
+        }
+
+        // Scalar tail for the remaining (l % 32) bases.
+        let processed = full_chunks * 32;
+        for (slot, i) in dst[processed..].iter_mut().zip(processed..l) {
+            *slot = BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize];
+        }
+    } else {
+        // Scalar path for short sequences.
+        for (slot, i) in dst.iter_mut().zip(0..l) {
+            *slot = BAM_BASE_TO_ASCII[get_base(bam, off, i) as usize];
+        }
+    }
 }
 
 /// Pack ASCII bases into BAM 4-bit-per-base format, appending to `dst`.

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -27,6 +27,8 @@ use clap::Parser;
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+// RecordBuf retained: SamRecordClipper (T2.9) requires typed CIGAR/sequence editing on RecordBuf;
+// all record flow in clip.rs is driven by that clipper and Template.records (T2.1).
 use noodles::sam::alignment::record::Cigar as CigarTrait;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -168,6 +170,7 @@ pub struct Clip {
 /// Result from processing a batch of templates through clipping.
 struct ClipProcessedBatch {
     /// Clipped records to write to output BAM.
+    // RecordBuf retained: SamRecordClipper (T2.9) mutates typed CIGAR/sequence on RecordBuf.
     clipped_records: Vec<RecordBuf>,
     /// Number of templates processed.
     templates_count: u64,
@@ -405,6 +408,8 @@ impl Clip {
     /// # Errors
     ///
     /// Returns an error if clipping operations fail.
+    // RecordBuf retained throughout clip_fragment / clip_pair / update_mate_info:
+    // SamRecordClipper (T2.9) requires typed CIGAR editing on RecordBuf.
     fn clip_fragment(
         &self,
         clipper: &SamRecordClipper,
@@ -853,6 +858,8 @@ impl Clip {
 ///
 /// * `record` - The record to update (mutable)
 /// * `mate` - The mate record to read information from
+// RecordBuf retained: records here are the same SamRecordClipper-mutated RecordBuf objects;
+// converting to raw bytes for tag ops and back would add overhead with no benefit until T2.9.
 #[allow(clippy::similar_names)] // mc_tag and mq_tag are standard SAM tags
 #[allow(clippy::cast_lossless)] // u8 to i32 cast is intentional for SAM tag format
 fn update_mate_info(

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -363,7 +363,7 @@ impl Command for Codec {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
                 Ok(0) => None, // EOF
-                Ok(_) => Some(Ok(record.into_inner())),
+                Ok(_) => Some(Ok(record)),
                 Err(e) => Some(Err(e.into())),
             }
         });
@@ -380,11 +380,8 @@ impl Command for Codec {
         for result in mi_group_iter {
             let (umi, records) = result.context("Failed to read MI group")?;
 
-            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-            let raw: Vec<fgumi_raw_bam::RawRecord> =
-                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
-            let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(raw);
+            // Call consensus — mi_group yields Vec<RawRecord>.
+            let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
             match result {
                 Ok(output) => {
                     let batch_size = output.count;
@@ -575,11 +572,8 @@ impl Codec {
                 for RawMiGroup { mi, records } in batch.groups {
                     caller.clear();
 
-                    // Call CODEC consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-                    let raw: Vec<fgumi_raw_bam::RawRecord> =
-                        records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
-                    let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(raw);
+                    // Call CODEC consensus — mi_group yields Vec<RawRecord>.
+                    let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
                     match result {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -27,8 +27,6 @@ use fgumi_raw_bam::{RawRecord, find_int_tag, find_string_tag};
 use itertools::Itertools;
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::record::Cigar as CigarTrait;
-use noodles::sam::alignment::record::cigar::op::Kind;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::alignment::record_buf::data::field::Value;
@@ -249,84 +247,81 @@ impl std::fmt::Display for DiffType {
 const FIELD_NAMES: [&str; 11] =
     ["QNAME", "FLAG", "RNAME", "POS", "MAPQ", "CIGAR", "RNEXT", "PNEXT", "TLEN", "SEQ", "QUAL"];
 
-/// Convert CIGAR op kind to its SAM character representation.
-fn cigar_kind_to_char(kind: Kind) -> char {
-    match kind {
-        Kind::Match => 'M',
-        Kind::Insertion => 'I',
-        Kind::Deletion => 'D',
-        Kind::Skip => 'N',
-        Kind::SoftClip => 'S',
-        Kind::HardClip => 'H',
-        Kind::Pad => 'P',
-        Kind::SequenceMatch => '=',
-        Kind::SequenceMismatch => 'X',
+/// Format CIGAR from raw BAM record bytes as a SAM-style string.
+fn format_cigar_raw(bam: &[u8]) -> String {
+    let s = fgumi_raw_bam::cigar_to_string_from_raw(bam);
+    if s.is_empty() { "*".to_string() } else { s }
+}
+
+/// Format sequence from raw BAM record bytes as an ASCII string.
+fn format_sequence_raw(bam: &[u8]) -> String {
+    let view = fgumi_raw_bam::RawRecordView::new(bam);
+    if view.l_seq() == 0 {
+        "*".to_string()
+    } else {
+        // extract_sequence returns uppercase ASCII bases (A/C/G/T/N/=…)
+        String::from_utf8_lossy(&fgumi_raw_bam::extract_sequence(bam)).into_owned()
     }
 }
 
-/// Format CIGAR as a string.
-fn format_cigar(record: &RecordBuf) -> String {
-    let cigar = record.cigar();
-    let ops: Vec<String> = cigar
-        .iter()
-        .flatten()
-        .map(|op| format!("{}{}", op.len(), cigar_kind_to_char(op.kind())))
-        .collect();
-    if ops.is_empty() { "*".to_string() } else { ops.join("") }
-}
+/// Extract core SAM fields as comparable strings directly from raw BAM bytes.
+///
+/// RNAME and RNEXT are resolved through `header` (requires typed API).
+/// All other fields are read from raw bytes via `RawRecordView`.
+fn get_core_fields_raw(raw: &RawRecord, header: &noodles::sam::Header) -> [String; 11] {
+    let view = fgumi_raw_bam::RawRecordView::new(raw.as_ref());
 
-/// Format sequence as a string.
-fn format_sequence(record: &RecordBuf) -> String {
-    let seq = record.sequence();
-    if seq.is_empty() {
+    let qname = String::from_utf8_lossy(view.read_name()).into_owned();
+    let flag = view.flags().to_string();
+
+    // ref_id is 0-based index into header reference sequences; -1 = unmapped
+    let ref_id = view.ref_id();
+    let rname = if ref_id < 0 {
         "*".to_string()
     } else {
-        seq.as_ref()
-            .iter()
-            .map(|&b| match b {
-                b'A' | b'a' => 'A',
-                b'C' | b'c' => 'C',
-                b'G' | b'g' => 'G',
-                b'T' | b't' => 'T',
-                _ => 'N',
-            })
-            .collect()
-    }
-}
+        header
+            .reference_sequences()
+            .get_index(ref_id as usize)
+            .map(|(name, _)| name.to_string())
+            .unwrap_or_else(|| "*".to_string())
+    };
 
-/// Extract core SAM fields as comparable strings.
-fn get_core_fields(record: &RecordBuf, header: &noodles::sam::Header) -> [String; 11] {
-    let qname = record_name_to_string(record);
-    let flag = record.flags().bits().to_string();
+    // pos is 0-based; SAM/display convention is 1-based (0 when unmapped)
+    let pos_raw = view.pos();
+    let pos = if pos_raw < 0 { "0".to_string() } else { (pos_raw + 1).to_string() };
 
-    let rname = record
-        .reference_sequence_id()
-        .and_then(|id| header.reference_sequences().get_index(id).map(|(name, _)| name.to_string()))
-        .unwrap_or_else(|| "*".to_string());
+    let mapq_raw = view.mapq();
+    let mapq = if mapq_raw == 255 { "255".to_string() } else { mapq_raw.to_string() };
 
-    // Position is 0-based internally, report as 1-based
-    let pos = record.alignment_start().map_or_else(|| "0".to_string(), |p| p.get().to_string());
+    let cigar = format_cigar_raw(raw.as_ref());
 
-    let mapq = record.mapping_quality().map_or_else(|| "255".to_string(), |q| q.get().to_string());
-
-    let cigar = format_cigar(record);
-
-    let rnext = record
-        .mate_reference_sequence_id()
-        .and_then(|id| header.reference_sequences().get_index(id).map(|(name, _)| name.to_string()))
-        .unwrap_or_else(|| "*".to_string());
-
-    let pnext =
-        record.mate_alignment_start().map_or_else(|| "0".to_string(), |p| p.get().to_string());
-
-    let tlen = record.template_length().to_string();
-
-    let seq = format_sequence(record);
-
-    let qual = if record.quality_scores().is_empty() {
+    let mate_ref_id = view.mate_ref_id();
+    let rnext = if mate_ref_id < 0 {
         "*".to_string()
     } else {
-        record.quality_scores().as_ref().iter().map(|q| (q + 33) as char).collect()
+        header
+            .reference_sequences()
+            .get_index(mate_ref_id as usize)
+            .map(|(name, _)| name.to_string())
+            .unwrap_or_else(|| "*".to_string())
+    };
+
+    let mate_pos_raw = view.mate_pos();
+    let pnext = if mate_pos_raw < 0 { "0".to_string() } else { (mate_pos_raw + 1).to_string() };
+
+    let tlen = view.template_length().to_string();
+
+    let seq = format_sequence_raw(raw.as_ref());
+
+    // Quality scores in raw BAM are 0-based Phred. Per SAM/BAM spec, absent QUAL is
+    // signaled by ALL bytes being 0xFF — match that exactly to avoid mis-classifying
+    // malformed records with a stray 0xFF. Saturate the Phred→ASCII conversion at '~'
+    // (Phred 93) to avoid u8 wraparound for any remaining out-of-range bytes.
+    let qual_bytes = fgumi_raw_bam::quality_scores_slice(raw.as_ref());
+    let qual = if qual_bytes.is_empty() || qual_bytes.iter().all(|&q| q == 0xFF) {
+        "*".to_string()
+    } else {
+        qual_bytes.iter().map(|&q| (q.saturating_add(33).min(b'~')) as char).collect()
     };
 
     [qname, flag, rname, pos, mapq, cigar, rnext, pnext, tlen, seq, qual]
@@ -379,9 +374,9 @@ fn record_name_to_string(record: &RecordBuf) -> String {
 }
 
 /// Check if the first-in-template (R1) flag is set in raw BAM record bytes.
+#[inline]
 fn is_first_segment_raw(raw: &RawRecord) -> bool {
-    let flags = fgumi_raw_bam::RawRecordView::new(raw.as_ref()).flags();
-    flags & raw_fields::flags::FIRST_SEGMENT != 0
+    fgumi_raw_bam::RawRecordView::new(raw.as_ref()).is_first_segment()
 }
 
 // ============================================================================
@@ -598,8 +593,9 @@ fn deserialize_raw_record(raw: &RawRecord) -> Result<RecordBuf> {
 /// **Tier 2:** Structured raw comparison — compare core fields and tags at the byte
 ///   level without full deserialization. If core and tags match (possibly with different
 ///   tag order), return without deserializing.
-/// **Tier 3:** Full deserialization — only when records actually differ, deserialize
-///   to `RecordBuf` for human-readable diff reporting.
+/// **Tier 3:** Targeted deserialization for diff reporting — deserialize to `RecordBuf`
+///   only for tag-diff cases that need typed tag display; render core-field diffs
+///   directly from raw bytes.
 ///
 /// Returns `(results, core_matches, core_diffs, tag_matches, tag_diffs, tag_order_diffs)`.
 fn compare_raw_batch_parallel(
@@ -638,44 +634,45 @@ fn compare_raw_batch_parallel(
                 };
             }
 
-            // Tier 3: Full deserialization for diff reporting
-            let rec1 = match deserialize_raw_record(r1) {
-                Ok(r) => r,
-                Err(e) => {
-                    return RecordCompareResult {
-                        core_match: false,
-                        tags_match: false,
-                        tag_order_match: false,
-                        diff_detail: Some(DiffDetail {
-                            record_num,
-                            qname: format!("<deserialization error: {e}>"),
-                            flags: String::new(),
-                            diff_type: DiffType::CoreDiff,
-                            diffs: vec![format!("Failed to deserialize record from BAM1: {e}")],
-                        }),
-                    };
-                }
-            };
-            let rec2 = match deserialize_raw_record(r2) {
-                Ok(r) => r,
-                Err(e) => {
-                    return RecordCompareResult {
-                        core_match: false,
-                        tags_match: false,
-                        tag_order_match: false,
-                        diff_detail: Some(DiffDetail {
-                            record_num,
-                            qname: record_name_to_string(&rec1),
-                            flags: rec1.flags().bits().to_string(),
-                            diff_type: DiffType::CoreDiff,
-                            diffs: vec![format!("Failed to deserialize record from BAM2: {e}")],
-                        }),
-                    };
-                }
-            };
-
+            // Tier 3: diff reporting — two sub-cases:
+            //   (a) core matches but tags differ: deserialize for typed tag value display
+            //   (b) core fields differ: use raw bytes directly (no deserialization needed)
             let diff_detail = if raw_result.core_match {
-                // Core matches but tags differ
+                // (a) Core matches but tags differ — deserialize for typed tag value display
+                let rec1 = match deserialize_raw_record(r1) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return RecordCompareResult {
+                            core_match: false,
+                            tags_match: false,
+                            tag_order_match: false,
+                            diff_detail: Some(DiffDetail {
+                                record_num,
+                                qname: format!("<deserialization error: {e}>"),
+                                flags: String::new(),
+                                diff_type: DiffType::TagDiff,
+                                diffs: vec![format!("Failed to deserialize record from BAM1: {e}")],
+                            }),
+                        };
+                    }
+                };
+                let rec2 = match deserialize_raw_record(r2) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return RecordCompareResult {
+                            core_match: false,
+                            tags_match: false,
+                            tag_order_match: false,
+                            diff_detail: Some(DiffDetail {
+                                record_num,
+                                qname: record_name_to_string(&rec1),
+                                flags: rec1.flags().bits().to_string(),
+                                diff_type: DiffType::TagDiff,
+                                diffs: vec![format!("Failed to deserialize record from BAM2: {e}")],
+                            }),
+                        };
+                    }
+                };
                 let tags1 = get_tags_map(&rec1);
                 let tags2 = get_tags_map(&rec2);
                 let mut all_tags: Vec<&String> = tags1.keys().chain(tags2.keys()).collect();
@@ -713,9 +710,9 @@ fn compare_raw_batch_parallel(
                     diffs,
                 })
             } else {
-                // Core fields differ
-                let core1 = get_core_fields(&rec1, header1);
-                let core2 = get_core_fields(&rec2, header2);
+                // (b) Core fields differ — extract from raw bytes via RawRecordView
+                let core1 = get_core_fields_raw(r1, header1);
+                let core2 = get_core_fields_raw(r2, header2);
                 let diffs: Vec<String> = core1
                     .iter()
                     .zip(core2.iter())

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -293,9 +293,9 @@ struct TemplateCorrection {
 /// Result from processing a batch of templates through UMI correction.
 struct CorrectProcessedBatch {
     /// Raw-byte kept records.
-    kept_raw_records: Vec<Vec<u8>>,
+    kept_raw_records: Vec<RawRecord>,
     /// Raw-byte rejected records.
-    rejected_raw_records: Vec<Vec<u8>>,
+    rejected_raw_records: Vec<RawRecord>,
     /// Number of templates processed.
     templates_count: u64,
     /// Number of missing UMI records.
@@ -314,11 +314,11 @@ impl MemoryEstimate for CorrectProcessedBatch {
             .kept_raw_records
             .iter()
             .chain(self.rejected_raw_records.iter())
-            .map(Vec::capacity)
+            .map(RawRecord::capacity)
             .sum();
         let raw_vec_overhead = (self.kept_raw_records.capacity()
             + self.rejected_raw_records.capacity())
-            * std::mem::size_of::<Vec<u8>>();
+            * std::mem::size_of::<RawRecord>();
         raw_size + raw_vec_overhead
     }
 }
@@ -337,7 +337,7 @@ struct CollectedCorrectMetrics {
     /// Per-UMI match counts (for metrics file).
     umi_matches: AHashMap<String, UmiCorrectionMetrics>,
     /// Rejected raw records (if tracking).
-    raw_rejects: Vec<Vec<u8>>,
+    raw_rejects: Vec<RawRecord>,
 }
 
 impl Command for CorrectUmis {
@@ -640,7 +640,7 @@ impl CorrectUmis {
     /// - Some records have UMIs and others don't
     /// - UMI tag has non-string type
     fn extract_and_validate_template_umi_raw(
-        raw_records: &[Vec<u8>],
+        raw_records: &[RawRecord],
         umi_tag: [u8; 2],
     ) -> anyhow::Result<Option<String>> {
         use crate::sort::bam_fields;
@@ -694,7 +694,7 @@ impl CorrectUmis {
 
     /// Apply UMI correction to a raw BAM record.
     fn apply_correction_to_raw(
-        record: &mut Vec<u8>,
+        record: &mut RawRecord,
         correction: &TemplateCorrection,
         umi_tag: [u8; 2],
         dont_store_original_umis: bool,
@@ -704,14 +704,14 @@ impl CorrectUmis {
         if correction.needs_correction {
             // Write corrected UMI first (in-place update avoids scanning past OX)
             if let Some(ref corrected) = correction.corrected_umi {
-                bam_fields::update_string_tag(record, &umi_tag, corrected.as_bytes());
+                bam_fields::update_string_tag(record.as_mut_vec(), &umi_tag, corrected.as_bytes());
             }
 
             // Store original UMI if there were actual mismatches
             // Use update_string_tag to avoid duplicate OX tags
             if !dont_store_original_umis && correction.has_mismatches {
                 bam_fields::update_string_tag(
-                    record,
+                    record.as_mut_vec(),
                     &SamTag::OX,
                     correction.original_umi.as_bytes(),
                 );
@@ -833,8 +833,8 @@ impl CorrectUmis {
                     ));
                 }
 
-                let mut kept_raw_records = Vec::new();
-                let mut rejected_raw_records: Vec<Vec<u8>> = Vec::new();
+                let mut kept_raw_records: Vec<RawRecord> = Vec::new();
+                let mut rejected_raw_records: Vec<RawRecord> = Vec::new();
                 let mut missing_umis = 0u64;
                 let mut wrong_length = 0u64;
                 let mut mismatched = 0u64;
@@ -853,7 +853,8 @@ impl CorrectUmis {
                         "Expected raw-byte mode template in pipeline; RecordBuf mode is no longer supported"
                     );
                     {
-                        let raw_records = template.into_raw_records().unwrap_or_default();
+                        let raw_records: Vec<RawRecord> =
+                            template.into_raw_records().unwrap_or_default();
                         let umi_opt = Self::extract_and_validate_template_umi_raw(
                             &raw_records,
                             umi_tag_bytes,
@@ -1011,7 +1012,7 @@ impl CorrectUmis {
         let mut total_wrong_length = 0u64;
         let mut total_mismatched = 0u64;
         let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
-        let mut all_raw_rejects: Vec<Vec<u8>> = Vec::new();
+        let mut all_raw_rejects: Vec<RawRecord> = Vec::new();
 
         for slot in collected_metrics.slots() {
             let mut m = slot.lock();
@@ -1172,7 +1173,7 @@ impl CorrectUmis {
 
         // Read raw records and group by QNAME
         let mut record = RawRecord::new();
-        let mut current_template: Vec<Vec<u8>> = Vec::new();
+        let mut current_template: Vec<RawRecord> = Vec::new();
         let mut current_name: Option<Vec<u8>> = None;
 
         loop {
@@ -1287,10 +1288,10 @@ impl CorrectUmis {
                 break;
             }
 
-            // Accumulate current record
-            let raw: &[u8] = record.as_ref();
-            current_name = Some(bam_fields::read_name(raw).to_vec());
-            current_template.push(raw.to_vec());
+            // Accumulate current record — move the reader's buffer instead of copying.
+            current_name = Some(bam_fields::read_name(record.as_ref()).to_vec());
+            let taken = std::mem::take(&mut record);
+            current_template.push(taken);
         }
 
         progress.log_final();
@@ -3022,7 +3023,7 @@ mod tests {
     // ========================================================================
 
     /// Build a minimal raw BAM record with a UMI tag for testing.
-    fn make_raw_bam_for_correct(name: &[u8], flag: u16, umi: &[u8]) -> Vec<u8> {
+    fn make_raw_bam_for_correct(name: &[u8], flag: u16, umi: &[u8]) -> RawRecord {
         let l_read_name = (name.len() + 1) as u8;
         let seq_len = 4usize;
         let cigar_ops: &[u32] = if (flag & crate::sort::bam_fields::flags::UNMAPPED) == 0 {
@@ -3060,7 +3061,7 @@ mod tests {
         buf.extend_from_slice(umi);
         buf.push(0);
 
-        buf
+        RawRecord::from(buf)
     }
 
     // ========================================================================
@@ -3122,15 +3123,16 @@ mod tests {
     #[test]
     fn test_extract_and_validate_template_umi_raw_no_umi_tag() {
         // Record with no UMI tag at all
-        let mut raw = vec![0u8; 42]; // minimal record
-        raw[8] = 4; // l_read_name
-        raw[14..16].copy_from_slice(
+        let mut raw_bytes = vec![0u8; 42]; // minimal record
+        raw_bytes[8] = 4; // l_read_name
+        raw_bytes[14..16].copy_from_slice(
             &(crate::sort::bam_fields::flags::PAIRED
                 | crate::sort::bam_fields::flags::FIRST_SEGMENT)
                 .to_le_bytes(),
         );
-        raw[16..20].copy_from_slice(&4u32.to_le_bytes()); // l_seq = 4
-        raw[32..36].copy_from_slice(b"rea\0");
+        raw_bytes[16..20].copy_from_slice(&4u32.to_le_bytes()); // l_seq = 4
+        raw_bytes[32..36].copy_from_slice(b"rea\0");
+        let raw = RawRecord::from(raw_bytes);
         let result =
             CorrectUmis::extract_and_validate_template_umi_raw(&[raw], *SamTag::RX).unwrap();
         assert!(result.is_none());

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -836,7 +836,7 @@ fn mark_duplicates_in_family(templates: &mut [&mut Template], dedup_metrics: &mu
 fn mark_template_as_duplicate(template: &mut Template, dedup_metrics: &mut DedupMetrics) {
     if let Some(raw_records) = template.all_raw_records_mut() {
         for raw in raw_records.iter_mut() {
-            let flg = RawRecordView::new(raw.as_slice()).flags();
+            let flg = RawRecordView::new(raw.as_ref()).flags();
             bam_fields::set_flags(raw, flg | DUPLICATE_FLAG);
             dedup_metrics.duplicate_reads += 1;
         }
@@ -901,7 +901,7 @@ fn process_position_group(
         .map(|mut t| {
             if let Some(raw_records) = t.all_raw_records_mut() {
                 for raw in raw_records.iter_mut() {
-                    let flg = RawRecordView::new(raw.as_slice()).flags();
+                    let flg = RawRecordView::new(raw.as_ref()).flags();
                     bam_fields::set_flags(raw, flg & !DUPLICATE_FLAG);
                 }
             } else {
@@ -968,7 +968,7 @@ fn process_position_group(
         if let Some(raw_records) = template.all_raw_records() {
             for raw in raw_records {
                 dedup_metrics.total_reads += 1;
-                let flg = RawRecordView::new(raw.as_slice()).flags();
+                let flg = RawRecordView::new(raw.as_ref()).flags();
                 let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
                 let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
 
@@ -2509,7 +2509,7 @@ mod tests {
         // (rejected as poor alignment due to missing UMI tag).
 
         let raw = make_raw_bam_record_truncated_aux();
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
 
         let config = DedupFilterConfig {
@@ -2553,7 +2553,7 @@ mod tests {
         rec.extend_from_slice(b"MQc"); // tag=MQ, type=c (signed byte)
         rec.push(10); // MAPQ = 10 (< min_mapq of 20)
 
-        let template = Template::from_raw_records(vec![rec])
+        let template = Template::from_raw_records(vec![rec].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
 
         let config = DedupFilterConfig {
@@ -2648,7 +2648,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         assert_eq!(score_template_raw(&template), 60);
     }
@@ -2664,7 +2664,7 @@ mod tests {
             &[10, 10, 10, 10],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         assert_eq!(score_template_raw(&template), 40);
     }
@@ -2688,8 +2688,9 @@ mod tests {
             &[10, 10, 10, 10],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![r1, r2])
-            .expect("test template construction should not fail");
+        let template =
+            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
+                .expect("test template construction should not fail");
         assert_eq!(score_template_raw(&template), 100);
     }
 
@@ -2708,7 +2709,7 @@ mod tests {
                 qualities,
                 b"ACGT",
             );
-            Template::from_raw_records(vec![raw])
+            Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
                 .expect("test template construction should not fail")
         };
         assert_eq!(score_template(&template_rb), score_template(&template_raw));
@@ -2730,7 +2731,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2756,7 +2757,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2783,7 +2784,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2809,7 +2810,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2835,7 +2836,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2860,7 +2861,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -3036,7 +3037,7 @@ mod tests {
             4,
             &[20, 20, 20, 20],
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -3064,7 +3065,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -3092,7 +3093,7 @@ mod tests {
             &[20, 20, 20, 20],
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -424,8 +424,7 @@ impl Command for Duplex {
                 match raw_reader.read_record(&mut record) {
                     Ok(0) => return None, // EOF
                     Ok(_) => {
-                        let raw = record.into_inner();
-                        let flg = RawRecordView::new(&raw).flags();
+                        let flg = RawRecordView::new(&record).flags();
                         // Skip secondary and supplementary reads
                         if flg & bam_fields::flags::SECONDARY != 0
                             || flg & bam_fields::flags::SUPPLEMENTARY != 0
@@ -437,7 +436,7 @@ impl Command for Duplex {
                         let has_mapped_mate = flg & bam_fields::flags::PAIRED != 0
                             && flg & bam_fields::flags::MATE_UNMAPPED == 0;
                         if is_mapped || has_mapped_mate {
-                            return Some(Ok(raw));
+                            return Some(Ok(record));
                         }
                         // Skip unmapped reads without mapped mates
                     }
@@ -475,11 +474,8 @@ impl Command for Duplex {
                 }
             }
 
-            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-            let raw: Vec<fgumi_raw_bam::RawRecord> =
-                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
-            let output = consensus_caller.consensus_reads(raw)?;
+            // Call consensus — mi_group now yields Vec<RawRecord> directly.
+            let output = consensus_caller.consensus_reads(records)?;
 
             // Write pre-serialized consensus reads
             let batch_size = output.count;
@@ -703,11 +699,8 @@ impl Duplex {
                         }
                     }
 
-                    // Call duplex consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-                    let group_raw: Vec<fgumi_raw_bam::RawRecord> =
-                        group_reads.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
-                    match caller.consensus_reads(group_raw) {
+                    // Call duplex consensus — mi_group yields Vec<RawRecord>.
+                    match caller.consensus_reads(group_reads) {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);
                             batch_stats.merge(&caller.statistics());
@@ -838,7 +831,7 @@ impl Duplex {
 /// It examines the MI tag of each record to check for /A and /B suffixes.
 /// Returns `true` only if there is at least one read with /A suffix AND at least
 /// one read with /B suffix.
-fn has_both_strands_raw(records: &[Vec<u8>]) -> bool {
+fn has_both_strands_raw(records: &[RawRecord]) -> bool {
     if records.len() < 2 {
         return false;
     }

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -3,15 +3,16 @@
 //! This tool reads a BAM file and outputs interleaved FASTQ to stdout for piping to aligners.
 //! Input should be queryname-sorted or template-coordinate sorted.
 
-use crate::bam_io::create_bam_reader;
+use crate::bam_io::create_raw_bam_reader;
 use crate::commands::common::parse_bool;
 use crate::logging::OperationTimer;
 use crate::validation::validate_file_exists;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
+use fgumi_raw_bam::{
+    RawRecord, extract_sequence_into, quality_scores_slice, read_name as raw_read_name,
+};
 use log::info;
-use noodles::bam;
-use noodles::sam::alignment::record::Flags;
 use std::io::{BufWriter, Write, stdout};
 use std::path::PathBuf;
 
@@ -117,7 +118,7 @@ impl Command for Fastq {
         info!("Read name suffix: {}", if self.no_suffix { "disabled" } else { "enabled" });
         info!("BWA chunk size: {} bases", self.bwa_chunk_size);
 
-        let (mut reader, _header) = create_bam_reader(&self.input, self.threads)?;
+        let (mut reader, _header) = create_raw_bam_reader(&self.input, self.threads)?;
 
         // Use 64MB buffer for efficient pipe throughput
         let mut writer = BufWriter::with_capacity(64 * 1024 * 1024, stdout().lock());
@@ -132,23 +133,27 @@ impl Command for Fastq {
         // Reusable buffers to avoid per-record allocations
         let mut seq_buf: Vec<u8> = Vec::with_capacity(512);
         let mut qual_buf: Vec<u8> = Vec::with_capacity(512);
+        let mut record = RawRecord::new();
 
-        for result in reader.records() {
-            let record = result.context("Failed to read BAM record")?;
+        loop {
+            let n = reader.read_record(&mut record)?;
+            if n == 0 {
+                break; // EOF
+            }
             total_records += 1;
 
             let flags = record.flags();
 
             // Filter by flags
-            if (flags.bits() & self.exclude_flags) != 0 {
+            if (flags & self.exclude_flags) != 0 {
                 continue;
             }
-            if (flags.bits() & self.require_flags) != self.require_flags {
+            if (flags & self.require_flags) != self.require_flags {
                 continue;
             }
 
             // Get sequence length for batch tracking
-            let seq_len = record.sequence().len();
+            let seq_len = record.l_seq() as usize;
 
             // Write FASTQ record
             write_fastq_record(
@@ -186,39 +191,38 @@ impl Command for Fastq {
 #[inline]
 fn write_fastq_record<W: Write>(
     writer: &mut W,
-    record: &bam::Record,
-    flags: Flags,
+    record: &RawRecord,
+    flags: u16,
     no_suffix: bool,
     seq_buf: &mut Vec<u8>,
     qual_buf: &mut Vec<u8>,
 ) -> Result<()> {
-    // Get read name - use concrete method for direct access
-    let name = record.name().context("Record missing name")?;
+    use fgumi_raw_bam::flags as flag_bits;
+
+    // Get read name (without null terminator)
+    let name = raw_read_name(record);
 
     // Determine read suffix (/1 or /2)
+    let is_first = (flags & flag_bits::FIRST_SEGMENT) != 0;
+    let is_last = (flags & flag_bits::LAST_SEGMENT) != 0;
     let suffix: &[u8] = if no_suffix {
         b""
-    } else if flags.is_first_segment() && !flags.is_last_segment() {
+    } else if is_first && !is_last {
         b"/1"
-    } else if flags.is_last_segment() && !flags.is_first_segment() {
+    } else if is_last && !is_first {
         b"/2"
     } else {
         b"" // Single-end or both flags set
     };
 
-    // Get sequence and quality - use concrete methods for direct slice access
-    let seq = record.sequence();
-    let qual = record.quality_scores();
+    // Decode sequence from 4-bit BAM encoding to ASCII bases (reuses seq_buf).
+    extract_sequence_into(record, seq_buf);
 
-    // Collect sequence bytes into reusable buffer
-    seq_buf.clear();
-    seq_buf.extend(seq.iter());
-
-    // Collect and transform quality bytes using direct slice access (no Result unwrapping)
+    // Copy quality bytes and transform to Phred+33 ASCII
     qual_buf.clear();
-    qual_buf.extend(qual.as_ref().iter().map(|&s| QUAL_TO_ASCII[s as usize]));
+    qual_buf.extend(quality_scores_slice(record).iter().map(|&s| QUAL_TO_ASCII[s as usize]));
 
-    if flags.is_reverse_complemented() {
+    if (flags & flag_bits::REVERSE) != 0 {
         // Reverse complement sequence in place using lookup table
         seq_buf.reverse();
         for base in seq_buf.iter_mut() {
@@ -230,7 +234,7 @@ fn write_fastq_record<W: Write>(
 
     // Write all parts
     writer.write_all(b"@")?;
-    writer.write_all(name.as_ref())?;
+    writer.write_all(name)?;
     writer.write_all(suffix)?;
     writer.write_all(b"\n")?;
     writer.write_all(seq_buf)?;

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -34,7 +34,7 @@ use crate::validation::validate_file_exists;
 use ahash::AHashMap;
 use anyhow::{Result, bail};
 use clap::Parser;
-use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use log::info;
 use noodles::sam::Header;
 use std::io;
@@ -222,9 +222,9 @@ pub struct Filter {
 /// Result from processing a batch of records through raw-byte filtering.
 struct FilterProcessedBatchRaw {
     /// Records that passed filtering (raw bytes).
-    kept_records: Vec<Vec<u8>>,
+    kept_records: Vec<RawRecord>,
     /// Records that failed filtering (raw bytes, if tracking rejects).
-    rejected_records: Vec<Vec<u8>>,
+    rejected_records: Vec<RawRecord>,
     /// Number of records processed.
     records_count: u64,
     /// Number of records that passed.
@@ -235,17 +235,17 @@ struct FilterProcessedBatchRaw {
 
 impl MemoryEstimate for FilterProcessedBatchRaw {
     fn estimate_heap_size(&self) -> usize {
-        let vec_overhead = std::mem::size_of::<Vec<u8>>();
+        let vec_overhead = std::mem::size_of::<RawRecord>();
         let kept_outer = self.kept_records.capacity() * vec_overhead;
-        let kept_inner: usize = self.kept_records.iter().map(|v| v.capacity()).sum();
+        let kept_inner: usize = self.kept_records.iter().map(RawRecord::capacity).sum();
         let rejected_outer = self.rejected_records.capacity() * vec_overhead;
-        let rejected_inner: usize = self.rejected_records.iter().map(|v| v.capacity()).sum();
+        let rejected_inner: usize = self.rejected_records.iter().map(RawRecord::capacity).sum();
         kept_outer + kept_inner + rejected_outer + rejected_inner
     }
 }
 
 /// Serialize raw BAM records directly (bypasses `bam_codec` encoder).
-fn serialize_raw_records(records: &[Vec<u8>], output: &mut Vec<u8>) -> io::Result<u64> {
+fn serialize_raw_records(records: &[RawRecord], output: &mut Vec<u8>) -> io::Result<u64> {
     for record in records {
         let len = u32::try_from(record.len()).map_err(|_| {
             io::Error::new(
@@ -557,12 +557,12 @@ impl Filter {
         let ctx = self.process_captures(&setup, &header);
 
         let grouper_fn = move |_header: &Header| {
-            Box::new(SingleRawRecordGrouper::new()) as Box<dyn Grouper<Group = Vec<u8>> + Send>
+            Box::new(SingleRawRecordGrouper::new()) as Box<dyn Grouper<Group = RawRecord> + Send>
         };
 
-        let process_fn = move |mut record: Vec<u8>| -> io::Result<FilterProcessedBatchRaw> {
-            let mut kept_records = Vec::new();
-            let mut rejected_records = Vec::new();
+        let process_fn = move |mut record: RawRecord| -> io::Result<FilterProcessedBatchRaw> {
+            let mut kept_records: Vec<RawRecord> = Vec::new();
+            let mut rejected_records: Vec<RawRecord> = Vec::new();
             let mut passed_count = 0u64;
 
             let (bases_masked, pass) = Self::process_record_raw(
@@ -631,14 +631,14 @@ impl Filter {
         };
 
         let process_fn = move |batch: TemplateBatch| -> io::Result<FilterProcessedBatchRaw> {
-            let mut kept_records: Vec<Vec<u8>> = Vec::new();
-            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
+            let mut kept_records: Vec<RawRecord> = Vec::new();
+            let mut rejected_records: Vec<RawRecord> = Vec::new();
             let mut total_records = 0u64;
             let mut passed_count = 0u64;
             let mut bases_masked = 0u64;
 
             for template in batch {
-                let mut template_records = template
+                let mut template_records: Vec<RawRecord> = template
                     .into_raw_records()
                     .ok_or_else(|| io::Error::other("template has no raw records"))?;
                 let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
@@ -737,7 +737,7 @@ impl Filter {
     /// Returns `(bases_masked, pass)`.
     #[allow(clippy::too_many_arguments)]
     fn process_record_raw(
-        record: &mut Vec<u8>,
+        record: &mut RawRecord,
         config: &FilterConfig,
         reference: Option<&ReferenceReader>,
         header: &Header,
@@ -831,7 +831,7 @@ impl Filter {
         }
 
         if let Some(reference) = reference {
-            regenerate_alignment_tags_raw(record, header, reference)?;
+            regenerate_alignment_tags_raw(record.as_mut_vec(), header, reference)?;
         }
 
         let mut pass = {
@@ -1683,7 +1683,7 @@ mod tests {
         let r1 = create_r1_record(b"ACGT", &[30, 30, 30, 30]);
         let r2 = create_r2_record(b"GGGG", &[30, 30, 30, 30]);
 
-        let records: Vec<Vec<u8>> = vec![r1.into_inner(), r2.into_inner()];
+        let records = vec![r1, r2];
         let mut pass_map = AHashMap::new();
         pass_map.insert(0, true);
         pass_map.insert(1, true);
@@ -1699,7 +1699,7 @@ mod tests {
         let r1 = create_r1_record(b"ACGT", &[30, 30, 30, 30]);
         let r2 = create_r2_record(b"GGGG", &[30, 30, 30, 30]);
 
-        let records: Vec<Vec<u8>> = vec![r1.into_inner(), r2.into_inner()];
+        let records = vec![r1, r2];
         let mut pass_map = AHashMap::new();
         pass_map.insert(0, true);
         pass_map.insert(1, false); // One fails
@@ -4263,8 +4263,9 @@ mod tests {
             .build();
 
         let header = Header::default();
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &header, &record)?;
+        let mut raw_bytes = Vec::new();
+        encode_record_buf(&mut raw_bytes, &header, &record)?;
+        let mut raw = RawRecord::from(raw_bytes);
 
         let config = FilterConfig::new(&[1], &[0.025], &[0.1], None, None, 0.2);
 
@@ -4313,8 +4314,9 @@ mod tests {
             )
             .build();
 
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &sam_builder.header, &record)?;
+        let mut raw_bytes = Vec::new();
+        encode_record_buf(&mut raw_bytes, &sam_builder.header, &record)?;
+        let mut raw = RawRecord::from(raw_bytes);
 
         let config = FilterConfig::new(&[1], &[0.025], &[0.1], None, None, 0.2);
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -15,7 +15,7 @@ use crate::logging::{OperationTimer, log_umi_grouping_summary};
 use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::progress::ProgressTracker;
-use crate::read_info::{LibraryIndex, compute_group_key};
+use crate::read_info::LibraryIndex;
 use crate::sam::{is_sorted, is_template_coordinate_sorted, unclipped_five_prime_position};
 use crate::template::{MoleculeId, Template};
 use crate::umi::parallel_assigner::{
@@ -24,6 +24,7 @@ use crate::umi::parallel_assigner::{
 };
 use crate::umi::{UmiValidation, validate_umi};
 use crate::unified_pipeline::DecodedRecord;
+use crate::unified_pipeline::compute_group_key_from_raw;
 use crate::unified_pipeline::{GroupKeyConfig, Grouper, run_bam_pipeline_from_reader};
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
@@ -36,6 +37,7 @@ use crate::sam::SamTag;
 use crate::unified_pipeline::MemoryEstimate;
 use crate::validation::validate_file_exists;
 use crate::vendored::bam_codec::encode_record_buf;
+use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
 use noodles::sam;
 use noodles::sam::Header;
@@ -105,9 +107,13 @@ struct GroupFilterConfig {
     allow_unmapped: bool,
 }
 
-/// Filter a template based on filtering criteria.
+/// Filter a template based on filtering criteria using the noodles typed API.
+///
 /// Returns true if the template should be kept, false if it should be discarded.
 /// Updates `filter_metrics` with the reason for filtering.
+///
+/// **Retention:** kept as a noodles fallback for any caller that supplies parsed (non-raw)
+/// templates. The primary execution paths use `filter_template_raw` instead.
 fn filter_template(
     template: &Template,
     config: &GroupFilterConfig,
@@ -475,7 +481,10 @@ fn truncate_umis_impl(umis: Vec<String>, min_umi_length: Option<usize>) -> Resul
     }
 }
 
-/// Check if R1 is genomically earlier than R2 (static implementation).
+/// Check if R1 is genomically earlier than R2 using the noodles typed API.
+///
+/// **Retention:** noodles fallback used by `assign_umi_groups_for_indices_impl` when
+/// templates carry parsed `RecordBuf` data (raw-byte mode uses `is_r1_genomically_earlier_raw`).
 fn is_r1_genomically_earlier_impl(
     r1: &sam::alignment::RecordBuf,
     r2: &sam::alignment::RecordBuf,
@@ -490,7 +499,10 @@ fn is_r1_genomically_earlier_impl(
     Ok(r1_pos <= r2_pos)
 }
 
-/// Get pair orientation for a template (static implementation).
+/// Get pair orientation for a template using the noodles typed API.
+///
+/// **Retention:** noodles fallback used by `assign_umi_groups_impl` when templates carry
+/// parsed `RecordBuf` data (raw-byte mode uses `get_pair_orientation_raw`).
 fn get_pair_orientation_impl(template: &Template) -> (bool, bool) {
     let r1_positive = template.r1().is_none_or(|r| !r.flags().is_reverse_complemented());
     let r2_positive = template.r2().is_none_or(|r| !r.flags().is_reverse_complemented());
@@ -660,6 +672,10 @@ fn assign_umi_groups_for_indices_impl(
 /// Converts the `MoleculeId` enum to a string representation with the base offset applied,
 /// and sets the MI tag on the record. This is called just before writing to minimize
 /// memory usage (strings are not stored until write time).
+///
+/// **Retention:** noodles fallback used by the serializer's non-raw branch
+/// (`!raw_mode`) in both the pipeline and `process_and_write_position_group`. The raw-byte
+/// path injects the MI tag directly via `bam_fields::update_string_tag`.
 #[inline]
 fn set_mi_tag_on_record(
     record: &mut noodles::sam::alignment::record_buf::RecordBuf,
@@ -1576,14 +1592,16 @@ impl GroupReadsByUmi {
     ) -> Result<()> {
         info!("Using single-threaded mode");
 
-        // Wrap the reader in a BufReader and create noodles BAM reader
-        // This reuses the already-opened reader (required for stdin support)
+        // Wrap the reader in a BufReader and use noodles to skip past the BAM header bytes.
+        // The reader is positioned at file start; we must discard the header to reach records.
+        // This reuses the already-opened reader (required for stdin support).
         let buf_reader = std::io::BufReader::new(reader);
-        let mut bam_reader = noodles::bam::io::Reader::new(buf_reader);
+        let mut noodles_reader = noodles::bam::io::Reader::new(buf_reader);
+        let _ = noodles_reader.read_header().context("Failed to skip BAM header")?;
 
-        // Skip past header bytes - the reader is positioned at file start, but we already
-        // have the header. We must read (and discard) it to position at the first record.
-        let _ = bam_reader.read_header().context("Failed to skip BAM header")?;
+        // After the header skip, extract the inner BufReader and wrap in RawBamReader.
+        // Raw-byte mode avoids the noodles decode/encode round-trip (~15% CPU savings).
+        let mut raw_reader = RawBamReader::new(noodles_reader.into_inner());
 
         // Create output writer (single-threaded for strict thread control)
         let mut writer =
@@ -1604,13 +1622,17 @@ impl GroupReadsByUmi {
         // Progress tracking
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Iterate over all records
-        for record_result in bam_reader.record_bufs(header) {
-            let record = record_result?;
+        // Iterate over all records in raw-byte mode
+        let mut raw_rec = RawRecord::new();
+        loop {
+            let bytes_read = raw_reader.read_record(&mut raw_rec)?;
+            if bytes_read == 0 {
+                break; // EOF
+            }
 
-            // Compute GroupKey for this record
-            let key = compute_group_key(&record, &library_index, Some(cell_tag));
-            let decoded = DecodedRecord::new(record, key);
+            // Compute GroupKey directly from raw bytes — no noodles decode needed
+            let key = compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag));
+            let decoded = DecodedRecord::from_raw_bytes(raw_rec.clone(), key);
 
             // Feed to RecordPositionGrouper - may emit completed groups
             let completed_groups = grouper.add_records(vec![decoded])?;
@@ -1679,6 +1701,11 @@ impl GroupReadsByUmi {
 
     /// Process a single position group: build templates, filter, assign UMIs, and write output.
     /// Used by `execute_single_threaded` for streaming processing.
+    ///
+    /// Dispatches on raw-byte vs noodles mode based on the template storage format.
+    /// In raw-byte mode (single-threaded path after migration), uses zero-allocation filter
+    /// and direct raw-byte MI-tag injection. The noodles path is kept as a fallback for
+    /// any future code path that supplies parsed templates (e.g. tests or external callers).
     #[allow(clippy::too_many_arguments)]
     fn process_and_write_position_group(
         group: RawPositionGroup,
@@ -1701,10 +1728,19 @@ impl GroupReadsByUmi {
 
         let mut filter_metrics = FilterMetrics::new();
 
-        // Filter templates
+        // Dispatch filter on template storage mode
+        let raw_mode = all_templates.first().is_some_and(Template::is_raw_byte_mode);
         let filtered_templates: Vec<Template> = all_templates
             .into_iter()
-            .filter(|t| filter_template(t, filter_config, &mut filter_metrics))
+            .filter(|t| {
+                if raw_mode {
+                    filter_template_raw(t, filter_config, &mut filter_metrics)
+                } else {
+                    // Noodles fallback: retained for any caller that supplies parsed templates
+                    // (e.g. external tests or future commands that don't opt into raw-byte mode).
+                    filter_template(t, filter_config, &mut filter_metrics)
+                }
+            })
             .collect();
 
         // Merge filter metrics
@@ -1793,19 +1829,55 @@ impl GroupReadsByUmi {
             templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
         let base_mi = *next_mi_base;
         *next_mi_base += distinct_mi_count;
-        let assign_tag = Tag::from(assign_tag_bytes);
 
-        for template in templates {
-            let mi = template.mi;
-            // Write primary reads with MI tags set just before writing
-            let (r1, r2) = template.into_primary_reads();
-            if let Some(mut r1) = r1 {
-                set_mi_tag_on_record(&mut r1, mi, assign_tag, base_mi);
-                writer.write_alignment_record(header, &r1)?;
+        if raw_mode {
+            // Raw-byte output: inject MI tag directly into raw bytes, write without noodles
+            use crate::sort::bam_fields;
+            use std::io::Write as _;
+            let mut scratch = Vec::with_capacity(512);
+            let mut mi_buf = String::with_capacity(16);
+            for template in templates {
+                let mi = template.mi;
+                let has_mi = mi.is_assigned();
+                if has_mi {
+                    // write_with_offset clears the buffer before writing.
+                    mi.write_with_offset(base_mi, &mut mi_buf);
+                }
+                for raw in [template.raw_r1(), template.raw_r2()].into_iter().flatten() {
+                    #[allow(clippy::cast_possible_truncation)]
+                    if has_mi {
+                        scratch.clear();
+                        scratch.extend_from_slice(raw);
+                        bam_fields::update_string_tag(
+                            &mut scratch,
+                            &assign_tag_bytes,
+                            mi_buf.as_bytes(),
+                        );
+                        let block_size = scratch.len() as u32;
+                        writer.get_mut().write_all(&block_size.to_le_bytes())?;
+                        writer.get_mut().write_all(&scratch)?;
+                    } else {
+                        let block_size = raw.len() as u32;
+                        writer.get_mut().write_all(&block_size.to_le_bytes())?;
+                        writer.get_mut().write_all(raw)?;
+                    }
+                }
             }
-            if let Some(mut r2) = r2 {
-                set_mi_tag_on_record(&mut r2, mi, assign_tag, base_mi);
-                writer.write_alignment_record(header, &r2)?;
+        } else {
+            // Noodles fallback: retained for callers that supply parsed (non-raw) templates.
+            // set_mi_tag_on_record and write_alignment_record use the typed RecordBuf API.
+            let assign_tag = Tag::from(assign_tag_bytes);
+            for template in templates {
+                let mi = template.mi;
+                let (r1, r2) = template.into_primary_reads();
+                if let Some(mut r1) = r1 {
+                    set_mi_tag_on_record(&mut r1, mi, assign_tag, base_mi);
+                    writer.write_alignment_record(header, &r1)?;
+                }
+                if let Some(mut r2) = r2 {
+                    set_mi_tag_on_record(&mut r2, mi, assign_tag, base_mi);
+                    writer.write_alignment_record(header, &r2)?;
+                }
             }
         }
 
@@ -5004,7 +5076,7 @@ mod tests {
             30,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5029,7 +5101,7 @@ mod tests {
             10,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5055,7 +5127,7 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5080,7 +5152,7 @@ mod tests {
             30,
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5105,7 +5177,7 @@ mod tests {
             30,
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5129,7 +5201,7 @@ mod tests {
             0,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw])
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
@@ -5178,7 +5250,7 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![supp])
+        let template = Template::from_raw_records(vec![supp].into_iter().map(Into::into).collect())
             .expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -16,11 +16,19 @@ use crate::variant_review::{
 };
 use anyhow::{Result, bail};
 use clap::Parser;
+use fgumi_raw_bam::{RawBamReader, RawRecord, find_string_tag_in_record};
 use log::info;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::Cigar;
+// RecordBuf retained at indexed-query sites (extract_consensus_reads, generate_review_file):
+// noodles indexed_reader::query() yields bam::Record whose inner bytes are not publicly
+// accessible as &[u8], so raw-byte helpers (find_string_tag_in_record, read_pos_at_ref_pos_raw)
+// cannot be applied there without a noodles-to-bytes serialisation round-trip that would
+// cost more than it saves.  Once noodles exposes raw bytes from bam::Record
+// (https://github.com/zaeleus/noodles/pull/373) these sites can be migrated.
 use noodles::sam::alignment::record_buf::RecordBuf;
 use std::collections::HashSet;
+use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
 use super::command::Command;
@@ -617,7 +625,8 @@ impl Review {
 
             for result in query.records() {
                 let bam_record = result?;
-                // Convert to RecordBuf for processing
+                // RecordBuf retained: noodles indexed_reader::query() yields bam::Record whose
+                // inner bytes are not publicly accessible; see retention comment at the import.
                 let record = RecordBuf::try_from_alignment_record(&header, &bam_record)?;
 
                 // Check if this read has a non-reference base at the variant position
@@ -665,33 +674,41 @@ impl Review {
     fn extract_grouped_reads(&self, mi_set: &HashSet<String>, command_line: &str) -> Result<()> {
         use noodles::bam;
 
-        let mut reader =
-            bam::io::indexed_reader::Builder::default().build_from_path(&self.grouped_bam)?;
-        let header = reader.read_header()?;
+        // Use a plain (non-indexed) reader for the sequential scan; raw-byte mode avoids
+        // the noodles decode/encode round-trip on every record.
+        let mut bam_reader = bam::io::reader::Builder.build_from_path(&self.grouped_bam)?;
+        let header = bam_reader.read_header()?;
 
-        // Add @PG record with PP chaining
+        // Add @PG record with PP chaining (must happen before we consume the reader below)
         let header = crate::commands::common::add_pg_record(header, command_line)?;
 
         let grouped_out_path = self.output.with_extension("grouped.bam");
         let mut writer = bam::io::writer::Builder.build_from_path(&grouped_out_path)?;
         writer.write_header(&header)?;
 
+        // Extract the inner BGZF reader and wrap in RawBamReader for zero-copy record iteration.
+        let mut raw_reader = RawBamReader::new(bam_reader.into_inner());
+        let mut raw_rec = RawRecord::new();
+
         // Read through entire grouped BAM and extract matching reads
         let progress = ProgressTracker::new("Processed grouped reads").with_interval(1_000_000);
-        let mut record = RecordBuf::default();
-        while reader.read_record_buf(&header, &mut record)? != 0 {
+        loop {
+            let bytes_read = raw_reader.read_record(&mut raw_rec)?;
+            if bytes_read == 0 {
+                break; // EOF
+            }
             progress.log_if_needed(1);
 
-            // Extract MI tag
-            let mi_tag = noodles::sam::alignment::record::data::field::Tag::from(SamTag::MI);
-            if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(mi_bytes)) =
-                record.data().get(&mi_tag)
-            {
-                let mi = String::from_utf8(mi_bytes.iter().copied().collect())?;
-                let mi_base = extract_mi_base(&mi);
+            // Extract MI tag directly from raw bytes; no RecordBuf decode needed.
+            if let Some(mi_bytes) = find_string_tag_in_record(&raw_rec, &SamTag::MI) {
+                let mi = std::str::from_utf8(mi_bytes)?;
+                let mi_base = extract_mi_base(mi);
 
                 if mi_set.contains(mi_base) {
-                    writer.write_alignment_record(&header, &record)?;
+                    // Write raw record: BAM block_size prefix + record bytes.
+                    let block_size = raw_rec.len() as u32;
+                    writer.get_mut().write_all(&block_size.to_le_bytes())?;
+                    writer.get_mut().write_all(&raw_rec)?;
                 }
             }
         }
@@ -750,6 +767,8 @@ impl Review {
             let mut consensus_reads = Vec::new();
             for result in query.records() {
                 let bam_record = result?;
+                // RecordBuf retained: noodles indexed_reader::query() yields bam::Record whose
+                // inner bytes are not publicly accessible; see retention comment at the import.
                 let record = RecordBuf::try_from_alignment_record(&consensus_header, &bam_record)?;
                 consensus_reads.push(record);
             }
@@ -827,6 +846,8 @@ impl Review {
 
                     for result in query.records() {
                         let bam_record = result?;
+                        // RecordBuf retained: noodles indexed_reader::query() yields bam::Record
+                        // whose inner bytes are not publicly accessible; see import comment.
                         let record =
                             RecordBuf::try_from_alignment_record(&grouped_header, &bam_record)?;
 
@@ -913,6 +934,8 @@ impl Review {
     }
 
     /// Get the base at a specific reference position in a read
+    // RecordBuf retained: these helpers are called from indexed-query loops where bam::Record
+    // has already been decoded to RecordBuf (see retention comment at the import).
     fn get_base_at_position(&self, record: &RecordBuf, ref_pos: i32) -> Result<Option<u8>> {
         if let Some(offset) = self.calculate_read_offset(record, ref_pos)? {
             let sequence = record.sequence();

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -377,7 +377,7 @@ impl Command for Simplex {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
                 Ok(0) => None, // EOF
-                Ok(_) => Some(Ok(record.into_inner())),
+                Ok(_) => Some(Ok(record)),
                 Err(e) => Some(Err(e.into())),
             }
         });
@@ -402,12 +402,10 @@ impl Command for Simplex {
                 apply_overlapping_consensus(&mut records, oc)?;
             }
 
-            // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-            // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-            let raw: Vec<fgumi_raw_bam::RawRecord> =
-                records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
+            // Call consensus — mi_group now yields Vec<RawRecord> directly, which is
+            // what ConsensusCaller::consensus_reads expects.
             let output = caller
-                .consensus_reads(raw)
+                .consensus_reads(records)
                 .with_context(|| format!("Failed to call consensus for UMI: {umi}"))?;
 
             let batch_size = output.count;
@@ -597,7 +595,8 @@ impl Simplex {
                             raw_records.len(),
                         );
                         if track_rejects {
-                            all_rejects.extend(raw_records); // Already raw bytes!
+                            // TODO(#272): bridge – remove when rejects Vec accepts RawRecord
+                            all_rejects.extend(raw_records.into_iter().map(RawRecord::into_inner));
                         }
                         continue;
                     }
@@ -610,18 +609,22 @@ impl Simplex {
                             batch_stats.record_input(raw_records.len());
                             batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
                             if track_rejects {
-                                all_rejects.extend(raw_records);
+                                // TODO(#272): bridge – remove when rejects Vec accepts RawRecord
+                                all_rejects
+                                    .extend(raw_records.into_iter().map(RawRecord::into_inner));
                             }
                             continue;
                         }
                         batch_overlapping.merge(oc.stats());
                     }
 
-                    // Call consensus. Bridge Vec<Vec<u8>> → Vec<RawRecord> for the new
-                    // trait signature; the MI iterator still yields raw bytes (PR-5 scope).
-                    let raw: Vec<fgumi_raw_bam::RawRecord> =
-                        raw_records.into_iter().map(fgumi_raw_bam::RawRecord::from).collect();
-                    match caller.consensus_reads(raw) {
+                    // Call consensus — mi_group now yields Vec<RawRecord> directly.
+                    // Preserve inputs for rejection bookkeeping on Err, since
+                    // consensus_reads consumes raw_records.
+                    let num_inputs = raw_records.len();
+                    let reject_on_error: Option<Vec<Vec<u8>>> = track_rejects
+                        .then(|| raw_records.iter().map(|r| r.as_ref().to_vec()).collect());
+                    match caller.consensus_reads(raw_records) {
                         Ok(batch_output) => {
                             all_output.merge(batch_output);
                             batch_stats.merge(&caller.statistics());
@@ -631,6 +634,11 @@ impl Simplex {
                         }
                         Err(e) => {
                             log::warn!("Consensus error for MI {mi}: {e}");
+                            batch_stats.record_input(num_inputs);
+                            batch_stats.record_rejection(RejectionReason::Other, num_inputs);
+                            if let Some(rejects) = reject_on_error {
+                                all_rejects.extend(rejects);
+                            }
                         }
                     }
                 }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -386,7 +386,7 @@ fn verify_sort_order<K>(
     for result in raw_reader {
         let record_bytes = result?;
         total_records += 1;
-        let bam = record_bytes.as_slice();
+        let bam: &[u8] = &record_bytes;
 
         let key = extract_key(bam);
 

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -741,10 +741,10 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
 
     let rr = mapped.raw_records.as_mut().unwrap();
     for record in rr.iter_mut() {
-        let f = RawRecordView::new(record.as_slice()).flags();
+        let f = RawRecordView::new(record.as_ref()).flags();
         if (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0 {
-            bam_fields::remove_tag(record, tc_tag);
-            bam_fields::append_i32_array_tag(record, tc_tag, &tc_values);
+            bam_fields::remove_tag(record.as_mut_vec(), tc_tag);
+            bam_fields::append_i32_array_tag(record.as_mut_vec(), tc_tag, &tc_values);
         }
     }
 }
@@ -762,7 +762,7 @@ fn convert_template_to_raw(template: &mut Template, header: &Header) -> Result<(
         let mut buf = Vec::with_capacity(256);
         encode_record_buf(&mut buf, header, record)
             .map_err(|e| anyhow::anyhow!("Failed to encode record: {e}"))?;
-        raw_records.push(buf);
+        raw_records.push(RawRecord::from(buf));
     }
     template.raw_records = Some(raw_records);
     // Keep records intact for read_count compatibility
@@ -831,7 +831,7 @@ pub fn merge_raw(
         for tag_str in &tag_info.remove {
             if tag_str.len() == 2 {
                 let tag_bytes: [u8; 2] = [tag_str.as_bytes()[0], tag_str.as_bytes()[1]];
-                bam_fields::remove_tag(record, &tag_bytes);
+                bam_fields::remove_tag(record.as_mut_vec(), &tag_bytes);
             }
         }
     }
@@ -885,8 +885,8 @@ pub fn merge_raw(
                     if tag_info.remove.contains(tag_str) {
                         continue;
                     }
-                    bam_fields::remove_tag(&mut rr[i], &tag_bytes);
-                    append_buf_value_raw(&mut rr[i], tag_bytes, value);
+                    bam_fields::remove_tag(rr[i].as_mut_vec(), &tag_bytes);
+                    append_buf_value_raw(rr[i].as_mut_vec(), tag_bytes, value);
                 }
             }
         }
@@ -916,9 +916,9 @@ pub fn merge_raw(
                         continue;
                     }
 
-                    bam_fields::remove_tag(&mut rr[i], &tag_bytes);
+                    bam_fields::remove_tag(rr[i].as_mut_vec(), &tag_bytes);
 
-                    append_buf_value_raw(&mut rr[i], tag_bytes, value);
+                    append_buf_value_raw(rr[i].as_mut_vec(), tag_bytes, value);
                     if has_transforms && tag_info.reverse.contains(tag_str) {
                         reverse_tag_in_place_raw(&mut rr[i], aux_offset, tag_bytes, value);
                     } else if has_transforms && tag_info.revcomp.contains(tag_str) {
@@ -945,8 +945,8 @@ pub fn merge_raw(
     // Step 6: Normalize AS/XS tags
     let rr = mapped.raw_records.as_mut().unwrap();
     for record in rr.iter_mut() {
-        bam_fields::normalize_int_tag_to_smallest_signed(record, b"AS");
-        bam_fields::normalize_int_tag_to_smallest_signed(record, b"XS");
+        bam_fields::normalize_int_tag_to_smallest_signed(record.as_mut_vec(), b"AS");
+        bam_fields::normalize_int_tag_to_smallest_signed(record.as_mut_vec(), b"XS");
     }
 
     // Step 7: Add TC tags
@@ -995,13 +995,16 @@ fn revcomp_tag_in_place_raw(
 }
 
 /// Encodes all records of an unmapped template to raw BAM bytes for output.
-fn encode_unmapped_template_records(template: &Template, header: &Header) -> Result<Vec<Vec<u8>>> {
+fn encode_unmapped_template_records(
+    template: &Template,
+    header: &Header,
+) -> Result<Vec<RawRecord>> {
     let mut raw = Vec::with_capacity(template.read_count());
     for record in template.all_reads() {
         let mut buf = Vec::with_capacity(256);
         encode_record_buf(&mut buf, header, record)
             .map_err(|e| anyhow::anyhow!("encode unmapped: {e}"))?;
-        raw.push(buf);
+        raw.push(RawRecord::from(buf));
     }
     Ok(raw)
 }
@@ -1183,10 +1186,8 @@ fn restore_unconverted_bases_in_raw_template(
     let raw_records = template.raw_records.as_mut().ok_or_else(|| {
         anyhow::anyhow!("restore_unconverted_bases_in_raw_template: template not in raw-byte mode")
     })?;
-    for bytes in raw_records.iter_mut() {
-        let mut rec = RawRecord::from(std::mem::take(bytes));
-        restore_unconverted_bases_in_raw_record(&mut rec, reference, header)?;
-        *bytes = rec.into_inner();
+    for rec in raw_records.iter_mut() {
+        restore_unconverted_bases_in_raw_record(rec, reference, header)?;
     }
     Ok(())
 }

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -14,6 +14,7 @@ use crate::sam::SamTag;
 use crate::sort::bam_fields;
 use crate::template::{Template, TemplateBatch};
 use crate::unified_pipeline::{BatchWeight, DecodedRecord, Grouper, MemoryEstimate};
+use fgumi_raw_bam::RawRecord;
 
 // ============================================================================
 // BatchWeight Implementations
@@ -30,6 +31,20 @@ impl BatchWeight for RecordBuf {
 impl BatchWeight for Vec<u8> {
     fn batch_weight(&self) -> usize {
         1
+    }
+}
+
+/// [`RawRecord`] has weight 1 (same semantics as the `Vec<u8>` impl above).
+impl BatchWeight for RawRecord {
+    fn batch_weight(&self) -> usize {
+        1
+    }
+}
+
+/// Heap size of a [`RawRecord`] is its buffer capacity.
+impl MemoryEstimate for RawRecord {
+    fn estimate_heap_size(&self) -> usize {
+        self.capacity()
     }
 }
 
@@ -110,7 +125,7 @@ impl SingleRawRecordGrouper {
 }
 
 impl Grouper for SingleRawRecordGrouper {
-    type Group = Vec<u8>;
+    type Group = RawRecord;
 
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
         records
@@ -165,8 +180,8 @@ pub struct TemplateGrouper {
     current_name_hash: Option<u64>,
     /// Records for current template (non-raw mode).
     current_records: Vec<RecordBuf>,
-    /// Raw byte records for current template (raw-byte mode).
-    current_raw_records: Vec<Vec<u8>>,
+    /// Raw records for current template (raw-byte mode).
+    current_raw_records: Vec<RawRecord>,
     /// Completed templates waiting to be batched.
     pending_templates: VecDeque<Template>,
 }
@@ -1002,8 +1017,8 @@ mod tests {
         use crate::unified_pipeline::{DecodedRecord, GroupKey};
 
         let mut grouper = SingleRawRecordGrouper::new();
-        let raw1 = vec![1u8; 36];
-        let raw2 = vec![2u8; 36];
+        let raw1 = RawRecord::from(vec![1u8; 36]);
+        let raw2 = RawRecord::from(vec![2u8; 36]);
         let records = vec![
             DecodedRecord::from_raw_bytes(raw1.clone(), GroupKey::default()),
             DecodedRecord::from_raw_bytes(raw2.clone(), GroupKey::default()),

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -5,6 +5,7 @@
 //! (e.g., output from `group`).
 
 use anyhow::{Result, bail};
+use fgumi_raw_bam::RawRecord;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
 use std::io;
@@ -706,13 +707,13 @@ pub struct RawMiGroup {
     /// The MI tag value (e.g., "0", "1/A", "1/B")
     pub mi: String,
     /// Raw BAM records sharing this MI value
-    pub records: Vec<Vec<u8>>,
+    pub records: Vec<RawRecord>,
 }
 
 impl RawMiGroup {
     /// Creates a new raw MI group.
     #[must_use]
-    pub fn new(mi: String, records: Vec<Vec<u8>>) -> Self {
+    pub fn new(mi: String, records: Vec<RawRecord>) -> Self {
         Self { mi, records }
     }
 }
@@ -726,8 +727,8 @@ impl BatchWeight for RawMiGroup {
 impl MemoryEstimate for RawMiGroup {
     fn estimate_heap_size(&self) -> usize {
         let mi_size = self.mi.capacity();
-        let records_size: usize = self.records.iter().map(std::vec::Vec::capacity).sum();
-        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<Vec<u8>>();
+        let records_size: usize = self.records.iter().map(RawRecord::capacity).sum();
+        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RawRecord>();
         mi_size + records_size + records_vec_overhead
     }
 }
@@ -780,7 +781,7 @@ pub struct RawMiGrouper {
     /// Current MI value being accumulated
     current_mi: Option<String>,
     /// Records in current MI group (raw bytes)
-    current_records: Vec<Vec<u8>>,
+    current_records: Vec<RawRecord>,
     /// Completed groups waiting to be batched
     pending_groups: VecDeque<RawMiGroup>,
     /// Whether `finish()` has been called
@@ -971,14 +972,14 @@ impl Grouper for RawMiGrouper {
 #[allow(clippy::type_complexity)]
 pub struct RawMiGroupIterator<I>
 where
-    I: Iterator<Item = Result<Vec<u8>>>,
+    I: Iterator<Item = Result<RawRecord>>,
 {
     record_iter: I,
     tag: [u8; 2],
     /// Optional cell barcode tag for composite grouping (MI + cell barcode)
     cell_tag: Option<[u8; 2]>,
     current_mi: Option<String>,
-    current_group: Vec<Vec<u8>>,
+    current_group: Vec<RawRecord>,
     done: bool,
     /// Pending error to return after flushing a group
     pending_error: Option<anyhow::Error>,
@@ -988,7 +989,7 @@ where
 
 impl<I> RawMiGroupIterator<I>
 where
-    I: Iterator<Item = Result<Vec<u8>>>,
+    I: Iterator<Item = Result<RawRecord>>,
 {
     /// Creates a new `RawMiGroupIterator`.
     ///
@@ -1067,9 +1068,9 @@ where
 
 impl<I> Iterator for RawMiGroupIterator<I>
 where
-    I: Iterator<Item = Result<Vec<u8>>>,
+    I: Iterator<Item = Result<RawRecord>>,
 {
-    type Item = Result<(String, Vec<Vec<u8>>)>;
+    type Item = Result<(String, Vec<RawRecord>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -1387,7 +1388,7 @@ mod tests {
     //   then: qual     (l_seq bytes)
     //   then: aux data
     #[allow(clippy::cast_possible_truncation)]
-    fn make_raw_bam_with_tag(tag_name: &str, tag_value: &str) -> Vec<u8> {
+    fn make_raw_bam_with_tag(tag_name: &str, tag_value: &str) -> RawRecord {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8; // +1 for NUL
         let seq_len: u32 = 4; // 4 bases (ACGT)
@@ -1427,12 +1428,12 @@ mod tests {
         let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
         buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
 
-        buf
+        RawRecord::from(buf)
     }
 
     /// Build a minimal raw BAM record with no aux tags.
     #[allow(clippy::cast_possible_truncation)]
-    fn make_raw_bam_without_tag() -> Vec<u8> {
+    fn make_raw_bam_without_tag() -> RawRecord {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8;
         let seq_len: u32 = 4;
@@ -1453,7 +1454,7 @@ mod tests {
         buf[name_start..name_start + name.len()].copy_from_slice(name);
         buf[name_start + name.len()] = 0;
 
-        buf
+        RawRecord::from(buf)
     }
 
     // ========================================================================
@@ -1462,14 +1463,14 @@ mod tests {
 
     #[test]
     fn test_raw_empty_iterator() {
-        let records: Vec<Result<Vec<u8>>> = vec![];
+        let records: Vec<Result<RawRecord>> = vec![];
         let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
         assert!(iter.next().is_none());
     }
 
     #[test]
     fn test_raw_single_group() {
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
@@ -1485,7 +1486,7 @@ mod tests {
 
     #[test]
     fn test_raw_multiple_groups() {
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "1")),
@@ -1512,7 +1513,7 @@ mod tests {
 
     #[test]
     fn test_raw_skips_records_without_mi_tag() {
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_without_tag()),
             Ok(make_raw_bam_with_tag("MI", "0")),
@@ -1534,7 +1535,7 @@ mod tests {
 
     #[test]
     fn test_raw_error_propagation() {
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Err(anyhow::anyhow!("test error")),
             Ok(make_raw_bam_with_tag("MI", "1")),
@@ -1555,7 +1556,7 @@ mod tests {
 
     #[test]
     fn test_raw_error_with_no_pending_group() {
-        let records: Vec<Result<Vec<u8>>> =
+        let records: Vec<Result<RawRecord>> =
             vec![Err(anyhow::anyhow!("immediate error")), Ok(make_raw_bam_with_tag("MI", "0"))];
         let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
 
@@ -1569,7 +1570,7 @@ mod tests {
 
     #[test]
     fn test_raw_custom_tag() {
-        let records: Vec<Result<Vec<u8>>> =
+        let records: Vec<Result<RawRecord>> =
             vec![Ok(make_raw_bam_with_tag("RX", "ACGT")), Ok(make_raw_bam_with_tag("RX", "ACGT"))];
         let mut iter = RawMiGroupIterator::new(records.into_iter(), "RX");
 
@@ -1583,14 +1584,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Tag name must be exactly 2 characters")]
     fn test_raw_invalid_tag_length() {
-        let records: Vec<Result<Vec<u8>>> = vec![];
+        let records: Vec<Result<RawRecord>> = vec![];
         let _ = RawMiGroupIterator::new(records.into_iter(), "M");
     }
 
     #[test]
     fn test_raw_with_transform() {
         // Simulate duplex reads: 1/A, 1/B should group under "1"
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "1/A")),
             Ok(make_raw_bam_with_tag("MI", "1/A")),
             Ok(make_raw_bam_with_tag("MI", "1/B")),
@@ -1618,7 +1619,7 @@ mod tests {
 
     #[test]
     fn test_raw_with_transform_empty() {
-        let records: Vec<Result<Vec<u8>>> = vec![];
+        let records: Vec<Result<RawRecord>> = vec![];
         let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
             String::from_utf8_lossy(raw).to_uppercase()
         });
@@ -1628,7 +1629,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Tag name must be exactly 2 characters")]
     fn test_raw_with_transform_invalid_tag_length() {
-        let records: Vec<Result<Vec<u8>>> = vec![];
+        let records: Vec<Result<RawRecord>> = vec![];
         let _ = RawMiGroupIterator::with_transform(records.into_iter(), "ABC", |raw| {
             String::from_utf8_lossy(raw).into_owned()
         });
@@ -1636,7 +1637,7 @@ mod tests {
 
     #[test]
     fn test_raw_get_mi_without_transform() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_with_tag("MI", "42");
         assert_eq!(iter.get_mi(&bam), Some("42".to_string()));
     }
@@ -1644,7 +1645,7 @@ mod tests {
     #[test]
     fn test_raw_get_mi_with_transform() {
         let iter = RawMiGroupIterator::with_transform(
-            std::iter::empty::<Result<Vec<u8>>>(),
+            std::iter::empty::<Result<RawRecord>>(),
             "MI",
             |raw| {
                 let s = String::from_utf8_lossy(raw);
@@ -1657,21 +1658,21 @@ mod tests {
 
     #[test]
     fn test_raw_get_mi_missing_tag() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_without_tag();
         assert_eq!(iter.get_mi(&bam), None);
     }
 
     #[test]
     fn test_raw_get_mi_wrong_tag() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<Vec<u8>>>(), "MI");
+        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_with_tag("RX", "ACGT");
         assert_eq!(iter.get_mi(&bam), None);
     }
 
     /// Build a minimal raw BAM record with two string tags.
     #[allow(clippy::cast_possible_truncation)]
-    fn make_raw_bam_with_two_tags(tag1: &str, val1: &str, tag2: &str, val2: &str) -> Vec<u8> {
+    fn make_raw_bam_with_two_tags(tag1: &str, val1: &str, tag2: &str, val2: &str) -> RawRecord {
         let name = b"read";
         let l_read_name: u8 = (name.len() + 1) as u8;
         let seq_len: u32 = 4;
@@ -1707,13 +1708,13 @@ mod tests {
         let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
         buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
 
-        buf
+        RawRecord::from(buf)
     }
 
     #[test]
     fn test_raw_cell_tag_composite_grouping() {
         // Same MI but different cell barcodes should form separate groups
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
@@ -1738,7 +1739,7 @@ mod tests {
     #[test]
     fn test_raw_cell_tag_none_groups_by_mi_only() {
         // Without cell_tag, same MI records group together regardless of other tags
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
         ];
@@ -1754,7 +1755,7 @@ mod tests {
     #[test]
     fn test_raw_cell_tag_missing_cell_value() {
         // Records with MI but no cell tag get grouped under "MI\t" (empty cell)
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "1")),
             Ok(make_raw_bam_with_tag("MI", "1")),
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
@@ -1778,7 +1779,7 @@ mod tests {
     #[test]
     fn test_raw_cell_tag_with_transform() {
         // Cell tag should work with MI transform (duplex-style /A /B stripping)
-        let records: Vec<Result<Vec<u8>>> = vec![
+        let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1/B", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "TGCA")),

--- a/src/lib/sort/inline_buffer.rs
+++ b/src/lib/sort/inline_buffer.rs
@@ -13,7 +13,7 @@ use crate::sort::bam_fields;
 use crate::sort::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::sort::radix::bytes_needed_u64;
 use crate::sort::segmented_buf::SegmentedBuf;
-use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use std::cmp::Ordering;
 use std::io::{Read, Write};
 
@@ -190,8 +190,11 @@ macro_rules! par_sort_into_chunks_impl {
 
         if $threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
             $sort_fn(&mut $self.refs);
-            let chunk =
-                $self.refs.iter().map(|r| ($key_fn(r), $self.get_record(r).to_vec())).collect();
+            let chunk = $self
+                .refs
+                .iter()
+                .map(|r| ($key_fn(r), RawRecord::from($self.get_record(r).to_vec())))
+                .collect();
             return vec![chunk];
         }
 
@@ -204,7 +207,12 @@ macro_rules! par_sort_into_chunks_impl {
         $self
             .refs
             .chunks(chunk_size)
-            .map(|chunk| chunk.iter().map(|r| ($key_fn(r), $self.get_record(r).to_vec())).collect())
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|r| ($key_fn(r), RawRecord::from($self.get_record(r).to_vec())))
+                    .collect()
+            })
             .collect()
     }};
 }
@@ -302,14 +310,14 @@ impl RecordBuffer {
     ///
     /// Instead of merging the parallel sort sub-arrays back into one sorted
     /// buffer (as `par_sort` does), this returns each sub-array as its own
-    /// `Vec<(RawCoordinateKey, Vec<u8>)>` so they can be passed as separate
+    /// `Vec<(RawCoordinateKey, RawRecord)>` so they can be passed as separate
     /// merge sources to the k-way merge, avoiding the intermediate merge step.
     ///
     /// When `threads <= 1`, returns a single chunk.
     pub fn par_sort_into_chunks(
         &mut self,
         threads: usize,
-    ) -> Vec<Vec<(RawCoordinateKey, Vec<u8>)>> {
+    ) -> Vec<Vec<(RawCoordinateKey, RawRecord)>> {
         par_sort_into_chunks_impl!(self, threads, radix_sort_record_refs, |r: &RecordRef| {
             RawCoordinateKey { sort_key: r.sort_key }
         })
@@ -910,11 +918,11 @@ impl TemplateRecordBuffer {
     ///
     /// Instead of merging the parallel sort sub-arrays back into one sorted
     /// buffer (as `par_sort` does), this returns each sub-array as its own
-    /// `Vec<(TemplateKey, Vec<u8>)>` so they can be passed as separate merge
+    /// `Vec<(TemplateKey, RawRecord)>` so they can be passed as separate merge
     /// sources to the k-way merge, avoiding the intermediate merge step.
     ///
     /// When `threads <= 1`, returns a single chunk.
-    pub fn par_sort_into_chunks(&mut self, threads: usize) -> Vec<Vec<(TemplateKey, Vec<u8>)>> {
+    pub fn par_sort_into_chunks(&mut self, threads: usize) -> Vec<Vec<(TemplateKey, RawRecord)>> {
         par_sort_into_chunks_impl!(
             self,
             threads,

--- a/src/lib/sort/memory_probe.rs
+++ b/src/lib/sort/memory_probe.rs
@@ -41,6 +41,8 @@
 use bytesize::ByteSize;
 use log::{Level, info, log_enabled};
 
+#[cfg(feature = "memory-debug")]
+pub use platform_ffi::print_mi_stats;
 pub use platform_ffi::{force_mi_collect, process_rss_bytes};
 
 /// Log target for the memory probe. Enable with
@@ -62,6 +64,18 @@ mod platform_ffi {
         // SAFETY: mi_collect(true) is a thread-safe arena maintenance call.
         unsafe {
             libmimalloc_sys::mi_collect(true);
+        }
+    }
+
+    /// Print mimalloc allocator statistics to stderr via the default output handler.
+    ///
+    /// `mi_stats_print_out(None, null_mut())` uses mimalloc's internal synchronization,
+    /// making it safe to call concurrently with allocation/deallocation on other threads.
+    #[cfg(feature = "memory-debug")]
+    pub fn print_mi_stats() {
+        // SAFETY: mimalloc synchronizes stats collection internally.
+        unsafe {
+            libmimalloc_sys::mi_stats_print_out(None, std::ptr::null_mut());
         }
     }
 

--- a/src/lib/sort/pipeline.rs
+++ b/src/lib/sort/pipeline.rs
@@ -24,9 +24,9 @@
 //! - **Buffered prefetch**: Records are prefetched ahead of merge consumption
 //! - **Multi-threaded output**: Writing uses parallel BGZF compression
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use crossbeam_channel::{Receiver, Sender, bounded};
-use noodles::bam::{self, Record};
+use fgumi_raw_bam::{RawRecord, read_raw_record};
 use noodles::bgzf;
 use noodles::sam::Header;
 use std::cmp::Ordering;
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
 
 use super::MERGE_BUFFER_SIZE;
-use crate::bam_io::create_bam_writer;
+use crate::bam_io::create_raw_bam_writer;
 
 /// Number of records to prefetch per chunk reader.
 const PREFETCH_BUFFER_SIZE: usize = 128;
@@ -45,7 +45,7 @@ const PREFETCH_BUFFER_SIZE: usize = 128;
 /// A record with its sort key and source chunk index.
 pub struct MergeEntry<K> {
     pub key: K,
-    pub record: Record,
+    pub record: RawRecord,
     pub chunk_idx: usize,
 }
 
@@ -85,13 +85,18 @@ impl Default for ParallelMergeConfig {
     }
 }
 
+/// One message from a [`PrefetchingChunkReader`] — `Ok(Some(_))` carries a record,
+/// `Ok(None)` signals clean EOF, and `Err(_)` carries a reader/I/O failure that
+/// must abort the merge instead of being silently treated as EOF.
+type ChunkReaderMsg = std::result::Result<Option<RawRecord>, String>;
+
 /// Prefetching chunk reader that runs in a background thread.
 ///
 /// This reader maintains a buffer of prefetched records, allowing the merge
 /// thread to consume records without blocking on I/O.
 struct PrefetchingChunkReader {
     /// Receiver for prefetched records.
-    record_rx: Receiver<Option<Record>>,
+    record_rx: Receiver<ChunkReaderMsg>,
     /// Handle to the reader thread.
     _handle: JoinHandle<()>,
     /// Chunk index for heap management.
@@ -105,11 +110,10 @@ impl PrefetchingChunkReader {
         // Channel for prefetched records
         let (record_tx, record_rx) = bounded(PREFETCH_BUFFER_SIZE);
 
-        // Spawn reader thread
+        // Spawn reader thread. Reader-side failures are surfaced over the
+        // channel so the merge loop can abort instead of truncating.
         let handle = thread::spawn(move || {
-            if let Err(e) = Self::reader_thread(path, record_tx) {
-                log::error!("Chunk reader thread failed: {e}");
-            }
+            Self::reader_thread(path, record_tx);
         });
 
         Ok(Self { record_rx, _handle: handle, idx })
@@ -117,48 +121,62 @@ impl PrefetchingChunkReader {
 
     /// Reader thread function.
     #[allow(clippy::needless_pass_by_value)]
-    fn reader_thread(path: PathBuf, tx: Sender<Option<Record>>) -> Result<()> {
-        let file = File::open(&path).context("Failed to open chunk file")?;
+    fn reader_thread(path: PathBuf, tx: Sender<ChunkReaderMsg>) {
+        let file = match File::open(&path).context("Failed to open chunk file") {
+            Ok(f) => f,
+            Err(e) => {
+                let _ = tx.send(Err(format!("{e:#}")));
+                return;
+            }
+        };
         let buf_reader = BufReader::with_capacity(MERGE_BUFFER_SIZE, file);
         let bgzf_reader = bgzf::io::Reader::new(buf_reader);
-        let mut reader = bam::io::Reader::from(bgzf_reader);
+        let mut noodles_reader = noodles::bam::io::Reader::from(bgzf_reader);
 
         // Read and discard header
-        reader.read_header()?;
+        if let Err(e) = noodles_reader.read_header() {
+            let _ = tx.send(Err(format!("Failed to read chunk header: {e}")));
+            return;
+        }
 
-        // Read records and send to channel
-        let mut record = Record::default();
+        // Extract the inner BGZF reader (header already consumed)
+        let mut bgzf_reader = noodles_reader.into_inner();
+
+        // Read raw records and send to channel
+        let mut record = RawRecord::new();
         loop {
-            match reader.read_record(&mut record) {
+            match read_raw_record(&mut bgzf_reader, &mut record) {
                 Ok(0) => {
-                    // EOF - send None to signal end
-                    let _ = tx.send(None);
+                    // Clean EOF
+                    let _ = tx.send(Ok(None));
                     break;
                 }
                 Ok(_) => {
-                    // Clone and send record (take ownership of current, reset for next)
+                    // Take ownership of current record and replace with empty one
                     let owned_record = std::mem::take(&mut record);
-                    if tx.send(Some(owned_record)).is_err() {
+                    if tx.send(Ok(Some(owned_record))).is_err() {
                         // Receiver dropped, exit
                         break;
                     }
                 }
                 Err(e) => {
-                    log::error!("Error reading chunk: {e}");
-                    let _ = tx.send(None);
+                    let _ = tx.send(Err(format!("Error reading chunk: {e}")));
                     break;
                 }
             }
         }
-
-        Ok(())
     }
 
     /// Get the next record from the prefetch buffer.
-    fn next(&self) -> Option<Record> {
+    ///
+    /// Returns `Ok(Some(_))` for a record, `Ok(None)` for clean EOF, and
+    /// `Err(_)` if the reader thread reported a failure or the channel was
+    /// dropped unexpectedly.
+    fn next(&self) -> Result<Option<RawRecord>> {
         match self.record_rx.recv() {
-            Ok(Some(record)) => Some(record),
-            Ok(None) | Err(_) => None,
+            Ok(Ok(record)) => Ok(record),
+            Ok(Err(e)) => Err(anyhow!("{e}")),
+            Err(e) => Err(anyhow!("chunk reader channel closed: {e}")),
         }
     }
 }
@@ -179,7 +197,7 @@ pub fn parallel_merge<K, F>(
 ) -> Result<u64>
 where
     K: Clone + Send + Sync + Ord,
-    F: Fn(&Record) -> K + Send + Sync,
+    F: Fn(&RawRecord) -> K + Send + Sync,
 {
     log::info!(
         "Starting parallel merge of {} chunks with {} reader threads",
@@ -199,27 +217,31 @@ where
         BinaryHeap::with_capacity(chunk_files.len());
 
     for reader in &chunk_readers {
-        if let Some(record) = reader.next() {
+        if let Some(record) = reader.next()? {
             let key = extract_key(&record);
             heap.push(std::cmp::Reverse(MergeEntry { key, record, chunk_idx: reader.idx }));
         }
     }
 
     // Create output writer with multi-threaded compression
-    let mut writer =
-        create_bam_writer(output, output_header, config.writer_threads, config.compression_level)?;
+    let mut writer = create_raw_bam_writer(
+        output,
+        output_header,
+        config.writer_threads,
+        config.compression_level,
+    )?;
 
     let mut records_merged = 0u64;
 
     // Merge loop
     while let Some(std::cmp::Reverse(entry)) = heap.pop() {
         // Write record to output
-        writer.write_record(output_header, &entry.record)?;
+        writer.write_raw_record(&entry.record)?;
         records_merged += 1;
 
         // Get next record from the same chunk (non-blocking due to prefetch buffer)
         let reader = &chunk_readers[entry.chunk_idx];
-        if let Some(record) = reader.next() {
+        if let Some(record) = reader.next()? {
             let key = extract_key(&record);
             heap.push(std::cmp::Reverse(MergeEntry { key, record, chunk_idx: entry.chunk_idx }));
         }
@@ -249,7 +271,7 @@ pub fn parallel_merge_buffered<K, F>(
 ) -> Result<u64>
 where
     K: Clone + Send + Sync + Ord,
-    F: Fn(&Record) -> K + Send + Sync,
+    F: Fn(&RawRecord) -> K + Send + Sync,
 {
     const OUTPUT_BUFFER_SIZE: usize = 1024;
 
@@ -271,18 +293,22 @@ where
         BinaryHeap::with_capacity(chunk_files.len());
 
     for reader in &chunk_readers {
-        if let Some(record) = reader.next() {
+        if let Some(record) = reader.next()? {
             let key = extract_key(&record);
             heap.push(std::cmp::Reverse(MergeEntry { key, record, chunk_idx: reader.idx }));
         }
     }
 
     // Create output writer with multi-threaded compression
-    let mut writer =
-        create_bam_writer(output, output_header, config.writer_threads, config.compression_level)?;
+    let mut writer = create_raw_bam_writer(
+        output,
+        output_header,
+        config.writer_threads,
+        config.compression_level,
+    )?;
 
     let mut records_merged = 0u64;
-    let mut output_buffer: Vec<Record> = Vec::with_capacity(OUTPUT_BUFFER_SIZE);
+    let mut output_buffer: Vec<RawRecord> = Vec::with_capacity(OUTPUT_BUFFER_SIZE);
 
     // Merge loop with output buffering
     while let Some(std::cmp::Reverse(entry)) = heap.pop() {
@@ -292,13 +318,13 @@ where
         // Flush buffer if full
         if output_buffer.len() >= OUTPUT_BUFFER_SIZE {
             for record in output_buffer.drain(..) {
-                writer.write_record(output_header, &record)?;
+                writer.write_raw_record(&record)?;
             }
         }
 
         // Get next record from the same chunk
         let reader = &chunk_readers[entry.chunk_idx];
-        if let Some(record) = reader.next() {
+        if let Some(record) = reader.next()? {
             let key = extract_key(&record);
             heap.push(std::cmp::Reverse(MergeEntry { key, record, chunk_idx: entry.chunk_idx }));
         }
@@ -306,7 +332,7 @@ where
 
     // Flush remaining buffered records
     for record in output_buffer {
-        writer.write_record(output_header, &record)?;
+        writer.write_raw_record(&record)?;
     }
 
     log::info!("Buffered parallel merge complete: {records_merged} records merged");
@@ -320,8 +346,8 @@ mod tests {
 
     #[test]
     fn test_merge_entry_ordering() {
-        let entry1 = MergeEntry { key: 1, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 2, record: Record::default(), chunk_idx: 1 };
+        let entry1 = MergeEntry { key: 1, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 2, record: RawRecord::new(), chunk_idx: 1 };
 
         assert!(entry1 < entry2);
     }
@@ -336,40 +362,40 @@ mod tests {
 
     #[test]
     fn test_merge_entry_equal_keys() {
-        let entry1 = MergeEntry { key: 5, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 5, record: Record::default(), chunk_idx: 1 };
+        let entry1 = MergeEntry { key: 5, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 5, record: RawRecord::new(), chunk_idx: 1 };
 
         assert_eq!(entry1.cmp(&entry2), Ordering::Equal);
     }
 
     #[test]
     fn test_merge_entry_greater_than() {
-        let entry1 = MergeEntry { key: 2, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 1, record: Record::default(), chunk_idx: 1 };
+        let entry1 = MergeEntry { key: 2, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 1, record: RawRecord::new(), chunk_idx: 1 };
 
         assert!(entry1 > entry2);
     }
 
     #[test]
     fn test_merge_entry_ordering_ignores_chunk_idx() {
-        let entry1 = MergeEntry { key: 42, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 42, record: Record::default(), chunk_idx: 99 };
+        let entry1 = MergeEntry { key: 42, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 42, record: RawRecord::new(), chunk_idx: 99 };
 
         assert_eq!(entry1.cmp(&entry2), Ordering::Equal);
     }
 
     #[test]
     fn test_merge_entry_partial_eq() {
-        let entry1 = MergeEntry { key: 10, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 10, record: Record::default(), chunk_idx: 3 };
+        let entry1 = MergeEntry { key: 10, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 10, record: RawRecord::new(), chunk_idx: 3 };
 
         assert!(entry1 == entry2);
     }
 
     #[test]
     fn test_merge_entry_partial_eq_different() {
-        let entry1 = MergeEntry { key: 10, record: Record::default(), chunk_idx: 0 };
-        let entry2 = MergeEntry { key: 20, record: Record::default(), chunk_idx: 0 };
+        let entry1 = MergeEntry { key: 10, record: RawRecord::new(), chunk_idx: 0 };
+        let entry2 = MergeEntry { key: 20, record: RawRecord::new(), chunk_idx: 0 };
 
         assert!(entry1 != entry2);
     }
@@ -377,11 +403,11 @@ mod tests {
     #[test]
     fn test_merge_entry_string_keys() {
         let entry_a =
-            MergeEntry { key: "apple".to_string(), record: Record::default(), chunk_idx: 0 };
+            MergeEntry { key: "apple".to_string(), record: RawRecord::new(), chunk_idx: 0 };
         let entry_b =
-            MergeEntry { key: "banana".to_string(), record: Record::default(), chunk_idx: 1 };
+            MergeEntry { key: "banana".to_string(), record: RawRecord::new(), chunk_idx: 1 };
         let entry_c =
-            MergeEntry { key: "cherry".to_string(), record: Record::default(), chunk_idx: 2 };
+            MergeEntry { key: "cherry".to_string(), record: RawRecord::new(), chunk_idx: 2 };
 
         assert!(entry_a < entry_b);
         assert!(entry_b < entry_c);
@@ -393,9 +419,9 @@ mod tests {
         use std::cmp::Reverse;
 
         let mut heap = BinaryHeap::new();
-        heap.push(Reverse(MergeEntry { key: 3, record: Record::default(), chunk_idx: 0 }));
-        heap.push(Reverse(MergeEntry { key: 1, record: Record::default(), chunk_idx: 1 }));
-        heap.push(Reverse(MergeEntry { key: 2, record: Record::default(), chunk_idx: 2 }));
+        heap.push(Reverse(MergeEntry { key: 3, record: RawRecord::new(), chunk_idx: 0 }));
+        heap.push(Reverse(MergeEntry { key: 1, record: RawRecord::new(), chunk_idx: 1 }));
+        heap.push(Reverse(MergeEntry { key: 2, record: RawRecord::new(), chunk_idx: 2 }));
 
         // Should come out in ascending order: 1, 2, 3
         assert_eq!(heap.pop().expect("heap should have elements").0.key, 1);

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -732,8 +732,8 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 enum ChunkSource<K: RawSortKey + Default + 'static> {
     /// Disk-based chunk with prefetching reader (legacy path with per-source threads).
     Disk(GenericKeyedChunkReader<K>),
-    /// In-memory sorted records.
-    Memory { records: Vec<(K, Vec<u8>)>, idx: usize },
+    /// In-memory sorted records from the inline buffer.
+    Memory { records: Vec<(K, fgumi_raw_bam::RawRecord)>, idx: usize },
     /// Pool-integrated disk source — workers read and decompress, main thread parses.
     /// The `source_id` maps to the `MainThreadChunkConsumer`'s per-source buffer.
     PoolDisk { source_id: usize },
@@ -754,7 +754,10 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
             ChunkSource::Memory { records, idx } => {
                 if *idx < records.len() {
                     let (ref mut key, ref mut data) = records[*idx];
-                    std::mem::swap(buf, data);
+                    // Bridge: RawRecord wraps Vec<u8>; swap via the inner vec to avoid
+                    // re-allocating. The caller's buf is a plain Vec<u8> (merge scratch).
+                    // TODO: change merge scratch to RawRecord to eliminate this bridge.
+                    std::mem::swap(buf, data.as_mut_vec());
                     let key = std::mem::take(key);
                     *idx += 1;
                     Ok(Some(key))
@@ -1839,7 +1842,9 @@ impl RawExternalSorter {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer); each
             // chunk becomes its own in-memory merge source.
-            let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
+            let memory_chunks: Vec<Vec<(RawCoordinateKey, fgumi_raw_bam::RawRecord)>> = if buffer
+                .is_empty()
+            {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -1852,7 +1857,7 @@ impl RawExternalSorter {
                     .iter()
                     .map(|r| {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
-                        (key, buffer.get_record(r).to_vec())
+                        (key, fgumi_raw_bam::RawRecord::from(buffer.get_record(r).to_vec()))
                     })
                     .collect();
                 vec![chunk]
@@ -2023,7 +2028,9 @@ impl RawExternalSorter {
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks
-            let memory_chunks: Vec<Vec<(RawCoordinateKey, Vec<u8>)>> = if buffer.is_empty() {
+            let memory_chunks: Vec<Vec<(RawCoordinateKey, fgumi_raw_bam::RawRecord)>> = if buffer
+                .is_empty()
+            {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -2036,7 +2043,7 @@ impl RawExternalSorter {
                     .iter()
                     .map(|r| {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
-                        (key, buffer.get_record(r).to_vec())
+                        (key, fgumi_raw_bam::RawRecord::from(buffer.get_record(r).to_vec()))
                     })
                     .collect();
                 vec![chunk]
@@ -2131,7 +2138,7 @@ impl RawExternalSorter {
         let estimated_records = init_cap / 300;
 
         let mut chunk_files: Vec<PathBuf> = Vec::new();
-        let mut entries: Vec<(K, Vec<u8>)> = Vec::with_capacity(estimated_records);
+        let mut entries: Vec<(K, fgumi_raw_bam::RawRecord)> = Vec::with_capacity(estimated_records);
         let mut memory_used = 0usize;
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
@@ -2146,14 +2153,13 @@ impl RawExternalSorter {
             progress.log_if_needed(1);
 
             // Extract key from raw bytes
-            let bam_bytes = record.as_ref();
-            let key = K::extract(bam_bytes, &ctx);
+            let key = K::extract(record.as_ref(), &ctx);
 
             // Estimate memory: record bytes + key overhead
-            let record_size = bam_bytes.len() + 50; // approximate key size
+            let record_size = record.as_ref().len() + 50; // approximate key size
             memory_used += record_size;
 
-            entries.push((key, bam_bytes.to_vec()));
+            entries.push((key, record));
 
             if probe.should_sample_read(stats.total_records) {
                 let bstats = BufferProbeStats::simple(memory_used as u64, entries.len() as u64);
@@ -2189,7 +2195,7 @@ impl RawExternalSorter {
                 let handle = timer.time_spill_write(|| {
                     let mut writer = PooledChunkWriter::<K>::new(Arc::clone(&pool), &chunk_path)?;
                     for (key, record) in entries.drain(..) {
-                        writer.write_record(&key, &record)?;
+                        writer.write_record(&key, record.as_ref())?;
                     }
                     writer.start_finish()
                 })?;
@@ -2243,7 +2249,7 @@ impl RawExternalSorter {
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
-            let memory_chunks: Vec<Vec<(K, Vec<u8>)>> = if entries.is_empty() {
+            let memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if entries.is_empty() {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| {
@@ -2260,7 +2266,8 @@ impl RawExternalSorter {
                     // and reverse. Each split_off is O(chunk_size) → O(n) total.
                     let mut remaining = std::mem::take(&mut entries);
                     let num_chunks = remaining.len().div_ceil(chunk_size);
-                    let mut chunks: Vec<Vec<(K, Vec<u8>)>> = Vec::with_capacity(num_chunks);
+                    let mut chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> =
+                        Vec::with_capacity(num_chunks);
                     let tail_len = remaining.len() % chunk_size;
                     if tail_len != 0 {
                         let split_at = remaining.len() - tail_len;
@@ -2454,7 +2461,9 @@ impl RawExternalSorter {
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
-            let memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>> = if buffer.is_empty() {
+            let memory_chunks: Vec<Vec<(TemplateKey, fgumi_raw_bam::RawRecord)>> = if buffer
+                .is_empty()
+            {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -2462,7 +2471,10 @@ impl RawExternalSorter {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
-                let chunk = buffer.iter_sorted_keyed().map(|(k, r)| (k, r.to_vec())).collect();
+                let chunk = buffer
+                    .iter_sorted_keyed()
+                    .map(|(k, r)| (k, fgumi_raw_bam::RawRecord::from(r.to_vec())))
+                    .collect();
                 vec![chunk]
             };
 
@@ -2503,7 +2515,7 @@ impl RawExternalSorter {
     /// does not yet support pool-integrated decompression.
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
+        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
         reader_concurrency: usize,
         pool_decompress: bool,
         pool: &Arc<SortWorkerPool>,
@@ -2548,7 +2560,7 @@ impl RawExternalSorter {
     fn merge_chunks_keyed(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(TemplateKey, Vec<u8>)>>,
+        memory_chunks: Vec<Vec<(TemplateKey, fgumi_raw_bam::RawRecord)>>,
         header: &Header,
         output: &Path,
         total_records: u64,
@@ -2573,7 +2585,7 @@ impl RawExternalSorter {
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
+        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
         header: &Header,
         output: &Path,
         total_records: u64,
@@ -2753,7 +2765,7 @@ impl RawExternalSorter {
     pub fn merge_chunks_for_test<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
+        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
         header: &Header,
         output: &Path,
         pool: &Arc<SortWorkerPool>,
@@ -2768,7 +2780,7 @@ impl RawExternalSorter {
     fn merge_chunks_with_index<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, Vec<u8>)>>,
+        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
         header: &Header,
         output: &Path,
         total_records: u64,

--- a/src/lib/sort/raw_bam_reader.rs
+++ b/src/lib/sort/raw_bam_reader.rs
@@ -32,7 +32,7 @@ use std::io::{self, BufReader, Read};
 /// Number of BGZF blocks to read per batch.
 const BLOCKS_PER_BATCH: usize = 64;
 
-use fgumi_raw_bam::BAM_MAGIC;
+use fgumi_raw_bam::{BAM_MAGIC, RawRecord};
 
 /// A raw BAM record reader that reads directly from BGZF blocks.
 ///
@@ -199,7 +199,7 @@ impl<R: Read> RawBamRecordReader<R> {
     /// # Errors
     ///
     /// Returns an error if the header has not been skipped or the record is truncated.
-    pub fn next_record(&mut self) -> io::Result<Option<Vec<u8>>> {
+    pub fn next_record(&mut self) -> io::Result<Option<RawRecord>> {
         if !self.header_skipped {
             return Err(io::Error::other("Must call skip_header() first"));
         }
@@ -232,7 +232,9 @@ impl<R: Read> RawBamRecordReader<R> {
         }
 
         // Copy record bytes (without the 4-byte block_size prefix, matching noodles format)
-        let record = self.decompressed[self.position + 4..self.position + total_size].to_vec();
+        let record = RawRecord::from(
+            self.decompressed[self.position + 4..self.position + total_size].to_vec(),
+        );
         self.position += total_size;
 
         Ok(Some(record))
@@ -307,7 +309,7 @@ impl<R: Read> RawBamRecordReader<R> {
 
 /// Iterator adapter for `RawBamRecordReader`.
 impl<R: Read> Iterator for RawBamRecordReader<R> {
-    type Item = io::Result<Vec<u8>>;
+    type Item = io::Result<RawRecord>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.next_record() {
@@ -353,7 +355,7 @@ impl<R: Read> BatchedRawBamReader<R> {
     /// # Errors
     ///
     /// Returns an error if a record is truncated or invalid.
-    pub fn next_batch(&mut self) -> io::Result<Option<Vec<Vec<u8>>>> {
+    pub fn next_batch(&mut self) -> io::Result<Option<Vec<RawRecord>>> {
         let mut batch = Vec::with_capacity(self.batch_size);
 
         for _ in 0..self.batch_size {
@@ -550,7 +552,7 @@ mod tests {
         let record = reader.next_record().expect("failed to read first record");
         assert!(record.is_some(), "Expected one record");
         let record = record.expect("record should be Some");
-        assert_eq!(record, rec, "Record bytes should match");
+        assert_eq!(record.as_ref(), rec.as_slice(), "Record bytes should match");
 
         // No more records
         let eof = reader.next_record().expect("failed to read at EOF");
@@ -572,9 +574,9 @@ mod tests {
         let r2 = reader.next_record().expect("failed to read record 2").expect("record 2");
         let r3 = reader.next_record().expect("failed to read record 3").expect("record 3");
 
-        assert_eq!(r1, rec_a);
-        assert_eq!(r2, rec_b);
-        assert_eq!(r3, rec_c);
+        assert_eq!(r1.as_ref(), rec_a.as_slice());
+        assert_eq!(r2.as_ref(), rec_b.as_slice());
+        assert_eq!(r3.as_ref(), rec_c.as_slice());
 
         assert!(reader.next_record().expect("failed to read at EOF").is_none(), "Expected EOF");
     }
@@ -588,11 +590,11 @@ mod tests {
             .expect("failed to create reader for iterator test");
         reader.skip_header().expect("failed to skip header");
 
-        let records: Vec<Vec<u8>> =
+        let records: Vec<RawRecord> =
             reader.map(|r| r.expect("failed to read record via iterator")).collect();
         assert_eq!(records.len(), 2);
-        assert_eq!(records[0], rec_a);
-        assert_eq!(records[1], rec_b);
+        assert_eq!(records[0].as_ref(), rec_a.as_slice());
+        assert_eq!(records[1].as_ref(), rec_b.as_slice());
     }
 
     #[test]
@@ -609,13 +611,13 @@ mod tests {
         // First batch: 2 records
         let batch1 = reader.next_batch().expect("failed to read batch 1").expect("batch 1");
         assert_eq!(batch1.len(), 2);
-        assert_eq!(batch1[0], rec_a);
-        assert_eq!(batch1[1], rec_b);
+        assert_eq!(batch1[0].as_ref(), rec_a.as_slice());
+        assert_eq!(batch1[1].as_ref(), rec_b.as_slice());
 
         // Second batch: 1 record (remainder)
         let batch2 = reader.next_batch().expect("failed to read batch 2").expect("batch 2");
         assert_eq!(batch2.len(), 1);
-        assert_eq!(batch2[0], rec_c);
+        assert_eq!(batch2[0].as_ref(), rec_c.as_slice());
 
         // No more batches
         assert!(

--- a/src/lib/sort/read_ahead.rs
+++ b/src/lib/sort/read_ahead.rs
@@ -15,8 +15,8 @@
 //!
 //! # Readers
 //!
-//! - [`ReadAheadReader`]: Yields `noodles::bam::Record` (uses noodles parsing)
-//! - [`RawReadAheadReader`]: Yields `RawRecord` (raw bytes, no noodles Record)
+//! - [`RawReadAheadReader`]: Yields [`RawRecord`] (raw bytes, no noodles Record),
+//!   with I/O-error propagation via `take_error()`
 //!
 //! # Batched Reading
 //!
@@ -24,10 +24,9 @@
 //! channel synchronization overhead by ~256x compared to per-record sends.
 
 use crossbeam_channel::{Receiver, Sender, bounded};
-use noodles::bam::Record;
 use std::thread::{self, JoinHandle};
 
-use crate::bam_io::{BamReaderAuto, RawBamReaderAuto};
+use crate::bam_io::RawBamReaderAuto;
 use fgumi_raw_bam::{RawBamReader, RawRecord};
 use std::io::Read as IoRead;
 
@@ -38,165 +37,6 @@ const BATCH_SIZE: usize = 256;
 /// Number of batches to buffer in the channel.
 /// Total prefetch = `BATCH_SIZE` * `CHANNEL_BUFFER_SIZE` = 256 * 16 = 4096 records.
 const CHANNEL_BUFFER_SIZE: usize = 16;
-
-/// Background reader that reads ahead while main thread processes.
-///
-/// This reader spawns a background thread that continuously reads records
-/// from the BAM file and sends them through a channel in batches. The main
-/// thread can then receive records without blocking on I/O.
-///
-/// Records are batched (256 per batch by default) to reduce channel
-/// synchronization overhead by ~256x compared to per-record sends.
-pub struct ReadAheadReader {
-    /// Receiver for prefetched record batches (Option to allow closing before join).
-    receiver: Option<Receiver<Vec<Record>>>,
-    /// Handle to the reader thread.
-    handle: Option<JoinHandle<()>>,
-    /// Current batch being consumed.
-    current_batch: Vec<Record>,
-    /// Index into current batch.
-    batch_index: usize,
-}
-
-impl ReadAheadReader {
-    /// Create a new read-ahead reader with default buffer size.
-    #[must_use]
-    pub fn new(reader: BamReaderAuto) -> Self {
-        Self::with_batch_size(reader, BATCH_SIZE, CHANNEL_BUFFER_SIZE)
-    }
-
-    /// Create a new read-ahead reader with specified batch and buffer sizes.
-    #[must_use]
-    pub fn with_batch_size(
-        mut reader: BamReaderAuto,
-        batch_size: usize,
-        channel_buffer: usize,
-    ) -> Self {
-        let (tx, rx) = bounded(channel_buffer);
-
-        let handle = thread::spawn(move || {
-            Self::reader_thread(&mut reader, tx, batch_size);
-        });
-
-        Self { receiver: Some(rx), handle: Some(handle), current_batch: Vec::new(), batch_index: 0 }
-    }
-
-    /// Create with legacy per-record behavior (for compatibility).
-    #[must_use]
-    pub fn with_buffer_size(reader: BamReaderAuto, buffer_size: usize) -> Self {
-        // Approximate the old behavior: buffer_size records total
-        let buffer_size = buffer_size.max(1);
-        let batch_size = BATCH_SIZE.min(buffer_size);
-        let channel_buffer = buffer_size.div_ceil(batch_size);
-        Self::with_batch_size(reader, batch_size, channel_buffer)
-    }
-
-    /// Reader thread function - reads records in batches.
-    ///
-    /// # Error handling
-    ///
-    /// Unlike [`RawReadAheadReader`], this reader does **not** propagate I/O errors
-    /// to the foreground thread. When a read fails the error is logged and the thread
-    /// sends an EOF sentinel, making the error indistinguishable from clean EOF.
-    ///
-    /// This is intentional: `ReadAheadReader` is used in paths (e.g. group/correct)
-    /// where errors are surfaced by the noodles layer before they reach here, and
-    /// adding an `error_slot` would complicate the public API for no practical gain.
-    /// If you need error propagation, use [`RawReadAheadReader`] which provides
-    /// `take_error()`.
-    #[allow(clippy::needless_pass_by_value)]
-    fn reader_thread(reader: &mut BamReaderAuto, tx: Sender<Vec<Record>>, batch_size: usize) {
-        let mut record = Record::default();
-        let mut batch = Vec::with_capacity(batch_size);
-
-        loop {
-            match reader.read_record(&mut record) {
-                Ok(0) => {
-                    // EOF - send any remaining records
-                    if !batch.is_empty() {
-                        let _ = tx.send(batch);
-                    }
-                    // Send empty batch to signal EOF
-                    let _ = tx.send(Vec::new());
-                    break;
-                }
-                Ok(_) => {
-                    // Successfully read a record
-                    batch.push(std::mem::take(&mut record));
-
-                    // Send batch when full
-                    if batch.len() >= batch_size {
-                        if tx.send(batch).is_err() {
-                            // Receiver dropped
-                            break;
-                        }
-                        batch = Vec::with_capacity(batch_size);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error reading BAM record: {e}");
-                    // Send any accumulated records before error
-                    if !batch.is_empty() {
-                        let _ = tx.send(batch);
-                    }
-                    let _ = tx.send(Vec::new());
-                    break;
-                }
-            }
-        }
-    }
-
-    /// Get the next record from the read-ahead buffer.
-    ///
-    /// Returns `Some(record)` if a record is available, `None` on EOF or error.
-    #[inline]
-    #[must_use]
-    pub fn next_record(&mut self) -> Option<Record> {
-        // Check if we have records in the current batch
-        if self.batch_index < self.current_batch.len() {
-            let record = std::mem::take(&mut self.current_batch[self.batch_index]);
-            self.batch_index += 1;
-            return Some(record);
-        }
-
-        // Need to fetch next batch
-        let receiver = self.receiver.as_ref()?;
-        match receiver.recv() {
-            Ok(batch) if !batch.is_empty() => {
-                self.current_batch = batch;
-                self.batch_index = 1; // We'll return index 0
-                Some(std::mem::take(&mut self.current_batch[0]))
-            }
-            Ok(_) | Err(_) => None, // Empty batch = EOF, or channel closed
-        }
-    }
-}
-
-impl Drop for ReadAheadReader {
-    fn drop(&mut self) {
-        // Close the receiver first to unblock any pending sends in the reader thread.
-        // This prevents deadlock when the channel is full and the thread is blocked on send.
-        drop(self.receiver.take());
-
-        // Now wait for the reader thread to finish
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-/// Iterator adapter for `ReadAheadReader`.
-impl Iterator for ReadAheadReader {
-    type Item = Record;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.next_record()
-    }
-}
-
-// ============================================================================
-// RawReadAheadReader - Raw bytes version (no noodles Record dependency)
-// ============================================================================
 
 /// Background reader that reads raw BAM bytes ahead while main thread processes.
 ///
@@ -654,7 +494,7 @@ mod tests {
     use std::num::NonZeroUsize;
     use tempfile::NamedTempFile;
 
-    use crate::bam_io::{create_bam_reader, create_raw_bam_reader};
+    use crate::bam_io::create_raw_bam_reader;
 
     /// Create a temporary BAM file with the given number of unmapped records.
     /// Returns the temp file handle (keeps the file alive) and the header used.
@@ -682,87 +522,6 @@ mod tests {
         }
 
         (tmp, header)
-    }
-
-    #[test]
-    fn test_read_ahead_reader_empty_bam() {
-        let (tmp, _header) = create_test_bam_file(0);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        let mut ra = ReadAheadReader::new(reader);
-        assert!(ra.next_record().is_none(), "Empty BAM should yield no records");
-    }
-
-    #[test]
-    fn test_read_ahead_reader_single_record() {
-        let (tmp, _header) = create_test_bam_file(1);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        let mut ra = ReadAheadReader::new(reader);
-        assert!(ra.next_record().is_some(), "Should yield exactly one record");
-        assert!(ra.next_record().is_none(), "Should yield no more records after the single record");
-    }
-
-    #[test]
-    fn test_read_ahead_reader_multiple_records() {
-        let num = 10;
-        let (tmp, _header) = create_test_bam_file(num);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        let mut ra = ReadAheadReader::new(reader);
-        let mut count = 0;
-        while ra.next_record().is_some() {
-            count += 1;
-        }
-        assert_eq!(count, num, "Should read exactly {num} records");
-    }
-
-    #[test]
-    fn test_read_ahead_reader_iterator() {
-        let num = 10;
-        let (tmp, _header) = create_test_bam_file(num);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        let ra = ReadAheadReader::new(reader);
-        let records: Vec<Record> = ra.collect();
-        assert_eq!(records.len(), num, "Iterator should collect exactly {num} records");
-    }
-
-    #[test]
-    fn test_read_ahead_reader_with_buffer_size() {
-        let num = 10;
-        let (tmp, _header) = create_test_bam_file(num);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        // Use a small buffer size (4) to exercise partial-batch logic
-        let ra = ReadAheadReader::with_buffer_size(reader, 4);
-        let records: Vec<Record> = ra.collect();
-        assert_eq!(records.len(), num, "with_buffer_size(4) should still read all {num} records");
-    }
-
-    #[test]
-    fn test_read_ahead_reader_drop_while_reading() {
-        // Create many records so the background thread is likely still reading
-        // when we drop the reader. This verifies the Drop impl does not deadlock.
-        let num = 5000;
-        let (tmp, _header) = create_test_bam_file(num);
-        let (reader, _header) =
-            create_bam_reader(tmp.path(), 1).expect("creating BAM reader should succeed");
-
-        let mut ra = ReadAheadReader::new(reader);
-        // Read only a few records
-        for _ in 0..5 {
-            let _ = ra.next_record();
-        }
-        // Drop the reader while there are still records pending in the channel
-        // or still being read by the background thread.
-        drop(ra);
-        // If we reach here, the Drop impl did not deadlock.
     }
 
     #[test]

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -38,7 +38,7 @@
 use crate::sam::{SamTag, record_utils, to_smallest_signed_int};
 use crate::unified_pipeline::MemoryEstimate;
 use anyhow::{Result, anyhow, bail};
-use fgumi_raw_bam::RawRecordView;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use noodles::sam::alignment::record::Cigar;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
@@ -66,8 +66,8 @@ pub struct Template {
     pub name: Vec<u8>,
     /// The records (empty in raw-byte mode)
     pub records: Vec<RecordBuf>,
-    /// Raw BAM record bytes (without `block_size` prefix). Present only in raw-byte mode.
-    pub raw_records: Option<Vec<Vec<u8>>>,
+    /// Raw BAM records (without `block_size` prefix). Present only in raw-byte mode.
+    pub raw_records: Option<Vec<RawRecord>>,
     /// Primary R1 read (first segment, non-secondary, non-supplementary)
     pub r1: Option<(usize, usize)>,
     /// Primary R2 read (second segment, non-secondary, non-supplementary)
@@ -568,34 +568,34 @@ impl Template {
         self.raw_records.is_some()
     }
 
-    /// Returns the raw R1 bytes if in raw-byte mode.
+    /// Returns the raw R1 record if in raw-byte mode.
     #[must_use]
-    pub fn raw_r1(&self) -> Option<&[u8]> {
+    pub fn raw_r1(&self) -> Option<&RawRecord> {
         let rr = self.raw_records.as_ref()?;
-        self.r1.map(|_| rr[0].as_slice())
+        self.r1.map(|_| &rr[0])
     }
 
-    /// Returns the raw R2 bytes if in raw-byte mode.
+    /// Returns the raw R2 record if in raw-byte mode.
     #[must_use]
-    pub fn raw_r2(&self) -> Option<&[u8]> {
+    pub fn raw_r2(&self) -> Option<&RawRecord> {
         let rr = self.raw_records.as_ref()?;
-        self.r2.map(|(i, _)| rr[i].as_slice())
+        self.r2.map(|(i, _)| &rr[i])
     }
 
     /// Returns all raw records if in raw-byte mode.
     #[must_use]
-    pub fn all_raw_records(&self) -> Option<&[Vec<u8>]> {
+    pub fn all_raw_records(&self) -> Option<&[RawRecord]> {
         self.raw_records.as_deref()
     }
 
     /// Consumes self and returns the raw records if in raw-byte mode.
     #[must_use]
-    pub fn into_raw_records(self) -> Option<Vec<Vec<u8>>> {
+    pub fn into_raw_records(self) -> Option<Vec<RawRecord>> {
         self.raw_records
     }
 
     /// Returns mutable access to all raw records if in raw-byte mode.
-    pub fn all_raw_records_mut(&mut self) -> Option<&mut [Vec<u8>]> {
+    pub fn all_raw_records_mut(&mut self) -> Option<&mut [RawRecord]> {
         self.raw_records.as_deref_mut()
     }
 
@@ -609,7 +609,7 @@ impl Template {
     ///
     /// Returns an error if multiple primary R1s or R2s are found.
     #[allow(clippy::too_many_lines)]
-    pub fn from_raw_records(mut raw_records: Vec<Vec<u8>>) -> Result<Self> {
+    pub fn from_raw_records(mut raw_records: Vec<RawRecord>) -> Result<Self> {
         use crate::sort::bam_fields;
 
         if raw_records.is_empty() {
@@ -636,6 +636,14 @@ impl Template {
 
         // Extract name from first record
         let name = bam_fields::read_name(&raw_records[0]).to_vec();
+
+        // Verify all records share the same QNAME (matching Builder behavior).
+        // Done before the fast path so mismatched names cannot slip past into a Template.
+        for rec in raw_records.iter().skip(1) {
+            if bam_fields::read_name(rec) != name.as_slice() {
+                bail!("Template name mismatch in from_raw_records");
+            }
+        }
 
         // Fast path for common 2-record paired-end case (no supplementals/secondaries)
         if raw_records.len() == 2 {
@@ -669,13 +677,6 @@ impl Template {
                     });
                 }
                 // Both R1 or both R2 — fall through to general path for error handling
-            }
-        }
-
-        // Verify all records share the same QNAME (matching Builder behavior)
-        for rec in raw_records.iter().skip(1) {
-            if bam_fields::read_name(rec) != name.as_slice() {
-                bail!("Template name mismatch in from_raw_records");
             }
         }
 
@@ -720,8 +721,8 @@ impl Template {
 
         // Build ordered Vec: r1, r2, r1_supplementals, r2_supplementals, r1_secondaries, r2_secondaries
         // (matching Builder::build() ordering, with supplementals/secondaries reversed)
-        let mut ordered: Vec<Vec<u8>> = Vec::with_capacity(raw_records.len());
-        let mut take = |idx: usize| -> Vec<u8> { std::mem::take(&mut raw_records[idx]) };
+        let mut ordered: Vec<RawRecord> = Vec::with_capacity(raw_records.len());
+        let mut take = |idx: usize| -> RawRecord { std::mem::take(&mut raw_records[idx]) };
 
         // Track indices
         let r1_pair = if let Some(idx) = r1_idx {
@@ -1066,14 +1067,14 @@ impl Template {
             let rr = self.raw_records.as_mut().unwrap();
             if let Some(as_value) = r2_as {
                 if let Ok(v) = i32::try_from(as_value) {
-                    bam_fields::remove_tag(&mut rr[r1_i], b"ms");
-                    bam_fields::append_signed_int_tag(&mut rr[r1_i], b"ms", v);
+                    bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"ms");
+                    bam_fields::append_signed_int_tag(rr[r1_i].as_mut_vec(), b"ms", v);
                 }
             }
             if let Some(as_value) = r1_as {
                 if let Ok(v) = i32::try_from(as_value) {
-                    bam_fields::remove_tag(&mut rr[r2_i], b"ms");
-                    bam_fields::append_signed_int_tag(&mut rr[r2_i], b"ms", v);
+                    bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"ms");
+                    bam_fields::append_signed_int_tag(rr[r2_i].as_mut_vec(), b"ms", v);
                 }
             }
         }
@@ -1100,18 +1101,22 @@ impl Template {
                     bam_fields::set_template_length(rec, -r2_tlen);
 
                     let mq_val = if r2_mapq == 255 { 255 } else { i32::from(r2_mapq) };
-                    bam_fields::update_int_tag(rec, b"MQ", mq_val);
+                    bam_fields::update_int_tag(rec.as_mut_vec(), b"MQ", mq_val);
 
                     if !r2_cigar_str.is_empty() && r2_cigar_str != "*" && !r2_is_unmapped {
-                        bam_fields::update_string_tag(rec, b"MC", r2_cigar_str.as_bytes());
+                        bam_fields::update_string_tag(
+                            rec.as_mut_vec(),
+                            b"MC",
+                            r2_cigar_str.as_bytes(),
+                        );
                     } else {
-                        bam_fields::remove_tag(rec, b"MC");
+                        bam_fields::remove_tag(rec.as_mut_vec(), b"MC");
                     }
 
                     if let Some(as_value) = r2_as {
                         if let Ok(v) = i32::try_from(as_value) {
-                            bam_fields::remove_tag(rec, b"ms");
-                            bam_fields::append_signed_int_tag(rec, b"ms", v);
+                            bam_fields::remove_tag(rec.as_mut_vec(), b"ms");
+                            bam_fields::append_signed_int_tag(rec.as_mut_vec(), b"ms", v);
                         }
                     }
                 }
@@ -1140,18 +1145,22 @@ impl Template {
                     bam_fields::set_template_length(rec, -r1_tlen);
 
                     let mq_val = if r1_mapq == 255 { 255 } else { i32::from(r1_mapq) };
-                    bam_fields::update_int_tag(rec, b"MQ", mq_val);
+                    bam_fields::update_int_tag(rec.as_mut_vec(), b"MQ", mq_val);
 
                     if !r1_cigar_str.is_empty() && r1_cigar_str != "*" && !r1_is_unmapped {
-                        bam_fields::update_string_tag(rec, b"MC", r1_cigar_str.as_bytes());
+                        bam_fields::update_string_tag(
+                            rec.as_mut_vec(),
+                            b"MC",
+                            r1_cigar_str.as_bytes(),
+                        );
                     } else {
-                        bam_fields::remove_tag(rec, b"MC");
+                        bam_fields::remove_tag(rec.as_mut_vec(), b"MC");
                     }
 
                     if let Some(as_value) = r1_as {
                         if let Ok(v) = i32::try_from(as_value) {
-                            bam_fields::remove_tag(rec, b"ms");
-                            bam_fields::append_signed_int_tag(rec, b"ms", v);
+                            bam_fields::remove_tag(rec.as_mut_vec(), b"ms");
+                            bam_fields::append_signed_int_tag(rec.as_mut_vec(), b"ms", v);
                         }
                     }
                 }
@@ -1193,11 +1202,11 @@ impl Template {
         bam_fields::set_mate_pos(&mut rr[r1_i], r2_pos);
         set_mate_flags_raw(&mut rr[r1_i], r2_is_reverse, false);
         let r2_mq_val = if r2_mapq == 255 { 255 } else { i32::from(r2_mapq) };
-        bam_fields::update_int_tag(&mut rr[r1_i], b"MQ", r2_mq_val);
+        bam_fields::update_int_tag(rr[r1_i].as_mut_vec(), b"MQ", r2_mq_val);
         if !r2_cigar_str.is_empty() && r2_cigar_str != "*" {
-            bam_fields::update_string_tag(&mut rr[r1_i], b"MC", r2_cigar_str.as_bytes());
+            bam_fields::update_string_tag(rr[r1_i].as_mut_vec(), b"MC", r2_cigar_str.as_bytes());
         } else {
-            bam_fields::remove_tag(&mut rr[r1_i], b"MC");
+            bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"MC");
         }
 
         // Set mate info on R2 from R1
@@ -1205,11 +1214,11 @@ impl Template {
         bam_fields::set_mate_pos(&mut rr[r2_i], r1_pos);
         set_mate_flags_raw(&mut rr[r2_i], r1_is_reverse, false);
         let r1_mq_val = if r1_mapq == 255 { 255 } else { i32::from(r1_mapq) };
-        bam_fields::update_int_tag(&mut rr[r2_i], b"MQ", r1_mq_val);
+        bam_fields::update_int_tag(rr[r2_i].as_mut_vec(), b"MQ", r1_mq_val);
         if !r1_cigar_str.is_empty() && r1_cigar_str != "*" {
-            bam_fields::update_string_tag(&mut rr[r2_i], b"MC", r1_cigar_str.as_bytes());
+            bam_fields::update_string_tag(rr[r2_i].as_mut_vec(), b"MC", r1_cigar_str.as_bytes());
         } else {
-            bam_fields::remove_tag(&mut rr[r2_i], b"MC");
+            bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"MC");
         }
 
         // Set insert size
@@ -1235,8 +1244,8 @@ impl Template {
         bam_fields::set_mate_ref_id(&mut rr[r1_i], -1);
         bam_fields::set_mate_pos(&mut rr[r1_i], -1);
         set_mate_flags_raw(&mut rr[r1_i], r2_is_reverse, true);
-        bam_fields::remove_tag(&mut rr[r1_i], b"MQ");
-        bam_fields::remove_tag(&mut rr[r1_i], b"MC");
+        bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"MQ");
+        bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[r1_i], 0);
 
         // R2: set to unmapped coordinates
@@ -1245,8 +1254,8 @@ impl Template {
         bam_fields::set_mate_ref_id(&mut rr[r2_i], -1);
         bam_fields::set_mate_pos(&mut rr[r2_i], -1);
         set_mate_flags_raw(&mut rr[r2_i], r1_is_reverse, true);
-        bam_fields::remove_tag(&mut rr[r2_i], b"MQ");
-        bam_fields::remove_tag(&mut rr[r2_i], b"MC");
+        bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"MQ");
+        bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[r2_i], 0);
     }
 
@@ -1277,8 +1286,8 @@ impl Template {
         bam_fields::set_mate_ref_id(&mut rr[mapped_i], mapped_ref_id);
         bam_fields::set_mate_pos(&mut rr[mapped_i], mapped_pos);
         set_mate_flags_raw(&mut rr[mapped_i], unmapped_is_reverse, true);
-        bam_fields::remove_tag(&mut rr[mapped_i], b"MQ");
-        bam_fields::remove_tag(&mut rr[mapped_i], b"MC");
+        bam_fields::remove_tag(rr[mapped_i].as_mut_vec(), b"MQ");
+        bam_fields::remove_tag(rr[mapped_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[mapped_i], 0);
 
         // Set mate info on unmapped read (mate is mapped)
@@ -1286,11 +1295,15 @@ impl Template {
         bam_fields::set_mate_pos(&mut rr[unmapped_i], mapped_pos);
         set_mate_flags_raw(&mut rr[unmapped_i], mapped_is_reverse, false);
         let mq_val = if mapped_mapq == 255 { 255 } else { i32::from(mapped_mapq) };
-        bam_fields::update_int_tag(&mut rr[unmapped_i], b"MQ", mq_val);
+        bam_fields::update_int_tag(rr[unmapped_i].as_mut_vec(), b"MQ", mq_val);
         if !mapped_cigar_str.is_empty() && mapped_cigar_str != "*" {
-            bam_fields::update_string_tag(&mut rr[unmapped_i], b"MC", mapped_cigar_str.as_bytes());
+            bam_fields::update_string_tag(
+                rr[unmapped_i].as_mut_vec(),
+                b"MC",
+                mapped_cigar_str.as_bytes(),
+            );
         } else {
-            bam_fields::remove_tag(&mut rr[unmapped_i], b"MC");
+            bam_fields::remove_tag(rr[unmapped_i].as_mut_vec(), b"MC");
         }
         bam_fields::set_template_length(&mut rr[unmapped_i], 0);
     }
@@ -1838,8 +1851,8 @@ impl MemoryEstimate for Template {
         let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RecordBuf>();
 
         let raw_records_size = self.raw_records.as_ref().map_or(0, |rr| {
-            rr.iter().map(Vec::capacity).sum::<usize>()
-                + rr.capacity() * std::mem::size_of::<Vec<u8>>()
+            rr.iter().map(RawRecord::capacity).sum::<usize>()
+                + rr.capacity() * std::mem::size_of::<RawRecord>()
         });
 
         name_size + records_size + records_vec_overhead + raw_records_size
@@ -4054,8 +4067,8 @@ mod tests {
     #[test]
     fn test_from_raw_records_creates_raw_mode_template() {
         let raw = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let template =
-            Template::from_raw_records(vec![raw]).expect("from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
+            .expect("from_raw_records should succeed");
 
         // Verify it's in raw-byte mode
         assert!(template.is_raw_byte_mode());
@@ -4069,8 +4082,8 @@ mod tests {
     fn test_r1_accessor_returns_none_in_raw_mode() {
         // After fix: calling r1() on a raw-mode Template returns None instead of panicking
         let raw = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let template =
-            Template::from_raw_records(vec![raw]).expect("from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
+            .expect("from_raw_records should succeed");
 
         // r1() should return None in raw mode (use raw_r1() instead)
         assert!(template.r1().is_none());
@@ -4084,7 +4097,8 @@ mod tests {
         let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
         let template =
-            Template::from_raw_records(vec![r1, r2]).expect("from_raw_records should succeed");
+            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
+                .expect("from_raw_records should succeed");
 
         assert!(template.is_raw_byte_mode());
 
@@ -4104,7 +4118,8 @@ mod tests {
         let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
         let template =
-            Template::from_raw_records(vec![r1, r2]).expect("from_raw_records should succeed");
+            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
+                .expect("from_raw_records should succeed");
 
         assert!(template.is_raw_byte_mode());
         assert!(template.raw_r1().is_some());
@@ -4120,7 +4135,9 @@ mod tests {
         // R2 first, R1 second — fast path should swap them
         let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template = Template::from_raw_records(vec![r2, r1]).expect("from_raw_records");
+        let template =
+            Template::from_raw_records(vec![r2, r1].into_iter().map(Into::into).collect())
+                .expect("from_raw_records");
 
         assert!(template.is_raw_byte_mode());
         // After swap, R1 should be at index 0
@@ -4137,8 +4154,19 @@ mod tests {
         // Both records are R1 — fast path should fall through to general path (error)
         let r1a = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r1b = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let result = Template::from_raw_records(vec![r1a, r1b]);
+        let result =
+            Template::from_raw_records(vec![r1a, r1b].into_iter().map(Into::into).collect());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_raw_records_fast_path_rejects_name_mismatch() {
+        // Two primary records (R1 + R2) with *different* QNAMEs must not slip through
+        // the two-record fast path — from_raw_records should bail on the name mismatch.
+        let r1 = make_minimal_raw_bam(b"readA", FLAG_PAIRED | FLAG_READ1);
+        let r2 = make_minimal_raw_bam(b"readB", FLAG_PAIRED | FLAG_READ2);
+        let result = Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect());
+        assert!(result.is_err(), "mismatched QNAMEs must not produce a Template");
     }
 
     #[test]
@@ -4150,7 +4178,8 @@ mod tests {
             FLAG_PAIRED | FLAG_READ1 | crate::sort::bam_fields::flags::SECONDARY,
         );
         let template =
-            Template::from_raw_records(vec![r1, sec]).expect("from_raw_records should succeed");
+            Template::from_raw_records(vec![r1, sec].into_iter().map(Into::into).collect())
+                .expect("from_raw_records should succeed");
         assert!(template.is_raw_byte_mode());
         assert!(template.raw_r1().is_some());
     }
@@ -4165,7 +4194,8 @@ mod tests {
         );
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
         let template =
-            Template::from_raw_records(vec![r1, r1_supp, r2]).expect("value should be present");
+            Template::from_raw_records(vec![r1, r1_supp, r2].into_iter().map(Into::into).collect())
+                .expect("value should be present");
         assert!(template.is_raw_byte_mode());
         assert!(template.raw_r1().is_some());
         assert!(template.raw_r2().is_some());
@@ -4175,8 +4205,8 @@ mod tests {
     fn test_from_raw_records_single_unpaired() {
         // Single unpaired record — should be treated as R1
         let r = make_minimal_raw_bam(b"read1", 0); // no PAIRED flag
-        let template =
-            Template::from_raw_records(vec![r]).expect("from_raw_records should succeed");
+        let template = Template::from_raw_records(vec![r].into_iter().map(Into::into).collect())
+            .expect("from_raw_records should succeed");
         assert!(template.is_raw_byte_mode());
         assert!(template.raw_r1().is_some());
         assert!(template.raw_r2().is_none());
@@ -4197,7 +4227,9 @@ mod tests {
             FLAG_PAIRED | FLAG_READ1 | crate::sort::bam_fields::flags::SUPPLEMENTARY,
         );
         let r2_wrong = make_minimal_raw_bam(b"read2", FLAG_PAIRED | FLAG_READ2);
-        let result = Template::from_raw_records(vec![r1, r1_supp, r2_wrong]);
+        let result = Template::from_raw_records(
+            vec![r1, r1_supp, r2_wrong].into_iter().map(Into::into).collect(),
+        );
         assert!(result.is_err());
     }
 
@@ -4206,7 +4238,8 @@ mod tests {
         let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
         let mut template =
-            Template::from_raw_records(vec![r1, r2]).expect("from_raw_records should succeed");
+            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
+                .expect("from_raw_records should succeed");
         // Should be able to get mutable access
         let recs = template.all_raw_records_mut().expect("all_raw_records_mut should succeed");
         assert_eq!(recs.len(), 2);
@@ -4217,7 +4250,8 @@ mod tests {
         let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
         let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
         let template =
-            Template::from_raw_records(vec![r1, r2]).expect("from_raw_records should succeed");
+            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
+                .expect("from_raw_records should succeed");
         let recs = template.into_raw_records().expect("into_raw_records should succeed");
         assert_eq!(recs.len(), 2);
     }
@@ -4226,7 +4260,8 @@ mod tests {
     fn test_from_raw_records_truncated_header() {
         // Record too short (< 32 bytes)
         let short = vec![0u8; 20];
-        let err = Template::from_raw_records(vec![short]).unwrap_err();
+        let err = Template::from_raw_records(vec![short].into_iter().map(Into::into).collect())
+            .unwrap_err();
         assert!(err.to_string().contains("too short"), "Error: {err}");
     }
 
@@ -4235,7 +4270,8 @@ mod tests {
         // Record has 32 bytes but l_read_name claims more bytes than available
         let mut buf = vec![0u8; 34]; // 32 header + 2 bytes
         buf[8] = 10; // l_read_name=10, but only 2 bytes after header
-        let err = Template::from_raw_records(vec![buf]).unwrap_err();
+        let err = Template::from_raw_records(vec![buf].into_iter().map(Into::into).collect())
+            .unwrap_err();
         assert!(err.to_string().contains("truncated"), "Error: {err}");
     }
 
@@ -4243,7 +4279,9 @@ mod tests {
     fn test_from_raw_records_valid_l_read_name() {
         // Record with l_read_name that exactly fits
         let rec = make_minimal_raw_bam(b"test", FLAG_PAIRED | FLAG_READ1);
-        assert!(Template::from_raw_records(vec![rec]).is_ok());
+        assert!(
+            Template::from_raw_records(vec![rec].into_iter().map(Into::into).collect()).is_ok()
+        );
     }
 
     // ========================================================================

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -332,9 +332,8 @@ pub fn decode_records(
 ) -> io::Result<Vec<DecodedRecord>> {
     let num_records = batch.offsets.len().saturating_sub(1);
     let mut records = Vec::with_capacity(num_records);
-    // read_record_buf requires a Header for reference name resolution and alignment parsing,
-    // but this non-production path only uses integer reference IDs, so an empty header suffices.
-    let header = noodles::sam::Header::default();
+    // Reused across records in the noodles decode path below.
+    let default_header = noodles::sam::Header::default();
 
     for i in 0..num_records {
         let start = batch.offsets[i];
@@ -375,6 +374,10 @@ pub fn decode_records(
         let record_data = &batch.buffer[start + 4..end];
 
         if group_key_config.raw_byte_mode {
+            // Raw-byte path: zero-copy GroupKey computation without the noodles RecordBuf
+            // round-trip. Activated only when raw_byte_mode = true (via GroupKeyConfig::new_raw).
+            // Used by `dedup`, `group`, and other commands that opt in via GroupKeyConfig::new_raw;
+            // other commands use the noodles path below via the default config.
             let raw = record_data.to_vec();
             if raw.len() < 32 {
                 return Err(io::Error::new(
@@ -402,12 +405,12 @@ pub fn decode_records(
             );
             records.push(DecodedRecord::from_raw_bytes(raw, key));
         } else {
-            // Use noodles' public Reader API for decoding, as recommended by the
-            // noodles maintainer (see noodles#364). Reader::from accepts any R: Read
-            // and read_record_buf reads the block_size prefix then decodes the record.
+            // Noodles decode path: retained for commands (e.g. clip) that need typed
+            // RecordBuf access in downstream Template processing (CIGAR edits, flag API).
+            // Uses noodles Reader::from per maintainer recommendation (noodles#364).
             let mut reader = noodles::bam::io::Reader::from(&batch.buffer[start..end]);
             let mut record = RecordBuf::default();
-            reader.read_record_buf(&header, &mut record)?;
+            reader.read_record_buf(&default_header, &mut record)?;
 
             let key = compute_group_key(
                 &record,
@@ -424,7 +427,14 @@ pub fn decode_records(
 /// Compute a `GroupKey` directly from raw BAM bytes, matching `compute_group_key()` exactly.
 ///
 /// Uses 1-based coordinate helpers to produce identical keys to the noodles path.
-fn compute_group_key_from_raw(
+///
+/// # Panics
+///
+/// Panics if `raw` is not a validated BAM record payload (as produced by the BAM
+/// reader / raw-record pipeline). Callers must not pass arbitrary external bytes;
+/// raw-field accessors will panic on malformed or truncated input.
+#[must_use]
+pub fn compute_group_key_from_raw(
     raw: &[u8],
     library_index: &LibraryIndex,
     cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
@@ -3482,14 +3492,13 @@ thread_local! {
         std::cell::RefCell::new(Vec::with_capacity(512));
 }
 
-/// Serialize a batch of BAM records to bytes.
-///
-/// This function encodes multiple BAM records into a single byte buffer,
-/// ready for BGZF compression. Uses thread-local buffer to avoid allocations.
 /// Serialize BAM records into a provided buffer.
 ///
 /// Appends serialized BAM bytes to the provided buffer and returns the record count.
 /// This variant is more efficient when the caller wants to reuse a buffer.
+///
+/// Accepts `RecordBuf` because callers (e.g., `clip`, `dedup`) produce records via
+/// noodles typed operations (CIGAR editing, tag mutation) and pass them directly here.
 ///
 /// # Errors
 ///
@@ -3544,6 +3553,8 @@ pub fn serialize_bam_records_into(
 /// a new buffer. Use `serialize_bam_records_into` for better performance when
 /// buffer reuse is possible.
 ///
+/// Accepts `RecordBuf` because callers produce records via noodles typed operations.
+///
 /// # Errors
 ///
 /// Returns an I/O error if record encoding fails.
@@ -3561,6 +3572,8 @@ pub fn serialize_bam_records(
 /// This produces raw BAM record bytes (`block_size` prefix + record data),
 /// suitable for BGZF compression in the pipeline. Uses thread-local buffer.
 ///
+/// Accepts `RecordBuf` because callers produce records via noodles typed operations.
+///
 /// # Errors
 ///
 /// Returns an I/O error if record encoding fails.
@@ -3576,6 +3589,8 @@ pub fn serialize_bam_record(record: &RecordBuf, header: &Header) -> io::Result<S
 /// suitable for BGZF compression in the pipeline. Uses thread-local buffer for encoding.
 ///
 /// Returns the number of records serialized (always 1 for a single record).
+///
+/// Accepts `RecordBuf` because callers produce records via noodles typed operations.
 ///
 /// # Errors
 ///
@@ -3607,6 +3622,8 @@ pub fn serialize_bam_record_into(
 /// This writes records directly to the compressor's internal buffer, avoiding
 /// the intermediate serialization buffer copy. Records are compressed into
 /// BGZF blocks as the buffer fills.
+///
+/// Accepts `RecordBuf` because callers produce records via noodles typed operations.
 ///
 /// Returns the number of records serialized.
 ///

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -92,6 +92,7 @@ use crate::bgzf_reader::{RawBgzfBlock, decompress_block_into, read_raw_blocks};
 use crate::read_info::LibraryIndex;
 use crate::reorder_buffer::ReorderBuffer;
 use crate::sam::SamTag;
+use fgumi_raw_bam::RawRecord;
 use noodles::sam::alignment::RecordBuf;
 use noodles::sam::alignment::record::data::field::Tag;
 
@@ -385,13 +386,7 @@ pub fn start_memory_monitor(
                     && peak_rss > 4_000_000_000
                 {
                     log::info!("=== MIMALLOC STATS AT PEAK (no mi_collect) ===");
-                    // SAFETY: `mi_stats_print_out(None, null_mut())` prints mimalloc allocator
-                    // statistics to stderr using the default output handler. mimalloc internally
-                    // synchronizes stats collection, making this safe to call concurrently with
-                    // allocation/deallocation on other threads.
-                    unsafe {
-                        libmimalloc_sys::mi_stats_print_out(None, std::ptr::null_mut());
-                    }
+                    crate::sort::memory_probe::print_mi_stats();
                     stats_printed = true;
                 }
                 if current_rss > peak_rss {
@@ -1493,10 +1488,15 @@ pub struct DecodedRecord {
 }
 
 /// Record data: either a parsed noodles `RecordBuf` or raw BAM bytes.
+///
+/// The `Parsed` variant is retained for commands (e.g. `clip`) that require typed
+/// `RecordBuf` access for CIGAR edits and the noodles flag API.
+/// The `Raw` variant uses [`RawRecord`] for zero-overhead byte access and
+/// direct output writes without re-encoding.
 #[derive(Debug)]
 pub enum DecodedRecordData {
     Parsed(RecordBuf),
-    Raw(Vec<u8>),
+    Raw(RawRecord),
 }
 
 impl DecodedRecord {
@@ -1507,23 +1507,26 @@ impl DecodedRecord {
     }
 
     /// Create a decoded record from raw bytes, skipping noodles decode.
+    ///
+    /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
+    /// an already-constructed `RawRecord`).
     #[must_use]
-    pub fn from_raw_bytes(raw: Vec<u8>, key: GroupKey) -> Self {
-        Self { key, data: DecodedRecordData::Raw(raw) }
+    pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
+        Self { key, data: DecodedRecordData::Raw(raw.into()) }
     }
 
-    /// Returns the raw bytes if this is a raw-mode record.
+    /// Returns a reference to the raw bytes if this is a raw-mode record.
     #[must_use]
     pub fn raw_bytes(&self) -> Option<&[u8]> {
         match &self.data {
-            DecodedRecordData::Raw(v) => Some(v),
+            DecodedRecordData::Raw(v) => Some(v.as_ref()),
             DecodedRecordData::Parsed(_) => None,
         }
     }
 
-    /// Takes the raw bytes out if this is a raw-mode record.
+    /// Takes the [`RawRecord`] out if this is a raw-mode record.
     #[must_use]
-    pub fn into_raw_bytes(self) -> Option<Vec<u8>> {
+    pub fn into_raw_bytes(self) -> Option<RawRecord> {
         match self.data {
             DecodedRecordData::Raw(v) => Some(v),
             DecodedRecordData::Parsed(_) => None,
@@ -1555,6 +1558,8 @@ impl MemoryEstimate for DecodedRecord {
             DecodedRecordData::Parsed(record) => {
                 crate::template::estimate_record_buf_heap_size(record)
             }
+            // RawRecord::capacity() returns the inner Vec<u8> capacity — same semantics
+            // as the previous Vec<u8>::capacity() call.
             DecodedRecordData::Raw(raw) => raw.capacity(),
         }
     }


### PR DESCRIPTION
## Summary

Part 5 of 7 in the series closing #272. Stacks on #291 (PR 9).

Migrates a collection of internal sites to the RawRecord-based API as a partial storage/pipeline collapse toward raw-byte records:

- **commands/** — `clip.rs`, `compare/bams.rs`, `group.rs`, `review.rs` migrated to RawRecord accessors and raw-byte tag manipulation.
- **unified_pipeline/bam.rs** — `DecodedRecordData::Raw` now holds `RawRecord` directly instead of `Vec<u8>`, eliminating wrapping at boundaries.
- **sort/** — `inline_buffer.rs`, `raw.rs`, `raw_bam_reader.rs`, `read_ahead.rs`, `pipeline.rs`: read pipeline yields `Vec<RawRecord>` end-to-end; inline buffer storage migrated from `Vec<Vec<u8>>` to `Vec<RawRecord>`.
- **template.rs** — `Template.raw_records` typed as `Option<Vec<RawRecord>>`.
- **mi_group.rs** — MI iterator yields `Vec<RawRecord>`; callers in `simplex`, `duplex`, `codec` adapted accordingly, dropping the `Vec<Vec<u8>> -> Vec<RawRecord>` bridge added in PR 9.
- **fgumi-consensus** — `template_passes` and `apply_overlapping_consensus` now take `&[RawRecord]`, matching the new storage type in callers.
- Miscellaneous Group C raw-byte sites across `correct.rs`, `filter.rs`, `sort.rs`, `sort/raw_bam_reader.rs`.
- Enable clippy `unsafe_code` override on the `memory-debug` mimalloc stats call (unblocks the `memory-debug` feature-gated build).

## Scope notes

The original plan also included the full Template dual-storage collapse (`0dbf11b`), the mi_group parsed-test port (`682f1c1`), the unified_pipeline `DecodedRecord` collapse (`782f7fa`), the RecordBuf-helper cleanup cascade (`7bc9706`), the clip → RawRecordClipper swap (`89783ef`), the `IndexedRawBamReader` review migration (`613370e`), and the zipper unmapped-reader swap (`3303ad8`).

Those commits conflicted extensively with `main`'s independent zipper evolution (#270, #271, #274) and bundled large volumes of unit-test migration that properly belong in the PR 11 test migration window. They are left for a follow-up stacked on this PR so PR 10 stays focused on the storage/pipeline migrations that are cleanly separable.

## Test plan

- [x] `cargo build --lib --tests --features compare,simulate`
- [x] `cargo ci-test` — 2541 tests, 0 failures, 23 skipped
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`