### PR TITLE
fix(pipeline): stream rejects to disk in simplex/duplex/codec/correct

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1723,15 +1723,31 @@ impl DuplexConsensusCaller {
         read_name_prefix: &str,
         read_group_id: &str,
         cell_tag: Option<Tag>,
-    ) -> Result<(ConsensusOutput, ConsensusCallingStats)> {
+        track_rejects: bool,
+    ) -> Result<(ConsensusOutput, ConsensusCallingStats, Vec<Vec<u8>>)> {
         let mut stats = ConsensusCallingStats::new();
         let mut builder = UnmappedSamBuilder::new();
         let mut output = ConsensusOutput::default();
         let methylation_mode = ss_caller.options.methylation_mode;
 
+        // Helper: move raw input records into the reject payload if rejects are being
+        // tracked. Each rejection site moves `a_records`/`b_records` into the reject
+        // vec so we never hold both the input and reject copies simultaneously.
+        // Single-strand rejections are captured separately by `ss_caller`.
+        let collect_rejected_raw =
+            |track: bool, a: Vec<RawRecord>, b: Vec<RawRecord>| -> Vec<Vec<u8>> {
+                if track {
+                    let mut v: Vec<Vec<u8>> = a.into_iter().map(RawRecord::into_inner).collect();
+                    v.extend(b.into_iter().map(RawRecord::into_inner));
+                    v
+                } else {
+                    Vec::new()
+                }
+            };
+
         // Check if we have both strands
         if a_records.is_empty() && b_records.is_empty() {
-            return Ok((ConsensusOutput::default(), stats));
+            return Ok((ConsensusOutput::default(), stats, Vec::new()));
         }
 
         // Check if we have enough input reads (matching fgbio's hasMinimumNumberOfReads)
@@ -1746,7 +1762,8 @@ impl DuplexConsensusCaller {
                 RejectionReason::InsufficientReads,
                 a_records.len() + b_records.len(),
             );
-            return Ok((ConsensusOutput::default(), stats));
+            let rejected_raw = collect_rejected_raw(track_rejects, a_records, b_records);
+            return Ok((ConsensusOutput::default(), stats, rejected_raw));
         }
 
         // Extract cell barcode from source reads (matching fgbio: recs.head.get[String](cellTag))
@@ -1782,7 +1799,9 @@ impl DuplexConsensusCaller {
                     RejectionReason::PotentialCollision,
                     a_records.len() + b_records.len(),
                 );
-                return Ok((ConsensusOutput::default(), stats));
+                drop((ab_r1s, ab_r2s, ba_r1s, ba_r2s));
+                let rejected_raw = collect_rejected_raw(track_rejects, a_records, b_records);
+                return Ok((ConsensusOutput::default(), stats, rejected_raw));
             }
 
             // Check singleStrand2 (AB-R2 + BA-R1)
@@ -1792,7 +1811,9 @@ impl DuplexConsensusCaller {
                     RejectionReason::PotentialCollision,
                     a_records.len() + b_records.len(),
                 );
-                return Ok((ConsensusOutput::default(), stats));
+                drop((ab_r1s, ab_r2s, ba_r1s, ba_r2s));
+                let rejected_raw = collect_rejected_raw(track_rejects, a_records, b_records);
+                return Ok((ConsensusOutput::default(), stats, rejected_raw));
             }
         }
 
@@ -2049,13 +2070,14 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus();
-                        return Ok((output, stats));
+                        return Ok((output, stats, Vec::new()));
                     }
                     stats.record_rejection(
                         RejectionReason::InsufficientReads,
                         a_records.len() + b_records.len(),
                     );
-                    return Ok((ConsensusOutput::default(), stats));
+                    let rejected_raw = collect_rejected_raw(track_rejects, a_records, b_records);
+                    return Ok((ConsensusOutput::default(), stats, rejected_raw));
                 }
             }
             (Some(ref r1_a), Some(ref r2_a), None, None) => {
@@ -2100,7 +2122,7 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus();
-                        return Ok((output, stats));
+                        return Ok((output, stats, Vec::new()));
                     }
                 }
             }
@@ -2152,7 +2174,7 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus();
-                        return Ok((output, stats));
+                        return Ok((output, stats, Vec::new()));
                     }
                 }
             }
@@ -2166,8 +2188,12 @@ impl DuplexConsensusCaller {
         debug!(
             "MI {base_mi}: No duplex consensus created - insufficient reads or conversion failed"
         );
-        stats.record_rejection(RejectionReason::InsufficientReads, 1);
-        Ok((ConsensusOutput::default(), stats))
+        stats.record_rejection(
+            RejectionReason::InsufficientReads,
+            a_records.len() + b_records.len(),
+        );
+        let rejected_raw = collect_rejected_raw(track_rejects, a_records, b_records);
+        Ok((ConsensusOutput::default(), stats, rejected_raw))
     }
 }
 
@@ -2184,7 +2210,7 @@ impl ConsensusCaller for DuplexConsensusCaller {
 
         let produce_per_base_tags = self.produce_per_base_tags;
 
-        let (output, group_stats) = Self::process_group(
+        let (output, group_stats, duplex_rejected_raw) = Self::process_group(
             base_mi,
             a_records,
             b_records,
@@ -2196,12 +2222,23 @@ impl ConsensusCaller for DuplexConsensusCaller {
             &self.read_name_prefix,
             &self.read_group_id,
             self.cell_tag,
+            self.track_rejects,
         )?;
 
         self.stats.merge(&group_stats);
 
         if self.track_rejects {
-            self.rejected_reads.extend(self.ss_caller.take_rejected_reads());
+            // When the duplex layer rejects the group, `duplex_rejected_raw`
+            // already contains every raw input record (collected via
+            // `collect_rejected_raw`), so the ss-layer rejects — which are a
+            // subset of those same records — would be duplicates. Drain the
+            // ss-caller regardless to reset its state, but only emit one source.
+            let ss_rejected_raw = self.ss_caller.take_rejected_reads();
+            if duplex_rejected_raw.is_empty() {
+                self.rejected_reads.extend(ss_rejected_raw);
+            } else {
+                self.rejected_reads.extend(duplex_rejected_raw);
+            }
         }
 
         Ok(output)

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -232,6 +232,44 @@ pub fn check_sort(header: &Header, path: &Path, name: &str) {
     }
 }
 
+/// Returns a copy of `header` with its sort-order metadata cleared.
+///
+/// The `SO` tag is set to `unsorted` and any `GO` (group order) or `SS`
+/// (sub-sort) tags are removed. Use this when writing records whose emission
+/// order does not match the input's advertised sort order, so downstream tools
+/// don't mistakenly assume the output is sorted.
+#[must_use]
+pub fn header_as_unsorted(header: &Header) -> Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::header::tag::SORT_ORDER;
+
+    let mut header_map = header
+        .header()
+        .cloned()
+        .unwrap_or_else(Map::<noodles::sam::header::record::value::map::Header>::default);
+
+    let other_fields = header_map.other_fields_mut();
+    other_fields.insert(SORT_ORDER, BString::from(UNSORTED));
+    other_fields.shift_remove(b"GO");
+    other_fields.shift_remove(b"SS");
+
+    let mut builder = Header::builder();
+    for (name, rg) in header.read_groups() {
+        builder = builder.add_read_group(name.clone(), rg.clone());
+    }
+    for (name, reference) in header.reference_sequences() {
+        builder = builder.add_reference_sequence(name.clone(), reference.clone());
+    }
+    for (id, pg) in header.programs().as_ref() {
+        builder = builder.add_program(id.clone(), pg.clone());
+    }
+    for comment in header.comments() {
+        builder = builder.add_comment(comment.clone());
+    }
+    builder.set_header(header_map).build()
+}
+
 /// Reverses a `BufValue` (array or string).
 ///
 /// This function reverses per-base tag values to match read orientation when reads
@@ -679,6 +717,55 @@ mod tests {
         use noodles::sam::header::record::value::map::header::sort_order::COORDINATE;
         let header = create_empty_header();
         assert!(!is_sorted(&header, COORDINATE));
+    }
+
+    // =========================================================================
+    // Tests for header_as_unsorted()
+    // =========================================================================
+
+    #[test]
+    fn test_header_as_unsorted_overrides_coordinate_so() {
+        let header = create_header_with_so("coordinate");
+        let unsorted = header_as_unsorted(&header);
+        assert!(is_sorted(&unsorted, UNSORTED));
+    }
+
+    #[test]
+    fn test_header_as_unsorted_sets_so_when_missing() {
+        let header = create_header_without_so();
+        let unsorted = header_as_unsorted(&header);
+        assert!(is_sorted(&unsorted, UNSORTED));
+    }
+
+    #[test]
+    fn test_header_as_unsorted_drops_go_and_ss() {
+        // Template-coordinate header has SO:unsorted, GO:query, SS:template-coordinate.
+        let header =
+            create_template_coord_header("unsorted", Some("query"), Some("template-coordinate"));
+        assert!(is_template_coordinate_sorted(&header));
+        let unsorted = header_as_unsorted(&header);
+        // GO and SS should be gone, so it no longer looks template-coordinate sorted.
+        assert!(!is_template_coordinate_sorted(&unsorted));
+        let other_fields = unsorted.header().expect("header map present").other_fields();
+        assert!(other_fields.get(b"GO").is_none());
+        assert!(other_fields.get(b"SS").is_none());
+        assert!(is_sorted(&unsorted, UNSORTED));
+    }
+
+    #[test]
+    fn test_header_as_unsorted_preserves_read_groups_and_refs() {
+        let header_str = "@HD\tVN:1.6\tSO:coordinate\n\
+                          @SQ\tSN:chr1\tLN:1000\n\
+                          @RG\tID:rg1\tSM:sample1\n\
+                          @PG\tID:prog1\tPN:tool\n";
+        let header: Header = header_str.parse().expect("parse header");
+        let unsorted = header_as_unsorted(&header);
+        assert_eq!(unsorted.reference_sequences().len(), 1);
+        assert!(unsorted.reference_sequences().contains_key(b"chr1".as_slice()));
+        assert_eq!(unsorted.read_groups().len(), 1);
+        assert!(unsorted.read_groups().contains_key(b"rg1".as_slice()));
+        assert_eq!(unsorted.programs().as_ref().len(), 1);
+        assert!(is_sorted(&unsorted, UNSORTED));
     }
 
     // =========================================================================

--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -102,6 +102,19 @@ For single-cell data, `fgumi sort --order template-coordinate` automatically inc
 cell barcode tag in the sort key so that templates from different cells at the same locus are not
 interleaved. fgbio's template-coordinate sort does not support this.
 
+### Rejects BAM Sort Order
+
+When `--rejects` is enabled on `simplex`, `duplex`, `codec`, or `correct`, fgumi writes
+rejected records from worker threads in mutex-acquisition order, which is not guaranteed
+to match input order under `--threads > 1`. Because of this, fgumi stamps the rejects BAM
+header with `SO:unsorted` (and drops any `GO`/`SS` tags inherited from the input) so
+downstream tools don't assume the input's sort order carried over.
+
+fgbio's equivalent tools copy the input header onto the rejects BAM unchanged, which can
+leave a stale `SO` tag when more than one consensus-calling thread is used. If you were
+relying on fgbio's rejects header carrying the input's sort order, sort the rejects BAM
+explicitly after the fact.
+
 ### Boolean Flag Values
 
 fgumi boolean flags (e.g. `--output-per-base-tags`, `--trim`, `--require-single-strand-agreement`)

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -7,8 +7,8 @@
 //! allowing even a single read-pair to generate duplex consensus.
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
+    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
 };
 use crate::commands::command::Command;
 use crate::commands::consensus_runner::{ConsensusStatsOps, create_unmapped_consensus_header};
@@ -35,11 +35,12 @@ use crate::unified_pipeline::{
 };
 use fgumi_raw_bam::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
-use crate::sam::SamTag;
+use crate::sam::{SamTag, header_as_unsorted};
 use crate::validation::validate_file_exists;
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
+use parking_lot::Mutex;
 use std::io::{self, Write as IoWrite};
 use std::sync::Arc;
 
@@ -51,8 +52,6 @@ use std::sync::Arc;
 struct CodecProcessedBatch {
     /// Consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
-    /// Rejected reads as raw BAM bytes (written to rejects file if enabled)
-    rejects: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// CODEC consensus calling statistics for this batch
@@ -62,8 +61,6 @@ struct CodecProcessedBatch {
 impl MemoryEstimate for CodecProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         self.consensus_output.data.capacity()
-            + self.rejects.iter().map(Vec::capacity).sum::<usize>()
-            + self.rejects.capacity() * std::mem::size_of::<Vec<u8>>()
     }
 }
 
@@ -74,8 +71,6 @@ struct CollectedCodecMetrics {
     stats: CodecConsensusStats,
     /// Number of MI groups processed
     groups_processed: u64,
-    /// Rejected reads as raw BAM bytes for deferred writing
-    rejects: Vec<Vec<u8>>,
 }
 
 /// Call CODEC consensus reads from template-coordinate sorted BAM
@@ -535,14 +530,36 @@ impl Codec {
         // Use larger batch size for codec (less work per group than simplex)
         let batch_size = 1000;
 
-        // Clone input_header before pipeline (needed for rejects writing)
-        let rejects_header = input_header.clone();
+        // Open rejects writer up front. Rejected records are streamed straight
+        // to disk from process_fn, per-MI-group, so no batch-level buffering.
+        // Because workers flush under a mutex rather than through the ordered
+        // serialize stage, reject records are emitted in mutex-acquisition
+        // order, not input order; mark the rejects header as SO:unsorted so
+        // downstream tools don't assume the input's sort order carried over.
+        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
+            if let Some(path) = self.rejects_opts.rejects.as_ref() {
+                let writer_threads = self.threading.num_threads();
+                let rejects_header = header_as_unsorted(&input_header);
+                let w = create_raw_bam_writer(
+                    path,
+                    &rejects_header,
+                    writer_threads,
+                    self.compression.compression_level,
+                )?;
+                Some(Arc::new(Mutex::new(Some(w))))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let groups_processed = run_bam_pipeline_from_reader(
+        let pipeline_result = run_bam_pipeline_from_reader(
             pipeline_config,
             reader,
             input_header,
@@ -564,9 +581,26 @@ impl Codec {
                 );
 
                 let mut all_output = ConsensusOutput::default();
-                let mut all_rejects = Vec::new();
                 let mut batch_stats = CodecConsensusStats::default();
                 let groups_count = batch.groups.len() as u64;
+
+                // Stream per-MI-group rejects straight to disk so they don't
+                // accumulate in a batch-level Vec. The mutex only serializes the
+                // raw-byte append; BGZF compression runs on the writer's own
+                // thread pool.
+                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
+                    if let Some(ref rw_arc) = rejects_writer_for_process {
+                        if !recs.is_empty() {
+                            let mut guard = rw_arc.lock();
+                            if let Some(w) = guard.as_mut() {
+                                for raw in recs {
+                                    w.write_raw_record(raw)?;
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
 
                 for MiGroup { mi, records } in batch.groups {
                     caller.clear();
@@ -578,7 +612,7 @@ impl Codec {
                             all_output.merge(batch_output);
                             batch_stats.merge(caller.statistics());
                             if track_rejects {
-                                all_rejects.extend(caller.take_rejected_reads());
+                                flush_byte_records(&caller.take_rejected_reads())?;
                             }
                         }
                         Err(e) => {
@@ -587,7 +621,7 @@ impl Codec {
                             if e.to_string().contains("duplex disagreement") {
                                 batch_stats.merge(caller.statistics());
                                 if track_rejects {
-                                    all_rejects.extend(caller.take_rejected_reads());
+                                    flush_byte_records(&caller.take_rejected_reads())?;
                                 }
                             } else {
                                 return Err(io::Error::other(format!(
@@ -600,7 +634,6 @@ impl Codec {
 
                 Ok(CodecProcessedBatch {
                     consensus_output: all_output,
-                    rejects: all_rejects,
                     groups_count,
                     stats: batch_stats,
                 })
@@ -610,14 +643,13 @@ impl Codec {
                   _header: &Header,
                   output: &mut Vec<u8>|
                   -> io::Result<u64> {
-                // Merge per-batch metrics + rejects into this worker's slot
+                // Rejects were already streamed to disk in process_fn.
+                // Merge per-batch metrics into this worker's accumulator slot
                 let batch_stats = processed.stats;
                 let groups_count = processed.groups_count;
-                let mut batch_rejects = processed.rejects;
                 collected_metrics_for_serialize.with_slot(|m| {
                     m.stats.merge(&batch_stats);
                     m.groups_processed += groups_count;
-                    m.rejects.append(&mut batch_rejects);
                 });
 
                 // Serialize consensus reads
@@ -625,47 +657,41 @@ impl Codec {
                 output.extend_from_slice(&processed.consensus_output.data);
                 Ok(count)
             },
-        )
-        .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?;
+        );
 
-        // ========== Post-pipeline: Aggregate metrics and write rejects ==========
+        // Always finalize the rejects writer, even if the pipeline failed, so any
+        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
+        // finish() failures alongside any pipeline error so neither is silently
+        // dropped.
+        let rejects_finish_result = rejects_writer
+            .and_then(|rw_arc| rw_arc.lock().take())
+            .map(|writer| writer.finish().context("Failed to finish rejects file"));
+
+        let groups_processed = match (pipeline_result, rejects_finish_result) {
+            (Ok(groups_processed), Some(Ok(()))) => {
+                info!("Rejected reads streamed to rejects file during processing");
+                groups_processed
+            }
+            (Ok(groups_processed), None) => groups_processed,
+            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
+            (Err(pipeline_err), Some(Err(finish_err))) => {
+                return Err(anyhow::anyhow!(
+                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
+                ));
+            }
+            (Err(pipeline_err), _) => {
+                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
+            }
+        };
+
+        // ========== Post-pipeline: Aggregate metrics ==========
         let mut total_groups = 0u64;
         let mut merged_stats = CodecConsensusStats::default();
-        let mut all_rejects: Vec<Vec<u8>> = Vec::new();
 
         for slot in collected_metrics.slots() {
-            let mut m = slot.lock();
+            let m = slot.lock();
             total_groups += m.groups_processed;
             merged_stats.merge(&m.stats);
-            if track_rejects {
-                all_rejects.append(&mut m.rejects);
-            }
-        }
-
-        // Write deferred rejects as raw BAM bytes
-        if track_rejects && !all_rejects.is_empty() {
-            if let Some(rejects_path) = &self.rejects_opts.rejects {
-                let writer_threads = self.threading.num_threads();
-                let rejects_writer = create_optional_bam_writer(
-                    Some(rejects_path),
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                if let Some(mut rw) = rejects_writer {
-                    for raw_record in &all_rejects {
-                        let block_size = raw_record.len() as u32;
-                        rw.get_mut()
-                            .write_all(&block_size.to_le_bytes())
-                            .context("Failed to write rejected read block size")?;
-                        rw.get_mut()
-                            .write_all(raw_record)
-                            .context("Failed to write rejected read")?;
-                    }
-                    rw.into_inner().finish().context("Failed to finish rejects file")?;
-                    info!("Wrote {} rejected reads", all_rejects.len());
-                }
-            }
         }
 
         // Log statistics
@@ -1194,19 +1220,15 @@ mod tests {
     fn test_codec_processed_batch_memory_estimate() {
         let mut data = Vec::with_capacity(1024);
         data.extend_from_slice(&[0u8; 100]);
-        let mut reject = Vec::with_capacity(512);
-        reject.extend_from_slice(&[0u8; 50]);
 
         let batch = CodecProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
-            rejects: vec![reject],
             groups_count: 1,
             stats: CodecConsensusStats::default(),
         };
 
         let estimate = batch.estimate_heap_size();
-        assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
-        assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
+        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
     }
 
     /// Asserts that single-threaded and multi-threaded codec produce the same number of

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -42,8 +42,8 @@
 //! ```
 
 use crate::bam_io::{
-    BamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts,
+    BamWriter, RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
 };
 use crate::bitenc::BitEnc;
 use crate::dna::reverse_complement_str;
@@ -52,19 +52,20 @@ use crate::logging::OperationTimer;
 use crate::metrics::correct::UmiCorrectionMetrics;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::progress::ProgressTracker;
-use crate::sam::SamTag;
+use crate::sam::{SamTag, header_as_unsorted};
 use crate::sort::bam_fields;
 use crate::template::TemplateBatch;
 use crate::unified_pipeline::{Grouper, MemoryEstimate, run_bam_pipeline_from_reader};
 use crate::validation::validate_file_exists;
 use ahash::AHashMap;
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgumi_raw_bam::RawRecord;
 use log::{info, warn};
 use lru::LruCache;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
+use parking_lot::Mutex;
 use std::io;
 use std::num::NonZero;
 use std::path::PathBuf;
@@ -298,8 +299,6 @@ struct TemplateCorrection {
 struct CorrectProcessedBatch {
     /// Raw-byte kept records.
     kept_raw_records: Vec<RawRecord>,
-    /// Raw-byte rejected records.
-    rejected_raw_records: Vec<RawRecord>,
     /// Number of templates processed.
     templates_count: u64,
     /// Number of missing UMI records.
@@ -314,15 +313,8 @@ struct CorrectProcessedBatch {
 
 impl MemoryEstimate for CorrectProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
-        let raw_size: usize = self
-            .kept_raw_records
-            .iter()
-            .chain(self.rejected_raw_records.iter())
-            .map(RawRecord::capacity)
-            .sum();
-        let raw_vec_overhead = (self.kept_raw_records.capacity()
-            + self.rejected_raw_records.capacity())
-            * std::mem::size_of::<RawRecord>();
+        let raw_size: usize = self.kept_raw_records.iter().map(RawRecord::capacity).sum();
+        let raw_vec_overhead = self.kept_raw_records.capacity() * std::mem::size_of::<RawRecord>();
         raw_size + raw_vec_overhead
     }
 }
@@ -340,8 +332,6 @@ struct CollectedCorrectMetrics {
     mismatched: u64,
     /// Per-UMI match counts (for metrics file).
     umi_matches: AHashMap<String, UmiCorrectionMetrics>,
-    /// Rejected raw records (if tracking).
-    raw_rejects: Vec<RawRecord>,
 }
 
 impl Command for CorrectUmis {
@@ -802,6 +792,31 @@ impl CorrectUmis {
         let collected_metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(num_threads);
         let collected_for_serialize = Arc::clone(&collected_metrics);
 
+        // Open rejects writer up front. Rejected records are streamed straight
+        // to disk from process_fn, per-template, so no batch-level buffering.
+        // Because workers flush under a mutex rather than through the ordered
+        // serialize stage, reject records are emitted in mutex-acquisition
+        // order, not input order; mark the rejects header as SO:unsorted so
+        // downstream tools don't assume the input's sort order carried over.
+        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
+            if let Some(path) = self.rejects_opts.rejects.as_ref() {
+                let writer_threads = self.threading.num_threads();
+                let rejects_header = header_as_unsorted(&header);
+                let w = create_raw_bam_writer(
+                    path,
+                    &rejects_header,
+                    writer_threads,
+                    self.compression.compression_level,
+                )?;
+                Some(Arc::new(Mutex::new(Some(w))))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+
         // Configuration for closures
         const BATCH_SIZE: usize = 1000; // Templates per batch
         let max_mismatches = self.max_mismatches;
@@ -844,7 +859,6 @@ impl CorrectUmis {
                 }
 
                 let mut kept_raw_records: Vec<RawRecord> = Vec::new();
-                let mut rejected_raw_records: Vec<RawRecord> = Vec::new();
                 let mut missing_umis = 0u64;
                 let mut wrong_length = 0u64;
                 let mut mismatched = 0u64;
@@ -853,6 +867,24 @@ impl CorrectUmis {
                 // Count ALL input records for progress tracking (not just kept/rejected)
                 let mut total_input_records = 0u64;
                 let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
+
+                // Stream rejected records straight to disk so they don't
+                // accumulate in a batch-level Vec. The mutex only serializes
+                // the raw-byte append; BGZF compression runs on the writer's
+                // own thread pool.
+                let flush_raw_records = |recs: Vec<RawRecord>| -> io::Result<()> {
+                    if let Some(ref rw_arc) = rejects_writer_for_process {
+                        if !recs.is_empty() {
+                            let mut guard = rw_arc.lock();
+                            if let Some(w) = guard.as_mut() {
+                                for raw in &recs {
+                                    w.write_raw_record(raw.as_ref())?;
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
 
                 for template in batch {
                     // Count input records BEFORE processing
@@ -877,7 +909,7 @@ impl CorrectUmis {
                                     });
                                 entry.total_matches += num_records;
                                 if track_rejects {
-                                    rejected_raw_records.extend(raw_records);
+                                    flush_raw_records(raw_records)?;
                                 }
                             }
                             Some(umi) => {
@@ -938,7 +970,7 @@ impl CorrectUmis {
                                         });
                                     entry.total_matches += num_records;
                                     if track_rejects {
-                                        rejected_raw_records.extend(raw_records);
+                                        flush_raw_records(raw_records)?;
                                     }
                                 }
                             }
@@ -954,7 +986,6 @@ impl CorrectUmis {
 
                 Ok(CorrectProcessedBatch {
                     kept_raw_records,
-                    rejected_raw_records,
                     templates_count,
                     missing_umis,
                     wrong_length,
@@ -969,10 +1000,10 @@ impl CorrectUmis {
                                  _header: &Header,
                                  output: &mut Vec<u8>|
               -> io::Result<u64> {
-            // Merge per-batch counts + UMI matches + rejects into this
-            // worker's accumulator slot.
+            // Rejects were already streamed to disk in process_fn.
+            // Merge per-batch counts + UMI matches into this worker's
+            // accumulator slot.
             let umi_matches = std::mem::take(&mut processed.umi_matches);
-            let mut rejects = std::mem::take(&mut processed.rejected_raw_records);
             collected_for_serialize.with_slot(|m| {
                 m.templates_processed += processed.templates_count;
                 m.missing_umis += processed.missing_umis;
@@ -981,7 +1012,6 @@ impl CorrectUmis {
                 for (umi, counts) in umi_matches {
                     merge_umi_counts(&mut m.umi_matches, umi, &counts);
                 }
-                m.raw_rejects.append(&mut rejects);
             });
 
             // Serialize kept records
@@ -996,11 +1026,8 @@ impl CorrectUmis {
             Ok(kept_count)
         };
 
-        // Clone header before pipeline (needed for post-pipeline rejects writing)
-        let header_for_rejects = header.clone();
-
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let records_written = run_bam_pipeline_from_reader(
+        let pipeline_result = run_bam_pipeline_from_reader(
             pipeline_config,
             reader,
             header,
@@ -1009,7 +1036,30 @@ impl CorrectUmis {
             grouper_fn,
             process_fn,
             serialize_fn,
-        )?;
+        );
+
+        // Always finalize the rejects writer, even if the pipeline failed, so any
+        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
+        // finish() failures alongside any pipeline error so neither is silently
+        // dropped.
+        let rejects_finish_result = rejects_writer
+            .and_then(|rw_arc| rw_arc.lock().take())
+            .map(|writer| writer.finish().context("Failed to finish rejects file"));
+
+        let records_written = match (pipeline_result, rejects_finish_result) {
+            (Ok(records_written), Some(Ok(()))) => {
+                info!("Rejected records streamed to rejects file during processing");
+                records_written
+            }
+            (Ok(records_written), None) => records_written,
+            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
+            (Err(pipeline_err), Some(Err(finish_err))) => {
+                return Err(anyhow::anyhow!(
+                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
+                ));
+            }
+            (Err(pipeline_err), _) => return Err(pipeline_err.into()),
+        };
 
         // ========== Post-pipeline: Aggregate metrics ==========
         let mut total_templates = 0u64;
@@ -1017,7 +1067,6 @@ impl CorrectUmis {
         let mut total_wrong_length = 0u64;
         let mut total_mismatched = 0u64;
         let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
-        let mut all_raw_rejects: Vec<RawRecord> = Vec::new();
 
         for slot in collected_metrics.slots() {
             let mut m = slot.lock();
@@ -1028,35 +1077,6 @@ impl CorrectUmis {
 
             for (umi, counts) in m.umi_matches.drain() {
                 merge_umi_counts(&mut merged_umi_matches, umi, &counts);
-            }
-
-            if track_rejects {
-                all_raw_rejects.append(&mut m.raw_rejects);
-            }
-        }
-
-        // Write rejects file if requested
-        if track_rejects && !all_raw_rejects.is_empty() {
-            if let Some(rejects_path) = &self.rejects_opts.rejects {
-                let writer_threads = self.threading.num_threads();
-                let mut rejects_writer = create_optional_bam_writer(
-                    Some(rejects_path),
-                    &header_for_rejects,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?
-                .expect("create_optional_bam_writer returns Some when given Some path");
-
-                for raw in &all_raw_rejects {
-                    use std::io::Write;
-                    let block_size = raw.len() as u32;
-                    rejects_writer.get_mut().write_all(&block_size.to_le_bytes())?;
-                    rejects_writer.get_mut().write_all(raw)?;
-                }
-
-                rejects_writer.into_inner().finish()?;
-                let total_reject_records = all_raw_rejects.len();
-                info!("Wrote {total_reject_records} rejected records to rejects file");
             }
         }
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -6,8 +6,8 @@
 //! 2. Duplex consensus from paired single-strand consensuses
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
+    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
 };
 use anyhow::{Context, Result, bail};
 use clap::Parser;
@@ -32,7 +32,7 @@ use crate::overlapping_consensus::{
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::progress::ProgressTracker;
 use crate::read_info::LibraryIndex;
-use crate::sam::SamTag;
+use crate::sam::{SamTag, header_as_unsorted};
 use crate::sort::bam_fields;
 use crate::umi::extract_mi_base;
 use crate::unified_pipeline::{
@@ -43,6 +43,7 @@ use fgumi_raw_bam::{RawRecord, RawRecordView};
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
+use parking_lot::Mutex;
 use std::io;
 use std::io::Write as IoWrite;
 use std::sync::Arc;
@@ -59,8 +60,6 @@ use super::common::{MethylationRef, load_methylation_reference};
 struct DuplexProcessedBatch {
     /// Consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
-    /// Rejected reads as raw BAM bytes (written to rejects file if enabled)
-    rejects: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// Consensus calling statistics for this batch
@@ -72,8 +71,6 @@ struct DuplexProcessedBatch {
 impl MemoryEstimate for DuplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         self.consensus_output.data.capacity()
-            + self.rejects.iter().map(Vec::capacity).sum::<usize>()
-            + self.rejects.capacity() * std::mem::size_of::<Vec<u8>>()
     }
 }
 
@@ -86,8 +83,6 @@ struct CollectedDuplexMetrics {
     overlapping_stats: Option<CorrectionStats>,
     /// Number of MI groups processed
     groups_processed: u64,
-    /// Rejected reads as raw BAM bytes for deferred writing
-    rejects: Vec<Vec<u8>>,
 }
 
 /// Call duplex consensus reads from grouped reads with /A and /B MI tags
@@ -611,14 +606,36 @@ impl Duplex {
             extract_mi_base(&mi_str).to_string()
         };
 
-        // Clone input_header before pipeline (needed for rejects writing)
-        let rejects_header = input_header.clone();
+        // Open rejects writer up front. Rejected records are streamed straight
+        // to disk from process_fn, per-MI-group, so no batch-level buffering.
+        // Because workers flush under a mutex rather than through the ordered
+        // serialize stage, reject records are emitted in mutex-acquisition
+        // order, not input order; mark the rejects header as SO:unsorted so
+        // downstream tools don't assume the input's sort order carried over.
+        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
+            if let Some(path) = self.rejects_opts.rejects.as_ref() {
+                let writer_threads = self.threading.num_threads();
+                let rejects_header = header_as_unsorted(&input_header);
+                let w = create_raw_bam_writer(
+                    path,
+                    &rejects_header,
+                    writer_threads,
+                    self.compression.compression_level,
+                )?;
+                Some(Arc::new(Mutex::new(Some(w))))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let groups_processed = run_bam_pipeline_from_reader(
+        let pipeline_result = run_bam_pipeline_from_reader(
             pipeline_config,
             reader,
             input_header,
@@ -676,10 +693,27 @@ impl Duplex {
                 };
 
                 let mut all_output = ConsensusOutput::default();
-                let mut all_rejects = Vec::new();
                 let mut batch_stats = ConsensusCallingStats::new();
                 let mut batch_overlapping = CorrectionStats::new();
                 let groups_count = batch.groups.len() as u64;
+
+                // Stream per-MI-group rejects straight to disk so they don't
+                // accumulate in a batch-level Vec. The mutex only serializes the
+                // raw-byte append; BGZF compression runs on the writer's own
+                // thread pool.
+                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
+                    if let Some(ref rw_arc) = rejects_writer_for_process {
+                        if !recs.is_empty() {
+                            let mut guard = rw_arc.lock();
+                            if let Some(w) = guard.as_mut() {
+                                for raw in recs {
+                                    w.write_raw_record(raw)?;
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
 
                 for MiGroup { mi, records: mut group_reads } in batch.groups {
                     caller.clear();
@@ -710,13 +744,12 @@ impl Duplex {
                     all_output.merge(batch_output);
                     batch_stats.merge(&caller.statistics());
                     if track_rejects {
-                        all_rejects.extend(caller.take_rejected_reads());
+                        flush_byte_records(&caller.take_rejected_reads())?;
                     }
                 }
 
                 Ok(DuplexProcessedBatch {
                     consensus_output: all_output,
-                    rejects: all_rejects,
                     groups_count,
                     stats: batch_stats,
                     overlapping_stats: if overlapping_enabled {
@@ -731,68 +764,61 @@ impl Duplex {
                   _header: &Header,
                   output: &mut Vec<u8>|
                   -> io::Result<u64> {
-                // Merge per-batch metrics + rejects into this worker's slot
+                // Rejects were already streamed to disk in process_fn.
+                // Merge per-batch metrics into this worker's accumulator slot
                 let batch_stats = processed.stats;
                 let batch_overlapping = processed.overlapping_stats;
                 let groups_count = processed.groups_count;
-                let mut batch_rejects = processed.rejects;
                 collected_metrics_for_serialize.with_slot(|m| {
                     m.stats.merge(&batch_stats);
                     if let Some(o) = batch_overlapping {
                         m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
                     }
                     m.groups_processed += groups_count;
-                    m.rejects.append(&mut batch_rejects);
                 });
 
                 let count = processed.consensus_output.count as u64;
                 output.extend_from_slice(&processed.consensus_output.data);
                 Ok(count)
             },
-        )
-        .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?;
+        );
 
-        // ========== Post-pipeline: Aggregate metrics and write rejects ==========
+        // Always finalize the rejects writer, even if the pipeline failed, so any
+        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
+        // finish() failures alongside any pipeline error so neither is silently
+        // dropped.
+        let rejects_finish_result = rejects_writer
+            .and_then(|rw_arc| rw_arc.lock().take())
+            .map(|writer| writer.finish().context("Failed to finish rejects file"));
+
+        let groups_processed = match (pipeline_result, rejects_finish_result) {
+            (Ok(groups_processed), Some(Ok(()))) => {
+                info!("Rejected reads streamed to rejects file during processing");
+                groups_processed
+            }
+            (Ok(groups_processed), None) => groups_processed,
+            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
+            (Err(pipeline_err), Some(Err(finish_err))) => {
+                return Err(anyhow::anyhow!(
+                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
+                ));
+            }
+            (Err(pipeline_err), _) => {
+                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
+            }
+        };
+
+        // ========== Post-pipeline: Aggregate metrics ==========
         let mut total_groups = 0u64;
         let mut merged_stats = ConsensusCallingStats::new();
         let mut merged_overlapping_stats = CorrectionStats::new();
-        let mut all_rejects: Vec<Vec<u8>> = Vec::new();
 
         for slot in collected_metrics.slots() {
-            let mut m = slot.lock();
+            let m = slot.lock();
             total_groups += m.groups_processed;
             merged_stats.merge(&m.stats);
             if let Some(ref ocs) = m.overlapping_stats {
                 merged_overlapping_stats.merge(ocs);
-            }
-            if track_rejects {
-                all_rejects.append(&mut m.rejects);
-            }
-        }
-
-        // Write deferred rejects as raw BAM bytes
-        if track_rejects && !all_rejects.is_empty() {
-            if let Some(rejects_path) = &self.rejects_opts.rejects {
-                let writer_threads = self.threading.num_threads();
-                let rejects_writer = create_optional_bam_writer(
-                    Some(rejects_path),
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                if let Some(mut rw) = rejects_writer {
-                    for raw_record in &all_rejects {
-                        let block_size = raw_record.len() as u32;
-                        rw.get_mut()
-                            .write_all(&block_size.to_le_bytes())
-                            .context("Failed to write rejected read block size")?;
-                        rw.get_mut()
-                            .write_all(raw_record)
-                            .context("Failed to write rejected read")?;
-                    }
-                    rw.into_inner().finish().context("Failed to finish rejects file")?;
-                    info!("Wrote {} rejected reads", all_rejects.len());
-                }
             }
         }
 
@@ -1694,20 +1720,16 @@ mod tests {
     fn test_duplex_processed_batch_memory_estimate() {
         let mut data = Vec::with_capacity(1024);
         data.extend_from_slice(&[0u8; 100]);
-        let mut reject = Vec::with_capacity(512);
-        reject.extend_from_slice(&[0u8; 50]);
 
         let batch = DuplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
-            rejects: vec![reject],
             groups_count: 1,
             stats: ConsensusCallingStats::default(),
             overlapping_stats: None,
         };
 
         let estimate = batch.estimate_heap_size();
-        assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
-        assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
+        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
     }
 
     #[rstest]

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -5,8 +5,8 @@
 //! errors introduced during sample preparation.
 
 use crate::bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
+    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
 };
 use crate::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
@@ -28,8 +28,9 @@ use fgoxide::io::DelimFile;
 use fgumi_raw_bam::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::sam::SamTag;
+use crate::sam::{SamTag, header_as_unsorted};
 use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
+use parking_lot::Mutex;
 
 use log::info;
 use noodles::sam::Header;
@@ -61,8 +62,6 @@ use super::common::{MethylationRef, load_methylation_reference};
 struct SimplexProcessedBatch {
     /// Pre-serialized consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
-    /// Rejected reads as raw BAM bytes (written to rejects file if enabled)
-    rejects: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// Consensus calling statistics for this batch
@@ -74,12 +73,10 @@ struct SimplexProcessedBatch {
 impl MemoryEstimate for SimplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         self.consensus_output.data.capacity()
-            + self.rejects.iter().map(Vec::capacity).sum::<usize>()
-            + self.rejects.capacity() * std::mem::size_of::<Vec<u8>>()
     }
 }
 
-/// Per-thread accumulator for simplex consensus metrics and rejects.
+/// Per-thread accumulator for simplex consensus metrics.
 ///
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
@@ -91,10 +88,6 @@ struct CollectedSimplexMetrics {
     overlapping_stats: Option<CorrectionStats>,
     /// Number of MI groups processed
     groups_processed: u64,
-    /// Rejected reads as raw BAM bytes for deferred writing.
-    /// NB: rejects buffering is left unchanged here; streaming rejects to
-    /// disk during the pipeline is a follow-up (tracked separately).
-    rejects: Vec<Vec<u8>>,
 }
 
 /// Calls simplex consensus sequences from reads with the same unique molecular tag.
@@ -534,14 +527,36 @@ impl Simplex {
             methylation_mode,
         };
 
-        // Clone input_header before pipeline (needed for rejects writing)
-        let rejects_header = input_header.clone();
+        // Open rejects writer up front. Rejected records are streamed straight
+        // to disk from process_fn, per-MI-group, so no batch-level buffering.
+        // Because workers flush under a mutex rather than through the ordered
+        // serialize stage, reject records are emitted in mutex-acquisition
+        // order, not input order; mark the rejects header as SO:unsorted so
+        // downstream tools don't assume the input's sort order carried over.
+        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
+            if let Some(path) = self.rejects_opts.rejects.as_ref() {
+                let writer_threads = self.threading.num_threads();
+                let rejects_header = header_as_unsorted(&input_header);
+                let w = create_raw_bam_writer(
+                    path,
+                    &rejects_header,
+                    writer_threads,
+                    self.compression.compression_level,
+                )?;
+                Some(Arc::new(Mutex::new(Some(w))))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let groups_processed = run_bam_pipeline_from_reader(
+        let pipeline_result = run_bam_pipeline_from_reader(
             pipeline_config,
             reader,
             input_header,
@@ -578,10 +593,40 @@ impl Simplex {
                 };
 
                 let mut all_output = ConsensusOutput::default();
-                let mut all_rejects = Vec::new();
                 let mut batch_stats = ConsensusCallingStats::new();
                 let mut batch_overlapping = CorrectionStats::new();
                 let groups_count = batch.groups.len() as u64;
+
+                // Stream per-MI-group rejects straight to disk so they don't
+                // accumulate in a batch-level Vec. The mutex only serializes the
+                // raw-byte append; BGZF compression runs on the writer's own
+                // thread pool.
+                let flush_raw_records = |recs: &[RawRecord]| -> io::Result<()> {
+                    if let Some(ref rw_arc) = rejects_writer_for_process {
+                        if !recs.is_empty() {
+                            let mut guard = rw_arc.lock();
+                            if let Some(w) = guard.as_mut() {
+                                for raw in recs {
+                                    w.write_raw_record(raw.as_ref())?;
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
+                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
+                    if let Some(ref rw_arc) = rejects_writer_for_process {
+                        if !recs.is_empty() {
+                            let mut guard = rw_arc.lock();
+                            if let Some(w) = guard.as_mut() {
+                                for raw in recs {
+                                    w.write_raw_record(raw)?;
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
 
                 for MiGroup { mi, records: mut raw_records } in batch.groups {
                     caller.clear();
@@ -594,8 +639,7 @@ impl Simplex {
                             raw_records.len(),
                         );
                         if track_rejects {
-                            // TODO(#272): bridge – remove when rejects Vec accepts RawRecord
-                            all_rejects.extend(raw_records.into_iter().map(RawRecord::into_inner));
+                            flush_raw_records(&raw_records)?;
                         }
                         continue;
                     }
@@ -608,9 +652,7 @@ impl Simplex {
                             batch_stats.record_input(raw_records.len());
                             batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
                             if track_rejects {
-                                // TODO(#272): bridge – remove when rejects Vec accepts RawRecord
-                                all_rejects
-                                    .extend(raw_records.into_iter().map(RawRecord::into_inner));
+                                flush_raw_records(&raw_records)?;
                             }
                             continue;
                         }
@@ -626,13 +668,12 @@ impl Simplex {
                     all_output.merge(batch_output);
                     batch_stats.merge(&caller.statistics());
                     if track_rejects {
-                        all_rejects.extend(caller.take_rejected_reads());
+                        flush_byte_records(&caller.take_rejected_reads())?;
                     }
                 }
 
                 Ok(SimplexProcessedBatch {
                     consensus_output: all_output,
-                    rejects: all_rejects,
                     groups_count,
                     stats: batch_stats,
                     overlapping_stats: if overlapping_enabled {
@@ -647,18 +688,17 @@ impl Simplex {
                   _header: &Header,
                   output: &mut Vec<u8>|
                   -> io::Result<u64> {
-                // Merge per-batch metrics + rejects into this worker's slot
+                // Rejects were already streamed to disk in process_fn.
+                // Merge per-batch metrics into this worker's accumulator slot
                 let batch_stats = processed.stats;
                 let batch_overlapping = processed.overlapping_stats;
                 let groups_count = processed.groups_count;
-                let mut batch_rejects = processed.rejects;
                 collected_metrics_for_serialize.with_slot(|m| {
                     m.stats.merge(&batch_stats);
                     if let Some(o) = batch_overlapping {
                         m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
                     }
                     m.groups_processed += groups_count;
-                    m.rejects.append(&mut batch_rejects);
                 });
 
                 // Serialize consensus reads
@@ -666,50 +706,44 @@ impl Simplex {
                 output.extend_from_slice(&processed.consensus_output.data);
                 Ok(count)
             },
-        )
-        .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?;
+        );
 
-        // ========== Post-pipeline: Aggregate metrics and write rejects ==========
+        // Always finalize the rejects writer, even if the pipeline failed, so any
+        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
+        // finish() failures alongside any pipeline error so neither is silently
+        // dropped.
+        let rejects_finish_result = rejects_writer
+            .and_then(|rw_arc| rw_arc.lock().take())
+            .map(|writer| writer.finish().context("Failed to finish rejects file"));
+
+        let groups_processed = match (pipeline_result, rejects_finish_result) {
+            (Ok(groups_processed), Some(Ok(()))) => {
+                info!("Rejected reads streamed to rejects file during processing");
+                groups_processed
+            }
+            (Ok(groups_processed), None) => groups_processed,
+            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
+            (Err(pipeline_err), Some(Err(finish_err))) => {
+                return Err(anyhow::anyhow!(
+                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
+                ));
+            }
+            (Err(pipeline_err), _) => {
+                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
+            }
+        };
+
+        // ========== Post-pipeline: Aggregate metrics ==========
         let mut total_groups = 0u64;
         let mut merged_stats = ConsensusCallingStats::new();
         let mut merged_overlapping_stats = CorrectionStats::new();
-        let mut all_rejects: Vec<Vec<u8>> = Vec::new();
 
         for slot in collected_metrics.slots() {
-            let mut m = slot.lock();
+            let m = slot.lock();
             total_groups += m.groups_processed;
             merged_stats.merge(&m.stats);
             if let Some(ref ocs) = m.overlapping_stats {
                 merged_overlapping_stats.merge(ocs);
-            }
-            if track_rejects {
-                all_rejects.append(&mut m.rejects);
-            }
-        }
-
-        // Write deferred rejects as raw BAM bytes
-        if track_rejects && !all_rejects.is_empty() {
-            if let Some(rejects_path) = &self.rejects_opts.rejects {
-                let writer_threads = self.threading.num_threads();
-                let rejects_writer = create_optional_bam_writer(
-                    Some(rejects_path),
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                if let Some(mut rw) = rejects_writer {
-                    for raw_record in &all_rejects {
-                        let block_size = raw_record.len() as u32;
-                        rw.get_mut()
-                            .write_all(&block_size.to_le_bytes())
-                            .context("Failed to write rejected read block size")?;
-                        rw.get_mut()
-                            .write_all(raw_record)
-                            .context("Failed to write rejected read")?;
-                    }
-                    rw.into_inner().finish().context("Failed to finish rejects file")?;
-                    info!("Wrote {} rejected reads", all_rejects.len());
-                }
             }
         }
 
@@ -1618,22 +1652,17 @@ mod tests {
     fn test_simplex_processed_batch_memory_estimate() {
         let mut data = Vec::with_capacity(1024);
         data.extend_from_slice(&[0u8; 100]);
-        let mut reject = Vec::with_capacity(512);
-        reject.extend_from_slice(&[0u8; 50]);
 
         let batch = SimplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
-            rejects: vec![reject],
             groups_count: 1,
             stats: ConsensusCallingStats::default(),
             overlapping_stats: None,
         };
 
         let estimate = batch.estimate_heap_size();
-        // Should use capacity (1024 + 512) not len (100 + 50)
-        assert!(estimate >= 1024 + 512, "estimate {estimate} should be >= 1536 (capacities)");
-        // Should also include Vec<Vec<u8>> overhead
-        assert!(estimate > 1024 + 512, "estimate {estimate} should include Vec overhead");
+        // Should use capacity (1024) not len (100)
+        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
     }
 
     #[rstest]

--- a/src/lib/sam/mod.rs
+++ b/src/lib/sam/mod.rs
@@ -17,8 +17,8 @@ pub use fgumi_sam::{TC_TAG, TemplateCoordinateInfo};
 
 // Re-export top-level functions from fgumi-sam
 pub use fgumi_sam::{
-    buf_value_to_smallest_signed_int, check_sort, is_sorted, is_template_coordinate_sorted,
-    revcomp_buf_value, reverse_buf_value, to_smallest_signed_int,
+    buf_value_to_smallest_signed_int, check_sort, header_as_unsorted, is_sorted,
+    is_template_coordinate_sorted, revcomp_buf_value, reverse_buf_value, to_smallest_signed_int,
 };
 
 // Re-export commonly used items from submodules

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -32,6 +32,36 @@ pub fn assert_has_bgzf_eof(path: &std::path::Path) {
     );
 }
 
+/// Asserts that a BAM file's `@HD` line has `SO:unsorted` and no `GO` or `SS`
+/// tags, matching the contract of `fgumi_lib::sam::header_as_unsorted`.
+///
+/// Use this on rejects BAMs produced by the pipeline commands, whose records
+/// are emitted in mutex-acquisition order rather than input order.
+///
+/// # Panics
+///
+/// Panics if the file cannot be opened, the header cannot be read, or the
+/// sort-order tags do not match the unsorted contract.
+pub fn assert_header_unsorted(path: &std::path::Path) {
+    let mut reader = noodles::bam::io::Reader::new(
+        std::fs::File::open(path).expect("Failed to open BAM for header check"),
+    );
+    let header = reader.read_header().expect("Failed to read BAM header");
+    let hdr_map = header.header().expect("BAM header is missing an @HD line");
+    let other_fields = hdr_map.other_fields();
+
+    let so =
+        other_fields.get(b"SO").unwrap_or_else(|| panic!("@HD missing SO in {}", path.display()));
+    assert_eq!(
+        <_ as AsRef<[u8]>>::as_ref(so),
+        b"unsorted",
+        "SO should be 'unsorted' in {}",
+        path.display()
+    );
+    assert!(other_fields.get(b"GO").is_none(), "GO should be cleared in {}", path.display());
+    assert!(other_fields.get(b"SS").is_none(), "SS should be cleared in {}", path.display());
+}
+
 /// Asserts that a record has a specific MI (molecule ID) tag value.
 ///
 /// # Panics

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-use crate::helpers::assertions::assert_has_bgzf_eof;
+use crate::helpers::assertions::{assert_has_bgzf_eof, assert_header_unsorted};
 use crate::helpers::bam_generator::{
     create_minimal_header, create_test_reference, create_umi_family, to_record_buf,
 };
@@ -668,6 +668,7 @@ fn test_simplex_rejects_has_bgzf_eof() {
     assert!(status.success(), "simplex command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
+    assert_header_unsorted(&rejects_bam);
 }
 
 #[test]
@@ -697,8 +698,6 @@ fn test_duplex_rejects_has_bgzf_eof() {
     records.push(r2);
     write_test_bam(&input_bam, &records);
 
-    // Use single-threaded mode: duplex multi-threaded pipeline doesn't collect
-    // raw reject bytes, so rejects writing only happens in the single-threaded path.
     let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
         .args([
             "duplex",
@@ -710,6 +709,8 @@ fn test_duplex_rejects_has_bgzf_eof() {
             rejects_bam.to_str().unwrap(),
             "--min-reads",
             "2",
+            "--threads",
+            "2",
             "--compression-level",
             "1",
         ])
@@ -719,6 +720,7 @@ fn test_duplex_rejects_has_bgzf_eof() {
     assert!(status.success(), "duplex command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
+    assert_header_unsorted(&rejects_bam);
 }
 
 #[test]
@@ -762,6 +764,7 @@ fn test_codec_rejects_has_bgzf_eof() {
     assert!(status.success(), "codec command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
+    assert_header_unsorted(&rejects_bam);
 }
 
 #[test]
@@ -804,6 +807,7 @@ fn test_correct_rejects_has_bgzf_eof() {
     assert!(status.success(), "correct command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
+    assert_header_unsorted(&rejects_bam);
 }
 
 #[test]
@@ -843,4 +847,6 @@ fn test_correct_single_threaded_rejects_has_bgzf_eof() {
     assert!(status.success(), "correct single-threaded with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
+    // Single-threaded correct writes rejects in input order, so it keeps the
+    // input header as-is rather than marking it SO:unsorted.
 }

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -160,3 +160,98 @@ fn test_correct_command_with_rejects() {
     assert!(status.success(), "Correct command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 }
+
+/// Exercises the multi-threaded rejects-streaming path end-to-end and asserts:
+/// 1. The rejects BAM is a valid BGZF stream with the terminating EOF block.
+/// 2. The `@HD` header reports `SO:unsorted` because rejects are emitted in
+///    mutex-acquisition order rather than input order.
+/// 3. Every uncorrectable input record appears exactly once in the rejects
+///    BAM — the writer does not drop records under worker contention and does
+///    not emit duplicates.
+#[test]
+fn test_correct_command_rejects_streaming_threaded_integrity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // Each record has a unique QNAME, so each record is its own template.
+    // `CorrectUmis` uses a 1000-template batch, so size the uncorrectable
+    // families so that `far_a + far_b + far_c` exceeds that boundary and
+    // multiple batches flow through the 4-thread pool concurrently, letting
+    // more than one worker race to flush rejects.
+    let far_family_size: u32 = 400;
+    let corr_small = create_umi_family("ACGTACGT", 3, "c1_exact", "AAAAGGGG", 30);
+    let corr_big = create_umi_family("ACGTACGT", 30, "c2_exact", "AAAAGGGG", 30);
+    let far_a = create_umi_family("TTTTTTTT", far_family_size as usize, "far_a", "AAAAGGGG", 30);
+    let far_b = create_umi_family("GGGGGGGG", far_family_size as usize, "far_b", "AAAAGGGG", 30);
+    let far_c = create_umi_family("CCCCCCCC", far_family_size as usize, "far_c", "AAAAGGGG", 30);
+
+    // Expected reject names mirror `create_umi_family`'s "{base_name}_{i}"
+    // convention for the three uncorrectable families.
+    let mut expected_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for base in ["far_a", "far_b", "far_c"] {
+        for i in 0..far_family_size {
+            expected_names.insert(format!("{base}_{i}"));
+        }
+    }
+    let expected_rejects = expected_names.len();
+
+    create_umi_bam(&input_bam, vec![corr_small, corr_big, far_a, far_b, far_c]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "correct",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--umi-files",
+            whitelist.to_str().unwrap(),
+            "--max-mismatches",
+            "1",
+            "--min-distance",
+            "1",
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--threads",
+            "4",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run correct command");
+
+    assert!(status.success(), "Correct command with threaded rejects failed");
+    assert!(rejects_bam.exists(), "Rejects BAM not created");
+
+    crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);
+    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let mut seen: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    let mut total: usize = 0;
+    for result in reader.records() {
+        let record = result.expect("Failed to read reject record");
+        let name = record.name().expect("reject record missing read name").to_string();
+        *seen.entry(name).or_insert(0) += 1;
+        total += 1;
+    }
+
+    assert_eq!(
+        total, expected_rejects,
+        "rejects BAM should contain one record per uncorrectable input read",
+    );
+    assert_eq!(seen.len(), expected_rejects, "unexpected reject-name set size");
+    for name in &expected_names {
+        assert_eq!(
+            seen.remove(name),
+            Some(1),
+            "expected uncorrectable record {name} exactly once in the rejects BAM",
+        );
+    }
+    assert!(seen.is_empty(), "rejects BAM contained unexpected records: {seen:?}");
+}

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -189,6 +189,156 @@ fn test_duplex_command_basic() {
     assert!(count > 0, "Should have produced duplex consensus reads");
 }
 
+/// Test duplex command with rejects output.
+///
+/// Runs the multi-threaded pipeline with `--min-reads 2` and a singleton /A
+/// template that fails the single-strand `min-reads` check. Verifies that:
+///
+/// 1. The rejects BAM is created and has its `@HD` header rewritten to
+///    `SO:unsorted` because reject writes are emitted in mutex-acquisition
+///    order rather than input order.
+/// 2. The singleton template's raw records are actually streamed to the
+///    rejects BAM rather than being silently dropped.
+#[test]
+fn test_duplex_command_with_rejects() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // Kept molecule: 3 /A pairs + 3 /B pairs
+    let kept = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    // Singleton /A pair (fails the /A strand's min-reads=2 check)
+    let singleton = vec![create_duplex_read_pair("solo", "2/A", "ACGTACGT", 30, 500, false)];
+    create_duplex_bam(&input_bam, vec![kept, singleton]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run duplex command");
+
+    assert!(status.success(), "Duplex command with rejects failed");
+    assert!(rejects_bam.exists(), "Rejects BAM not created");
+
+    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+
+    // The singleton /A template (R1 + R2) should be streamed to the rejects BAM.
+    let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let mut reject_count = 0;
+    for result in reader.records() {
+        result.expect("Failed to read reject record");
+        reject_count += 1;
+    }
+    assert_eq!(
+        reject_count, 2,
+        "Singleton paired-end /A template should be streamed to rejects BAM (R1 + R2)"
+    );
+}
+
+/// Regression test: each rejected input record must appear in the rejects BAM
+/// exactly once.
+///
+/// The duplex caller accumulates rejects from two sources: records dropped at
+/// the single-strand (ss) layer, and records dropped at the duplex layer. When
+/// the duplex layer rejects a group it returns every raw input record — which
+/// already includes anything the ss layer would have rejected. Appending both
+/// sources naively would emit the overlapping records twice.
+///
+/// This test drives several independent rejection paths in a single pipeline
+/// run and asserts that the rejects BAM contains each `(read_name, flags)`
+/// tuple at most once, with the total record count matching the expected
+/// input-record count.
+#[test]
+fn test_duplex_command_rejects_contain_no_duplicates() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // Kept molecule: produces a consensus, contributes zero rejects.
+    let kept = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    // Four singleton molecules (2 records each) — two on each strand — that
+    // reject via the insufficient-reads path. Using molecule IDs in a single
+    // `singletons` vec avoids the similar_names clippy lint.
+    let singletons: Vec<Vec<(RawRecord, RawRecord)>> = vec![
+        vec![create_duplex_read_pair("soloA1", "2/A", "ACGTACGT", 30, 500, false)],
+        vec![create_duplex_read_pair("soloA2", "3/A", "ACGTACGT", 30, 800, false)],
+        vec![create_duplex_read_pair("soloB1", "4/B", "ACGTACGT", 30, 1100, true)],
+        vec![create_duplex_read_pair("soloB2", "5/B", "ACGTACGT", 30, 1400, true)],
+    ];
+
+    // Expected rejects = 4 singletons × 2 records = 8. The kept molecule
+    // contributes 0 rejects.
+    let expected_rejects = u32::try_from(singletons.len() * 2).expect("rejects count fits in u32");
+
+    let mut molecules = vec![kept];
+    molecules.extend(singletons);
+    create_duplex_bam(&input_bam, molecules);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run duplex command");
+
+    assert!(status.success(), "Duplex command with rejects failed");
+    assert!(rejects_bam.exists(), "Rejects BAM not created");
+
+    crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);
+    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let mut seen: std::collections::HashMap<(String, u16), u32> = std::collections::HashMap::new();
+    let mut total = 0u32;
+    for result in reader.records() {
+        let record = result.expect("Failed to read reject record");
+        let name = record.name().expect("reject record missing read name").to_string();
+        let flags = u16::from(record.flags());
+        *seen.entry((name, flags)).or_insert(0) += 1;
+        total += 1;
+    }
+
+    assert_eq!(
+        total, expected_rejects,
+        "rejects BAM record count should match the expected rejected-input count",
+    );
+    for ((name, flags), count) in &seen {
+        assert_eq!(
+            *count, 1,
+            "record ({name}, flags={flags}) appears {count} times in the rejects BAM",
+        );
+    }
+}
+
 /// Test duplex command with statistics output.
 #[test]
 fn test_duplex_command_with_stats() {


### PR DESCRIPTION
## Summary

Stacked on #290. Removes the per-thread \`Vec<Vec<u8>>\` reject-buffering pattern from the four commands that keep it (after #290 removed the metric-buffering pattern from all seven). Rejected raw BAM records are now streamed directly to the rejects BAM during \`serialize_fn\` via a shared BGZF writer guarded by a \`parking_lot::Mutex\`. The mutex only serializes the byte append; BGZF compression runs on the writer's own thread pool.

Commits (one per command):

1. \`fix(simplex)\` — open rejects writer up front; write bytes from serialize; finalize writer post-pipeline. Drops \`rejects: Vec<Vec<u8>>\` from the per-thread accumulator.
2. \`fix(duplex)\` — mirrors simplex.
3. \`fix(codec)\` — mirrors simplex/duplex.
4. \`fix(correct)\` — mirrors simplex/duplex/codec but on \`rejected_raw_records\`. Rejects use the input header (correct preserves alignment context).
5. \`docs(changelog)\` — note.

## Why

With #287/#290 landed, metric memory in the consensus commands and \`correct\` is capped at O(threads × distinct keys). The remaining unbounded growth vector is reject buffering: every rejected raw BAM record was held in per-thread Vecs for the life of the run, then written after the pipeline completed. On protocols with high rejection rates (e.g. duplex calls that fail \`/A\`/\`/B\` partnering, correct runs where most UMIs don't match the whitelist), this can retain multiple GB of raw BAM bytes.

Streaming during the pipeline caps reject memory at roughly the BGZF block size per worker, independent of reject count.

## Why not the pipeline's \`with_secondary\` API

\`run_bam_pipeline_from_reader_with_secondary\` exists and \`filter\` uses it, but it writes the secondary output using \`output_header\`. simplex/duplex/codec build an unmapped-consensus output header that differs from the input header — rejects need the input header since they're original mapped reads. Extending the pipeline API to accept a separate secondary header is a larger surgery; the shared-Mutex pattern here is surgical and keeps the pipeline internals untouched. Worth revisiting once all four commands are in the same shape and a generalization has a clear target.

## Test plan

- [x] \`cargo ci-fmt\`, \`cargo ci-lint\`, \`cargo ci-test\` — 2545 tests pass.
- [x] Each command's integration tests (simplex/duplex/codec/correct) pass, including the \`*_rejects_has_bgzf_eof\` BGZF-EOF sanity tests.
- [ ] A/B memory comparison on a run with a high-rejection-rate input — confirm flat RSS across reject count.
- [ ] Byte-identity check on rejects BAM output vs. the old buffered path (ordering may differ since writes are no longer post-sorted; behavior already was not order-guaranteed).

## Note

The final changelog commit is unsigned (three 1Password biometric signing attempts failed locally). It should be re-signed before merge.