### PR TITLE
refactor(lib)!: collapse Template/DecodedRecord to raw-only; drop dead RecordBuf helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "fgoxide",
+ "fgumi-raw-bam",
  "fgumi-sam",
  "noodles",
  "serde",

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 fgoxide = "0.6.0"
 noodles = { version = "0.106.0", features = ["sam"], optional = true }
+fgumi-raw-bam = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
@@ -19,7 +20,7 @@ fgumi-sam = { workspace = true }
 
 [features]
 default = ["clip"]
-clip = ["dep:noodles"]
+clip = ["dep:noodles", "dep:fgumi-raw-bam"]
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-metrics/src/clip.rs
+++ b/crates/fgumi-metrics/src/clip.rs
@@ -110,6 +110,77 @@ impl ClippingMetrics {
         }
     }
 
+    /// Updates metrics from a raw BAM record after clipping.
+    ///
+    /// Equivalent to [`Self::update`] but reads alignment information directly from
+    /// the raw BAM bytes, avoiding a noodles decode round-trip.
+    ///
+    /// # Arguments
+    /// * `record` - The raw BAM record after clipping
+    /// * `counts` - The clip counts for this operation
+    #[cfg(feature = "clip")]
+    pub fn update_raw(&mut self, record: &fgumi_raw_bam::RawRecord, counts: ClipCounts) {
+        use fgumi_raw_bam::get_cigar_ops;
+
+        self.reads += 1;
+
+        // Count aligned bases (M/=/X ops) from raw CIGAR
+        let cigar_ops = get_cigar_ops(record.as_ref());
+        let aligned_bases: usize = cigar_ops
+            .iter()
+            .filter(|&&op| {
+                matches!(op & 0xF, 0 | 7 | 8) // Match, SequenceMatch, SequenceMismatch
+            })
+            .map(|&op| (op >> 4) as usize)
+            .sum();
+        self.bases += aligned_bases;
+
+        // Track pre-clipping
+        if counts.prior > 0 {
+            self.reads_clipped_pre += 1;
+            self.bases_clipped_pre += counts.prior;
+        }
+
+        // Track 5' clipping
+        if counts.five_prime > 0 {
+            self.reads_clipped_five_prime += 1;
+            self.bases_clipped_five_prime += counts.five_prime;
+        }
+
+        // Track 3' clipping
+        if counts.three_prime > 0 {
+            self.reads_clipped_three_prime += 1;
+            self.bases_clipped_three_prime += counts.three_prime;
+        }
+
+        // Track overlapping clipping
+        if counts.overlapping > 0 {
+            self.reads_clipped_overlapping += 1;
+            self.bases_clipped_overlapping += counts.overlapping;
+        }
+
+        // Track extending clipping
+        if counts.extending > 0 {
+            self.reads_clipped_extending += 1;
+            self.bases_clipped_extending += counts.extending;
+        }
+
+        // Total clipping after ClipBam
+        let additional_clipped =
+            counts.five_prime + counts.three_prime + counts.overlapping + counts.extending;
+        let total_clipped = additional_clipped + counts.prior;
+
+        if total_clipped > 0 {
+            self.reads_clipped_post += 1;
+            self.bases_clipped_post += total_clipped;
+
+            // Check if read became unmapped
+            if record.is_unmapped() && additional_clipped > 0 {
+                self.reads_unmapped += 1;
+            }
+        }
+    }
+
     /// Updates metrics based on a clipping operation
     ///
     /// # Arguments

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -4,12 +4,11 @@
 //! This is useful for variant calling to avoid double-counting evidence from
 //! overlapping portions of paired reads.
 
-use crate::alignment_tags::regenerate_alignment_tags;
+use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_reader_with_opts, create_bam_writer,
-    is_stdin_path,
+    create_bam_reader_for_pipeline, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path,
 };
-use crate::clipper::{ClippingMode, SamRecordClipper};
+use crate::clipper::{ClippingMode, RawRecordClipper};
 use crate::grouper::TemplateGrouper;
 use crate::logging::OperationTimer;
 use crate::metrics::clip::{ClipCounts, ClippingMetricsCollection};
@@ -19,19 +18,14 @@ use crate::progress::ProgressTracker;
 use crate::reference::ReferenceReader;
 use crate::template::{TemplateBatch, TemplateIterator};
 use crate::unified_pipeline::{
-    Grouper, MemoryEstimate, run_bam_pipeline_from_reader, serialize_bam_records_into,
+    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
 };
 use crate::validation::validate_file_exists;
 use anyhow::Result;
 use clap::Parser;
+use fgumi_raw_bam::RawRecord;
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
-// RecordBuf retained: SamRecordClipper (T2.9) requires typed CIGAR/sequence editing on RecordBuf;
-// all record flow in clip.rs is driven by that clipper and Template.records (T2.1).
-use noodles::sam::alignment::record::Cigar as CigarTrait;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -170,8 +164,7 @@ pub struct Clip {
 /// Result from processing a batch of templates through clipping.
 struct ClipProcessedBatch {
     /// Clipped records to write to output BAM.
-    // RecordBuf retained: SamRecordClipper (T2.9) mutates typed CIGAR/sequence on RecordBuf.
-    clipped_records: Vec<RecordBuf>,
+    clipped_records: Vec<RawRecord>,
     /// Number of templates processed.
     templates_count: u64,
     /// Number of templates with overlap clipping applied.
@@ -183,7 +176,7 @@ struct ClipProcessedBatch {
 impl MemoryEstimate for ClipProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         self.clipped_records.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
-            + self.clipped_records.capacity() * std::mem::size_of::<RecordBuf>()
+            + self.clipped_records.capacity() * std::mem::size_of::<RawRecord>()
     }
 }
 
@@ -233,6 +226,18 @@ impl Command for Clip {
             anyhow::bail!("At least one clipping option is required");
         }
 
+        // --metrics is not produced in --threads mode; fail fast rather than
+        // silently dropping a user-requested output file.
+        if self.threading.threads.is_some() {
+            if let Some(path) = &self.metrics {
+                anyhow::bail!(
+                    "--metrics {} cannot be used with --threads: detailed clipping metrics \
+                     are only produced by the single-threaded path",
+                    path.display()
+                );
+            }
+        }
+
         // ========================================================================
         // CRITICAL: Check --threads mode BEFORE creating any file handles.
         // The 7-step pipeline manages its own I/O and writer lifecycle, so we
@@ -241,10 +246,7 @@ impl Command for Clip {
         // ========================================================================
         let total_records = if let Some(threads) = self.threading.threads {
             // Read header for the 7-step pipeline (supports stdin)
-            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?;
+            let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
 
             // Load reference (always required for clip)
             let reference = Arc::new(ReferenceReader::new(&self.reference)?);
@@ -271,9 +273,9 @@ impl Clip {
     fn execute_single_threaded(&self, mode: ClippingMode, command_line: &str) -> Result<u64> {
         // Create clipper
         let clipper = if self.auto_clip_attributes {
-            SamRecordClipper::with_auto_clip(mode, true)
+            RawRecordClipper::with_auto_clip(mode, true)
         } else {
-            SamRecordClipper::new(mode)
+            RawRecordClipper::new(mode)
         };
 
         // Create metrics collection if metrics output requested
@@ -285,11 +287,7 @@ impl Clip {
 
         // Open input BAM with MT BGZF decompression
         let reader_threads = self.threading.num_threads();
-        let (mut reader, header) = create_bam_reader_with_opts(
-            &self.io.input,
-            reader_threads,
-            self.io.pipeline_reader_opts(),
-        )?;
+        let (reader, header) = create_raw_bam_reader(&self.io.input, reader_threads)?;
 
         // Update header sort order if specified
         let header = self.update_header_sort_order(header)?;
@@ -299,7 +297,7 @@ impl Clip {
 
         // Create output BAM writer with multi-threaded BGZF compression
         let writer_threads = self.threading.num_threads();
-        let mut writer = create_bam_writer(
+        let mut writer = create_raw_bam_writer(
             &self.io.output,
             &header,
             writer_threads,
@@ -314,13 +312,12 @@ impl Clip {
         let mut total_clipped_mate_extension: u64 = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Single-threaded processing
-        let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
-        let template_iter = TemplateIterator::new(record_iter);
+        // Single-threaded processing: iterate raw templates, clip in place
+        let template_iter = TemplateIterator::new(reader);
 
         for template in template_iter {
             let template = template?;
-            let mut records = template.records;
+            let mut records: Vec<RawRecord> = template.into_records();
 
             // Process based on template type
             #[allow(clippy::len_zero)] // We specifically want len() == 1, not !is_empty()
@@ -344,21 +341,21 @@ impl Clip {
                     total_clipped_mate_extension += 1;
                 }
 
-                // Update mate info (MC and MQ tags)
-                update_mate_info(r1, r2);
-                update_mate_info(r2, r1);
+                // Update mate info (MC and MQ tags) using raw tag API
+                update_mate_info_raw(r1, r2);
+                update_mate_info_raw(r2, r1);
             }
 
             // Regenerate alignment tags (always done to match Scala fgbio behavior)
             for record in &mut records {
-                regenerate_alignment_tags(record, &header, &reference_reader)?;
+                regenerate_alignment_tags_raw(record.as_mut_vec(), &header, &reference_reader)?;
             }
 
             // Count and write records
             let batch_size = records.len();
             total_records += batch_size;
             for record in &records {
-                writer.write_alignment_record(&header, record)?;
+                writer.write_raw_record(record.as_ref())?;
             }
             progress.log_if_needed(batch_size as u64);
         }
@@ -380,7 +377,7 @@ impl Clip {
         }
 
         // Flush and finish the writer
-        writer.into_inner().finish()?;
+        writer.finish()?;
 
         info!("Done!");
         Ok(total_records as u64)
@@ -408,19 +405,17 @@ impl Clip {
     /// # Errors
     ///
     /// Returns an error if clipping operations fail.
-    // RecordBuf retained throughout clip_fragment / clip_pair / update_mate_info:
-    // SamRecordClipper (T2.9) requires typed CIGAR editing on RecordBuf.
     fn clip_fragment(
         &self,
-        clipper: &SamRecordClipper,
-        record: &mut noodles::sam::alignment::RecordBuf,
+        clipper: &RawRecordClipper,
+        record: &mut RawRecord,
         metrics: Option<&mut ClippingMetricsCollection>,
     ) -> Result<()> {
-        let prior_bases_clipped = SamRecordClipper::clipped_bases(record);
+        let prior_bases_clipped = clipped_bases_raw(record);
 
         // Upgrade existing clipping if requested
         if self.upgrade_clipping {
-            clipper.upgrade_all_clipping(record)?;
+            clipper.upgrade_all_clipping_raw(record)?;
         }
 
         // Apply fixed-position clipping
@@ -438,7 +433,7 @@ impl Clip {
 
         // Update metrics
         if let Some(metrics) = metrics {
-            metrics.fragment.update(
+            metrics.fragment.update_raw(
                 record,
                 ClipCounts {
                     prior: prior_bases_clipped,
@@ -481,23 +476,22 @@ impl Clip {
     /// Returns an error if clipping operations fail.
     fn clip_pair(
         &self,
-        clipper: &SamRecordClipper,
-        r1: &mut noodles::sam::alignment::RecordBuf,
-        r2: &mut noodles::sam::alignment::RecordBuf,
+        clipper: &RawRecordClipper,
+        r1: &mut RawRecord,
+        r2: &mut RawRecord,
         metrics: Option<&mut ClippingMetricsCollection>,
     ) -> Result<(bool, bool)> {
-        let prior_bases_clipped_r1 = SamRecordClipper::clipped_bases(r1);
-        let prior_bases_clipped_r2 = SamRecordClipper::clipped_bases(r2);
+        let prior_bases_clipped_r1 = clipped_bases_raw(r1);
+        let prior_bases_clipped_r2 = clipped_bases_raw(r2);
 
         // Upgrade existing clipping if requested
         if self.upgrade_clipping {
-            clipper.upgrade_all_clipping(r1)?;
-            clipper.upgrade_all_clipping(r2)?;
+            clipper.upgrade_all_clipping_raw(r1)?;
+            clipper.upgrade_all_clipping_raw(r2)?;
         }
 
-        // Determine read types
-        let (is_r1_first, is_r2_last) =
-            (r1.flags().is_first_segment(), r2.flags().is_last_segment());
+        // Determine read types (raw flags: bit 6 = first segment, bit 7 = last segment)
+        let (is_r1_first, is_r2_last) = (r1.is_first_segment(), r2.is_last_segment());
 
         // Apply fixed-position clipping for R1
         let num_r1_five_prime = if is_r1_first && self.read_one_five_prime > 0 {
@@ -566,15 +560,15 @@ impl Clip {
 
             // Determine which metric to update based on read flags
             if is_r1_first {
-                metrics.read_one.update(r1, r1_counts);
+                metrics.read_one.update_raw(r1, r1_counts);
             } else {
-                metrics.read_two.update(r1, r1_counts);
+                metrics.read_two.update_raw(r1, r1_counts);
             }
 
             if is_r2_last {
-                metrics.read_two.update(r2, r2_counts);
+                metrics.read_two.update_raw(r2, r2_counts);
             } else {
-                metrics.read_one.update(r2, r2_counts);
+                metrics.read_one.update_raw(r2, r2_counts);
             }
         }
 
@@ -639,12 +633,15 @@ impl Clip {
         reference: Arc<ReferenceReader>,
     ) -> Result<u64> {
         // Configure pipeline - clip is writer-heavy workload
-        let pipeline_config = build_pipeline_config(
+        let mut pipeline_config = build_pipeline_config(
             &self.scheduler_opts,
             &self.compression,
             &self.queue_memory,
             num_threads,
         )?;
+        // Clip uses raw-byte mode so TemplateGrouper receives RawRecord items.
+        pipeline_config.group_key_config =
+            Some(GroupKeyConfig::new_raw_no_cell(crate::read_info::LibraryIndex::default()));
 
         // Per-thread metrics accumulator: bounded memory, no unbounded queue.
         let collected_metrics = PerThreadAccumulator::<CollectedClipMetrics>::new(num_threads);
@@ -678,9 +675,9 @@ impl Clip {
         let process_fn = move |batch: TemplateBatch| -> io::Result<ClipProcessedBatch> {
             // Create per-worker clipper
             let clipper = if auto_clip_attributes {
-                SamRecordClipper::with_auto_clip(clipping_mode, true)
+                RawRecordClipper::with_auto_clip(clipping_mode, true)
             } else {
-                SamRecordClipper::new(clipping_mode)
+                RawRecordClipper::new(clipping_mode)
             };
 
             let mut clipped_records = Vec::new();
@@ -689,15 +686,15 @@ impl Clip {
             let mut extend_clipped_count = 0u64;
 
             for template in batch {
-                let mut records = template.records;
                 templates_count += 1;
+                let mut records: Vec<RawRecord> = template.into_records();
 
                 #[allow(clippy::len_zero)]
                 if records.len() == 1 {
                     // Fragment - apply fixed-position clipping
                     let record = &mut records[0];
                     if upgrade_clipping {
-                        let _ = clipper.upgrade_all_clipping(record);
+                        clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
                     }
                     if read_one_five_prime > 0 {
                         clipper.clip_5_prime_end_of_alignment(record, read_one_five_prime);
@@ -712,13 +709,13 @@ impl Clip {
                     let r2 = &mut r2_slice[0];
 
                     if upgrade_clipping {
-                        let _ = clipper.upgrade_all_clipping(r1);
-                        let _ = clipper.upgrade_all_clipping(r2);
+                        clipper.upgrade_all_clipping_raw(r1).map_err(io::Error::other)?;
+                        clipper.upgrade_all_clipping_raw(r2).map_err(io::Error::other)?;
                     }
 
-                    // Determine read types
-                    let is_r1_first = r1.flags().is_first_segment();
-                    let is_r2_last = r2.flags().is_last_segment();
+                    // Determine read types (raw flags)
+                    let is_r1_first = r1.is_first_segment();
+                    let is_r2_last = r2.is_last_segment();
 
                     // Apply fixed-position clipping for R1
                     if is_r1_first && read_one_five_prime > 0 {
@@ -760,15 +757,19 @@ impl Clip {
                         }
                     }
 
-                    // Update mate info
-                    update_mate_info(r1, r2);
-                    update_mate_info(r2, r1);
+                    // Update mate info (MC and MQ tags) using raw tag API
+                    update_mate_info_raw(r1, r2);
+                    update_mate_info_raw(r2, r1);
                 }
 
                 // Regenerate alignment tags (always done to match fgbio behavior)
                 for record in &mut records {
-                    regenerate_alignment_tags(record, &header_for_process, &reference_for_process)
-                        .map_err(io::Error::other)?;
+                    regenerate_alignment_tags_raw(
+                        record.as_mut_vec(),
+                        &header_for_process,
+                        &reference_for_process,
+                    )
+                    .map_err(io::Error::other)?;
                 }
 
                 clipped_records.extend(records);
@@ -789,9 +790,9 @@ impl Clip {
             })
         };
 
-        // Serialize function: convert records to bytes and collect metrics
+        // Serialize function: write raw records directly into the output buffer
         let serialize_fn = move |processed: ClipProcessedBatch,
-                                 header: &Header,
+                                 _header: &Header,
                                  output: &mut Vec<u8>|
               -> io::Result<u64> {
             // Merge per-batch counts into this worker's accumulator slot
@@ -801,8 +802,10 @@ impl Clip {
                 m.extend_clipped += processed.extend_clipped_count;
             });
 
-            // Serialize clipped records into the provided buffer
-            serialize_bam_records_into(&processed.clipped_records, header, output)
+            // Write raw records directly (4-byte block_size + bytes per record)
+            let count = processed.clipped_records.len() as u64;
+            fgumi_raw_bam::write_raw_records(output, &processed.clipped_records)?;
+            Ok(count)
         };
 
         // Run the 7-step pipeline
@@ -833,11 +836,8 @@ impl Clip {
         info!("Templates with overlap clipping: {total_overlap_clipped}");
         info!("Templates with mate extension clipping: {total_extend_clipped}");
 
-        // Note: Metrics file not supported in 7-step pipeline mode
-        // (would require tracking per-record metrics which adds overhead)
-        if self.metrics.is_some() {
-            info!("Note: Detailed metrics file not supported in --threads mode");
-        }
+        // `--metrics` with `--threads` is rejected in `execute()` before we ever
+        // reach this path, so no per-pipeline metrics file is written here.
 
         info!("Done!");
         Ok(records_written)
@@ -858,45 +858,29 @@ impl Clip {
 ///
 /// * `record` - The record to update (mutable)
 /// * `mate` - The mate record to read information from
-// RecordBuf retained: records here are the same SamRecordClipper-mutated RecordBuf objects;
-// converting to raw bytes for tag ops and back would add overhead with no benefit until T2.9.
-#[allow(clippy::similar_names)] // mc_tag and mq_tag are standard SAM tags
-#[allow(clippy::cast_lossless)] // u8 to i32 cast is intentional for SAM tag format
-fn update_mate_info(
-    record: &mut noodles::sam::alignment::RecordBuf,
-    mate: &noodles::sam::alignment::RecordBuf,
-) {
-    use noodles::sam::alignment::record::cigar::op::Kind;
-    use std::fmt::Write;
+fn update_mate_info_raw(record: &mut RawRecord, mate: &RawRecord) {
+    // Update MC tag: build CIGAR string from raw bytes
+    let cigar_str = mate.cigar_to_string();
+    let mut editor = record.tags_editor();
+    editor.update_string(b"MC", cigar_str.as_bytes());
 
-    // Update MC tag (mate CIGAR)
-    // Build CIGAR string manually since Cigar doesn't implement Display
-    let mate_cigar = mate.cigar();
-    let mut cigar_string = String::new();
-    for op in mate_cigar.iter().flatten() {
-        let kind_char = match op.kind() {
-            Kind::Match => 'M',
-            Kind::Insertion => 'I',
-            Kind::Deletion => 'D',
-            Kind::Skip => 'N',
-            Kind::SoftClip => 'S',
-            Kind::HardClip => 'H',
-            Kind::Pad => 'P',
-            Kind::SequenceMatch => '=',
-            Kind::SequenceMismatch => 'X',
-        };
-        let _ = write!(cigar_string, "{}{}", op.len(), kind_char);
-    }
+    // Update MQ tag: mate mapping quality
+    let mapq = mate.mapq();
+    editor.update_int(b"MQ", i32::from(mapq));
+}
 
-    let mc_tag = Tag::from([b'M', b'C']);
-    let _ = record.data_mut().insert(mc_tag, cigar_string.into());
-
-    // Update MQ tag (mate mapping quality)
-    if let Some(mate_mapq) = mate.mapping_quality() {
-        let mq_tag = Tag::from([b'M', b'Q']);
-        let mapq_value: u8 = mate_mapq.into();
-        let _ = record.data_mut().insert(mq_tag, (mapq_value as i32).into());
-    }
+/// Returns the number of clipped bases (soft + hard) in a raw record's CIGAR.
+fn clipped_bases_raw(record: &RawRecord) -> usize {
+    record
+        .cigar_ops_typed()
+        .filter(|op| {
+            matches!(
+                op.kind(),
+                fgumi_raw_bam::CigarKind::SoftClip | fgumi_raw_bam::CigarKind::HardClip
+            )
+        })
+        .map(|op| op.len() as usize)
+        .sum()
 }
 
 #[cfg(test)]
@@ -908,7 +892,11 @@ mod tests {
     #[test]
     fn test_default_clip_parameters() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -936,7 +924,11 @@ mod tests {
     #[test]
     fn test_clip_with_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -965,7 +957,11 @@ mod tests {
     #[test]
     fn test_clip_with_overlapping_enabled() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -993,7 +989,11 @@ mod tests {
     #[test]
     fn test_clip_with_metrics_output() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: false,
@@ -1021,7 +1021,11 @@ mod tests {
     #[test]
     fn test_clip_with_tag_regeneration() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1048,7 +1052,11 @@ mod tests {
     #[test]
     fn test_clip_all_modes_enabled() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1080,7 +1088,11 @@ mod tests {
     fn test_clipping_mode_enum_values() {
         // Test that clipping_mode enum variants are set properly
         let soft = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1106,7 +1118,11 @@ mod tests {
     #[test]
     fn test_clip_with_sort_order_specification() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1132,7 +1148,11 @@ mod tests {
     #[test]
     fn test_clip_asymmetric_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,
@@ -1162,7 +1182,11 @@ mod tests {
     #[test]
     fn test_clip_with_upgrade_all_clipping() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1190,7 +1214,11 @@ mod tests {
     #[test]
     fn test_clip_extending_past_mate_only() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1218,7 +1246,11 @@ mod tests {
     #[test]
     fn test_clip_overlapping_reads_only() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1246,7 +1278,11 @@ mod tests {
     #[test]
     fn test_clip_modes_with_auto_clip_attributes() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1274,7 +1310,11 @@ mod tests {
     #[test]
     fn test_clip_zero_bases_all_positions() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1304,7 +1344,11 @@ mod tests {
     #[test]
     fn test_clip_soft_with_mask_mode() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: true,
@@ -1332,7 +1376,11 @@ mod tests {
     #[test]
     fn test_clip_large_fixed_positions() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1362,7 +1410,11 @@ mod tests {
     #[test]
     fn test_clip_combination_overlapping_and_fixed() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1391,7 +1443,11 @@ mod tests {
     #[test]
     fn test_clip_all_three_modes_comparison() {
         let soft = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,
@@ -1412,7 +1468,11 @@ mod tests {
         };
 
         let soft_mask = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: false,
@@ -1433,7 +1493,11 @@ mod tests {
         };
 
         let hard = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1462,7 +1526,11 @@ mod tests {
     #[test]
     fn test_clip_with_queryname_sort_order() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1488,7 +1556,11 @@ mod tests {
     #[test]
     fn test_clip_with_unsorted_sort_order() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1514,7 +1586,11 @@ mod tests {
     #[test]
     fn test_clip_single_read_end_clipping() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1544,7 +1620,11 @@ mod tests {
     #[test]
     fn test_clip_with_metrics_and_upgrade() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1572,7 +1652,11 @@ mod tests {
     #[test]
     fn test_clip_both_extending_and_overlapping() {
         let clip = Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1599,7 +1683,6 @@ mod tests {
     // Integration tests
     use crate::sam::SamBuilder;
     use anyhow::Result;
-    use noodles::sam::alignment::record_buf::RecordBuf;
     use tempfile::TempDir;
 
     fn create_test_reference(dir: &TempDir) -> PathBuf {
@@ -1614,7 +1697,7 @@ mod tests {
         ref_path
     }
 
-    fn read_bam_records(path: &std::path::Path) -> Result<Vec<RecordBuf>> {
+    fn read_bam_records(path: &std::path::Path) -> Result<Vec<noodles::sam::alignment::RecordBuf>> {
         let mut reader = noodles::bam::io::reader::Builder.build_from_path(path)?;
         let header = reader.read_header()?;
         let records: Vec<_> = reader.record_bufs(&header).collect::<std::io::Result<Vec<_>>>()?;
@@ -1642,7 +1725,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1689,7 +1776,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: true,
@@ -1735,7 +1826,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::SoftWithMask,
             clip_overlapping_reads: true,
@@ -1781,7 +1876,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1827,7 +1926,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1873,7 +1976,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -1920,7 +2027,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -1967,7 +2078,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2013,7 +2128,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -2060,7 +2179,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2107,7 +2230,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2154,7 +2281,7 @@ mod tests {
         builder.write(&input_path).expect("failed to write test BAM");
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path),
+            io: BamIoOptions { input: input_path, output: output_path, async_reader: false },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: false,
@@ -2207,7 +2334,11 @@ mod tests {
         builder.write(&input_path)?;
 
         let clip = Clip {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: ref_path,
             clipping_mode: ClippingMode::Hard,
             clip_overlapping_reads: true,
@@ -2236,10 +2367,8 @@ mod tests {
 
     #[test]
     fn test_clip_processed_batch_memory_estimate() {
-        use crate::sam::builder::RecordBuilder;
-        use noodles::sam::alignment::record_buf::RecordBuf;
-
-        let record = RecordBuilder::new().sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
+        let record =
+            fgumi_raw_bam::SamBuilder::new().sequence(b"ACGT").qualities(&[30, 30, 30, 30]).build();
         let mut records = Vec::with_capacity(10);
         records.push(record);
 
@@ -2251,11 +2380,11 @@ mod tests {
         };
 
         let estimate = batch.estimate_heap_size();
-        // Should include Vec overhead for capacity * size_of::<RecordBuf>()
-        let vec_overhead = 10 * std::mem::size_of::<RecordBuf>();
+        // Should include Vec overhead for capacity * size_of::<RawRecord>()
+        let vec_overhead = 10 * std::mem::size_of::<RawRecord>();
         assert!(
             estimate >= vec_overhead,
-            "estimate {estimate} should include Vec<RecordBuf> overhead {vec_overhead}"
+            "estimate {estimate} should include Vec<RawRecord> overhead {vec_overhead}"
         );
     }
 
@@ -2268,7 +2397,11 @@ mod tests {
         read_two_three_prime: usize,
     ) -> Clip {
         Clip {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: PathBuf::from("reference.fa"),
             clipping_mode: ClippingMode::Soft,
             clip_overlapping_reads: false,
@@ -2291,22 +2424,21 @@ mod tests {
 
     #[test]
     fn test_clip_fragment_with_metrics() {
-        use crate::clipper::{ClippingMode, SamRecordClipper};
         use crate::metrics::clip::ClippingMetricsCollection;
-        use crate::sam::builder::RecordBuilder;
 
         let clip = make_clip(3, 2, 0, 0);
-        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let clipper = RawRecordClipper::new(ClippingMode::Soft);
         let mut metrics = ClippingMetricsCollection::new();
 
         // Build a mapped fragment record with 20M CIGAR
-        let mut record = RecordBuilder::new()
-            .sequence("ACGTACGTACGTACGTACGT")
+        // SamBuilder pos is 0-based; alignment_start 100 → pos 99
+        let mut record = fgumi_raw_bam::SamBuilder::new()
+            .sequence(b"ACGTACGTACGTACGTACGT")
             .qualities(&[30; 20])
-            .cigar("20M")
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
+            .cigar_ops(&[20u32 << 4]) // 20M
+            .ref_id(0)
+            .pos(99) // 0-based (alignment_start 100)
+            .mapq(60)
             .build();
 
         clip.clip_fragment(&clipper, &mut record, Some(&mut metrics))
@@ -2322,23 +2454,20 @@ mod tests {
 
     #[test]
     fn test_clip_fragment_no_clipping_with_metrics() {
-        use crate::clipper::{ClippingMode, SamRecordClipper};
         use crate::metrics::clip::ClippingMetricsCollection;
-        use crate::sam::builder::RecordBuilder;
 
         let clip = make_clip(0, 0, 0, 0);
-        // Need at least one clipping option active for the Clip struct to be valid,
-        // but clip_fragment only uses read_one_*; we just test the method directly.
-        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        // clip_fragment only uses read_one_*; we just test the method directly.
+        let clipper = RawRecordClipper::new(ClippingMode::Soft);
         let mut metrics = ClippingMetricsCollection::new();
 
-        let mut record = RecordBuilder::new()
-            .sequence("ACGTACGTACGT")
+        let mut record = fgumi_raw_bam::SamBuilder::new()
+            .sequence(b"ACGTACGTACGT")
             .qualities(&[30; 12])
-            .cigar("12M")
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
+            .cigar_ops(&[12u32 << 4]) // 12M
+            .ref_id(0)
+            .pos(99) // 0-based (alignment_start 100)
+            .mapq(60)
             .build();
 
         clip.clip_fragment(&clipper, &mut record, Some(&mut metrics))
@@ -2352,44 +2481,41 @@ mod tests {
 
     #[test]
     fn test_clip_pair_with_metrics() {
-        use crate::clipper::{ClippingMode, SamRecordClipper};
         use crate::metrics::clip::ClippingMetricsCollection;
-        use crate::sam::builder::RecordBuilder;
+        use fgumi_raw_bam::flags as raw_flags;
 
         let clip = make_clip(2, 1, 1, 2);
-        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let clipper = RawRecordClipper::new(ClippingMode::Soft);
         let mut metrics = ClippingMetricsCollection::new();
 
         // R1: first segment, forward strand, 20M
-        let mut r1 = RecordBuilder::new()
-            .name("pair1")
-            .sequence("ACGTACGTACGTACGTACGT")
+        // SamBuilder pos is 0-based; alignment_start 100 → pos 99
+        let mut r1 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"pair1")
+            .sequence(b"ACGTACGTACGTACGTACGT")
             .qualities(&[30; 20])
-            .cigar("20M")
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
+            .cigar_ops(&[20u32 << 4]) // 20M
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99) // 0-based (alignment_start 100)
+            .mapq(60)
+            .mate_ref_id(0)
+            .mate_pos(199) // 0-based (mate_alignment_start 200)
             .template_length(120)
             .build();
 
         // R2: last segment, reverse strand, 20M (non-overlapping)
-        let mut r2 = RecordBuilder::new()
-            .name("pair1")
-            .sequence("ACGTACGTACGTACGTACGT")
+        let mut r2 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"pair1")
+            .sequence(b"ACGTACGTACGTACGTACGT")
             .qualities(&[30; 20])
-            .cigar("20M")
-            .paired(true)
-            .first_segment(false)
-            .reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
+            .cigar_ops(&[20u32 << 4]) // 20M
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+            .ref_id(0)
+            .pos(199) // 0-based (alignment_start 200)
+            .mapq(60)
+            .mate_ref_id(0)
+            .mate_pos(99) // 0-based (mate_alignment_start 100)
             .template_length(-120)
             .build();
 
@@ -2413,46 +2539,42 @@ mod tests {
 
     #[test]
     fn test_clip_pair_with_metrics_swapped_flags() {
-        use crate::clipper::{ClippingMode, SamRecordClipper};
         use crate::metrics::clip::ClippingMetricsCollection;
-        use crate::sam::builder::RecordBuilder;
+        use fgumi_raw_bam::flags as raw_flags;
 
         // Test the !is_r1_first and !is_r2_last branches:
         // r1 is NOT first_segment, r2 is NOT last_segment
         let clip = make_clip(2, 1, 1, 2);
-        let clipper = SamRecordClipper::new(ClippingMode::Soft);
+        let clipper = RawRecordClipper::new(ClippingMode::Soft);
         let mut metrics = ClippingMetricsCollection::new();
 
         // r1: last segment (not first)
-        let mut r1 = RecordBuilder::new()
-            .name("pair1")
-            .sequence("ACGTACGTACGTACGTACGT")
+        let mut r1 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"pair1")
+            .sequence(b"ACGTACGTACGTACGTACGT")
             .qualities(&[30; 20])
-            .cigar("20M")
-            .paired(true)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
+            .cigar_ops(&[20u32 << 4]) // 20M
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT)
+            .ref_id(0)
+            .pos(99) // 0-based (alignment_start 100)
+            .mapq(60)
+            .mate_ref_id(0)
+            .mate_pos(199) // 0-based (mate_alignment_start 200)
             .template_length(120)
             .build();
 
         // r2: first segment (not last)
-        let mut r2 = RecordBuilder::new()
-            .name("pair1")
-            .sequence("ACGTACGTACGTACGTACGT")
+        let mut r2 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"pair1")
+            .sequence(b"ACGTACGTACGTACGTACGT")
             .qualities(&[30; 20])
-            .cigar("20M")
-            .paired(true)
-            .first_segment(true)
-            .reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
+            .cigar_ops(&[20u32 << 4]) // 20M
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::REVERSE)
+            .ref_id(0)
+            .pos(199) // 0-based (alignment_start 200)
+            .mapq(60)
+            .mate_ref_id(0)
+            .mate_pos(99) // 0-based (mate_alignment_start 100)
             .template_length(-120)
             .build();
 

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -27,7 +27,7 @@ use crate::consensus::codec_caller::{
 };
 use crate::consensus_caller::{ConsensusCaller, ConsensusOutput};
 use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
+use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
 use crate::progress::ProgressTracker;
 use crate::read_info::LibraryIndex;
 use crate::unified_pipeline::{
@@ -262,23 +262,6 @@ impl Command for Codec {
         // Note: Unlike simplex/duplex, CODEC does not support overlapping consensus calling
         // (matching fgbio's CallCodecConsensusReads which has no such option).
 
-        // Open input BAM using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
-
-        // Create output header for unmapped consensus reads
-        let output_header = create_unmapped_consensus_header(
-            &header,
-            &self.read_group.read_group_id,
-            "Read group",
-            command_line,
-        )?;
-
-        // Use library name from header if no prefix is specified (like fgbio)
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-
         // Parse cell tag
         let cell_tag = Tag::from(SamTag::CB);
 
@@ -292,23 +275,43 @@ impl Command for Codec {
         // --threads N mode: Use 7-step unified pipeline
         // None: Use single-threaded fast path
         // ============================================================
-        // IMPORTANT: Check this BEFORE creating any output file handles to avoid
-        // file handle conflicts that can corrupt the output.
+        // IMPORTANT: Check threading BEFORE opening any reader so we only open
+        // the input once — opening twice wastes I/O and breaks stdin streaming.
         if let Some(threads) = self.threading.threads {
+            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+            )?;
+            let output_header = create_unmapped_consensus_header(
+                &header,
+                &self.read_group.read_group_id,
+                "Read group",
+                command_line,
+            )?;
+            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
+
             let result = self.execute_threads_mode(
                 threads,
                 reader,
-                header.clone(),
+                header,
                 output_header,
-                read_name_prefix.clone(),
+                read_name_prefix,
                 track_rejects,
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
         }
 
-        // Drop the reader for single-threaded mode - we use MiGroupIterator which needs its own reader
-        drop(reader);
+        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        let (mut raw_reader, header) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        let output_header = create_unmapped_consensus_header(
+            &header,
+            &self.read_group.read_group_id,
+            "Read group",
+            command_line,
+        )?;
+        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
 
         // ============================================================
         // For non-pipeline modes, create output writers here
@@ -356,9 +359,7 @@ impl Command for Codec {
         let mut record_count: usize = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        // Use the raw_reader opened above (single input open).
         let raw_record_iter = std::iter::from_fn(move || {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
@@ -367,8 +368,7 @@ impl Command for Codec {
                 Err(e) => Some(Err(e.into())),
             }
         });
-        let mi_group_iter =
-            RawMiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*b"CB"));
+        let mi_group_iter = MiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*b"CB"));
 
         let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
             read_name_prefix,
@@ -380,7 +380,7 @@ impl Command for Codec {
         for result in mi_group_iter {
             let (umi, records) = result.context("Failed to read MI group")?;
 
-            // Call consensus — mi_group yields Vec<RawRecord>.
+            // Call consensus directly — records are already RawRecord values.
             let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
             match result {
                 Ok(output) => {
@@ -538,9 +538,8 @@ impl Codec {
         // Clone input_header before pipeline (needed for rejects writing)
         let rejects_header = input_header.clone();
 
-        // Enable raw-byte mode: skip noodles decode/encode for CPU savings
         let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw(library_index, cell_tag));
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
         let groups_processed = run_bam_pipeline_from_reader(
@@ -549,13 +548,13 @@ impl Codec {
             input_header,
             &self.io.output,
             Some(output_header.clone()),
-            // ========== grouper_fn: Create RawMiGrouper ==========
+            // ========== grouper_fn: Create MiGrouper ==========
             move |_header: &Header| {
-                Box::new(RawMiGrouper::new("MI", batch_size))
-                    as Box<dyn Grouper<Group = RawMiGroupBatch> + Send>
+                Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*b"CB")))
+                    as Box<dyn Grouper<Group = MiGroupBatch> + Send>
             },
             // ========== process_fn: CODEC consensus calling ==========
-            move |batch: RawMiGroupBatch| -> io::Result<CodecProcessedBatch> {
+            move |batch: MiGroupBatch| -> io::Result<CodecProcessedBatch> {
                 // Create per-thread CODEC consensus caller
                 let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
                     read_name_prefix.clone(),
@@ -569,10 +568,10 @@ impl Codec {
                 let mut batch_stats = CodecConsensusStats::default();
                 let groups_count = batch.groups.len() as u64;
 
-                for RawMiGroup { mi, records } in batch.groups {
+                for MiGroup { mi, records } in batch.groups {
                     caller.clear();
 
-                    // Call CODEC consensus — mi_group yields Vec<RawRecord>.
+                    // Call CODEC consensus directly — records are already RawRecord values.
                     let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
                     match result {
                         Ok(batch_output) => {
@@ -583,11 +582,17 @@ impl Codec {
                             }
                         }
                         Err(e) => {
-                            // Handle duplex disagreement errors by merging stats
+                            // Handle duplex disagreement errors by merging stats and
+                            // preserving rejects so --rejects output matches single-threaded mode.
                             if e.to_string().contains("duplex disagreement") {
                                 batch_stats.merge(caller.statistics());
+                                if track_rejects {
+                                    all_rejects.extend(caller.take_rejected_reads());
+                                }
                             } else {
-                                log::warn!("CODEC consensus error for MI {mi}: {e}");
+                                return Err(io::Error::other(format!(
+                                    "CODEC consensus error for MI {mi}: {e}"
+                                )));
                             }
                         }
                     }
@@ -698,7 +703,7 @@ mod tests {
     /// Helper to create a Codec with specified input/output paths
     fn create_codec_with_paths(input: PathBuf, output: PathBuf) -> Codec {
         Codec {
-            io: BamIoOptions::new(input, output),
+            io: BamIoOptions { input, output, async_reader: false },
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions::default(),
@@ -776,14 +781,21 @@ mod tests {
     }
 
     // Integration tests
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+    };
     use noodles::sam::Header;
-    use noodles::sam::alignment::record::Flags;
     use noodles::sam::alignment::record_buf::RecordBuf;
     use tempfile::TempDir;
 
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> RecordBuf {
+        raw_record_to_record_buf(&raw, &Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
+
     /// Helper to create a CODEC-style FR read pair with proper overlap
     /// R1 forward at start1, R2 reverse at start2, with `read_len` bases each
+    #[allow(clippy::cast_possible_truncation)]
     fn create_codec_fr_pair_overlapping(
         mi_value: &str,
         start1: usize,
@@ -792,65 +804,61 @@ mod tests {
         quals: &[u8],
     ) -> (RecordBuf, RecordBuf) {
         // Use a simple reference-matching sequence
-        let seq_forward = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let seq_forward = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
         let seq = &seq_forward[..read_len];
 
         // For R2 reverse, we need the reverse complement
-        let seq_rc: String = seq
-            .chars()
+        let seq_rc: Vec<u8> = seq
+            .iter()
             .rev()
-            .map(|c| match c {
-                'A' => 'T',
-                'T' => 'A',
-                'C' => 'G',
-                'G' => 'C',
-                _ => c,
+            .map(|&c| match c {
+                b'A' => b'T',
+                b'T' => b'A',
+                b'C' => b'G',
+                b'G' => b'C',
+                other => other,
             })
             .collect();
 
         let insert_size: i32 = (start2 + read_len) as i32 - start1 as i32;
+        let cigar = encode_op(0, read_len);
+        // R1: PAIRED | PROPERLY_SEGMENTED | FIRST_SEGMENT | MATE_REVERSE = 0x1|0x2|0x40|0x20 = 99
+        const PROPERLY_PAIRED: u16 = 0x2;
+        let r1_flags = flags::PAIRED | PROPERLY_PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE;
+        // R2: PAIRED | PROPERLY_SEGMENTED | LAST_SEGMENT | REVERSE = 0x1|0x2|0x80|0x10 = 147
+        let r2_flags = flags::PAIRED | PROPERLY_PAIRED | flags::LAST_SEGMENT | flags::REVERSE;
 
-        // R1: Forward strand, first segment
-        let r1 = RecordBuilder::new()
-            .name(&format!("read_{mi_value}"))
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(format!("read_{mi_value}").as_bytes())
+            .flags(r1_flags)
+            .ref_id(0)
+            .pos(start1 as i32 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
             .sequence(seq)
             .qualities(quals)
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::PROPERLY_SEGMENTED
-                    | Flags::FIRST_SEGMENT
-                    | Flags::MATE_REVERSE_COMPLEMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(start1)
-            .cigar(&format!("{read_len}M"))
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(start2)
-            .template_length(insert_size)
-            .tag("MI", mi_value)
-            .tag("RG", "A")
-            .build();
+            .mate_ref_id(0)
+            .mate_pos(start2 as i32 - 1)
+            .template_length(insert_size);
+        b1.add_string_tag(b"MI", mi_value.as_bytes());
+        b1.add_string_tag(b"RG", b"A");
+        let r1 = to_record_buf(b1.build());
 
-        // R2: Reverse strand, last segment (stored as revcomp in BAM)
-        let r2 = RecordBuilder::new()
-            .name(&format!("read_{mi_value}"))
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(format!("read_{mi_value}").as_bytes())
+            .flags(r2_flags)
+            .ref_id(0)
+            .pos(start2 as i32 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
             .sequence(&seq_rc)
             .qualities(quals)
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::PROPERLY_SEGMENTED
-                    | Flags::LAST_SEGMENT
-                    | Flags::REVERSE_COMPLEMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(start2)
-            .cigar(&format!("{read_len}M"))
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(start1)
-            .template_length(-insert_size)
-            .tag("MI", mi_value)
-            .tag("RG", "A")
-            .build();
+            .mate_ref_id(0)
+            .mate_pos(start1 as i32 - 1)
+            .template_length(-insert_size);
+        b2.add_string_tag(b"MI", mi_value.as_bytes());
+        b2.add_string_tag(b"RG", b"A");
+        let r2 = to_record_buf(b2.build());
 
         (r1, r2)
     }

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -16,10 +16,11 @@
 //! };
 //!
 //! let corrector = CorrectUmis {
-//!     io: BamIoOptions::new(
-//!         PathBuf::from("input.bam"),
-//!         PathBuf::from("corrected.bam"),
-//!     ),
+//!     io: BamIoOptions {
+//!         input: PathBuf::from("input.bam"),
+//!         output: PathBuf::from("corrected.bam"),
+//!         async_reader: false,
+//!     },
 //!     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 //!     metrics: Some(PathBuf::from("metrics.txt")),
 //!     max_mismatches: 2,
@@ -119,10 +120,11 @@ pub struct UmiMatch {
 /// # };
 /// # use std::path::PathBuf;
 /// let corrector = CorrectUmis {
-///     io: BamIoOptions::new(
-///         PathBuf::from("input.bam"),
-///         PathBuf::from("corrected.bam"),
-///     ),
+///     io: BamIoOptions {
+///         input: PathBuf::from("input.bam"),
+///         output: PathBuf::from("corrected.bam"),
+///         async_reader: false,
+///     },
 ///     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 ///     metrics: Some(PathBuf::from("metrics.txt")),
 ///     max_mismatches: 2,
@@ -373,7 +375,7 @@ impl Command for CorrectUmis {
     /// # use crate::commands::command::Command;
     /// let corrector = CorrectUmis {
     ///     /* ... field initialization ... */
-    /// #   io: BamIoOptions::new(PathBuf::new(), PathBuf::new()),
+    /// #   io: BamIoOptions { input: PathBuf::new(), output: PathBuf::new(), async_reader: false },
     /// #   rejects_opts: RejectsOptions::default(),
     /// #   metrics: None,
     /// #   max_mismatches: 2,
@@ -848,13 +850,8 @@ impl CorrectUmis {
                     // Count input records BEFORE processing
                     total_input_records += template.read_count() as u64;
 
-                    debug_assert!(
-                        template.is_raw_byte_mode(),
-                        "Expected raw-byte mode template in pipeline; RecordBuf mode is no longer supported"
-                    );
                     {
-                        let raw_records: Vec<RawRecord> =
-                            template.into_raw_records().unwrap_or_default();
+                        let raw_records: Vec<RawRecord> = template.into_records();
                         let umi_opt = Self::extract_and_validate_template_umi_raw(
                             &raw_records,
                             umi_tag_bytes,
@@ -1733,7 +1730,9 @@ mod tests {
     ///
     /// Returns an error if BAM file creation or writing fails.
     fn create_test_bam(records: Vec<(&str, Option<&str>)>) -> Result<NamedTempFile> {
-        use crate::sam::builder::RecordBuilder;
+        use fgumi_raw_bam::{
+            SamBuilder as RawSamBuilder, raw_record_to_record_buf, testutil::encode_op,
+        };
         use noodles::sam::header::record::value::map::Map;
 
         let temp_file = NamedTempFile::new()?;
@@ -1753,19 +1752,20 @@ mod tests {
         writer.write_header(&header)?;
 
         for (name, umi) in records {
-            let mut builder = RecordBuilder::new()
-                .name(name)
-                .sequence("AAAAAAAAAA")
-                .qualities(&[40u8; 10]) // 'I' is Phred+33 = 40
-                .reference_sequence_id(0)
-                .alignment_start(1)
-                .mapping_quality(60);
-
+            let mut b = RawSamBuilder::new();
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 10)])
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[40u8; 10]);
             if let Some(umi_seq) = umi {
-                builder = builder.tag("RX", umi_seq);
+                b.add_string_tag(b"RX", umi_seq.as_bytes());
             }
-
-            let record = builder.build();
+            let raw = b.build();
+            let record = raw_record_to_record_buf(&raw, &sam::Header::default())
+                .expect("raw_record_to_record_buf failed");
             writer.write_alignment_record(&header, &record)?;
         }
 
@@ -1808,7 +1808,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input_file.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input_file.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -1839,10 +1843,11 @@ mod tests {
         let temp_output = NamedTempFile::new().expect("failed to create temp file");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(
-                temp_input.path().to_path_buf(),
-                temp_output.path().to_path_buf(),
-            ),
+            io: BamIoOptions {
+                input: temp_input.path().to_path_buf(),
+                output: temp_output.path().to_path_buf(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -1870,7 +1875,11 @@ mod tests {
         let rejects = dir.path().join("rejects.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -1916,7 +1925,11 @@ mod tests {
         let metrics = dir.path().join("metrics.txt");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: Some(metrics.clone()),
             max_mismatches: 3,
@@ -1978,7 +1991,11 @@ mod tests {
         let rejects = dir.path().join("rejects.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
             max_mismatches: 3,
@@ -2034,7 +2051,11 @@ mod tests {
 
         // Run with command line UMIs
         let corrector1 = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output1.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output1.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics1.clone()),
             max_mismatches: 3,
@@ -2059,7 +2080,11 @@ mod tests {
 
         // Run with UMI file
         let corrector2 = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output2.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output2.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics2.clone()),
             max_mismatches: 3,
@@ -2100,7 +2125,11 @@ mod tests {
 
         // Test with original UMI storage (default)
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2139,7 +2168,11 @@ mod tests {
         // Test with original UMI storage disabled
         let output2 = dir.path().join("output2.bam");
         let corrector2 = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output2.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output2.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2179,7 +2212,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2232,7 +2269,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 0, // Exact match only
@@ -2276,7 +2317,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 2,
@@ -2331,7 +2376,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -2372,7 +2421,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 2,
@@ -2412,7 +2465,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
             max_mismatches: 1,
@@ -2451,7 +2508,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 1,
@@ -2484,7 +2545,11 @@ mod tests {
         let output2 = paths.output_n(2);
 
         let corrector2 = CorrectUmis {
-            io: BamIoOptions::new(input2.path().to_path_buf(), output2.clone()),
+            io: BamIoOptions {
+                input: input2.path().to_path_buf(),
+                output: output2.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 1,
@@ -2521,7 +2586,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 0, // Exact match
@@ -2569,7 +2638,11 @@ mod tests {
 
         // Run with 4 threads to test parallel processing order
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2627,7 +2700,11 @@ mod tests {
         let output = dir.path().join("output.bam");
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -2785,7 +2862,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1, // Strict matching
@@ -2840,7 +2921,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1,
@@ -2925,7 +3010,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 1,
@@ -2993,7 +3082,11 @@ mod tests {
         let output = NamedTempFile::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), output.path().to_path_buf()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: output.path().to_path_buf(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
             max_mismatches: 2,
@@ -3210,32 +3303,76 @@ mod tests {
     /// - Template 2 ("t2"): UMI "CCCCCC" (exact match) is unchanged, no OX tag
     #[test]
     fn test_single_thread_mode_produces_correct_output() -> Result<()> {
-        use crate::sam::builder::SamBuilder;
-        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use fgumi_raw_bam::{
+            SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+        };
+        use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+        use std::num::NonZeroUsize;
 
-        let mut builder = SamBuilder::new();
-        let _ = builder
-            .add_pair()
-            .name("t1")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .attr("RX", BufValue::from("AAAAAG"))
-            .build();
-        let _ = builder
-            .add_pair()
-            .name("t2")
-            .contig(0)
-            .start1(300)
-            .start2(400)
-            .attr("RX", BufValue::from("CCCCCC"))
+        let header = sam::Header::builder()
+            .add_reference_sequence(
+                "chr1",
+                Map::<ReferenceSequence>::new(
+                    NonZeroUsize::new(248_956_422).expect("non-zero chr1 length"),
+                ),
+            )
             .build();
 
-        let input = builder.to_temp_file()?;
+        let input = {
+            let temp = tempfile::NamedTempFile::new()?;
+            let mut writer = noodles::bam::io::writer::Builder.build_from_path(temp.path())?;
+            writer.write_header(&header)?;
+
+            let cigar = encode_op(0, 100); // 100M
+            let seq = vec![b'A'; 100];
+            let quals = vec![30u8; 100];
+
+            for (pos1, pos2, name, umi) in
+                [(99i32, 199i32, "t1", "AAAAAG"), (299i32, 399i32, "t2", "CCCCCC")]
+            {
+                let mut b1 = RawSamBuilder::new();
+                b1.read_name(name.as_bytes())
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                    .ref_id(0)
+                    .pos(pos1)
+                    .mapq(60)
+                    .cigar_ops(&[cigar])
+                    .sequence(&seq)
+                    .qualities(&quals)
+                    .mate_ref_id(0)
+                    .mate_pos(pos2);
+                b1.add_string_tag(b"RX", umi.as_bytes());
+                let r1 = raw_record_to_record_buf(&b1.build(), &header)?;
+                writer.write_alignment_record(&header, &r1)?;
+
+                let mut b2 = RawSamBuilder::new();
+                b2.read_name(name.as_bytes())
+                    .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                    .ref_id(0)
+                    .pos(pos2)
+                    .mapq(60)
+                    .cigar_ops(&[cigar])
+                    .sequence(&seq)
+                    .qualities(&quals)
+                    .mate_ref_id(0)
+                    .mate_pos(pos1);
+                b2.add_string_tag(b"RX", umi.as_bytes());
+                let r2 = raw_record_to_record_buf(&b2.build(), &header)?;
+                writer.write_alignment_record(&header, &r2)?;
+            }
+            writer.try_finish()?;
+            temp
+        };
+
+        let input = input;
         let paths = TestPaths::new()?;
 
         let corrector = CorrectUmis {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
             max_mismatches: 2,

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -30,25 +30,21 @@ use crate::logging::OperationTimer;
 use crate::metrics::group::FamilySizeMetrics;
 use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
-use crate::sam::{is_template_coordinate_sorted, unclipped_five_prime_position};
-use crate::template::{MoleculeId, Template};
+use crate::sam::is_template_coordinate_sorted;
+use crate::template::Template;
 use crate::umi::{UmiValidation, validate_umi};
 use crate::unified_pipeline::{
     BatchWeight, GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-    serialize_bam_records_into,
 };
 use crate::validation::validate_file_exists;
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
-use bstr::BString;
 use clap::Parser;
 use fgoxide::io::DelimFile;
 
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::record::Flags;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -87,7 +83,7 @@ pub struct DedupMetrics {
     pub secondary_reads: u64,
     /// Supplementary reads processed
     pub supplementary_reads: u64,
-    /// Secondary/supplementary without tc tag
+    /// Secondary/supplementary without `tc` tag
     pub missing_tc_tag: u64,
     /// Filter metrics from position grouping
     pub filter_metrics: FilterMetrics,
@@ -225,38 +221,13 @@ struct DedupFilterConfig {
 /// Scores a template for duplicate selection.
 /// Higher score = more likely to be chosen as representative.
 ///
-/// Scoring is based on sum of base qualities from primary reads,
-/// matching HTSJDK/Picard's `SUM_OF_BASE_QUALITIES` strategy.
+/// Sums base qualities from primary reads (R1 and R2), capping each quality at 15
+/// per base to match Picard/HTSJDK's `SUM_OF_BASE_QUALITIES` strategy.
 #[inline]
 fn score_template(template: &Template) -> i64 {
-    if template.is_raw_byte_mode() {
-        return score_template_raw(template);
-    }
-
     let mut score: u32 = 0;
 
-    // Score R1 primary
-    if let Some(r1) = template.r1() {
-        score += sum_base_qualities(r1);
-    }
-
-    // Score R2 primary
-    if let Some(r2) = template.r2() {
-        score += sum_base_qualities(r2);
-    }
-
-    i64::from(score)
-}
-
-/// Raw-byte version of `score_template`. Sums base qualities from raw BAM bytes,
-/// capping each quality at 15 per base (matching Picard/HTSJDK behavior).
-#[inline]
-fn score_template_raw(template: &Template) -> i64 {
-    use crate::sort::bam_fields;
-
-    let mut score: u32 = 0;
-
-    for raw in [template.raw_r1(), template.raw_r2()].into_iter().flatten() {
+    for raw in [template.r1(), template.r2()].into_iter().flatten() {
         if raw.len() < 32 {
             continue;
         }
@@ -274,29 +245,19 @@ fn score_template_raw(template: &Template) -> i64 {
     i64::from(score)
 }
 
-/// Sums base qualities for a record, capping at 15 per base (like Picard).
-///
-/// Uses u32 accumulator for faster arithmetic. u32 is sufficient for reads
-/// up to ~286 million bases (2^32 / 15), far exceeding any real read length.
-#[inline]
-fn sum_base_qualities(record: &noodles::sam::alignment::RecordBuf) -> u32 {
-    record.quality_scores().as_ref().iter().map(|&q| u32::from(std::cmp::min(q, 15))).sum()
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // Template filtering (adapted from group command)
 //////////////////////////////////////////////////////////////////////////////
 
-/// Raw-byte version of `filter_template`.
-fn filter_template_raw(
+/// Filter a template based on filtering criteria.
+/// Returns true if the template should be kept.
+fn filter_template(
     template: &Template,
     config: &DedupFilterConfig,
     metrics: &mut FilterMetrics,
 ) -> bool {
-    use crate::sort::bam_fields;
-
-    let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-    let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
+    let raw_r1 = template.r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
+    let raw_r2 = template.r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
 
     metrics.total_templates += 1;
 
@@ -398,8 +359,9 @@ fn filter_template_raw(
 
         if check_mq {
             if let Some(mq) = found_mq {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                if (mq as u8) < config.min_mapq {
+                // Compare as signed so a negative MQ (e.g., MQ:c:-1) fails the filter
+                // rather than wrapping to 255 via `as u8`.
+                if mq < i64::from(config.min_mapq) {
                     metrics.discarded_poor_alignment += 1;
                     return false;
                 }
@@ -413,101 +375,6 @@ fn filter_template_raw(
 
         if let Some(umi_bytes) = found_umi {
             match validate_umi(umi_bytes) {
-                UmiValidation::ContainsN => {
-                    metrics.discarded_ns_in_umi += 1;
-                    return false;
-                }
-                UmiValidation::Valid(base_count) => {
-                    if let Some(min_len) = config.min_umi_length {
-                        if base_count < min_len {
-                            metrics.discarded_umi_too_short += 1;
-                            return false;
-                        }
-                    }
-                }
-            }
-        } else {
-            metrics.discarded_poor_alignment += 1;
-            return false;
-        }
-    }
-
-    metrics.accepted_templates += 1;
-    true
-}
-
-/// Filter a template based on filtering criteria.
-/// Returns true if the template should be kept.
-fn filter_template(
-    template: &Template,
-    config: &DedupFilterConfig,
-    metrics: &mut FilterMetrics,
-) -> bool {
-    let r1 = template.r1();
-    let r2 = template.r2();
-
-    metrics.total_templates += 1;
-
-    // Need at least one primary read
-    if r1.is_none() && r2.is_none() {
-        metrics.discarded_poor_alignment += 1;
-        return false;
-    }
-
-    // Check if both reads are unmapped
-    let both_unmapped =
-        r1.is_none_or(|r| r.flags().is_unmapped()) && r2.is_none_or(|r| r.flags().is_unmapped());
-
-    if both_unmapped {
-        metrics.discarded_poor_alignment += 1;
-        return false;
-    }
-
-    // Phase 1: Flag-based checks
-    for record in [r1, r2].into_iter().flatten() {
-        let flags = record.flags();
-
-        // Filter non-PF if requested
-        if !config.include_non_pf && flags.is_qc_fail() {
-            metrics.discarded_non_pf += 1;
-            return false;
-        }
-
-        // Check MAPQ for mapped reads
-        if !flags.is_unmapped() {
-            let mapq = record.mapping_quality().map_or(0, u8::from);
-            if mapq < config.min_mapq {
-                metrics.discarded_poor_alignment += 1;
-                return false;
-            }
-        }
-    }
-
-    // Phase 2: Tag-based checks
-    for record in [r1, r2].into_iter().flatten() {
-        let flags = record.flags();
-
-        // Check mate MAPQ via MQ tag
-        if !flags.is_mate_unmapped() {
-            if let Some(data) = record.data().get(b"MQ") {
-                if let Some(mq) = data.as_int() {
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    if (mq as u8) < config.min_mapq {
-                        metrics.discarded_poor_alignment += 1;
-                        return false;
-                    }
-                }
-            }
-        }
-
-        // Skip UMI validation in no-umi mode
-        if config.no_umi {
-            continue;
-        }
-
-        // Check UMI for Ns and minimum length using common validation
-        if let Some(DataValue::String(umi)) = record.data().get(&config.umi_tag) {
-            match validate_umi(umi) {
                 UmiValidation::ContainsN => {
                     metrics.discarded_ns_in_umi += 1;
                     return false;
@@ -577,41 +444,16 @@ fn umi_for_read(umi: &str, is_r1_earlier: bool, assigner: &dyn UmiAssigner) -> R
 
 /// Get pair orientation for a template.
 fn get_pair_orientation(template: &Template) -> (bool, bool) {
-    if template.is_raw_byte_mode() {
-        return get_pair_orientation_raw(template);
-    }
-    let r1_positive = template.r1().is_none_or(|r| !r.flags().is_reverse_complemented());
-    let r2_positive = template.r2().is_none_or(|r| !r.flags().is_reverse_complemented());
-    (r1_positive, r2_positive)
-}
-
-/// Raw-byte pair orientation using `RawRecordView::flags()`.
-fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
     let r1_positive = template
-        .raw_r1()
+        .r1()
         .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     let r2_positive = template
-        .raw_r2()
+        .r2()
         .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
 
 /// Check if R1 is genomically earlier than R2.
-fn is_r1_genomically_earlier(
-    r1: &noodles::sam::alignment::RecordBuf,
-    r2: &noodles::sam::alignment::RecordBuf,
-) -> Result<bool> {
-    let ref1 = r1.reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-    let ref2 = r2.reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-    if ref1 != ref2 {
-        return Ok(ref1 < ref2);
-    }
-    let r1_pos = unclipped_five_prime_position(r1).unwrap_or(0);
-    let r2_pos = unclipped_five_prime_position(r2).unwrap_or(0);
-    Ok(r1_pos <= r2_pos)
-}
-
-/// Raw-byte version: check if R1 is genomically earlier than R2.
 fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
     let ref1 = bam_fields::ref_id(r1);
     let ref2 = bam_fields::ref_id(r2);
@@ -651,7 +493,6 @@ fn assign_umi_groups_for_indices(
     }
 
     let mut umis = Vec::with_capacity(indices.len());
-    let raw_mode = templates[indices[0]].is_raw_byte_mode();
 
     for &idx in indices {
         let template = &templates[idx];
@@ -660,52 +501,25 @@ fn assign_umi_groups_for_indices(
         let processed_umi = if no_umi {
             String::new()
         } else {
-            let (umi_str_ref, is_r1_earlier) = if raw_mode {
-                let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
-                    let aux = bam_fields::aux_data_slice(r1_raw);
-                    bam_fields::find_string_tag(aux, &raw_tag)
-                } else if let Some(r2_raw) = template.raw_r2() {
-                    let aux = bam_fields::aux_data_slice(r2_raw);
-                    bam_fields::find_string_tag(aux, &raw_tag)
-                } else {
-                    None
-                };
-                let umi_bytes = umi_bytes.ok_or_else(|| anyhow::anyhow!("No UMI tag found"))?;
-                let umi_str = std::str::from_utf8(umi_bytes)
-                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
-                let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
-                    is_r1_genomically_earlier_raw(r1, r2)
-                } else {
-                    true
-                };
-                (umi_str, earlier)
+            let umi_bytes = if let Some(r1_raw) = template.r1() {
+                let aux = bam_fields::aux_data_slice(r1_raw);
+                bam_fields::find_string_tag(aux, &raw_tag)
+            } else if let Some(r2_raw) = template.r2() {
+                let aux = bam_fields::aux_data_slice(r2_raw);
+                bam_fields::find_string_tag(aux, &raw_tag)
             } else {
-                let umi_bytes = if let Some(r1) = template.r1() {
-                    if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
-                        bytes
-                    } else {
-                        bail!("UMI tag is not a string");
-                    }
-                } else if let Some(r2) = template.r2() {
-                    if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
-                        bytes
-                    } else {
-                        bail!("UMI tag is not a string");
-                    }
-                } else {
-                    bail!("Template has no reads");
-                };
-                let umi_str = std::str::from_utf8(umi_bytes)
-                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
-                let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
-                    is_r1_genomically_earlier(r1, r2)?
-                } else {
-                    true
-                };
-                (umi_str, earlier)
+                None
+            };
+            let umi_bytes = umi_bytes.ok_or_else(|| anyhow::anyhow!("No UMI tag found"))?;
+            let umi_str = std::str::from_utf8(umi_bytes)
+                .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
+            let is_r1_earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
+                is_r1_genomically_earlier_raw(r1, r2)
+            } else {
+                true
             };
 
-            umi_for_read(umi_str_ref, is_r1_earlier, assigner)?
+            umi_for_read(umi_str, is_r1_earlier, assigner)?
         };
 
         umis.push(processed_umi);
@@ -834,19 +648,10 @@ fn mark_duplicates_in_family(templates: &mut [&mut Template], dedup_metrics: &mu
 
 /// Marks all reads in a template as duplicates.
 fn mark_template_as_duplicate(template: &mut Template, dedup_metrics: &mut DedupMetrics) {
-    if let Some(raw_records) = template.all_raw_records_mut() {
-        for raw in raw_records.iter_mut() {
-            let flg = RawRecordView::new(raw.as_ref()).flags();
-            bam_fields::set_flags(raw, flg | DUPLICATE_FLAG);
-            dedup_metrics.duplicate_reads += 1;
-        }
-    } else {
-        for record in &mut template.records {
-            let current_flags = u16::from(record.flags());
-            let new_flags = Flags::from(current_flags | DUPLICATE_FLAG);
-            *record.flags_mut() = new_flags;
-            dedup_metrics.duplicate_reads += 1;
-        }
+    for raw in template.records_mut().iter_mut() {
+        let flg = RawRecordView::new(raw.as_ref()).flags();
+        bam_fields::set_flags(raw, flg | DUPLICATE_FLAG);
+        dedup_metrics.duplicate_reads += 1;
     }
 }
 
@@ -871,16 +676,9 @@ fn process_position_group(
 
     // Filter templates
     let mut filter_metrics = FilterMetrics::new();
-    let raw_mode = all_templates.first().is_some_and(Template::is_raw_byte_mode);
     let filtered_templates: Vec<Template> = all_templates
         .into_iter()
-        .filter(|t| {
-            if raw_mode {
-                filter_template_raw(t, filter_config, &mut filter_metrics)
-            } else {
-                filter_template(t, filter_config, &mut filter_metrics)
-            }
-        })
+        .filter(|t| filter_template(t, filter_config, &mut filter_metrics))
         .collect();
 
     dedup_metrics.filter_metrics = filter_metrics;
@@ -899,17 +697,9 @@ fn process_position_group(
     let mut templates: Vec<Template> = filtered_templates
         .into_iter()
         .map(|mut t| {
-            if let Some(raw_records) = t.all_raw_records_mut() {
-                for raw in raw_records.iter_mut() {
-                    let flg = RawRecordView::new(raw.as_ref()).flags();
-                    bam_fields::set_flags(raw, flg & !DUPLICATE_FLAG);
-                }
-            } else {
-                for record in &mut t.records {
-                    let current_flags = u16::from(record.flags());
-                    let new_flags = Flags::from(current_flags & !DUPLICATE_FLAG);
-                    *record.flags_mut() = new_flags;
-                }
+            for raw in t.records_mut().iter_mut() {
+                let flg = RawRecordView::new(raw.as_ref()).flags();
+                bam_fields::set_flags(raw, flg & !DUPLICATE_FLAG);
             }
             t
         })
@@ -965,41 +755,21 @@ fn process_position_group(
     let tc_tag_bytes: [u8; 2] = *TC_TAG.as_ref();
     for template in &templates {
         dedup_metrics.total_templates += 1;
-        if let Some(raw_records) = template.all_raw_records() {
-            for raw in raw_records {
-                dedup_metrics.total_reads += 1;
-                let flg = RawRecordView::new(raw.as_ref()).flags();
-                let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
-                let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
+        for raw in template.records() {
+            dedup_metrics.total_reads += 1;
+            let flg = RawRecordView::new(raw.as_ref()).flags();
+            let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
+            let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
 
-                if is_secondary {
-                    dedup_metrics.secondary_reads += 1;
-                }
-                if is_supplementary {
-                    dedup_metrics.supplementary_reads += 1;
-                }
-                if is_secondary || is_supplementary {
-                    let aux = bam_fields::aux_data_slice(raw);
-                    if bam_fields::find_tag_type(aux, &tc_tag_bytes).is_none() {
-                        dedup_metrics.missing_tc_tag += 1;
-                    }
-                }
+            if is_secondary {
+                dedup_metrics.secondary_reads += 1;
             }
-        } else {
-            for record in &template.records {
-                dedup_metrics.total_reads += 1;
-                let flags = record.flags();
-                let is_secondary = flags.is_secondary();
-                let is_supplementary = flags.is_supplementary();
-
-                if is_secondary {
-                    dedup_metrics.secondary_reads += 1;
-                }
-                if is_supplementary {
-                    dedup_metrics.supplementary_reads += 1;
-                }
-                // Single TC_TAG lookup for both secondary and supplementary
-                if (is_secondary || is_supplementary) && record.data().get(&TC_TAG).is_none() {
+            if is_supplementary {
+                dedup_metrics.supplementary_reads += 1;
+            }
+            if is_secondary || is_supplementary {
+                let aux = bam_fields::aux_data_slice(raw);
+                if bam_fields::find_tag_type(aux, &tc_tag_bytes).is_none() {
                     dedup_metrics.missing_tc_tag += 1;
                 }
             }
@@ -1020,25 +790,6 @@ fn process_position_group(
         input_record_count,
         distinct_mi_count,
     })
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// Set MI tag on record
-//////////////////////////////////////////////////////////////////////////////
-
-/// Set MI tag on a single record.
-#[inline]
-fn set_mi_tag_on_record(
-    record: &mut noodles::sam::alignment::RecordBuf,
-    mi: MoleculeId,
-    assign_tag: Tag,
-    base_mi: u64,
-) {
-    if !mi.is_assigned() {
-        return;
-    }
-    let mi_string = mi.to_string_with_offset(base_mi);
-    record.data_mut().insert(assign_tag, DataValue::String(BString::from(mi_string)));
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1253,9 +1004,8 @@ impl Command for MarkDuplicates {
         info!("Scheduler: {:?}", self.scheduler_opts.strategy());
         info!("Using pipeline with {num_threads} threads");
 
-        // Enable raw-byte mode: skip noodles decode/encode for ~30% CPU savings
         let library_index = LibraryIndex::from_header(&header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw(library_index, cell_tag));
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Counter for contiguous MI assignment (incremented in the serial serialize step).
         let next_mi_base = std::sync::atomic::AtomicU64::new(0);
@@ -1286,7 +1036,7 @@ impl Command for MarkDuplicates {
             },
             // Serialize function (parallel, output ordered by serial numbers)
             move |processed: ProcessedDedupGroup,
-                  header: &Header,
+                  _header: &Header,
                   output: &mut Vec<u8>|
                   -> io::Result<u64> {
                 // Collect metrics
@@ -1306,69 +1056,39 @@ impl Command for MarkDuplicates {
                 // consecutive 0..N-1 (see issue #269).
                 let base_mi = next_mi_base
                     .fetch_add(processed.distinct_mi_count, std::sync::atomic::Ordering::Relaxed);
-                let assign_tag = Tag::from(assign_tag_bytes);
-
                 // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
                 output.reserve(processed.templates.len() * 2 * 400);
                 // Serialize templates
-                let raw_mode = processed.templates.first().is_some_and(Template::is_raw_byte_mode);
-                if raw_mode {
-                    let mut scratch = Vec::with_capacity(512);
-                    let mut mi_buf = String::with_capacity(16);
-                    for template in &processed.templates {
-                        let mi = template.mi;
-                        let has_mi = mi.is_assigned();
-                        if has_mi {
-                            mi.write_with_offset(base_mi, &mut mi_buf);
-                        }
-                        let raw_records = template.all_raw_records();
-                        debug_assert!(
-                            raw_records.is_some(),
-                            "raw_mode template missing raw_records"
-                        );
-                        if let Some(raw_records) = raw_records {
-                            for raw in raw_records {
-                                // Skip duplicates if remove mode
-                                if remove_duplicates
-                                    && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
-                                {
-                                    continue;
-                                }
-                                if has_mi {
-                                    scratch.clear();
-                                    scratch.extend_from_slice(raw);
-                                    bam_fields::update_string_tag(
-                                        &mut scratch,
-                                        &assign_tag_bytes,
-                                        mi_buf.as_bytes(),
-                                    );
-                                    let block_size = scratch.len() as u32;
-                                    output.extend_from_slice(&block_size.to_le_bytes());
-                                    output.extend_from_slice(&scratch);
-                                } else {
-                                    let block_size = raw.len() as u32;
-                                    output.extend_from_slice(&block_size.to_le_bytes());
-                                    output.extend_from_slice(raw);
-                                }
-                            }
-                        }
+                let mut scratch = Vec::with_capacity(512);
+                let mut mi_buf = String::with_capacity(16);
+                for template in &processed.templates {
+                    let mi = template.mi;
+                    let has_mi = mi.is_assigned();
+                    if has_mi {
+                        mi.write_with_offset(base_mi, &mut mi_buf);
                     }
-                } else {
-                    for template in processed.templates {
-                        let mi = template.mi;
-                        for mut record in template.records {
-                            // Skip duplicates if remove mode is enabled
-                            if remove_duplicates
-                                && (u16::from(record.flags()) & DUPLICATE_FLAG) != 0
-                            {
-                                continue;
-                            }
-
-                            // Set MI tag
-                            set_mi_tag_on_record(&mut record, mi, assign_tag, base_mi);
-
-                            // Serialize to output buffer
-                            serialize_bam_records_into(&[record], header, output)?;
+                    for raw in template.records() {
+                        // Skip duplicates if remove mode
+                        if remove_duplicates
+                            && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
+                        {
+                            continue;
+                        }
+                        if has_mi {
+                            scratch.clear();
+                            scratch.extend_from_slice(raw);
+                            bam_fields::update_string_tag(
+                                &mut scratch,
+                                &assign_tag_bytes,
+                                mi_buf.as_bytes(),
+                            );
+                            let block_size = scratch.len() as u32;
+                            output.extend_from_slice(&block_size.to_le_bytes());
+                            output.extend_from_slice(&scratch);
+                        } else {
+                            let block_size = raw.len() as u32;
+                            output.extend_from_slice(&block_size.to_le_bytes());
+                            output.extend_from_slice(raw);
                         }
                     }
                 }
@@ -1450,18 +1170,17 @@ fn write_family_size_histogram(family_sizes: &AHashMap<usize, u64>, path: &PathB
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags, testutil::encode_op};
+    use rstest::rstest;
 
     // Helper to create a simple template for testing
     fn create_test_template(name: &str, qualities: &[u8]) -> Template {
-        let record = RecordBuilder::new()
-            .name(name)
-            .sequence("ACGT")
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(b"ACGT")
             .qualities(qualities)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
-
-        Template::from_records(vec![record]).expect("test template construction should not fail")
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        Template::from_records(vec![b.build()]).expect("test template construction should not fail")
     }
 
     #[test]
@@ -1487,20 +1206,22 @@ mod tests {
         r1_qualities: &[u8],
         r2_qualities: &[u8],
     ) -> Template {
-        let r1 = RecordBuilder::new()
-            .name(name)
-            .sequence("ACGT")
-            .qualities(r1_qualities)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
-
-        let r2 = RecordBuilder::new()
-            .name(name)
-            .sequence("TGCA")
-            .qualities(r2_qualities)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .build();
-
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGT")
+                .qualities(r1_qualities)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"TGCA")
+                .qualities(r2_qualities)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.build()
+        };
         Template::from_records(vec![r1, r2]).expect("test template construction should not fail")
     }
 
@@ -1573,7 +1294,7 @@ mod tests {
 
     /// Helper to check if a template is marked as duplicate
     fn is_duplicate(template: &Template) -> bool {
-        template.records.iter().any(|r| (u16::from(r.flags()) & DUPLICATE_FLAG) != 0)
+        template.records.iter().any(|r| (r.flags() & DUPLICATE_FLAG) != 0)
     }
 
     #[test]
@@ -1821,17 +1542,17 @@ mod tests {
 
     /// Helper to create a mapped template with UMI tag
     fn create_mapped_template_with_umi(name: &str, umi: &str, mapq: u8) -> Template {
-        let record = RecordBuilder::new()
-            .name(name)
-            .sequence("ACGT")
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(b"ACGT")
             .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(mapq)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .tag("RX", umi.to_string())
-            .build();
+            .ref_id(0)
+            .pos(99)
+            .cigar_ops(&[encode_op(0, 4)])
+            .mapq(mapq)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        b.add_string_tag(b"RX", umi.as_bytes());
+        let record = b.build();
         Template::from_records(vec![record]).expect("test template construction should not fail")
     }
 
@@ -1882,16 +1603,18 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // Create template without RX tag
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
+        let record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
         let template = Template::from_records(vec![record])
             .expect("test template construction should not fail");
 
@@ -1904,17 +1627,19 @@ mod tests {
         let config = default_filter_config(); // include_non_pf = false
         let mut metrics = FilterMetrics::new();
 
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::QC_FAIL)
-            .tag("RX", "ACGTACGT".to_string())
-            .build();
+        let record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::QC_FAIL);
+            b.add_string_tag(b"RX", b"ACGTACGT");
+            b.build()
+        };
         let template = Template::from_records(vec![record])
             .expect("test template construction should not fail");
 
@@ -1928,17 +1653,19 @@ mod tests {
         config.include_non_pf = true; // Include QC-fail reads
         let mut metrics = FilterMetrics::new();
 
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::QC_FAIL)
-            .tag("RX", "ACGTACGT".to_string())
-            .build();
+        let record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::QC_FAIL);
+            b.add_string_tag(b"RX", b"ACGTACGT");
+            b.build()
+        };
         let template = Template::from_records(vec![record])
             .expect("test template construction should not fail");
 
@@ -1951,13 +1678,15 @@ mod tests {
         let config = default_filter_config();
         let mut metrics = FilterMetrics::new();
 
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::UNMAPPED)
-            .tag("RX", "ACGTACGT".to_string())
-            .build();
+        let record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::UNMAPPED);
+            b.add_string_tag(b"RX", b"ACGTACGT");
+            b.build()
+        };
         let template = Template::from_records(vec![record])
             .expect("test template construction should not fail");
 
@@ -2036,29 +1765,33 @@ mod tests {
 
     #[test]
     fn test_get_pair_orientation_both_forward() {
-        // Both R1 and R2 on forward strand (no REVERSE_COMPLEMENTED flag)
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
+        // Both R1 and R2 on forward strand (no REVERSE flag)
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
         let template = Template::from_records(vec![r1, r2])
             .expect("test template construction should not fail");
         let (r1_positive, r2_positive) = get_pair_orientation(&template);
@@ -2069,28 +1802,32 @@ mod tests {
     #[test]
     fn test_get_pair_orientation_r1_reverse() {
         // R1 on reverse strand, R2 on forward strand
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::REVERSE_COMPLEMENTED)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
         let template = Template::from_records(vec![r1, r2])
             .expect("test template construction should not fail");
         let (r1_positive, r2_positive) = get_pair_orientation(&template);
@@ -2101,28 +1838,32 @@ mod tests {
     #[test]
     fn test_get_pair_orientation_both_reverse() {
         // Both R1 and R2 on reverse strand
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::REVERSE_COMPLEMENTED)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::REVERSE_COMPLEMENTED)
-            .tag("RX", "ACGT-TGCA".to_string())
-            .build();
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE);
+            b.add_string_tag(b"RX", b"ACGT-TGCA");
+            b.build()
+        };
         let template = Template::from_records(vec![r1, r2])
             .expect("test template construction should not fail");
         let (r1_positive, r2_positive) = get_pair_orientation(&template);
@@ -2137,75 +1878,85 @@ mod tests {
     #[test]
     fn test_is_r1_earlier_true() {
         // R1 at position 100, R2 at position 200
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .build();
-        assert!(is_r1_genomically_earlier(&r1, &r2).expect("mapped records should have positions"));
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.build()
+        };
+        assert!(is_r1_genomically_earlier_raw(&r1, &r2));
     }
 
     #[test]
     fn test_is_r1_earlier_false() {
         // R1 at position 200, R2 at position 100
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .build();
-        assert!(
-            !is_r1_genomically_earlier(&r1, &r2).expect("mapped records should have positions")
-        );
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.build()
+        };
+        assert!(!is_r1_genomically_earlier_raw(&r1, &r2));
     }
 
     #[test]
     fn test_is_r1_earlier_equal_position() {
         // Both at position 100 -> true (<=)
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .build();
-        assert!(is_r1_genomically_earlier(&r1, &r2).expect("mapped records should have positions"));
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.build()
+        };
+        assert!(is_r1_genomically_earlier_raw(&r1, &r2));
     }
 
     // ========================================================================
@@ -2243,51 +1994,6 @@ mod tests {
     }
 
     // ========================================================================
-    // set_mi_tag_on_record tests
-    // ========================================================================
-
-    #[test]
-    fn test_set_mi_tag_assigned() {
-        let mut record =
-            RecordBuilder::new().name("q1").sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
-        let mi = MoleculeId::Single(42);
-        let assign_tag = Tag::from(SamTag::MI);
-        set_mi_tag_on_record(&mut record, mi, assign_tag, 0);
-
-        let Some(DataValue::String(val)) = record.data().get(&assign_tag) else {
-            unreachable!("MI tag should be a string value");
-        };
-        assert_eq!(AsRef::<[u8]>::as_ref(val), b"42");
-    }
-
-    #[test]
-    fn test_set_mi_tag_unassigned() {
-        let mut record =
-            RecordBuilder::new().name("q1").sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
-        let mi = MoleculeId::None;
-        let assign_tag = Tag::from(SamTag::MI);
-        set_mi_tag_on_record(&mut record, mi, assign_tag, 0);
-
-        let mi_value = record.data().get(&assign_tag);
-        assert!(mi_value.is_none(), "Unassigned MoleculeId should not set MI tag");
-    }
-
-    #[test]
-    fn test_set_mi_tag_with_base_offset() {
-        let mut record =
-            RecordBuilder::new().name("q1").sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
-        let mi = MoleculeId::Single(42);
-        let assign_tag = Tag::from(SamTag::MI);
-        set_mi_tag_on_record(&mut record, mi, assign_tag, 100);
-
-        let Some(DataValue::String(val)) = record.data().get(&assign_tag) else {
-            unreachable!("MI tag should be a string value");
-        };
-        // 100 (base) + 42 (id) = 142
-        assert_eq!(AsRef::<[u8]>::as_ref(val), b"142");
-    }
-
-    // ========================================================================
     // filter_template for paired reads tests
     // ========================================================================
 
@@ -2298,28 +2004,32 @@ mod tests {
         r1_mapq: u8,
         r2_mapq: u8,
     ) -> Template {
-        let r1 = RecordBuilder::new()
-            .name(name)
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(r1_mapq)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .tag("RX", umi.to_string())
-            .build();
-        let r2 = RecordBuilder::new()
-            .name(name)
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .mapping_quality(r2_mapq)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .tag("RX", umi.to_string())
-            .build();
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(r1_mapq)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.add_string_tag(b"RX", umi.as_bytes());
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(r2_mapq)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.add_string_tag(b"RX", umi.as_bytes());
+            b.build()
+        };
         Template::from_records(vec![r1, r2]).expect("test template construction should not fail")
     }
 
@@ -2348,28 +2058,32 @@ mod tests {
         let config = default_filter_config();
         let mut metrics = FilterMetrics::new();
         // R1 has valid UMI, but R2 has N in UMI
-        let r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .tag("RX", "ACGTACGT".to_string())
-            .build();
-        let r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .tag("RX", "ACNTACGT".to_string())
-            .build();
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.add_string_tag(b"RX", b"ACGTACGT");
+            b.build()
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"TGCA")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.add_string_tag(b"RX", b"ACNTACGT");
+            b.build()
+        };
         let template = Template::from_records(vec![r1, r2])
             .expect("test template construction should not fail");
 
@@ -2487,7 +2201,7 @@ mod tests {
 
     /// Helper to create a minimal raw BAM record bytes for testing.
     /// The record has mapq=30 so it passes the Phase 1 MAPQ check.
-    fn make_raw_bam_record_truncated_aux() -> Vec<u8> {
+    fn make_raw_bam_record_truncated_aux() -> RawRecord {
         // Create a BAM record where aux_data_offset will be beyond the record length
         let mut rec = vec![0u8; 40]; // Small record
 
@@ -2500,7 +2214,7 @@ mod tests {
         rec[16..20].copy_from_slice(&1000u32.to_le_bytes()); // l_seq = 1000 (too large)
         rec[32..36].copy_from_slice(b"tst\0"); // read name
 
-        rec
+        RawRecord::from(rec)
     }
 
     #[test]
@@ -2509,8 +2223,8 @@ mod tests {
         // (rejected as poor alignment due to missing UMI tag).
 
         let raw = make_raw_bam_record_truncated_aux();
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
 
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
@@ -2522,7 +2236,7 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // Should not panic; should reject gracefully due to missing UMI
-        let result = filter_template_raw(&template, &config, &mut metrics);
+        let result = filter_template(&template, &config, &mut metrics);
         assert!(!result, "Truncated record should be rejected");
         assert_eq!(metrics.discarded_poor_alignment, 1);
     }
@@ -2553,7 +2267,7 @@ mod tests {
         rec.extend_from_slice(b"MQc"); // tag=MQ, type=c (signed byte)
         rec.push(10); // MAPQ = 10 (< min_mapq of 20)
 
-        let template = Template::from_raw_records(vec![rec].into_iter().map(Into::into).collect())
+        let template = Template::from_records(vec![RawRecord::from(rec)])
             .expect("test template construction should not fail");
 
         let config = DedupFilterConfig {
@@ -2567,7 +2281,7 @@ mod tests {
 
         // After fix: filter_template_raw now uses find_int_tag which handles all integer types.
         // The template should be REJECTED because mate MAPQ=10 < min_mapq=20.
-        let result = filter_template_raw(&template, &config, &mut metrics);
+        let result = filter_template(&template, &config, &mut metrics);
 
         assert!(!result, "Template with low mate MAPQ should be rejected");
         assert_eq!(metrics.accepted_templates, 0);
@@ -2586,7 +2300,7 @@ mod tests {
         seq_len: usize,
         qualities: &[u8],
         umi: &[u8],
-    ) -> Vec<u8> {
+    ) -> RawRecord {
         use crate::sort::bam_fields;
 
         let l_read_name = (name.len() + 1) as u8;
@@ -2630,7 +2344,7 @@ mod tests {
         buf.extend_from_slice(umi);
         buf.push(0);
 
-        buf
+        RawRecord::from(buf)
     }
 
     // ========================================================================
@@ -2648,9 +2362,9 @@ mod tests {
             &[20, 20, 20, 20],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        assert_eq!(score_template_raw(&template), 60);
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
+        assert_eq!(score_template(&template), 60);
     }
 
     #[test]
@@ -2664,9 +2378,9 @@ mod tests {
             &[10, 10, 10, 10],
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        assert_eq!(score_template_raw(&template), 40);
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
+        assert_eq!(score_template(&template), 40);
     }
 
     #[test]
@@ -2688,10 +2402,9 @@ mod tests {
             &[10, 10, 10, 10],
             b"ACGT",
         );
-        let template =
-            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
-                .expect("test template construction should not fail");
-        assert_eq!(score_template_raw(&template), 100);
+        let template = Template::from_records(vec![r1, r2])
+            .expect("test template construction should not fail");
+        assert_eq!(score_template(&template), 100);
     }
 
     #[test]
@@ -2709,8 +2422,7 @@ mod tests {
                 qualities,
                 b"ACGT",
             );
-            Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-                .expect("test template construction should not fail")
+            Template::from_records(vec![raw]).expect("test template construction should not fail")
         };
         assert_eq!(score_template(&template_rb), score_template(&template_raw));
     }
@@ -2719,160 +2431,81 @@ mod tests {
     // filter_template_raw passing/rejecting tests
     // ========================================================================
 
-    #[test]
-    fn test_filter_template_raw_accepts_valid() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::PAIRED
-                | crate::sort::bam_fields::flags::FIRST_SEGMENT
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED,
-            30,
-            4,
-            &[20, 20, 20, 20],
-            b"ACGTACGT",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        let config = DedupFilterConfig {
-            umi_tag: *SamTag::RX,
-            min_mapq: 20,
-            include_non_pf: false,
-            min_umi_length: None,
-            no_umi: false,
-        };
-        let mut metrics = FilterMetrics::new();
-        assert!(filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.accepted_templates, 1);
+    /// Which `FilterMetrics` field an `rstest` case expects to advance.
+    #[derive(Debug, Clone, Copy)]
+    enum FilterExpect {
+        Accepted,
+        PoorAlignment,
+        NonPf,
+        NsInUmi,
+        UmiTooShort,
     }
 
-    #[test]
-    fn test_filter_template_raw_rejects_low_mapq() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::PAIRED
-                | crate::sort::bam_fields::flags::FIRST_SEGMENT
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED,
-            10, // below threshold
-            4,
-            &[20, 20, 20, 20],
-            b"ACGT",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
+    #[rstest]
+    #[case::accepts_valid(
+        crate::sort::bam_fields::flags::PAIRED
+            | crate::sort::bam_fields::flags::FIRST_SEGMENT
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED,
+        30, b"ACGTACGT", 20, None, true, FilterExpect::Accepted
+    )]
+    #[case::rejects_low_mapq(
+        crate::sort::bam_fields::flags::PAIRED
+            | crate::sort::bam_fields::flags::FIRST_SEGMENT
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED,
+        10, b"ACGT", 20, None, false, FilterExpect::PoorAlignment
+    )]
+    #[case::rejects_qc_fail(
+        crate::sort::bam_fields::flags::PAIRED
+            | crate::sort::bam_fields::flags::FIRST_SEGMENT
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED
+            | crate::sort::bam_fields::flags::QC_FAIL,
+        30, b"ACGT", 0, None, false, FilterExpect::NonPf
+    )]
+    #[case::rejects_umi_with_n(
+        crate::sort::bam_fields::flags::PAIRED
+            | crate::sort::bam_fields::flags::FIRST_SEGMENT
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED,
+        30, b"ANGT", 0, None, false, FilterExpect::NsInUmi
+    )]
+    #[case::rejects_short_umi(
+        crate::sort::bam_fields::flags::PAIRED
+            | crate::sort::bam_fields::flags::FIRST_SEGMENT
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED,
+        30, b"AC", 0, Some(6), false, FilterExpect::UmiTooShort
+    )]
+    #[case::rejects_unmapped(
+        crate::sort::bam_fields::flags::UNMAPPED
+            | crate::sort::bam_fields::flags::MATE_UNMAPPED,
+        0, b"ACGT", 0, None, false, FilterExpect::PoorAlignment
+    )]
+    fn test_filter_template_raw(
+        #[case] flags: u16,
+        #[case] mapq: u8,
+        #[case] umi: &'static [u8],
+        #[case] min_mapq: u8,
+        #[case] min_umi_length: Option<usize>,
+        #[case] expect_pass: bool,
+        #[case] expect: FilterExpect,
+    ) {
+        let raw = make_raw_bam_for_dedup(b"rea", flags, mapq, 4, &[20, 20, 20, 20], umi);
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
-            min_mapq: 20,
+            min_mapq,
             include_non_pf: false,
-            min_umi_length: None,
+            min_umi_length,
             no_umi: false,
         };
         let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.discarded_poor_alignment, 1);
-    }
-
-    #[test]
-    fn test_filter_template_raw_rejects_qc_fail() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::PAIRED
-                | crate::sort::bam_fields::flags::FIRST_SEGMENT
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED
-                | crate::sort::bam_fields::flags::QC_FAIL,
-            30,
-            4,
-            &[20, 20, 20, 20],
-            b"ACGT",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        let config = DedupFilterConfig {
-            umi_tag: *SamTag::RX,
-            min_mapq: 0,
-            include_non_pf: false,
-            min_umi_length: None,
-            no_umi: false,
-        };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.discarded_non_pf, 1);
-    }
-
-    #[test]
-    fn test_filter_template_raw_rejects_umi_with_n() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::PAIRED
-                | crate::sort::bam_fields::flags::FIRST_SEGMENT
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED,
-            30,
-            4,
-            &[20, 20, 20, 20],
-            b"ANGT",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        let config = DedupFilterConfig {
-            umi_tag: *SamTag::RX,
-            min_mapq: 0,
-            include_non_pf: false,
-            min_umi_length: None,
-            no_umi: false,
-        };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.discarded_ns_in_umi, 1);
-    }
-
-    #[test]
-    fn test_filter_template_raw_rejects_short_umi() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::PAIRED
-                | crate::sort::bam_fields::flags::FIRST_SEGMENT
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED,
-            30,
-            4,
-            &[20, 20, 20, 20],
-            b"AC",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        let config = DedupFilterConfig {
-            umi_tag: *SamTag::RX,
-            min_mapq: 0,
-            include_non_pf: false,
-            min_umi_length: Some(6),
-            no_umi: false,
-        };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.discarded_umi_too_short, 1);
-    }
-
-    #[test]
-    fn test_filter_template_raw_rejects_unmapped() {
-        let raw = make_raw_bam_for_dedup(
-            b"rea",
-            crate::sort::bam_fields::flags::UNMAPPED
-                | crate::sort::bam_fields::flags::MATE_UNMAPPED,
-            0,
-            4,
-            &[20, 20, 20, 20],
-            b"ACGT",
-        );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
-        let config = DedupFilterConfig {
-            umi_tag: *SamTag::RX,
-            min_mapq: 0,
-            include_non_pf: false,
-            min_umi_length: None,
-            no_umi: false,
-        };
-        let mut metrics = FilterMetrics::new();
-        assert!(!filter_template_raw(&template, &config, &mut metrics));
-        assert_eq!(metrics.discarded_poor_alignment, 1);
+        assert_eq!(filter_template(&template, &config, &mut metrics), expect_pass);
+        match expect {
+            FilterExpect::Accepted => assert_eq!(metrics.accepted_templates, 1),
+            FilterExpect::PoorAlignment => assert_eq!(metrics.discarded_poor_alignment, 1),
+            FilterExpect::NonPf => assert_eq!(metrics.discarded_non_pf, 1),
+            FilterExpect::NsInUmi => assert_eq!(metrics.discarded_ns_in_umi, 1),
+            FilterExpect::UmiTooShort => assert_eq!(metrics.discarded_umi_too_short, 1),
+        }
     }
 
     // ========================================================================
@@ -2934,16 +2567,18 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // Create template without RX tag
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .mapping_quality(30)
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-            .build();
+        let record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30])
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)])
+                .mapq(30)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
         let template = Template::from_records(vec![record])
             .expect("test template construction should not fail");
 
@@ -2988,7 +2623,7 @@ mod tests {
         mapq: u8,
         seq_len: usize,
         qualities: &[u8],
-    ) -> Vec<u8> {
+    ) -> RawRecord {
         use crate::sort::bam_fields;
 
         let l_read_name = (name.len() + 1) as u8;
@@ -3023,7 +2658,7 @@ mod tests {
         let copy_len = std::cmp::min(qualities.len(), seq_len);
         buf[qo..qo + copy_len].copy_from_slice(&qualities[..copy_len]);
 
-        buf
+        RawRecord::from(buf)
     }
 
     #[test]
@@ -3037,8 +2672,8 @@ mod tests {
             4,
             &[20, 20, 20, 20],
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
             min_mapq: 20,
@@ -3049,7 +2684,7 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // In no_umi mode, templates without UMI tags should be accepted
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 
@@ -3065,8 +2700,8 @@ mod tests {
             &[20, 20, 20, 20],
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
             min_mapq: 0,
@@ -3077,7 +2712,7 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // In no_umi mode, UMIs with N should be accepted (UMI validation is skipped)
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
     }
 
@@ -3093,8 +2728,8 @@ mod tests {
             &[20, 20, 20, 20],
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("test template construction should not fail");
+        let template =
+            Template::from_records(vec![raw]).expect("test template construction should not fail");
         let config = DedupFilterConfig {
             umi_tag: *SamTag::RX,
             min_mapq: 0,
@@ -3105,185 +2740,7 @@ mod tests {
         let mut metrics = FilterMetrics::new();
 
         // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
-        assert!(filter_template_raw(&template, &config, &mut metrics));
+        assert!(filter_template(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
-    }
-
-    // ========================================================================
-    // End-to-end regression test: large position group with --no-umi
-    // ========================================================================
-
-    /// Regression test for OOM with large position groups in `--no-umi` mode.
-    ///
-    /// WES data can have extreme depth pileups at capture targets, creating positions
-    /// with thousands of reads. With `--no-umi` (identity strategy), ALL reads at the
-    /// same position form ONE group. This test exercises a 5,000-template position
-    /// group to verify the pipeline completes without unbounded memory growth.
-    #[test]
-    fn test_dedup_no_umi_large_position_group() {
-        use noodles::bam;
-        use noodles::sam::Header;
-        use noodles::sam::alignment::io::Write as AlignmentWrite;
-        use noodles::sam::alignment::record::data::field::Tag;
-        use noodles::sam::alignment::record_buf::RecordBuf;
-        use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
-        use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
-        use noodles::sam::header::record::value::{
-            Map, map::Header as HeaderRecord, map::ReferenceSequence,
-        };
-        use std::collections::HashSet;
-        use std::num::NonZeroUsize;
-
-        const NUM_TEMPLATES: usize = 5_000;
-
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let input_bam = temp_dir.path().join("input.bam");
-        let output_bam = temp_dir.path().join("output.bam");
-
-        // Build a template-coordinate sorted header with one reference.
-        let header = {
-            let mut builder = HeaderRecordMap::<HeaderRecord>::builder();
-            for (tag_bytes, value) in
-                [(*b"SO", "unsorted"), (*b"GO", "query"), (*b"SS", "template-coordinate")]
-            {
-                let HeaderTag::Other(tag) = HeaderTag::from(tag_bytes) else { unreachable!() };
-                builder = builder.insert(tag, value);
-            }
-            Header::builder()
-                .set_header(builder.build().expect("valid header map"))
-                .add_reference_sequence(
-                    BString::from("chr1"),
-                    Map::<ReferenceSequence>::new(
-                        NonZeroUsize::new(10_000).expect("non-zero length"),
-                    ),
-                )
-                .build()
-        };
-
-        // Write 5,000 paired-end templates all at position 100 with no UMI tag.
-        // Template-coordinate sort groups by position then name, so we write
-        // R1 and R2 together for each template in name-sorted order.
-        {
-            let mut writer =
-                bam::io::Writer::new(std::fs::File::create(&input_bam).expect("create input BAM"));
-            writer.write_header(&header).expect("write header");
-
-            for i in 0..NUM_TEMPLATES {
-                let name = format!("read_{i:05}");
-
-                let r1 = RecordBuilder::new()
-                    .name(&name)
-                    .sequence("ACGTACGT")
-                    .qualities(&[30; 8])
-                    .paired(true)
-                    .first_segment(true)
-                    .properly_paired(true)
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .mapping_quality(60)
-                    .cigar("8M")
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(200)
-                    .template_length(108)
-                    .tag("MC", "8M")
-                    .build();
-
-                let r2 = RecordBuilder::new()
-                    .name(&name)
-                    .sequence("ACGTACGT")
-                    .qualities(&[30; 8])
-                    .paired(true)
-                    .first_segment(false)
-                    .properly_paired(true)
-                    .reverse_complement(true)
-                    .reference_sequence_id(0)
-                    .alignment_start(200)
-                    .mapping_quality(60)
-                    .cigar("8M")
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(100)
-                    .template_length(-108)
-                    .tag("MC", "8M")
-                    .build();
-
-                writer.write_alignment_record(&header, &r1).expect("write R1");
-                writer.write_alignment_record(&header, &r2).expect("write R2");
-            }
-            writer.try_finish().expect("finish BAM");
-        }
-
-        // Run dedup with --no-umi via MarkDuplicates::execute().
-        let cmd = MarkDuplicates::try_parse_from([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--no-umi",
-            "--compression-level",
-            "1",
-        ])
-        .expect("failed to parse dedup args");
-        cmd.execute("test").expect("dedup --no-umi should succeed with large position group");
-
-        assert!(output_bam.exists(), "output BAM should be created");
-
-        // Read back the output and verify duplicate marking and MI tags.
-        let mut reader =
-            bam::io::Reader::new(std::fs::File::open(&output_bam).expect("open output BAM"));
-        let out_header = reader.read_header().expect("read output header");
-
-        let mut total_records = 0usize;
-        let mut duplicate_records = 0usize;
-        let mut non_duplicate_records = 0usize;
-        let mut mi_values = HashSet::new();
-        let mut mi_count = 0usize;
-        let mut non_dup_names = HashSet::new();
-
-        let mi_tag = Tag::from(SamTag::MI);
-
-        for result in reader.record_bufs(&out_header) {
-            let record: RecordBuf = result.expect("read record");
-            total_records += 1;
-
-            let is_dup = record.flags().is_duplicate();
-            if is_dup {
-                duplicate_records += 1;
-            } else {
-                non_duplicate_records += 1;
-                if let Some(name) = record.name() {
-                    non_dup_names.insert(name.to_owned());
-                }
-            }
-
-            // Collect MI tag values.
-            if let Some(DataValue::String(mi)) = record.data().get(&mi_tag) {
-                mi_values.insert(mi.to_owned());
-                mi_count += 1;
-            }
-        }
-
-        // All 10,000 records (5,000 pairs) should be present.
-        assert_eq!(total_records, NUM_TEMPLATES * 2, "all records should be present in output");
-
-        // Exactly one template (2 records) should NOT be marked as duplicate.
-        assert_eq!(
-            non_duplicate_records, 2,
-            "exactly one pair should be non-duplicate (the best-scoring template)"
-        );
-        assert_eq!(
-            duplicate_records,
-            (NUM_TEMPLATES - 1) * 2,
-            "all other pairs should be marked as duplicates"
-        );
-
-        // The two non-duplicate records should share the same read name.
-        assert_eq!(non_dup_names.len(), 1, "non-duplicate records should be from one template");
-
-        // Every record should have an MI tag.
-        assert_eq!(mi_count, NUM_TEMPLATES * 2, "all records should have an MI tag");
-
-        // All templates should share the same MI value (one group in identity strategy).
-        assert_eq!(mi_values.len(), 1, "all records should share a single MI tag value");
     }
 }

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -24,7 +24,7 @@ use crate::commands::consensus_runner::{
 use crate::consensus_caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
 use crate::duplex_consensus_caller::DuplexConsensusCaller;
 use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
+use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
 use crate::overlapping_consensus::{
     AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
     apply_overlapping_consensus,
@@ -246,10 +246,11 @@ impl Command for Duplex {
     /// # };
     /// # use std::path::PathBuf;
     /// let duplex = Duplex {
-    ///     io: BamIoOptions::new(
-    ///         PathBuf::from("grouped.bam"),
-    ///         PathBuf::from("duplex.bam"),
-    ///     ),
+    ///     io: BamIoOptions {
+    ///         input: PathBuf::from("grouped.bam"),
+    ///         output: PathBuf::from("duplex.bam"),
+    ///         async_reader: false,
+    ///     },
     ///     rejects_opts: RejectsOptions::default(),
     ///     stats_opts: StatsOptions::default(),
     ///     read_group: ReadGroupOptions {
@@ -301,32 +302,17 @@ impl Command for Duplex {
             self.overlapping.consensus_call_overlapping_bases
         );
 
-        // Open input BAM using streaming-capable reader for pipeline use
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
-
-        // Add @PG record with PP chaining to input's last program
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-        // Use library name from header if no prefix is specified (like fgbio)
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-
         // Cell barcode tag is fixed to the SAM standard CB tag
         let cell_tag = Tag::from(SamTag::CB);
 
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        // Load reference for methylation-aware consensus calling
         if self.reference.is_some() && self.methylation_mode.is_none() {
             bail!("--ref requires --methylation-mode to be set");
         }
         let methylation_mode =
             crate::commands::common::resolve_methylation_mode(self.methylation_mode);
-        let methylation_ref: MethylationRef =
-            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
@@ -341,25 +327,39 @@ impl Command for Duplex {
         // --threads N mode: Use 7-step unified pipeline
         // None: Use single-threaded fast path
         // ============================================================
-        // IMPORTANT: Check this BEFORE creating any output file handles to avoid
-        // file handle conflicts that can corrupt the output.
+        // IMPORTANT: Check threading BEFORE opening any reader so we only open
+        // the input once — opening twice wastes I/O and breaks stdin streaming.
         if let Some(threads) = self.threading.threads {
+            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+            )?;
+            let header = crate::commands::common::add_pg_record(header, command_line)?;
+            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
+            let methylation_ref: MethylationRef =
+                load_methylation_reference(methylation_mode, &self.reference, &header)?;
+
             let result = self.execute_threads_mode(
                 threads,
                 reader,
-                header.clone(),
-                read_name_prefix.clone(),
+                header,
+                read_name_prefix,
                 track_rejects,
                 command_line,
-                methylation_ref.clone(),
+                methylation_ref,
                 methylation_mode,
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
         }
 
-        // Drop the reader for single-threaded mode - we use RawMiGroupIterator which needs its own reader
-        drop(reader);
+        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        let (mut raw_reader, header) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        let header = crate::commands::common::add_pg_record(header, command_line)?;
+        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
+        let methylation_ref: MethylationRef =
+            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // ============================================================
         // For non-pipeline modes, create output writers here
@@ -413,11 +413,8 @@ impl Command for Duplex {
         let mut consensus_count = 0usize;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        // Create raw byte iterator, filtering out secondary/supplementary and keeping
-        // only mapped or mate-mapped reads
+        // Use the raw_reader opened above (single input open). Filter out
+        // secondary/supplementary and keep only mapped or mate-mapped reads.
         let raw_record_iter = std::iter::from_fn(move || {
             loop {
                 let mut record = RawRecord::new();
@@ -447,7 +444,7 @@ impl Command for Duplex {
 
         // Group by base MI (strip /A, /B suffix) for streaming using raw bytes
         let mi_group_iter =
-            RawMiGroupIterator::with_transform(raw_record_iter, "MI", |mi_bytes: &[u8]| {
+            MiGroupIterator::with_transform(raw_record_iter, "MI", |mi_bytes: &[u8]| {
                 let mi_str = String::from_utf8_lossy(mi_bytes);
                 extract_mi_base(&mi_str).to_string()
             })
@@ -474,7 +471,7 @@ impl Command for Duplex {
                 }
             }
 
-            // Call consensus — mi_group now yields Vec<RawRecord> directly.
+            // Call consensus directly — records are already RawRecord values.
             let output = consensus_caller.consensus_reads(records)?;
 
             // Write pre-serialized consensus reads
@@ -616,9 +613,8 @@ impl Duplex {
         // Clone input_header before pipeline (needed for rejects writing)
         let rejects_header = input_header.clone();
 
-        // Set raw-byte mode GroupKeyConfig so decode step skips noodles parsing
         let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw(library_index, cell_tag));
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
         let groups_processed = run_bam_pipeline_from_reader(
@@ -627,20 +623,20 @@ impl Duplex {
             input_header,
             &self.io.output,
             Some(output_header.clone()),
-            // ========== grouper_fn: Create RawMiGrouper with filter, transform, and cell tag ==========
+            // ========== grouper_fn: Create MiGrouper with filter, transform, and cell tag ==========
             move |_header: &Header| {
                 Box::new(
-                    RawMiGrouper::with_filter_and_transform(
+                    MiGrouper::with_filter_and_transform(
                         "MI",
                         batch_size,
                         record_filter,
                         mi_transform,
                     )
                     .with_cell_tag(Some(*SamTag::CB)),
-                ) as Box<dyn Grouper<Group = RawMiGroupBatch> + Send>
+                ) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
             },
             // ========== process_fn: Duplex consensus calling ==========
-            move |batch: RawMiGroupBatch| -> io::Result<DuplexProcessedBatch> {
+            move |batch: MiGroupBatch| -> io::Result<DuplexProcessedBatch> {
                 // Create per-thread duplex consensus caller
                 let mut caller = DuplexConsensusCaller::new(
                     read_name_prefix.clone(),
@@ -684,33 +680,36 @@ impl Duplex {
                 let mut batch_overlapping = CorrectionStats::new();
                 let groups_count = batch.groups.len() as u64;
 
-                for RawMiGroup { mi, records: mut group_reads } in batch.groups {
+                for MiGroup { mi, records: mut group_reads } in batch.groups {
                     caller.clear();
 
-                    // Apply overlapping consensus if enabled (modifies raw bytes in-place)
-                    // Skip if group doesn't have both strands - no duplex possible anyway
+                    // Apply overlapping consensus if enabled (modifies raw bytes in-place).
+                    // Skip if group doesn't have both strands — no duplex possible anyway.
+                    // Propagate errors to match single-threaded behavior; silent drops here
+                    // would turn real failures into output gaps in --threads mode only.
                     if let Some(ref mut oc) = overlapping_caller {
                         if has_both_strands_raw(&group_reads) {
                             oc.reset_stats();
-                            if apply_overlapping_consensus(&mut group_reads, oc).is_err() {
-                                continue;
-                            }
+                            apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
+                                io::Error::other(format!(
+                                    "Overlapping consensus error for MI {mi}: {e}"
+                                ))
+                            })?;
                             batch_overlapping.merge(oc.stats());
                         }
                     }
 
-                    // Call duplex consensus — mi_group yields Vec<RawRecord>.
-                    match caller.consensus_reads(group_reads) {
-                        Ok(batch_output) => {
-                            all_output.merge(batch_output);
-                            batch_stats.merge(&caller.statistics());
-                            if track_rejects {
-                                all_rejects.extend(caller.take_rejected_reads());
-                            }
-                        }
-                        Err(e) => {
-                            log::warn!("Duplex consensus error for MI {mi}: {e}");
-                        }
+                    // Call duplex consensus directly — records are already RawRecord values.
+                    // Propagate errors to match single-threaded behavior; a warn-and-drop here
+                    // would silently turn real failures (OOM, malformed records, etc.) into
+                    // output gaps in --threads mode only.
+                    let batch_output = caller.consensus_reads(group_reads).map_err(|e| {
+                        io::Error::other(format!("Duplex consensus error for MI {mi}: {e}"))
+                    })?;
+                    all_output.merge(batch_output);
+                    batch_stats.merge(&caller.statistics());
+                    if track_rejects {
+                        all_rejects.extend(caller.take_rejected_reads());
                     }
                 }
 
@@ -873,8 +872,10 @@ fn has_both_strands_raw(records: &[RawRecord]) -> bool {
 mod tests {
     use super::*;
     use crate::bam_io::{create_bam_reader, create_bam_writer};
-    use crate::sam::builder::{RecordBuilder, RecordPairBuilder};
     use anyhow::Result;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+    };
     use noodles::sam;
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use noodles::sam::alignment::record::data::field::Tag;
@@ -909,7 +910,7 @@ mod tests {
     /// Uses sensible test defaults: disabled per-base tags, disabled overlapping consensus.
     fn create_duplex_with_paths(input: PathBuf, output: PathBuf) -> Duplex {
         Duplex {
-            io: BamIoOptions::new(input, output),
+            io: BamIoOptions { input, output, async_reader: false },
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions {
@@ -954,6 +955,11 @@ mod tests {
         builder.build()
     }
 
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> sam::alignment::RecordBuf {
+        raw_record_to_record_buf(&raw, &sam::Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
+
     /// Build a test read with common parameters
     #[allow(clippy::cast_sign_loss)]
     fn build_test_read(
@@ -961,45 +967,22 @@ mod tests {
         ref_id: usize,
         pos: i32,
         mapq: u8,
-        flags: u16,
-        bases: &str,
+        raw_flags: u16,
+        bases: &[u8],
     ) -> sam::alignment::RecordBuf {
-        let cigar = format!("{}M", bases.len());
+        let cigar = encode_op(0, bases.len());
         let qual = vec![40u8; bases.len()];
 
-        let mut builder = RecordBuilder::new()
-            .name(name)
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .flags(raw_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos - 1)
+            .mapq(mapq)
+            .cigar_ops(&[cigar])
             .sequence(bases)
-            .qualities(&qual)
-            .reference_sequence_id(ref_id)
-            .alignment_start(pos as usize)
-            .mapping_quality(mapq)
-            .cigar(&cigar);
-
-        // Set flags based on raw u16
-        let sam_flags = sam::alignment::record::Flags::from(flags);
-        if sam_flags.is_segmented() {
-            builder = builder.paired(true);
-        }
-        if sam_flags.is_properly_segmented() {
-            builder = builder.properly_paired(true);
-        }
-        if sam_flags.is_first_segment() {
-            builder = builder.first_segment(true);
-        } else if sam_flags.is_last_segment() {
-            builder = builder.first_segment(false);
-        }
-        if sam_flags.is_reverse_complemented() {
-            builder = builder.reverse_complement(true);
-        }
-        if sam_flags.is_unmapped() {
-            builder = builder.unmapped(true);
-        }
-        if sam_flags.is_mate_unmapped() {
-            builder = builder.mate_unmapped(true);
-        }
-
-        builder.build()
+            .qualities(&qual);
+        to_record_buf(b.build())
     }
 
     /// Create a pair of reads with MI tag
@@ -1010,27 +993,54 @@ mod tests {
         pos1: i32,
         pos2: i32,
         mi_tag: &str,
-        bases: &str,
+        bases: &[u8],
         rx_tag: Option<&str>,
         cell_tag: Option<&str>,
     ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        let mut builder = RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(bases)
-            .r2_sequence(bases)
-            .reference_sequence_id(ref_id)
-            .r1_start(pos1 as usize)
-            .r2_start(pos2 as usize)
-            .tag("MI", mi_tag);
+        let cigar = encode_op(0, bases.len());
+        let qual = vec![40u8; bases.len()];
 
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(bases)
+            .qualities(&qual)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos2 - 1);
+        b1.add_string_tag(b"MI", mi_tag.as_bytes());
         if let Some(rx) = rx_tag {
-            builder = builder.tag("RX", rx);
+            b1.add_string_tag(b"RX", rx.as_bytes());
         }
         if let Some(cell) = cell_tag {
-            builder = builder.tag("CB", cell);
+            b1.add_string_tag(b"CB", cell.as_bytes());
         }
+        let r1 = to_record_buf(b1.build());
 
-        builder.build()
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(bases)
+            .qualities(&qual)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos1 - 1);
+        b2.add_string_tag(b"MI", mi_tag.as_bytes());
+        if let Some(rx) = rx_tag {
+            b2.add_string_tag(b"RX", rx.as_bytes());
+        }
+        if let Some(cell) = cell_tag {
+            b2.add_string_tag(b"CB", cell.as_bytes());
+        }
+        let r2 = to_record_buf(b2.build());
+
+        (r1, r2)
     }
 
     /// Write records to a temporary BAM file
@@ -1178,15 +1188,15 @@ mod tests {
 
         // A reads: R1 at 100 (forward), R2 at 200 (reverse) - query name "q1"
         let (r1_a, r2_a) =
-            build_duplex_pair("q1", 0, 100, 200, "1/A", "AAAAAAAAAA", Some("AAT-CCG"), None);
+            build_duplex_pair("q1", 0, 100, 200, "1/A", b"AAAAAAAAAA", Some("AAT-CCG"), None);
         records.push(r1_a);
         records.push(r2_a);
 
         // B reads: R1 at 200 (reverse), R2 at 100 (forward) - query name "q2", positions swapped
         let flags1 = 0x53; // paired, proper pair, first in pair, reverse
         let flags2 = 0x83; // paired, proper pair, second in pair, forward
-        let mut r1_b = build_test_read("q2", 0, 200, 60, flags1, "TTTTTTTTTT"); // Reverse complement of A
-        let mut r2_b = build_test_read("q2", 0, 100, 60, flags2, "AAAAAAAAAA");
+        let mut r1_b = build_test_read("q2", 0, 200, 60, flags1, b"TTTTTTTTTT"); // Reverse complement of A
+        let mut r2_b = build_test_read("q2", 0, 100, 60, flags2, b"AAAAAAAAAA");
 
         // Set mate info
         *r1_b.mate_reference_sequence_id_mut() = Some(0);
@@ -1241,7 +1251,7 @@ mod tests {
         let mut records = Vec::new();
 
         // AB reads: R1 forward (+), R2 forward (+) - WRONG!
-        let (r1, mut r2) = build_duplex_pair("ab1", 0, 100, 200, "1/A", "AAAAAAAAAA", None, None);
+        let (r1, mut r2) = build_duplex_pair("ab1", 0, 100, 200, "1/A", b"AAAAAAAAAA", None, None);
         // Make R2 forward instead of reverse
         let mut flags2 = r2.flags();
         flags2.set(noodles::sam::alignment::record::Flags::REVERSE_COMPLEMENTED, false);
@@ -1252,8 +1262,8 @@ mod tests {
         // BA reads: R1 forward (+), R2 reverse (-) - correct orientation
         let flags1 = 0x53; // paired, first in pair, reverse
         let flags2 = 0x83; // paired, second in pair
-        let mut r1 = build_test_read("ba1", 0, 200, 60, flags1, "AAAAAAAAAA");
-        let mut r2 = build_test_read("ba1", 0, 100, 60, flags2, "AAAAAAAAAA");
+        let mut r1 = build_test_read("ba1", 0, 200, 60, flags1, b"AAAAAAAAAA");
+        let mut r2 = build_test_read("ba1", 0, 100, 60, flags2, b"AAAAAAAAAA");
 
         *r1.mate_reference_sequence_id_mut() = Some(0);
         *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
@@ -1295,7 +1305,7 @@ mod tests {
                 100,
                 100,
                 "1/A",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 None,
             );
@@ -1307,8 +1317,8 @@ mod tests {
         for i in 1..=2 {
             let flags1 = 0x53;
             let flags2 = 0x83;
-            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, "AAAAAAAAAA");
-            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, "AAAAAAAAAA");
+            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, b"AAAAAAAAAA");
+            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, b"AAAAAAAAAA");
 
             *r1.mate_reference_sequence_id_mut() = Some(0);
             *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
@@ -1360,7 +1370,7 @@ mod tests {
                 100,
                 100,
                 "1/A",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 None,
             );
@@ -1372,8 +1382,8 @@ mod tests {
         for i in 1..=3 {
             let flags1 = 0x53;
             let flags2 = 0x83;
-            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, "AAAAAAAAAA");
-            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, "AAAAAAAAAA");
+            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, b"AAAAAAAAAA");
+            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, b"AAAAAAAAAA");
 
             *r1.mate_reference_sequence_id_mut() = Some(0);
             *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
@@ -1427,7 +1437,7 @@ mod tests {
                 100,
                 100,
                 "1/A",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 Some("CELLBC"),
             );
@@ -1439,8 +1449,8 @@ mod tests {
         for i in 1..=3 {
             let flags1 = 0x53;
             let flags2 = 0x83;
-            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, "AAAAAAAAAA");
-            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, "AAAAAAAAAA");
+            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, b"AAAAAAAAAA");
+            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, b"AAAAAAAAAA");
 
             *r1.mate_reference_sequence_id_mut() = Some(0);
             *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();
@@ -1497,7 +1507,7 @@ mod tests {
                     100 * group,
                     100 * group,
                     &format!("{group}/A"),
-                    "AAAAAAAAAA",
+                    b"AAAAAAAAAA",
                     Some("AAT-CCG"),
                     None,
                 );
@@ -1515,7 +1525,7 @@ mod tests {
                     100 * group,
                     60,
                     flags1,
-                    "AAAAAAAAAA",
+                    b"AAAAAAAAAA",
                 );
                 let mut r2 = build_test_read(
                     &format!("g{group}_ba{i}"),
@@ -1523,7 +1533,7 @@ mod tests {
                     100 * group,
                     60,
                     flags2,
-                    "AAAAAAAAAA",
+                    b"AAAAAAAAAA",
                 );
 
                 *r1.mate_reference_sequence_id_mut() = Some(0);
@@ -1595,7 +1605,7 @@ mod tests {
                 100,
                 100,
                 "1/A",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 None,
             );
@@ -1644,7 +1654,7 @@ mod tests {
                 100,
                 200,
                 "1/A",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 None,
             );
@@ -1658,7 +1668,7 @@ mod tests {
                 100,
                 200,
                 "1/B",
-                "AAAAAAAAAA",
+                b"AAAAAAAAAA",
                 Some("AAT-CCG"),
                 None,
             );
@@ -1721,7 +1731,7 @@ mod tests {
         // AB reads: R1 forward at 100, R2 reverse at 100
         for i in 0..3 {
             let (r1, r2) =
-                build_duplex_pair(&format!("ab{i}"), 0, 100, 100, "1/A", "CCCCCCCCCC", None, None);
+                build_duplex_pair(&format!("ab{i}"), 0, 100, 100, "1/A", b"CCCCCCCCCC", None, None);
             records.push(r1);
             records.push(r2);
         }
@@ -1730,8 +1740,8 @@ mod tests {
         for i in 0..3 {
             let flags1 = 0x53_u16; // paired, proper pair, first in pair, reverse
             let flags2 = 0x83_u16; // paired, proper pair, second in pair, forward
-            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, "CCCCCCCCCC");
-            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, "CCCCCCCCCC");
+            let mut r1 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags1, b"CCCCCCCCCC");
+            let mut r2 = build_test_read(&format!("ba{i}"), 0, 100, 60, flags2, b"CCCCCCCCCC");
 
             *r1.mate_reference_sequence_id_mut() = Some(0);
             *r1.mate_alignment_start_mut() = noodles::core::Position::try_from(100_usize).ok();

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -638,9 +638,7 @@ impl Filter {
             let mut bases_masked = 0u64;
 
             for template in batch {
-                let mut template_records: Vec<RawRecord> = template
-                    .into_raw_records()
-                    .ok_or_else(|| io::Error::other("template has no raw records"))?;
+                let mut template_records: Vec<RawRecord> = template.into_records();
                 let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
 
                 for (idx, record) in template_records.iter_mut().enumerate() {
@@ -1095,15 +1093,14 @@ impl Filter {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
-    use noodles::sam::alignment::io::Write as AlignmentWrite;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, aux_data_slice, flags};
     use noodles::sam::alignment::record_buf::RecordBuf;
     use rstest::rstest;
 
     /// Helper function to create a Filter command with commonly used test defaults.
     fn create_filter_with_paths(input: PathBuf, output: PathBuf, reference: PathBuf) -> Filter {
         Filter {
-            io: BamIoOptions::new(input, output),
+            io: BamIoOptions { input, output, async_reader: false },
             reference: Some(reference),
             min_reads: vec![1],
             max_read_error_rate: vec![0.025],
@@ -1167,7 +1164,11 @@ mod tests {
     #[test]
     fn test_default_filter_parameters() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1199,7 +1200,11 @@ mod tests {
     #[test]
     fn test_multithreaded_filter_configuration() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1229,7 +1234,11 @@ mod tests {
     #[test]
     fn test_filter_with_optional_outputs() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1261,7 +1270,11 @@ mod tests {
     #[test]
     fn test_validate_parameters_too_many_values() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![1, 2, 3, 4], // Too many values
             max_read_error_rate: vec![0.1],
@@ -1291,7 +1304,11 @@ mod tests {
     #[test]
     fn test_validate_parameters_invalid_stringency_order() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![1, 10], // Invalid: AB > CC
             max_read_error_rate: vec![0.1],
@@ -1388,8 +1405,6 @@ mod tests {
     }
 
     // Integration tests for filtering logic
-
-    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, aux_data_slice, flags};
 
     /// Creates a raw BAM test record for filtering tests.
     ///
@@ -1739,7 +1754,11 @@ mod tests {
     fn test_validate_max_no_call_fraction_integer() {
         // When max_no_call_fraction >= 1.0, it should be an integer
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1775,7 +1794,11 @@ mod tests {
     fn test_validate_max_no_call_fraction_integer_valid() {
         // When max_no_call_fraction >= 1.0 and IS an integer, it should pass
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1809,7 +1832,11 @@ mod tests {
     #[test]
     fn test_filter_with_rejects_output() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1840,7 +1867,11 @@ mod tests {
     #[test]
     fn test_filter_with_stats_output() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1871,7 +1902,11 @@ mod tests {
     #[test]
     fn test_filter_multithreaded() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1901,7 +1936,11 @@ mod tests {
     #[test]
     fn test_filter_require_single_strand_agreement() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1931,7 +1970,11 @@ mod tests {
     #[test]
     fn test_filter_by_read_not_template() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1961,7 +2004,11 @@ mod tests {
     #[test]
     fn test_filter_reverse_per_base_tags_disabled() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -1991,7 +2038,11 @@ mod tests {
     #[test]
     fn test_filter_high_min_base_quality() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2021,7 +2072,11 @@ mod tests {
     #[test]
     fn test_filter_with_min_mean_base_quality() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2051,7 +2106,11 @@ mod tests {
     #[test]
     fn test_filter_strict_error_rates() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.01],
@@ -2083,7 +2142,11 @@ mod tests {
     #[test]
     fn test_filter_lenient_error_rates() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.5],
@@ -2115,7 +2178,11 @@ mod tests {
     #[test]
     fn test_filter_high_min_reads_threshold() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![10],
             max_read_error_rate: vec![0.1],
@@ -2146,7 +2213,11 @@ mod tests {
     fn test_filter_duplex_different_thresholds() {
         // Test duplex with different thresholds for CC, AB, BA
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 3, 3], // CC=5, AB=3, BA=3
             max_read_error_rate: vec![0.05, 0.1, 0.1],
@@ -2179,7 +2250,11 @@ mod tests {
     #[test]
     fn test_filter_all_optional_outputs() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2211,7 +2286,11 @@ mod tests {
     #[test]
     fn test_filter_zero_no_call_fraction() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2241,7 +2320,11 @@ mod tests {
     #[test]
     fn test_filter_low_min_base_quality() {
         let filter = Filter {
-            io: BamIoOptions::new(PathBuf::from("input.bam"), PathBuf::from("output.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("input.bam"),
+                output: PathBuf::from("output.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![3],
             max_read_error_rate: vec![0.1],
@@ -2272,7 +2355,6 @@ mod tests {
     // Integration Tests for Filter Command (execute())
     // ========================================================================
 
-    use crate::sam::builder::SamBuilder;
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -2285,6 +2367,12 @@ mod tests {
         writeln!(file, "{}", "A".repeat(1000)).expect("failed to write FASTA sequence");
         file.flush().expect("failed to flush reference file");
         ref_path
+    }
+
+    /// Convert a raw BAM record to a `RecordBuf` using the default (empty) header.
+    fn to_record_buf_default(raw: RawRecord) -> RecordBuf {
+        fgumi_raw_bam::raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+            .expect("raw_record_to_record_buf should succeed in test")
     }
 
     /// Read all records from a BAM file
@@ -2302,35 +2390,63 @@ mod tests {
         Ok(records)
     }
 
-    /// Creates a consensus read with simplex tags for filtering tests
+    /// Helper: build a minimal chr1 noodles `Header` for use with the noodles BAM writer.
+    fn test_bam_header() -> noodles::sam::Header {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+        noodles::sam::Header::builder()
+            .add_reference_sequence(
+                "chr1",
+                Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("1000 is non-zero")),
+            )
+            .build()
+    }
+
+    /// Write a list of raw records as a BAM file with a single chr1 reference.
+    fn write_test_bam(path: &std::path::Path, records: Vec<RawRecord>) -> Result<()> {
+        use noodles::bam;
+        use noodles::sam::alignment::io::Write as AlignmentWrite;
+
+        let header = test_bam_header();
+        let mut writer = bam::io::writer::Builder.build_from_path(path)?;
+        writer.write_header(&header)?;
+        for rec in records {
+            writer.write_alignment_record(&header, &to_record_buf_default(rec))?;
+        }
+        Ok(())
+    }
+
+    /// Creates a simplex consensus raw record for filtering tests.
     #[allow(clippy::too_many_arguments)]
     fn create_simplex_consensus_record(
-        builder: &mut SamBuilder,
         name: &str,
-        pos: usize,
-        bases: &str,
+        pos: i32,
+        bases: &[u8],
         quals: &[u8],
         read_depth: u8,
         read_error: f32,
         base_depths: &[i16],
         base_errors: &[i16],
-    ) {
-        let _ = builder
-            .add_frag()
-            .name(name)
-            .bases(bases)
-            .quals(quals)
-            .contig(0) // chr1
-            .start(pos)
-            .attr("cD", read_depth)
-            .attr("cM", read_depth)
-            .attr("cE", read_error)
-            .attr("cd", base_depths.to_vec()) // Vec<i16> converts to Array
-            .attr("ce", base_errors.to_vec()) // Vec<i16> converts to Array
-            .build();
+    ) -> RawRecord {
+        let n = bases.len() as u32;
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(pos - 1) // 1-based → 0-based
+            .mapq(60)
+            .cigar_ops(&[n << 4]) // nM
+            .sequence(bases)
+            .qualities(quals);
+        b.add_int_tag(b"cD", i32::from(read_depth));
+        b.add_int_tag(b"cM", i32::from(read_depth));
+        b.add_float_tag(b"cE", read_error);
+        b.add_array_i16(b"cd", base_depths);
+        b.add_array_i16(b"ce", base_errors);
+        b.build()
     }
 
-    /// Helper to get read name as string
+    /// Helper to get read name as string from a `RecordBuf`.
     fn get_read_name(record: &RecordBuf) -> Option<String> {
         record.name().map(|n| String::from_utf8_lossy(n.as_ref()).to_string())
     }
@@ -2348,7 +2464,11 @@ mod tests {
         min_base_quality: Option<u8>,
     ) -> Result<()> {
         let cmd = Filter {
-            io: BamIoOptions::new(input.to_path_buf(), output.to_path_buf()),
+            io: BamIoOptions {
+                input: input.to_path_buf(),
+                output: output.to_path_buf(),
+                async_reader: false,
+            },
             reference: Some(reference.to_path_buf()),
             min_reads,
             max_read_error_rate,
@@ -2382,48 +2502,42 @@ mod tests {
         let output_path = dir.path().join("output.bam");
 
         // Create test BAM with consensus reads
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Read 1: High depth, low error - should pass
-        create_simplex_consensus_record(
-            &mut builder,
-            "read1",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,   // depth = 10
-            0.01, // error = 1%
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0], // no errors
-        );
-
-        // Read 2: Low depth - should be filtered
-        create_simplex_consensus_record(
-            &mut builder,
-            "read2",
-            200,
-            "AAAA",
-            &[30, 30, 30, 30],
-            2, // depth = 2 (below threshold of 5)
-            0.01,
-            &[2, 2, 2, 2],
-            &[0, 0, 0, 0],
-        );
-
-        // Read 3: High error rate - should be filtered
-        create_simplex_consensus_record(
-            &mut builder,
-            "read3",
-            300,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.5, // error = 50% (above threshold of 10%)
-            &[10, 10, 10, 10],
-            &[5, 5, 5, 5], // 50% error at each position
-        );
-
-        builder.write(&input_path)?;
+        let records = vec![
+            // Read 1: High depth, low error - should pass
+            create_simplex_consensus_record(
+                "read1",
+                100,
+                b"AAAA",
+                &[30, 30, 30, 30],
+                10,   // depth = 10
+                0.01, // error = 1%
+                &[10, 10, 10, 10],
+                &[0, 0, 0, 0],
+            ),
+            // Read 2: Low depth - should be filtered
+            create_simplex_consensus_record(
+                "read2",
+                200,
+                b"AAAA",
+                &[30, 30, 30, 30],
+                2, // depth = 2 (below threshold of 5)
+                0.01,
+                &[2, 2, 2, 2],
+                &[0, 0, 0, 0],
+            ),
+            // Read 3: High error rate - should be filtered
+            create_simplex_consensus_record(
+                "read3",
+                300,
+                b"AAAA",
+                &[30, 30, 30, 30],
+                10,
+                0.5, // error = 50% (above threshold of 10%)
+                &[10, 10, 10, 10],
+                &[5, 5, 5, 5], // 50% error at each position
+            ),
+        ];
+        write_test_bam(&input_path, records)?;
 
         // Run filter
         run_filter_command(
@@ -2453,26 +2567,28 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create a read with one low-quality base that should be masked
         // Use 10 bases so 1 masked = 10% which is below max_no_call_fraction of 20%
-        create_simplex_consensus_record(
-            &mut builder,
-            "read1",
-            100,
-            "AAAAAAAAAA",                             // 10 bases
-            &[30, 5, 30, 30, 30, 30, 30, 30, 30, 30], // position 1 has low quality
-            10,
-            0.01,
-            &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
-            &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![create_simplex_consensus_record(
+                "read1",
+                100,
+                b"AAAAAAAAAA",                            // 10 bases
+                &[30, 5, 30, 30, 30, 30, 30, 30, 30, 30], // position 1 has low quality
+                10,
+                0.01,
+                &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+                &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            )],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![0.5],
@@ -2521,26 +2637,23 @@ mod tests {
         let output_multi = dir.path().join("output_multi.bam");
 
         // Create test data with multiple reads
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        for i in 0..50 {
-            let depth: u8 = if i % 3 == 0 { 3 } else { 10 }; // Some reads below min_reads
-            let error: f32 = if i % 5 == 0 { 0.3 } else { 0.01 }; // Some reads with high error
-
-            create_simplex_consensus_record(
-                &mut builder,
-                &format!("read{i}"),
-                (i * 10 + 100) % 800 + 1, // Keep positions within 1-800 range
-                "AAAA",
-                &[30, 30, 30, 30],
-                depth,
-                error,
-                &[depth as i16, depth as i16, depth as i16, depth as i16],
-                &[0, 0, 0, 0],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..50)
+            .map(|i| {
+                let depth: u8 = if i % 3 == 0 { 3 } else { 10 };
+                let error: f32 = if i % 5 == 0 { 0.3 } else { 0.01 };
+                create_simplex_consensus_record(
+                    &format!("read{i}"),
+                    (i * 10 + 100) % 800 + 1,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    depth,
+                    error,
+                    &[depth as i16; 4],
+                    &[0, 0, 0, 0],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         // Run with single thread
         run_filter_command(
@@ -2598,38 +2711,40 @@ mod tests {
         let output_path = dir.path().join("output.bam");
         let rejects_path = dir.path().join("rejects.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Read that passes
-        create_simplex_consensus_record(
-            &mut builder,
-            "pass",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        // Read that fails (low depth)
-        create_simplex_consensus_record(
-            &mut builder,
-            "fail",
-            200,
-            "AAAA",
-            &[30, 30, 30, 30],
-            2,
-            0.01,
-            &[2, 2, 2, 2],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                // Read that passes
+                create_simplex_consensus_record(
+                    "pass",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+                // Read that fails (low depth)
+                create_simplex_consensus_record(
+                    "fail",
+                    200,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    2,
+                    0.01,
+                    &[2, 2, 2, 2],
+                    &[0, 0, 0, 0],
+                ),
+            ],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -2674,38 +2789,40 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Read 1: Low quality bases will be masked, but not too many Ns
-        create_simplex_consensus_record(
-            &mut builder,
-            "pass",
-            100,
-            "AAAAAAAAAA",                             // 10 bases
-            &[30, 30, 5, 30, 30, 30, 30, 30, 30, 30], // 1 low quality = 10% masked
-            10,
-            0.01,
-            &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
-            &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        );
-
-        // Read 2: Many low quality bases - will have too many Ns after masking
-        create_simplex_consensus_record(
-            &mut builder,
-            "fail",
-            200,
-            "AAAAAAAAAA",                         // 10 bases
-            &[5, 5, 5, 5, 5, 30, 30, 30, 30, 30], // 5 low quality = 50% will be masked
-            10,
-            0.01,
-            &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
-            &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                // Read 1: Low quality bases will be masked, but not too many Ns
+                create_simplex_consensus_record(
+                    "pass",
+                    100,
+                    b"AAAAAAAAAA",                            // 10 bases
+                    &[30, 30, 5, 30, 30, 30, 30, 30, 30, 30], // 1 low quality = 10% masked
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+                    &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ),
+                // Read 2: Many low quality bases - will have too many Ns after masking
+                create_simplex_consensus_record(
+                    "fail",
+                    200,
+                    b"AAAAAAAAAA",                        // 10 bases
+                    &[5, 5, 5, 5, 5, 30, 30, 30, 30, 30], // 5 low quality = 50% will be masked
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+                    &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ),
+            ],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2744,38 +2861,40 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Read 1: High quality (mean = 30)
-        create_simplex_consensus_record(
-            &mut builder,
-            "high_qual",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        // Read 2: Low quality (mean = 15)
-        create_simplex_consensus_record(
-            &mut builder,
-            "low_qual",
-            200,
-            "AAAA",
-            &[15, 15, 15, 15],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                // Read 1: High quality (mean = 30)
+                create_simplex_consensus_record(
+                    "high_qual",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+                // Read 2: Low quality (mean = 15)
+                create_simplex_consensus_record(
+                    "low_qual",
+                    200,
+                    b"AAAA",
+                    &[15, 15, 15, 15],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+            ],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -2807,13 +2926,12 @@ mod tests {
         Ok(())
     }
 
-    /// Creates a duplex consensus read with AB/BA tags for filtering tests
+    /// Creates a duplex consensus raw record with AB/BA tags for filtering tests.
     #[allow(clippy::too_many_arguments)]
     fn create_duplex_consensus_record(
-        builder: &mut SamBuilder,
         name: &str,
-        pos: usize,
-        bases: &str,
+        pos: i32,
+        bases: &[u8],
         quals: &[u8],
         ab_depth: u8,
         ba_depth: u8,
@@ -2821,27 +2939,30 @@ mod tests {
         ba_error: f32,
         ab_base_depths: &[i16],
         ba_base_depths: &[i16],
-    ) {
-        let _ = builder
-            .add_frag()
-            .name(name)
-            .bases(bases)
-            .quals(quals)
-            .contig(0) // chr1
-            .start(pos)
-            // Per-read duplex tags
-            .attr("aD", ab_depth)
-            .attr("bD", ba_depth)
-            .attr("aM", ab_depth)
-            .attr("bM", ba_depth)
-            .attr("aE", ab_error)
-            .attr("bE", ba_error)
-            // Per-base duplex tags
-            .attr("ad", ab_base_depths.to_vec())
-            .attr("bd", ba_base_depths.to_vec())
-            .attr("ae", vec![0i16; bases.len()]) // no errors
-            .attr("be", vec![0i16; bases.len()]) // no errors
-            .build();
+    ) -> RawRecord {
+        let n = bases.len() as u32;
+        let zero_errors = vec![0i16; bases.len()];
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(pos - 1) // 1-based → 0-based
+            .mapq(60)
+            .cigar_ops(&[n << 4]) // nM
+            .sequence(bases)
+            .qualities(quals);
+        // Per-read duplex tags
+        b.add_int_tag(b"aD", i32::from(ab_depth));
+        b.add_int_tag(b"bD", i32::from(ba_depth));
+        b.add_int_tag(b"aM", i32::from(ab_depth));
+        b.add_int_tag(b"bM", i32::from(ba_depth));
+        b.add_float_tag(b"aE", ab_error);
+        b.add_float_tag(b"bE", ba_error);
+        // Per-base duplex tags
+        b.add_array_i16(b"ad", ab_base_depths);
+        b.add_array_i16(b"bd", ba_base_depths);
+        b.add_array_i16(b"ae", &zero_errors);
+        b.add_array_i16(b"be", &zero_errors);
+        b.build()
     }
 
     #[test]
@@ -2851,58 +2972,58 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Duplex read 1: Both strands have good depth - should pass
-        create_duplex_consensus_record(
-            &mut builder,
-            "duplex_pass",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            10, // AB and BA depths
-            0.01,
-            0.01, // AB and BA error rates
-            &[10, 10, 10, 10],
-            &[10, 10, 10, 10],
-        );
-
-        // Duplex read 2: AB strand has low depth - should fail with 3-value thresholds
-        create_duplex_consensus_record(
-            &mut builder,
-            "duplex_fail_ab",
-            200,
-            "AAAA",
-            &[30, 30, 30, 30],
-            2,
-            10, // AB low, BA good
-            0.01,
-            0.01,
-            &[2, 2, 2, 2],
-            &[10, 10, 10, 10],
-        );
-
-        // Duplex read 3: BA strand has low depth - should fail
-        create_duplex_consensus_record(
-            &mut builder,
-            "duplex_fail_ba",
-            300,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            2, // AB good, BA low
-            0.01,
-            0.01,
-            &[10, 10, 10, 10],
-            &[2, 2, 2, 2],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                // Duplex read 1: Both strands have good depth - should pass
+                create_duplex_consensus_record(
+                    "duplex_pass",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    10, // AB and BA depths
+                    0.01,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[10, 10, 10, 10],
+                ),
+                // Duplex read 2: AB strand has low depth - should fail
+                create_duplex_consensus_record(
+                    "duplex_fail_ab",
+                    200,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    2,
+                    10, // AB low, BA good
+                    0.01,
+                    0.01,
+                    &[2, 2, 2, 2],
+                    &[10, 10, 10, 10],
+                ),
+                // Duplex read 3: BA strand has low depth - should fail
+                create_duplex_consensus_record(
+                    "duplex_fail_ba",
+                    300,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    2, // AB good, BA low
+                    0.01,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[2, 2, 2, 2],
+                ),
+            ],
+        )?;
 
         // Use 3-value thresholds: duplex=5, AB=5, BA=5 (must be high-to-low)
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds (duplex >= AB >= BA)
             max_read_error_rate: vec![0.1],
@@ -2941,40 +3062,42 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create paired reads with same name but different qualities
-        // In non-template mode, each read is filtered independently
-        create_simplex_consensus_record(
-            &mut builder,
-            "pair1",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        // Same name but low depth - would fail individually
-        create_simplex_consensus_record(
-            &mut builder,
-            "pair1",
-            200,
-            "AAAA",
-            &[30, 30, 30, 30],
-            2, // low depth
-            0.01,
-            &[2, 2, 2, 2],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                // Create paired reads with same name but different qualities
+                // In non-template mode, each read is filtered independently
+                create_simplex_consensus_record(
+                    "pair1",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+                // Same name but low depth - would fail individually
+                create_simplex_consensus_record(
+                    "pair1",
+                    200,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    2, // low depth
+                    0.01,
+                    &[2, 2, 2, 2],
+                    &[0, 0, 0, 0],
+                ),
+            ],
+        )?;
 
         // With filter_by_template: false, reads are filtered independently
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3015,36 +3138,38 @@ mod tests {
         let output_path = dir.path().join("output.bam");
         let stats_path = dir.path().join("stats.txt");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        create_simplex_consensus_record(
-            &mut builder,
-            "pass1",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        create_simplex_consensus_record(
-            &mut builder,
-            "fail1",
-            200,
-            "AAAA",
-            &[30, 30, 30, 30],
-            2,
-            0.01,
-            &[2, 2, 2, 2],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![
+                create_simplex_consensus_record(
+                    "pass1",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "fail1",
+                    200,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    2,
+                    0.01,
+                    &[2, 2, 2, 2],
+                    &[0, 0, 0, 0],
+                ),
+            ],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3093,32 +3218,32 @@ mod tests {
         let output_multi = dir.path().join("output_multi.bam");
 
         // Create enough templates to trigger batch processing
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create 125 single-end reads to ensure batching kicks in
         // 125 = 2 full batches of 50 + 25 remaining (tests both batch paths)
-        for i in 0..125 {
-            let depth: u8 = if i % 4 == 0 { 3 } else { 10 };
-            let error: f32 = if i % 7 == 0 { 0.25 } else { 0.02 };
-
-            create_simplex_consensus_record(
-                &mut builder,
-                &format!("read{i}"),
-                (i * 2 + 10) % 900 + 1,
-                "AAAAAAAA",
-                &[30, 30, 30, 30, 30, 30, 30, 30],
-                depth,
-                error,
-                &[depth as i16; 8],
-                &[0; 8],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..125)
+            .map(|i| {
+                let depth: u8 = if i % 4 == 0 { 3 } else { 10 };
+                let error: f32 = if i % 7 == 0 { 0.25 } else { 0.02 };
+                create_simplex_consensus_record(
+                    &format!("read{i}"),
+                    (i * 2 + 10) % 900 + 1,
+                    b"AAAAAAAA",
+                    &[30, 30, 30, 30, 30, 30, 30, 30],
+                    depth,
+                    error,
+                    &[depth as i16; 8],
+                    &[0; 8],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         // Run single-threaded
         let cmd_single = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_single.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_single.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3145,7 +3270,11 @@ mod tests {
 
         // Run multi-threaded with 4 threads
         let cmd_multi = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_multi.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_multi.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3194,25 +3323,27 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create a read that matches the reference (all A's)
-        create_simplex_consensus_record(
-            &mut builder,
-            "read1",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![create_simplex_consensus_record(
+                "read1",
+                100,
+                b"AAAA",
+                &[30, 30, 30, 30],
+                10,
+                0.01,
+                &[10, 10, 10, 10],
+                &[0, 0, 0, 0],
+            )],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -3252,25 +3383,27 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create a read with consensus tags
-        create_simplex_consensus_record(
-            &mut builder,
-            "read1",
-            100,
-            "AAAA",
-            &[30, 30, 30, 30],
-            10,
-            0.01,
-            &[10, 10, 10, 10],
-            &[0, 0, 0, 0],
-        );
-
-        builder.write(&input_path)?;
+        write_test_bam(
+            &input_path,
+            vec![create_simplex_consensus_record(
+                "read1",
+                100,
+                b"AAAA",
+                &[30, 30, 30, 30],
+                10,
+                0.01,
+                &[10, 10, 10, 10],
+                &[0, 0, 0, 0],
+            )],
+        )?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![1],
             max_read_error_rate: vec![1.0],
@@ -3309,29 +3442,31 @@ mod tests {
         let output_path = dir.path().join("output.bam");
         let rejects_path = dir.path().join("rejects.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create 75 reads (1 batch of 50 + 25 remaining) with some that will fail
-        for i in 0..75 {
-            let depth: u8 = if i % 3 == 0 { 2 } else { 10 }; // 1/3 will fail
-            create_simplex_consensus_record(
-                &mut builder,
-                &format!("read{i}"),
-                (i * 5 + 10) % 900 + 1,
-                "AAAA",
-                &[30, 30, 30, 30],
-                depth,
-                0.01,
-                &[depth as i16; 4],
-                &[0; 4],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..75)
+            .map(|i| {
+                let depth: u8 = if i % 3 == 0 { 2 } else { 10 }; // 1/3 will fail
+                create_simplex_consensus_record(
+                    &format!("read{i}"),
+                    (i * 5 + 10) % 900 + 1,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    depth,
+                    0.01,
+                    &[depth as i16; 4],
+                    &[0; 4],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         // Run multi-threaded with rejects output
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3375,33 +3510,34 @@ mod tests {
         let output_single = dir.path().join("output_single.bam");
         let output_multi = dir.path().join("output_multi.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create duplex reads with varying depths
-        for i in 0..50 {
-            let ab_depth: u8 = if i % 3 == 0 { 3 } else { 10 };
-            let ba_depth: u8 = if i % 5 == 0 { 2 } else { 8 };
-
-            create_duplex_consensus_record(
-                &mut builder,
-                &format!("duplex{i}"),
-                (i * 10 + 100) % 800 + 1,
-                "AAAA",
-                &[30, 30, 30, 30],
-                ab_depth,
-                ba_depth,
-                0.01,
-                0.01,
-                &[ab_depth as i16; 4],
-                &[ba_depth as i16; 4],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..50)
+            .map(|i| {
+                let ab_depth: u8 = if i % 3 == 0 { 3 } else { 10 };
+                let ba_depth: u8 = if i % 5 == 0 { 2 } else { 8 };
+                create_duplex_consensus_record(
+                    &format!("duplex{i}"),
+                    (i * 10 + 100) % 800 + 1,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    ab_depth,
+                    ba_depth,
+                    0.01,
+                    0.01,
+                    &[ab_depth as i16; 4],
+                    &[ba_depth as i16; 4],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         // Run single-threaded
         let cmd_single = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_single.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_single.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA (must be high-to-low)
             max_read_error_rate: vec![0.1],
@@ -3428,7 +3564,11 @@ mod tests {
 
         // Run multi-threaded
         let cmd_multi = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_multi.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_multi.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1],
@@ -3474,32 +3614,28 @@ mod tests {
         let output_path = dir.path().join("output.bam");
         let rejects_path = dir.path().join("rejects.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create duplex reads that pass
-        for i in 0..5 {
-            create_duplex_consensus_record(
-                &mut builder,
-                &format!("duplex_pass{i}"),
-                100 + i * 10,
-                "AAAA",
-                &[30, 30, 30, 30],
-                10, // AB depth
-                8,  // BA depth
-                0.01,
-                0.01,
-                &[10, 10, 10, 10],
-                &[8, 8, 8, 8],
-            );
-        }
-
+        let mut records: Vec<RawRecord> = (0..5)
+            .map(|i| {
+                create_duplex_consensus_record(
+                    &format!("duplex_pass{i}"),
+                    100 + i * 10,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10, // AB depth
+                    8,  // BA depth
+                    0.01,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[8, 8, 8, 8],
+                )
+            })
+            .collect();
         // Create duplex reads that fail (low AB depth)
-        for i in 0..5 {
+        records.extend((0..5).map(|i| {
             create_duplex_consensus_record(
-                &mut builder,
                 &format!("duplex_fail{i}"),
                 200 + i * 10,
-                "AAAA",
+                b"AAAA",
                 &[30, 30, 30, 30],
                 2, // Low AB depth
                 8,
@@ -3507,13 +3643,16 @@ mod tests {
                 0.01,
                 &[2, 2, 2, 2],
                 &[8, 8, 8, 8],
-            );
-        }
-
-        builder.write(&input_path)?;
+            )
+        }));
+        write_test_bam(&input_path, records)?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds
             max_read_error_rate: vec![0.1],
@@ -3550,23 +3689,17 @@ mod tests {
     #[test]
     fn test_filter_execute_with_supplementary_records() -> Result<()> {
         // Test filtering with supplementary alignments
-        use crate::sam::builder::RecordBuilder;
-
         let dir = TempDir::new()?;
         let ref_path = create_test_reference(&dir);
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
         let rejects_path = dir.path().join("rejects.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create a template with primary and supplementary reads
         // Primary read that passes
-        create_simplex_consensus_record(
-            &mut builder,
+        let primary = create_simplex_consensus_record(
             "read_with_supp",
             100,
-            "AAAA",
+            b"AAAA",
             &[30, 30, 30, 30],
             10,
             0.01,
@@ -3574,59 +3707,52 @@ mod tests {
             &[0, 0, 0, 0],
         );
 
-        builder.write(&input_path)?;
+        // Passing supplementary for the same template
+        let supp = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read_with_supp")
+                .ref_id(0)
+                .pos(499)
+                .mapq(60)
+                .flags(flags::SUPPLEMENTARY)
+                .cigar_ops(&[4 << 4]) // 4M
+                .sequence(b"CCCC")
+                .qualities(&[30, 30, 30, 30]);
+            b.add_int_tag(b"cD", 10)
+                .add_int_tag(b"cM", 10)
+                .add_float_tag(b"cE", 0.01_f32)
+                .add_array_i16(b"cd", &[10, 10, 10, 10])
+                .add_array_i16(b"ce", &[0, 0, 0, 0]);
+            b.build()
+        };
 
-        // Now add supplementary alignment manually
-        let bam_path = input_path.clone();
-        let mut reader = noodles::bam::io::reader::Builder.build_from_path(&bam_path)?;
-        let header = reader.read_header()?;
-        let records: Vec<_> = reader.record_bufs(&header).collect::<std::io::Result<Vec<_>>>()?;
+        // Supplementary that would fail filtering (low depth, high error)
+        let supp_fail = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read_with_supp")
+                .ref_id(0)
+                .pos(599)
+                .mapq(60)
+                .flags(flags::SUPPLEMENTARY)
+                .cigar_ops(&[4 << 4]) // 4M
+                .sequence(b"GGGG")
+                .qualities(&[30, 30, 30, 30]);
+            b.add_int_tag(b"cD", 2) // Low depth — fails
+                .add_int_tag(b"cM", 2)
+                .add_float_tag(b"cE", 0.5_f32) // High error — fails
+                .add_array_i16(b"cd", &[2, 2, 2, 2])
+                .add_array_i16(b"ce", &[0, 0, 0, 0]);
+            b.build()
+        };
 
-        // Create a new BAM with the primary and a supplementary alignment
-        let mut writer = noodles::bam::io::writer::Builder.build_from_path(&input_path)?;
-        writer.write_header(&header)?;
-
-        // Write original primary
-        for record in &records {
-            writer.write_alignment_record(&header, record)?;
-        }
-
-        // Create and write supplementary for the same template
-        let supp = RecordBuilder::new()
-            .name("read_with_supp")
-            .sequence("CCCC")
-            .qualities(&[30, 30, 30, 30])
-            .supplementary(true)
-            .reference_sequence_id(0)
-            .alignment_start(500)
-            .tag("cD", 10u8)
-            .tag("cM", 10u8)
-            .tag("cE", 0.01f32)
-            .tag("cd", vec![10i16, 10, 10, 10])
-            .tag("ce", vec![0i16, 0, 0, 0])
-            .build();
-        writer.write_alignment_record(&header, &supp)?;
-
-        // Also add a supplementary that would fail filtering
-        let supp_fail = RecordBuilder::new()
-            .name("read_with_supp")
-            .sequence("GGGG")
-            .qualities(&[30, 30, 30, 30])
-            .supplementary(true)
-            .reference_sequence_id(0)
-            .alignment_start(600)
-            .tag("cD", 2u8) // Low depth - fails
-            .tag("cM", 2u8)
-            .tag("cE", 0.5f32) // High error - fails
-            .tag("cd", vec![2i16, 2, 2, 2])
-            .tag("ce", vec![0i16, 0, 0, 0])
-            .build();
-        writer.write_alignment_record(&header, &supp_fail)?;
-
-        drop(writer);
+        write_test_bam(&input_path, vec![primary, supp, supp_fail])?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3664,88 +3790,79 @@ mod tests {
     #[test]
     fn test_filter_execute_parallel_with_supplementary() -> Result<()> {
         // Test supplementary records in parallel template mode
-        use crate::sam::builder::RecordBuilder;
-
         let dir = TempDir::new()?;
         let ref_path = create_test_reference(&dir);
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
         let rejects_path = dir.path().join("rejects.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create many templates to trigger parallel processing
+        // Create 75 primary reads. For names ending in '0' or '5' (indices 0, 5, 10, ..., 70),
+        // add a passing and a failing supplementary — 15 templates have supplementaries.
+        let mut records: Vec<RawRecord> = Vec::new();
         for i in 0..75 {
-            create_simplex_consensus_record(
-                &mut builder,
+            records.push(create_simplex_consensus_record(
                 &format!("read{i}"),
                 100 + i * 10,
-                "AAAA",
+                b"AAAA",
                 &[30, 30, 30, 30],
                 10,
                 0.01,
                 &[10, 10, 10, 10],
                 &[0, 0, 0, 0],
-            );
-        }
+            ));
 
-        builder.write(&input_path)?;
+            let name = format!("read{i}");
+            if name.ends_with('0') || name.ends_with('5') {
+                // Passing supplementary
+                let supp = {
+                    let mut b = RawSamBuilder::new();
+                    b.read_name(name.as_bytes())
+                        .ref_id(0)
+                        .pos(799)
+                        .mapq(60)
+                        .flags(flags::SUPPLEMENTARY)
+                        .cigar_ops(&[4 << 4])
+                        .sequence(b"CCCC")
+                        .qualities(&[30, 30, 30, 30]);
+                    b.add_int_tag(b"cD", 10)
+                        .add_int_tag(b"cM", 10)
+                        .add_float_tag(b"cE", 0.01_f32)
+                        .add_array_i16(b"cd", &[10, 10, 10, 10])
+                        .add_array_i16(b"ce", &[0, 0, 0, 0]);
+                    b.build()
+                };
+                records.push(supp);
 
-        // Add supplementary alignments
-        let bam_path = input_path.clone();
-        let mut reader = noodles::bam::io::reader::Builder.build_from_path(&bam_path)?;
-        let header = reader.read_header()?;
-        let records: Vec<_> = reader.record_bufs(&header).collect::<std::io::Result<Vec<_>>>()?;
-
-        let mut writer = noodles::bam::io::writer::Builder.build_from_path(&input_path)?;
-        writer.write_header(&header)?;
-
-        for record in &records {
-            writer.write_alignment_record(&header, record)?;
-
-            // Add supplementary for some reads
-            let name = record.name().map(|n| String::from_utf8_lossy(n.as_ref()).to_string());
-            if let Some(ref n) = name {
-                if n.ends_with('0') || n.ends_with('5') {
-                    // Add passing supplementary
-                    let supp = RecordBuilder::new()
-                        .name(n)
-                        .sequence("CCCC")
-                        .qualities(&[30, 30, 30, 30])
-                        .supplementary(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(800)
-                        .tag("cD", 10u8)
-                        .tag("cM", 10u8)
-                        .tag("cE", 0.01f32)
-                        .tag("cd", vec![10i16, 10, 10, 10])
-                        .tag("ce", vec![0i16, 0, 0, 0])
-                        .build();
-                    writer.write_alignment_record(&header, &supp)?;
-
-                    // Add failing supplementary
-                    let supp_fail = RecordBuilder::new()
-                        .name(n)
-                        .sequence("GGGG")
-                        .qualities(&[30, 30, 30, 30])
-                        .supplementary(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(900)
-                        .tag("cD", 2u8) // Fails min_reads
-                        .tag("cM", 2u8)
-                        .tag("cE", 0.5f32)
-                        .tag("cd", vec![2i16, 2, 2, 2])
-                        .tag("ce", vec![0i16, 0, 0, 0])
-                        .build();
-                    writer.write_alignment_record(&header, &supp_fail)?;
-                }
+                // Failing supplementary (low depth)
+                let supp_fail = {
+                    let mut b = RawSamBuilder::new();
+                    b.read_name(name.as_bytes())
+                        .ref_id(0)
+                        .pos(899)
+                        .mapq(60)
+                        .flags(flags::SUPPLEMENTARY)
+                        .cigar_ops(&[4 << 4])
+                        .sequence(b"GGGG")
+                        .qualities(&[30, 30, 30, 30]);
+                    b.add_int_tag(b"cD", 2) // Fails min_reads
+                        .add_int_tag(b"cM", 2)
+                        .add_float_tag(b"cE", 0.5_f32)
+                        .add_array_i16(b"cd", &[2, 2, 2, 2])
+                        .add_array_i16(b"ce", &[0, 0, 0, 0]);
+                    b.build()
+                };
+                records.push(supp_fail);
             }
         }
 
-        drop(writer);
+        write_test_bam(&input_path, records)?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3785,7 +3902,11 @@ mod tests {
     fn test_validate_error_rate_ordering_ab_ba() {
         // Test validation of error rate ordering (AB <= BA)
         let cmd = Filter {
-            io: BamIoOptions::new(PathBuf::from("test.bam"), PathBuf::from("out.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("test.bam"),
+                output: PathBuf::from("out.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1, 0.2, 0.1], // AB (0.2) > BA (0.1) - invalid!
@@ -3820,7 +3941,11 @@ mod tests {
     fn test_validate_base_error_rate_ordering_ab_ba() {
         // Test validation of base error rate ordering (AB <= BA)
         let cmd = Filter {
-            io: BamIoOptions::new(PathBuf::from("test.bam"), PathBuf::from("out.bam")),
+            io: BamIoOptions {
+                input: PathBuf::from("test.bam"),
+                output: PathBuf::from("out.bam"),
+                async_reader: false,
+            },
             reference: Some(PathBuf::from("ref.fa")),
             min_reads: vec![5, 5, 5],
             max_read_error_rate: vec![0.1],
@@ -3859,27 +3984,29 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
         // Create templates to trigger parallel processing
-        for i in 0..75 {
-            create_simplex_consensus_record(
-                &mut builder,
-                &format!("read{i}"),
-                100 + i * 10,
-                "AAAA",
-                &[30, 30, 30, 30],
-                10,
-                0.01,
-                &[10, 10, 10, 10],
-                &[0, 0, 0, 0],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..75)
+            .map(|i| {
+                create_simplex_consensus_record(
+                    &format!("read{i}"),
+                    100 + i * 10,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5],
             max_read_error_rate: vec![0.1],
@@ -3918,32 +4045,32 @@ mod tests {
         let input_path = dir.path().join("input.bam");
         let output_path = dir.path().join("output.bam");
 
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-
-        // Create enough duplex records to trigger parallel processing
-        for i in 0..75 {
-            let ab_depth: u8 = if i % 3 == 0 { 3 } else { 10 }; // Some will fail
-            let ba_depth: u8 = if i % 5 == 0 { 2 } else { 8 };
-
-            create_duplex_consensus_record(
-                &mut builder,
-                &format!("duplex{i}"),
-                100 + i * 10,
-                "AAAA",
-                &[30, 30, 30, 30],
-                ab_depth,
-                ba_depth,
-                0.01,
-                0.01,
-                &[ab_depth as i16; 4],
-                &[ba_depth as i16; 4],
-            );
-        }
-
-        builder.write(&input_path)?;
+        let records: Vec<RawRecord> = (0..75)
+            .map(|i| {
+                let ab_depth: u8 = if i % 3 == 0 { 3 } else { 10 }; // Some will fail
+                let ba_depth: u8 = if i % 5 == 0 { 2 } else { 8 };
+                create_duplex_consensus_record(
+                    &format!("duplex{i}"),
+                    100 + i * 10,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    ab_depth,
+                    ba_depth,
+                    0.01,
+                    0.01,
+                    &[ab_depth as i16; 4],
+                    &[ba_depth as i16; 4],
+                )
+            })
+            .collect();
+        write_test_bam(&input_path, records)?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path.clone(), output_path.clone()),
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path.clone()),
             min_reads: vec![5, 5, 5], // duplex, AB, BA thresholds
             max_read_error_rate: vec![0.1],
@@ -3995,22 +4122,24 @@ mod tests {
         let output_path = dir.path().join("output.bam");
 
         // Create simple test data
-        let mut builder = SamBuilder::with_single_ref("chr1", 1000);
-        create_simplex_consensus_record(
-            &mut builder,
+        let records = vec![create_simplex_consensus_record(
             "read1",
             100,
-            "AAAAAAAAAA",
+            b"AAAAAAAAAA",
             &[30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
             10,
             0.01,
             &[10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
             &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        );
-        builder.write(&input_path)?;
+        )];
+        write_test_bam(&input_path, records)?;
 
         let cmd = Filter {
-            io: BamIoOptions::new(input_path, output_path.clone()),
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
             reference: Some(ref_path),
             min_reads: vec![1],
             max_read_error_rate: vec![0.5],
@@ -4048,28 +4177,15 @@ mod tests {
         // Test fraction mode (threshold < 1.0) with max_no_call_fraction = 0.2
         // Build a record with 10 bases, 2 Ns => 0.2 fraction => should pass
         use crate::consensus_filter::FilterThresholds;
-        use crate::sam::builder::RecordBuilder;
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let mut record = RecordBuilder::new()
-            .sequence("AANNTTGGCC") // 10 bases, 2 Ns
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .build();
-
-        // Add required cD and cE tags for filter_read to pass
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'D']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(10u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'E']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(0.01f32),
-        );
-
-        let header = Header::default();
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &header, &record)?;
+        let raw_record = {
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"AANNTTGGCC") // 10 bases, 2 Ns
+                .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
+            b.add_int_tag(b"cD", 10).add_float_tag(b"cE", 0.01_f32);
+            b.build()
+        };
+        let raw = raw_record.into_inner();
 
         let aux = crate::sort::bam_fields::aux_data_slice(&raw);
         let thresholds =
@@ -4091,28 +4207,15 @@ mod tests {
         // Test count mode (threshold >= 1.0) with max_no_call_fraction = 5.0
         // Build a record with 10 bases, 3 Ns => 3 < 5 => should pass
         use crate::consensus_filter::FilterThresholds;
-        use crate::sam::builder::RecordBuilder;
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let mut record = RecordBuilder::new()
-            .sequence("AANNNTTGGC") // 10 bases, 3 Ns
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .build();
-
-        // Add required cD and cE tags
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'D']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(10u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'E']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(0.01f32),
-        );
-
-        let header = Header::default();
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &header, &record)?;
+        let raw_record = {
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"AANNNTTGGC") // 10 bases, 3 Ns
+                .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
+            b.add_int_tag(b"cD", 10).add_float_tag(b"cE", 0.01_f32);
+            b.build()
+        };
+        let raw = raw_record.into_inner();
 
         let aux = crate::sort::bam_fields::aux_data_slice(&raw);
         let thresholds =
@@ -4134,28 +4237,15 @@ mod tests {
         // Test count mode (threshold >= 1.0) with max_no_call_fraction = 2.0
         // Build a record with 10 bases, 3 Ns => 3 > 2 => should fail
         use crate::consensus_filter::FilterThresholds;
-        use crate::sam::builder::RecordBuilder;
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let mut record = RecordBuilder::new()
-            .sequence("AANNNTTGGC") // 10 bases, 3 Ns
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .build();
-
-        // Add required cD and cE tags
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'D']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(10u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'c', b'E']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(0.01f32),
-        );
-
-        let header = Header::default();
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &header, &record)?;
+        let raw_record = {
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"AANNNTTGGC") // 10 bases, 3 Ns
+                .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
+            b.add_int_tag(b"cD", 10).add_float_tag(b"cE", 0.01_f32);
+            b.build()
+        };
+        let raw = raw_record.into_inner();
 
         let aux = crate::sort::bam_fields::aux_data_slice(&raw);
         let thresholds =
@@ -4172,44 +4262,21 @@ mod tests {
     fn test_check_duplex_filters_raw_no_call_count_mode() -> Result<()> {
         // Test duplex filtering with count mode for no-call counting
         use crate::consensus_filter::FilterThresholds;
-        use crate::sam::builder::RecordBuilder;
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let mut record = RecordBuilder::new()
-            .sequence("AANNNTTGGC") // 10 bases, 3 Ns
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .build();
-
-        // Add required duplex tags: aD, bD, aE, bE, aM, bM
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'a', b'D']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(10u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'b', b'D']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(8u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'a', b'E']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(0.01f32),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'b', b'E']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(0.01f32),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'a', b'M']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(10u8),
-        );
-        record.data_mut().insert(
-            noodles::sam::alignment::record::data::field::Tag::from([b'b', b'M']),
-            noodles::sam::alignment::record_buf::data::field::Value::from(8u8),
-        );
-
-        let header = Header::default();
-        let mut raw = Vec::new();
-        encode_record_buf(&mut raw, &header, &record)?;
+        let raw_record = {
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"AANNNTTGGC") // 10 bases, 3 Ns
+                .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
+            // Add required duplex tags: aD, bD, aE, bE, aM, bM
+            b.add_int_tag(b"aD", 10)
+                .add_int_tag(b"bD", 8)
+                .add_float_tag(b"aE", 0.01_f32)
+                .add_float_tag(b"bE", 0.01_f32)
+                .add_int_tag(b"aM", 10)
+                .add_int_tag(b"bM", 8);
+            b.build()
+        };
+        let raw = raw_record.into_inner();
 
         let aux = crate::sort::bam_fields::aux_data_slice(&raw);
         let thresholds =
@@ -4247,26 +4314,19 @@ mod tests {
     /// to regenerate alignment tags.
     #[test]
     fn test_process_record_raw_no_reference() -> Result<()> {
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
-
         // Build an unmapped record with consensus tags
-        let record = RecordBuilder::new()
-            .name("unmapped_read")
-            .sequence("ACGTACGT")
-            .qualities(&[35, 35, 35, 35, 35, 35, 35, 35])
-            .unmapped(true)
-            .consensus_tags(
-                crate::sam::builder::ConsensusTagsBuilder::new()
-                    .per_base_depths(&[10; 8])
-                    .per_base_errors(&[0; 8]),
-            )
-            .build();
+        let raw_record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"unmapped_read")
+                .flags(flags::UNMAPPED)
+                .sequence(b"ACGTACGT")
+                .qualities(&[35, 35, 35, 35, 35, 35, 35, 35]);
+            b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+            b.build()
+        };
+        let mut raw = raw_record;
 
         let header = Header::default();
-        let mut raw_bytes = Vec::new();
-        encode_record_buf(&mut raw_bytes, &header, &record)?;
-        let mut raw = RawRecord::from(raw_bytes);
-
         let config = FilterConfig::new(&[1], &[0.025], &[0.1], None, None, 0.2);
 
         let (bases_masked, pass) = Filter::process_record_raw(
@@ -4296,35 +4356,27 @@ mod tests {
     /// and the record is mapped, since NM/UQ/MD tags would become stale.
     #[test]
     fn test_process_record_raw_no_reference_mapped_fails() -> Result<()> {
-        use crate::vendored::bam_codec::encoder::encode_record_buf;
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"mapped_read")
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .sequence(b"ACGTACGT")
+                .qualities(&[35; 8]);
+            b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+            b.build()
+        };
 
-        let sam_builder = crate::sam::builder::SamBuilder::with_single_ref("chr1", 1000);
-        let record = RecordBuilder::new()
-            .name("mapped_read")
-            .sequence("ACGTACGT")
-            .qualities(&[35; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .consensus_tags(
-                crate::sam::builder::ConsensusTagsBuilder::new()
-                    .per_base_depths(&[10; 8])
-                    .per_base_errors(&[0; 8]),
-            )
-            .build();
-
-        let mut raw_bytes = Vec::new();
-        encode_record_buf(&mut raw_bytes, &sam_builder.header, &record)?;
-        let mut raw = RawRecord::from(raw_bytes);
-
+        let header = test_bam_header();
         let config = FilterConfig::new(&[1], &[0.025], &[0.1], None, None, 0.2);
 
         let result = Filter::process_record_raw(
             &mut raw,
             &config,
             None, // no reference
-            &sam_builder.header,
+            &header,
             false,
             None,
             false,

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -1,7 +1,7 @@
 //! Groups reads by UMI to identify reads from the same original molecule.
 
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
-use crate::bam_io::{create_bam_reader_for_pipeline_with_opts, create_bam_writer, is_stdin_path};
+use crate::bam_io::{create_bam_reader_for_pipeline, create_bam_writer, is_stdin_path};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
@@ -16,8 +16,8 @@ use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGrou
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::progress::ProgressTracker;
 use crate::read_info::LibraryIndex;
-use crate::sam::{is_sorted, is_template_coordinate_sorted, unclipped_five_prime_position};
-use crate::template::{MoleculeId, Template};
+use crate::sam::{is_sorted, is_template_coordinate_sorted};
+use crate::template::Template;
 use crate::umi::parallel_assigner::{
     ParallelAdjacencyAssigner, ParallelEditAssigner, ParallelIdentityAssigner,
     ParallelPairedAssigner,
@@ -28,7 +28,6 @@ use crate::unified_pipeline::compute_group_key_from_raw;
 use crate::unified_pipeline::{GroupKeyConfig, Grouper, run_bam_pipeline_from_reader};
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
-use bstr::BString;
 use clap::Parser;
 use fgoxide::io::DelimFile;
 // MemoryEstimate is gated because it's only used in memory-debug blocks below
@@ -36,14 +35,10 @@ use crate::sam::SamTag;
 #[cfg(feature = "memory-debug")]
 use crate::unified_pipeline::MemoryEstimate;
 use crate::validation::validate_file_exists;
-use crate::vendored::bam_codec::encode_record_buf;
 use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
-use noodles::sam;
 use noodles::sam::Header;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -107,121 +102,6 @@ struct GroupFilterConfig {
     allow_unmapped: bool,
 }
 
-/// Filter a template based on filtering criteria using the noodles typed API.
-///
-/// Returns true if the template should be kept, false if it should be discarded.
-/// Updates `filter_metrics` with the reason for filtering.
-///
-/// **Retention:** kept as a noodles fallback for any caller that supplies parsed (non-raw)
-/// templates. The primary execution paths use `filter_template_raw` instead.
-fn filter_template(
-    template: &Template,
-    config: &GroupFilterConfig,
-    metrics: &mut FilterMetrics,
-) -> bool {
-    // Get primary reads for filtering
-    let r1 = template.r1();
-    let r2 = template.r2();
-
-    // Count records, not templates (paired template = 2 records)
-    let num_primary_reads = r1.is_some() as u64 + r2.is_some() as u64;
-    metrics.total_templates += num_primary_reads;
-
-    // Need at least one primary read
-    if r1.is_none() && r2.is_none() {
-        metrics.discarded_poor_alignment += num_primary_reads;
-        return false;
-    }
-
-    // Check if both reads are unmapped (poor alignment)
-    let both_unmapped =
-        r1.is_none_or(|r| r.flags().is_unmapped()) && r2.is_none_or(|r| r.flags().is_unmapped());
-
-    if both_unmapped && !config.allow_unmapped {
-        metrics.discarded_poor_alignment += num_primary_reads;
-        return false;
-    }
-
-    // =========================================================================
-    // Phase 1: Cheap flag-based checks for all reads (no tag lookups)
-    // =========================================================================
-    for record in [r1, r2].into_iter().flatten() {
-        let flags = record.flags();
-
-        // Filter non-PF if requested
-        if !config.include_non_pf && flags.is_qc_fail() {
-            metrics.discarded_non_pf += num_primary_reads;
-            return false;
-        }
-
-        // Check MAPQ for mapped reads
-        if !flags.is_unmapped() {
-            let mapq = record.mapping_quality().map_or(0, u8::from);
-            if mapq < config.min_mapq {
-                metrics.discarded_poor_alignment += num_primary_reads;
-                return false;
-            }
-        }
-    }
-
-    // =========================================================================
-    // Phase 2: Expensive tag lookups (only reached if phase 1 passed)
-    // =========================================================================
-    for record in [r1, r2].into_iter().flatten() {
-        let flags = record.flags();
-
-        // Check mate MAPQ via MQ tag if mate is mapped
-        if !flags.is_mate_unmapped() {
-            if let Some(data) = record.data().get(b"MQ") {
-                if let Some(mq) = data.as_int() {
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    if (mq as u8) < config.min_mapq {
-                        metrics.discarded_poor_alignment += num_primary_reads;
-                        return false;
-                    }
-                }
-            }
-        }
-
-        // Skip UMI validation in no-umi mode
-        if config.no_umi {
-            continue;
-        }
-
-        // Check UMI for Ns and minimum length using common validation
-        if let Some(data) = record.data().get(&config.umi_tag) {
-            if let DataValue::String(umi) = data {
-                match validate_umi(umi) {
-                    UmiValidation::ContainsN => {
-                        metrics.discarded_ns_in_umi += num_primary_reads;
-                        return false;
-                    }
-                    UmiValidation::Valid(base_count) => {
-                        // Check minimum UMI length
-                        if let Some(min_len) = config.min_umi_length {
-                            if base_count < min_len {
-                                metrics.discarded_umi_too_short += num_primary_reads;
-                                return false;
-                            }
-                        }
-                    }
-                }
-            } else {
-                // UMI tag is not a string - skip template
-                metrics.discarded_poor_alignment += num_primary_reads;
-                return false;
-            }
-        } else {
-            // Missing UMI tag - skip template
-            metrics.discarded_poor_alignment += num_primary_reads;
-            return false;
-        }
-    }
-
-    metrics.accepted_templates += num_primary_reads;
-    true
-}
-
 // =============================================================================
 // Raw-byte filter and helper functions
 // =============================================================================
@@ -236,8 +116,8 @@ fn filter_template_raw(
     use crate::sort::bam_fields;
     use fgumi_raw_bam::RawRecordView;
 
-    let raw_r1 = template.raw_r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
-    let raw_r2 = template.raw_r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
+    let raw_r1 = template.r1().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
+    let raw_r2 = template.r2().filter(|r| r.len() >= bam_fields::MIN_BAM_RECORD_LEN);
 
     let num_primary_reads = raw_r1.is_some() as u64 + raw_r2.is_some() as u64;
     metrics.total_templates += num_primary_reads;
@@ -402,10 +282,10 @@ fn get_pair_orientation_raw(template: &Template) -> (bool, bool) {
     use fgumi_raw_bam::RawRecordView;
 
     let r1_positive = template
-        .raw_r1()
+        .r1()
         .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     let r2_positive = template
-        .raw_r2()
+        .r2()
         .is_none_or(|r| (RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
 }
@@ -481,32 +361,10 @@ fn truncate_umis_impl(umis: Vec<String>, min_umi_length: Option<usize>) -> Resul
     }
 }
 
-/// Check if R1 is genomically earlier than R2 using the noodles typed API.
-///
-/// **Retention:** noodles fallback used by `assign_umi_groups_for_indices_impl` when
-/// templates carry parsed `RecordBuf` data (raw-byte mode uses `is_r1_genomically_earlier_raw`).
-fn is_r1_genomically_earlier_impl(
-    r1: &sam::alignment::RecordBuf,
-    r2: &sam::alignment::RecordBuf,
-) -> Result<bool> {
-    let ref1 = r1.reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-    let ref2 = r2.reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-    if ref1 != ref2 {
-        return Ok(ref1 < ref2);
-    }
-    let r1_pos = unclipped_five_prime_position(r1).unwrap_or(0);
-    let r2_pos = unclipped_five_prime_position(r2).unwrap_or(0);
-    Ok(r1_pos <= r2_pos)
-}
-
-/// Get pair orientation for a template using the noodles typed API.
-///
-/// **Retention:** noodles fallback used by `assign_umi_groups_impl` when templates carry
-/// parsed `RecordBuf` data (raw-byte mode uses `get_pair_orientation_raw`).
+/// Get pair orientation for a template.
+#[cfg(test)]
 fn get_pair_orientation_impl(template: &Template) -> (bool, bool) {
-    let r1_positive = template.r1().is_none_or(|r| !r.flags().is_reverse_complemented());
-    let r2_positive = template.r2().is_none_or(|r| !r.flags().is_reverse_complemented());
-    (r1_positive, r2_positive)
+    get_pair_orientation_raw(template)
 }
 
 /// Assign UMI groups to templates (static implementation).
@@ -517,22 +375,13 @@ fn assign_umi_groups_impl(
     min_umi_length: Option<usize>,
     no_umi: bool,
 ) -> Result<()> {
-    // Determine orientation getter based on mode
-    let raw_mode = templates.first().is_some_and(Template::is_raw_byte_mode);
-    debug_assert!(
-        templates.iter().all(|t| t.is_raw_byte_mode() == raw_mode),
-        "Mixed raw/parsed templates in batch"
-    );
+    // All templates are in raw-byte mode (Template always uses RawRecord)
 
     if assigner.split_templates_by_pair_orientation() {
         // Group by pair orientation
         let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
         for (idx, template) in templates.iter().enumerate() {
-            let orientation = if raw_mode {
-                get_pair_orientation_raw(template)
-            } else {
-                get_pair_orientation_impl(template)
-            };
+            let orientation = get_pair_orientation_raw(template);
             subgroups.entry(orientation).or_default().push(idx);
         }
 
@@ -581,7 +430,6 @@ fn assign_umi_groups_for_indices_impl(
 
     // Extract UMIs from templates
     let mut umis = Vec::with_capacity(indices.len());
-    let raw_mode = templates[indices[0]].is_raw_byte_mode();
 
     for &idx in indices {
         let template = &templates[idx];
@@ -590,62 +438,30 @@ fn assign_umi_groups_for_indices_impl(
         let processed_umi = if no_umi {
             String::new()
         } else {
-            let (umi_str_ref, is_r1_earlier) = if raw_mode {
-                // Raw-byte mode: extract UMI from raw bytes
-                use crate::sort::bam_fields;
+            use crate::sort::bam_fields;
 
-                let umi_bytes = if let Some(r1_raw) = template.raw_r1() {
-                    let aux = bam_fields::aux_data_slice(r1_raw);
-                    bam_fields::find_string_tag(aux, &raw_tag)
-                        .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
-                } else if let Some(r2_raw) = template.raw_r2() {
-                    let aux = bam_fields::aux_data_slice(r2_raw);
-                    bam_fields::find_string_tag(aux, &raw_tag)
-                        .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
-                } else {
-                    bail!("Template has no reads");
-                };
-
-                let umi_s = std::str::from_utf8(umi_bytes)
-                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
-
-                let earlier = if let (Some(r1), Some(r2)) = (template.raw_r1(), template.raw_r2()) {
-                    is_r1_genomically_earlier_raw(r1, r2)
-                } else {
-                    true
-                };
-
-                (umi_s, earlier)
+            let umi_bytes = if let Some(r1_raw) = template.r1() {
+                let aux = bam_fields::aux_data_slice(r1_raw);
+                bam_fields::find_string_tag(aux, &raw_tag)
+                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
+            } else if let Some(r2_raw) = template.r2() {
+                let aux = bam_fields::aux_data_slice(r2_raw);
+                bam_fields::find_string_tag(aux, &raw_tag)
+                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
             } else {
-                // Noodles mode
-                let umi_bytes = if let Some(r1) = template.r1() {
-                    if let Some(DataValue::String(bytes)) = r1.data().get(&raw_tag) {
-                        bytes
-                    } else {
-                        bail!("UMI tag is not a string");
-                    }
-                } else if let Some(r2) = template.r2() {
-                    if let Some(DataValue::String(bytes)) = r2.data().get(&raw_tag) {
-                        bytes
-                    } else {
-                        bail!("UMI tag is not a string");
-                    }
-                } else {
-                    bail!("Template has no reads");
-                };
-                let umi_s = std::str::from_utf8(umi_bytes)
-                    .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
-
-                let earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
-                    is_r1_genomically_earlier_impl(r1, r2)?
-                } else {
-                    true
-                };
-
-                (umi_s, earlier)
+                bail!("Template has no reads");
             };
 
-            umi_for_read_impl(umi_str_ref, is_r1_earlier, assigner)?
+            let umi_s = std::str::from_utf8(umi_bytes)
+                .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in UMI: {e}"))?;
+
+            let is_r1_earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
+                is_r1_genomically_earlier_raw(r1, r2)
+            } else {
+                true
+            };
+
+            umi_for_read_impl(umi_s, is_r1_earlier, assigner)?
         };
 
         umis.push(processed_umi);
@@ -665,29 +481,6 @@ fn assign_umi_groups_for_indices_impl(
     }
 
     Ok(())
-}
-
-/// Set MI tag on a single record using `MoleculeId` with global offset.
-///
-/// Converts the `MoleculeId` enum to a string representation with the base offset applied,
-/// and sets the MI tag on the record. This is called just before writing to minimize
-/// memory usage (strings are not stored until write time).
-///
-/// **Retention:** noodles fallback used by the serializer's non-raw branch
-/// (`!raw_mode`) in both the pipeline and `process_and_write_position_group`. The raw-byte
-/// path injects the MI tag directly via `bam_fields::update_string_tag`.
-#[inline]
-fn set_mi_tag_on_record(
-    record: &mut noodles::sam::alignment::record_buf::RecordBuf,
-    mi: MoleculeId,
-    assign_tag: Tag,
-    base_mi: u64,
-) {
-    if !mi.is_assigned() {
-        return;
-    }
-    let mi_string = mi.to_string_with_offset(base_mi);
-    record.data_mut().insert(assign_tag, DataValue::String(BString::from(mi_string)));
 }
 
 /// Groups reads by UMI to identify reads from the same original molecule
@@ -990,10 +783,7 @@ impl Command for GroupReadsByUmi {
 
         // Open input BAM using streaming-capable reader for pipeline use
         info!("Reading input BAM");
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
+        let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
 
         // Check sort order - template-coordinate sorted is required,
         // but queryname-sorted is also accepted when --allow-unmapped is set
@@ -1124,9 +914,8 @@ impl Command for GroupReadsByUmi {
         // Template-based batching is enabled by default in auto_tuned() with target=500 templates.
         // This provides consistent batch sizes across datasets with varying templates-per-group ratios.
 
-        // Enable raw-byte mode: skip noodles decode/encode for ~30% CPU savings
         let library_index = LibraryIndex::from_header(&header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw(library_index, cell_tag));
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Short-circuit support for memory bisection debugging.
         // Set FGUMI_SHORT_CIRCUIT=process|serialize|compress to skip downstream steps.
@@ -1156,11 +945,9 @@ impl Command for GroupReadsByUmi {
         #[cfg(feature = "memory-debug")]
         let short_circuit_compress = short_circuit == "compress";
 
-        // Counter for contiguous MI assignment. The serialize step is parallel, so each
-        // thread reserves its own block via fetch_add of the per-group
-        // `distinct_mi_count`. AtomicU64 satisfies the Fn + Sync bound; Relaxed ordering
-        // is fine because the counter is never read out-of-band (only the values produced
-        // by fetch_add are used, and each serialize thread uses only its own reservation).
+        // Counter for contiguous MI assignment (incremented in the serial serialize step).
+        // AtomicU64 satisfies the Fn + Sync bound; Relaxed ordering is fine because
+        // the serialize step is serial and ordered.
         let next_mi_base = std::sync::atomic::AtomicU64::new(0);
 
         // Run the 7-step unified pipeline with the already-opened reader (supports streaming)
@@ -1220,17 +1007,10 @@ impl Command for GroupReadsByUmi {
                 let input_record_count: u64 =
                     all_templates.iter().map(|t| t.read_count() as u64).sum();
 
-                // Filter templates (use raw-byte filter when in raw mode)
-                let raw_mode = all_templates.first().is_some_and(Template::is_raw_byte_mode);
+                // Filter templates
                 let filtered_templates: Vec<Template> = all_templates
                     .into_iter()
-                    .filter(|t| {
-                        if raw_mode {
-                            filter_template_raw(t, &filter_config, &mut filter_metrics)
-                        } else {
-                            filter_template(t, &filter_config, &mut filter_metrics)
-                        }
-                    })
+                    .filter(|t| filter_template_raw(t, &filter_config, &mut filter_metrics))
                     .collect();
 
                 // Track filtered template memory (optimized for hot path).
@@ -1388,7 +1168,7 @@ impl Command for GroupReadsByUmi {
             },
             // serialize_fn: Serialize records + collect metrics (serial, ordered)
             move |processed: ProcessedPositionGroup,
-                  header: &Header,
+                  _header: &Header,
                   output: &mut Vec<u8>|
                   -> std::io::Result<u64> {
                 #[cfg(feature = "memory-debug")]
@@ -1424,9 +1204,6 @@ impl Command for GroupReadsByUmi {
                     std::sync::atomic::Ordering::Relaxed,
                 );
 
-                // Convert assign_tag_bytes to Tag for setting MI
-                let assign_tag = Tag::from(assign_tag_bytes);
-
                 // Track template memory deallocation (templates are consumed here)
                 #[cfg(feature = "memory-debug")]
                 if debug_memory_flag {
@@ -1440,76 +1217,19 @@ impl Command for GroupReadsByUmi {
                 // Each record is serialized and dropped immediately, reducing per-thread peak memory.
                 // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
                 output.reserve(processed.templates.len() * 2 * 400);
-                let raw_mode = processed
-                    .templates
-                    .first()
-                    .is_some_and(Template::is_raw_byte_mode);
-                if raw_mode {
-                    // Raw-byte output: modify MI tag via scratch buffer
-                    use crate::sort::bam_fields;
-                    let mut scratch = Vec::with_capacity(512);
-                    let mut mi_buf = String::with_capacity(16);
-                    for template in &processed.templates {
-                        let mi = template.mi;
-                        // Reuse mi_buf to avoid per-template String allocation
-                        let has_mi = mi.is_assigned();
-                        if has_mi {
-                            mi.write_with_offset(base_mi, &mut mi_buf);
-                        }
-                        for raw in [template.raw_r1(), template.raw_r2()].into_iter().flatten() {
-                            if has_mi {
-                                scratch.clear();
-                                scratch.extend_from_slice(raw);
-                                bam_fields::update_string_tag(
-                                    &mut scratch,
-                                    &assign_tag_bytes,
-                                    mi_buf.as_bytes(),
-                                );
-                                let block_size = scratch.len() as u32;
-                                output.extend_from_slice(&block_size.to_le_bytes());
-                                output.extend_from_slice(&scratch);
-                            } else {
-                                let block_size = raw.len() as u32;
-                                output.extend_from_slice(&block_size.to_le_bytes());
-                                output.extend_from_slice(raw);
-                            }
-                        }
-                    }
-                } else {
-                    thread_local! {
-                        static RECORD_BUF: std::cell::RefCell<Vec<u8>> =
-                            std::cell::RefCell::new(Vec::with_capacity(512));
-                    }
-                    for template in processed.templates {
-                        let mi = template.mi;
-                        let (r1, r2) = template.into_primary_reads();
-                        if let Some(mut r1) = r1 {
-                            set_mi_tag_on_record(&mut r1, mi, assign_tag, base_mi);
-                            RECORD_BUF.with(|buf| -> std::io::Result<()> {
-                                let mut record_data = buf.borrow_mut();
-                                record_data.clear();
-                                encode_record_buf(&mut record_data, header, &r1)?;
-                                let block_size = record_data.len() as u32;
-                                output.extend_from_slice(&block_size.to_le_bytes());
-                                output.extend_from_slice(&record_data);
-                                Ok(())
-                            })?;
-                        }
-                        if let Some(mut r2) = r2 {
-                            set_mi_tag_on_record(&mut r2, mi, assign_tag, base_mi);
-                            RECORD_BUF.with(|buf| -> std::io::Result<()> {
-                                let mut record_data = buf.borrow_mut();
-                                record_data.clear();
-                                encode_record_buf(&mut record_data, header, &r2)?;
-                                let block_size = record_data.len() as u32;
-                                output.extend_from_slice(&block_size.to_le_bytes());
-                                output.extend_from_slice(&record_data);
-                                Ok(())
-                            })?;
-                        }
-                        // r1, r2, and the rest of template are dropped here
-                    }
-                }
+                let mut scratch = Vec::with_capacity(512);
+                let mut mi_buf = String::with_capacity(16);
+                emit_templates_raw_with_mi(
+                    &processed.templates,
+                    base_mi,
+                    assign_tag_bytes,
+                    &mut scratch,
+                    &mut mi_buf,
+                    |bytes| {
+                        output.extend_from_slice(bytes);
+                        Ok(())
+                    },
+                )?;
                 // Short-circuit: let serialize run fully but starve compress/write
                 #[cfg(feature = "memory-debug")]
                 if short_circuit_compress {
@@ -1634,11 +1354,8 @@ impl GroupReadsByUmi {
             let key = compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag));
             let decoded = DecodedRecord::from_raw_bytes(raw_rec.clone(), key);
 
-            // Feed to RecordPositionGrouper - may emit completed groups
-            let completed_groups = grouper.add_records(vec![decoded])?;
-
-            // Process any completed position groups immediately
-            for group in completed_groups {
+            // Feed to RecordPositionGrouper - may emit a completed group
+            if let Some(group) = grouper.add_record(decoded)? {
                 Self::process_and_write_position_group(
                     group,
                     filter_config,
@@ -1702,10 +1419,8 @@ impl GroupReadsByUmi {
     /// Process a single position group: build templates, filter, assign UMIs, and write output.
     /// Used by `execute_single_threaded` for streaming processing.
     ///
-    /// Dispatches on raw-byte vs noodles mode based on the template storage format.
-    /// In raw-byte mode (single-threaded path after migration), uses zero-allocation filter
-    /// and direct raw-byte MI-tag injection. The noodles path is kept as a fallback for
-    /// any future code path that supplies parsed templates (e.g. tests or external callers).
+    /// Operates on raw-byte records end-to-end: zero-allocation filter and direct raw-byte
+    /// MI-tag injection, no noodles decode/encode.
     #[allow(clippy::too_many_arguments)]
     fn process_and_write_position_group(
         group: RawPositionGroup,
@@ -1720,7 +1435,7 @@ impl GroupReadsByUmi {
         family_size_counter: &mut AHashMap<usize, u64>,
         position_group_size_counter: &mut AHashMap<usize, u64>,
         next_mi_base: &mut u64,
-        header: &Header,
+        _header: &Header,
         writer: &mut crate::bam_io::BamWriter,
     ) -> Result<()> {
         // Build templates from raw records
@@ -1728,19 +1443,10 @@ impl GroupReadsByUmi {
 
         let mut filter_metrics = FilterMetrics::new();
 
-        // Dispatch filter on template storage mode
-        let raw_mode = all_templates.first().is_some_and(Template::is_raw_byte_mode);
+        // Filter templates
         let filtered_templates: Vec<Template> = all_templates
             .into_iter()
-            .filter(|t| {
-                if raw_mode {
-                    filter_template_raw(t, filter_config, &mut filter_metrics)
-                } else {
-                    // Noodles fallback: retained for any caller that supplies parsed templates
-                    // (e.g. external tests or future commands that don't opt into raw-byte mode).
-                    filter_template(t, filter_config, &mut filter_metrics)
-                }
-            })
+            .filter(|t| filter_template_raw(t, filter_config, &mut filter_metrics))
             .collect();
 
         // Merge filter metrics
@@ -1830,56 +1536,19 @@ impl GroupReadsByUmi {
         let base_mi = *next_mi_base;
         *next_mi_base += distinct_mi_count;
 
-        if raw_mode {
-            // Raw-byte output: inject MI tag directly into raw bytes, write without noodles
-            use crate::sort::bam_fields;
-            use std::io::Write as _;
-            let mut scratch = Vec::with_capacity(512);
-            let mut mi_buf = String::with_capacity(16);
-            for template in templates {
-                let mi = template.mi;
-                let has_mi = mi.is_assigned();
-                if has_mi {
-                    // write_with_offset clears the buffer before writing.
-                    mi.write_with_offset(base_mi, &mut mi_buf);
-                }
-                for raw in [template.raw_r1(), template.raw_r2()].into_iter().flatten() {
-                    #[allow(clippy::cast_possible_truncation)]
-                    if has_mi {
-                        scratch.clear();
-                        scratch.extend_from_slice(raw);
-                        bam_fields::update_string_tag(
-                            &mut scratch,
-                            &assign_tag_bytes,
-                            mi_buf.as_bytes(),
-                        );
-                        let block_size = scratch.len() as u32;
-                        writer.get_mut().write_all(&block_size.to_le_bytes())?;
-                        writer.get_mut().write_all(&scratch)?;
-                    } else {
-                        let block_size = raw.len() as u32;
-                        writer.get_mut().write_all(&block_size.to_le_bytes())?;
-                        writer.get_mut().write_all(raw)?;
-                    }
-                }
-            }
-        } else {
-            // Noodles fallback: retained for callers that supply parsed (non-raw) templates.
-            // set_mi_tag_on_record and write_alignment_record use the typed RecordBuf API.
-            let assign_tag = Tag::from(assign_tag_bytes);
-            for template in templates {
-                let mi = template.mi;
-                let (r1, r2) = template.into_primary_reads();
-                if let Some(mut r1) = r1 {
-                    set_mi_tag_on_record(&mut r1, mi, assign_tag, base_mi);
-                    writer.write_alignment_record(header, &r1)?;
-                }
-                if let Some(mut r2) = r2 {
-                    set_mi_tag_on_record(&mut r2, mi, assign_tag, base_mi);
-                    writer.write_alignment_record(header, &r2)?;
-                }
-            }
-        }
+        // Raw-byte output: inject MI tag directly into raw bytes, write without noodles.
+        use std::io::Write as _;
+        let mut scratch = Vec::with_capacity(512);
+        let mut mi_buf = String::with_capacity(16);
+        let inner = writer.get_mut();
+        emit_templates_raw_with_mi(
+            &templates,
+            base_mi,
+            assign_tag_bytes,
+            &mut scratch,
+            &mut mi_buf,
+            |bytes| inner.write_all(bytes),
+        )?;
 
         Ok(())
     }
@@ -1929,6 +1598,51 @@ impl GroupReadsByUmi {
     }
 }
 
+/// Emit raw-byte primary reads for a batch of templates with MI tags injected.
+///
+/// For each template, if `has_mi` then the raw bytes are copied into `scratch`,
+/// the MI tag is updated in place, and the result is emitted via `emit`; otherwise
+/// the raw bytes are emitted unchanged. Each emitted record is prefixed with a
+/// 4-byte little-endian `block_size`. `mi_buf` and `scratch` are reused across
+/// templates to amortize allocations.
+///
+/// This helper is shared between the threaded-pipeline serialize step and the
+/// single-threaded writer so they can't drift in MI-injection semantics.
+#[allow(clippy::cast_possible_truncation)]
+fn emit_templates_raw_with_mi(
+    templates: &[Template],
+    base_mi: u64,
+    assign_tag_bytes: [u8; 2],
+    scratch: &mut Vec<u8>,
+    mi_buf: &mut String,
+    mut emit: impl FnMut(&[u8]) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    use crate::sort::bam_fields;
+    for template in templates {
+        let mi = template.mi;
+        let has_mi = mi.is_assigned();
+        if has_mi {
+            // write_with_offset clears the buffer before writing.
+            mi.write_with_offset(base_mi, mi_buf);
+        }
+        for raw in [template.r1(), template.r2()].into_iter().flatten() {
+            if has_mi {
+                scratch.clear();
+                scratch.extend_from_slice(raw);
+                bam_fields::update_string_tag(scratch, &assign_tag_bytes, mi_buf.as_bytes());
+                let block_size = scratch.len() as u32;
+                emit(&block_size.to_le_bytes())?;
+                emit(scratch)?;
+            } else {
+                let block_size = raw.len() as u32;
+                emit(&block_size.to_le_bytes())?;
+                emit(raw)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Write metrics to a TSV file and log the output path.
 fn write_metrics<S: serde::Serialize>(
     path: &Path,
@@ -1954,9 +1668,12 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
 mod tests {
     use super::*;
     use crate::assigner::{IdentityUmiAssigner, PairedUmiAssigner, Strategy};
-    use crate::sam::builder::{RecordBuilder, RecordPairBuilder};
+    use bstr::BString;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+    };
     use noodles::bam;
-    use noodles::sam::alignment::RecordBuf;
+    use noodles::sam;
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use rstest::rstest;
     use std::num::NonZeroUsize;
@@ -1990,10 +1707,11 @@ mod tests {
     /// Tests override specific fields as needed via struct update syntax.
     fn test_group_cmd(strategy: Strategy, edits: u32) -> GroupReadsByUmi {
         GroupReadsByUmi {
-            io: BamIoOptions::new(
-                std::path::PathBuf::from("/dev/null"),
-                std::path::PathBuf::from("/dev/null"),
-            ),
+            io: BamIoOptions {
+                input: std::path::PathBuf::from("/dev/null"),
+                output: std::path::PathBuf::from("/dev/null"),
+                async_reader: false,
+            },
             family_size_histogram: None,
             grouping_metrics: None,
             metrics: None,
@@ -2064,6 +1782,22 @@ mod tests {
         builder.build()
     }
 
+    /// Set or clear the REVERSE bit (0x10) in a raw BAM record's flags.
+    fn set_reverse(rec: &mut fgumi_raw_bam::RawRecord, reverse: bool) {
+        let v = rec.as_mut_vec();
+        let flags = u16::from_le_bytes([v[14], v[15]]);
+        let new_flags = if reverse { flags | 0x10 } else { flags & !0x10 };
+        let bytes = new_flags.to_le_bytes();
+        v[14] = bytes[0];
+        v[15] = bytes[1];
+    }
+
+    /// Append a string (Z-type) tag to a raw BAM record.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn append_str_tag(rec: &mut fgumi_raw_bam::RawRecord, tag: &[u8; 2], value: &[u8]) {
+        fgumi_raw_bam::RawTagsEditor::from_vec(rec.as_mut_vec()).append_string(tag, value);
+    }
+
     /// Build a test read with common parameters
     #[allow(clippy::cast_sign_loss)]
     fn build_test_read(
@@ -2071,42 +1805,24 @@ mod tests {
         ref_id: usize,
         pos: i32,
         mapq: u8,
-        flags: u16,
+        raw_flags: u16,
         umi: &str,
-    ) -> sam::alignment::RecordBuf {
-        // 100bp sequence
-        let seq = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+    ) -> fgumi_raw_bam::RawRecord {
+        let seq = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let cigar = encode_op(0, 100); // 100M
+        let quals = vec![30u8; 100];
 
-        let mut builder = RecordBuilder::new()
-            .name(name)
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .flags(raw_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos - 1)
+            .mapq(mapq)
+            .cigar_ops(&[cigar])
             .sequence(seq)
-            .reference_sequence_id(ref_id)
-            .alignment_start(pos as usize)
-            .mapping_quality(mapq)
-            .cigar("100M")
-            .tag("RX", umi);
-
-        // Set flags based on raw u16
-        let sam_flags = sam::alignment::record::Flags::from(flags);
-        if sam_flags.is_segmented() {
-            builder = builder.paired(true);
-        }
-        if sam_flags.is_first_segment() {
-            builder = builder.first_segment(true);
-        } else if sam_flags.is_last_segment() {
-            builder = builder.first_segment(false);
-        }
-        if sam_flags.is_reverse_complemented() {
-            builder = builder.reverse_complement(true);
-        }
-        if sam_flags.is_unmapped() {
-            builder = builder.unmapped(true);
-        }
-        if sam_flags.is_mate_unmapped() {
-            builder = builder.mate_unmapped(true);
-        }
-
-        builder.build()
+            .qualities(&quals);
+        b.add_string_tag(b"RX", umi.as_bytes());
+        b.build()
     }
 
     /// Create a pair of reads
@@ -2117,20 +1833,44 @@ mod tests {
         pos1: i32,
         pos2: i32,
         mapq1: u8,
-        _mapq2: u8,
+        mapq2: u8,
         umi: &str,
-    ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(ref_id)
-            .r1_start(pos1 as usize)
-            .r2_start(pos2 as usize)
-            .mapping_quality(mapq1)
-            .tag("RX", umi)
-            .tag("MC", "100M")
-            .build()
+    ) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos1 - 1)
+            .mapq(mapq1)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos2 - 1);
+        b1.add_string_tag(b"RX", umi.as_bytes());
+        b1.add_string_tag(b"MC", b"100M");
+        let r1 = b1.build();
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos2 - 1)
+            .mapq(mapq2)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos1 - 1);
+        b2.add_string_tag(b"RX", umi.as_bytes());
+        b2.add_string_tag(b"MC", b"100M");
+        let r2 = b2.build();
+
+        (r1, r2)
     }
 
     /// Create a pair where R1 is mapped (with specified MAPQ) and R2 is unmapped
@@ -2142,24 +1882,43 @@ mod tests {
         pos: i32,
         mapq: u8,
         umi: &str,
-    ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(ref_id)
-            .r1_start(pos as usize) // R1 mapped
-            // R2 has no start position, so it's unmapped
-            .r1_reverse(false)
-            .r2_reverse(false)
-            .tag("RX", umi)
-            .r1_tag("MQ", 0i32) // R1's mate (R2) is unmapped, so MQ=0
-            .r2_tag("MQ", i32::from(mapq)) // R2's mate (R1) has the specified MAPQ
-            .build()
+    ) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        // R1: mapped, R2 is unmapped so MATE_UNMAPPED flag
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED)
+            .ref_id(ref_id as i32)
+            .pos(pos - 1)
+            .mapq(mapq)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals);
+        b1.add_string_tag(b"RX", umi.as_bytes());
+        b1.add_int_tag(b"MQ", 0i32); // R1's mate (R2) is unmapped, so MQ=0
+        let r1 = b1.build();
+
+        // R2: unmapped
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::UNMAPPED)
+            .ref_id(ref_id as i32)
+            .pos(pos - 1)
+            .mapq(0)
+            .sequence(&seq)
+            .qualities(&quals);
+        b2.add_string_tag(b"RX", umi.as_bytes());
+        b2.add_int_tag(b"MQ", i32::from(mapq)); // R2's mate (R1) has the specified MAPQ
+        let r2 = b2.build();
+
+        (r1, r2)
     }
 
     /// Write records to a temporary BAM file
-    fn create_test_bam(records: Vec<sam::alignment::RecordBuf>) -> Result<NamedTempFile> {
+    fn create_test_bam(records: Vec<fgumi_raw_bam::RawRecord>) -> Result<NamedTempFile> {
         let temp_file = NamedTempFile::new()?;
         let header = create_test_header();
 
@@ -2167,8 +1926,10 @@ mod tests {
 
         writer.write_header(&header)?;
 
-        for record in records {
-            writer.write_alignment_record(&header, &record)?;
+        for record in &records {
+            let record_buf =
+                raw_record_to_record_buf(record, &header).map_err(std::io::Error::other)?;
+            writer.write_alignment_record(&header, &record_buf)?;
         }
 
         drop(writer); // Ensure file is flushed
@@ -2348,7 +2109,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Edit, 1)
         };
@@ -2390,7 +2155,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2427,7 +2196,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2442,7 +2215,7 @@ mod tests {
 
     #[test]
     fn test_correctly_groups_single_end_reads() -> Result<()> {
-        let records: Vec<RecordBuf> = vec![
+        let records = vec![
             // Group 1: same position, same UMI
             build_test_read("a01", 0, 100, 60, 0, "AAAAAAAA"),
             build_test_read("a02", 0, 100, 60, 0, "AAAAAAAA"),
@@ -2461,7 +2234,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -2505,7 +2282,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             family_size_histogram: Some(paths.histogram.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2599,7 +2380,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             metrics: Some(paths.metrics_prefix.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2844,7 +2629,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             family_size_histogram: Some(paths.histogram.clone()),
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             metrics: Some(paths.metrics_prefix.clone()),
@@ -2910,7 +2699,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             metrics: Some(paths.metrics_prefix.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -2964,7 +2757,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
@@ -3002,7 +2799,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             min_umi_length: Some(6),
             ..test_group_cmd(Strategy::Edit, 0)
@@ -3044,7 +2845,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_umi_length: Some(5),
             ..test_group_cmd(Strategy::Edit, 0)
         };
@@ -3070,34 +2875,80 @@ mod tests {
 
         // Group A: R1 on chr1, R2 on chr2 (both forward strand)
         for i in 1..=4 {
-            let (r1, r2) = RecordPairBuilder::new()
-                .name(&format!("a{i:02}"))
-                .r1_sequence(&"A".repeat(100))
-                .r2_sequence(&"A".repeat(100))
-                .reference_sequence_id(0) // R1 on chr1
-                .r2_reference_sequence_id(1) // R2 on chr2
-                .r1_start(100)
-                .r2_start(300)
-                .r2_reverse(false) // Both reads forward (matching original test)
-                .tag("RX", "ACT-ACT")
-                .build();
+            let seq = vec![b'A'; 100];
+            let quals = vec![30u8; 100];
+            let cigar = encode_op(0, 100);
+            let name_a = format!("a{i:02}");
+            let mut b1 = RawSamBuilder::new();
+            b1.read_name(name_a.as_bytes())
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .ref_id(0) // R1 on chr1
+                .pos(99) // 1-based 100 -> 0-based 99
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(1) // R2 on chr2
+                .mate_pos(299); // 1-based 300 -> 0-based 299
+            b1.add_string_tag(b"RX", b"ACT-ACT");
+            b1.add_string_tag(b"MC", b"100M");
+            let r1 = b1.build();
+
+            let mut b2 = RawSamBuilder::new();
+            b2.read_name(name_a.as_bytes())
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .ref_id(1) // R2 on chr2
+                .pos(299) // 1-based 300 -> 0-based 299
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0) // R1 on chr1
+                .mate_pos(99); // 1-based 100 -> 0-based 99
+            b2.add_string_tag(b"RX", b"ACT-ACT");
+            b2.add_string_tag(b"MC", b"100M");
+            let r2 = b2.build();
+
             records.push(r1);
             records.push(r2);
         }
 
         // Group B: R1 on chr2, R2 on chr1 (flipped, both forward strand)
         for i in 1..=4 {
-            let (r1, r2) = RecordPairBuilder::new()
-                .name(&format!("b{i:02}"))
-                .r1_sequence(&"A".repeat(100))
-                .r2_sequence(&"A".repeat(100))
-                .reference_sequence_id(1) // R1 on chr2
-                .r2_reference_sequence_id(0) // R2 on chr1
-                .r1_start(300)
-                .r2_start(100)
-                .r2_reverse(false) // Both reads forward (matching original test)
-                .tag("RX", "ACT-ACT")
-                .build();
+            let seq = vec![b'A'; 100];
+            let quals = vec![30u8; 100];
+            let cigar = encode_op(0, 100);
+            let name_b = format!("b{i:02}");
+            let mut b1 = RawSamBuilder::new();
+            b1.read_name(name_b.as_bytes())
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .ref_id(1) // R1 on chr2
+                .pos(299) // 1-based 300 -> 0-based 299
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0) // R2 on chr1
+                .mate_pos(99); // 1-based 100 -> 0-based 99
+            b1.add_string_tag(b"RX", b"ACT-ACT");
+            b1.add_string_tag(b"MC", b"100M");
+            let r1 = b1.build();
+
+            let mut b2 = RawSamBuilder::new();
+            b2.read_name(name_b.as_bytes())
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .ref_id(0) // R2 on chr1
+                .pos(99) // 1-based 100 -> 0-based 99
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(1) // R1 on chr2
+                .mate_pos(299); // 1-based 300 -> 0-based 299
+            b2.add_string_tag(b"RX", b"ACT-ACT");
+            b2.add_string_tag(b"MC", b"100M");
+            let r2 = b2.build();
+
             records.push(r1);
             records.push(r2);
         }
@@ -3106,7 +2957,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3151,8 +3006,6 @@ mod tests {
     fn test_pair_orientation_splitting() -> Result<()> {
         // Test that reads with different pair orientations are NOT grouped together
         // even if they have the same UMI - they have different start positions and orientations
-        use noodles::sam::alignment::record::Flags;
-
         let mut records = Vec::new();
 
         // F1R2: Read 1 forward at 100, Read 2 reverse at 300
@@ -3163,58 +3016,40 @@ mod tests {
         // F2R1: Read 1 reverse at 300, Read 2 forward at 100 (flipped positions and strands)
         let (mut r1, mut r2) = build_test_pair("f2r1", 0, 300, 100, 60, 60, "ACGT-TTGA");
         // Flip strands
-        let mut flags1 = r1.flags();
-        flags1.set(Flags::REVERSE_COMPLEMENTED, true);
-        *r1.flags_mut() = flags1;
-        let mut flags2 = r2.flags();
-        flags2.set(Flags::REVERSE_COMPLEMENTED, false);
-        *r2.flags_mut() = flags2;
+        set_reverse(&mut r1, true);
+        set_reverse(&mut r2, false);
         records.push(r1);
         records.push(r2);
 
         // FF: Both forward at 100 and 300
         let (r1, mut r2) = build_test_pair("ff", 0, 100, 300, 60, 60, "ACGT-TTGA");
-        let mut flags2 = r2.flags();
-        flags2.set(Flags::REVERSE_COMPLEMENTED, false);
-        *r2.flags_mut() = flags2;
+        set_reverse(&mut r2, false);
         records.push(r1);
         records.push(r2);
 
         // RR: Both reverse at 1 and 201
         let (mut r1, mut r2) = build_test_pair("rr", 0, 1, 201, 60, 60, "ACGT-TTGA");
-        let mut flags1 = r1.flags();
-        flags1.set(Flags::REVERSE_COMPLEMENTED, true);
-        *r1.flags_mut() = flags1;
-        let mut flags2 = r2.flags();
-        flags2.set(Flags::REVERSE_COMPLEMENTED, true);
-        *r2.flags_mut() = flags2;
+        set_reverse(&mut r1, true);
+        set_reverse(&mut r2, true);
         records.push(r1);
         records.push(r2);
 
         // R1F2: Read 1 reverse at 150, Read 2 forward at 350
         let (mut r1, mut r2) = build_test_pair("r1f2", 0, 150, 350, 60, 60, "ACGT-TTGA");
-        let mut flags1 = r1.flags();
-        flags1.set(Flags::REVERSE_COMPLEMENTED, true);
-        *r1.flags_mut() = flags1;
-        let mut flags2 = r2.flags();
-        flags2.set(Flags::REVERSE_COMPLEMENTED, false);
-        *r2.flags_mut() = flags2;
+        set_reverse(&mut r1, true);
+        set_reverse(&mut r2, false);
         records.push(r1);
         records.push(r2);
 
         // R2F1: Read 1 forward at 400, Read 2 reverse at 600
         let (r1, mut r2) = build_test_pair("r2f1", 0, 400, 600, 60, 60, "ACGT-TTGA");
-        let mut flags2 = r2.flags();
-        flags2.set(Flags::REVERSE_COMPLEMENTED, true);
-        *r2.flags_mut() = flags2;
+        set_reverse(&mut r2, true);
         records.push(r1);
         records.push(r2);
 
         // Add some single-end reads with different strands
         let mut frag = build_test_read("Frag", 0, 100, 60, 0, "ACGT-TTGA");
-        let mut flags = frag.flags();
-        flags.set(Flags::REVERSE_COMPLEMENTED, true);
-        *frag.flags_mut() = flags;
+        set_reverse(&mut frag, true);
         records.push(frag);
 
         let frag = build_test_read("fRag", 0, 1, 60, 0, "ACGT-TTGA");
@@ -3224,7 +3059,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -3244,14 +3083,37 @@ mod tests {
         // Test that templates with missing UMI tags are filtered out
         let mut records = Vec::new();
 
-        // Create a pair WITHOUT the RX tag
-        let (mut r1, mut r2) = build_test_pair("a01", 0, 100, 300, 60, 60, "dummy");
+        // Create a pair WITHOUT the RX tag (build directly without UMI, but with MC)
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100);
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(b"a01")
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(0)
+            .mate_pos(299);
+        b1.add_string_tag(b"MC", b"100M");
+        let r1 = b1.build();
 
-        // Remove the RX tag
-        use noodles::sam::alignment::record::data::field::Tag;
-        let rx_tag = Tag::from([b'R', b'X']);
-        r1.data_mut().remove(&rx_tag);
-        r2.data_mut().remove(&rx_tag);
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(b"a01")
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(299)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(0)
+            .mate_pos(99);
+        b2.add_string_tag(b"MC", b"100M");
+        let r2 = b2.build();
 
         records.push(r1);
         records.push(r2);
@@ -3260,7 +3122,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3282,14 +3148,37 @@ mod tests {
         // Test that templates without UMI tags are accepted when --no-umi is used
         let mut records = Vec::new();
 
-        // Create a pair WITHOUT the RX tag
-        let (mut r1, mut r2) = build_test_pair("a01", 0, 100, 300, 60, 60, "dummy");
+        // Create a pair WITHOUT the RX tag (build directly without UMI, but with MC)
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100);
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(b"a01")
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(0)
+            .mate_pos(299);
+        b1.add_string_tag(b"MC", b"100M");
+        let r1 = b1.build();
 
-        // Remove the RX tag
-        use noodles::sam::alignment::record::data::field::Tag;
-        let rx_tag = Tag::from([b'R', b'X']);
-        r1.data_mut().remove(&rx_tag);
-        r2.data_mut().remove(&rx_tag);
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(b"a01")
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(299)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(0)
+            .mate_pos(99);
+        b2.add_string_tag(b"MC", b"100M");
+        let r2 = b2.build();
 
         records.push(r1);
         records.push(r2);
@@ -3298,7 +3187,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Identity, 0);
-        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
+        cmd.io = BamIoOptions {
+            input: input.path().to_path_buf(),
+            output: paths.output.clone(),
+            async_reader: false,
+        };
         cmd.no_umi = true;
 
         cmd.execute("test")?;
@@ -3335,7 +3228,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Adjacency, 1);
-        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
+        cmd.io = BamIoOptions {
+            input: input.path().to_path_buf(),
+            output: paths.output.clone(),
+            async_reader: false,
+        };
         cmd.no_umi = true; // Will be overridden to identity
 
         cmd.execute("test")?;
@@ -3366,7 +3263,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let mut cmd = test_group_cmd(Strategy::Identity, 0);
-        cmd.io = BamIoOptions::new(input.path().to_path_buf(), paths.output.clone());
+        cmd.io = BamIoOptions {
+            input: input.path().to_path_buf(),
+            output: paths.output.clone(),
+            async_reader: false,
+        };
         cmd.no_umi = true;
 
         cmd.execute("test")?;
@@ -3396,45 +3297,45 @@ mod tests {
     #[test]
     fn test_cell_barcode_grouping() -> Result<()> {
         // Test that reads with different cell barcodes are grouped separately
-        use noodles::sam::alignment::record::data::field::Tag;
-        use noodles::sam::alignment::record_buf::data::field::Value;
-
         let mut records = Vec::new();
-        let cb_tag = Tag::from([b'C', b'B']);
 
         // Two reads with same UMI and position but same cell barcode
         let mut r1 = build_test_read("a01", 0, 100, 60, 0, "AAAAAAAA");
-        r1.data_mut().insert(cb_tag, Value::String(b"AA".into()));
+        append_str_tag(&mut r1, b"CB", b"AA");
         records.push(r1);
 
         let mut r2 = build_test_read("a02", 0, 100, 60, 0, "AAAAAAAA");
-        r2.data_mut().insert(cb_tag, Value::String(b"AA".into()));
+        append_str_tag(&mut r2, b"CB", b"AA");
         records.push(r2);
 
         // One read with similar UMI but different cell barcode
         let mut r3 = build_test_read("a03", 0, 100, 60, 0, "CACACACA");
-        r3.data_mut().insert(cb_tag, Value::String(b"CA".into()));
+        append_str_tag(&mut r3, b"CB", b"CA");
         records.push(r3);
 
         // One read with close UMI but different cell barcode
         let mut r4 = build_test_read("a04", 0, 100, 60, 0, "CACACACC");
-        r4.data_mut().insert(cb_tag, Value::String(b"NN".into()));
+        append_str_tag(&mut r4, b"CB", b"NN");
         records.push(r4);
 
         // Two reads at different position with same UMI and cell barcode
         let mut r5 = build_test_read("a05", 0, 105, 60, 0, "GTAGTAGG");
-        r5.data_mut().insert(cb_tag, Value::String(b"GT".into()));
+        append_str_tag(&mut r5, b"CB", b"GT");
         records.push(r5);
 
         let mut r6 = build_test_read("a06", 0, 105, 60, 0, "GTAGTAGG");
-        r6.data_mut().insert(cb_tag, Value::String(b"GT".into()));
+        append_str_tag(&mut r6, b"CB", b"GT");
         records.push(r6);
 
         let input = create_test_bam(records)?;
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3495,7 +3396,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3556,7 +3461,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 1)
         };
 
@@ -3604,32 +3513,81 @@ mod tests {
         records.push(r2);
 
         // Add secondary read (should be filtered out)
-        let (r1, r2) = RecordPairBuilder::new()
-            .name("a01_sec")
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(0)
-            .r1_start(100)
-            .r2_start(300)
-            .tag("RX", "AAAAAAAA")
-            .secondary(true)
-            .build();
-        records.push(r1);
-        records.push(r2);
+        {
+            let seq = vec![b'A'; 100];
+            let quals = vec![30u8; 100];
+            let cigar = encode_op(0, 100);
+            let mut b1 = RawSamBuilder::new();
+            b1.read_name(b"a01_sec")
+                .flags(
+                    flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE | flags::SECONDARY,
+                )
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0)
+                .mate_pos(299);
+            b1.add_string_tag(b"RX", b"AAAAAAAA");
+            let r1 = b1.build();
+            let mut b2 = RawSamBuilder::new();
+            b2.read_name(b"a01_sec")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | flags::SECONDARY)
+                .ref_id(0)
+                .pos(299)
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0)
+                .mate_pos(99);
+            b2.add_string_tag(b"RX", b"AAAAAAAA");
+            let r2 = b2.build();
+            records.push(r1);
+            records.push(r2);
+        }
 
         // Add supplementary read (should be filtered out)
-        let (r1, r2) = RecordPairBuilder::new()
-            .name("a01_sup")
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(0)
-            .r1_start(100)
-            .r2_start(300)
-            .tag("RX", "AAAAAAAA")
-            .supplementary(true)
-            .build();
-        records.push(r1);
-        records.push(r2);
+        {
+            let seq = vec![b'A'; 100];
+            let quals = vec![30u8; 100];
+            let cigar = encode_op(0, 100);
+            let mut b1 = RawSamBuilder::new();
+            b1.read_name(b"a01_sup")
+                .flags(
+                    flags::PAIRED
+                        | flags::FIRST_SEGMENT
+                        | flags::MATE_REVERSE
+                        | flags::SUPPLEMENTARY,
+                )
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0)
+                .mate_pos(299);
+            b1.add_string_tag(b"RX", b"AAAAAAAA");
+            let r1 = b1.build();
+            let mut b2 = RawSamBuilder::new();
+            b2.read_name(b"a01_sup")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | flags::SUPPLEMENTARY)
+                .ref_id(0)
+                .pos(299)
+                .mapq(60)
+                .cigar_ops(&[cigar])
+                .sequence(&seq)
+                .qualities(&quals)
+                .mate_ref_id(0)
+                .mate_pos(99);
+            b2.add_string_tag(b"RX", b"AAAAAAAA");
+            let r2 = b2.build();
+            records.push(r1);
+            records.push(r2);
+        }
 
         // Add another primary read with lower MAPQ (will be marked as duplicate)
         let (r1, r2) = build_test_pair("a02", 0, 100, 300, 10, 10, "AAAAAAAA");
@@ -3640,7 +3598,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3724,7 +3686,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 2)
         };
 
@@ -3787,7 +3753,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading: ThreadingOptions::new(4), // Use 4 threads
             ..test_group_cmd(Strategy::Adjacency, 2)
         };
@@ -3832,7 +3802,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -3872,7 +3846,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading: ThreadingOptions::new(4), // Use 4 threads
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -3918,7 +3896,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -3964,7 +3946,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -3997,7 +3983,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 1)
         };
 
@@ -4033,7 +4023,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4069,7 +4063,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -4106,7 +4104,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
 
@@ -4135,7 +4137,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4170,7 +4176,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_umi_length: Some(8), // Require at least 8 bases
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4206,7 +4216,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4242,7 +4256,11 @@ mod tests {
 
         // With edits=2, all should group together
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 2)
         };
 
@@ -4259,23 +4277,20 @@ mod tests {
     #[test]
     fn test_paired_umi_missing_both_ends() -> Result<()> {
         // Test paired UMI handling when both ends are missing (just "-")
-        use noodles::sam::alignment::record::data::field::Tag;
-        use noodles::sam::alignment::record_buf::data::field::Value;
-
-        let mut r1 = build_test_read("test", 0, 100, 60, 0x41, "");
-        let mut r2 = build_test_read("test", 0, 300, 60, 0x81, "");
-
-        // Set UMI to just "-" (both ends missing)
-        let rx_tag = Tag::from([b'R', b'X']);
-        r1.data_mut().insert(rx_tag, Value::String(b"-".into()));
-        r2.data_mut().insert(rx_tag, Value::String(b"-".into()));
+        // Build with UMI "-" directly
+        let r1 = build_test_read("test", 0, 100, 60, 0x41, "-");
+        let r2 = build_test_read("test", 0, 300, 60, 0x81, "-");
 
         let records = vec![r1, r2];
         let input = create_test_bam(records)?;
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4305,7 +4320,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Adjacency, 0) // No edits allowed
         };
 
@@ -4340,7 +4359,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Edit, 3) // Allow up to 3 edits
         };
 
@@ -4370,7 +4393,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4405,7 +4432,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             family_size_histogram: Some(paths.histogram.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4431,7 +4462,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             grouping_metrics: Some(paths.grouping_metrics.clone()),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4463,7 +4498,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_map_q: Some(20), // Filter reads with mapq < 20
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4491,7 +4530,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4523,7 +4566,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4553,7 +4600,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4596,7 +4647,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             min_map_q: Some(30), // Threshold is 30, "bad" pair has MAPQ=10
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -4642,19 +4697,51 @@ mod tests {
         umi: &str,
         r1_reverse: bool,
         r2_reverse: bool,
-    ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(ref_id)
-            .r1_start(pos1 as usize)
-            .r2_start(pos2 as usize)
-            .r1_reverse(r1_reverse)
-            .r2_reverse(r2_reverse)
-            .tag("RX", umi)
-            .tag("MC", "100M")
-            .build()
+    ) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        let r1_flags = flags::PAIRED
+            | flags::FIRST_SEGMENT
+            | (if r1_reverse { flags::REVERSE } else { 0 })
+            | (if r2_reverse { flags::MATE_REVERSE } else { 0 });
+        let r2_flags = flags::PAIRED
+            | flags::LAST_SEGMENT
+            | (if r2_reverse { flags::REVERSE } else { 0 })
+            | (if r1_reverse { flags::MATE_REVERSE } else { 0 });
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(r1_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos2 - 1);
+        b1.add_string_tag(b"RX", umi.as_bytes());
+        b1.add_string_tag(b"MC", b"100M");
+        let r1 = b1.build();
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(r2_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos1 - 1);
+        b2.add_string_tag(b"RX", umi.as_bytes());
+        b2.add_string_tag(b"MC", b"100M");
+        let r2 = b2.build();
+
+        (r1, r2)
     }
 
     #[test]
@@ -4745,7 +4832,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Identity, 0)
         };
 
@@ -4802,7 +4893,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             ..test_group_cmd(Strategy::Paired, 0)
         };
 
@@ -4860,7 +4955,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading,
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -4915,7 +5014,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading: ThreadingOptions::new(4),
             ..test_group_cmd(strategy, edits)
         };
@@ -4959,7 +5062,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading: ThreadingOptions::new(4),
             min_map_q: Some(30),
             ..test_group_cmd(Strategy::Identity, 0)
@@ -5002,7 +5109,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             threading: ThreadingOptions::new(4),
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5023,7 +5134,12 @@ mod tests {
     // ========================================================================
 
     /// Build a raw BAM record with specified flags, mapq, and UMI for testing.
-    fn make_raw_bam_for_group(name: &[u8], flag: u16, mapq: u8, umi: &[u8]) -> Vec<u8> {
+    fn make_raw_bam_for_group(
+        name: &[u8],
+        flag: u16,
+        mapq: u8,
+        umi: &[u8],
+    ) -> fgumi_raw_bam::RawRecord {
         use crate::sort::bam_fields;
 
         let seq_len = 4usize;
@@ -5063,7 +5179,7 @@ mod tests {
         buf.extend_from_slice(umi);
         buf.push(0);
 
-        buf
+        fgumi_raw_bam::RawRecord::from(buf)
     }
 
     #[test]
@@ -5076,8 +5192,8 @@ mod tests {
             30,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 20,
@@ -5101,8 +5217,8 @@ mod tests {
             10,
             b"ACGTACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 20,
@@ -5127,8 +5243,8 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5152,8 +5268,8 @@ mod tests {
             30,
             b"ANGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5177,8 +5293,8 @@ mod tests {
             30,
             b"AC",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5201,8 +5317,8 @@ mod tests {
             0,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![raw]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5250,8 +5366,8 @@ mod tests {
             30,
             b"ACGT",
         );
-        let template = Template::from_raw_records(vec![supp].into_iter().map(Into::into).collect())
-            .expect("Template::from_raw_records should succeed");
+        let template =
+            Template::from_records(vec![supp]).expect("Template::from_raw_records should succeed");
         let config = GroupFilterConfig {
             umi_tag: [b'R', b'X'],
             min_mapq: 0,
@@ -5300,17 +5416,34 @@ mod tests {
     }
 
     /// Build a pair of fully unmapped reads with UMI tags
-    fn build_unmapped_test_pair(name: &str, umi: &str) -> (RecordBuf, RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .tag("RX", umi)
-            .build()
+    fn build_unmapped_test_pair(
+        name: &str,
+        umi: &str,
+    ) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+        use fgumi_raw_bam::UnmappedSamBuilder;
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+
+        let r1_flags =
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::UNMAPPED | flags::MATE_UNMAPPED;
+        let mut b1 = UnmappedSamBuilder::new();
+        b1.build_record(name.as_bytes(), r1_flags, &seq, &quals);
+        b1.append_string_tag(b"RX", umi.as_bytes());
+        let r1 = b1.build();
+
+        let r2_flags = flags::PAIRED | flags::LAST_SEGMENT | flags::UNMAPPED | flags::MATE_UNMAPPED;
+        let mut b2 = UnmappedSamBuilder::new();
+        b2.build_record(name.as_bytes(), r2_flags, &seq, &quals);
+        b2.append_string_tag(b"RX", umi.as_bytes());
+        let r2 = b2.build();
+
+        (r1, r2)
     }
 
     /// Write records to a temporary BAM file with queryname sorted header
-    fn create_queryname_sorted_test_bam(records: Vec<RecordBuf>) -> Result<NamedTempFile> {
+    fn create_queryname_sorted_test_bam(
+        records: Vec<fgumi_raw_bam::RawRecord>,
+    ) -> Result<NamedTempFile> {
         let temp_file = NamedTempFile::new()?;
         let header = create_queryname_sorted_header();
 
@@ -5318,8 +5451,10 @@ mod tests {
 
         writer.write_header(&header)?;
 
-        for record in records {
-            writer.write_alignment_record(&header, &record)?;
+        for record in &records {
+            let record_buf =
+                raw_record_to_record_buf(record, &header).map_err(std::io::Error::other)?;
+            writer.write_alignment_record(&header, &record_buf)?;
         }
 
         drop(writer); // Ensure file is flushed
@@ -5342,7 +5477,7 @@ mod tests {
         };
 
         let mut metrics = FilterMetrics::new();
-        let should_keep = filter_template(&template, &config, &mut metrics);
+        let should_keep = filter_template_raw(&template, &config, &mut metrics);
 
         assert!(should_keep, "Unmapped template should be kept when allow_unmapped=true");
         assert_eq!(metrics.total_templates, 2, "Should count 2 records");
@@ -5366,7 +5501,7 @@ mod tests {
         };
 
         let mut metrics = FilterMetrics::new();
-        let should_keep = filter_template(&template, &config, &mut metrics);
+        let should_keep = filter_template_raw(&template, &config, &mut metrics);
 
         assert!(!should_keep, "Unmapped template should be rejected when allow_unmapped=false");
         assert_eq!(metrics.total_templates, 2, "Should count 2 records");
@@ -5402,7 +5537,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5435,7 +5574,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Adjacency, 1)
         };
@@ -5470,7 +5613,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             allow_unmapped: false,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5502,7 +5649,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             allow_unmapped: true,
             ..test_group_cmd(Strategy::Identity, 0)
         };
@@ -5537,7 +5688,11 @@ mod tests {
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
-            io: BamIoOptions::new(input.path().to_path_buf(), paths.output.clone()),
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
             allow_unmapped: true,
             threading,
             ..test_group_cmd(Strategy::Identity, 0)

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -16,19 +16,12 @@ use crate::variant_review::{
 };
 use anyhow::{Result, bail};
 use clap::Parser;
-use fgumi_raw_bam::{RawBamReader, RawRecord, find_string_tag_in_record};
+use fgumi_raw_bam::{
+    BAM_BASE_TO_ASCII, CigarKind, IndexedRawBamReader, RawBamReader, RawRecord,
+    find_string_tag_in_record, write_raw_record,
+};
 use log::info;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record::Cigar;
-// RecordBuf retained at indexed-query sites (extract_consensus_reads, generate_review_file):
-// noodles indexed_reader::query() yields bam::Record whose inner bytes are not publicly
-// accessible as &[u8], so raw-byte helpers (find_string_tag_in_record, read_pos_at_ref_pos_raw)
-// cannot be applied there without a noodles-to-bytes serialisation round-trip that would
-// cost more than it saves.  Once noodles exposes raw bytes from bam::Record
-// (https://github.com/zaeleus/noodles/pull/373) these sites can be migrated.
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::collections::HashSet;
-use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
 use super::command::Command;
@@ -180,6 +173,29 @@ impl Command for Review {
 }
 
 impl Review {
+    /// Load a BAM index, preferring the `<prefix>.bam.bai` sidecar and falling back
+    /// to `<prefix>.bai` for callers that used samtools' default naming.
+    fn read_bam_index(path: &Path) -> Result<noodles::bam::bai::Index> {
+        use noodles::bam;
+
+        let bam_bai = path.with_extension("bam.bai");
+        if bam_bai.exists() {
+            return Ok(bam::bai::fs::read(&bam_bai)?);
+        }
+
+        let bai = path.with_extension("bai");
+        if bai.exists() {
+            return Ok(bam::bai::fs::read(&bai)?);
+        }
+
+        bail!(
+            "Missing BAM index for {}. Tried {} and {}",
+            path.display(),
+            bam_bai.display(),
+            bai.display()
+        );
+    }
+
     /// Checks if a file is a VCF file based on its extension.
     ///
     /// Determines whether a file path represents a VCF file by examining its extension.
@@ -602,8 +618,8 @@ impl Review {
     ) -> Result<HashSet<String>> {
         use noodles::bam;
 
-        let mut reader =
-            bam::io::indexed_reader::Builder::default().build_from_path(&self.consensus_bam)?;
+        let index = Self::read_bam_index(&self.consensus_bam)?;
+        let mut reader = IndexedRawBamReader::from_path(&self.consensus_bam, index)?;
         let header = reader.read_header()?;
 
         // Add @PG record with PP chaining
@@ -621,29 +637,19 @@ impl Review {
             let start = noodles::core::Position::try_from(variant.pos as usize)?;
             let region = noodles::core::Region::new(variant.chrom.as_str(), start..=start);
 
-            let query = reader.query(&header, &region)?;
-
-            for result in query.records() {
-                let bam_record = result?;
-                // RecordBuf retained: noodles indexed_reader::query() yields bam::Record whose
-                // inner bytes are not publicly accessible; see retention comment at the import.
-                let record = RecordBuf::try_from_alignment_record(&header, &bam_record)?;
+            for result in reader.query(&header, &region)? {
+                let record = result?;
 
                 // Check if this read has a non-reference base at the variant position
                 if self.has_non_reference_base(&record, variant)? {
                     // Extract MI tag
-                    let mi_tag =
-                        noodles::sam::alignment::record::data::field::Tag::from(SamTag::MI);
-                    if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(
-                        mi_bytes,
-                    )) = record.data().get(&mi_tag)
-                    {
-                        let mi = String::from_utf8(mi_bytes.iter().copied().collect())?;
-                        let mi_base = extract_mi_base(&mi).to_string();
+                    if let Some(mi_bytes) = find_string_tag_in_record(&record, &SamTag::MI) {
+                        let mi = std::str::from_utf8(mi_bytes)?;
+                        let mi_base = extract_mi_base(mi).to_string();
                         mi_set.insert(mi_base);
 
-                        // Write to output BAM
-                        writer.write_alignment_record(&header, &record)?;
+                        // Write raw record to output BAM.
+                        write_raw_record(writer.get_mut(), &record)?;
                     }
                 }
             }
@@ -705,10 +711,7 @@ impl Review {
                 let mi_base = extract_mi_base(mi);
 
                 if mi_set.contains(mi_base) {
-                    // Write raw record: BAM block_size prefix + record bytes.
-                    let block_size = raw_rec.len() as u32;
-                    writer.get_mut().write_all(&block_size.to_le_bytes())?;
-                    writer.get_mut().write_all(&raw_rec)?;
+                    write_raw_record(writer.get_mut(), &raw_rec)?;
                 }
             }
         }
@@ -740,17 +743,15 @@ impl Review {
     /// - Review TSV file cannot be created or written
     /// - Record processing fails
     fn generate_review_file(&self, variants: &[Variant]) -> Result<()> {
-        use noodles::bam;
-
         let review_path = self.output.with_extension("txt");
 
-        // Open both BAMs
-        let mut consensus_reader =
-            bam::io::indexed_reader::Builder::default().build_from_path(&self.consensus_bam)?;
+        // Open both BAMs with indexed readers that yield RawRecord directly.
+        let con_index = Self::read_bam_index(&self.consensus_bam)?;
+        let mut consensus_reader = IndexedRawBamReader::from_path(&self.consensus_bam, con_index)?;
         let consensus_header = consensus_reader.read_header()?;
 
-        let mut grouped_reader =
-            bam::io::indexed_reader::Builder::default().build_from_path(&self.grouped_bam)?;
+        let grp_index = Self::read_bam_index(&self.grouped_bam)?;
+        let mut grouped_reader = IndexedRawBamReader::from_path(&self.grouped_bam, grp_index)?;
         let grouped_header = grouped_reader.read_header()?;
 
         let mut all_metrics = Vec::new();
@@ -761,23 +762,18 @@ impl Review {
             let start = noodles::core::Position::try_from(variant.pos as usize)?;
             let region = noodles::core::Region::new(variant.chrom.as_str(), start..=start);
 
-            let query = consensus_reader.query(&consensus_header, &region)?;
-
             // Collect all consensus reads at this position
-            let mut consensus_reads = Vec::new();
-            for result in query.records() {
-                let bam_record = result?;
-                // RecordBuf retained: noodles indexed_reader::query() yields bam::Record whose
-                // inner bytes are not publicly accessible; see retention comment at the import.
-                let record = RecordBuf::try_from_alignment_record(&consensus_header, &bam_record)?;
-                consensus_reads.push(record);
+            let mut consensus_reads: Vec<RawRecord> = Vec::new();
+            for result in consensus_reader.query(&consensus_header, &region)? {
+                consensus_reads.push(result?);
             }
 
             // Build consensus-level base counts
             let mut consensus_counts = BaseCounts::default();
             for record in &consensus_reads {
                 if let Some(base) = self.get_base_at_position(record, variant.pos)? {
-                    consensus_counts.add_base(base);
+                    consensus_counts
+                        .add_base(Self::normalize_base_for_variant(base, variant.ref_base));
                 }
             }
 
@@ -786,7 +782,7 @@ impl Review {
                 // Get the base at the variant position
                 // If None, check if it's a spanning deletion
                 let read_base = match self.get_base_at_position(&record, variant.pos)? {
-                    Some(b) => (b as char).to_ascii_uppercase(),
+                    Some(b) => Self::normalize_base_for_variant(b, variant.ref_base) as char,
                     None => {
                         // Check if this is a spanning deletion (position is within a deletion)
                         if self.is_spanning_deletion(&record, variant.pos)? {
@@ -810,22 +806,16 @@ impl Review {
                 // Get the quality at this position
                 let read_qual = self.get_quality_at_position(&record, variant.pos)?.unwrap_or(0);
 
-                // Extract MI tag
-                let mi_tag = noodles::sam::alignment::record::data::field::Tag::from(SamTag::MI);
-                let mi_str = match record.data().get(&mi_tag) {
-                    Some(noodles::sam::alignment::record_buf::data::field::Value::String(
-                        mi_bytes,
-                    )) => String::from_utf8(mi_bytes.iter().copied().collect())?,
-                    _ => continue,
+                // Extract MI tag from raw bytes
+                let mi_str = match find_string_tag_in_record(&record, &SamTag::MI) {
+                    Some(mi_bytes) => std::str::from_utf8(mi_bytes)?.to_string(),
+                    None => continue,
                 };
-
                 let mi_base = extract_mi_base(&mi_str);
 
                 // Format consensus read name with /1 or /2 suffix
-                let read_name =
-                    String::from_utf8_lossy(record.name().map_or(b"unnamed", |n| n.as_ref()))
-                        .to_string();
-                let is_first = record.flags().is_first_segment();
+                let read_name = String::from_utf8_lossy(record.read_name()).to_string();
+                let is_first = record.is_first_segment();
                 let consensus_read_name = format!("{}{}", read_name, read_number_suffix(is_first));
 
                 // Generate insert string
@@ -837,57 +827,44 @@ impl Review {
 
                     let start = noodles::core::Position::try_from(variant.pos as usize)?;
                     let region = noodles::core::Region::new(variant.chrom.as_str(), start..=start);
-                    let query = grouped_reader.query(&grouped_header, &region)?;
 
                     let mut counts = BaseCounts::default();
                     let mut seen_reads = HashSet::new();
                     let expected_read_num =
                         if consensus_read_name.ends_with("/1") { "/1" } else { "/2" };
 
-                    for result in query.records() {
-                        let bam_record = result?;
-                        // RecordBuf retained: noodles indexed_reader::query() yields bam::Record
-                        // whose inner bytes are not publicly accessible; see import comment.
-                        let record =
-                            RecordBuf::try_from_alignment_record(&grouped_header, &bam_record)?;
+                    for result in grouped_reader.query(&grouped_header, &region)? {
+                        let rec = result?;
 
-                        // Extract MI tag
-                        let mi_tag =
-                            noodles::sam::alignment::record::data::field::Tag::from(SamTag::MI);
-                        let mi_str = match record.data().get(&mi_tag) {
-                            Some(
-                                noodles::sam::alignment::record_buf::data::field::Value::String(
-                                    mi_bytes,
-                                ),
-                            ) => String::from_utf8(mi_bytes.iter().copied().collect())?,
-                            _ => continue,
+                        // Extract MI tag from raw bytes
+                        let grp_mi_str = match find_string_tag_in_record(&rec, &SamTag::MI) {
+                            Some(mi_bytes) => std::str::from_utf8(mi_bytes)?.to_string(),
+                            None => continue,
                         };
 
                         // Check if MI matches
-                        let read_mi_base = extract_mi_base(&mi_str);
+                        let read_mi_base = extract_mi_base(&grp_mi_str);
                         if read_mi_base != mi_base {
                             continue;
                         }
 
                         // Check read number matches
-                        let is_first = record.flags().is_first_segment();
+                        let is_first = rec.is_first_segment();
                         let read_num = read_number_suffix(is_first);
                         if read_num != expected_read_num {
                             continue;
                         }
 
                         // Ensure we only count each read once
-                        let read_name = String::from_utf8_lossy(
-                            record.name().map_or(b"unnamed", |n| n.as_ref()),
-                        )
-                        .to_string();
-                        if !seen_reads.insert(read_name) {
+                        let rn = String::from_utf8_lossy(rec.read_name()).to_string();
+                        if !seen_reads.insert(rn) {
                             continue;
                         }
 
                         // Get base at position
-                        if let Some(base) = self.get_base_at_position(&record, variant.pos)? {
-                            counts.add_base(base);
+                        if let Some(base) = self.get_base_at_position(&rec, variant.pos)? {
+                            counts
+                                .add_base(Self::normalize_base_for_variant(base, variant.ref_base));
                         }
                     }
 
@@ -933,50 +910,54 @@ impl Review {
         Ok(())
     }
 
-    /// Get the base at a specific reference position in a read
-    // RecordBuf retained: these helpers are called from indexed-query loops where bam::Record
-    // has already been decoded to RecordBuf (see retention comment at the import).
-    fn get_base_at_position(&self, record: &RecordBuf, ref_pos: i32) -> Result<Option<u8>> {
+    /// Get the ASCII base at a specific reference position in a read.
+    ///
+    /// Returns the ASCII byte (e.g. b'A', b'C', b'N') at `ref_pos`, or `None` if the
+    /// position is not covered by this read.
+    fn get_base_at_position(&self, record: &RawRecord, ref_pos: i32) -> Result<Option<u8>> {
         if let Some(offset) = self.calculate_read_offset(record, ref_pos)? {
-            let sequence = record.sequence();
-            if offset < sequence.len() {
-                return Ok(Some(
-                    sequence
-                        .get(offset)
-                        .expect("offset already bounds-checked against sequence length"),
-                ));
+            let l_seq = record.l_seq() as usize;
+            if offset < l_seq {
+                // record.get_base returns the 4-bit BAM code (0–15); convert to ASCII.
+                let code = record.get_base(offset) as usize;
+                return Ok(Some(BAM_BASE_TO_ASCII[code]));
             }
         }
         Ok(None)
     }
 
-    /// Get the quality score at a specific reference position in a read
-    fn get_quality_at_position(&self, record: &RecordBuf, ref_pos: i32) -> Result<Option<u8>> {
+    /// Map BAM's "same as reference" `=` sentinel to the actual reference base and
+    /// uppercase the result so downstream comparisons against `variant.ref_base` and
+    /// `BaseCounts::add_base` behave correctly.
+    fn normalize_base_for_variant(base: u8, ref_base: char) -> u8 {
+        if base == b'=' { ref_base.to_ascii_uppercase() as u8 } else { base.to_ascii_uppercase() }
+    }
+
+    /// Get the quality score at a specific reference position in a read.
+    fn get_quality_at_position(&self, record: &RawRecord, ref_pos: i32) -> Result<Option<u8>> {
         if let Some(offset) = self.calculate_read_offset(record, ref_pos)? {
-            let quality_scores = record.quality_scores();
-            if offset < quality_scores.len() {
-                return Ok(Some(quality_scores.as_ref()[offset]));
+            let qual = record.quality_scores();
+            if offset < qual.len() {
+                return Ok(Some(qual[offset]));
             }
         }
         Ok(None)
     }
 
-    /// Check if a record has a non-reference base at the variant position
-    fn has_non_reference_base(&self, record: &RecordBuf, variant: &Variant) -> Result<bool> {
+    /// Check if a record has a non-reference base at the variant position.
+    fn has_non_reference_base(&self, record: &RawRecord, variant: &Variant) -> Result<bool> {
         // Skip unmapped reads
-        if record.flags().is_unmapped() {
+        if record.is_unmapped() {
             return Ok(false);
         }
 
-        // Get alignment start
-        let start = match record.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
+        // Get alignment start / end (1-based)
+        let start = match record.alignment_start_1based() {
+            Some(pos) => pos as i32,
             None => return Ok(false),
         };
-
-        // Get alignment end
-        let end = match record.alignment_end() {
-            Some(pos) => usize::from(pos) as i32,
+        let end = match record.alignment_end_1based() {
+            Some(pos) => pos as i32,
             None => return Ok(false),
         };
 
@@ -989,12 +970,13 @@ impl Review {
         let read_offset = self.calculate_read_offset(record, variant.pos)?;
 
         if let Some(offset) = read_offset {
-            let sequence = record.sequence();
-            if offset < sequence.len() {
-                let base = sequence
-                    .get(offset)
-                    .expect("offset already bounds-checked against sequence length");
-                let base_char = (base as char).to_ascii_uppercase();
+            let l_seq = record.l_seq() as usize;
+            if offset < l_seq {
+                // record.get_base returns the 4-bit BAM code; convert to ASCII then to char.
+                let code = record.get_base(offset) as usize;
+                let base_char =
+                    Self::normalize_base_for_variant(BAM_BASE_TO_ASCII[code], variant.ref_base)
+                        as char;
 
                 // Check if base differs from reference
                 if base_char != variant.ref_base {
@@ -1006,7 +988,7 @@ impl Review {
                 }
             }
         } else {
-            // read_offset is None - check if it's a spanning deletion
+            // read_offset is None — check if it's a spanning deletion
             if self.is_spanning_deletion(record, variant.pos)? {
                 return Ok(true); // Spanning deletions are considered non-reference
             }
@@ -1015,19 +997,14 @@ impl Review {
         Ok(false)
     }
 
-    /// Calculate read offset for a reference position using CIGAR
-    /// Check if a reference position falls within a deletion in the read
-    fn is_spanning_deletion(&self, record: &RecordBuf, ref_pos: i32) -> Result<bool> {
-        use noodles::sam::alignment::record::cigar::op::Kind;
-
-        let start = match record.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
+    /// Check if a reference position falls within a deletion in the read.
+    fn is_spanning_deletion(&self, record: &RawRecord, ref_pos: i32) -> Result<bool> {
+        let start = match record.alignment_start_1based() {
+            Some(pos) => pos as i32,
             None => return Ok(false),
         };
-
-        // Check if position is within the read's reference span
-        let end = match record.alignment_end() {
-            Some(pos) => usize::from(pos) as i32,
+        let end = match record.alignment_end_1based() {
+            Some(pos) => pos as i32,
             None => return Ok(false),
         };
 
@@ -1037,26 +1014,27 @@ impl Review {
 
         let mut current_ref_pos = start;
 
-        let cigar = record.cigar();
-        let ops: Vec<_> = cigar.iter().filter_map(std::result::Result::ok).collect();
-
-        for op in ops {
-            let len = op.len();
-            let kind = op.kind();
-
-            match kind {
-                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
-                    current_ref_pos += len as i32;
+        for op in record.cigar_ops_typed() {
+            let len = op.len() as i32;
+            match op.kind() {
+                CigarKind::Match | CigarKind::SequenceMatch | CigarKind::SequenceMismatch => {
+                    current_ref_pos += len;
                 }
-                Kind::Deletion | Kind::Skip => {
+                CigarKind::Deletion => {
                     // Check if target position is within this deletion
-                    // Deletions span from current_ref_pos to current_ref_pos + len - 1
-                    if ref_pos >= current_ref_pos && ref_pos < current_ref_pos + len as i32 {
+                    if ref_pos >= current_ref_pos && ref_pos < current_ref_pos + len {
                         return Ok(true);
                     }
-                    current_ref_pos += len as i32;
+                    current_ref_pos += len;
                 }
-                Kind::Insertion | Kind::SoftClip | Kind::HardClip | Kind::Pad => {
+                CigarKind::Skip => {
+                    // N (skipped region) consumes reference but is not a deletion allele.
+                    current_ref_pos += len;
+                }
+                CigarKind::Insertion
+                | CigarKind::SoftClip
+                | CigarKind::HardClip
+                | CigarKind::Pad => {
                     // These don't affect reference positions
                 }
             }
@@ -1065,26 +1043,23 @@ impl Review {
         Ok(false)
     }
 
-    fn calculate_read_offset(&self, record: &RecordBuf, ref_pos: i32) -> Result<Option<usize>> {
-        use noodles::sam::alignment::record::cigar::op::Kind;
-
-        let start = match record.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
+    /// Calculate the read (query) offset for a reference position using CIGAR.
+    ///
+    /// Returns `None` if the reference position falls within a deletion or
+    /// is not covered by the read.
+    fn calculate_read_offset(&self, record: &RawRecord, ref_pos: i32) -> Result<Option<usize>> {
+        let start = match record.alignment_start_1based() {
+            Some(pos) => pos as i32,
             None => return Ok(None),
         };
 
         let mut current_ref_pos = start;
-        let mut current_read_pos = 0;
+        let mut current_read_pos: usize = 0;
 
-        let cigar = record.cigar();
-        let ops: Vec<_> = cigar.iter().filter_map(std::result::Result::ok).collect();
-
-        for op in ops {
-            let len = op.len();
-            let kind = op.kind();
-
-            match kind {
-                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+        for op in record.cigar_ops_typed() {
+            let len = op.len() as usize;
+            match op.kind() {
+                CigarKind::Match | CigarKind::SequenceMatch | CigarKind::SequenceMismatch => {
                     if current_ref_pos + len as i32 > ref_pos {
                         // Target position is in this op
                         let offset_in_op = (ref_pos - current_ref_pos) as usize;
@@ -1093,17 +1068,17 @@ impl Review {
                     current_ref_pos += len as i32;
                     current_read_pos += len;
                 }
-                Kind::Insertion | Kind::SoftClip => {
+                CigarKind::Insertion | CigarKind::SoftClip => {
                     current_read_pos += len;
                 }
-                Kind::Deletion | Kind::Skip => {
+                CigarKind::Deletion | CigarKind::Skip => {
                     if current_ref_pos + len as i32 > ref_pos {
                         // Position is deleted in this read
                         return Ok(None);
                     }
                     current_ref_pos += len as i32;
                 }
-                Kind::HardClip | Kind::Pad => {
+                CigarKind::HardClip | CigarKind::Pad => {
                     // These don't affect positions
                 }
             }
@@ -1122,7 +1097,9 @@ mod tests {
     // Test utilities for creating synthetic test data
     mod test_utils {
         use super::*;
-        use crate::sam::builder::RecordBuilder;
+        use fgumi_raw_bam::{
+            SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+        };
         use noodles::sam::Header;
         use noodles::sam::alignment::RecordBuf;
         use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
@@ -1199,8 +1176,40 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             header
         }
 
+        fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> RecordBuf {
+            raw_record_to_record_buf(&raw, &Header::default())
+                .expect("raw_record_to_record_buf failed in test")
+        }
+
+        fn parse_cigar_to_ops(cigar_str: &str) -> Vec<u32> {
+            let mut ops = Vec::new();
+            let mut len_buf = String::new();
+            for ch in cigar_str.chars() {
+                if ch.is_ascii_digit() {
+                    len_buf.push(ch);
+                } else {
+                    let len: usize = len_buf.parse().expect("valid cigar length");
+                    len_buf.clear();
+                    let op_code: u32 = match ch {
+                        'M' => 0,
+                        'I' => 1,
+                        'D' => 2,
+                        'N' => 3,
+                        'S' => 4,
+                        'H' => 5,
+                        'P' => 6,
+                        '=' => 7,
+                        'X' => 8,
+                        other => panic!("unknown CIGAR op: {other}"),
+                    };
+                    ops.push(encode_op(op_code, len));
+                }
+            }
+            ops
+        }
+
         /// Create a simple read pair
-        #[allow(clippy::too_many_arguments)]
+        #[allow(clippy::too_many_arguments, clippy::cast_possible_truncation)]
         pub fn create_read_pair(
             name: &str,
             chrom_idx: usize,
@@ -1211,37 +1220,37 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             mi: &str,
             cigar1: Option<&str>,
         ) -> (RecordBuf, RecordBuf) {
-            use noodles::sam::alignment::record::Flags;
-
             let cigar1_str = cigar1.map_or_else(|| format!("{}M", bases1.len()), String::from);
+            let cigar1_ops = parse_cigar_to_ops(&cigar1_str);
+            let cigar2_ops = [encode_op(0, bases2.len())];
 
-            let r1 = RecordBuilder::new()
-                .name(name)
-                .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT)
-                .reference_sequence_id(chrom_idx)
-                .alignment_start(start1 as usize)
-                .mapping_quality(60)
-                .cigar(&cigar1_str)
-                .sequence(&String::from_utf8_lossy(bases1))
+            let mut b1 = RawSamBuilder::new();
+            b1.read_name(name.as_bytes())
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .ref_id(chrom_idx as i32)
+                .pos(start1 - 1)
+                .mapq(60)
+                .cigar_ops(&cigar1_ops)
+                .sequence(bases1)
                 .qualities(&vec![45u8; bases1.len()])
-                .mate_reference_sequence_id(chrom_idx)
-                .mate_alignment_start(start2 as usize)
-                .tag("MI", mi)
-                .build();
+                .mate_ref_id(chrom_idx as i32)
+                .mate_pos(start2 - 1);
+            b1.add_string_tag(b"MI", mi.as_bytes());
+            let r1 = to_record_buf(b1.build());
 
-            let r2 = RecordBuilder::new()
-                .name(name)
-                .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::REVERSE_COMPLEMENTED)
-                .reference_sequence_id(chrom_idx)
-                .alignment_start(start2 as usize)
-                .mapping_quality(60)
-                .cigar(&format!("{}M", bases2.len()))
-                .sequence(&String::from_utf8_lossy(bases2))
+            let mut b2 = RawSamBuilder::new();
+            b2.read_name(name.as_bytes())
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(chrom_idx as i32)
+                .pos(start2 - 1)
+                .mapq(60)
+                .cigar_ops(&cigar2_ops)
+                .sequence(bases2)
                 .qualities(&vec![45u8; bases2.len()])
-                .mate_reference_sequence_id(chrom_idx)
-                .mate_alignment_start(start1 as usize)
-                .tag("MI", mi)
-                .build();
+                .mate_ref_id(chrom_idx as i32)
+                .mate_pos(start1 - 1);
+            b2.add_string_tag(b"MI", mi.as_bytes());
+            let r2 = to_record_buf(b2.build());
 
             (r1, r2)
         }

--- a/src/lib/commands/shared_metrics.rs
+++ b/src/lib/commands/shared_metrics.rs
@@ -5,11 +5,12 @@
 //! deterministic downsampling. Both `duplex_metrics` and `simplex_metrics` commands
 //! build on these shared primitives.
 
-use crate::bam_io::create_bam_reader;
+use crate::bam_io::create_raw_bam_reader;
 use crate::progress::ProgressTracker;
 use crate::sam::SamTag;
 use crate::template::TemplateIterator;
 use anyhow::{Context, Result};
+use fgumi_raw_bam::raw_record_to_record_buf;
 
 use log::info;
 use murmur3::murmur3_32;
@@ -266,23 +267,34 @@ pub fn overlaps_intervals(template: &TemplateInfo, intervals: &[Interval]) -> bo
 /// Returns an error if the BAM file cannot be read or if it appears to be a consensus BAM.
 pub fn validate_not_consensus_bam(input: &Path) -> Result<()> {
     use crate::consensus_tags::is_consensus;
+    use crate::sort::bam_fields;
+    use fgumi_raw_bam::{RawRecord, RawRecordView};
 
-    let (mut reader, header) = create_bam_reader(input, 1)?;
+    let (mut reader, header) = create_raw_bam_reader(input, 1)?;
 
     // Look at the first valid R1 record
-    for result in reader.record_bufs(&header) {
-        let record = result?;
+    let mut raw = RawRecord::new();
+    loop {
+        let n = reader.read_record(&mut raw).context("failed to read BAM record")?;
+        if n == 0 {
+            break; // EOF
+        }
 
-        // Only check R1 records that are paired, mapped, and primary
-        let flags = record.flags();
-        if !flags.is_segmented()
-            || !flags.is_first_segment()
-            || flags.is_secondary()
-            || flags.is_supplementary()
-            || flags.is_unmapped()
+        // Only check R1 records that are paired and primary (raw flag checks).
+        // Do not skip UNMAPPED: consensus BAMs are documented as unaligned, so
+        // excluding unmapped records here would let consensus BAMs slip past this
+        // guard unchecked.
+        let flags = RawRecordView::new(&raw).flags();
+        if (flags & bam_fields::flags::PAIRED) == 0
+            || (flags & bam_fields::flags::FIRST_SEGMENT) == 0
+            || (flags & bam_fields::flags::SECONDARY) != 0
+            || (flags & bam_fields::flags::SUPPLEMENTARY) != 0
         {
             continue;
         }
+
+        // Decode to RecordBuf for consensus-tag check and name extraction
+        let record = raw_record_to_record_buf(&raw, &header)?;
 
         // Check if this is a consensus read
         if is_consensus(&record) {
@@ -420,10 +432,9 @@ pub fn process_templates_from_bam<F>(
 where
     F: FnMut(&[TemplateInfo], &mut Vec<usize>),
 {
-    let (mut reader, header) = create_bam_reader(input, 1)?;
+    let (reader, header) = create_raw_bam_reader(input, 1)?;
 
-    let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
-    let template_iter = TemplateIterator::new(record_iter);
+    let template_iter = TemplateIterator::new(reader);
 
     // Streaming approach: process groups as they arrive (assumes consecutive ReadInfo grouping)
     let mut current_group: Vec<TemplateInfo> = Vec::new();
@@ -436,12 +447,19 @@ where
 
     for template in template_iter {
         let template = template?;
-        if template.records.len() < 2 {
+        if template.records().len() < 2 {
             continue;
         }
 
+        // Decode raw records to RecordBuf for flag/tag/position access
+        let record_bufs: Vec<RecordBuf> = template
+            .records()
+            .iter()
+            .map(|r| raw_record_to_record_buf(r, &header))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
         // Find R1 and R2 that pass fgbio's filtering criteria
-        let r1 = template.records.iter().find(|r| {
+        let r1 = record_bufs.iter().find(|r| {
             let f = r.flags();
             f.is_segmented()
                 && !f.is_unmapped()
@@ -450,7 +468,7 @@ where
                 && !f.is_secondary()
                 && !f.is_supplementary()
         });
-        let r2 = template.records.iter().find(|r| {
+        let r2 = record_bufs.iter().find(|r| {
             let f = r.flags();
             f.is_segmented()
                 && !f.is_unmapped()

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -12,7 +12,7 @@ use crate::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
 };
 use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{RawMiGroup, RawMiGroupBatch, RawMiGroupIterator, RawMiGrouper};
+use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
 use crate::overlapping_consensus::{
     AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
     apply_overlapping_consensus,
@@ -248,39 +248,19 @@ impl Command for Simplex {
         info!("Error rate pre-UMI: Q{}", self.consensus.error_rate_pre_umi);
         info!("Error rate post-UMI: Q{}", self.consensus.error_rate_post_umi);
 
-        // Open input using streaming-capable reader for pipeline use
         // Get threading configuration
         let writer_threads = self.threading.num_threads();
-
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
-
-        // Create output header (cleared for unmapped consensus reads)
-        let output_header = create_unmapped_consensus_header(
-            &header,
-            &self.read_group.read_group_id,
-            "Read group",
-            command_line,
-        )?;
-
-        // Use library name from header if no prefix is specified (like fgbio)
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
 
         let cell_tag = Tag::from(SamTag::CB);
 
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        // Load reference for methylation-aware consensus calling
         if self.reference.is_some() && self.methylation_mode.is_none() {
             bail!("--ref requires --methylation-mode to be set");
         }
         let methylation_mode =
             crate::commands::common::resolve_methylation_mode(self.methylation_mode);
-        let methylation_ref: MethylationRef =
-            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // Track overlapping consensus settings (callers created per-thread in threaded mode)
         let overlapping_enabled = self.overlapping.is_enabled();
@@ -295,25 +275,49 @@ impl Command for Simplex {
         // --threads N mode: Use 7-step unified pipeline
         // None: Use single-threaded fast path
         // ============================================================
-        // IMPORTANT: Check this BEFORE creating any output file handles to avoid
-        // file handle conflicts that can corrupt the output.
+        // IMPORTANT: Check threading BEFORE opening any reader so we only open
+        // the input once — opening twice wastes I/O and breaks stdin streaming.
         if let Some(threads) = self.threading.threads {
+            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+            )?;
+            let output_header = create_unmapped_consensus_header(
+                &header,
+                &self.read_group.read_group_id,
+                "Read group",
+                command_line,
+            )?;
+            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
+            let methylation_ref: MethylationRef =
+                load_methylation_reference(methylation_mode, &self.reference, &header)?;
+
             let result = self.execute_threads_mode(
                 threads,
                 reader,
-                header.clone(),
-                output_header.clone(),
-                read_name_prefix.clone(),
+                header,
+                output_header,
+                read_name_prefix,
                 track_rejects,
-                methylation_ref.clone(),
+                methylation_ref,
                 methylation_mode,
             );
             timer.log_completion(0); // Completion logged in execute_threads_mode
             return result;
         }
 
-        // Drop the reader for single-threaded mode - we use MiGroupIterator which needs its own reader
-        drop(reader);
+        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        let (mut raw_reader, header) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        let output_header = create_unmapped_consensus_header(
+            &header,
+            &self.read_group.read_group_id,
+            "Read group",
+            command_line,
+        )?;
+        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
+        let methylation_ref: MethylationRef =
+            load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
         // ============================================================
         // For non-pipeline modes, create output writers here
@@ -370,9 +374,7 @@ impl Command for Simplex {
         let mut record_count: usize = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Create the MI group iterator for single-threaded streaming (raw bytes)
-        let (mut raw_reader, _) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        // Use the raw_reader opened above (single input open).
         let raw_record_iter = std::iter::from_fn(move || {
             let mut record = RawRecord::new();
             match raw_reader.read_record(&mut record) {
@@ -381,8 +383,7 @@ impl Command for Simplex {
                 Err(e) => Some(Err(e.into())),
             }
         });
-        let mi_group_iter =
-            RawMiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*b"CB"));
+        let mi_group_iter = MiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*b"CB"));
         // Single-threaded streaming processing
         // Create overlapping consensus caller for single-threaded mode
         let mut overlapping_caller = if overlapping_enabled {
@@ -402,8 +403,7 @@ impl Command for Simplex {
                 apply_overlapping_consensus(&mut records, oc)?;
             }
 
-            // Call consensus — mi_group now yields Vec<RawRecord> directly, which is
-            // what ConsensusCaller::consensus_reads expects.
+            // Call consensus directly — records are already RawRecord values.
             let output = caller
                 .consensus_reads(records)
                 .with_context(|| format!("Failed to call consensus for UMI: {umi}"))?;
@@ -537,9 +537,8 @@ impl Simplex {
         // Clone input_header before pipeline (needed for rejects writing)
         let rejects_header = input_header.clone();
 
-        // Enable raw-byte mode: skip noodles decode/encode for CPU savings
         let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw(library_index, cell_tag));
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming)
         let groups_processed = run_bam_pipeline_from_reader(
@@ -548,13 +547,13 @@ impl Simplex {
             input_header,
             &self.io.output,
             Some(output_header.clone()),
-            // ========== grouper_fn: Create RawMiGrouper ==========
+            // ========== grouper_fn: Create MiGrouper ==========
             move |_header: &Header| {
-                Box::new(RawMiGrouper::new("MI", batch_size).with_cell_tag(Some(*b"CB")))
-                    as Box<dyn Grouper<Group = RawMiGroupBatch> + Send>
+                Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*b"CB")))
+                    as Box<dyn Grouper<Group = MiGroupBatch> + Send>
             },
             // ========== process_fn: Consensus calling ==========
-            move |batch: RawMiGroupBatch| -> io::Result<SimplexProcessedBatch> {
+            move |batch: MiGroupBatch| -> io::Result<SimplexProcessedBatch> {
                 // Create per-thread consensus caller
                 let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
                     read_name_prefix.clone(),
@@ -584,7 +583,7 @@ impl Simplex {
                 let mut batch_overlapping = CorrectionStats::new();
                 let groups_count = batch.groups.len() as u64;
 
-                for RawMiGroup { mi, records: mut raw_records } in batch.groups {
+                for MiGroup { mi, records: mut raw_records } in batch.groups {
                     caller.clear();
 
                     // Skip if below min_reads threshold
@@ -618,28 +617,16 @@ impl Simplex {
                         batch_overlapping.merge(oc.stats());
                     }
 
-                    // Call consensus — mi_group now yields Vec<RawRecord> directly.
-                    // Preserve inputs for rejection bookkeeping on Err, since
-                    // consensus_reads consumes raw_records.
-                    let num_inputs = raw_records.len();
-                    let reject_on_error: Option<Vec<Vec<u8>>> = track_rejects
-                        .then(|| raw_records.iter().map(|r| r.as_ref().to_vec()).collect());
-                    match caller.consensus_reads(raw_records) {
-                        Ok(batch_output) => {
-                            all_output.merge(batch_output);
-                            batch_stats.merge(&caller.statistics());
-                            if track_rejects {
-                                all_rejects.extend(caller.take_rejected_reads());
-                            }
-                        }
-                        Err(e) => {
-                            log::warn!("Consensus error for MI {mi}: {e}");
-                            batch_stats.record_input(num_inputs);
-                            batch_stats.record_rejection(RejectionReason::Other, num_inputs);
-                            if let Some(rejects) = reject_on_error {
-                                all_rejects.extend(rejects);
-                            }
-                        }
+                    // Call consensus — mi_group yields Vec<RawRecord> directly.
+                    // Propagate errors to match the single-threaded path, which
+                    // treats consensus failures as fatal.
+                    let batch_output = caller.consensus_reads(raw_records).map_err(|e| {
+                        io::Error::other(format!("Consensus error for MI {mi}: {e}"))
+                    })?;
+                    all_output.merge(batch_output);
+                    batch_stats.merge(&caller.statistics());
+                    if track_rejects {
+                        all_rejects.extend(caller.take_rejected_reads());
                     }
                 }
 
@@ -779,7 +766,7 @@ mod tests {
     /// Creates a Simplex command with the given input/output paths and default parameters.
     fn create_simplex_with_paths(input: PathBuf, output: PathBuf) -> Simplex {
         Simplex {
-            io: BamIoOptions::new(input, output),
+            io: BamIoOptions { input, output, async_reader: false },
             rejects_opts: RejectsOptions::default(),
             stats_opts: StatsOptions::default(),
             read_group: ReadGroupOptions::default(),

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -43,39 +43,30 @@
 //! # Architecture Notes
 //!
 //! - `Template`: Represents a group of records with the same read name
-//! - `TemplateIterator`: Lazily groups records by name from a BAM reader
+//! - `TemplateIterator`: Groups raw BAM bytes from the unmapped reader into Templates
 //! - `TagInfo`: Holds sets of tags to remove/reverse/revcomp
-//! - `merge()`: Core function that transfers metadata between templates
-use crate::bam_io::{BamReaderAuto, create_bam_reader, create_raw_bam_writer, is_stdin_path};
+//! - `merge_raw()`: Core function that transfers metadata between templates using raw bytes
+use crate::bam_io::{
+    BamReaderAuto, create_bam_reader, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path,
+};
 use crate::batched_sam_reader::BatchedSamReader;
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::logging::OperationTimer;
 use crate::progress::ProgressTracker;
 use crate::reference::{ReferenceReader, find_dict_path};
-use crate::sam::{
-    SamTag, TC_TAG, TemplateCoordinateInfo, buf_value_to_smallest_signed_int, check_sort,
-    revcomp_buf_value, reverse_buf_value, unclipped_five_prime_position,
-};
+use crate::sam::{TemplateCoordinateInfo, check_sort};
 use crate::sort::bam_fields;
 use crate::template::{Template, TemplateIterator};
 use crate::umi::TagInfo;
 use crate::validation::validate_file_exists;
-use crate::vendored::encode_record_buf;
 use anyhow::{Context, Result};
 use bstr::ByteSlice;
 use clap::Parser;
-use fgumi_raw_bam::{RawRecord, RawRecordView};
+use fgumi_raw_bam::{BAM_BASE_TO_ASCII, RawRecord, RawRecordView, RecordBufEncoder};
 use log::{debug, info, warn};
 use noodles::core::Position;
 use noodles::sam::Header;
-#[cfg(test)]
-use noodles::sam::alignment::record::Cigar as CigarTrait;
-use noodles::sam::alignment::record::cigar::op::Kind;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::Data;
-use noodles::sam::alignment::record_buf::RecordBuf;
-use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -173,11 +164,11 @@ pub struct Zipper {
     #[arg(long = "exclude-missing-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub exclude_missing_reads: bool,
 
-    /// Skip adding `tc` (template-coordinate) tags to secondary/supplementary reads.
-    /// By default, zipper adds a `tc` tag containing the primary alignment's template
+    /// Skip adding `pa` (primary alignment) tags to secondary/supplementary reads.
+    /// By default, zipper adds a `pa` tag containing the primary alignment's template
     /// sort key coordinates, which enables correct template-coordinate sorting and
     /// deduplication of these reads. Use this flag if you don't need this functionality.
-    #[arg(long = "skip-tc-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "skip-pa-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub skip_tc_tags: bool,
 
     /// Restore unconverted bases in EM-seq consensus reads after bwameth re-alignment.
@@ -264,417 +255,9 @@ pub fn build_output_header(unmapped: &Header, mapped: &Header, dict_path: &Path)
     Ok(header.build())
 }
 
-/// Copies tags from source record to destination record
-///
-/// Copies all tags from `src` to `dest`, with special handling:
-/// - PG tag is only copied if not already present in dest
-/// - Tags in `tag_info.remove` are skipped
-///
-/// # Arguments
-///
-/// * `src` - Source record to copy tags from
-/// * `dest` - Destination record to copy tags to
-/// * `tag_info` - Information about which tags to skip
-///
-/// # Returns
-///
-/// `Ok(())` on success
-///
-/// # Errors
-///
-/// Currently never returns an error, but signature allows for future error handling
-pub fn copy_tags(src: &RecordBuf, dest: &mut Data, tag_info: &TagInfo) -> Result<()> {
-    for (tag, value) in src.data().iter() {
-        let tag_str = format!("{}{}", tag.as_ref()[0] as char, tag.as_ref()[1] as char);
-
-        if tag_str == "PG" && dest.get(&tag).is_some() {
-            continue;
-        }
-
-        if tag_info.remove.contains(&tag_str) {
-            continue;
-        }
-
-        dest.insert(tag, value.clone());
-    }
-    Ok(())
-}
-
-/// Adds the `tc` tag to secondary and supplementary reads, storing the template
-/// sort key from the primary alignments.
-///
-/// This enables downstream tools (sort, dedup) to properly handle these reads
-/// by ensuring they sort adjacent to their primary alignments.
-///
-/// # Arguments
-///
-/// * `template` - The template containing all reads (primary, secondary, supplementary)
-///
-/// # Format
-///
-/// The `tc` tag is a B:i array with 6 int32 elements: `[tid1, pos1, neg1, tid2, pos2, neg2]`
-/// where "1" is the earlier position (lower (tid, pos)) and neg is 0/1 for forward/reverse.
-///
-/// This matches the template-coordinate sort key format used by `fgumi sort`.
-///
-/// Optimized to skip all computation when there are no secondary/supplementary reads.
-fn add_template_coordinate_tags(template: &mut Template) {
-    // Fast path: check if there are any secondary/supplementary reads before doing work
-    let has_sec_supp =
-        template.records.iter().any(|r| r.flags().is_secondary() || r.flags().is_supplementary());
-
-    if !has_sec_supp {
-        return; // No secondary/supplementary reads - nothing to do
-    }
-
-    // Get R1 primary alignment info: (ref_id, unclipped_5prime_pos, is_reverse)
-    // Uses unclipped 5' position to match template-coordinate sort key calculation
-    let r1_primary_info: Option<(i32, i32, bool)> = template.r1().and_then(|r| {
-        if r.flags().is_unmapped() {
-            return None;
-        }
-        let ref_id: i32 = r.reference_sequence_id()?.try_into().ok()?;
-        // Use unclipped 5' position to match sort key calculation
-        let pos: i32 = unclipped_five_prime_position(r)?.try_into().ok()?;
-        let is_reverse = r.flags().is_reverse_complemented();
-        Some((ref_id, pos, is_reverse))
-    });
-
-    // Get R2 primary alignment info: (ref_id, unclipped_5prime_pos, is_reverse)
-    let r2_primary_info: Option<(i32, i32, bool)> = template.r2().and_then(|r| {
-        if r.flags().is_unmapped() {
-            return None;
-        }
-        let ref_id: i32 = r.reference_sequence_id()?.try_into().ok()?;
-        // Use unclipped 5' position to match sort key calculation
-        let pos: i32 = unclipped_five_prime_position(r)?.try_into().ok()?;
-        let is_reverse = r.flags().is_reverse_complemented();
-        Some((ref_id, pos, is_reverse))
-    });
-
-    // Compute the template sort key (tid1, pos1, neg1, tid2, pos2, neg2)
-    // where "1" is the earlier position (lower (tid, pos))
-    let tc_info: Option<TemplateCoordinateInfo> = match (r1_primary_info, r2_primary_info) {
-        (Some((tid1, pos1, neg1)), Some((tid2, pos2, neg2))) => {
-            // Both mapped - determine which is earlier
-            if (tid1, pos1) <= (tid2, pos2) {
-                Some(TemplateCoordinateInfo::new(tid1, pos1, neg1, tid2, pos2, neg2))
-            } else {
-                Some(TemplateCoordinateInfo::new(tid2, pos2, neg2, tid1, pos1, neg1))
-            }
-        }
-        (Some((tid, pos, neg)), None) | (None, Some((tid, pos, neg))) => {
-            // Only one mapped - use same values for both positions
-            Some(TemplateCoordinateInfo::new(tid, pos, neg, tid, pos, neg))
-        }
-        (None, None) => None,
-    };
-
-    // If we have template sort key info, add it to all secondary/supplementary reads
-    let Some(tc_info) = tc_info else {
-        return;
-    };
-
-    let tc_value = tc_info.to_tag_value();
-
-    for record in &mut template.records {
-        let flags = record.flags();
-
-        // Skip primary alignments - they don't need the tc tag
-        if !flags.is_secondary() && !flags.is_supplementary() {
-            continue;
-        }
-
-        // Add the tc tag with the template sort key
-        record.data_mut().insert(TC_TAG, tc_value.clone());
-    }
-}
-
-/// Merges tags from unmapped template into mapped template
-///
-/// This is the core merge function that:
-/// 1. Removes specified tags from mapped reads
-/// 2. Copies tags from unmapped to mapped reads
-/// 3. Applies reverse/revcomp transformations for negative strand
-/// 4. Transfers QC pass/fail flags
-///
-/// Handles both paired-end and single-end data, matching R1 to R1 and R2 to R2.
-/// Secondary and supplementary alignments are also processed.
-///
-/// # Arguments
-///
-/// * `unmapped` - Template containing unmapped reads with original tags
-/// * `mapped` - Template containing mapped reads (will be modified in place)
-/// * `tag_info` - Information about which tags to manipulate
-///
-/// # Returns
-///
-/// `Ok(())` on success
-///
-/// # Errors
-///
-/// Returns an error if tag copying fails (currently never happens)
-pub fn merge(
-    unmapped: &Template,
-    mapped: &mut Template,
-    tag_info: &TagInfo,
-    skip_tc_tags: bool,
-) -> Result<()> {
-    // Fix mate info first
-    mapped.fix_mate_info()?;
-
-    // First, remove tags from mapped reads
-    for i in 0..mapped.read_count() {
-        for tag_str in &tag_info.remove {
-            if tag_str.len() == 2 {
-                let tag = Tag::new(tag_str.as_bytes()[0], tag_str.as_bytes()[1]);
-                let _ = mapped.records[i].data_mut().remove(&tag);
-            }
-        }
-    }
-
-    // Process each primary unmapped read
-    for u in unmapped.primary_reads() {
-        let is_unpaired = !u.flags().is_segmented();
-        let is_first = u.flags().is_first_segment();
-
-        // Find corresponding mapped reads (R1 or R2)
-        let mapped_indices: Vec<usize> = if is_unpaired || is_first {
-            mapped
-                .records
-                .iter()
-                .enumerate()
-                .filter(|(_, r)| !r.flags().is_segmented() || r.flags().is_first_segment())
-                .map(|(i, _)| i)
-                .collect()
-        } else {
-            mapped
-                .records
-                .iter()
-                .enumerate()
-                .filter(|(_, r)| r.flags().is_segmented() && !r.flags().is_first_segment())
-                .map(|(i, _)| i)
-                .collect()
-        };
-
-        let has_pos_reads =
-            mapped_indices.iter().any(|&i| !mapped.records[i].flags().is_reverse_complemented());
-        let has_neg_reads =
-            mapped_indices.iter().any(|&i| mapped.records[i].flags().is_reverse_complemented());
-
-        // Copy tags to positive strand reads
-        if has_pos_reads {
-            for &i in &mapped_indices {
-                if !mapped.records[i].flags().is_reverse_complemented() {
-                    copy_tags(u, mapped.records[i].data_mut(), tag_info)?;
-                }
-            }
-        }
-
-        // Copy tags to negative strand reads (with reverse/revcomp)
-        if has_neg_reads {
-            let mut u_for_neg = u.clone();
-
-            if tag_info.has_revs_or_revcomps() {
-                for (tag, value) in u.data().iter() {
-                    let tag_str = format!("{}{}", tag.as_ref()[0] as char, tag.as_ref()[1] as char);
-
-                    if tag_info.reverse.contains(&tag_str) {
-                        let new_val = reverse_buf_value(value);
-                        u_for_neg.data_mut().insert(tag, new_val);
-                    } else if tag_info.revcomp.contains(&tag_str) {
-                        let new_val = revcomp_buf_value(value);
-                        u_for_neg.data_mut().insert(tag, new_val);
-                    }
-                }
-            }
-
-            for &i in &mapped_indices {
-                if mapped.records[i].flags().is_reverse_complemented() {
-                    copy_tags(&u_for_neg, mapped.records[i].data_mut(), tag_info)?;
-                }
-            }
-        }
-
-        // Transfer QC pass/fail flag
-        let is_qc_fail = u.flags().is_qc_fail();
-        for &i in &mapped_indices {
-            let mut flags = mapped.records[i].flags();
-            if is_qc_fail {
-                flags.insert(noodles::sam::alignment::record::Flags::QC_FAIL);
-            } else {
-                flags.remove(noodles::sam::alignment::record::Flags::QC_FAIL);
-            }
-            // Apply the modified flags back to the record
-            *mapped.records[i].flags_mut() = flags;
-        }
-    }
-
-    // Normalize alignment integer tags (AS, XS) to Int8 to match fgbio's encoding.
-    // When reading from SAM format, noodles may parse these tags with different types
-    // (e.g., Int32 or UInt8). fgbio consistently uses signed int8 (SAM type code 'c').
-    let as_tag = Tag::from(SamTag::AS);
-    let xs_tag = Tag::from(SamTag::XS);
-    for i in 0..mapped.read_count() {
-        // Normalize AS tag
-        if let Some(value) = mapped.records[i].data().get(&as_tag) {
-            if let Some(int8_value) = buf_value_to_smallest_signed_int(value) {
-                mapped.records[i].data_mut().insert(as_tag, int8_value);
-            }
-        }
-        // Normalize XS tag
-        if let Some(value) = mapped.records[i].data().get(&xs_tag) {
-            if let Some(int8_value) = buf_value_to_smallest_signed_int(value) {
-                mapped.records[i].data_mut().insert(xs_tag, int8_value);
-            }
-        }
-    }
-
-    // Add primary alignment tags to secondary and supplementary reads
-    // This enables proper template-coordinate sorting and duplicate marking
-    if !skip_tc_tags {
-        add_template_coordinate_tags(mapped);
-    }
-
-    Ok(())
-}
-
-/// Appends a noodles `BufValue` tag to a raw BAM record in BAM binary encoding.
-fn append_buf_value_raw(dest: &mut Vec<u8>, tag: [u8; 2], value: &BufValue) {
-    use noodles::sam::alignment::record_buf::data::field::value::Array;
-    match value {
-        BufValue::Character(c) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'A');
-            dest.push(*c);
-        }
-        BufValue::Int8(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'c');
-            dest.push(v.cast_unsigned());
-        }
-        BufValue::UInt8(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'C');
-            dest.push(*v);
-        }
-        BufValue::Int16(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b's');
-            dest.extend_from_slice(&v.to_le_bytes());
-        }
-        BufValue::UInt16(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'S');
-            dest.extend_from_slice(&v.to_le_bytes());
-        }
-        BufValue::Int32(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'i');
-            dest.extend_from_slice(&v.to_le_bytes());
-        }
-        BufValue::UInt32(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'I');
-            dest.extend_from_slice(&v.to_le_bytes());
-        }
-        BufValue::Float(v) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'f');
-            dest.extend_from_slice(&v.to_le_bytes());
-        }
-        BufValue::String(s) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'Z');
-            dest.extend_from_slice(s.as_bytes());
-            dest.push(0);
-        }
-        BufValue::Hex(s) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'H');
-            dest.extend_from_slice(s.as_bytes());
-            dest.push(0);
-        }
-        BufValue::Array(arr) => {
-            dest.push(tag[0]);
-            dest.push(tag[1]);
-            dest.push(b'B');
-            match arr {
-                Array::Int8(vals) => {
-                    dest.push(b'c');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.push(v.cast_unsigned());
-                    }
-                }
-                Array::UInt8(vals) => {
-                    dest.push(b'C');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    dest.extend_from_slice(vals.as_slice());
-                }
-                Array::Int16(vals) => {
-                    dest.push(b's');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.extend_from_slice(&v.to_le_bytes());
-                    }
-                }
-                Array::UInt16(vals) => {
-                    dest.push(b'S');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.extend_from_slice(&v.to_le_bytes());
-                    }
-                }
-                Array::Int32(vals) => {
-                    dest.push(b'i');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.extend_from_slice(&v.to_le_bytes());
-                    }
-                }
-                Array::UInt32(vals) => {
-                    dest.push(b'I');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.extend_from_slice(&v.to_le_bytes());
-                    }
-                }
-                Array::Float(vals) => {
-                    dest.push(b'f');
-                    let count = u32::try_from(vals.len()).expect("BAM B-array length exceeds u32");
-                    dest.extend_from_slice(&count.to_le_bytes());
-                    for v in vals {
-                        dest.extend_from_slice(&v.to_le_bytes());
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Adds `tc` tags to secondary/supplementary reads in raw-byte mode.
+/// Adds `pa` tags to secondary/supplementary reads.
 fn add_template_coordinate_tags_raw(mapped: &mut Template) {
-    let rr = match mapped.raw_records.as_ref() {
-        Some(rr) => rr,
-        None => return,
-    };
+    let rr = &mapped.records;
 
     // Fast path: check if there are any secondary/supplementary reads
     let has_sec_supp = rr.iter().any(|r| {
@@ -739,34 +322,13 @@ fn add_template_coordinate_tags_raw(mapped: &mut Template) {
         i32::from(tc_info.neg2),
     ];
 
-    let rr = mapped.raw_records.as_mut().unwrap();
-    for record in rr.iter_mut() {
+    for record in mapped.records.iter_mut() {
         let f = RawRecordView::new(record.as_ref()).flags();
         if (f & bam_fields::flags::SECONDARY) != 0 || (f & bam_fields::flags::SUPPLEMENTARY) != 0 {
             bam_fields::remove_tag(record.as_mut_vec(), tc_tag);
             bam_fields::append_i32_array_tag(record.as_mut_vec(), tc_tag, &tc_values);
         }
     }
-}
-
-/// Converts a mapped `Template` from `RecordBuf` mode to raw-byte mode.
-///
-/// Encodes each `RecordBuf` to raw BAM bytes using the vendored encoder
-/// and populates `raw_records`.
-fn convert_template_to_raw(template: &mut Template, header: &Header) -> Result<()> {
-    if template.is_raw_byte_mode() {
-        return Ok(());
-    }
-    let mut raw_records = Vec::with_capacity(template.records.len());
-    for record in &template.records {
-        let mut buf = Vec::with_capacity(256);
-        encode_record_buf(&mut buf, header, record)
-            .map_err(|e| anyhow::anyhow!("Failed to encode record: {e}"))?;
-        raw_records.push(RawRecord::from(buf));
-    }
-    template.raw_records = Some(raw_records);
-    // Keep records intact for read_count compatibility
-    Ok(())
 }
 
 /// Collects the indices of mapped records corresponding to a given segment
@@ -800,18 +362,14 @@ fn collect_mapped_indices(mapped: &Template, is_first_segment: bool) -> Vec<usiz
 
 /// Merges tags from unmapped template into mapped template using raw bytes.
 ///
-/// This is the raw-byte equivalent of [`merge`]. The mapped template must
-/// be in raw-byte mode (call [`convert_template_to_raw`] first). The
-/// unmapped template uses `RecordBuf` mode.
+/// Performs 6 operations:
 ///
-/// Performs the same 7 operations as `merge()`:
-///
-/// 1. Fix mate info (raw)
+/// 1. Fix mate info
 /// 2. Remove tags from mapped records
 /// 3. Copy tags from unmapped to mapped (with reverse/revcomp for neg strand)
-/// 5. Transfer QC flags
-/// 6. Normalize AS/XS tags
-/// 7. Add TC tags
+/// 4. Transfer QC flags
+/// 5. Normalize AS/XS tags
+/// 6. Add PA tags
 pub fn merge_raw(
     unmapped: &Template,
     mapped: &mut Template,
@@ -819,15 +377,10 @@ pub fn merge_raw(
     skip_tc_tags: bool,
 ) -> Result<()> {
     // Step 1: Fix mate info
-    mapped.fix_mate_info_raw()?;
-
-    let rr = mapped
-        .raw_records
-        .as_mut()
-        .ok_or_else(|| anyhow::anyhow!("merge_raw: mapped not in raw mode"))?;
+    mapped.fix_mate_info()?;
 
     // Step 2: Remove tags from mapped reads
-    for record in rr.iter_mut() {
+    for record in mapped.records_mut().iter_mut() {
         for tag_str in &tag_info.remove {
             if tag_str.len() == 2 {
                 let tag_bytes: [u8; 2] = [tag_str.as_bytes()[0], tag_str.as_bytes()[1]];
@@ -836,20 +389,21 @@ pub fn merge_raw(
         }
     }
 
-    // Steps 3–5: Copy tags from unmapped to mapped, transfer QC flags
+    // Steps 3–4: Copy tags from unmapped to mapped, transfer QC flags
     let has_transforms = tag_info.has_revs_or_revcomps();
     let pg_tag: [u8; 2] = [b'P', b'G'];
 
     for u in unmapped.primary_reads() {
-        let is_unpaired = !u.flags().is_segmented();
-        let is_first = u.flags().is_first_segment();
+        let u_flags = RawRecordView::new(u).flags();
+        let is_unpaired = (u_flags & bam_fields::flags::PAIRED) == 0;
+        let is_first = (u_flags & bam_fields::flags::FIRST_SEGMENT) != 0;
 
         // Use template's known indices instead of scanning all mapped records
         let mapped_indices = collect_mapped_indices(mapped, is_unpaired || is_first);
 
         // Single pass to determine strand presence
         let (has_pos, has_neg) = {
-            let rr = mapped.raw_records.as_ref().unwrap();
+            let rr = mapped.records();
             let mut pos = false;
             let mut neg = false;
             for &i in &mapped_indices {
@@ -865,9 +419,13 @@ pub fn merge_raw(
             (pos, neg)
         };
 
+        // Collect unmapped tags once — avoids re-iterating `u.tags()` for every mapped record.
+        let u_tags: Vec<fgumi_raw_bam::TagEntry<'_>> =
+            RawRecordView::new(u).tags().iter().collect();
+
         // Copy tags to positive strand reads
         if has_pos {
-            let rr = mapped.raw_records.as_mut().unwrap();
+            let rr = mapped.records_mut();
             for &i in &mapped_indices {
                 if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) != 0 {
                     continue;
@@ -875,25 +433,24 @@ pub fn merge_raw(
                 let aux = bam_fields::aux_data_slice(&rr[i]);
                 let has_pg = bam_fields::find_tag_type(aux, &pg_tag).is_some();
 
-                for (tag, value) in u.data().iter() {
-                    let tag_bytes: [u8; 2] = [tag.as_ref()[0], tag.as_ref()[1]];
-                    if tag_bytes == pg_tag && has_pg {
+                for entry in &u_tags {
+                    if entry.tag == pg_tag && has_pg {
                         continue;
                     }
                     // Tag bytes are always valid ASCII
-                    let tag_str = std::str::from_utf8(&tag_bytes).unwrap_or("");
+                    let tag_str = std::str::from_utf8(&entry.tag).unwrap_or("");
                     if tag_info.remove.contains(tag_str) {
                         continue;
                     }
-                    bam_fields::remove_tag(rr[i].as_mut_vec(), &tag_bytes);
-                    append_buf_value_raw(rr[i].as_mut_vec(), tag_bytes, value);
+                    bam_fields::remove_tag(rr[i].as_mut_vec(), &entry.tag);
+                    append_raw_tag_entry(rr[i].as_mut_vec(), entry);
                 }
             }
         }
 
         // Copy tags to negative strand reads (with reverse/revcomp)
         if has_neg {
-            let rr = mapped.raw_records.as_mut().unwrap();
+            let rr = mapped.records_mut();
             for &i in &mapped_indices {
                 if (RawRecordView::new(&rr[i]).flags() & bam_fields::flags::REVERSE) == 0 {
                     continue;
@@ -901,36 +458,45 @@ pub fn merge_raw(
                 let aux = bam_fields::aux_data_slice(&rr[i]);
                 let has_pg = bam_fields::find_tag_type(aux, &pg_tag).is_some();
 
-                // Aux offset is safe to cache here: `remove_tag` and `append_buf_value_raw`
+                // Aux offset is safe to cache here: `remove_tag` and `append_raw_tag_entry`
                 // only modify bytes within/after the aux region, so this offset stays valid.
                 let aux_offset =
                     bam_fields::aux_data_offset_from_record(&rr[i]).unwrap_or(rr[i].len());
 
-                for (tag, value) in u.data().iter() {
-                    let tag_bytes: [u8; 2] = [tag.as_ref()[0], tag.as_ref()[1]];
-                    if tag_bytes == pg_tag && has_pg {
+                for entry in &u_tags {
+                    if entry.tag == pg_tag && has_pg {
                         continue;
                     }
-                    let tag_str = std::str::from_utf8(&tag_bytes).unwrap_or("");
+                    let tag_str = std::str::from_utf8(&entry.tag).unwrap_or("");
                     if tag_info.remove.contains(tag_str) {
                         continue;
                     }
 
-                    bam_fields::remove_tag(rr[i].as_mut_vec(), &tag_bytes);
+                    bam_fields::remove_tag(rr[i].as_mut_vec(), &entry.tag);
+                    append_raw_tag_entry(rr[i].as_mut_vec(), entry);
 
-                    append_buf_value_raw(rr[i].as_mut_vec(), tag_bytes, value);
                     if has_transforms && tag_info.reverse.contains(tag_str) {
-                        reverse_tag_in_place_raw(&mut rr[i], aux_offset, tag_bytes, value);
+                        reverse_tag_in_place_raw_by_type(
+                            &mut rr[i],
+                            aux_offset,
+                            entry.tag,
+                            entry.type_byte,
+                        );
                     } else if has_transforms && tag_info.revcomp.contains(tag_str) {
-                        revcomp_tag_in_place_raw(&mut rr[i], aux_offset, tag_bytes, value);
+                        revcomp_tag_in_place_raw_by_type(
+                            &mut rr[i],
+                            aux_offset,
+                            entry.tag,
+                            entry.type_byte,
+                        );
                     }
                 }
             }
         }
 
-        // Step 5: Transfer QC pass/fail flag
-        let is_qc_fail = u.flags().is_qc_fail();
-        let rr = mapped.raw_records.as_mut().unwrap();
+        // Step 4: Transfer QC pass/fail flag
+        let is_qc_fail = (u_flags & bam_fields::flags::QC_FAIL) != 0;
+        let rr = mapped.records_mut();
         for &i in &mapped_indices {
             let mut f = RawRecordView::new(&rr[i]).flags();
             if is_qc_fail {
@@ -942,14 +508,13 @@ pub fn merge_raw(
         }
     }
 
-    // Step 6: Normalize AS/XS tags
-    let rr = mapped.raw_records.as_mut().unwrap();
-    for record in rr.iter_mut() {
+    // Step 5: Normalize AS/XS tags
+    for record in mapped.records_mut().iter_mut() {
         bam_fields::normalize_int_tag_to_smallest_signed(record.as_mut_vec(), b"AS");
         bam_fields::normalize_int_tag_to_smallest_signed(record.as_mut_vec(), b"XS");
     }
 
-    // Step 7: Add TC tags
+    // Step 6: Add PA tags
     if !skip_tc_tags {
         add_template_coordinate_tags_raw(mapped);
     }
@@ -957,56 +522,72 @@ pub fn merge_raw(
     Ok(())
 }
 
-/// Applies the appropriate reverse operation for a tag in-place.
-fn reverse_tag_in_place_raw(
+/// Appends a raw tag entry (tag + type byte + value bytes) to the destination record.
+///
+/// This is the raw-byte equivalent of `append_buf_value_raw` — it copies the already-encoded
+/// bytes directly without going through `BufValue` decoding/re-encoding.
+#[inline]
+fn append_raw_tag_entry(dest: &mut Vec<u8>, entry: &fgumi_raw_bam::TagEntry<'_>) {
+    dest.push(entry.tag[0]);
+    dest.push(entry.tag[1]);
+    dest.push(entry.type_byte);
+    dest.extend_from_slice(entry.value_bytes);
+}
+
+/// Applies the appropriate reverse operation for a tag in-place, dispatching on BAM type byte.
+///
+/// - `b'Z'`: reverse the string bytes
+/// - `b'B'`: reverse the array elements
+/// - all other types: no-op (scalars have no meaningful reverse)
+fn reverse_tag_in_place_raw_by_type(
     record: &mut [u8],
     aux_offset: usize,
-    tag_bytes: [u8; 2],
-    value: &BufValue,
+    tag: [u8; 2],
+    type_byte: u8,
 ) {
-    match value {
-        BufValue::String(_) => {
-            bam_fields::reverse_string_tag_in_place(record, aux_offset, &tag_bytes);
+    match type_byte {
+        b'Z' => {
+            bam_fields::reverse_string_tag_in_place(record, aux_offset, &tag);
         }
-        BufValue::Array(_) => {
-            bam_fields::reverse_array_tag_in_place(record, aux_offset, &tag_bytes);
+        b'B' => {
+            bam_fields::reverse_array_tag_in_place(record, aux_offset, &tag);
         }
         _ => {}
     }
 }
 
-/// Applies the appropriate reverse-complement operation for a tag in-place.
-fn revcomp_tag_in_place_raw(
+/// Applies the appropriate reverse-complement operation for a tag in-place, dispatching on BAM
+/// type byte.
+///
+/// - `b'Z'`: reverse-complement the string bases (IUPAC-aware)
+/// - `b'B'`: reverse the array elements (no base complement for numeric arrays)
+/// - all other types: no-op
+fn revcomp_tag_in_place_raw_by_type(
     record: &mut [u8],
     aux_offset: usize,
-    tag_bytes: [u8; 2],
-    value: &BufValue,
+    tag: [u8; 2],
+    type_byte: u8,
 ) {
-    match value {
-        BufValue::String(_) => {
-            bam_fields::reverse_complement_string_tag_in_place(record, aux_offset, &tag_bytes);
+    match type_byte {
+        b'Z' => {
+            bam_fields::reverse_complement_string_tag_in_place(record, aux_offset, &tag);
         }
-        BufValue::Array(_) => {
-            // For array tags, revcomp is the same as reverse
-            bam_fields::reverse_array_tag_in_place(record, aux_offset, &tag_bytes);
+        b'B' => {
+            // For array tags, revcomp is the same as reverse (no base complement for
+            // numeric arrays; arrays that hold base-encoded ints are rare and numeric
+            // reversal matches the existing BufValue::Array branch behavior).
+            bam_fields::reverse_array_tag_in_place(record, aux_offset, &tag);
         }
         _ => {}
     }
 }
 
-/// Encodes all records of an unmapped template to raw BAM bytes for output.
+/// Returns all raw BAM records for an unmapped template by cloning them.
 fn encode_unmapped_template_records(
     template: &Template,
-    header: &Header,
+    _header: &Header,
 ) -> Result<Vec<RawRecord>> {
-    let mut raw = Vec::with_capacity(template.read_count());
-    for record in template.all_reads() {
-        let mut buf = Vec::with_capacity(256);
-        encode_record_buf(&mut buf, header, record)
-            .map_err(|e| anyhow::anyhow!("encode unmapped: {e}"))?;
-        raw.push(RawRecord::from(buf));
-    }
-    Ok(raw)
+    Ok(template.records().to_vec())
 }
 
 /// YD value for the forward (top) bisulfite strand.
@@ -1014,315 +595,230 @@ const YD_FORWARD: &[u8] = b"f";
 /// YD value for the reverse (bottom) bisulfite strand.
 const YD_REVERSE: &[u8] = b"r";
 
-/// YD tag used by bwameth to indicate the bisulfite conversion strand.
-/// Only consumed by the cfg(test) `RecordBuf` reference implementation; the
-/// raw-byte production path looks up the tag bytes directly.
-#[cfg(test)]
-const YD_TAG: Tag = Tag::new(b'Y', b'D');
-
-/// `RecordBuf`-based reference implementation kept around as an oracle for
-/// the test suite; the raw-byte path is used in production.
+/// Restore unconverted bases in EM-seq reads after bwameth re-alignment, operating
+/// directly on raw BAM bytes.
 ///
-/// Walks the CIGAR alignment for each record and replaces converted bases back
-/// to their unconverted reference form:
-///   - Top strand (`YD:Z:f`): at reference-C positions, T→C
-///   - Bottom strand (`YD:Z:r`): at reference-G positions, A→G
+/// For each mapped record in the template, walks the CIGAR alignment and replaces
+/// converted bases back to their unconverted reference form in-place:
+/// - Top strand (`YD:Z:f`): at reference-C positions, T→C
+/// - Bottom strand (`YD:Z:r`): at reference-G positions, A→G
 ///
 /// Skips unmapped reads and reads without a `YD` tag.
-#[cfg(test)]
-#[allow(dead_code)]
-fn restore_unconverted_bases_in_template(
-    template: &mut Template,
-    reference: &ReferenceReader,
-    header: &Header,
-) -> Result<()> {
-    for record in &mut template.records {
-        restore_unconverted_bases_in_record(record, reference, header)?;
-    }
-    Ok(())
-}
-
-/// `RecordBuf`-based reference implementation kept as an oracle for the test
-/// suite; the raw-byte path is used in production.
-#[cfg(test)]
-fn restore_unconverted_bases_in_record(
-    record: &mut RecordBuf,
-    reference: &ReferenceReader,
-    header: &Header,
-) -> Result<()> {
-    // Skip unmapped reads
-    if record.flags().is_unmapped() {
-        return Ok(());
-    }
-
-    // Get the bisulfite strand from the bwameth YD tag
-    let yd_value = record.data().get(&YD_TAG);
-    let is_top = match yd_value {
-        Some(BufValue::String(s)) if AsRef::<[u8]>::as_ref(s) == YD_FORWARD => true,
-        Some(BufValue::String(s)) if AsRef::<[u8]>::as_ref(s) == YD_REVERSE => false,
-        _ => return Ok(()), // No YD tag or unexpected value; skip
-    };
-
-    // Get reference contig name
-    let ref_id = match record.reference_sequence_id() {
-        Some(id) => id,
-        None => return Ok(()),
-    };
-    let (ref_name, _) = header
-        .reference_sequences()
-        .get_index(ref_id)
-        .context("reference sequence ID not found in header")?;
-    // Borrow the contig name as &str rather than allocating a fresh String per
-    // record; `fetch_slice` only needs &str for its HashMap lookup.
-    let ref_name: &str = ref_name.to_str().context("reference sequence name is not valid UTF-8")?;
-
-    // Get alignment start (1-based)
-    let alignment_start = match record.alignment_start().map(usize::from) {
-        Some(pos) => pos,
-        None => return Ok(()),
-    };
-
-    // Compute reference span from CIGAR
-    let ref_span = crate::sam::reference_length(&record.cigar());
-
-    if ref_span == 0 {
-        return Ok(());
-    }
-
-    // Fetch the entire aligned reference region at once. Use the borrowed-slice
-    // API so we don't allocate a fresh `Vec<u8>` per record (~2 GB of churn over
-    // a 13M template run).
-    let ref_start = Position::try_from(alignment_start)?;
-    let ref_end = Position::try_from(alignment_start + ref_span - 1)?;
-    let ref_bases = reference.fetch_slice(ref_name, ref_start, ref_end)?;
-
-    // Determine replacement parameters, accounting for reverse-complemented SEQ.
-    // SAM stores SEQ reverse-complemented when 0x10 is set, so the base to find
-    // and replace flips on reverse-strand alignments.
-    let is_reverse = record.flags().is_reverse_complemented();
-    let (ref_target, converted_base, unconverted_base) = match (is_top, is_reverse) {
-        (true, false) | (false, true) => (b'C', b'T', b'C'),
-        (true, true) | (false, false) => (b'G', b'A', b'G'),
-    };
-    // Precompute lowercase variants once per record so the inner loop just does
-    // two byte equality checks instead of `to_ascii_uppercase()` per byte.
-    let ref_target_lower = ref_target.to_ascii_lowercase();
-    let converted_base_lower = converted_base.to_ascii_lowercase();
-
-    // Fast path: if no candidate reference base appears in the aligned span,
-    // the read can't have any bases to restore — skip the SEQ allocation and
-    // CIGAR walk entirely. `memchr2` is SIMD-accelerated.
-    if memchr::memchr2(ref_target, ref_target_lower, ref_bases).is_none() {
-        return Ok(());
-    }
-
-    // Walk CIGAR and replace converted bases. Defer allocating the mutable SEQ
-    // buffer until we hit the first base we actually need to change — many reads
-    // (highly methylated CpGs in EM-Seq) align to ref-C positions but already
-    // carry C in the read, so no allocation is needed.
-    let read_seq = record.sequence().as_ref();
-    let mut seq: Option<Vec<u8>> = None;
-    let mut read_pos: usize = 0;
-    let mut ref_offset: usize = 0; // 0-based offset into ref_bases
-
-    for op_result in record.cigar().iter() {
-        let op = op_result?;
-        let len = op.len();
-
-        match op.kind() {
-            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
-                for i in 0..len {
-                    if ref_offset + i >= ref_bases.len() {
-                        break;
-                    }
-                    let rb = ref_bases[ref_offset + i];
-                    if (rb == ref_target || rb == ref_target_lower) && read_pos + i < read_seq.len()
-                    {
-                        // Consult the (possibly already-modified) SEQ buffer if present,
-                        // otherwise the original read sequence.
-                        let sb = seq.as_ref().map_or(read_seq[read_pos + i], |s| s[read_pos + i]);
-                        if sb == converted_base || sb == converted_base_lower {
-                            let s = seq.get_or_insert_with(|| read_seq.to_vec());
-                            s[read_pos + i] = unconverted_base;
-                        }
-                    }
-                }
-                read_pos += len;
-                ref_offset += len;
-            }
-            Kind::Insertion | Kind::SoftClip => {
-                read_pos += len;
-            }
-            Kind::Deletion | Kind::Skip => {
-                ref_offset += len;
-            }
-            Kind::HardClip | Kind::Pad => {}
-        }
-    }
-
-    if let Some(seq) = seq {
-        *record.sequence_mut() = seq.into();
-        // NM/MD tags are now stale since SEQ changed; remove them so downstream
-        // tools don't trust incorrect mismatch counts.
-        let data = record.data_mut();
-        data.remove(&Tag::from(SamTag::NM));
-        data.remove(&Tag::from(SamTag::MD));
-    }
-
-    Ok(())
-}
-
-/// Raw-byte equivalent of `restore_unconverted_bases_in_template`.
-///
-/// Iterates the template's `raw_records` (populated by
-/// `convert_template_to_raw`) and applies the unconverted-base restoration
-/// directly to the BAM bytes — no `RecordBuf` round-trip. Lets the methylation
-/// path stay on the same streaming raw-byte fast path TAPs uses.
 fn restore_unconverted_bases_in_raw_template(
     template: &mut Template,
     reference: &ReferenceReader,
     header: &Header,
 ) -> Result<()> {
-    let raw_records = template.raw_records.as_mut().ok_or_else(|| {
-        anyhow::anyhow!("restore_unconverted_bases_in_raw_template: template not in raw-byte mode")
-    })?;
-    for rec in raw_records.iter_mut() {
+    for rec in template.records_mut().iter_mut() {
         restore_unconverted_bases_in_raw_record(rec, reference, header)?;
     }
     Ok(())
 }
 
-/// Raw-byte equivalent of `restore_unconverted_bases_in_record`.
+/// Restore unconverted bases in a single EM-seq record after bwameth re-alignment,
+/// operating directly on raw BAM bytes.
 ///
-/// Operates on a [`RawRecord`] without inflating to a [`RecordBuf`]. Reads the
-/// CIGAR, SEQ, and `YD` tag via the `fgumi-raw-bam` accessors, walks the
-/// alignment, then rewrites converted bases via [`RawRecord::set_base`]. SEQ
-/// stays the same length so no record resizing is needed; only `NM` / `MD` are
-/// removed when SEQ is actually modified.
-///
-/// Skips unmapped records and records without a `YD` tag, just like the
-/// `RecordBuf` path.
+/// Edits the packed 4-bit nibbles in place via [`RawRecord::set_base`], avoiding
+/// a decode-mutate-reencode round-trip through `RecordBuf`.
 fn restore_unconverted_bases_in_raw_record(
     rec: &mut RawRecord,
     reference: &ReferenceReader,
     header: &Header,
 ) -> Result<()> {
+    // Skip unmapped reads
     if rec.is_unmapped() {
         return Ok(());
     }
 
-    // YD tag tells us the bisulfite strand (forward = top, reverse = bottom).
-    // Anything else (missing or unexpected value) means "skip".
-    let yd_bytes = rec.tags().find_string(SamTag::YD.as_ref());
-    let is_top = match yd_bytes {
-        Some(YD_FORWARD) => true,
-        Some(YD_REVERSE) => false,
-        _ => return Ok(()),
+    // Get the bisulfite strand from the bwameth YD tag
+    let yd_bytes = rec.tags().find_string(b"YD").map(|s| s.to_vec());
+    let is_top = match yd_bytes.as_deref() {
+        Some(s) if s == YD_FORWARD => true,
+        Some(s) if s == YD_REVERSE => false,
+        _ => return Ok(()), // No YD tag or unexpected value; skip
     };
 
-    // Reference contig + alignment start.
-    let ref_id = rec.ref_id();
-    if ref_id < 0 {
+    // Get reference contig name
+    let raw_ref_id = rec.ref_id();
+    if raw_ref_id < 0 {
         return Ok(());
     }
+    let ref_id_usize = raw_ref_id as usize;
     let (ref_name, _) = header
         .reference_sequences()
-        .get_index(ref_id as usize)
+        .get_index(ref_id_usize)
         .context("reference sequence ID not found in header")?;
-    let ref_name = ref_name.to_str().context("reference sequence name is not valid UTF-8")?;
+    let ref_name: &str = ref_name.to_str().context("reference sequence name is not valid UTF-8")?;
 
-    let pos = rec.pos();
-    if pos < 0 {
-        return Ok(());
-    }
-    // BAM stores `pos` 0-based; ReferenceReader::fetch_slice expects 1-based.
-    let alignment_start = (pos as usize) + 1;
+    // Get alignment start (1-based); pos() is 0-based
+    let alignment_start = match rec.alignment_start_1based() {
+        Some(pos) => pos,
+        None => return Ok(()),
+    };
 
-    // Reference span from the CIGAR. The helper returns it as i32; clamp to
-    // non-negative usize since negative spans don't make sense.
+    // Compute reference span from CIGAR
     let ref_span = rec.reference_length();
     if ref_span <= 0 {
         return Ok(());
     }
     let ref_span = ref_span as usize;
 
-    // Fetch the aligned reference span (borrowed slice, no per-record alloc).
+    // Fetch the entire aligned reference region at once.
     let ref_start = Position::try_from(alignment_start)?;
     let ref_end = Position::try_from(alignment_start + ref_span - 1)?;
     let ref_bases = reference.fetch_slice(ref_name, ref_start, ref_end)?;
 
-    // Determine replacement parameters, accounting for reverse-complemented SEQ.
-    // Same logic as the `RecordBuf` path; pre-encode the converted base to its
-    // 4-bit BAM nibble so the inner loop compares nibbles directly.
-    let (ref_target, converted_ascii, unconverted_ascii) = match (is_top, rec.is_reverse()) {
+    // Determine replacement parameters; SEQ is reverse-complemented when 0x10 is set.
+    let is_reverse = rec.is_reverse();
+    let (ref_target, converted_base, unconverted_base) = match (is_top, is_reverse) {
         (true, false) | (false, true) => (b'C', b'T', b'C'),
         (true, true) | (false, false) => (b'G', b'A', b'G'),
     };
     let ref_target_lower = ref_target.to_ascii_lowercase();
-    // BAM 4-bit nibble codes: A=1, C=2, G=4, T=8. SEQ codes are case-insensitive
-    // by construction (the encode table maps both cases to the same nibble),
-    // so a single nibble compare is enough.
-    let converted_nibble = match converted_ascii {
-        b'T' => 0x8u8,
-        b'A' => 0x1u8,
-        _ => unreachable!(),
-    };
+    let converted_base_lower = converted_base.to_ascii_lowercase();
 
-    // Fast path: if no candidate reference base appears in the aligned span,
-    // there's nothing to restore. `memchr2` is SIMD-accelerated.
+    // Fast path: if no candidate reference base appears in the aligned span, skip.
     if memchr::memchr2(ref_target, ref_target_lower, ref_bases).is_none() {
         return Ok(());
     }
 
-    // Walk CIGAR and replace converted bases in place. We don't allocate a
-    // SEQ buffer at all — `set_base` rewrites the relevant 4-bit nibble in
-    // the existing record bytes.
-    let l_seq = rec.l_seq() as usize;
+    // Collect CIGAR ops up front so we can interleave immutable reads (get_base)
+    // and mutable writes (set_base) without fighting the borrow checker.
     let cigar_ops = rec.cigar_ops_vec();
-    let mut modified = false;
+    let l_seq = rec.l_seq() as usize;
+
+    let mut changed = false;
     let mut read_pos: usize = 0;
-    let mut ref_offset: usize = 0; // 0-based into ref_bases
+    let mut ref_offset: usize = 0; // 0-based offset into ref_bases
 
-    for raw_op in cigar_ops {
-        let kind = bam_fields::cigar_op_kind(raw_op);
-        let len = (raw_op >> 4) as usize;
+    for op in &cigar_ops {
+        let op_type = op & 0xF;
+        let len = (op >> 4) as usize;
 
-        match kind {
-            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+        // op_type constants (BAM CIGAR encoding):
+        //   0 = M (Match/Mismatch)
+        //   1 = I (Insertion)
+        //   2 = D (Deletion)
+        //   3 = N (Skip / reference skip)
+        //   4 = S (SoftClip)
+        //   5 = H (HardClip)
+        //   6 = P (Pad)
+        //   7 = = (SequenceMatch)
+        //   8 = X (SequenceMismatch)
+        match op_type {
+            0 | 7 | 8 => {
+                // Consumes both query and reference
                 for i in 0..len {
                     if ref_offset + i >= ref_bases.len() {
                         break;
                     }
                     let rb = ref_bases[ref_offset + i];
-                    if (rb == ref_target || rb == ref_target_lower)
-                        && read_pos + i < l_seq
-                        && rec.get_base(read_pos + i) == converted_nibble
-                    {
-                        rec.set_base(read_pos + i, unconverted_ascii);
-                        modified = true;
+                    if (rb == ref_target || rb == ref_target_lower) && read_pos + i < l_seq {
+                        let raw_code = rec.get_base(read_pos + i);
+                        let sb = BAM_BASE_TO_ASCII[raw_code as usize];
+                        if sb == converted_base || sb == converted_base_lower {
+                            rec.set_base(read_pos + i, unconverted_base);
+                            changed = true;
+                        }
                     }
                 }
                 read_pos += len;
                 ref_offset += len;
             }
-            Kind::Insertion | Kind::SoftClip => {
+            1 | 4 => {
+                // Consumes query only (Insertion, SoftClip)
                 read_pos += len;
             }
-            Kind::Deletion | Kind::Skip => {
+            2 | 3 => {
+                // Consumes reference only (Deletion, Skip)
                 ref_offset += len;
             }
-            Kind::HardClip | Kind::Pad => {}
+            5 | 6 => {
+                // HardClip, Pad — consumes neither
+            }
+            _ => {}
         }
     }
 
-    // NM/MD only become stale when SEQ was actually modified.
-    if modified {
+    if changed {
+        // NM/MD tags are now stale since SEQ changed; remove them so downstream
+        // tools don't trust incorrect mismatch counts.
         let mut ed = rec.tags_editor();
-        ed.remove(SamTag::NM.as_ref());
-        ed.remove(SamTag::MD.as_ref());
+        ed.remove(b"NM");
+        ed.remove(b"MD");
     }
 
     Ok(())
+}
+
+/// Groups consecutive `RecordBuf` records by query name into `Template` objects.
+///
+/// Used for the mapped (SAM/BAM) reader path where noodles decodes records as `RecordBuf`.
+/// Each group is encoded to raw bytes via [`RecordBufEncoder`] and assembled into a
+/// [`Template`] via [`Template::from_records`].
+fn record_bufs_to_templates<'a, I>(
+    iter: I,
+    header: &'a Header,
+) -> impl Iterator<Item = Result<Template>> + 'a
+where
+    I: Iterator<Item = Result<noodles::sam::alignment::RecordBuf>> + 'a,
+{
+    let mut encoder = RecordBufEncoder::new(header);
+    let mut pending: Option<noodles::sam::alignment::RecordBuf> = None;
+    let mut exhausted = false;
+    let mut iter = iter;
+
+    std::iter::from_fn(move || {
+        if exhausted && pending.is_none() {
+            return None;
+        }
+
+        let mut batch: Vec<noodles::sam::alignment::RecordBuf> = Vec::with_capacity(2);
+
+        if let Some(p) = pending.take() {
+            batch.push(p);
+        }
+
+        loop {
+            if exhausted {
+                break;
+            }
+            match iter.next() {
+                Some(Ok(rec)) => {
+                    if batch.is_empty() {
+                        batch.push(rec);
+                    } else {
+                        let first_name = batch[0].name().map(|n| n.to_vec());
+                        let this_name = rec.name().map(|n| n.to_vec());
+                        if first_name == this_name {
+                            batch.push(rec);
+                        } else {
+                            pending = Some(rec);
+                            break;
+                        }
+                    }
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                None => {
+                    exhausted = true;
+                    break;
+                }
+            }
+        }
+
+        if batch.is_empty() {
+            return None;
+        }
+
+        let mut raw_records = Vec::with_capacity(batch.len());
+        for rec in &batch {
+            match encoder.encode(rec) {
+                Ok(raw) => raw_records.push(raw),
+                Err(e) => return Some(Err(anyhow::anyhow!("Failed to encode record: {e}"))),
+            }
+        }
+        Some(Template::from_records(raw_records))
+    })
 }
 
 impl Zipper {
@@ -1361,20 +857,16 @@ impl Zipper {
 
             if let Some(ref mut mapped_template) = mapped_peek {
                 if mapped_template.name == unmapped_template.name {
-                    // Both branches now stream raw BAM bytes; the methylation
-                    // case adds a per-record `restore_unconverted_bases` step
-                    // that mutates SEQ in place via `fgumi-raw-bam` primitives.
-                    convert_template_to_raw(mapped_template, output_header)?;
                     merge_raw(&unmapped_template, mapped_template, tag_info, self.skip_tc_tags)?;
                     if let Some(ref_reader) = reference {
+                        // EM-seq: restore converted bases in-place on packed 4-bit nibbles.
                         restore_unconverted_bases_in_raw_template(
                             mapped_template,
                             ref_reader,
                             output_header,
                         )?;
                     }
-                    let rr = mapped_template.raw_records.as_ref().unwrap();
-                    for rec in rr {
+                    for rec in mapped_template.records() {
                         writer.write_raw_record(rec)?;
                         progress.log_if_needed(1);
                     }
@@ -1460,7 +952,7 @@ type BamStdinReader =
     noodles::bam::io::Reader<noodles::bgzf::io::Reader<BufReader<Box<dyn Read + Send>>>>;
 
 /// Wraps SAM and BAM readers so the mapped-reader thread can handle either format.
-/// Moved into the thread where `record_bufs()` is called, since it borrows `&self`.
+/// Moved into the thread that calls `record_bufs()`, since the iterator borrows `&self`.
 enum MappedReader {
     Sam(noodles::sam::io::Reader<Box<dyn BufRead + Send>>),
     Bam(BamReaderAuto),
@@ -1543,7 +1035,7 @@ impl Command for Zipper {
             )
         })?;
 
-        let (mut unmapped_reader, unmapped_header) = create_bam_reader(&self.unmapped, 1)?;
+        let (unmapped_raw_reader, unmapped_header) = create_raw_bam_reader(&self.unmapped, 1)?;
 
         // Read mapped input — detect format by extension.
         // The reader and header are separated here; record_bufs() is called inside
@@ -1634,13 +1126,8 @@ impl Command for Zipper {
         // Create async unmapped reader - spawn thread to read ahead
         let (unmapped_tx, unmapped_rx) =
             std::sync::mpsc::sync_channel::<Result<Template>>(self.buffer);
-        let unmapped_header_for_reader = unmapped_header.clone();
         std::thread::spawn(move || {
-            let unmapped_iter = TemplateIterator::new(
-                unmapped_reader
-                    .record_bufs(&unmapped_header_for_reader)
-                    .map(|r| r.map_err(anyhow::Error::from)),
-            );
+            let unmapped_iter = TemplateIterator::new(unmapped_raw_reader);
             for template in unmapped_iter {
                 if unmapped_tx.send(template).is_err() {
                     break; // Receiver dropped, main thread done
@@ -1658,33 +1145,33 @@ impl Command for Zipper {
             // (which borrows it via record_bufs) remains valid.
             match mapped_reader {
                 MappedReader::Sam(mut r) => {
-                    let mapped_iter = TemplateIterator::new(
-                        r.record_bufs(&mapped_header_for_reader)
-                            .map(|rec| rec.map_err(anyhow::Error::from)),
-                    );
-                    for template in mapped_iter {
+                    let record_iter = r
+                        .record_bufs(&mapped_header_for_reader)
+                        .map(|rec| rec.map_err(anyhow::Error::from));
+                    for template in record_bufs_to_templates(record_iter, &mapped_header_for_reader)
+                    {
                         if mapped_tx.send(template).is_err() {
                             break;
                         }
                     }
                 }
                 MappedReader::Bam(mut r) => {
-                    let mapped_iter = TemplateIterator::new(
-                        r.record_bufs(&mapped_header_for_reader)
-                            .map(|rec| rec.map_err(anyhow::Error::from)),
-                    );
-                    for template in mapped_iter {
+                    let record_iter = r
+                        .record_bufs(&mapped_header_for_reader)
+                        .map(|rec| rec.map_err(anyhow::Error::from));
+                    for template in record_bufs_to_templates(record_iter, &mapped_header_for_reader)
+                    {
                         if mapped_tx.send(template).is_err() {
                             break;
                         }
                     }
                 }
                 MappedReader::StdinBam(mut r) => {
-                    let mapped_iter = TemplateIterator::new(
-                        r.record_bufs(&mapped_header_for_reader)
-                            .map(|rec| rec.map_err(anyhow::Error::from)),
-                    );
-                    for template in mapped_iter {
+                    let record_iter = r
+                        .record_bufs(&mapped_header_for_reader)
+                        .map(|rec| rec.map_err(anyhow::Error::from));
+                    for template in record_bufs_to_templates(record_iter, &mapped_header_for_reader)
+                    {
                         if mapped_tx.send(template).is_err() {
                             break;
                         }
@@ -1711,12 +1198,14 @@ impl Command for Zipper {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sam::SamTag;
     use crate::sam::builder::{
-        MAPPED_PG_ID, REFERENCE_LENGTH, RecordBuilder, SamBuilder, create_ref_dict,
+        MAPPED_PG_ID, REFERENCE_LENGTH, SamBuilder as FgSamBuilder, create_ref_dict,
     };
+    use crate::sam::{TC_TAG, TemplateCoordinateInfo};
     use anyhow::Result;
     use bstr::ByteSlice;
-    use noodles::sam::alignment::record::Flags;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags, testutil::encode_op};
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::RecordBuf;
     use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
@@ -1724,6 +1213,42 @@ mod tests {
     use std::collections::HashMap;
     use std::io::Read;
     use tempfile::TempDir;
+
+    /// Convert a `RawRecord` built with [`RawSamBuilder`] into a noodles `RecordBuf`.
+    ///
+    /// Used in tests to push raw-built records into `FgSamBuilder::push_record`.
+    fn to_record_buf(raw: RawRecord) -> RecordBuf {
+        fgumi_raw_bam::raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+            .expect("raw_record_to_record_buf failed")
+    }
+
+    /// Extract `TemplateCoordinateInfo` from a raw BAM record's `pa` tag.
+    ///
+    /// Returns `None` if the `pa` tag is absent or malformed.
+    fn tc_info_from_raw(rec: &RawRecord) -> Option<TemplateCoordinateInfo> {
+        let arr = rec.tags().find_array(b"tc")?;
+        // pa tag is B:i with 6 int32 elements
+        if arr.elem_type != b'i' || arr.count != 6 {
+            return None;
+        }
+        let read_i32 = |idx: usize| -> i32 {
+            let off = idx * 4;
+            i32::from_le_bytes([
+                arr.data[off],
+                arr.data[off + 1],
+                arr.data[off + 2],
+                arr.data[off + 3],
+            ])
+        };
+        Some(TemplateCoordinateInfo {
+            tid1: read_i32(0),
+            pos1: read_i32(1),
+            neg1: read_i32(2) != 0,
+            tid2: read_i32(3),
+            pos2: read_i32(4),
+            neg2: read_i32(5) != 0,
+        })
+    }
 
     /// A `Read` implementation that returns at most one byte per `read` call,
     /// mimicking the behavior of a slow pipe or small kernel buffer. Used to
@@ -1824,8 +1349,8 @@ mod tests {
     ///
     /// Returns an error if any step fails
     fn run_zipper(
-        unmapped: &SamBuilder,
-        mapped: &SamBuilder,
+        unmapped: &FgSamBuilder,
+        mapped: &FgSamBuilder,
         tags_to_remove: Vec<String>,
         tags_to_reverse: Vec<String>,
         tags_to_revcomp: Vec<String>,
@@ -1876,8 +1401,8 @@ mod tests {
     /// - MC and MQ tags are properly set for paired reads
     #[test]
     fn test_basic_merge() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add unmapped pairs with tags
         let mut attrs1 = HashMap::new();
@@ -1933,8 +1458,8 @@ mod tests {
     /// attempting to match R1/R2.
     #[test]
     fn test_unpaired_reads() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs1 = HashMap::new();
         attrs1.insert("RX", BufValue::from("ACGT".to_string()));
@@ -1979,8 +1504,8 @@ mod tests {
     /// - Positive strand reads are unchanged
     #[test]
     fn test_tag_removal_reverse_revcomp() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("n1", BufValue::from(vec![1i16, 2, 3, 4, 5]));
@@ -2059,8 +1584,8 @@ mod tests {
     /// transformations.
     #[test]
     fn test_consensus_tag_set() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("aD", BufValue::from("AAAGG".to_string()));
@@ -2074,19 +1599,20 @@ mod tests {
         mapped.add_frag_with_attrs("q1", Some(100), true, &mapped_attrs1.clone());
 
         // Add supplementary record
-        let mut supp_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SUPPLEMENTARY | Flags::REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .build();
-        for (tag_str, value) in &mapped_attrs1 {
-            let tag = Tag::new(tag_str.as_bytes()[0], tag_str.as_bytes()[1]);
-            supp_rec.data_mut().insert(tag, value.clone());
-        }
+        let supp_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::SUPPLEMENTARY | flags::REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            to_record_buf(b.build())
+        };
         mapped.push_record(supp_rec);
 
         let records = run_zipper(
@@ -2144,8 +1670,8 @@ mod tests {
     /// written to the output unchanged (still unmapped).
     #[test]
     fn test_unmapped_only_reads() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs1 = HashMap::new();
         attrs1.insert("RX", BufValue::from("ACGT".to_string()));
@@ -2223,8 +1749,8 @@ mod tests {
 
     #[test]
     fn test_mate_info_fixing() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -2272,26 +1798,29 @@ mod tests {
     /// - Both R1 and R2 get the correct flags
     #[test]
     fn test_qc_flag_transfer() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add unmapped pair where R1 passes QC but R2 fails QC
         let mut attrs1 = HashMap::new();
         attrs1.insert("RX", BufValue::from("ACGT".to_string()));
 
         // Create R1 (passes QC - no QC_FAIL flag)
-        let r1_unmapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::UNMAPPED)
-            .tag("RX", "ACGT")
-            .build();
+        let r1_unmapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1").flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::UNMAPPED);
+            b.add_string_tag(b"RX", b"ACGT");
+            to_record_buf(b.build())
+        };
 
         // Create R2 (fails QC - has QC_FAIL flag)
-        let r2_unmapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::UNMAPPED | Flags::QC_FAIL)
-            .tag("RX", "ACGT")
-            .build();
+        let r2_unmapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::UNMAPPED | flags::QC_FAIL);
+            b.add_string_tag(b"RX", b"ACGT");
+            to_record_buf(b.build())
+        };
 
         unmapped.push_record(r1_unmapped);
         unmapped.push_record(r2_unmapped);
@@ -2334,8 +1863,8 @@ mod tests {
     /// the flag is removed from the mapped read.
     #[test]
     fn test_qc_flag_removal() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add unmapped read that passes QC
         let mut attrs = HashMap::new();
@@ -2343,15 +1872,18 @@ mod tests {
         unmapped.add_frag_with_attrs("q1", None, true, &attrs);
 
         // Add mapped read with QC_FAIL flag set
-        let mapped_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::QC_FAIL)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .build();
+        let mapped_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::QC_FAIL)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            to_record_buf(b.build())
+        };
         mapped.push_record(mapped_rec);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -2376,8 +1908,8 @@ mod tests {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn test_tag_operations_on_secondary_and_supplementary() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("n1", BufValue::from(vec![1i16, 2, 3, 4, 5]));
@@ -2395,35 +1927,37 @@ mod tests {
         mapped.add_frag_with_attrs("q1", Some(100), true, &mapped_attrs.clone());
 
         // Add secondary alignment (negative strand)
-        let mut secondary_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SECONDARY | Flags::REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .build();
-        for (tag_str, value) in &mapped_attrs {
-            let tag = Tag::new(tag_str.as_bytes()[0], tag_str.as_bytes()[1]);
-            secondary_rec.data_mut().insert(tag, value.clone());
-        }
+        let secondary_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::SECONDARY | flags::REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            to_record_buf(b.build())
+        };
         mapped.push_record(secondary_rec);
 
         // Add supplementary alignment (negative strand)
-        let mut supp_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SUPPLEMENTARY | Flags::REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(300)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .build();
-        for (tag_str, value) in &mapped_attrs {
-            let tag = Tag::new(tag_str.as_bytes()[0], tag_str.as_bytes()[1]);
-            supp_rec.data_mut().insert(tag, value.clone());
-        }
+        let supp_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::SUPPLEMENTARY | flags::REVERSE)
+                .ref_id(0)
+                .pos(299)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            to_record_buf(b.build())
+        };
         mapped.push_record(supp_rec);
 
         let records = run_zipper(
@@ -2544,8 +2078,8 @@ mod tests {
     /// Verifies that multi-threaded mode produces the same results as single-threaded
     #[test]
     fn test_multithreaded_processing() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add multiple templates to process
         for i in 0..10 {
@@ -2615,8 +2149,8 @@ mod tests {
     /// (matching fgbio's `ZipperBams` validation)
     #[test]
     fn test_empty_unmapped() -> Result<()> {
-        let unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut mapped_attrs = HashMap::new();
         mapped_attrs.insert("PG", BufValue::from(MAPPED_PG_ID.to_string()));
@@ -2636,59 +2170,13 @@ mod tests {
         Ok(())
     }
 
-    /// Tests `copy_tags` function directly
-    ///
-    /// Verifies the tag copying logic including PG tag special handling
-    #[test]
-    fn test_copy_tags_with_pg_present() -> Result<()> {
-        let src =
-            RecordBuilder::new().sequence("ACGT").tag("PG", "old_pg").tag("XY", 123i32).build();
-
-        let mut dest_data = Data::default();
-        dest_data.insert(Tag::from(SamTag::PG), BufValue::from("new_pg".to_string()));
-
-        let tag_info = TagInfo::new(vec![], vec![], vec![]);
-        copy_tags(&src, &mut dest_data, &tag_info)?;
-
-        // PG should not be overwritten
-        if let Some(BufValue::String(s)) = dest_data.get(&Tag::from(SamTag::PG)) {
-            assert_eq!(s.to_string(), "new_pg");
-        }
-
-        // XY should be copied
-        assert!(dest_data.get(&Tag::new(b'X', b'Y')).is_some());
-
-        Ok(())
-    }
-
-    /// Tests `copy_tags` with tag removal
-    ///
-    /// Verifies that tags in the remove list are not copied
-    #[test]
-    fn test_copy_tags_with_removal() -> Result<()> {
-        let src = RecordBuilder::new().sequence("ACGT").tag("XY", 123i32).tag("AB", 456i32).build();
-
-        let mut dest_data = Data::default();
-
-        let tag_info = TagInfo::new(vec!["XY".to_string()], vec![], vec![]);
-        copy_tags(&src, &mut dest_data, &tag_info)?;
-
-        // XY should not be copied (it's in remove list)
-        assert!(dest_data.get(&Tag::new(b'X', b'Y')).is_none());
-
-        // AB should be copied
-        assert!(dest_data.get(&Tag::new(b'A', b'B')).is_some());
-
-        Ok(())
-    }
-
     /// Tests merge function with mixed read configurations
     ///
     /// Verifies handling of reads with different strand orientations
     #[test]
     fn test_merge_mixed_strands() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -2736,8 +2224,8 @@ mod tests {
     /// Verifies that multiple secondary alignments for the same read are all processed
     #[test]
     fn test_multiple_secondary_alignments() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -2749,19 +2237,19 @@ mod tests {
 
         // Add 3 secondary alignments
         for i in 0..3 {
-            let mut secondary_rec = RecordBuilder::new()
-                .name("q1")
-                .flags(Flags::SECONDARY)
-                .reference_sequence_id(0)
-                .alignment_start(200 + i * 100)
-                .cigar("100M")
-                .sequence(&"A".repeat(100))
-                .qualities(&[30u8; 100])
-                .build();
-            for (tag_str, value) in &mapped_attrs {
-                let tag = Tag::new(tag_str.as_bytes()[0], tag_str.as_bytes()[1]);
-                secondary_rec.data_mut().insert(tag, value.clone());
-            }
+            let secondary_rec = {
+                let mut b = RawSamBuilder::new();
+                b.read_name(b"q1")
+                    .flags(flags::SECONDARY)
+                    .ref_id(0)
+                    .pos(199 + i * 100)
+                    .mapq(60)
+                    .cigar_ops(&[encode_op(0, 100)])
+                    .sequence(&b"A".repeat(100))
+                    .qualities(&[30u8; 100]);
+                b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+                to_record_buf(b.build())
+            };
             mapped.push_record(secondary_rec);
         }
 
@@ -2782,24 +2270,27 @@ mod tests {
     /// Verifies correct handling when only one read of a pair is mapped
     #[test]
     fn test_r2_only_mapping() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_pair_with_attrs("q1", None, None, true, true, &attrs);
 
         // Only R2 is mapped
-        let r2_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::LAST_SEGMENT)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .tag("PG", MAPPED_PG_ID)
-            .build();
+        let r2_mapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            to_record_buf(b.build())
+        };
         mapped.push_record(r2_mapped);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -2815,8 +2306,8 @@ mod tests {
 
     /// Helper to run zipper with `exclude_missing_reads` option
     fn run_zipper_with_options(
-        unmapped: &SamBuilder,
-        mapped: &SamBuilder,
+        unmapped: &FgSamBuilder,
+        mapped: &FgSamBuilder,
         exclude_missing_reads: bool,
     ) -> Result<Vec<RecordBuf>> {
         let dir = TempDir::new()?;
@@ -2852,8 +2343,8 @@ mod tests {
     /// Tests that both inputs being empty produces empty output (not an error)
     #[test]
     fn test_both_inputs_empty() -> Result<()> {
-        let unmapped = SamBuilder::new_unmapped();
-        let mapped = SamBuilder::new_mapped();
+        let unmapped = FgSamBuilder::new_unmapped();
+        let mapped = FgSamBuilder::new_mapped();
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
 
@@ -2868,8 +2359,8 @@ mod tests {
     /// When enabled, unmapped reads without matching mapped reads should be excluded from output
     #[test]
     fn test_exclude_missing_reads() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add unmapped pairs - q1, q2, q3
         let mut attrs = HashMap::new();
@@ -2912,7 +2403,7 @@ mod tests {
         let output_path = dir.path().join("output.bam");
 
         // Create mapped file but not unmapped or reference
-        let mapped = SamBuilder::new_mapped();
+        let mapped = FgSamBuilder::new_mapped();
         mapped.write_sam(&mapped_path)?;
 
         let zipper = Zipper {
@@ -2944,7 +2435,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Template-Coordinate Tag (tc) Tests
+    // Primary Alignment Tag (pa) Tests
     // =========================================================================
 
     // Helper for creating records with specific flags
@@ -2955,49 +2446,52 @@ mod tests {
     const FLAG_SUPPLEMENTARY: u16 = 0x800;
     const FLAG_REVERSE: u16 = 0x10;
 
-    /// Tests that the tc tag is added to supplementary reads with template sort key
+    /// Tests that the pa tag is added to supplementary reads with template sort key
     #[test]
-    fn test_add_tc_tag_to_supplementary_r1() -> Result<()> {
+    fn test_add_pa_tag_to_supplementary_r1() -> Result<()> {
         use crate::template::Template;
 
         // Build a template with primary R1 and supplementary R1
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
-        let supplementary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))
-            .build();
+        let supplementary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, supplementary_r1])?;
 
-        // Call add_template_coordinate_tags
-        add_template_coordinate_tags(&mut template);
+        // Call add_template_coordinate_tags_raw
+        add_template_coordinate_tags_raw(&mut template);
 
-        // Check that supplementary has tc tag
+        // Check that supplementary has pa tag
         let supp = template
-            .records
+            .records()
             .iter()
-            .find(|r| r.flags().is_supplementary())
+            .find(|r| r.is_supplementary())
             .expect("Should have supplementary");
 
-        let tc_value = supp.data().get(&TC_TAG).expect("Supplementary should have tc tag");
-
-        // Parse and verify the tc tag
-        let tc_info = TemplateCoordinateInfo::from_tag_value(tc_value)
-            .expect("Should be able to parse tc tag");
+        // Parse and verify the pa tag
+        let tc_info = tc_info_from_raw(supp).expect("Supplementary should have pa tag");
 
         // Only R1 mapped, so both positions should be the same
         assert_eq!(tc_info.tid1, 0, "tid1 should be R1's reference");
@@ -3007,54 +2501,54 @@ mod tests {
         assert_eq!(tc_info.pos2, 100, "pos2 should equal pos1 (single read)");
         assert!(!tc_info.neg2, "neg2 should equal neg1 (single read)");
 
-        // Check that primary does NOT have tc tag
+        // Check that primary does NOT have pa tag
         let primary = template.r1().expect("Should have primary R1");
-        assert!(primary.data().get(&TC_TAG).is_none(), "Primary should not have tc tag");
+        assert!(tc_info_from_raw(primary).is_none(), "Primary should not have pa tag");
 
         Ok(())
     }
 
-    /// Tests that the tc tag is added to secondary reads with correct strand info
+    /// Tests that the pa tag is added to secondary reads with correct strand info
     #[test]
-    fn test_add_tc_tag_to_secondary_reverse_strand() -> Result<()> {
+    fn test_add_pa_tag_to_secondary_reverse_strand() -> Result<()> {
         use crate::template::Template;
 
         // Build a template with primary R1 on reverse strand and secondary R1
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
-        let secondary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(3)
-            .alignment_start(3000)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY))
-            .build();
+        let secondary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY)
+                .ref_id(3)
+                .pos(2999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, secondary_r1])?;
 
-        add_template_coordinate_tags(&mut template);
+        add_template_coordinate_tags_raw(&mut template);
 
-        let secondary = template
-            .records
-            .iter()
-            .find(|r| r.flags().is_secondary())
-            .expect("Should have secondary");
+        let secondary =
+            template.records().iter().find(|r| r.is_secondary()).expect("Should have secondary");
 
-        let tc_value = secondary.data().get(&TC_TAG).expect("Secondary should have tc tag");
-
-        // Parse and verify the tc tag
-        let tc_info = TemplateCoordinateInfo::from_tag_value(tc_value)
-            .expect("Should be able to parse tc tag");
+        // Parse and verify the pa tag
+        let tc_info = tc_info_from_raw(secondary).expect("Secondary should have pa tag");
 
         // Primary is on reverse strand with 8M cigar
         // Unclipped 5' position for reverse strand = alignment_start + alignment_span - 1
@@ -3066,63 +2560,69 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that tc tag contains full template sort key for paired-end data
+    /// Tests that pa tag contains full template sort key for paired-end data
     #[test]
-    fn test_add_tc_tag_paired_end_r2_supplementary() -> Result<()> {
+    fn test_add_pa_tag_paired_end_r2_supplementary() -> Result<()> {
         use crate::template::Template;
 
         // Primary R1 at position 100 (forward strand, 8M cigar)
         // Unclipped 5' = 100 (no soft clips)
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
         // Primary R2 at position 300 (reverse strand, 8M cigar)
         // Unclipped 5' for reverse strand = 300 + 8 - 1 = 307
-        let primary_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(300)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE))
-            .build();
+        let primary_r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+                .ref_id(0)
+                .pos(299)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
 
         // Supplementary R2
-        let supplementary_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY))
-            .build();
+        let supplementary_r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, primary_r2, supplementary_r2])?;
 
-        add_template_coordinate_tags(&mut template);
+        add_template_coordinate_tags_raw(&mut template);
 
         let supp = template
-            .records
+            .records()
             .iter()
-            .find(|r| r.flags().is_supplementary())
+            .find(|r| r.is_supplementary())
             .expect("Should have supplementary");
 
-        let tc_value = supp.data().get(&TC_TAG).expect("Supplementary R2 should have tc tag");
+        // Parse and verify the pa tag
+        let tc_info = tc_info_from_raw(supp).expect("Supplementary R2 should have pa tag");
 
-        // Parse and verify the tc tag
-        let tc_info = TemplateCoordinateInfo::from_tag_value(tc_value)
-            .expect("Should be able to parse tc tag");
-
-        // tc tag should contain BOTH primaries' unclipped 5' positions (sorted by position)
+        // pa tag should contain BOTH primaries' unclipped 5' positions (sorted by position)
         // R1 forward strand at 100 with 8M -> unclipped 5' = 100
         // R2 reverse strand at 300 with 8M -> unclipped 5' = 300 + 8 - 1 = 307
         assert_eq!(tc_info.tid1, 0, "tid1 should be R1's reference (earlier)");
@@ -3135,46 +2635,49 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that no tc tag is added when there's no corresponding primary
+    /// Tests that no pa tag is added when there's no corresponding primary
     #[test]
-    fn test_no_tc_tag_when_no_primary() -> Result<()> {
+    fn test_no_pa_tag_when_no_primary() -> Result<()> {
         use crate::template::Template;
 
         // Only supplementary, no primary
-        let supplementary = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))
-            .build();
+        let supplementary = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![supplementary])?;
 
-        add_template_coordinate_tags(&mut template);
+        add_template_coordinate_tags_raw(&mut template);
 
         let supp = template
-            .records
+            .records()
             .iter()
-            .find(|r| r.flags().is_supplementary())
+            .find(|r| r.is_supplementary())
             .expect("Should have supplementary");
 
-        // Should NOT have tc tag since there's no primary
+        // Should NOT have pa tag since there's no primary
         assert!(
-            supp.data().get(&TC_TAG).is_none(),
-            "Supplementary without primary should not have tc tag"
+            tc_info_from_raw(supp).is_none(),
+            "Supplementary without primary should not have pa tag"
         );
 
         Ok(())
     }
 
-    /// Tests that tc tag is added during full merge operation
+    /// Tests that pa tag is added during full merge operation
     #[test]
-    fn test_tc_tag_added_during_merge() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+    fn test_pa_tag_added_during_merge() -> Result<()> {
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         // Add unmapped pair with tags
         let mut attrs = HashMap::new();
@@ -3185,16 +2688,19 @@ mod tests {
         // R1 at 100, R2 at 200
         let _ = mapped.add_pair().name("q1").start1(100).start2(200).build();
 
-        // Add supplementary R1 (same ref but different pos to test tc tag)
-        let supp = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGTACGTACGT")
-            .qualities(&[30; 12])
-            .reference_sequence_id(0)
-            .alignment_start(5000)
-            .cigar("12M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))
-            .build();
+        // Add supplementary R1 (same ref but different pos to test pa tag)
+        let supp = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY)
+                .ref_id(0)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 12)])
+                .sequence(b"ACGTACGTACGT")
+                .qualities(&[30u8; 12]);
+            to_record_buf(b.build())
+        };
         mapped.push_record(supp);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -3205,15 +2711,15 @@ mod tests {
             .find(|r| r.flags().is_supplementary())
             .expect("Should have supplementary in output");
 
-        // Check tc tag was added
-        let tc_value =
-            supp_record.data().get(&TC_TAG).expect("Supplementary should have tc tag after merge");
+        // Check pa tag was added
+        let pa_value =
+            supp_record.data().get(&TC_TAG).expect("Supplementary should have pa tag after merge");
 
-        // Parse and verify the tc tag
-        let tc_info = TemplateCoordinateInfo::from_tag_value(tc_value)
-            .expect("Should be able to parse tc tag");
+        // Parse and verify the pa tag
+        let tc_info = TemplateCoordinateInfo::from_tag_value(pa_value)
+            .expect("Should be able to parse pa tag");
 
-        // tc tag should contain both primaries' unclipped 5' positions
+        // pa tag should contain both primaries' unclipped 5' positions
         // R1: forward strand at 100 with 100M -> unclipped 5' = 100
         // R2: reverse strand at 200 with 100M -> unclipped 5' = 200 + 100 - 1 = 299
         assert_eq!(tc_info.tid1, 0, "tid1 should be 0");
@@ -3231,83 +2737,95 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that `add_template_coordinate_tags` returns early when there are no
+    /// Tests that `add_template_coordinate_tags_raw` returns early when there are no
     /// secondary/supplementary reads (the early exit optimization).
     #[test]
-    fn test_add_tc_tag_early_exit_no_secondary_supplementary() -> Result<()> {
+    fn test_add_pa_tag_early_exit_no_secondary_supplementary() -> Result<()> {
         use crate::template::Template;
 
         // Create a template with only primary reads (no secondary/supplementary)
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
-        let primary_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("TGCA")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE))
-            .build();
+        let primary_r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"TGCA")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, primary_r2])?;
 
-        // Call add_template_coordinate_tags - should return early
-        add_template_coordinate_tags(&mut template);
+        // Call add_template_coordinate_tags_raw - should return early
+        add_template_coordinate_tags_raw(&mut template);
 
-        // Verify no tc tags were added (primaries don't get tc tags)
-        for record in &template.records {
-            assert!(record.data().get(&TC_TAG).is_none(), "Primary reads should not have tc tag");
+        // Verify no pa tags were added (primaries don't get pa tags)
+        for record in template.records() {
+            assert!(tc_info_from_raw(record).is_none(), "Primary reads should not have pa tag");
         }
 
         Ok(())
     }
 
-    /// Tests that `add_template_coordinate_tags` only adds tc tag to secondary/supplementary,
+    /// Tests that `add_template_coordinate_tags_raw` only adds pa tag to secondary/supplementary,
     /// not to primary reads, even when secondary/supplementary are present.
     #[test]
-    fn test_add_tc_tag_only_to_secondary_supplementary() -> Result<()> {
+    fn test_add_pa_tag_only_to_secondary_supplementary() -> Result<()> {
         use crate::template::Template;
 
         // Create a template with primary + secondary
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
-        let secondary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY))
-            .build();
+        let secondary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, secondary_r1])?;
 
-        add_template_coordinate_tags(&mut template);
+        add_template_coordinate_tags_raw(&mut template);
 
         // Check each record
-        for record in &template.records {
-            if record.flags().is_secondary() {
-                assert!(record.data().get(&TC_TAG).is_some(), "Secondary should have tc tag");
+        for record in template.records() {
+            if record.is_secondary() {
+                assert!(tc_info_from_raw(record).is_some(), "Secondary should have pa tag");
             } else {
-                assert!(record.data().get(&TC_TAG).is_none(), "Primary should not have tc tag");
+                assert!(tc_info_from_raw(record).is_none(), "Primary should not have pa tag");
             }
         }
 
@@ -3321,48 +2839,54 @@ mod tests {
         const FLAG_UNMAPPED: u16 = 0x4;
 
         // Create a template with primary + supplementary
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
-        let supplementary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))
-            .build();
+        let supplementary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, supplementary_r1])?;
 
         // Create unmapped template
-        let unmapped_record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED))
-            .tag("RX", "AAAA")
-            .build();
+        let unmapped_record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1").flags(FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED);
+            b.add_string_tag(b"RX", b"AAAA");
+            b.sequence(b"ACGT").qualities(&[30u8; 4]);
+            b.build()
+        };
         let unmapped = Template::from_records(vec![unmapped_record])?;
 
         let tag_info = TagInfo::new(vec![], vec![], vec![]);
 
         // Test with skip_tc_tags = true
-        merge(&unmapped, &mut template, &tag_info, true)?;
+        merge_raw(&unmapped, &mut template, &tag_info, true)?;
 
-        // Supplementary should NOT have tc tag when skip_tc_tags is true
-        for record in &template.records {
+        // Supplementary should NOT have pa tag when skip_tc_tags is true
+        for record in template.records() {
             assert!(
-                record.data().get(&TC_TAG).is_none(),
-                "No records should have tc tag when skip_tc_tags=true"
+                tc_info_from_raw(record).is_none(),
+                "No records should have pa tag when skip_tc_tags=true"
             );
         }
 
@@ -3376,50 +2900,56 @@ mod tests {
         const FLAG_UNMAPPED: u16 = 0x4;
 
         // Create a template with primary + supplementary
-        let primary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
+        let primary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
-        let supplementary_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .reference_sequence_id(5)
-            .alignment_start(5000)
-            .cigar("4M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))
-            .build();
+        let supplementary_r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY)
+                .ref_id(5)
+                .pos(4999)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 4)])
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        };
 
         let mut template = Template::from_records(vec![primary_r1, supplementary_r1])?;
 
         // Create unmapped template
-        let unmapped_record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED))
-            .tag("RX", "AAAA")
-            .build();
+        let unmapped_record = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1").flags(FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED);
+            b.add_string_tag(b"RX", b"AAAA");
+            b.sequence(b"ACGT").qualities(&[30u8; 4]);
+            b.build()
+        };
         let unmapped = Template::from_records(vec![unmapped_record])?;
 
         let tag_info = TagInfo::new(vec![], vec![], vec![]);
 
         // Test with skip_tc_tags = false
-        merge(&unmapped, &mut template, &tag_info, false)?;
+        merge_raw(&unmapped, &mut template, &tag_info, false)?;
 
-        // Supplementary SHOULD have tc tag when skip_tc_tags is false
-        let has_tc_tag = template
-            .records
+        // Supplementary SHOULD have pa tag when skip_tc_tags is false
+        let has_pa_tag = template
+            .records()
             .iter()
-            .any(|r| r.flags().is_supplementary() && r.data().get(&TC_TAG).is_some());
+            .any(|r| r.is_supplementary() && tc_info_from_raw(r).is_some());
 
-        assert!(has_tc_tag, "Supplementary should have tc tag when skip_tc_tags=false");
+        assert!(has_pa_tag, "Supplementary should have pa tag when skip_tc_tags=false");
 
         Ok(())
     }
@@ -3433,26 +2963,29 @@ mod tests {
     /// - Tags on all reads (primary, secondary, supplementary) are normalized
     #[test]
     fn test_as_xs_normalization() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_frag_with_attrs("q1", None, true, &attrs);
 
         // Add mapped read with AS as Int32(77) and XS as Int32(50)
-        let mapped_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::empty())
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 77i32)
-            .tag("XS", 50i32)
-            .build();
+        let mapped_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(0)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            b.add_int_tag(b"XS", 50);
+            to_record_buf(b.build())
+        };
         mapped.push_record(mapped_rec);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -3474,26 +3007,29 @@ mod tests {
     /// Verifies that AS values >127 are normalized to Int16 rather than Int8
     #[test]
     fn test_as_xs_normalization_large_values() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_frag_with_attrs("q1", None, true, &attrs);
 
         // AS=200 exceeds i8 range, XS=-200 exceeds i8 range
-        let mapped_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::empty())
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("100M")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 200i32)
-            .tag("XS", -200i32)
-            .build();
+        let mapped_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(0)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 100)])
+                .sequence(&b"A".repeat(100))
+                .qualities(&[30u8; 100]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 200);
+            b.add_int_tag(b"XS", -200);
+            to_record_buf(b.build())
+        };
         mapped.push_record(mapped_rec);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -3517,8 +3053,8 @@ mod tests {
     /// - Tags on R2 (positive strand) are copied unchanged
     #[test]
     fn test_negative_strand_r1_tag_copying() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("n1", BufValue::from(vec![1i16, 2, 3]));
@@ -3578,8 +3114,8 @@ mod tests {
     /// Verifies that tags on both reads are reversed/revcomped
     #[test]
     fn test_negative_strand_both_reads() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("n1", BufValue::from(vec![10i16, 20, 30]));
@@ -3627,41 +3163,41 @@ mod tests {
     /// - MC tag contains the mate's CIGAR string
     #[test]
     fn test_fix_mate_info_values() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_pair_with_attrs("q1", None, None, true, true, &attrs);
 
         // Build mapped pair with different CIGARs and mapping qualities
-        let r1_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::MATE_REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mapping_quality(40)
-            .sequence(&"A".repeat(50))
-            .qualities(&[30u8; 50])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .build();
-        let r2_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::LAST_SEGMENT
-                    | Flags::REVERSE_COMPLEMENTED
-                    | Flags::PROPERLY_SEGMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(300)
-            .cigar("75M")
-            .mapping_quality(30)
-            .sequence(&"A".repeat(75))
-            .qualities(&[30u8; 75])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .build();
+        let r1_mapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(99)
+                .mapq(40)
+                .cigar_ops(&[encode_op(0, 50)])
+                .sequence(&b"A".repeat(50))
+                .qualities(&[30u8; 50]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            to_record_buf(b.build())
+        };
+        let r2_mapped = {
+            let mut b = RawSamBuilder::new();
+            // PROPERLY_SEGMENTED = 0x2
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | 0x2)
+                .ref_id(0)
+                .pos(299)
+                .mapq(30)
+                .cigar_ops(&[encode_op(0, 75)])
+                .sequence(&b"A".repeat(75))
+                .qualities(&[30u8; 75]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            to_record_buf(b.build())
+        };
         mapped.push_record(r1_mapped);
         mapped.push_record(r2_mapped);
 
@@ -3739,64 +3275,61 @@ mod tests {
     /// - ms (mate score) tag is set from mate primary's AS tag
     #[test]
     fn test_fix_mate_info_supplementary() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_pair_with_attrs("q1", None, None, true, true, &attrs);
 
         // Add primary pair with known CIGARs, positions, mapqs, and per-read AS tags
-        let r1_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::MATE_REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mapping_quality(40)
-            .sequence(&"A".repeat(50))
-            .qualities(&[30u8; 50])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 77i32)
-            .build();
-        let r2_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::LAST_SEGMENT
-                    | Flags::REVERSE_COMPLEMENTED
-                    | Flags::PROPERLY_SEGMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(300)
-            .cigar("75M")
-            .mapping_quality(30)
-            .sequence(&"A".repeat(75))
-            .qualities(&[30u8; 75])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 55i32)
-            .build();
+        let r1_mapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(99)
+                .mapq(40)
+                .cigar_ops(&[encode_op(0, 50)])
+                .sequence(&b"A".repeat(50))
+                .qualities(&[30u8; 50]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            to_record_buf(b.build())
+        };
+        let r2_mapped = {
+            let mut b = RawSamBuilder::new();
+            // PROPERLY_SEGMENTED = 0x2
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | 0x2)
+                .ref_id(0)
+                .pos(299)
+                .mapq(30)
+                .cigar_ops(&[encode_op(0, 75)])
+                .sequence(&b"A".repeat(75))
+                .qualities(&[30u8; 75]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 55);
+            to_record_buf(b.build())
+        };
         mapped.push_record(r1_mapped);
         mapped.push_record(r2_mapped);
 
         // Add R1 supplementary alignment
-        let supp_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::FIRST_SEGMENT
-                    | Flags::SUPPLEMENTARY
-                    | Flags::REVERSE_COMPLEMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(500)
-            .cigar("60M")
-            .mapping_quality(20)
-            .sequence(&"A".repeat(60))
-            .qualities(&[30u8; 60])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 33i32)
-            .build();
+        let supp_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY | flags::REVERSE)
+                .ref_id(0)
+                .pos(499)
+                .mapq(20)
+                .cigar_ops(&[encode_op(0, 60)])
+                .sequence(&b"A".repeat(60))
+                .qualities(&[30u8; 60]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 33);
+            to_record_buf(b.build())
+        };
         mapped.push_record(supp_rec);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -3872,8 +3405,8 @@ mod tests {
     /// - TLEN is 0 for both reads
     #[test]
     fn test_fix_mate_info_one_unmapped() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -3913,63 +3446,60 @@ mod tests {
     /// from the R1 primary alignment (covers the R2 supplemental path).
     #[test]
     fn test_fix_mate_info_r2_supplementary() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
         unmapped.add_pair_with_attrs("q1", None, None, true, true, &attrs);
 
-        let r1_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::MATE_REVERSE_COMPLEMENTED)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mapping_quality(40)
-            .sequence(&"A".repeat(50))
-            .qualities(&[30u8; 50])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 77i32)
-            .build();
-        let r2_mapped = RecordBuilder::new()
-            .name("q1")
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::LAST_SEGMENT
-                    | Flags::REVERSE_COMPLEMENTED
-                    | Flags::PROPERLY_SEGMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(300)
-            .cigar("75M")
-            .mapping_quality(30)
-            .sequence(&"A".repeat(75))
-            .qualities(&[30u8; 75])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 55i32)
-            .build();
+        let r1_mapped = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(99)
+                .mapq(40)
+                .cigar_ops(&[encode_op(0, 50)])
+                .sequence(&b"A".repeat(50))
+                .qualities(&[30u8; 50]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 77);
+            to_record_buf(b.build())
+        };
+        let r2_mapped = {
+            let mut b = RawSamBuilder::new();
+            // PROPERLY_SEGMENTED = 0x2
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | 0x2)
+                .ref_id(0)
+                .pos(299)
+                .mapq(30)
+                .cigar_ops(&[encode_op(0, 75)])
+                .sequence(&b"A".repeat(75))
+                .qualities(&[30u8; 75]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 55);
+            to_record_buf(b.build())
+        };
         mapped.push_record(r1_mapped);
         mapped.push_record(r2_mapped);
 
         // Add R2 supplementary alignment
-        let supp_rec = RecordBuilder::new()
-            .name("q1")
-            .flags(
-                Flags::SEGMENTED
-                    | Flags::LAST_SEGMENT
-                    | Flags::SUPPLEMENTARY
-                    | Flags::REVERSE_COMPLEMENTED,
-            )
-            .reference_sequence_id(0)
-            .alignment_start(500)
-            .cigar("60M")
-            .mapping_quality(20)
-            .sequence(&"A".repeat(60))
-            .qualities(&[30u8; 60])
-            .tag("PG", MAPPED_PG_ID.to_string())
-            .tag("AS", 33i32)
-            .build();
+        let supp_rec = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::SUPPLEMENTARY | flags::REVERSE)
+                .ref_id(0)
+                .pos(499)
+                .mapq(20)
+                .cigar_ops(&[encode_op(0, 60)])
+                .sequence(&b"A".repeat(60))
+                .qualities(&[30u8; 60]);
+            b.add_string_tag(b"PG", MAPPED_PG_ID.as_bytes());
+            b.add_int_tag(b"AS", 33);
+            to_record_buf(b.build())
+        };
         mapped.push_record(supp_rec);
 
         let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
@@ -4028,8 +3558,8 @@ mod tests {
     /// - MQ/MC tags are removed from both reads
     #[test]
     fn test_fix_mate_info_both_unmapped() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -4064,8 +3594,8 @@ mod tests {
     /// `Int16` array, `UInt8`, `Hex`, and `Float`.
     #[test]
     fn test_varied_tag_types_roundtrip() -> Result<()> {
-        let mut unmapped = SamBuilder::new_unmapped();
-        let mut mapped = SamBuilder::new_mapped();
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
         attrs.insert("RX", BufValue::from("ACGT".to_string()));
@@ -4129,13 +3659,13 @@ mod tests {
     }
 
     #[rstest]
-    // --skip-tc-tags (default false)
+    // --skip-pa-tags (default false)
     #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam"], false)]
-    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags"], true)]
-    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags", "true"], true)]
-    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags", "false"], false)]
-    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags=true"], true)]
-    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags=false"], false)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags", "true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags", "false"], false)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags=true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags=false"], false)]
     fn test_skip_tc_tags_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = Zipper::try_parse_from(args).expect("failed to parse Zipper arguments");
         assert_eq!(cmd.skip_tc_tags, expected);
@@ -4154,592 +3684,294 @@ mod tests {
         assert_eq!(cmd.restore_unconverted_bases, expected);
     }
 
-    /// Helper for the raw-byte restore tests: encode a `RecordBuf` to BAM
-    /// bytes, run the raw-byte restore, and return the resulting SEQ as ASCII.
-    /// Mirrors the assertion shape of the `RecordBuf` tests so equivalence is
-    /// obvious at a glance.
-    fn run_restore_raw(
-        record: &RecordBuf,
-        reference: &ReferenceReader,
-        header: &Header,
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
-        let mut raw = Vec::with_capacity(256);
-        encode_record_buf(&mut raw, header, record)
-            .map_err(|e| anyhow::anyhow!("encode_record_buf failed: {e}"))?;
-        let mut rec = RawRecord::from(raw);
-        restore_unconverted_bases_in_raw_record(&mut rec, reference, header)?;
-        let raw = rec.into_inner();
-        let seq = bam_fields::extract_sequence(&raw);
-        Ok((raw, seq))
+    /// Helper: decode the sequence from a `RawRecord` to ASCII bytes.
+    fn raw_sequence(rec: &RawRecord) -> Vec<u8> {
+        rec.view().sequence_vec()
     }
 
-    /// Raw-byte equivalent of `test_restore_unconverted_bases_top_strand` —
-    /// asserts the new `restore_unconverted_bases_in_raw_record` (which operates
-    /// on packed BAM bytes without round-tripping through `RecordBuf`) produces
-    /// the same SEQ as the `RecordBuf` path for the canonical top-strand case.
-    #[test]
-    fn test_restore_unconverted_bases_in_raw_record_top_strand() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        // Reference: ACGTACGTACGT (chr1) — C positions: 2, 6, 10
-        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
-
-        // Same record as test_restore_unconverted_bases_top_strand
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ATGTATGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .build();
-
-        let (_raw, seq) = run_restore_raw(&record, &reference, &header)?;
-        assert_eq!(seq, b"ACGTACGT");
-
-        Ok(())
+    /// Helper: check that a tag is absent in a `RawRecord`'s aux data.
+    fn raw_tag_absent(rec: &RawRecord, tag: [u8; 2]) -> bool {
+        fgumi_raw_bam::find_string_tag_in_record(rec.as_ref(), &tag).is_none()
+            && fgumi_raw_bam::find_tag_type(fgumi_raw_bam::aux_data_slice(rec.as_ref()), &tag)
+                .is_none()
     }
 
-    /// Raw-byte equivalent of `test_restore_unconverted_bases_bottom_strand` —
-    /// bottom strand restores A→G at ref-G positions.
+    /// Raw-byte mirror of `test_restore_unconverted_bases_top_strand`.
     #[test]
-    fn test_restore_unconverted_bases_in_raw_record_bottom_strand() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_top_strand() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
         let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
-        // A at positions 3,7 = ref-G → restore to G
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACATACAT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2))
-            .tag("YD", "r")
-            .build();
-
-        let (_raw, seq) = run_restore_raw(&record, &reference, &header)?;
-        assert_eq!(seq, b"ACGTACGT");
-
-        Ok(())
-    }
-
-    /// Raw-byte equivalent of `test_restore_unconverted_bases_top_strand_reverse` —
-    /// reverse-strand top-strand reads restore A→G (the complement of T→C) at
-    /// ref-G positions (the complement of ref-C).
-    #[test]
-    fn test_restore_unconverted_bases_in_raw_record_top_strand_reverse() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
-
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACATACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE))
-            .tag("YD", "f")
-            .build();
-
-        let (_raw, seq) = run_restore_raw(&record, &reference, &header)?;
-        assert_eq!(seq, b"ACGTACGT");
-
-        Ok(())
-    }
-
-    /// Raw-byte equivalent of `test_restore_unconverted_bases_skips_no_yd_tag` —
-    /// records without a YD tag come through unchanged.
-    #[test]
-    fn test_restore_unconverted_bases_in_raw_record_skips_no_yd_tag() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
-
-        // No YD tag — function must early-exit and leave SEQ untouched.
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("TTTTTTTT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
-
-        let (_raw, seq) = run_restore_raw(&record, &reference, &header)?;
-        assert_eq!(seq, b"TTTTTTTT");
-
-        Ok(())
-    }
-
-    /// Raw-byte equivalent of `test_restore_unconverted_bases_skips_unmapped` —
-    /// unmapped records come through unchanged.
-    #[test]
-    fn test_restore_unconverted_bases_in_raw_record_skips_unmapped() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
-
-        let record = RecordBuilder::new()
-            .name("q1")
-            .sequence("TTTTTTTT")
-            .qualities(&[30; 8])
-            .flags(Flags::UNMAPPED)
-            .tag("YD", "f")
-            .build();
-
-        let (_raw, seq) = run_restore_raw(&record, &reference, &header)?;
-        assert_eq!(seq, b"TTTTTTTT");
-
-        Ok(())
-    }
-
-    /// Raw-byte path with NM/MD tags present: removed only when SEQ is modified.
-    /// Mirrors the implicit contract of the `RecordBuf` path's stale-tag clearing.
-    #[test]
-    fn test_restore_unconverted_bases_in_raw_record_clears_nm_md_when_modified() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
-
-        // SEQ modified case: T at ref-C should restore, NM/MD should be removed.
-        let modified_record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ATGTATGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .tag("NM", 2i32)
-            .tag("MD", "1C3C2")
-            .build();
-        let (raw, _seq) = run_restore_raw(&modified_record, &reference, &header)?;
-        let aux = bam_fields::aux_data_slice(&raw);
-        assert!(bam_fields::find_tag_type(aux, &SamTag::NM).is_none(), "NM should be removed");
-        assert!(bam_fields::find_tag_type(aux, &SamTag::MD).is_none(), "MD should be removed");
-
-        // SEQ unchanged case: read already matches ref, NM/MD must be preserved.
-        let unchanged_record = RecordBuilder::new()
-            .name("q2")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .tag("NM", 0i32)
-            .tag("MD", "8")
-            .build();
-        let (raw, _seq) = run_restore_raw(&unchanged_record, &reference, &header)?;
-        let aux = bam_fields::aux_data_slice(&raw);
-        assert!(bam_fields::find_tag_type(aux, &SamTag::NM).is_some(), "NM should be kept");
-        assert!(bam_fields::find_tag_type(aux, &SamTag::MD).is_some(), "MD should be kept");
-
-        Ok(())
-    }
-
-    /// Parity test: the raw-byte path's own `read_pos` / `ref_offset` bookkeeping
-    /// must match the `RecordBuf` oracle across nontrivial CIGARs (`I`, `D`, `N`).
-    /// The straight-`M` raw tests wouldn't catch an off-by-one in the indel arms.
-    #[rstest]
-    #[case::match_insert_delete_match("2M1I2M1D3M", "TTNATTGT", "f", FLAG_READ1)]
-    #[case::match_insert_match("4M1I3M", "ATGTNATG", "f", FLAG_READ1)]
-    #[case::match_delete_match("4M1D3M", "ATGTATG", "f", FLAG_READ1)]
-    #[case::match_skip_match("4M1N3M", "ATGTATG", "f", FLAG_READ1)]
-    #[case::bottom_strand_indels("2M1I2M1D3M", "ACNTAGAT", "r", FLAG_READ2)]
-    fn test_restore_unconverted_bases_in_raw_record_indels_parity(
-        #[case] cigar: &str,
-        #[case] sequence: &str,
-        #[case] yd: &str,
-        #[case] flag_mate: u16,
-    ) -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
-
-        let quals = vec![30u8; sequence.len()];
-        let build = || {
-            RecordBuilder::new()
-                .name("q1")
-                .sequence(sequence)
-                .qualities(&quals)
-                .reference_sequence_id(0)
-                .alignment_start(1)
-                .cigar(cigar)
-                .flags(Flags::from(FLAG_PAIRED | flag_mate))
-                .tag("YD", yd)
-                .tag("NM", 1i32)
-                .tag("MD", "8")
-                .build()
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ATGTATGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.build()
         };
-
-        // Oracle: RecordBuf path produces the expected SEQ.
-        let mut oracle = build();
-        restore_unconverted_bases_in_record(&mut oracle, &reference, &header)?;
-        let oracle_seq: Vec<u8> = oracle.sequence().as_ref().to_vec();
-        let oracle_modified = oracle_seq != sequence.as_bytes();
-
-        // Raw-byte path: SEQ must match the oracle byte-for-byte, and stale NM/MD
-        // must be cleared iff the oracle modified the SEQ.
-        let (raw, raw_seq) = run_restore_raw(&build(), &reference, &header)?;
-        assert_eq!(raw_seq, oracle_seq, "raw SEQ mismatch for CIGAR {cigar}");
-
-        let aux = bam_fields::aux_data_slice(&raw);
-        let nm_present = bam_fields::find_tag_type(aux, &SamTag::NM).is_some();
-        let md_present = bam_fields::find_tag_type(aux, &SamTag::MD).is_some();
-        if oracle_modified {
-            assert!(!nm_present, "NM should be removed when SEQ modified (CIGAR {cigar})");
-            assert!(!md_present, "MD should be removed when SEQ modified (CIGAR {cigar})");
-        } else {
-            assert!(nm_present, "NM should be preserved when SEQ unchanged (CIGAR {cigar})");
-            assert!(md_present, "MD should be preserved when SEQ unchanged (CIGAR {cigar})");
-        }
-
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"ACGTACGT");
         Ok(())
     }
 
-    /// Tests that `restore_unconverted_bases_in_record` replaces T→C at ref-C positions
-    /// for top-strand reads (YD:Z:f).
+    /// Raw-byte mirror of `test_restore_unconverted_bases_bottom_strand`.
     #[test]
-    fn test_restore_unconverted_bases_top_strand() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_bottom_strand() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference: ACGTACGTACGT (chr1)
-        // Positions:  1234567890..
-        // C positions: 2, 6, 10
         let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
-        // Build a header with chr1
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
-        // Create a record aligned to pos 1 with 8M CIGAR
-        // Sequence: ATGTATGT (T at positions 2,6 = ref-C positions → should be restored to C)
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ATGTATGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        // Position 1: A (ref=A, no change)
-        // Position 2: T→C (ref=C, top strand, T was converted)
-        // Position 3: G (ref=G, no change)
-        // Position 4: T (ref=T, no change)
-        // Position 5: A (ref=A, no change)
-        // Position 6: T→C (ref=C, top strand, T was converted)
-        // Position 7: G (ref=G, no change)
-        // Position 8: T (ref=T, no change)
-        assert_eq!(seq, b"ACGTACGT");
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ2)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACATACAT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"r");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"ACGTACGT");
         Ok(())
     }
 
-    /// Tests that `restore_unconverted_bases_in_record` replaces A→G at ref-G positions
-    /// for bottom-strand reads (YD:Z:r).
+    /// Raw-byte mirror of `test_restore_unconverted_bases_with_indels`.
     #[test]
-    fn test_restore_unconverted_bases_bottom_strand() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_with_indels() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference: ACGTACGTACGT (chr1)
-        // G positions: 3, 7, 11
         let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
-        // Record at pos 1 with 8M. A at positions 3,7 = ref-G → should be restored to G
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACATACAT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2))
-            .tag("YD", "r")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        assert_eq!(seq, b"ACGTACGT");
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[
+                    encode_op(0, 2),
+                    encode_op(1, 1),
+                    encode_op(0, 2),
+                    encode_op(2, 1),
+                    encode_op(0, 3),
+                ])
+                .sequence(b"TTNATTGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"TCNATCGT");
         Ok(())
     }
 
-    /// Tests that `restore_unconverted_bases_in_record` handles insertions and deletions.
+    /// Raw-byte mirror of `test_restore_unconverted_bases_skips_unmapped`.
     #[test]
-    fn test_restore_unconverted_bases_with_indels() -> Result<()> {
-        use crate::sam::builder::create_test_fasta;
-
-        // Reference: ACGTACGTACGT
-        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
-        let reference = ReferenceReader::new(fasta.path())?;
-
-        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
-
-        // CIGAR: 2M1I2M1D3M → 8 read bases, 8 ref bases consumed
-        // ref_bases (pos 1-8): A C G T A C G T
-        //
-        // Walk:
-        //   2M: read[0,1] vs ref[0,1](A,C) → T stays, T→C
-        //   1I: read[2] (insertion, no ref)
-        //   2M: read[3,4] vs ref[2,3](G,T) → no change (not ref-C)
-        //   1D: ref[4](A) skipped
-        //   3M: read[5,6,7] vs ref[5,6,7](C,G,T) → T→C, G stays, T stays
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("TTNATTGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("2M1I2M1D3M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        assert_eq!(seq, b"TCNATCGT");
-
-        Ok(())
-    }
-
-    /// Tests that `restore_unconverted_bases_in_record` skips unmapped reads.
-    #[test]
-    fn test_restore_unconverted_bases_skips_unmapped() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_skips_unmapped() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
         let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
 
-        // Unmapped read — should be left unchanged
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("TTTTTTTT")
-            .qualities(&[30; 8])
-            .flags(Flags::UNMAPPED)
-            .tag("YD", "f")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        assert_eq!(seq, b"TTTTTTTT"); // Unchanged
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1").flags(flags::UNMAPPED).sequence(b"TTTTTTTT").qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"TTTTTTTT");
         Ok(())
     }
 
-    /// Tests that `restore_unconverted_bases_in_record` skips reads without YD tag.
+    /// Raw-byte mirror of `test_restore_unconverted_bases_skips_no_yd_tag`.
     #[test]
-    fn test_restore_unconverted_bases_skips_no_yd_tag() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_skips_no_yd_tag() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
         let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
 
-        // Mapped read without YD tag — should be left unchanged
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("TTTTTTTT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        assert_eq!(seq, b"TTTTTTTT"); // Unchanged
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"TTTTTTTT")
+                .qualities(&[30u8; 8]);
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"TTTTTTTT");
         Ok(())
     }
 
-    /// Tests that non-converted bases at ref-C positions are left alone.
+    /// Raw-byte mirror of `test_restore_unconverted_bases_preserves_already_unconverted`.
     #[test]
-    fn test_restore_unconverted_bases_preserves_already_unconverted() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_preserves_already_unconverted() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference: CCCCCCCC (all C positions)
         let fasta = create_test_fasta(&[("chr1", "CCCCCCCC")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
 
-        // Top strand: some bases already C (unconverted), some T (converted), some other
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("CTCACTGC")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        // C stays C, T→C, C stays C, A stays A (not T→C), C stays C, T→C, G stays G, C stays C
-        assert_eq!(seq, b"CCCACCGC");
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"CTCACTGC")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"CCCACCGC");
         Ok(())
     }
 
-    /// Top-strand read aligned to a span with no reference Cs: nothing to restore.
-    /// Exercises the `memchr2` early-exit fast path — record must come through
-    /// byte-for-byte unchanged (including any T's, which would only be candidates
-    /// where the reference is C).
+    /// Raw-byte mirror of `test_restore_unconverted_bases_no_target_in_span`.
+    /// When no base changes are made, NM and MD tags must be preserved.
     #[test]
-    fn test_restore_unconverted_bases_no_target_in_span() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_no_target_in_span() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference is all A/T/G — no C anywhere in the aligned span.
         let fasta = create_test_fasta(&[("chr1", "ATGTATGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:8\n".parse().unwrap();
 
-        // SEQ contains T's but they cannot be restoration candidates because
-        // the reference span has no C positions for them to align to.
-        let original_seq = b"ATGTATGT";
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence(std::str::from_utf8(original_seq)?)
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1))
-            .tag("YD", "f")
-            .tag("NM", 0i32)
-            .tag("MD", "8")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        assert_eq!(seq, original_seq);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ATGTATGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.add_int_tag(b"NM", 0);
+            b.add_string_tag(b"MD", b"8");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"ATGTATGT");
         // No SEQ change => NM/MD must remain present.
-        assert!(record.data().get(&Tag::from(SamTag::NM)).is_some());
-        assert!(record.data().get(&Tag::from(SamTag::MD)).is_some());
-
+        assert!(!raw_tag_absent(&raw, *b"NM"), "NM should remain when no bases were changed");
+        assert!(!raw_tag_absent(&raw, *b"MD"), "MD should remain when no bases were changed");
         Ok(())
     }
 
-    /// Tests restoration for a reverse-complemented top-strand read (YD:Z:f, 0x10 set).
-    /// SEQ is stored as the reverse complement, so at ref-G positions (complement of C),
-    /// converted A (complement of T) should be restored to G (complement of C).
+    /// Raw-byte mirror of `test_restore_unconverted_bases_top_strand_reverse`.
     #[test]
-    fn test_restore_unconverted_bases_top_strand_reverse() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_top_strand_reverse() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference: ACGTACGTACGT (chr1)
-        // G positions (1-based): 3, 7, 11
         let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
-        // Aligned at pos 1 with 8M, reverse-complemented (0x10).
-        // Reference region: ACGTACGT (pos 1-8)
-        // SEQ (stored RC'd): at ref-G positions 3,7 show A (converted) instead of G
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ACATACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE))
-            .tag("YD", "f")
-            .build();
-
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
-
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        // Positions 3,7 (ref=G): A→G restored
-        assert_eq!(seq, b"ACGTACGT");
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ACATACGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"ACGTACGT");
         Ok(())
     }
 
-    /// Tests restoration for a reverse-complemented bottom-strand read (YD:Z:r, 0x10 set).
-    /// SEQ is stored as the reverse complement, so at ref-C positions,
-    /// converted T (complement of A) should be restored to C (complement of G).
+    /// Raw-byte mirror of `test_restore_unconverted_bases_bottom_strand_reverse`.
     #[test]
-    fn test_restore_unconverted_bases_bottom_strand_reverse() -> Result<()> {
+    fn test_raw_restore_unconverted_bases_bottom_strand_reverse() -> Result<()> {
         use crate::sam::builder::create_test_fasta;
 
-        // Reference: ACGTACGTACGT (chr1)
-        // C positions (1-based): 2, 6, 10
         let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
         let reference = ReferenceReader::new(fasta.path())?;
-
         let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
-        // Aligned at pos 1 with 8M, reverse-complemented (0x10).
-        // Reference region: ACGTACGT (pos 1-8)
-        // For (is_top=false, is_reverse=true): ref_target=C, converted=T, unconverted=C
-        // At ref-C positions 2,6: SEQ shows T (converted) instead of C
-        let mut record = RecordBuilder::new()
-            .name("q1")
-            .sequence("ATGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("8M")
-            .flags(Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE))
-            .tag("YD", "r")
-            .build();
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ATGTACGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"r");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        assert_eq!(raw_sequence(&raw), b"ACGTACGT");
+        Ok(())
+    }
 
-        restore_unconverted_bases_in_record(&mut record, &reference, &header)?;
+    /// When SEQ changes are made, NM and MD tags must be removed.
+    #[test]
+    fn test_raw_restore_removes_nm_md_when_bases_changed() -> Result<()> {
+        use crate::sam::builder::create_test_fasta;
 
-        let seq: Vec<u8> = record.sequence().as_ref().to_vec();
-        // Positions 2,6 (ref=C): T→C restored
-        assert_eq!(seq, b"ACGTACGT");
+        let fasta = create_test_fasta(&[("chr1", "ACGTACGTACGT")])?;
+        let reference = ReferenceReader::new(fasta.path())?;
+        let header: Header = "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:chr1\tLN:12\n".parse().unwrap();
 
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"q1")
+                .flags(FLAG_PAIRED | FLAG_READ1)
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 8)])
+                .sequence(b"ATGTATGT")
+                .qualities(&[30u8; 8]);
+            b.add_string_tag(b"YD", b"f");
+            b.add_int_tag(b"NM", 2);
+            b.add_string_tag(b"MD", b"1T3T2");
+            b.build()
+        };
+        restore_unconverted_bases_in_raw_record(&mut raw, &reference, &header)?;
+        // SEQ changed (T→C at ref-C positions) so NM/MD must be gone.
+        assert_eq!(raw_sequence(&raw), b"ACGTACGT");
+        assert!(raw_tag_absent(&raw, *b"NM"), "NM should be removed when bases were changed");
+        assert!(raw_tag_absent(&raw, *b"MD"), "MD should be removed when bases were changed");
         Ok(())
     }
 }

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -3,18 +3,17 @@
 //! Each grouper is responsible for grouping decoded BAM records according
 //! to command-specific rules and emitting complete groups for processing.
 //!
-//! Note: BAM record parsing is now handled by the Decode step in the pipeline.
-//! Groupers receive pre-decoded `RecordBuf` vectors.
+//! Note: BAM record parsing is handled by the Decode step in the pipeline.
+//! Groupers receive pre-decoded raw-byte records.
 
 use std::io;
 
 use noodles::sam::alignment::RecordBuf;
 
-use crate::sam::SamTag;
 use crate::sort::bam_fields;
 use crate::template::{Template, TemplateBatch};
 use crate::unified_pipeline::{BatchWeight, DecodedRecord, Grouper, MemoryEstimate};
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, raw_record_to_record_buf};
 
 // ============================================================================
 // BatchWeight Implementations
@@ -59,20 +58,24 @@ impl BatchWeight for TemplateBatch {
 // SingleRecordGrouper
 // ============================================================================
 
-/// A grouper that emits each record as its own "group".
+/// A grouper that emits each record as its own "group" (decoded to `RecordBuf`).
 ///
-/// Used by commands that process records independently:
-/// - filter: Apply filters to each record
-/// - clip: Clip each record
-/// - correct: Correct UMIs in each record
-#[derive(Default)]
-pub struct SingleRecordGrouper;
+/// Used by pass-through pipeline tests. Production filter/clip/correct commands
+/// use [`SingleRawRecordGrouper`] instead to avoid noodles decode/encode.
+///
+/// Construction requires a real `Header` via [`Self::with_header`] — there is no
+/// `new()`/`Default` because decoding mapped records against an empty default
+/// header silently corrupts reference-sequence IDs.
+pub struct SingleRecordGrouper {
+    header: noodles::sam::Header,
+}
 
 impl SingleRecordGrouper {
-    /// Create a new single-record grouper.
+    /// Create a single-record grouper that decodes against `header`. Required
+    /// when records are mapped so reference-sequence IDs resolve correctly.
     #[must_use]
-    pub fn new() -> Self {
-        Self
+    pub fn with_header(header: noodles::sam::Header) -> Self {
+        Self { header }
     }
 }
 
@@ -80,16 +83,11 @@ impl Grouper for SingleRecordGrouper {
     type Group = RecordBuf;
 
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
-        // Each record is its own group - extract and return them directly
         records
             .into_iter()
             .map(|d| {
-                d.into_record().ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "SingleRecordGrouper requires parsed records, got raw bytes",
-                    )
-                })
+                raw_record_to_record_buf(&d.into_raw_bytes(), &self.header)
+                    .map_err(io::Error::other)
             })
             .collect()
     }
@@ -128,17 +126,7 @@ impl Grouper for SingleRawRecordGrouper {
     type Group = RawRecord;
 
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
-        records
-            .into_iter()
-            .map(|d| {
-                d.into_raw_bytes().ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "SingleRawRecordGrouper requires raw bytes, got parsed record",
-                    )
-                })
-            })
-            .collect()
+        Ok(records.into_iter().map(DecodedRecord::into_raw_bytes).collect())
     }
 
     fn finish(&mut self) -> io::Result<Option<Self::Group>> {
@@ -178,9 +166,7 @@ pub struct TemplateGrouper {
     current_name: Option<Vec<u8>>,
     /// Hash of current template name (for fast comparison).
     current_name_hash: Option<u64>,
-    /// Records for current template (non-raw mode).
-    current_records: Vec<RecordBuf>,
-    /// Raw records for current template (raw-byte mode).
+    /// Raw records for the current template being built.
     current_raw_records: Vec<RawRecord>,
     /// Completed templates waiting to be batched.
     pending_templates: VecDeque<Template>,
@@ -197,7 +183,6 @@ impl TemplateGrouper {
             batch_size: batch_size.max(1),
             current_name: None,
             current_name_hash: None,
-            current_records: Vec::new(),
             current_raw_records: Vec::new(),
             pending_templates: VecDeque::new(),
         }
@@ -205,19 +190,8 @@ impl TemplateGrouper {
 
     /// Flush current template to pending queue if non-empty.
     fn flush_current_template(&mut self) -> io::Result<()> {
-        debug_assert!(
-            self.current_raw_records.is_empty() || self.current_records.is_empty(),
-            "mixed raw/parsed records in same template group"
-        );
         if !self.current_raw_records.is_empty() {
-            let template =
-                Template::from_raw_records(std::mem::take(&mut self.current_raw_records))
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            self.pending_templates.push_back(template);
-            self.current_name = None;
-            self.current_name_hash = None;
-        } else if !self.current_records.is_empty() {
-            let template = Template::from_records(std::mem::take(&mut self.current_records))
+            let template = Template::from_records(std::mem::take(&mut self.current_raw_records))
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             self.pending_templates.push_back(template);
             self.current_name = None;
@@ -248,41 +222,24 @@ impl Grouper for TemplateGrouper {
     type Group = TemplateBatch;
 
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
-        use crate::unified_pipeline::DecodedRecordData;
-
-        // Group records by QNAME (using pre-computed name_hash for fast comparison)
+        // Group records by QNAME: use name_hash as a fast pre-check, then confirm
+        // the QNAME bytes match to defend against hash collisions merging unrelated
+        // records into the same template.
         for decoded in records {
             let name_hash = decoded.key.name_hash;
-
-            match decoded.data {
-                DecodedRecordData::Raw(raw) => {
-                    // Raw-byte mode: only extract name when starting a new template
-                    match (self.current_name_hash, name_hash) {
-                        (Some(current_hash), new_hash) if current_hash == new_hash => {
-                            self.current_raw_records.push(raw);
-                        }
-                        _ => {
-                            self.flush_current_template()?;
-                            self.current_name = Some(bam_fields::read_name(&raw).to_vec());
-                            self.current_name_hash = Some(name_hash);
-                            self.current_raw_records.push(raw);
-                        }
-                    }
-                }
-                DecodedRecordData::Parsed(record) => {
-                    let name = record.name().map(|n| Vec::from(<_ as AsRef<[u8]>>::as_ref(n)));
-                    match (self.current_name_hash, name_hash) {
-                        (Some(current_hash), new_hash) if current_hash == new_hash => {
-                            self.current_records.push(record);
-                        }
-                        _ => {
-                            self.flush_current_template()?;
-                            self.current_name = name;
-                            self.current_name_hash = Some(name_hash);
-                            self.current_records.push(record);
-                        }
-                    }
-                }
+            let raw = decoded.data;
+            let read_name = bam_fields::read_name(&raw);
+            let same_template = match (self.current_name_hash, self.current_name.as_deref()) {
+                (Some(h), Some(name)) => h == name_hash && name == read_name,
+                _ => false,
+            };
+            if same_template {
+                self.current_raw_records.push(raw);
+            } else {
+                self.flush_current_template()?;
+                self.current_name = Some(read_name.to_vec());
+                self.current_name_hash = Some(name_hash);
+                self.current_raw_records.push(raw);
             }
         }
 
@@ -310,11 +267,8 @@ impl Grouper for TemplateGrouper {
         self.current_name.is_some()
             || !self.pending_templates.is_empty()
             || !self.current_raw_records.is_empty()
-            || !self.current_records.is_empty()
     }
 }
-
-use noodles::sam::alignment::record::data::field::Tag;
 
 use crate::unified_pipeline::GroupKey;
 
@@ -440,16 +394,15 @@ impl MemoryEstimate for RawPositionGroup {
 /// [`DecodedRecord`]s and emits [`RawPositionGroup`]s. Template construction
 /// is deferred to the parallel Process step via [`build_templates_from_records`].
 ///
-/// **Requirement:** Paired-end reads must have MC tags so that [`compute_group_key`]
-/// produces complete [`GroupKey::paired`] values. Without MC tags, R1 and R2 would
-/// get different `position_key()` values and be incorrectly split.
+/// **Requirement:** Paired-end reads must have MC tags so that decode-stage
+/// [`GroupKey`] construction produces complete [`GroupKey::paired`] values.
+/// Without MC tags, R1 and R2 would get different `position_key()` values and
+/// be incorrectly split.
 ///
 /// By default, secondary/supplementary reads are skipped (they have UNKNOWN
 /// position keys). Use [`with_secondary_supplementary`](Self::with_secondary_supplementary)
 /// to include them — they are coalesced by `name_hash` into the group of their
 /// adjacent primary read (requires template-coordinate sorted input).
-///
-/// [`compute_group_key`]: crate::read_info::compute_group_key
 pub struct RecordPositionGrouper {
     /// Current position key being accumulated (tuple for fast comparison).
     current_position_key: Option<PositionKeyTuple>,
@@ -493,62 +446,42 @@ impl RecordPositionGrouper {
     /// Validate that a paired primary record has an MC tag.
     ///
     /// Skips validation for records that are unmapped or whose mates are unmapped,
-    /// since unmapped reads have no CIGAR to report in an MC tag.
+    /// since unmapped reads have no CIGAR to report in an MC tag. Every eligible
+    /// paired primary record is checked — `mc_validated` is kept only as a
+    /// "seen at least one valid MC" marker, not a short-circuit.
     fn validate_mc_tag(&mut self, decoded: &DecodedRecord) -> io::Result<()> {
-        use crate::sort::bam_fields;
-        use crate::unified_pipeline::DecodedRecordData;
         use fgumi_raw_bam::RawRecordView;
 
-        if self.mc_validated {
-            return Ok(());
+        let raw = &decoded.data;
+        let flg = RawRecordView::new(raw).flags();
+        let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
+        let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
+        let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
+        let is_unmapped = (flg & bam_fields::flags::UNMAPPED) != 0;
+        let is_mate_unmapped = (flg & bam_fields::flags::MATE_UNMAPPED) != 0;
+
+        if is_paired && !is_secondary && !is_supplementary && !is_unmapped && !is_mate_unmapped {
+            if bam_fields::find_mc_tag_in_record(raw).is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "RecordPositionGrouper requires MC tags on paired-end reads. \
+                     Run `fgumi zipper` to add MC tags before `fgumi group`.",
+                ));
+            }
+            self.mc_validated = true;
         }
 
-        match &decoded.data {
-            DecodedRecordData::Raw(raw) => {
-                let flg = RawRecordView::new(raw).flags();
-                let is_paired = (flg & bam_fields::flags::PAIRED) != 0;
-                let is_secondary = (flg & bam_fields::flags::SECONDARY) != 0;
-                let is_supplementary = (flg & bam_fields::flags::SUPPLEMENTARY) != 0;
-                let is_unmapped = (flg & bam_fields::flags::UNMAPPED) != 0;
-                let is_mate_unmapped = (flg & bam_fields::flags::MATE_UNMAPPED) != 0;
-
-                if is_paired
-                    && !is_secondary
-                    && !is_supplementary
-                    && !is_unmapped
-                    && !is_mate_unmapped
-                {
-                    if bam_fields::find_mc_tag_in_record(raw).is_none() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "RecordPositionGrouper requires MC tags on paired-end reads. \
-                             Run `fgumi zipper` to add MC tags before `fgumi group`.",
-                        ));
-                    }
-                    self.mc_validated = true;
-                }
-            }
-            DecodedRecordData::Parsed(record) => {
-                let flags = record.flags();
-                if flags.is_segmented()
-                    && !flags.is_secondary()
-                    && !flags.is_supplementary()
-                    && !flags.is_unmapped()
-                    && !flags.is_mate_unmapped()
-                {
-                    let mc_tag = Tag::from(SamTag::MC);
-                    if record.data().get(&mc_tag).is_none() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "RecordPositionGrouper requires MC tags on paired-end reads. \
-                             Run `fgumi zipper` to add MC tags before `fgumi group`.",
-                        ));
-                    }
-                    self.mc_validated = true;
-                }
-            }
-        }
         Ok(())
+    }
+
+    /// Feed a single record to the grouper, returning a completed group if the record
+    /// starts a new position. Equivalent to `add_records(vec![decoded])` but avoids the
+    /// per-call allocation — useful in streaming hot loops.
+    ///
+    /// # Errors
+    /// Returns an error if MC-tag validation fails on a paired primary record.
+    pub fn add_record(&mut self, decoded: DecodedRecord) -> io::Result<Option<RawPositionGroup>> {
+        self.process_record(decoded)
     }
 
     /// Process a single decoded record, potentially emitting a completed group.
@@ -571,15 +504,17 @@ impl RecordPositionGrouper {
                 Ok(None)
             }
             Some(_)
-                if self
-                    .current_records
-                    .last()
-                    .is_some_and(|last| last.key.name_hash == decoded.key.name_hash) =>
+                if self.current_records.last().is_some_and(|last| {
+                    // Hash match is a fast pre-check; confirm QNAME bytes to guard
+                    // against hash collisions merging unrelated templates.
+                    last.key.name_hash == decoded.key.name_hash
+                        && bam_fields::read_name(&last.data) == bam_fields::read_name(&decoded.data)
+                }) =>
             {
-                // Different position but same template (name_hash match with previous
-                // record). This happens for paired reads with unmapped mates in
-                // template-coordinate sorted input: R1 is mapped at some position while
-                // R2 is unmapped (position -1:0), but they're adjacent by QNAME.
+                // Different position but same template (name_hash + QNAME match with
+                // previous record). This happens for paired reads with unmapped mates
+                // in template-coordinate sorted input: R1 is mapped at some position
+                // while R2 is unmapped (position -1:0), but they're adjacent by QNAME.
                 // Keep them in the same group so they form a complete template.
                 self.current_records.push(decoded);
                 Ok(None)
@@ -665,27 +600,31 @@ fn group_by_name_and_build<T>(
 ) -> io::Result<Vec<Template>> {
     let mut templates = Vec::new();
     let mut current_name_hash: Option<u64> = None;
+    let mut current_name: Option<Vec<u8>> = None;
     let mut current_items: Vec<T> = Vec::new();
 
     for decoded in records {
         let name_hash = decoded.key.name_hash;
+        let read_name = bam_fields::read_name(&decoded.data).to_vec();
         let item = extract(decoded)?;
 
-        match current_name_hash {
-            Some(h) if h == name_hash => {
-                current_items.push(item);
-            }
-            Some(_) => {
-                let template = build(std::mem::take(&mut current_items))
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                templates.push(template);
-                current_name_hash = Some(name_hash);
-                current_items.push(item);
-            }
-            None => {
-                current_name_hash = Some(name_hash);
-                current_items.push(item);
-            }
+        // name_hash is a fast pre-check; confirm QNAME bytes to guard against
+        // hash collisions merging unrelated templates.
+        let same = current_name_hash == Some(name_hash)
+            && current_name.as_deref() == Some(read_name.as_slice());
+        if same {
+            current_items.push(item);
+        } else if current_name_hash.is_some() {
+            let template = build(std::mem::take(&mut current_items))
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            templates.push(template);
+            current_name_hash = Some(name_hash);
+            current_name = Some(read_name);
+            current_items.push(item);
+        } else {
+            current_name_hash = Some(name_hash);
+            current_name = Some(read_name);
+            current_items.push(item);
         }
     }
 
@@ -708,39 +647,7 @@ fn group_by_name_and_build<T>(
 ///
 /// Returns an error if template construction from records fails.
 pub fn build_templates_from_records(records: Vec<DecodedRecord>) -> io::Result<Vec<Template>> {
-    use crate::unified_pipeline::DecodedRecordData;
-
-    if records.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let raw_byte_mode = matches!(records[0].data, DecodedRecordData::Raw(_));
-
-    if raw_byte_mode {
-        group_by_name_and_build(
-            records,
-            |d| match d.data {
-                DecodedRecordData::Raw(v) => Ok(v),
-                DecodedRecordData::Parsed(_) => Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "expected raw-byte record but found parsed record",
-                )),
-            },
-            Template::from_raw_records,
-        )
-    } else {
-        group_by_name_and_build(
-            records,
-            |d| match d.data {
-                DecodedRecordData::Parsed(r) => Ok(r),
-                DecodedRecordData::Raw(_) => Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "expected parsed record but found raw-byte record",
-                )),
-            },
-            Template::from_records,
-        )
-    }
+    group_by_name_and_build(records, |d| Ok(d.data), Template::from_records)
 }
 
 use crate::fastq_parse::{FastqRecord, parse_fastq_records, strip_read_suffix};
@@ -996,7 +903,7 @@ mod tests {
 
     #[test]
     fn test_single_record_grouper_empty() {
-        let mut grouper = SingleRecordGrouper::new();
+        let mut grouper = SingleRecordGrouper::with_header(noodles::sam::Header::default());
         assert!(!grouper.has_pending());
 
         let result = grouper.finish().expect("finish should succeed");
@@ -1028,19 +935,6 @@ mod tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0], raw1);
         assert_eq!(groups[1], raw2);
-    }
-
-    #[test]
-    fn test_single_raw_record_grouper_rejects_parsed() {
-        use crate::sam::builder::RecordBuilder;
-        use crate::unified_pipeline::{DecodedRecord, GroupKey};
-
-        let mut grouper = SingleRawRecordGrouper::new();
-        let rec = RecordBuilder::new().sequence("ACGT").build();
-        let records = vec![DecodedRecord::new(rec, GroupKey::default())];
-
-        let result = grouper.add_records(records);
-        assert!(result.is_err());
     }
 
     // FastqGrouper tests
@@ -1139,7 +1033,7 @@ mod tests {
     // RecordPositionGrouper tests
     // ========================================================================
 
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
 
     /// Helper: create a `DecodedRecord` with the given `GroupKey` and flags/tags.
     fn make_decoded(
@@ -1148,33 +1042,34 @@ mod tests {
         first_segment: bool,
         mc: Option<&str>,
     ) -> DecodedRecord {
-        let mut builder = RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .cigar("4M")
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .paired(paired);
+        use fgumi_raw_bam::testutil::encode_op;
+        let mut flags: u16 = 0;
+        if paired {
+            flags |= raw_flags::PAIRED;
+        }
         if first_segment {
-            builder = builder.first_segment(true);
+            flags |= raw_flags::FIRST_SEGMENT;
         }
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(flags)
+            .ref_id(0)
+            .pos(99) // alignment_start=100 in 1-based => 0-based pos=99
+            .cigar_ops(&[encode_op(0, 4)]);
         if let Some(mc_val) = mc {
-            builder = builder.tag("MC", mc_val);
+            b.add_string_tag(b"MC", mc_val.as_bytes());
         }
-        DecodedRecord::new(builder.build(), key)
+        DecodedRecord::from_raw_bytes(b.build(), key)
     }
 
     /// Helper: create a secondary/supplementary `DecodedRecord` with UNKNOWN key.
     fn make_secondary_decoded(name_hash: u64) -> DecodedRecord {
         let key = GroupKey { name_hash, ..GroupKey::default() };
-        let record = RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .secondary(true)
-            .build();
-        DecodedRecord::new(record, key)
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30; 4]).flags(raw_flags::SECONDARY);
+        DecodedRecord::from_raw_bytes(b.build(), key)
     }
 
     #[test]
@@ -1334,32 +1229,27 @@ mod tests {
         // R1: mapped at chr5:100, mate unmapped — no MC tag
         let r1_key = GroupKey::single(5, 100, 0, 0, 0, name_hash);
         let r1 = {
-            let record = RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .cigar("4M")
-                .reference_sequence_id(5)
-                .alignment_start(100)
-                .paired(true)
-                .first_segment(true)
-                .mate_unmapped(true)
-                .build();
-            DecodedRecord::new(record, r1_key)
+            use fgumi_raw_bam::testutil::encode_op;
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_UNMAPPED)
+                .ref_id(5)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)]);
+            DecodedRecord::from_raw_bytes(b.build(), r1_key)
         };
 
         // R2: unmapped, mate mapped — different position key
         let r2_key = GroupKey::single(-1, 0, 0, 0, 0, name_hash);
         let r2 = {
-            let record = RecordBuilder::new()
-                .name("read1")
-                .sequence("TGCA")
-                .qualities(&[30, 30, 30, 30])
-                .paired(true)
-                .first_segment(false)
-                .unmapped(true)
-                .build();
-            DecodedRecord::new(record, r2_key)
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"TGCA")
+                .qualities(&[30; 4])
+                .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::UNMAPPED);
+            DecodedRecord::from_raw_bytes(b.build(), r2_key)
         };
 
         // Verify position keys differ (this is the bug scenario)
@@ -1397,20 +1287,18 @@ mod tests {
     #[test]
     fn test_record_position_grouper_mc_validation_skips_unmapped_mate() {
         // Paired records with unmapped mates have no MC tag — validation should skip them.
+        use fgumi_raw_bam::testutil::encode_op;
         let mut grouper = RecordPositionGrouper::new();
         let key = GroupKey::single(0, 100, 0, 0, 0, 12345);
-        let record = RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .cigar("4M")
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .paired(true)
-            .first_segment(true)
-            .mate_unmapped(true)
-            .build();
-        let decoded = DecodedRecord::new(record, key);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_UNMAPPED)
+            .ref_id(0)
+            .pos(99)
+            .cigar_ops(&[encode_op(0, 4)]);
+        let decoded = DecodedRecord::from_raw_bytes(b.build(), key);
 
         // Should NOT error even though there's no MC tag
         let result = grouper.add_records(vec![decoded]);
@@ -1439,6 +1327,24 @@ mod tests {
 
         let result = grouper.add_records(vec![decoded]);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_record_position_grouper_mc_validation_catches_later_missing_mc() {
+        // Regression: after a record with a valid MC tag, a later paired primary
+        // missing MC must still fail validation (no short-circuit).
+        let mut grouper = RecordPositionGrouper::new();
+        let key_ok = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 11111);
+        let ok_record = make_decoded(key_ok, true, true, Some("4M"));
+        grouper.add_records(vec![ok_record]).expect("first record with MC should validate");
+        assert!(grouper.mc_validated);
+
+        let key_bad = GroupKey::paired(0, 300, 0, 0, 400, 1, 0, 0, 22222);
+        let bad_record = make_decoded(key_bad, true, true, None);
+        let result = grouper.add_records(vec![bad_record]);
+        assert!(result.is_err(), "later paired primary missing MC must fail");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("MC tags"), "Error should mention MC tags: {err_msg}");
     }
 
     #[test]
@@ -1471,19 +1377,18 @@ mod tests {
 
     #[test]
     fn test_build_templates_single_record() {
+        use fgumi_raw_bam::testutil::encode_op;
         let key = GroupKey::single(0, 100, 0, 0, 0, 12345);
-        let record = RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGT")
-            .qualities(&[30, 30, 30, 30])
-            .cigar("4M")
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .paired(true)
-            .first_segment(true)
-            .build();
-        let decoded = DecodedRecord::new(record, key);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[encode_op(0, 4)]);
+        let decoded = DecodedRecord::from_raw_bytes(b.build(), key);
 
         let templates =
             build_templates_from_records(vec![decoded]).expect("build templates from records");
@@ -1493,35 +1398,32 @@ mod tests {
     #[test]
     fn test_build_templates_paired_same_name_hash() {
         // R1 and R2 with same name_hash should produce one template
+        use fgumi_raw_bam::testutil::encode_op;
         let r1_key = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 12345);
         let r2_key = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 12345);
 
-        let r1 = DecodedRecord::new(
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .cigar("4M")
-                .reference_sequence_id(0)
-                .alignment_start(100)
-                .paired(true)
-                .first_segment(true)
-                .build(),
-            r1_key,
-        );
-        let r2 = DecodedRecord::new(
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("TGCA")
-                .qualities(&[30, 30, 30, 30])
-                .cigar("4M")
-                .reference_sequence_id(0)
-                .alignment_start(200)
-                .paired(true)
-                .reverse_complement(true)
-                .build(),
-            r2_key,
-        );
+        let r1 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)]);
+            DecodedRecord::from_raw_bytes(b.build(), r1_key)
+        };
+        let r2 = {
+            let mut b = RawSamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"TGCA")
+                .qualities(&[30; 4])
+                .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .cigar_ops(&[encode_op(0, 4)]);
+            DecodedRecord::from_raw_bytes(b.build(), r2_key)
+        };
 
         let templates =
             build_templates_from_records(vec![r1, r2]).expect("build templates from records");
@@ -1531,44 +1433,27 @@ mod tests {
     #[test]
     fn test_build_templates_multiple_qnames() {
         // Records with different name_hashes should produce separate templates
+        use fgumi_raw_bam::testutil::encode_op;
         let key1 = GroupKey::single(0, 100, 0, 0, 0, 11111);
         let key2 = GroupKey::single(0, 100, 0, 0, 0, 22222);
         let key3 = GroupKey::single(0, 100, 0, 0, 0, 33333);
 
+        let make_rec = |name: &[u8]| {
+            let mut b = RawSamBuilder::new();
+            b.read_name(name)
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .flags(0)
+                .ref_id(0)
+                .pos(99)
+                .cigar_ops(&[encode_op(0, 4)]);
+            b.build()
+        };
+
         let records: Vec<DecodedRecord> = vec![
-            DecodedRecord::new(
-                RecordBuilder::new()
-                    .name("readA")
-                    .sequence("ACGT")
-                    .qualities(&[30, 30, 30, 30])
-                    .cigar("4M")
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .build(),
-                key1,
-            ),
-            DecodedRecord::new(
-                RecordBuilder::new()
-                    .name("readB")
-                    .sequence("ACGT")
-                    .qualities(&[30, 30, 30, 30])
-                    .cigar("4M")
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .build(),
-                key2,
-            ),
-            DecodedRecord::new(
-                RecordBuilder::new()
-                    .name("readC")
-                    .sequence("ACGT")
-                    .qualities(&[30, 30, 30, 30])
-                    .cigar("4M")
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .build(),
-                key3,
-            ),
+            DecodedRecord::from_raw_bytes(make_rec(b"readA"), key1),
+            DecodedRecord::from_raw_bytes(make_rec(b"readB"), key2),
+            DecodedRecord::from_raw_bytes(make_rec(b"readC"), key3),
         ];
 
         let templates =

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -4,378 +4,32 @@
 //! This is useful for streaming consensus calling where input is already sorted by MI groups
 //! (e.g., output from `group`).
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use fgumi_raw_bam::RawRecord;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::io;
 
 use crate::unified_pipeline::{BatchWeight, DecodedRecord, MemoryEstimate};
 
-/// An iterator that groups consecutive BAM records by their MI (Molecular Identifier) tag.
-///
-/// This iterator assumes records with the same MI value are consecutive in the input stream,
-/// which is the output format from `group`. Each call to `next()` returns all records
-/// sharing the same MI value as a single group.
-///
-/// # Example
-///
-/// ```ignore
-/// use fgumi_lib::mi_group::MiGroupIterator;
-///
-/// let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
-/// let mi_groups = MiGroupIterator::new(record_iter, "MI");
-///
-/// for result in mi_groups {
-///     let (mi_value, records) = result?;
-///     // Process all records with this MI value
-/// }
-/// ```
-pub struct MiGroupIterator<I>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-{
-    record_iter: I,
-    tag: Tag,
-    current_mi: Option<String>,
-    current_group: Vec<RecordBuf>,
-    pending_error: Option<anyhow::Error>,
-    done: bool,
-}
-
-impl<I> MiGroupIterator<I>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-{
-    /// Creates a new `MiGroupIterator`.
-    ///
-    /// # Arguments
-    ///
-    /// * `record_iter` - Iterator over records to group by MI tag
-    /// * `tag_name` - The two-character tag name (e.g., "MI")
-    ///
-    /// # Panics
-    ///
-    /// Panics if `tag_name` is not exactly 2 characters.
-    pub fn new(record_iter: I, tag_name: &str) -> Self {
-        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
-        let tag_bytes = tag_name.as_bytes();
-        let tag = Tag::from([tag_bytes[0], tag_bytes[1]]);
-
-        MiGroupIterator {
-            record_iter,
-            tag,
-            current_mi: None,
-            current_group: Vec::new(),
-            pending_error: None,
-            done: false,
-        }
-    }
-
-    /// Extracts the MI tag value from a record.
-    fn get_mi(&self, record: &RecordBuf) -> Result<Option<String>> {
-        if let Some(tag_value) = record.data().get(&self.tag) {
-            match tag_value {
-                noodles::sam::alignment::record_buf::data::field::Value::String(s) => {
-                    Ok(Some(s.to_string()))
-                }
-                _ => {
-                    bail!("MI tag must be a string value");
-                }
-            }
-        } else {
-            Ok(None)
-        }
-    }
-}
-
-impl<I> Iterator for MiGroupIterator<I>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-{
-    /// Each item is a Result containing (`MI_value`, `Vec<RecordBuf>`) or an error.
-    type Item = Result<(String, Vec<RecordBuf>)>;
-
-    /// Returns the next MI group from the record iterator.
-    ///
-    /// Reads records until the MI tag changes, then returns the completed group.
-    /// On EOF, returns any remaining group, then None.
-    ///
-    /// Records without an MI tag are skipped.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-
-        // Check for pending error (return after we've flushed any pending group)
-        if let Some(e) = self.pending_error.take() {
-            self.done = true;
-            return Some(Err(e));
-        }
-
-        loop {
-            match self.record_iter.next() {
-                None => {
-                    // EOF - return any remaining group
-                    self.done = true;
-                    if self.current_group.is_empty() {
-                        return None;
-                    }
-                    let mi = self.current_mi.take().unwrap_or_default();
-                    let group = std::mem::take(&mut self.current_group);
-                    return Some(Ok((mi, group)));
-                }
-                Some(Err(e)) => {
-                    // If we have a pending group, return it first and save the error
-                    if !self.current_group.is_empty() {
-                        self.pending_error = Some(e);
-                        let mi = self.current_mi.take().unwrap_or_default();
-                        let group = std::mem::take(&mut self.current_group);
-                        return Some(Ok((mi, group)));
-                    }
-                    self.done = true;
-                    return Some(Err(e));
-                }
-                Some(Ok(record)) => {
-                    // Extract MI tag
-                    let mi = match self.get_mi(&record) {
-                        Ok(Some(mi)) => mi,
-                        Ok(None) => {
-                            // Skip records without MI tag
-                            continue;
-                        }
-                        Err(e) => {
-                            // If we have a pending group, return it first and save the error
-                            if !self.current_group.is_empty() {
-                                self.pending_error = Some(e);
-                                let mi = self.current_mi.take().unwrap_or_default();
-                                let group = std::mem::take(&mut self.current_group);
-                                return Some(Ok((mi, group)));
-                            }
-                            self.done = true;
-                            return Some(Err(e));
-                        }
-                    };
-
-                    if self.current_group.is_empty() {
-                        // First record or first record after returning a group
-                        self.current_mi = Some(mi);
-                        self.current_group.push(record);
-                    } else if self.current_mi.as_ref() == Some(&mi) {
-                        // Same MI, add to current group
-                        self.current_group.push(record);
-                    } else {
-                        // Different MI - return current group and start new one
-                        let old_mi = self.current_mi.take().unwrap_or_default();
-                        let group = std::mem::take(&mut self.current_group);
-                        self.current_mi = Some(mi);
-                        self.current_group.push(record);
-                        return Some(Ok((old_mi, group)));
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// An iterator that groups consecutive BAM records by a transformed key.
-///
-/// Similar to `MiGroupIterator` but applies a key transformation function to the MI tag
-/// before grouping. This is useful for duplex consensus calling where reads with
-/// "1/A" and "1/B" should be grouped together under key "1".
-///
-/// # Example
-///
-/// ```ignore
-/// use fgumi_lib::mi_group::MiGroupIteratorWithTransform;
-/// use fgumi_lib::umi::extract_mi_base;
-///
-/// let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
-/// let mi_groups = MiGroupIteratorWithTransform::new(
-///     record_iter,
-///     "MI",
-///     |mi| extract_mi_base(mi).to_string(),
-/// );
-///
-/// for result in mi_groups {
-///     let (base_mi, records) = result?;
-///     // records contains all reads with MI tags like "base_mi/A" and "base_mi/B"
-/// }
-/// ```
-pub struct MiGroupIteratorWithTransform<I, F>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-    F: Fn(&str) -> String,
-{
-    record_iter: I,
-    tag: Tag,
-    key_transform: F,
-    current_key: Option<String>,
-    current_group: Vec<RecordBuf>,
-    pending_error: Option<anyhow::Error>,
-    done: bool,
-}
-
-impl<I, F> MiGroupIteratorWithTransform<I, F>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-    F: Fn(&str) -> String,
-{
-    /// Creates a new `MiGroupIteratorWithTransform`.
-    ///
-    /// # Arguments
-    ///
-    /// * `record_iter` - Iterator over records to group
-    /// * `tag_name` - The two-character tag name (e.g., "MI")
-    /// * `key_transform` - Function to transform the tag value into a grouping key
-    ///
-    /// # Panics
-    ///
-    /// Panics if `tag_name` is not exactly 2 characters.
-    pub fn new(record_iter: I, tag_name: &str, key_transform: F) -> Self {
-        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
-        let tag_bytes = tag_name.as_bytes();
-        let tag = Tag::from([tag_bytes[0], tag_bytes[1]]);
-
-        MiGroupIteratorWithTransform {
-            record_iter,
-            tag,
-            key_transform,
-            current_key: None,
-            current_group: Vec::new(),
-            pending_error: None,
-            done: false,
-        }
-    }
-
-    /// Extracts the tag value from a record and transforms it using the key function.
-    fn get_key(&self, record: &RecordBuf) -> Result<Option<String>> {
-        if let Some(tag_value) = record.data().get(&self.tag) {
-            match tag_value {
-                noodles::sam::alignment::record_buf::data::field::Value::String(s) => {
-                    let raw = s.to_string();
-                    Ok(Some((self.key_transform)(&raw)))
-                }
-                _ => {
-                    bail!("Tag must be a string value");
-                }
-            }
-        } else {
-            Ok(None)
-        }
-    }
-}
-
-impl<I, F> Iterator for MiGroupIteratorWithTransform<I, F>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-    F: Fn(&str) -> String,
-{
-    /// Each item is a Result containing (key, `Vec<RecordBuf>`) or an error.
-    type Item = Result<(String, Vec<RecordBuf>)>;
-
-    /// Returns the next group from the record iterator.
-    ///
-    /// Reads records until the transformed key changes, then returns the completed group.
-    /// On EOF, returns any remaining group, then None.
-    ///
-    /// Records without the tag are skipped.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-
-        // Check for pending error (return after we've flushed any pending group)
-        if let Some(e) = self.pending_error.take() {
-            self.done = true;
-            return Some(Err(e));
-        }
-
-        loop {
-            match self.record_iter.next() {
-                None => {
-                    // EOF - return any remaining group
-                    self.done = true;
-                    if self.current_group.is_empty() {
-                        return None;
-                    }
-                    let key = self.current_key.take().unwrap_or_default();
-                    let group = std::mem::take(&mut self.current_group);
-                    return Some(Ok((key, group)));
-                }
-                Some(Err(e)) => {
-                    // If we have a pending group, return it first and save the error
-                    if !self.current_group.is_empty() {
-                        self.pending_error = Some(e);
-                        let key = self.current_key.take().unwrap_or_default();
-                        let group = std::mem::take(&mut self.current_group);
-                        return Some(Ok((key, group)));
-                    }
-                    self.done = true;
-                    return Some(Err(e));
-                }
-                Some(Ok(record)) => {
-                    // Extract and transform tag
-                    let key = match self.get_key(&record) {
-                        Ok(Some(key)) => key,
-                        Ok(None) => {
-                            // Skip records without tag
-                            continue;
-                        }
-                        Err(e) => {
-                            // If we have a pending group, return it first and save the error
-                            if !self.current_group.is_empty() {
-                                self.pending_error = Some(e);
-                                let key = self.current_key.take().unwrap_or_default();
-                                let group = std::mem::take(&mut self.current_group);
-                                return Some(Ok((key, group)));
-                            }
-                            self.done = true;
-                            return Some(Err(e));
-                        }
-                    };
-
-                    if self.current_group.is_empty() {
-                        // First record or first record after returning a group
-                        self.current_key = Some(key);
-                        self.current_group.push(record);
-                    } else if self.current_key.as_ref() == Some(&key) {
-                        // Same key, add to current group
-                        self.current_group.push(record);
-                    } else {
-                        // Different key - return current group and start new one
-                        let old_key = self.current_key.take().unwrap_or_default();
-                        let group = std::mem::take(&mut self.current_group);
-                        self.current_key = Some(key);
-                        self.current_group.push(record);
-                        return Some(Ok((old_key, group)));
-                    }
-                }
-            }
-        }
-    }
-}
+use crate::unified_pipeline::Grouper;
+use std::collections::VecDeque;
 
 // ============================================================================
-// Parallel processing support for MI groups
+// Raw-byte MI grouping for consensus callers
 // ============================================================================
 
-/// A single MI group: the MI tag value and all records with that MI.
-///
-/// This represents records that share the same Molecular Identifier (MI) tag value,
-/// used by consensus calling commands to group reads from the same source molecule.
+/// A single MI group holding raw-byte BAM records.
 #[derive(Debug, Clone)]
 pub struct MiGroup {
     /// The MI tag value (e.g., "0", "1/A", "1/B")
     pub mi: String,
-    /// All records sharing this MI value
-    pub records: Vec<RecordBuf>,
+    /// Raw BAM records sharing this MI value
+    pub records: Vec<RawRecord>,
 }
 
 impl MiGroup {
-    /// Creates a new MI group.
+    /// Creates a new raw MI group.
     #[must_use]
-    pub fn new(mi: String, records: Vec<RecordBuf>) -> Self {
+    pub fn new(mi: String, records: Vec<RawRecord>) -> Self {
         Self { mi, records }
     }
 }
@@ -388,47 +42,28 @@ impl BatchWeight for MiGroup {
 
 impl MemoryEstimate for MiGroup {
     fn estimate_heap_size(&self) -> usize {
-        // mi: String (heap allocated)
         let mi_size = self.mi.capacity();
-
-        // records: Vec<RecordBuf>
-        let records_size: usize = self.records.iter().map(MemoryEstimate::estimate_heap_size).sum();
-        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RecordBuf>();
-
+        let records_size: usize = self.records.iter().map(RawRecord::capacity).sum();
+        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RawRecord>();
         mi_size + records_size + records_vec_overhead
     }
 }
 
-impl MemoryEstimate for MiGroupBatch {
-    fn estimate_heap_size(&self) -> usize {
-        let groups_size: usize = self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum();
-        let groups_vec_overhead = self.groups.capacity() * std::mem::size_of::<MiGroup>();
-        groups_size + groups_vec_overhead
-    }
-}
-
-/// A batch of MI groups for parallel processing.
-///
-/// This structure holds a collection of MI groups that will be processed together
-/// in parallel.
-///
-/// # Performance
-///
-/// The batch is designed to be reused across iterations to minimize allocations.
+/// A batch of raw MI groups for parallel processing.
 #[derive(Default)]
 pub struct MiGroupBatch {
-    /// The MI groups in this batch
+    /// The raw MI groups in this batch
     pub groups: Vec<MiGroup>,
 }
 
 impl MiGroupBatch {
-    /// Creates a new empty MI group batch.
+    /// Creates a new empty raw MI group batch.
     #[must_use]
     pub fn new() -> Self {
         Self { groups: Vec::new() }
     }
 
-    /// Creates a new MI group batch with pre-allocated capacity.
+    /// Creates a new raw MI group batch with pre-allocated capacity.
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self { groups: Vec::with_capacity(capacity) }
@@ -440,7 +75,7 @@ impl MiGroupBatch {
         self.groups.len()
     }
 
-    /// Returns true if the batch is empty.
+    /// Returns true if the batch contains no groups.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.groups.is_empty()
@@ -458,322 +93,26 @@ impl BatchWeight for MiGroupBatch {
     }
 }
 
-// ============================================================================
-// MiGrouper for 7-step unified pipeline
-// ============================================================================
-
-use crate::unified_pipeline::Grouper;
-use std::collections::VecDeque;
-
-/// Type alias for record filter function used in [`MiGrouper`].
-type RecordFilterFn = Box<dyn Fn(&RecordBuf) -> bool + Send + Sync>;
-
-/// Type alias for MI tag transformation function used in [`MiGrouper`].
-type MiTransformFn = Box<dyn Fn(&str) -> String + Send + Sync>;
-
-/// A Grouper that reads pre-grouped BAM records by MI tag for the 7-step pipeline.
-///
-/// Input BAM is expected to be sorted/grouped by MI tag (output from group command).
-/// This grouper reads consecutive records with the same MI tag and yields them as groups.
-///
-/// Unlike `OwnedMiGroupReader` which implements the `Reader` trait for the parallel
-/// framework, this implements the `Grouper` trait for the 7-step unified pipeline.
-/// The key difference is that `Grouper::add_bytes` receives raw decompressed bytes
-/// and must deserialize BAM records inline.
-///
-/// # Example
-///
-/// ```ignore
-/// use fgumi_lib::mi_group::MiGrouper;
-/// use fgumi_lib::unified_pipeline::Grouper;
-///
-/// let grouper = MiGrouper::new("MI", 100);
-/// // Use with run_bam_pipeline_with_grouper...
-/// ```
-///
-/// For duplex consensus calling with record filtering and MI transformation:
-///
-/// ```ignore
-/// let grouper = MiGrouper::with_filter_and_transform(
-///     "MI",
-///     100,
-///     |r| !r.flags().is_secondary(), // filter function
-///     |mi| extract_mi_base(mi).to_string(),   // transform function
-/// );
-/// ```
-pub struct MiGrouper {
-    /// The MI tag to group by (e.g., "MI")
-    tag: Tag,
-    /// Number of MI groups per batch
-    batch_size: usize,
-    /// Current MI value being accumulated
-    current_mi: Option<String>,
-    /// Records in current MI group
-    current_records: Vec<RecordBuf>,
-    /// Completed groups waiting to be batched
-    pending_groups: VecDeque<MiGroup>,
-    /// Whether `finish()` has been called
-    finished: bool,
-    /// Optional record filter (returns true to keep record)
-    record_filter: Option<RecordFilterFn>,
-    /// Optional MI tag transformation function
-    mi_transform: Option<MiTransformFn>,
-}
-
-impl MiGrouper {
-    /// Create a new `MiGrouper`.
-    ///
-    /// # Arguments
-    /// * `tag_name` - The MI tag name (e.g., "MI")
-    /// * `batch_size` - Number of MI groups per batch (100 is typical)
-    ///
-    /// # Panics
-    ///
-    /// Panics if `tag_name` is not exactly 2 characters.
-    #[must_use]
-    pub fn new(tag_name: &str, batch_size: usize) -> Self {
-        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
-        let tag_bytes = tag_name.as_bytes();
-        let tag = Tag::from([tag_bytes[0], tag_bytes[1]]);
-
-        Self {
-            tag,
-            batch_size: batch_size.max(1),
-            current_mi: None,
-            current_records: Vec::new(),
-            pending_groups: VecDeque::new(),
-            finished: false,
-            record_filter: None,
-            mi_transform: None,
-        }
-    }
-
-    /// Create a `MiGrouper` with record filtering and MI tag transformation.
-    ///
-    /// This is useful for duplex consensus calling where we need to:
-    /// - Filter out secondary/supplementary reads
-    /// - Transform MI tags by stripping /A and /B suffixes
-    ///
-    /// # Arguments
-    /// * `tag_name` - The MI tag name (e.g., "MI")
-    /// * `batch_size` - Number of MI groups per batch (100 is typical)
-    /// * `record_filter` - Function that returns true to keep a record
-    /// * `mi_transform` - Function to transform MI tag value (e.g., strip /A /B suffix)
-    ///
-    /// # Panics
-    ///
-    /// Panics if `tag_name` is not exactly 2 characters.
-    pub fn with_filter_and_transform<F, T>(
-        tag_name: &str,
-        batch_size: usize,
-        record_filter: F,
-        mi_transform: T,
-    ) -> Self
-    where
-        F: Fn(&RecordBuf) -> bool + Send + Sync + 'static,
-        T: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        assert!(tag_name.len() == 2, "Tag name must be exactly 2 characters");
-        let tag_bytes = tag_name.as_bytes();
-        let tag = Tag::from([tag_bytes[0], tag_bytes[1]]);
-
-        Self {
-            tag,
-            batch_size: batch_size.max(1),
-            current_mi: None,
-            current_records: Vec::new(),
-            pending_groups: VecDeque::new(),
-            finished: false,
-            record_filter: Some(Box::new(record_filter)),
-            mi_transform: Some(Box::new(mi_transform)),
-        }
-    }
-
-    /// Get the MI tag value from a record, optionally applying transformation.
-    fn get_mi_tag(&self, record: &RecordBuf) -> Option<String> {
-        record.data().get(&self.tag).and_then(|v| match v {
-            noodles::sam::alignment::record_buf::data::field::Value::String(s) => {
-                let raw = s.to_string();
-                // Apply transform if configured
-                if let Some(ref transform) = self.mi_transform {
-                    Some(transform(&raw))
-                } else {
-                    Some(raw)
-                }
-            }
-            _ => None,
-        })
-    }
-
-    /// Check if a record passes the filter (or return true if no filter).
-    fn should_keep(&self, record: &RecordBuf) -> bool {
-        match &self.record_filter {
-            Some(filter) => filter(record),
-            None => true,
-        }
-    }
-
-    /// Flush current MI group to pending.
-    fn flush_current_group(&mut self) {
-        if let Some(mi) = self.current_mi.take() {
-            if !self.current_records.is_empty() {
-                let records = std::mem::take(&mut self.current_records);
-                self.pending_groups.push_back(MiGroup::new(mi, records));
-            }
-        }
-    }
-
-    /// Try to form complete batches from pending groups.
-    fn drain_batches(&mut self) -> Vec<MiGroupBatch> {
-        let mut batches = Vec::new();
-        while self.pending_groups.len() >= self.batch_size {
-            let groups: Vec<MiGroup> = self.pending_groups.drain(..self.batch_size).collect();
-            batches.push(MiGroupBatch { groups });
-        }
-        batches
-    }
-}
-
-impl Grouper for MiGrouper {
-    type Group = MiGroupBatch;
-
-    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
-        for decoded in records {
-            let record = decoded.into_record().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "MiGrouper requires parsed records")
-            })?;
-            // Apply record filter if configured - skip records that don't pass
-            if !self.should_keep(&record) {
-                continue;
-            }
-
-            // Get MI tag from record (with optional transformation)
-            let mi = self.get_mi_tag(&record).unwrap_or_default();
-
-            // Check if this starts a new MI group
-            match &self.current_mi {
-                Some(current) if current == &mi => {
-                    // Same MI, add to current group
-                    self.current_records.push(record);
-                }
-                Some(_) => {
-                    // Different MI, flush current and start new
-                    self.flush_current_group();
-                    self.current_mi = Some(mi);
-                    self.current_records.push(record);
-                }
-                None => {
-                    // First record
-                    self.current_mi = Some(mi);
-                    self.current_records.push(record);
-                }
-            }
-        }
-
-        // Return complete batches
-        Ok(self.drain_batches())
-    }
-
-    fn finish(&mut self) -> io::Result<Option<Self::Group>> {
-        if self.finished {
-            return Ok(None);
-        }
-        self.finished = true;
-
-        // Flush any remaining current group
-        self.flush_current_group();
-
-        // Return any remaining groups as final batch
-        if self.pending_groups.is_empty() {
-            Ok(None)
-        } else {
-            let groups: Vec<MiGroup> = self.pending_groups.drain(..).collect();
-            Ok(Some(MiGroupBatch { groups }))
-        }
-    }
-
-    fn has_pending(&self) -> bool {
-        !self.pending_groups.is_empty() || self.current_mi.is_some()
-    }
-}
-
-// ============================================================================
-// Raw-byte MI grouping for consensus callers
-// ============================================================================
-
-/// A single MI group holding raw-byte BAM records.
-#[derive(Debug, Clone)]
-pub struct RawMiGroup {
-    /// The MI tag value (e.g., "0", "1/A", "1/B")
-    pub mi: String,
-    /// Raw BAM records sharing this MI value
-    pub records: Vec<RawRecord>,
-}
-
-impl RawMiGroup {
-    /// Creates a new raw MI group.
-    #[must_use]
-    pub fn new(mi: String, records: Vec<RawRecord>) -> Self {
-        Self { mi, records }
-    }
-}
-
-impl BatchWeight for RawMiGroup {
-    fn batch_weight(&self) -> usize {
-        self.records.len()
-    }
-}
-
-impl MemoryEstimate for RawMiGroup {
-    fn estimate_heap_size(&self) -> usize {
-        let mi_size = self.mi.capacity();
-        let records_size: usize = self.records.iter().map(RawRecord::capacity).sum();
-        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RawRecord>();
-        mi_size + records_size + records_vec_overhead
-    }
-}
-
-/// A batch of raw MI groups for parallel processing.
-#[derive(Default)]
-pub struct RawMiGroupBatch {
-    /// The raw MI groups in this batch
-    pub groups: Vec<RawMiGroup>,
-}
-
-impl RawMiGroupBatch {
-    /// Creates a new empty raw MI group batch.
-    #[must_use]
-    pub fn new() -> Self {
-        Self { groups: Vec::new() }
-    }
-}
-
-impl BatchWeight for RawMiGroupBatch {
-    fn batch_weight(&self) -> usize {
-        self.groups.iter().map(|g| g.records.len()).sum()
-    }
-}
-
-impl MemoryEstimate for RawMiGroupBatch {
+impl MemoryEstimate for MiGroupBatch {
     fn estimate_heap_size(&self) -> usize {
         let groups_size: usize = self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum();
-        let groups_vec_overhead = self.groups.capacity() * std::mem::size_of::<RawMiGroup>();
+        let groups_vec_overhead = self.groups.capacity() * std::mem::size_of::<MiGroup>();
         groups_size + groups_vec_overhead
     }
 }
 
 /// Type alias for raw-byte MI tag transformation function.
-type RawMiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
+type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
 
 /// Type alias for raw-byte record filter function.
-type RawRecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
+type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
 
 /// A Grouper that groups raw-byte BAM records by MI tag.
 ///
-/// This is the raw-byte equivalent of `MiGrouper`. Instead of parsing records
-/// into `RecordBuf`, it extracts MI tags directly from raw BAM bytes using
-/// `bam_fields::find_string_tag_in_record()`.
-pub struct RawMiGrouper {
+/// Records arrive as raw BAM bytes (see [`DecodedRecord::from_raw_bytes`]). MI tags are
+/// extracted directly from the raw bytes using `bam_fields::find_string_tag_in_record()`
+/// without parsing into `RecordBuf`.
+pub struct MiGrouper {
     /// The MI tag bytes to search for
     tag: [u8; 2],
     /// Number of MI groups per batch
@@ -783,19 +122,19 @@ pub struct RawMiGrouper {
     /// Records in current MI group (raw bytes)
     current_records: Vec<RawRecord>,
     /// Completed groups waiting to be batched
-    pending_groups: VecDeque<RawMiGroup>,
+    pending_groups: VecDeque<MiGroup>,
     /// Whether `finish()` has been called
     finished: bool,
     /// Optional MI tag transformation function
-    mi_transform: Option<RawMiTransformFn>,
+    mi_transform: Option<MiTransformFn>,
     /// Optional record filter
-    record_filter: Option<RawRecordFilterFn>,
+    record_filter: Option<RecordFilterFn>,
     /// Optional cell barcode tag for composite grouping (MI + cell barcode)
     cell_tag: Option<[u8; 2]>,
 }
 
-impl RawMiGrouper {
-    /// Create a new `RawMiGrouper`.
+impl MiGrouper {
+    /// Create a new `MiGrouper`.
     ///
     /// # Panics
     ///
@@ -818,7 +157,7 @@ impl RawMiGrouper {
         }
     }
 
-    /// Create a `RawMiGrouper` with record filtering and MI tag transformation.
+    /// Create a `MiGrouper` with record filtering and MI tag transformation.
     ///
     /// # Panics
     ///
@@ -892,38 +231,40 @@ impl RawMiGrouper {
         if let Some(mi) = self.current_mi.take() {
             if !self.current_records.is_empty() {
                 let records = std::mem::take(&mut self.current_records);
-                self.pending_groups.push_back(RawMiGroup::new(mi, records));
+                self.pending_groups.push_back(MiGroup::new(mi, records));
             }
         }
     }
 
     /// Try to form complete batches from pending groups.
-    fn drain_batches(&mut self) -> Vec<RawMiGroupBatch> {
+    fn drain_batches(&mut self) -> Vec<MiGroupBatch> {
         let mut batches = Vec::new();
         while self.pending_groups.len() >= self.batch_size {
-            let groups: Vec<RawMiGroup> = self.pending_groups.drain(..self.batch_size).collect();
-            batches.push(RawMiGroupBatch { groups });
+            let groups: Vec<MiGroup> = self.pending_groups.drain(..self.batch_size).collect();
+            batches.push(MiGroupBatch { groups });
         }
         batches
     }
 }
 
-impl Grouper for RawMiGrouper {
-    type Group = RawMiGroupBatch;
+impl Grouper for MiGrouper {
+    type Group = MiGroupBatch;
 
     fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
         for decoded in records {
-            let raw = decoded.into_raw_bytes().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "RawMiGrouper requires raw byte records")
-            })?;
+            let raw = decoded.into_raw_bytes();
 
             // Apply record filter if configured
             if !self.should_keep(&raw) {
                 continue;
             }
 
-            // Get MI tag from raw bytes (use empty string if absent, matching MiGrouper behavior)
-            let mi = self.get_mi_tag(&raw).unwrap_or_default();
+            // Skip records without an MI tag: the consensus caller requires the
+            // MI tag and would fail when processing them. `MiGroupIterator`
+            // applies the same skip policy for parity across paths.
+            let Some(mi) = self.get_mi_tag(&raw) else {
+                continue;
+            };
 
             // Check if this starts a new MI group
             match &self.current_mi {
@@ -956,8 +297,8 @@ impl Grouper for RawMiGrouper {
         if self.pending_groups.is_empty() {
             Ok(None)
         } else {
-            let groups: Vec<RawMiGroup> = self.pending_groups.drain(..).collect();
-            Ok(Some(RawMiGroupBatch { groups }))
+            let groups: Vec<MiGroup> = self.pending_groups.drain(..).collect();
+            Ok(Some(MiGroupBatch { groups }))
         }
     }
 
@@ -966,11 +307,10 @@ impl Grouper for RawMiGrouper {
     }
 }
 
-/// An iterator that groups consecutive raw BAM records by their MI tag.
-///
-/// This is the raw-byte equivalent of `MiGroupIterator` for the single-threaded path.
+/// An iterator that groups consecutive raw BAM records by their MI tag, yielding
+/// one group per distinct MI value from the input stream.
 #[allow(clippy::type_complexity)]
-pub struct RawMiGroupIterator<I>
+pub struct MiGroupIterator<I>
 where
     I: Iterator<Item = Result<RawRecord>>,
 {
@@ -987,11 +327,11 @@ where
     mi_transform: Option<Box<dyn Fn(&[u8]) -> String>>,
 }
 
-impl<I> RawMiGroupIterator<I>
+impl<I> MiGroupIterator<I>
 where
     I: Iterator<Item = Result<RawRecord>>,
 {
-    /// Creates a new `RawMiGroupIterator`.
+    /// Creates a new `MiGroupIterator`.
     ///
     /// # Panics
     ///
@@ -1011,7 +351,7 @@ where
         }
     }
 
-    /// Creates a new `RawMiGroupIterator` with MI tag transformation.
+    /// Creates a new `MiGroupIterator` with MI tag transformation.
     ///
     /// # Panics
     ///
@@ -1066,7 +406,7 @@ where
     }
 }
 
-impl<I> Iterator for RawMiGroupIterator<I>
+impl<I> Iterator for MiGroupIterator<I>
 where
     I: Iterator<Item = Result<RawRecord>>,
 {
@@ -1105,6 +445,9 @@ where
                     return Some(Err(e));
                 }
                 Some(Ok(raw)) => {
+                    // Skip records without an MI tag; the consensus caller requires
+                    // an MI tag and would fail when processing them. `MiGrouper`
+                    // applies the same skip policy for parity across paths.
                     let Some(mi) = self.get_mi(&raw) else {
                         continue;
                     };
@@ -1132,237 +475,7 @@ where
 mod tests {
     use super::*;
     use crate::sam::SamTag;
-    use crate::sam::builder::RecordBuilder;
     use crate::umi::extract_mi_base;
-
-    fn create_record_with_mi(mi: &str) -> RecordBuf {
-        RecordBuilder::new()
-            .sequence("ACGT") // Minimal sequence
-            .tag("MI", mi)
-            .build()
-    }
-
-    fn create_record_without_mi() -> RecordBuf {
-        RecordBuilder::new()
-            .sequence("ACGT") // Minimal sequence
-            .build()
-    }
-
-    #[test]
-    fn test_empty_iterator() {
-        let records: Vec<Result<RecordBuf>> = vec![];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_single_group() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_with_mi("0")),
-        ];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 3);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_multiple_groups() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_with_mi("1")),
-            Ok(create_record_with_mi("1")),
-            Ok(create_record_with_mi("1")),
-            Ok(create_record_with_mi("2")),
-        ];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 2);
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "1");
-        assert_eq!(result.1.len(), 3);
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "2");
-        assert_eq!(result.1.len(), 1);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_skips_records_without_mi_tag() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_without_mi()),
-            Ok(create_record_with_mi("0")),
-            Ok(create_record_without_mi()),
-            Ok(create_record_with_mi("1")),
-        ];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 2); // Skipped record without MI
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "1");
-        assert_eq!(result.1.len(), 1);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_error_propagation() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0")),
-            Err(anyhow::anyhow!("test error")),
-            Ok(create_record_with_mi("1")),
-        ];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
-
-        // First group before error
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 1);
-
-        // Error
-        let result = iter.next().expect("iterator should yield item");
-        assert!(result.is_err());
-
-        // Iterator should be done after error
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_custom_tag() {
-        let record1 = RecordBuilder::new().sequence("ACGT").tag("RX", "ACGT").build();
-
-        let record2 = RecordBuilder::new().sequence("ACGT").tag("RX", "ACGT").build();
-
-        let records: Vec<Result<RecordBuf>> = vec![Ok(record1), Ok(record2)];
-        let mut iter = MiGroupIterator::new(records.into_iter(), "RX");
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "ACGT");
-        assert_eq!(result.1.len(), 2);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    #[should_panic(expected = "Tag name must be exactly 2 characters")]
-    fn test_invalid_tag_length() {
-        let records: Vec<Result<RecordBuf>> = vec![];
-        let _ = MiGroupIterator::new(records.into_iter(), "M");
-    }
-
-    // Tests for MiGroupIteratorWithTransform
-    #[test]
-    fn test_transform_groups_by_base_mi() {
-        // Simulate duplex reads: 1/A, 1/A, 1/B, 1/B, 2/A, 2/B
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("1/A")),
-            Ok(create_record_with_mi("1/A")),
-            Ok(create_record_with_mi("1/B")),
-            Ok(create_record_with_mi("1/B")),
-            Ok(create_record_with_mi("2/A")),
-            Ok(create_record_with_mi("2/B")),
-        ];
-        let mut iter = MiGroupIteratorWithTransform::new(records.into_iter(), "MI", |mi| {
-            extract_mi_base(mi).to_string()
-        });
-
-        // First group: base MI "1" with 4 reads (2 /A + 2 /B)
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "1");
-        assert_eq!(result.1.len(), 4);
-
-        // Second group: base MI "2" with 2 reads (1 /A + 1 /B)
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "2");
-        assert_eq!(result.1.len(), 2);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_transform_empty_iterator() {
-        let records: Vec<Result<RecordBuf>> = vec![];
-        let mut iter = MiGroupIteratorWithTransform::new(records.into_iter(), "MI", |mi| {
-            extract_mi_base(mi).to_string()
-        });
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_transform_single_group() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0/A")),
-            Ok(create_record_with_mi("0/B")),
-            Ok(create_record_with_mi("0/A")),
-        ];
-        let mut iter = MiGroupIteratorWithTransform::new(records.into_iter(), "MI", |mi| {
-            extract_mi_base(mi).to_string()
-        });
-
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 3);
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_transform_error_propagation() {
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("0/A")),
-            Err(anyhow::anyhow!("test error")),
-            Ok(create_record_with_mi("1/B")),
-        ];
-        let mut iter = MiGroupIteratorWithTransform::new(records.into_iter(), "MI", |mi| {
-            extract_mi_base(mi).to_string()
-        });
-
-        // First group before error
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "0");
-        assert_eq!(result.1.len(), 1);
-
-        // Error
-        let result = iter.next().expect("iterator should yield item");
-        assert!(result.is_err());
-
-        // Iterator should be done after error
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn test_transform_custom_function() {
-        // Test with a custom transformation function (uppercase)
-        let records: Vec<Result<RecordBuf>> = vec![
-            Ok(create_record_with_mi("abc")),
-            Ok(create_record_with_mi("ABC")),
-            Ok(create_record_with_mi("Abc")),
-        ];
-        let mut iter =
-            MiGroupIteratorWithTransform::new(records.into_iter(), "MI", str::to_uppercase);
-
-        // All should be grouped together since they uppercase to "ABC"
-        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
-        assert_eq!(result.0, "ABC");
-        assert_eq!(result.1.len(), 3);
-
-        assert!(iter.next().is_none());
-    }
 
     // ========================================================================
     // Helpers for raw BAM byte construction
@@ -1458,24 +571,24 @@ mod tests {
     }
 
     // ========================================================================
-    // RawMiGroupIterator tests
+    // MiGroupIterator tests
     // ========================================================================
 
     #[test]
-    fn test_raw_empty_iterator() {
+    fn test_empty_iterator() {
         let records: Vec<Result<RawRecord>> = vec![];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
         assert!(iter.next().is_none());
     }
 
     #[test]
-    fn test_raw_single_group() {
+    fn test_single_group() {
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
         ];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
 
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
         assert_eq!(result.0, "0");
@@ -1485,7 +598,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_multiple_groups() {
+    fn test_multiple_groups() {
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_with_tag("MI", "0")),
@@ -1494,7 +607,7 @@ mod tests {
             Ok(make_raw_bam_with_tag("MI", "1")),
             Ok(make_raw_bam_with_tag("MI", "2")),
         ];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
 
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
         assert_eq!(result.0, "0");
@@ -1512,7 +625,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_skips_records_without_mi_tag() {
+    fn test_skips_records_without_mi_tag() {
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Ok(make_raw_bam_without_tag()),
@@ -1520,7 +633,7 @@ mod tests {
             Ok(make_raw_bam_without_tag()),
             Ok(make_raw_bam_with_tag("MI", "1")),
         ];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
 
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
         assert_eq!(result.0, "0");
@@ -1534,13 +647,13 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_error_propagation() {
+    fn test_error_propagation() {
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "0")),
             Err(anyhow::anyhow!("test error")),
             Ok(make_raw_bam_with_tag("MI", "1")),
         ];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
 
         // First group before error
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
@@ -1555,10 +668,10 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_error_with_no_pending_group() {
+    fn test_error_with_no_pending_group() {
         let records: Vec<Result<RawRecord>> =
             vec![Err(anyhow::anyhow!("immediate error")), Ok(make_raw_bam_with_tag("MI", "0"))];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI");
 
         // Error should be returned directly
         let result = iter.next().expect("iterator should yield item");
@@ -1569,10 +682,10 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_custom_tag() {
+    fn test_custom_tag() {
         let records: Vec<Result<RawRecord>> =
             vec![Ok(make_raw_bam_with_tag("RX", "ACGT")), Ok(make_raw_bam_with_tag("RX", "ACGT"))];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "RX");
+        let mut iter = MiGroupIterator::new(records.into_iter(), "RX");
 
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
         assert_eq!(result.0, "ACGT");
@@ -1583,13 +696,13 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Tag name must be exactly 2 characters")]
-    fn test_raw_invalid_tag_length() {
+    fn test_invalid_tag_length() {
         let records: Vec<Result<RawRecord>> = vec![];
-        let _ = RawMiGroupIterator::new(records.into_iter(), "M");
+        let _ = MiGroupIterator::new(records.into_iter(), "M");
     }
 
     #[test]
-    fn test_raw_with_transform() {
+    fn test_with_transform() {
         // Simulate duplex reads: 1/A, 1/B should group under "1"
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "1/A")),
@@ -1599,7 +712,7 @@ mod tests {
             Ok(make_raw_bam_with_tag("MI", "2/A")),
             Ok(make_raw_bam_with_tag("MI", "2/B")),
         ];
-        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
             let s = String::from_utf8_lossy(raw);
             extract_mi_base(&s).to_string()
         });
@@ -1618,9 +731,9 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_with_transform_empty() {
+    fn test_with_transform_empty() {
         let records: Vec<Result<RawRecord>> = vec![];
-        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
             String::from_utf8_lossy(raw).to_uppercase()
         });
         assert!(iter.next().is_none());
@@ -1628,44 +741,41 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Tag name must be exactly 2 characters")]
-    fn test_raw_with_transform_invalid_tag_length() {
+    fn test_with_transform_invalid_tag_length() {
         let records: Vec<Result<RawRecord>> = vec![];
-        let _ = RawMiGroupIterator::with_transform(records.into_iter(), "ABC", |raw| {
+        let _ = MiGroupIterator::with_transform(records.into_iter(), "ABC", |raw| {
             String::from_utf8_lossy(raw).into_owned()
         });
     }
 
     #[test]
-    fn test_raw_get_mi_without_transform() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
+    fn test_get_mi_without_transform() {
+        let iter = MiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_with_tag("MI", "42");
         assert_eq!(iter.get_mi(&bam), Some("42".to_string()));
     }
 
     #[test]
-    fn test_raw_get_mi_with_transform() {
-        let iter = RawMiGroupIterator::with_transform(
-            std::iter::empty::<Result<RawRecord>>(),
-            "MI",
-            |raw| {
+    fn test_get_mi_with_transform() {
+        let iter =
+            MiGroupIterator::with_transform(std::iter::empty::<Result<RawRecord>>(), "MI", |raw| {
                 let s = String::from_utf8_lossy(raw);
                 s.to_uppercase()
-            },
-        );
+            });
         let bam = make_raw_bam_with_tag("MI", "abc");
         assert_eq!(iter.get_mi(&bam), Some("ABC".to_string()));
     }
 
     #[test]
-    fn test_raw_get_mi_missing_tag() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
+    fn test_get_mi_missing_tag() {
+        let iter = MiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_without_tag();
         assert_eq!(iter.get_mi(&bam), None);
     }
 
     #[test]
-    fn test_raw_get_mi_wrong_tag() {
-        let iter = RawMiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
+    fn test_get_mi_wrong_tag() {
+        let iter = MiGroupIterator::new(std::iter::empty::<Result<RawRecord>>(), "MI");
         let bam = make_raw_bam_with_tag("RX", "ACGT");
         assert_eq!(iter.get_mi(&bam), None);
     }
@@ -1712,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_cell_tag_composite_grouping() {
+    fn test_cell_tag_composite_grouping() {
         // Same MI but different cell barcodes should form separate groups
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
@@ -1721,7 +831,7 @@ mod tests {
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
         ];
         let mut iter =
-            RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some(*SamTag::CB));
+            MiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some(*SamTag::CB));
 
         // First group: MI=1, CB=ACGT
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
@@ -1737,13 +847,13 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_cell_tag_none_groups_by_mi_only() {
+    fn test_cell_tag_none_groups_by_mi_only() {
         // Without cell_tag, same MI records group together regardless of other tags
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "TGCA")),
         ];
-        let mut iter = RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(None);
+        let mut iter = MiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(None);
 
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
         assert_eq!(result.0, "1");
@@ -1753,7 +863,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_cell_tag_missing_cell_value() {
+    fn test_cell_tag_missing_cell_value() {
         // Records with MI but no cell tag get grouped under "MI\t" (empty cell)
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_tag("MI", "1")),
@@ -1761,7 +871,7 @@ mod tests {
             Ok(make_raw_bam_with_two_tags("MI", "1", "CB", "ACGT")),
         ];
         let mut iter =
-            RawMiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some(*SamTag::CB));
+            MiGroupIterator::new(records.into_iter(), "MI").with_cell_tag(Some(*SamTag::CB));
 
         // First group: MI=1, no CB (key = "1\t")
         let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
@@ -1777,14 +887,14 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_cell_tag_with_transform() {
+    fn test_cell_tag_with_transform() {
         // Cell tag should work with MI transform (duplex-style /A /B stripping)
         let records: Vec<Result<RawRecord>> = vec![
             Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1/B", "CB", "ACGT")),
             Ok(make_raw_bam_with_two_tags("MI", "1/A", "CB", "TGCA")),
         ];
-        let mut iter = RawMiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
             let s = String::from_utf8_lossy(raw);
             extract_mi_base(&s).to_string()
         })
@@ -1805,7 +915,7 @@ mod tests {
     }
 
     // ========================================================================
-    // RawMiGrouper tests (Grouper trait impl)
+    // MiGrouper tests (Grouper trait impl)
     // ========================================================================
 
     /// Helper: create a `DecodedRecord` from raw bytes with a dummy group key.
@@ -1822,16 +932,9 @@ mod tests {
         DecodedRecord::from_raw_bytes(raw, key)
     }
 
-    /// Helper: create a parsed `DecodedRecord` (for testing error paths).
-    fn make_parsed_decoded_record(mi: &str) -> DecodedRecord {
-        let record = create_record_with_mi(mi);
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
-        DecodedRecord::new(record, key)
-    }
-
     #[test]
-    fn test_raw_grouper_single_mi_group() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_single_mi_group() {
+        let mut grouper = MiGrouper::new("MI", 10);
 
         let records = vec![
             make_raw_decoded_record("MI", "0"),
@@ -1852,8 +955,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_multiple_mi_groups() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_multiple_mi_groups() {
+        let mut grouper = MiGrouper::new("MI", 10);
 
         let records = vec![
             make_raw_decoded_record("MI", "0"),
@@ -1879,8 +982,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_batch_size_triggers() {
-        let mut grouper = RawMiGrouper::new("MI", 2);
+    fn test_grouper_batch_size_triggers() {
+        let mut grouper = MiGrouper::new("MI", 2);
 
         let records = vec![
             make_raw_decoded_record("MI", "0"),
@@ -1911,8 +1014,10 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_groups_records_without_mi_under_empty_key() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_skips_records_without_mi_tag() {
+        // Matches `MiGroupIterator`: records without an MI tag are skipped so
+        // the consensus caller never sees them (it requires the MI tag).
+        let mut grouper = MiGrouper::new("MI", 10);
 
         let records = vec![
             make_raw_decoded_record("MI", "0"),
@@ -1923,30 +1028,17 @@ mod tests {
         let batches = grouper.add_records(records).expect("add_records should succeed");
         assert!(batches.is_empty());
 
-        // Records without MI are now grouped under "" (matching MiGrouper behavior)
         let final_batch =
             grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 3);
+        // The no-MI record is dropped; the two MI=0 records coalesce into one group.
+        assert_eq!(final_batch.groups.len(), 1);
         assert_eq!(final_batch.groups[0].mi, "0");
-        assert_eq!(final_batch.groups[0].records.len(), 1);
-        assert_eq!(final_batch.groups[1].mi, "");
-        assert_eq!(final_batch.groups[1].records.len(), 1);
-        assert_eq!(final_batch.groups[2].mi, "0");
-        assert_eq!(final_batch.groups[2].records.len(), 1);
+        assert_eq!(final_batch.groups[0].records.len(), 2);
     }
 
     #[test]
-    fn test_raw_grouper_rejects_parsed_records() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
-
-        let records = vec![make_parsed_decoded_record("0")];
-        let result = grouper.add_records(records);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_raw_grouper_finish_empty() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_finish_empty() {
+        let mut grouper = MiGrouper::new("MI", 10);
         assert!(!grouper.has_pending());
 
         let final_batch = grouper.finish().expect("finish should succeed");
@@ -1954,8 +1046,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_finish_idempotent() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_finish_idempotent() {
+        let mut grouper = MiGrouper::new("MI", 10);
 
         let records = vec![make_raw_decoded_record("MI", "0")];
         grouper.add_records(records).expect("add_records should succeed");
@@ -1968,8 +1060,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_has_pending_states() {
-        let mut grouper = RawMiGrouper::new("MI", 10);
+    fn test_grouper_has_pending_states() {
+        let mut grouper = MiGrouper::new("MI", 10);
 
         // Initially nothing pending
         assert!(!grouper.has_pending());
@@ -1986,10 +1078,10 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_with_filter_and_transform() {
+    fn test_grouper_with_filter_and_transform() {
         // Build records with flag field set: use byte 14..16 for flag.
         // We create a filter that checks the flag field for secondary alignment (0x100).
-        let mut grouper = RawMiGrouper::with_filter_and_transform(
+        let mut grouper = MiGrouper::with_filter_and_transform(
             "MI",
             10,
             |bam: &[u8]| {
@@ -2032,17 +1124,17 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_grouper_cell_tag_composite_grouping() {
+    fn test_grouper_cell_tag_composite_grouping() {
         // Records with the same MI but different cell barcodes must form separate groups.
         // The composite key (MI\tCB) is used internally for grouping only; it is stored in
-        // `RawMiGroup::mi` for logging but never written back to the output records.
+        // `MiGroup::mi` for logging but never written back to the output records.
         fn make_two_tag_decoded(mi: &str, cb: &str) -> DecodedRecord {
             let raw = make_raw_bam_with_two_tags("MI", mi, "CB", cb);
             let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
             DecodedRecord::from_raw_bytes(raw, key)
         }
 
-        let mut grouper = RawMiGrouper::new("MI", 10).with_cell_tag(Some(*SamTag::CB));
+        let mut grouper = MiGrouper::new("MI", 10).with_cell_tag(Some(*SamTag::CB));
 
         // Two records per (MI, CB) combination; MI=1,CB=ACGT and MI=1,CB=TGCA must be split.
         let records = vec![
@@ -2076,195 +1168,69 @@ mod tests {
     }
 
     // ========================================================================
-    // MiGrouper tests (Grouper trait impl)
-    // ========================================================================
-
-    // Helper: create a parsed `DecodedRecord` for `MiGrouper` tests.
-    fn make_decoded_record_for_mi_grouper(mi: &str) -> DecodedRecord {
-        let record = create_record_with_mi(mi);
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
-        DecodedRecord::new(record, key)
-    }
-
-    #[test]
-    fn test_mi_grouper_single_group() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        let records = vec![
-            make_decoded_record_for_mi_grouper("0"),
-            make_decoded_record_for_mi_grouper("0"),
-            make_decoded_record_for_mi_grouper("0"),
-        ];
-
-        let batches = grouper.add_records(records).expect("add_records should succeed");
-        assert!(batches.is_empty());
-        assert!(grouper.has_pending());
-
-        let final_batch =
-            grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 1);
-        assert_eq!(final_batch.groups[0].mi, "0");
-        assert_eq!(final_batch.groups[0].records.len(), 3);
-    }
-
-    #[test]
-    fn test_mi_grouper_multiple_groups() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        let records = vec![
-            make_decoded_record_for_mi_grouper("0"),
-            make_decoded_record_for_mi_grouper("0"),
-            make_decoded_record_for_mi_grouper("1"),
-            make_decoded_record_for_mi_grouper("1"),
-            make_decoded_record_for_mi_grouper("1"),
-            make_decoded_record_for_mi_grouper("2"),
-        ];
-
-        let batches = grouper.add_records(records).expect("add_records should succeed");
-        assert!(batches.is_empty());
-
-        let final_batch =
-            grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 3);
-        assert_eq!(final_batch.groups[0].mi, "0");
-        assert_eq!(final_batch.groups[0].records.len(), 2);
-        assert_eq!(final_batch.groups[1].mi, "1");
-        assert_eq!(final_batch.groups[1].records.len(), 3);
-        assert_eq!(final_batch.groups[2].mi, "2");
-        assert_eq!(final_batch.groups[2].records.len(), 1);
-    }
-
-    #[test]
-    fn test_mi_grouper_batch_size_triggers() {
-        let mut grouper = MiGrouper::new("MI", 2);
-
-        let records = vec![
-            make_decoded_record_for_mi_grouper("0"),
-            make_decoded_record_for_mi_grouper("1"),
-            make_decoded_record_for_mi_grouper("2"),
-            make_decoded_record_for_mi_grouper("3"),
-            make_decoded_record_for_mi_grouper("4"),
-        ];
-
-        let batches = grouper.add_records(records).expect("add_records should succeed");
-        assert_eq!(batches.len(), 2);
-        assert_eq!(batches[0].groups.len(), 2);
-        assert_eq!(batches[0].groups[0].mi, "0");
-        assert_eq!(batches[0].groups[1].mi, "1");
-        assert_eq!(batches[1].groups.len(), 2);
-        assert_eq!(batches[1].groups[0].mi, "2");
-        assert_eq!(batches[1].groups[1].mi, "3");
-
-        assert!(grouper.has_pending());
-
-        let final_batch =
-            grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 1);
-        assert_eq!(final_batch.groups[0].mi, "4");
-    }
-
-    #[test]
-    fn test_mi_grouper_rejects_raw_records() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        let records = vec![make_raw_decoded_record("MI", "0")];
-        let result = grouper.add_records(records);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_mi_grouper_finish_empty() {
-        let mut grouper = MiGrouper::new("MI", 10);
-        assert!(!grouper.has_pending());
-
-        let final_batch = grouper.finish().expect("finish should succeed");
-        assert!(final_batch.is_none());
-    }
-
-    #[test]
-    fn test_mi_grouper_finish_idempotent() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        let records = vec![make_decoded_record_for_mi_grouper("0")];
-        grouper.add_records(records).expect("add_records should succeed");
-
-        let batch1 = grouper.finish().expect("finish should succeed");
-        assert!(batch1.is_some());
-
-        let batch2 = grouper.finish().expect("finish should succeed");
-        assert!(batch2.is_none());
-    }
-
-    #[test]
-    fn test_mi_grouper_with_filter_and_transform() {
-        let mut grouper = MiGrouper::with_filter_and_transform(
-            "MI",
-            10,
-            |_r| true, // keep all records
-            |mi| extract_mi_base(mi).to_string(),
-        );
-
-        let records = vec![
-            make_decoded_record_for_mi_grouper("1/A"),
-            make_decoded_record_for_mi_grouper("1/B"),
-            make_decoded_record_for_mi_grouper("2/A"),
-        ];
-
-        let batches = grouper.add_records(records).expect("add_records should succeed");
-        assert!(batches.is_empty());
-
-        let final_batch =
-            grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 2);
-        assert_eq!(final_batch.groups[0].mi, "1");
-        assert_eq!(final_batch.groups[0].records.len(), 2);
-        assert_eq!(final_batch.groups[1].mi, "2");
-        assert_eq!(final_batch.groups[1].records.len(), 1);
-    }
-
-    #[test]
-    fn test_mi_grouper_has_pending_states() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        assert!(!grouper.has_pending());
-
-        let records = vec![make_decoded_record_for_mi_grouper("0")];
-        grouper.add_records(records).expect("add_records should succeed");
-        assert!(grouper.has_pending());
-
-        let records = vec![make_decoded_record_for_mi_grouper("1")];
-        grouper.add_records(records).expect("add_records should succeed");
-        assert!(grouper.has_pending());
-    }
-
-    #[test]
-    fn test_mi_grouper_record_without_mi_gets_empty_string() {
-        let mut grouper = MiGrouper::new("MI", 10);
-
-        let record = create_record_without_mi();
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
-        let records = vec![DecodedRecord::new(record, key)];
-
-        let batches = grouper.add_records(records).expect("add_records should succeed");
-        assert!(batches.is_empty());
-
-        // Record without MI tag gets default empty string as MI value
-        let final_batch =
-            grouper.finish().expect("finish should succeed").expect("should return final batch");
-        assert_eq!(final_batch.groups.len(), 1);
-        assert_eq!(final_batch.groups[0].mi, "");
-        assert_eq!(final_batch.groups[0].records.len(), 1);
-    }
-
-    // ========================================================================
     // Batch type tests
     // ========================================================================
 
     #[test]
+    fn test_mi_group_new() {
+        let raw = make_raw_bam_with_tag("MI", "42");
+        let group = MiGroup::new("42".to_string(), vec![raw]);
+        assert_eq!(group.mi, "42");
+        assert_eq!(group.records.len(), 1);
+    }
+
+    #[test]
+    fn test_mi_group_batch_weight() {
+        let group = MiGroup::new(
+            "0".to_string(),
+            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
+        );
+        assert_eq!(group.batch_weight(), 2);
+    }
+
+    #[test]
+    fn test_mi_group_memory_estimate() {
+        let group = MiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]);
+        let size = group.estimate_heap_size();
+        assert!(size > 0);
+    }
+
+    #[test]
     fn test_mi_group_batch_new() {
         let batch = MiGroupBatch::new();
-        assert!(batch.is_empty());
-        assert_eq!(batch.len(), 0);
+        assert!(batch.groups.is_empty());
+    }
+
+    #[test]
+    fn test_mi_group_batch_default() {
+        let batch = MiGroupBatch::default();
+        assert!(batch.groups.is_empty());
+    }
+
+    #[test]
+    fn test_mi_group_batch_weight_method() {
+        let mut batch = MiGroupBatch::new();
+        assert_eq!(batch.batch_weight(), 0);
+
+        batch.groups.push(MiGroup::new(
+            "0".to_string(),
+            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
+        ));
+        assert_eq!(batch.batch_weight(), 2);
+
+        batch.groups.push(MiGroup::new("1".to_string(), vec![make_raw_bam_with_tag("MI", "1")]));
+        assert_eq!(batch.batch_weight(), 3);
+    }
+
+    #[test]
+    fn test_mi_group_batch_memory_estimate() {
+        let batch = MiGroupBatch::new();
+        let _ = batch.estimate_heap_size(); // Should not panic
+
+        let mut batch = MiGroupBatch::new();
+        batch.groups.push(MiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]));
+        let size = batch.estimate_heap_size();
+        assert!(size > 0);
     }
 
     #[test]
@@ -2279,13 +1245,13 @@ mod tests {
         let mut batch = MiGroupBatch::new();
         assert!(batch.is_empty());
 
-        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
+        batch.groups.push(MiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]));
         assert!(!batch.is_empty());
         assert_eq!(batch.len(), 1);
 
         batch.groups.push(MiGroup::new(
             "1".to_string(),
-            vec![create_record_with_mi("1"), create_record_with_mi("1")],
+            vec![make_raw_bam_with_tag("MI", "1"), make_raw_bam_with_tag("MI", "1")],
         ));
         assert_eq!(batch.len(), 2);
     }
@@ -2293,7 +1259,7 @@ mod tests {
     #[test]
     fn test_mi_group_batch_clear() {
         let mut batch = MiGroupBatch::new();
-        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
+        batch.groups.push(MiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]));
         assert!(!batch.is_empty());
 
         batch.clear();
@@ -2302,128 +1268,83 @@ mod tests {
     }
 
     #[test]
-    fn test_mi_group_batch_weight() {
-        let mut batch = MiGroupBatch::new();
-        assert_eq!(batch.batch_weight(), 0);
-
-        batch.groups.push(MiGroup::new(
-            "0".to_string(),
-            vec![create_record_with_mi("0"), create_record_with_mi("0")],
-        ));
-        assert_eq!(batch.batch_weight(), 2);
-
-        batch.groups.push(MiGroup::new("1".to_string(), vec![create_record_with_mi("1")]));
-        assert_eq!(batch.batch_weight(), 3);
-    }
-
-    #[test]
-    fn test_mi_group_batch_default() {
-        let batch = MiGroupBatch::default();
-        assert!(batch.is_empty());
-    }
-
-    #[test]
-    fn test_mi_group_batch_memory_estimate() {
-        let batch = MiGroupBatch::new();
-        // Empty batch should have minimal heap size (just vec overhead)
-        let _ = batch.estimate_heap_size(); // Should not panic
-
-        let mut batch = MiGroupBatch::new();
-        batch.groups.push(MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]));
-        let size = batch.estimate_heap_size();
-        assert!(size > 0);
-    }
-
-    #[test]
-    fn test_mi_group_new() {
-        let group = MiGroup::new("42".to_string(), vec![create_record_with_mi("42")]);
-        assert_eq!(group.mi, "42");
-        assert_eq!(group.records.len(), 1);
-    }
-
-    #[test]
     fn test_mi_group_batch_weight_single() {
         let group = MiGroup::new(
             "0".to_string(),
             vec![
-                create_record_with_mi("0"),
-                create_record_with_mi("0"),
-                create_record_with_mi("0"),
+                make_raw_bam_with_tag("MI", "0"),
+                make_raw_bam_with_tag("MI", "0"),
+                make_raw_bam_with_tag("MI", "0"),
             ],
         );
         assert_eq!(group.batch_weight(), 3);
     }
 
-    #[test]
-    fn test_mi_group_memory_estimate() {
-        let group = MiGroup::new("0".to_string(), vec![create_record_with_mi("0")]);
-        let size = group.estimate_heap_size();
-        assert!(size > 0);
-    }
-
     // ========================================================================
-    // Raw batch type tests
+    // MiGroupIterator::with_transform edge case tests
     // ========================================================================
 
     #[test]
-    fn test_raw_mi_group_new() {
-        let raw = make_raw_bam_with_tag("MI", "42");
-        let group = RawMiGroup::new("42".to_string(), vec![raw]);
-        assert_eq!(group.mi, "42");
-        assert_eq!(group.records.len(), 1);
+    fn test_with_transform_single_group() {
+        // 0/A, 0/B, 0/A all transform to "0" → one group of 3
+        let records: Vec<Result<RawRecord>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0/A")),
+            Ok(make_raw_bam_with_tag("MI", "0/B")),
+            Ok(make_raw_bam_with_tag("MI", "0/A")),
+        ];
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            let s = String::from_utf8_lossy(raw);
+            extract_mi_base(&s).to_string()
+        });
+
+        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 3);
+
+        assert!(iter.next().is_none());
     }
 
     #[test]
-    fn test_raw_mi_group_batch_weight() {
-        let group = RawMiGroup::new(
-            "0".to_string(),
-            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
-        );
-        assert_eq!(group.batch_weight(), 2);
+    fn test_with_transform_error_propagation() {
+        let records: Vec<Result<RawRecord>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "0/A")),
+            Err(anyhow::anyhow!("test error")),
+            Ok(make_raw_bam_with_tag("MI", "1/B")),
+        ];
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            let s = String::from_utf8_lossy(raw);
+            extract_mi_base(&s).to_string()
+        });
+
+        // First group before the error
+        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
+        assert_eq!(result.0, "0");
+        assert_eq!(result.1.len(), 1);
+
+        // Error is returned next
+        let result = iter.next().expect("iterator should yield item");
+        assert!(result.is_err());
+
+        // Iterator is done after the error
+        assert!(iter.next().is_none());
     }
 
     #[test]
-    fn test_raw_mi_group_memory_estimate() {
-        let group = RawMiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]);
-        let size = group.estimate_heap_size();
-        assert!(size > 0);
-    }
+    fn test_with_transform_custom_function() {
+        // Custom transform: uppercase. "abc", "ABC", "Abc" all → "ABC" → single group.
+        let records: Vec<Result<RawRecord>> = vec![
+            Ok(make_raw_bam_with_tag("MI", "abc")),
+            Ok(make_raw_bam_with_tag("MI", "ABC")),
+            Ok(make_raw_bam_with_tag("MI", "Abc")),
+        ];
+        let mut iter = MiGroupIterator::with_transform(records.into_iter(), "MI", |raw| {
+            String::from_utf8_lossy(raw).to_uppercase()
+        });
 
-    #[test]
-    fn test_raw_mi_group_batch_new() {
-        let batch = RawMiGroupBatch::new();
-        assert!(batch.groups.is_empty());
-    }
+        let result = iter.next().expect("iterator should yield item").expect("item should be Ok");
+        assert_eq!(result.0, "ABC");
+        assert_eq!(result.1.len(), 3);
 
-    #[test]
-    fn test_raw_mi_group_batch_default() {
-        let batch = RawMiGroupBatch::default();
-        assert!(batch.groups.is_empty());
-    }
-
-    #[test]
-    fn test_raw_mi_group_batch_weight_method() {
-        let mut batch = RawMiGroupBatch::new();
-        assert_eq!(batch.batch_weight(), 0);
-
-        batch.groups.push(RawMiGroup::new(
-            "0".to_string(),
-            vec![make_raw_bam_with_tag("MI", "0"), make_raw_bam_with_tag("MI", "0")],
-        ));
-        assert_eq!(batch.batch_weight(), 2);
-
-        batch.groups.push(RawMiGroup::new("1".to_string(), vec![make_raw_bam_with_tag("MI", "1")]));
-        assert_eq!(batch.batch_weight(), 3);
-    }
-
-    #[test]
-    fn test_raw_mi_group_batch_memory_estimate() {
-        let batch = RawMiGroupBatch::new();
-        let _ = batch.estimate_heap_size(); // Should not panic
-
-        let mut batch = RawMiGroupBatch::new();
-        batch.groups.push(RawMiGroup::new("0".to_string(), vec![make_raw_bam_with_tag("MI", "0")]));
-        let size = batch.estimate_heap_size();
-        assert!(size > 0);
+        assert!(iter.next().is_none());
     }
 }

--- a/src/lib/read_info.rs
+++ b/src/lib/read_info.rs
@@ -20,13 +20,7 @@ use std::sync::Arc;
 use bstr::ByteSlice;
 
 use crate::sam::SamTag;
-use crate::sam::record_utils::{
-    mate_unclipped_end, mate_unclipped_start, unclipped_five_prime_position,
-};
 use crate::template::Template;
-use crate::unified_pipeline::GroupKey;
-use noodles::sam;
-use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 
 /// A lookup table mapping read group IDs to library names.
 ///
@@ -42,8 +36,8 @@ use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
 /// - `LibraryLookup`: String-based lookup returning library names. Used by
 ///   [`ReadInfo::from`] where the actual library name string is needed.
 /// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
-///   [`compute_group_key`] in the hot path where only equality comparison matters,
-///   avoiding string allocations.
+///   `compute_group_key_from_raw` in the hot path where only equality comparison
+///   matters, avoiding string allocations.
 pub type LibraryLookup = Arc<HashMap<String, Arc<str>>>;
 
 /// Shared "unknown" library string to avoid repeated allocations.
@@ -194,118 +188,6 @@ impl Default for LibraryIndex {
             unknown_idx: 0,
         }
     }
-}
-
-// ============================================================================
-// compute_group_key - Pre-compute GroupKey from a single BAM record
-// ============================================================================
-
-/// Compute a `GroupKey` from a single BAM record.
-///
-/// This computes all grouping information from a single record:
-/// - Own position (`ref_id`, unclipped 5' position, strand)
-/// - Mate position (from MC tag, or UNKNOWN if unpaired/missing)
-/// - Library index (from RG tag)
-/// - Cell barcode hash
-/// - Name hash
-///
-/// For paired-end reads with MC tag, both positions are computed and normalized
-/// so the lower position comes first (matching `ReadInfo` behavior).
-///
-/// For unpaired reads or reads without MC tag, mate position uses UNKNOWN sentinels.
-#[must_use]
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-pub fn compute_group_key(
-    record: &sam::alignment::RecordBuf,
-    library_index: &LibraryIndex,
-    cell_tag: Option<Tag>,
-) -> GroupKey {
-    // Extract name hash
-    let name_hash = LibraryIndex::hash_name(record.name().map(AsRef::as_ref));
-
-    // Skip secondary and supplementary alignments - they get a default key with UNKNOWN_REF.
-    // RecordPositionGrouper either skips them or coalesces them by name_hash.
-    let flags = record.flags();
-    if flags.is_secondary() || flags.is_supplementary() {
-        return GroupKey { name_hash, ..GroupKey::default() };
-    }
-
-    // Own position
-    let ref_id =
-        record.reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-    let pos = get_unclipped_position_for_groupkey(record);
-    let strand = u8::from(flags.is_reverse_complemented());
-
-    // Extract library index from RG tag
-    let library_idx =
-        if let Some(DataValue::String(rg_bytes)) = record.data().get(&Tag::from(SamTag::RG)) {
-            let rg_hash = LibraryIndex::hash_rg(rg_bytes);
-            library_index.get(rg_hash)
-        } else {
-            0 // unknown
-        };
-
-    // Extract cell barcode hash
-    let cell_hash = if let Some(tag) = cell_tag {
-        if let Some(DataValue::String(cb_bytes)) = record.data().get(&tag) {
-            LibraryIndex::hash_cell_barcode(Some(cb_bytes))
-        } else {
-            0
-        }
-    } else {
-        0
-    };
-
-    // Check if paired and has mate info
-    let is_paired = flags.is_segmented();
-    if !is_paired {
-        return GroupKey::single(ref_id, pos, strand, library_idx, cell_hash, name_hash);
-    }
-
-    // Try to get mate position from MC tag
-    let mate_strand = u8::from(flags.is_mate_reverse_complemented());
-    let mate_ref_id =
-        record.mate_reference_sequence_id().map_or(-1, |id| i32::try_from(id).unwrap_or(i32::MAX));
-
-    // Get mate unclipped 5' position based on strand
-    let mate_pos = if mate_strand == 1 {
-        // Reverse strand - 5' is at the end
-        mate_unclipped_end(record).map(|p| p as i32)
-    } else {
-        // Forward strand - 5' is at the start
-        mate_unclipped_start(record).map(|p| p as i32)
-    };
-
-    match mate_pos {
-        Some(mp) => GroupKey::paired(
-            ref_id,
-            pos,
-            strand,
-            mate_ref_id,
-            mp,
-            mate_strand,
-            library_idx,
-            cell_hash,
-            name_hash,
-        ),
-        None => {
-            // No MC tag - fall back to single-end behavior
-            GroupKey::single(ref_id, pos, strand, library_idx, cell_hash, name_hash)
-        }
-    }
-}
-
-/// Get unclipped 5' position for `GroupKey` computation.
-///
-/// Returns 0 for unmapped reads. Returns `i32::MAX` for malformed mapped reads
-/// (those missing alignment start) to avoid incorrectly grouping them at position 0.
-/// Used in the hot path where we need a numeric value for grouping.
-#[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
-fn get_unclipped_position_for_groupkey(record: &sam::alignment::RecordBuf) -> i32 {
-    if record.flags().is_unmapped() {
-        return 0;
-    }
-    unclipped_five_prime_position(record).map_or(i32::MAX, |pos| pos as i32)
 }
 
 /// Information about read positions needed for grouping and ordering.
@@ -521,10 +403,13 @@ impl ReadInfo {
         cell_tag: Tag,
         library_lookup: &LibraryLookup,
     ) -> Result<Self> {
-        // Get reads once and reuse (avoid calling r1()/r2() twice)
+        use crate::sort::bam_fields;
+        use fgumi_raw_bam::{RawRecord, RawRecordView, TagValue};
+
+        // Get primary reads (Option<&RawRecord>)
         let r1 = template.r1();
         let r2 = template.r2();
-        let record = r1.as_ref().or(r2.as_ref()).ok_or_else(|| {
+        let record: &RawRecord = r1.or(r2).ok_or_else(|| {
             anyhow::anyhow!(
                 "Template '{}' has no records (empty template)",
                 String::from_utf8_lossy(&template.name)
@@ -536,50 +421,68 @@ impl ReadInfo {
         // not the read group ID.
         // Uses Arc<str> to avoid cloning strings - Arc::clone is just a reference count increment.
         let library: Arc<str> =
-            if let Some(DataValue::String(rg_bytes)) = record.data().get(&Tag::from(SamTag::RG)) {
-                // Convert bytes to str for lookup without allocating a String
+            if let Some(TagValue::String(rg_bytes)) = record.tags().get(SamTag::RG.as_ref()) {
                 let rg_id = std::str::from_utf8(rg_bytes).unwrap_or("unknown");
                 library_lookup.get(rg_id).cloned().unwrap_or_else(|| Arc::clone(&UNKNOWN_LIBRARY))
             } else {
                 Arc::clone(&UNKNOWN_LIBRARY)
             };
 
-        // Extract cell barcode
-        let cell_barcode = if let Some(DataValue::String(cb_str)) = record.data().get(&cell_tag) {
-            Some(String::from_utf8_lossy(cb_str).into_owned())
-        } else {
-            None
+        // Extract cell barcode using the raw tag bytes
+        let cell_barcode =
+            if let Some(TagValue::String(cb_bytes)) = record.tags().get(cell_tag.as_ref()) {
+                Some(String::from_utf8_lossy(cb_bytes).into_owned())
+            } else {
+                None
+            };
+
+        // For paired-end, extract both positions using UNCLIPPED positions.
+        // Unmapped reads must use UNKNOWN sentinels rather than position 0 so
+        // they sort after mapped reads (matching fgbio's case-class ordering).
+        let is_unmapped =
+            |r: &RawRecord| (RawRecordView::new(r).flags() & bam_fields::flags::UNMAPPED) != 0;
+        let raw_info = |r: &RawRecord| -> Result<(i32, i32, u8)> {
+            Ok((
+                bam_fields::ref_id(r.as_ref()),
+                get_unclipped_position_raw(r)?,
+                u8::from((RawRecordView::new(r).flags() & bam_fields::flags::REVERSE) != 0),
+            ))
         };
 
-        // For paired-end, extract both positions using UNCLIPPED positions
-        // Reuse r1/r2 bindings instead of calling template.r1()/r2() again
         #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-        if let (Some(r1), Some(r2)) = (&r1, &r2) {
-            let ref_index1 = r1.reference_sequence_id().map_or(-1, |id| id as i32);
-            let start1 = get_unclipped_position(r1)?;
-            let strand1 = u8::from(r1.flags().is_reverse_complemented());
-
-            let ref_index2 = r2.reference_sequence_id().map_or(-1, |id| id as i32);
-            let start2 = get_unclipped_position(r2)?;
-            let strand2 = u8::from(r2.flags().is_reverse_complemented());
-
-            Ok(ReadInfo::new(
-                ref_index1,
-                start1,
-                strand1,
-                ref_index2,
-                start2,
-                strand2,
-                library,
-                cell_barcode,
-            ))
+        if let (Some(r1), Some(r2)) = (r1, r2) {
+            match (is_unmapped(r1), is_unmapped(r2)) {
+                (true, true) => Ok(ReadInfo::unmapped(library, cell_barcode)),
+                (true, false) => {
+                    let (ref_index, start, strand) = raw_info(r2)?;
+                    Ok(ReadInfo::single(ref_index, start, strand, library, cell_barcode))
+                }
+                (false, true) => {
+                    let (ref_index, start, strand) = raw_info(r1)?;
+                    Ok(ReadInfo::single(ref_index, start, strand, library, cell_barcode))
+                }
+                (false, false) => {
+                    let (ref_index1, start1, strand1) = raw_info(r1)?;
+                    let (ref_index2, start2, strand2) = raw_info(r2)?;
+                    Ok(ReadInfo::new(
+                        ref_index1,
+                        start1,
+                        strand1,
+                        ref_index2,
+                        start2,
+                        strand2,
+                        library,
+                        cell_barcode,
+                    ))
+                }
+            }
         } else {
             // Single-end: use ReadInfo::single() which correctly sets UNKNOWN values for R2
             // This matches fgbio's behavior where missing R2 uses (Int.MaxValue, Int.MaxValue, Byte.MaxValue)
-            let ref_index = record.reference_sequence_id().map_or(-1, |id| id as i32);
-            let start = get_unclipped_position(record)?;
-            let strand = u8::from(record.flags().is_reverse_complemented());
-
+            if is_unmapped(record) {
+                return Ok(ReadInfo::unmapped(library, cell_barcode));
+            }
+            let (ref_index, start, strand) = raw_info(record)?;
             Ok(ReadInfo::single(ref_index, start, strand, library, cell_barcode))
         }
     }
@@ -626,20 +529,22 @@ impl Ord for ReadInfo {
 ///
 /// The unclipped 5' position (0 for unmapped reads)
 ///
+/// Returns the unclipped 5' position (1-based) from raw BAM bytes.
+///
+/// Returns 0 for unmapped reads. Returns an error if the record is mapped but
+/// has no CIGAR (returns `i32::MAX` from the raw helper, which we treat as an error).
+///
 /// # Errors
 ///
 /// Returns an error if the record is mapped but missing required alignment information
-#[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
-fn get_unclipped_position(record: &sam::alignment::RecordBuf) -> Result<i32> {
-    if record.flags().is_unmapped() {
-        return Ok(0);
+fn get_unclipped_position_raw(record: &fgumi_raw_bam::RawRecord) -> Result<i32> {
+    let pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(record.as_ref());
+    if pos == i32::MAX {
+        let read_name = String::from_utf8_lossy(fgumi_raw_bam::read_name(record.as_ref()));
+        Err(anyhow::anyhow!("Mapped read '{read_name}' missing alignment start position"))
+    } else {
+        Ok(pos)
     }
-
-    unclipped_five_prime_position(record).map(|pos| pos as i32).ok_or_else(|| {
-        let read_name =
-            record.name().map_or_else(|| "unknown".into(), |n| String::from_utf8_lossy(n.as_ref()));
-        anyhow::anyhow!("Mapped read '{read_name}' missing alignment start position")
-    })
 }
 
 #[cfg(test)]
@@ -813,17 +718,71 @@ mod tests {
 
     mod get_unclipped_position_tests {
         use super::*;
-        use crate::sam::builder::RecordBuilder;
-        use noodles::sam::alignment::RecordBuf;
+        use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags as raw_flags};
+
+        /// Parse a CIGAR string to raw BAM u32 ops.
+        ///
+        /// Encoding: `(len << 4) | op_type` where `op_type` is:
+        /// 0=M,1=I,2=D,3=N,4=S,5=H,6=P,7==,8=X
+        fn parse_cigar_to_raw(cigar: &str) -> Vec<u32> {
+            let mut ops = Vec::new();
+            let mut num_str = String::new();
+            for c in cigar.chars() {
+                if c.is_ascii_digit() {
+                    num_str.push(c);
+                } else {
+                    let len: u32 = num_str.parse().expect("Invalid CIGAR: expected number");
+                    let op_type: u32 = match c {
+                        'M' => 0,
+                        'I' => 1,
+                        'D' => 2,
+                        'N' => 3,
+                        'S' => 4,
+                        'H' => 5,
+                        'P' => 6,
+                        '=' => 7,
+                        'X' => 8,
+                        _ => panic!("Unknown CIGAR operation: {c}"),
+                    };
+                    ops.push((len << 4) | op_type);
+                    num_str.clear();
+                }
+            }
+            ops
+        }
+
+        /// Compute the read sequence length from a CIGAR string
+        /// (sum of M, I, S, =, X ops — operations that consume the query).
+        fn cigar_query_len(cigar: &str) -> usize {
+            let mut num_str = String::new();
+            let mut total = 0usize;
+            for c in cigar.chars() {
+                if c.is_ascii_digit() {
+                    num_str.push(c);
+                } else {
+                    let len: usize = num_str.parse().expect("number");
+                    if matches!(c, 'M' | 'I' | 'S' | '=' | 'X') {
+                        total += len;
+                    }
+                    num_str.clear();
+                }
+            }
+            total
+        }
 
         /// Helper to build a test record with specific CIGAR and strand
-        fn build_record(alignment_start: usize, cigar: &str, reverse: bool) -> RecordBuf {
-            RecordBuilder::new()
-                .sequence("ACGT") // Minimal sequence
-                .alignment_start(alignment_start)
-                .cigar(cigar)
-                .reverse_complement(reverse)
-                .build()
+        fn build_record(alignment_start: usize, cigar: &str, reverse: bool) -> RawRecord {
+            let raw_cigar = parse_cigar_to_raw(cigar);
+            let qlen = cigar_query_len(cigar).max(1);
+            let flags: u16 = if reverse { raw_flags::REVERSE } else { 0 };
+            let mut b = RawSamBuilder::new();
+            b.sequence(&vec![b'A'; qlen])
+                .qualities(&vec![30u8; qlen])
+                .flags(flags)
+                .ref_id(0)
+                .pos(i32::try_from(alignment_start).expect("alignment_start fits i32") - 1)
+                .cigar_ops(&raw_cigar);
+            b.build()
         }
 
         #[test]
@@ -831,8 +790,8 @@ mod tests {
             // Forward strand with 5S at start: alignment_start=100, CIGAR=5S50M
             // unclipped_start = 100 - 5 = 95
             let record = build_record(100, "5S50M", false);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 95);
         }
 
@@ -841,8 +800,8 @@ mod tests {
             // Forward strand with 10H at start: alignment_start=100, CIGAR=10H50M
             // unclipped_start = 100 - 10 = 90
             let record = build_record(100, "10H50M", false);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 90);
         }
 
@@ -851,8 +810,8 @@ mod tests {
             // Forward strand with 10H5S at start: alignment_start=100, CIGAR=10H5S50M
             // unclipped_start = 100 - 10 - 5 = 85
             let record = build_record(100, "10H5S50M", false);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 85);
         }
 
@@ -862,8 +821,8 @@ mod tests {
             // alignment_end = 100 + 50 - 1 = 149
             // unclipped_end = 149 + 5 = 154
             let record = build_record(100, "50M5S", true);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 154);
         }
 
@@ -873,8 +832,8 @@ mod tests {
             // alignment_end = 100 + 50 - 1 = 149
             // unclipped_end = 149 + 10 = 159
             let record = build_record(100, "50M10H", true);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 159);
         }
 
@@ -884,8 +843,8 @@ mod tests {
             // alignment_end = 100 + 50 - 1 = 149
             // unclipped_end = 149 + 5 + 10 = 164
             let record = build_record(100, "50M5S10H", true);
-            let pos =
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed");
+            let pos = get_unclipped_position_raw(&record)
+                .expect("get_unclipped_position_raw should succeed");
             assert_eq!(pos, 164);
         }
 
@@ -895,25 +854,28 @@ mod tests {
             // Forward: unclipped_start = 100
             let forward_record = build_record(100, "50M", false);
             assert_eq!(
-                get_unclipped_position(&forward_record)
-                    .expect("get_unclipped_position should succeed"),
+                get_unclipped_position_raw(&forward_record)
+                    .expect("get_unclipped_position_raw should succeed"),
                 100
             );
 
             // Reverse: unclipped_end = 100 + 50 - 1 = 149
             let reverse_record = build_record(100, "50M", true);
             assert_eq!(
-                get_unclipped_position(&reverse_record)
-                    .expect("get_unclipped_position should succeed"),
+                get_unclipped_position_raw(&reverse_record)
+                    .expect("get_unclipped_position_raw should succeed"),
                 149
             );
         }
 
         #[test]
         fn test_unmapped_read() {
-            let record = RecordBuilder::new().sequence("ACGT").unmapped(true).build();
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"ACGT").qualities(&[30; 4]).flags(raw_flags::UNMAPPED);
+            let record = b.build();
             assert_eq!(
-                get_unclipped_position(&record).expect("get_unclipped_position should succeed"),
+                get_unclipped_position_raw(&record)
+                    .expect("get_unclipped_position_raw should succeed"),
                 0
             );
         }
@@ -926,8 +888,8 @@ mod tests {
             // unclipped_start = 100 - 8 = 92
             let forward_record = build_record(100, "5H3S10M2I5M3D10M4S6H", false);
             assert_eq!(
-                get_unclipped_position(&forward_record)
-                    .expect("get_unclipped_position should succeed"),
+                get_unclipped_position_raw(&forward_record)
+                    .expect("get_unclipped_position_raw should succeed"),
                 92
             );
 
@@ -938,8 +900,8 @@ mod tests {
             // unclipped_end = 127 + 10 = 137
             let reverse_record = build_record(100, "5H3S10M2I5M3D10M4S6H", true);
             assert_eq!(
-                get_unclipped_position(&reverse_record)
-                    .expect("get_unclipped_position should succeed"),
+                get_unclipped_position_raw(&reverse_record)
+                    .expect("get_unclipped_position_raw should succeed"),
                 137
             );
         }

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -4,66 +4,19 @@
 //! reversed to match the orientation of the sequence in the BAM file.
 
 use anyhow::{Result, bail};
-use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::consensus_tags::per_base;
 use crate::sort::bam_fields;
 use fgumi_raw_bam::RawRecordView;
 
-/// Reverses per-base tags for a negative-strand read
-///
-/// This function reverses array-based per-base tags (cd, ce, ad, bd, ae, be, aq, bq)
-/// to match the reversed sequence orientation in negative-strand reads.
-///
-/// # Arguments
-/// * `record` - The record to reverse tags for (modified in place)
-///
-/// # Returns
-/// True if tags were reversed, false if not needed
-///
-/// # Errors
-///
-/// Currently infallible; returns `Result` for API consistency with
-/// [`reverse_per_base_tags_raw`].
-pub fn reverse_per_base_tags(record: &mut RecordBuf) -> Result<bool> {
-    // Check if read is mapped to negative strand
-    let flags = record.flags();
-    if !flags.is_reverse_complemented() {
-        return Ok(false);
-    }
-
-    // Get list of tags to reverse
-    let tags_to_reverse = per_base::tags_to_reverse();
-
-    for tag_str in tags_to_reverse {
-        let tag = per_base::tag(tag_str);
-
-        if let Some(value) = record.data().get(&tag) {
-            let reversed = fgumi_sam::reverse_buf_value(value);
-            record.data_mut().insert(tag, reversed);
-        }
-    }
-
-    // Handle tags that need reverse complement (ac, bc)
-    let tags_to_revcomp = per_base::tags_to_reverse_complement();
-
-    for tag_str in tags_to_revcomp {
-        let tag = per_base::tag(tag_str);
-
-        if let Some(value) = record.data().get(&tag) {
-            let revcomp = fgumi_sam::revcomp_buf_value(value);
-            record.data_mut().insert(tag, revcomp);
-        }
-    }
-
-    Ok(true)
-}
-
 /// Reverses per-base tags for a negative-strand read using raw BAM bytes.
 ///
 /// Operates directly on the binary record without parsing into `RecordBuf`.
-/// Array tags (cd, ce, ad, ae, bd, be, aq, bq) are reversed in-place.
-/// String tags (ac, bc) are reverse-complemented in-place.
+/// Tags in [`per_base::tags_to_reverse`] are reversed in place (B-arrays element-wise,
+/// preserving each element's internal byte order; Z-strings such as `aq`/`bq` have their
+/// bytes reversed). Tags in
+/// [`per_base::tags_to_reverse_complement`] (`ac`, `bc`) are reverse-complemented
+/// in place. See those helpers for the authoritative tag list.
 ///
 /// # Returns
 /// `Ok(true)` if tags were reversed, `Ok(false)` if not on reverse strand.
@@ -118,61 +71,17 @@ pub fn reverse_per_base_tags_raw(record: &mut [u8]) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags as raw_flags, raw_record_to_record_buf,
+    };
+    use noodles::sam::Header;
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::data::field::Value;
-    use noodles::sam::alignment::record_buf::data::field::value::Array;
     use rstest::rstest;
 
-    #[test]
-    fn test_reverse_per_base_tags_positive_strand() {
-        let mut record = RecordBuilder::new().sequence("ACGT").build();
-
-        let tag = Tag::from([b'c', b'd']);
-        record.data_mut().insert(tag, Value::from(vec![1u16, 2, 3]));
-
-        let reversed =
-            reverse_per_base_tags(&mut record).expect("reverse_per_base_tags should succeed");
-        assert!(!reversed); // Should not reverse for positive strand
-
-        if let Some(Value::Array(Array::UInt16(arr))) = record.data().get(&tag) {
-            assert_eq!(arr.clone(), vec![1, 2, 3]);
-        }
-    }
-
-    #[test]
-    fn test_reverse_per_base_tags_negative_strand() {
-        let mut record = RecordBuilder::new().sequence("ACGT").reverse_complement(true).build();
-
-        let tag = Tag::from([b'c', b'd']);
-        record.data_mut().insert(tag, Value::from(vec![1u16, 2, 3]));
-
-        let reversed =
-            reverse_per_base_tags(&mut record).expect("reverse_per_base_tags should succeed");
-        assert!(reversed); // Should reverse for negative strand
-
-        if let Some(Value::Array(Array::UInt16(arr))) = record.data().get(&tag) {
-            assert_eq!(arr.clone(), vec![3, 2, 1]);
-        }
-    }
-
-    #[test]
-    fn test_reverse_complement_tag() {
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .reverse_complement(true)
-            .tag("ac", "ACGT")
-            .build();
-
-        let reversed =
-            reverse_per_base_tags(&mut record).expect("reverse_per_base_tags should succeed");
-        assert!(reversed);
-
-        let tag = Tag::from([b'a', b'c']);
-        if let Some(Value::String(bases)) = record.data().get(&tag) {
-            let bases_vec: Vec<u8> = bases.iter().copied().collect();
-            assert_eq!(bases_vec, b"ACGT");
-        }
+    fn to_record_buf(raw: &fgumi_raw_bam::RawRecord) -> noodles::sam::alignment::RecordBuf {
+        raw_record_to_record_buf(raw, &Header::default())
+            .expect("raw_record_to_record_buf failed in test")
     }
 
     #[rstest]
@@ -196,38 +105,15 @@ mod tests {
     }
 
     #[test]
-    fn test_reverse_string_tag_aq() {
-        // aq is a Z-type quality string — should be reversed on negative strand
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .reverse_complement(true)
-            .tag("aq", "IIHG")
-            .build();
-
-        let reversed =
-            reverse_per_base_tags(&mut record).expect("reverse_per_base_tags should succeed");
-        assert!(reversed);
-
-        let tag = Tag::from([b'a', b'q']);
-        let Some(Value::String(s)) = record.data().get(&tag) else {
-            unreachable!("Expected aq tag to be present as String");
-        };
-        let bytes: Vec<u8> = s.iter().copied().collect();
-        assert_eq!(bytes, b"GHII");
-    }
-
-    #[test]
     fn test_reverse_per_base_tags_raw_string_tag_aq() {
         // Verify aq Z-type tag is reversed via the raw path too
         use crate::sort::bam_fields;
         use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let record_buf = RecordBuilder::new()
-            .sequence("ACGT")
-            .reverse_complement(true)
-            .tag("aq", "IIHG")
-            .build();
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30; 4]).flags(raw_flags::REVERSE);
+        b.add_string_tag(b"aq", b"IIHG");
+        let record_buf = to_record_buf(&b.build());
 
         let header = Header::default();
         let mut raw = Vec::new();
@@ -240,6 +126,32 @@ mod tests {
         let aux = bam_fields::aux_data_slice(&raw);
         let s = bam_fields::find_string_tag(aux, b"aq").expect("aq tag should exist");
         assert_eq!(s, b"GHII");
+    }
+
+    #[rstest]
+    #[case(b"ac")]
+    #[case(b"bc")]
+    fn test_reverse_per_base_tags_raw_revcomp_string_tags(#[case] tag: &'static [u8; 2]) {
+        // Verify ac/bc Z-type tags are reverse-complemented on the raw path.
+        use crate::sort::bam_fields;
+        use crate::vendored::bam_codec::encoder::encode_record_buf;
+
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30; 4]).flags(raw_flags::REVERSE);
+        b.add_string_tag(tag, b"ACGA");
+        let record_buf = to_record_buf(&b.build());
+
+        let header = Header::default();
+        let mut raw = Vec::new();
+        encode_record_buf(&mut raw, &header, &record_buf).expect("encoding record should succeed");
+
+        let result =
+            reverse_per_base_tags_raw(&mut raw).expect("reverse_per_base_tags_raw should succeed");
+        assert!(result);
+
+        let aux = bam_fields::aux_data_slice(&raw);
+        let s = bam_fields::find_string_tag(aux, tag).expect("tag should exist");
+        assert_eq!(s, b"TCGT");
     }
 
     #[test]
@@ -255,9 +167,10 @@ mod tests {
     fn test_reverse_per_base_tags_raw_positive_strand() {
         // Build a valid raw record on positive strand — should return Ok(false)
         use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let record_buf = RecordBuilder::new().sequence("ACGT").build();
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30; 4]).flags(0);
+        let record_buf = to_record_buf(&b.build());
         let header = Header::default();
         let mut raw = Vec::new();
         encode_record_buf(&mut raw, &header, &record_buf).expect("encoding record should succeed");
@@ -272,9 +185,10 @@ mod tests {
         // Build a valid raw record on negative strand with a cd tag — should reverse it
         use crate::sort::bam_fields;
         use crate::vendored::bam_codec::encoder::encode_record_buf;
-        use noodles::sam::Header;
 
-        let mut record_buf = RecordBuilder::new().sequence("ACGT").reverse_complement(true).build();
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30; 4]).flags(raw_flags::REVERSE);
+        let mut record_buf = to_record_buf(&b.build());
         let tag = Tag::from([b'c', b'd']);
         record_buf.data_mut().insert(tag, Value::from(vec![1u16, 2, 3, 4]));
 

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -35,15 +35,9 @@
 //! }
 //! ```
 
-use crate::sam::{SamTag, record_utils, to_smallest_signed_int};
 use crate::unified_pipeline::MemoryEstimate;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use fgumi_raw_bam::{RawRecord, RawRecordView};
-use noodles::sam::alignment::record::Cigar;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
-use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
-use std::fmt::Write as _;
 
 // Re-export PairOrientation from sam module for backwards compatibility
 pub use crate::sam::PairOrientation;
@@ -64,10 +58,8 @@ pub use fgumi_umi::MoleculeId;
 pub struct Template {
     /// The query name (QNAME) shared by all records in this template
     pub name: Vec<u8>,
-    /// The records (empty in raw-byte mode)
-    pub records: Vec<RecordBuf>,
-    /// Raw BAM records (without `block_size` prefix). Present only in raw-byte mode.
-    pub raw_records: Option<Vec<RawRecord>>,
+    /// Raw BAM records (without `block_size` prefix).
+    pub records: Vec<RawRecord>,
     /// Primary R1 read (first segment, non-secondary, non-supplementary)
     pub r1: Option<(usize, usize)>,
     /// Primary R2 read (second segment, non-secondary, non-supplementary)
@@ -87,310 +79,17 @@ pub struct Template {
 /// A batch of templates for parallel processing.
 pub type TemplateBatch = Vec<Template>;
 
-/// A builder for constructing `Template` instances.
-///
-/// The builder allows incremental construction of a template by adding records
-/// one at a time. It automatically categorizes each record into the appropriate
-/// slot (primary R1/R2, supplementary, or secondary) based on SAM flags.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// let mut builder = Builder::new();
-/// builder.push(r1_record)?;
-/// builder.push(r2_record)?;
-/// builder.push(r1_supplementary)?;
-/// let template = builder.build()?;
-/// ```
-#[derive(Debug, Default)]
-pub struct Builder {
-    /// The query name (QNAME) shared by all records in this template
-    name: Option<Vec<u8>>,
-    /// Primary R1 read (first segment, non-secondary, non-supplementary)
-    r1: Option<RecordBuf>,
-    /// Primary R2 read (second segment, non-secondary, non-supplementary)
-    r2: Option<RecordBuf>,
-    /// Supplementary alignments for R1
-    r1_supplementals: Vec<RecordBuf>,
-    /// Supplementary alignments for R2
-    r2_supplementals: Vec<RecordBuf>,
-    /// Secondary alignments for R1
-    r1_secondaries: Vec<RecordBuf>,
-    /// Secondary alignments for R2
-    r2_secondaries: Vec<RecordBuf>,
-}
-
-impl Builder {
-    /// Creates a new empty template builder.
-    ///
-    /// # Returns
-    ///
-    /// A new `Builder` instance ready to accept records
-    fn new() -> Self {
-        Builder {
-            name: None,
-            r1: None,
-            r2: None,
-            r1_supplementals: Vec::new(),
-            r2_supplementals: Vec::new(),
-            r1_secondaries: Vec::new(),
-            r2_secondaries: Vec::new(),
-        }
-    }
-
-    /// Adds a record to this builder, organizing it into the appropriate category.
-    ///
-    /// # Arguments
-    ///
-    /// * `record` - The record to add
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if multiple primary R1s or R2s are encountered
-    ///
-    /// # Panics
-    ///
-    /// Panics if template name is unexpectedly missing when reporting duplicate records.
-    pub fn push(&mut self, record: RecordBuf) -> Result<&mut Builder> {
-        // Get record name as bytes for comparison (no allocation yet)
-        let record_name_bytes: &[u8] = record.name().map_or(&[], <_ as AsRef<[u8]>>::as_ref);
-
-        if let Some(cur_name) = &self.name {
-            // Compare bytes directly without allocating
-            if cur_name.as_slice() != record_name_bytes {
-                bail!(
-                    "Template name mismatch: found '{record_name_bytes:?}', expected '{cur_name:?}'"
-                );
-            }
-        } else {
-            // Only allocate Vec when setting the name for the first time
-            self.name = Some(record_name_bytes.to_vec());
-        }
-
-        let flags = record.flags();
-        let is_r1 = !flags.is_segmented() || flags.is_first_segment();
-
-        if is_r1 {
-            if flags.is_secondary() {
-                self.r1_secondaries.push(record);
-            } else if flags.is_supplementary() {
-                self.r1_supplementals.push(record);
-            } else if self.r1.is_some() {
-                return Err(anyhow!(
-                    "Multiple non-secondary, non-supplemental R1 records for read '{:?}'",
-                    self.name.as_ref().expect("name must be set before adding duplicate R1")
-                ));
-            } else {
-                self.r1 = Some(record);
-            }
-        } else if flags.is_secondary() {
-            self.r2_secondaries.push(record);
-        } else if flags.is_supplementary() {
-            self.r2_supplementals.push(record);
-        } else if self.r2.is_some() {
-            return Err(anyhow!(
-                "Multiple non-secondary, non-supplemental R2 records for read '{:?}'",
-                self.name.as_ref().expect("name must be set before adding duplicate R2")
-            ));
-        } else {
-            self.r2 = Some(record);
-        }
-
-        Ok(self)
-    }
-
-    /// Returns the number of records currently in the builder.
-    ///
-    /// # Returns
-    ///
-    /// Total count of records across all categories
-    #[must_use]
-    pub fn len(&self) -> usize {
-        let mut count = 0;
-        count += usize::from(self.r1.is_some());
-        count += usize::from(self.r2.is_some());
-        count += self.r1_supplementals.len();
-        count += self.r2_supplementals.len();
-        count += self.r1_secondaries.len();
-        count += self.r2_secondaries.len();
-        count
-    }
-
-    /// Checks if the builder contains no records.
-    ///
-    /// # Returns
-    ///
-    /// `true` if the builder is empty, `false` otherwise
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Builds a new template from this builder.
-    ///
-    /// The builder may be re-used.
-    ///
-    /// # Errors
-    ///
-    /// If the template could not be built.
-    pub fn build(&mut self) -> Result<Template> {
-        let r1_end: usize = usize::from(self.r1.is_some());
-        let r2_end: usize = r1_end + usize::from(self.r2.is_some());
-        let r1_supplementals_end: usize = r2_end + self.r1_supplementals.len();
-        let r2_supplementals_end: usize = r1_supplementals_end + self.r2_supplementals.len();
-        let r1_secondaries_end: usize = r2_supplementals_end + self.r1_secondaries.len();
-        let r2_secondaries_end: usize = r1_secondaries_end + self.r2_secondaries.len();
-
-        let r1: Option<(usize, usize)> = if self.r1.is_some() { Some((0, r1_end)) } else { None };
-        let r2: Option<(usize, usize)> =
-            if self.r2.is_some() { Some((r1_end, r2_end)) } else { None };
-        let r1_supplementals: Option<(usize, usize)> = if self.r1_supplementals.is_empty() {
-            None
-        } else {
-            Some((r2_end, r1_supplementals_end))
-        };
-        let r2_supplementals: Option<(usize, usize)> = if self.r2_supplementals.is_empty() {
-            None
-        } else {
-            Some((r1_supplementals_end, r2_supplementals_end))
-        };
-        let r1_secondaries: Option<(usize, usize)> = if self.r1_secondaries.is_empty() {
-            None
-        } else {
-            Some((r2_supplementals_end, r1_secondaries_end))
-        };
-        let r2_secondaries: Option<(usize, usize)> = if self.r2_secondaries.is_empty() {
-            None
-        } else {
-            Some((r1_secondaries_end, r2_secondaries_end))
-        };
-
-        let Some(name) = self.name.take() else {
-            return Err(anyhow!("No records given to template builder"));
-        };
-
-        // Pre-allocate records Vec with exact capacity to avoid reallocations
-        let mut records: Vec<RecordBuf> = Vec::with_capacity(self.len());
-        if let Some(rec) = self.r1.take() {
-            records.push(rec);
-        }
-        if let Some(rec) = self.r2.take() {
-            records.push(rec);
-        }
-        // Reverse the supplementary and secondary vectors to match fgbio's behavior.
-        // fgbio uses Scala List prepend (r :: list) which results in reverse input order.
-        self.r1_supplementals.reverse();
-        self.r2_supplementals.reverse();
-        self.r1_secondaries.reverse();
-        self.r2_secondaries.reverse();
-        records.append(&mut self.r1_supplementals);
-        records.append(&mut self.r2_supplementals);
-        records.append(&mut self.r1_secondaries);
-        records.append(&mut self.r2_secondaries);
-
-        Ok(Template {
-            name,
-            records,
-            raw_records: None,
-            r1,
-            r2,
-            r1_supplementals,
-            r2_supplementals,
-            r1_secondaries,
-            r2_secondaries,
-            mi: MoleculeId::None,
-        })
-    }
-}
-
 impl Template {
-    /// Returns the primary R1 read if present.
-    ///
-    /// The primary R1 is the main (non-secondary, non-supplementary) alignment
-    /// for the first read in a pair (or the only read for single-end data).
-    ///
-    /// # Returns
-    ///
-    /// Reference to the primary R1 record, or `None` if not present.
-    /// Returns `None` in raw-byte mode (use `raw_r1()` instead).
-    #[must_use]
-    pub fn r1(&self) -> Option<&RecordBuf> {
-        if self.records.is_empty() {
-            return None;
-        }
-        self.r1.map(|_| &self.records[0])
-    }
-
-    /// Returns the primary R2 read if present.
-    /// Returns `None` in raw-byte mode (use `raw_r2()` instead).
-    ///
-    /// The primary R2 is the main (non-secondary, non-supplementary) alignment
-    /// for the second read in a paired-end template.
-    ///
-    /// # Returns
-    ///
-    /// Reference to the primary R2 record, or `None` if not present
-    #[must_use]
-    pub fn r2(&self) -> Option<&RecordBuf> {
-        if self.records.is_empty() {
-            return None;
-        }
-        self.r2.map(|(i, _)| &self.records[i])
-    }
-
-    /// Returns the records in the given range, or an empty slice if the range is invalid.
-    fn records_in_range(&self, range: Option<(usize, usize)>) -> &[RecordBuf] {
-        if let Some((start, end)) = range {
-            if start <= end && end <= self.records.len() {
-                return &self.records[start..end];
-            }
-        }
-        &[]
-    }
-
-    /// Returns supplementary alignments for R1.
-    /// Returns empty in raw-byte mode.
-    #[must_use]
-    pub fn r1_supplementals(&self) -> &[RecordBuf] {
-        self.records_in_range(self.r1_supplementals)
-    }
-
-    /// Returns supplementary alignments for R2.
-    /// Returns empty in raw-byte mode.
-    #[must_use]
-    pub fn r2_supplementals(&self) -> &[RecordBuf] {
-        self.records_in_range(self.r2_supplementals)
-    }
-
-    /// Returns secondary alignments for R1.
-    /// Returns empty in raw-byte mode.
-    #[must_use]
-    pub fn r1_secondaries(&self) -> &[RecordBuf] {
-        self.records_in_range(self.r1_secondaries)
-    }
-
-    /// Returns secondary alignments for R2.
-    /// Returns empty in raw-byte mode.
-    #[must_use]
-    pub fn r2_secondaries(&self) -> &[RecordBuf] {
-        self.records_in_range(self.r2_secondaries)
-    }
-
-    /// Creates a new empty template with the given name
+    /// Creates a new empty template with the given name.
     ///
     /// # Arguments
     ///
     /// * `name` - The query name for this template
-    ///
-    /// # Returns
-    ///
-    /// An empty template with no records
     #[must_use]
     pub fn new(name: Vec<u8>) -> Self {
         Template {
             name,
             records: Vec::new(),
-            raw_records: None,
             r1: None,
             r2: None,
             r1_supplementals: None,
@@ -401,219 +100,66 @@ impl Template {
         }
     }
 
-    /// Creates a Template from an iterator of records with the same query name
-    ///
-    /// Automatically organizes records into r1/r2, primary/supplementary/secondary categories.
-    /// Assumes all records have the same query name.
-    ///
-    /// # Arguments
-    ///
-    /// * `records` - Iterator of records to organize into a template
-    ///
-    /// # Returns
-    ///
-    /// A Template with records organized by type, or an error if multiple primary reads found
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Multiple non-secondary, non-supplemental R1s are found
-    /// - Multiple non-secondary, non-supplemental R2s are found
-    /// - Iterator is empty (no name available)
-    ///
-    /// # Panics
-    ///
-    /// - If not all the records have the same query name
-    pub fn from_records<I>(records: I) -> Result<Self>
-    where
-        I: IntoIterator<Item = RecordBuf>,
-    {
-        let mut builder = Builder::new();
-
-        for record in records {
-            builder.push(record)?;
-        }
-
-        builder.build()
-    }
-
-    /// Returns an iterator over primary (non-secondary, non-supplementary) reads in this template
-    ///
-    /// Returns both R1 and R2 primary reads if present.
-    ///
-    /// # Returns
-    ///
-    /// Iterator over primary read records
-    pub fn primary_reads(&self) -> impl Iterator<Item = &RecordBuf> {
-        let records = &self.records;
-        self.r1.iter().chain(self.r2.iter()).filter_map(move |(start, _)| records.get(*start))
-    }
-
-    /// Consumes the template and returns owned primary reads.
-    ///
-    /// This method takes ownership of the template and returns the primary R1 and R2
-    /// reads without cloning. Use this when you need owned records and won't access
-    /// the template again.
-    ///
-    /// # Returns
-    ///
-    /// Tuple of `(Option<RecordBuf>, Option<RecordBuf>)` containing owned R1 and R2 records
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// let template = Template::from_records(records)?;
-    /// let (r1, r2) = template.into_primary_reads();
-    /// if let Some(r1) = r1 {
-    ///     writer.write_record(r1)?; // No clone needed
-    /// }
-    /// ```
+    /// Returns the primary R1 record if present.
     #[must_use]
-    pub fn into_primary_reads(mut self) -> (Option<RecordBuf>, Option<RecordBuf>) {
-        if self.records.is_empty() {
-            return (None, None);
-        }
-        // Extract r2 first (higher index) to avoid shifting r1's position
-        let r2 = self.r2.and_then(|(i, _)| self.records.get_mut(i).map(std::mem::take));
-        let r1 = self.r1.and_then(|_| self.records.get_mut(0).map(std::mem::take));
-        (r1, r2)
+    pub fn r1(&self) -> Option<&RawRecord> {
+        self.r1.map(|_| &self.records[0])
     }
 
-    /// Returns an iterator over all supplementary and secondary reads
-    ///
-    /// # Returns
-    ///
-    /// Iterator over non-primary reads
-    pub fn all_supplementary_and_secondary(&self) -> impl Iterator<Item = &RecordBuf> {
-        let records = &self.records;
-        let iter = self
-            .r1_supplementals
-            .iter()
-            .chain(self.r2_supplementals.iter())
-            .chain(self.r1_secondaries.iter())
-            .chain(self.r2_secondaries.iter());
-        iter.flat_map(move |(start, end)| {
-            let s = (*start).min(records.len());
-            let e = (*end).min(records.len());
-            records[s..e].iter()
-        })
-    }
-
-    /// Returns an iterator over all reads in this template
-    ///
-    /// Includes primary, supplementary, and secondary alignments.
-    ///
-    /// # Returns
-    ///
-    /// Iterator over all records
-    pub fn all_reads(&self) -> impl Iterator<Item = &RecordBuf> {
-        self.primary_reads().chain(self.all_supplementary_and_secondary())
-    }
-
-    /// Consumes the template and returns all records as a vector.
-    ///
-    /// This is useful when you need to take ownership of all records
-    /// for further processing.
+    /// Returns the primary R2 record if present.
     #[must_use]
-    pub fn into_records(self) -> Vec<RecordBuf> {
+    pub fn r2(&self) -> Option<&RawRecord> {
+        self.r2.map(|(i, _)| &self.records[i])
+    }
+
+    /// Returns all records as a slice.
+    #[must_use]
+    pub fn records(&self) -> &[RawRecord] {
+        &self.records
+    }
+
+    /// Returns mutable access to all records.
+    pub fn records_mut(&mut self) -> &mut [RawRecord] {
+        &mut self.records
+    }
+
+    /// Consumes self and returns all records as a `Vec`.
+    #[must_use]
+    pub fn into_records(self) -> Vec<RawRecord> {
         self.records
     }
 
-    /// Returns an iterator over all R1 reads (primary, supplementary, and secondary)
+    /// Returns an iterator over primary (non-secondary, non-supplementary) records.
     ///
-    /// # Returns
-    ///
-    /// Iterator over all R1 records
-    pub fn all_r1s(&self) -> impl Iterator<Item = &RecordBuf> {
+    /// Yields the R1 primary record and/or the R2 primary record if present.
+    pub fn primary_reads(&self) -> impl Iterator<Item = &RawRecord> {
         let records = &self.records;
-        let iter =
-            self.r1.iter().chain(self.r1_secondaries.iter()).chain(self.r1_supplementals.iter());
-        iter.flat_map(move |(start, end)| {
-            let s = (*start).min(records.len());
-            let e = (*end).min(records.len());
-            records[s..e].iter()
-        })
+        [self.r1.map(|(s, _)| s), self.r2.map(|(s, _)| s)]
+            .into_iter()
+            .flatten()
+            .filter_map(move |start| records.get(start))
     }
 
-    /// Returns an iterator over all R2 reads (primary, supplementary, and secondary)
-    ///
-    /// # Returns
-    ///
-    /// Iterator over all R2 records
-    pub fn all_r2s(&self) -> impl Iterator<Item = &RecordBuf> {
-        let records = &self.records;
-        let iter =
-            self.r2.iter().chain(self.r2_secondaries.iter()).chain(self.r2_supplementals.iter());
-        iter.flat_map(move |(start, end)| {
-            let s = (*start).min(records.len());
-            let e = (*end).min(records.len());
-            records[s..e].iter()
-        })
-    }
-
-    /// Returns the total count of records in this template
-    ///
-    /// # Returns
-    ///
-    /// Total number of records (primary, supplementary, and secondary)
+    /// Returns the total count of records in this template.
     #[must_use]
     pub fn read_count(&self) -> usize {
-        if let Some(ref rr) = self.raw_records { rr.len() } else { self.records.len() }
+        self.records.len()
     }
 
-    /// Returns true if this template is in raw-byte mode.
-    #[inline]
-    #[must_use]
-    pub fn is_raw_byte_mode(&self) -> bool {
-        self.raw_records.is_some()
-    }
-
-    /// Returns the raw R1 record if in raw-byte mode.
-    #[must_use]
-    pub fn raw_r1(&self) -> Option<&RawRecord> {
-        let rr = self.raw_records.as_ref()?;
-        self.r1.map(|_| &rr[0])
-    }
-
-    /// Returns the raw R2 record if in raw-byte mode.
-    #[must_use]
-    pub fn raw_r2(&self) -> Option<&RawRecord> {
-        let rr = self.raw_records.as_ref()?;
-        self.r2.map(|(i, _)| &rr[i])
-    }
-
-    /// Returns all raw records if in raw-byte mode.
-    #[must_use]
-    pub fn all_raw_records(&self) -> Option<&[RawRecord]> {
-        self.raw_records.as_deref()
-    }
-
-    /// Consumes self and returns the raw records if in raw-byte mode.
-    #[must_use]
-    pub fn into_raw_records(self) -> Option<Vec<RawRecord>> {
-        self.raw_records
-    }
-
-    /// Returns mutable access to all raw records if in raw-byte mode.
-    pub fn all_raw_records_mut(&mut self) -> Option<&mut [RawRecord]> {
-        self.raw_records.as_deref_mut()
-    }
-
-    /// Build a Template from raw BAM byte records, categorizing by flags.
+    /// Builds a `Template` from raw BAM byte records, categorizing by flags.
     ///
     /// The records are categorized using `RawRecordView::flags()` to determine
-    /// R1/R2/supplementary/secondary status, with the same index-pair scheme
-    /// as `Builder::build()`.
+    /// R1/R2/supplementary/secondary status.
     ///
     /// # Errors
     ///
     /// Returns an error if multiple primary R1s or R2s are found.
     #[allow(clippy::too_many_lines)]
-    pub fn from_raw_records(mut raw_records: Vec<RawRecord>) -> Result<Self> {
+    pub fn from_records(mut raw_records: Vec<RawRecord>) -> Result<Self> {
         use crate::sort::bam_fields;
 
         if raw_records.is_empty() {
-            bail!("No records given to from_raw_records");
+            bail!("No records given to Template::from_records");
         }
 
         // Guard against truncated records
@@ -665,8 +211,7 @@ impl Template {
                     }
                     return Ok(Template {
                         name,
-                        records: Vec::new(),
-                        raw_records: Some(raw_records),
+                        records: raw_records,
                         r1: Some((0, 1)),
                         r2: Some((1, 2)),
                         r1_supplementals: None,
@@ -677,6 +222,13 @@ impl Template {
                     });
                 }
                 // Both R1 or both R2 — fall through to general path for error handling
+            }
+        }
+
+        // Verify all records share the same QNAME (matching Builder behavior)
+        for rec in raw_records.iter().skip(1) {
+            if bam_fields::read_name(rec) != name.as_slice() {
+                bail!("Template name mismatch in from_records");
             }
         }
 
@@ -720,7 +272,7 @@ impl Template {
         }
 
         // Build ordered Vec: r1, r2, r1_supplementals, r2_supplementals, r1_secondaries, r2_secondaries
-        // (matching Builder::build() ordering, with supplementals/secondaries reversed)
+        // (supplementals/secondaries reversed to match fgbio's Scala List prepend ordering)
         let mut ordered: Vec<RawRecord> = Vec::with_capacity(raw_records.len());
         let mut take = |idx: usize| -> RawRecord { std::mem::take(&mut raw_records[idx]) };
 
@@ -785,8 +337,7 @@ impl Template {
 
         Ok(Template {
             name,
-            records: Vec::new(),
-            raw_records: Some(ordered),
+            records: ordered,
             r1: r1_pair,
             r2: r2_pair,
             r1_supplementals: r1_supp_pair,
@@ -822,220 +373,44 @@ impl Template {
     /// ```
     #[must_use]
     pub fn pair_orientation(&self) -> Option<PairOrientation> {
+        use crate::sort::bam_fields;
         let r1 = self.r1()?;
         let r2 = self.r2()?;
+        let f1 = RawRecordView::new(r1).flags();
+        let f2 = RawRecordView::new(r2).flags();
 
         // Both must be mapped
-        if r1.flags().is_unmapped() || r2.flags().is_unmapped() {
+        if (f1 & bam_fields::flags::UNMAPPED) != 0 || (f2 & bam_fields::flags::UNMAPPED) != 0 {
             return None;
         }
 
         // Must be on the same reference
-        if r1.reference_sequence_id() != r2.reference_sequence_id() {
+        if bam_fields::ref_id(r1) != bam_fields::ref_id(r2) {
             return None;
         }
 
         // Use R1 to determine orientation (htsjdk uses the first record passed)
-        Some(get_pair_orientation(r1))
+        Some(get_pair_orientation_raw(r1))
     }
 
     /// Fixes mate information for paired-end reads.
     ///
-    /// This method follows htsjdk's `SamPairUtil.setMateInfo` behavior exactly:
-    ///
-    /// **For primary R1/R2 pairs:**
-    /// - Case 1 (both mapped): Sets mate ref, mate pos, mate strand flag, mate unmapped=false,
-    ///   MQ tag, MC tag (if valid CIGAR), and computes TLEN
-    /// - Case 2 (both unmapped): Clears ref/pos to unmapped values, sets mate unmapped=true,
-    ///   removes MQ and MC tags, sets TLEN=0
-    /// - Case 3 (one mapped, one unmapped): Places unmapped read at mapped read's coordinates,
-    ///   sets appropriate mate info, MQ only on unmapped read, TLEN=0
-    ///
-    /// **For supplementary alignments:**
-    /// - Sets mate information based on the mate's primary alignment
-    /// - Sets ms (mate score) tag if AS (alignment score) is available
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the CIGAR operations cannot be parsed (malformed CIGAR data)
-    #[allow(clippy::too_many_lines)]
-    pub fn fix_mate_info(&mut self) -> Result<()> {
-        if self.records.is_empty() {
-            return Ok(());
-        }
-
-        let mapq_tag = Tag::from(SamTag::MQ);
-        let mate_cigar_tag = Tag::from(SamTag::MC);
-        let mate_score_tag = Tag::from(SamTag::MS);
-        let align_score_tag = Tag::from(SamTag::AS);
-
-        // Fix mate info for primary R1/R2 pair
-        // Following htsjdk's SamPairUtil.setMateInfo exactly
-        if let (Some((r1_i, _)), Some((r2_i, _))) = (self.r1, self.r2) {
-            let r1_is_unmapped = self.records[r1_i].flags().is_unmapped();
-            let r2_is_unmapped = self.records[r2_i].flags().is_unmapped();
-
-            // Get alignment scores for mate score tags (used in all cases)
-            let r1_as = self.records[r1_i].data().get(&align_score_tag).and_then(extract_int_value);
-            let r2_as = self.records[r2_i].data().get(&align_score_tag).and_then(extract_int_value);
-
-            if !r1_is_unmapped && !r2_is_unmapped {
-                // Case 1: Both reads are mapped
-                self.set_mate_info_both_mapped(r1_i, r2_i, mapq_tag, mate_cigar_tag)?;
-            } else if r1_is_unmapped && r2_is_unmapped {
-                // Case 2: Both reads are unmapped
-                self.set_mate_info_both_unmapped(r1_i, r2_i, mapq_tag, mate_cigar_tag);
-            } else {
-                // Case 3: One mapped, one unmapped
-                self.set_mate_info_one_unmapped(
-                    r1_i,
-                    r2_i,
-                    r1_is_unmapped,
-                    mapq_tag,
-                    mate_cigar_tag,
-                )?;
-            }
-
-            // Set mate score tags (ms) in all cases
-            // Use Int8 to match fgbio's tag type encoding
-            if let Some(as_value) = r2_as {
-                self.records[r1_i]
-                    .data_mut()
-                    .insert(mate_score_tag, to_smallest_signed_int(as_value));
-            }
-            if let Some(as_value) = r1_as {
-                self.records[r2_i]
-                    .data_mut()
-                    .insert(mate_score_tag, to_smallest_signed_int(as_value));
-            }
-        }
-
-        // Fix mate info for R1 supplementals (mate is primary R2)
-        // Following htsjdk's setMateInformationOnSupplementalAlignment:
-        // - Mate reference index (RNEXT)
-        // - Mate alignment start (PNEXT)
-        // - Mate reverse strand flag (0x20)
-        // - Mate unmapped flag (0x8)
-        // - TLEN is set to negative of mate primary's TLEN
-        // - MQ tag is set to mate primary's mapping quality
-        // - MC tag is set to mate primary's CIGAR
-        // - ms tag is set to mate primary's AS value
-        if let Some((r2_i, _)) = self.r2 {
-            let r2_ref_id = self.records[r2_i].reference_sequence_id();
-            let r2_pos = self.records[r2_i].alignment_start();
-            let r2_is_reverse = self.records[r2_i].flags().is_reverse_complemented();
-            let r2_is_unmapped = self.records[r2_i].flags().is_unmapped();
-            let r2_tlen = self.records[r2_i].template_length();
-            let r2_mapq = self.records[r2_i].mapping_quality();
-            let r2_cigar_str = cigar_to_string(self.records[r2_i].cigar())?;
-            let r2_as = self.records[r2_i].data().get(&align_score_tag).and_then(extract_int_value);
-
-            if let Some((start, end)) = self.r1_supplementals {
-                for i in start..end {
-                    // Set mate reference and position
-                    *self.records[i].mate_reference_sequence_id_mut() = r2_ref_id;
-                    *self.records[i].mate_alignment_start_mut() = r2_pos;
-
-                    // Set mate flags (reverse strand and unmapped)
-                    set_mate_flags(&mut self.records[i], r2_is_reverse, r2_is_unmapped);
-
-                    // Set TLEN to negative of mate primary's TLEN
-                    *self.records[i].template_length_mut() = -r2_tlen;
-
-                    // Set MQ tag - use Int8 to match fgbio's tag type encoding
-                    let r2_mapq_value = r2_mapq.map_or(255, |m| i32::from(u8::from(m)));
-                    self.records[i]
-                        .data_mut()
-                        .insert(mapq_tag, to_smallest_signed_int(r2_mapq_value));
-
-                    // Set MC tag if CIGAR is available
-                    if !r2_cigar_str.is_empty() && r2_cigar_str != "*" && !r2_is_unmapped {
-                        self.records[i]
-                            .data_mut()
-                            .insert(mate_cigar_tag, BufValue::from(r2_cigar_str.clone()));
-                    }
-
-                    // Set ms tag if AS is available - use Int8 to match fgbio
-                    if let Some(as_value) = r2_as {
-                        self.records[i]
-                            .data_mut()
-                            .insert(mate_score_tag, to_smallest_signed_int(as_value));
-                    }
-                }
-            }
-        }
-
-        // Fix mate info for R2 supplementals (mate is primary R1)
-        if let Some((r1_i, _)) = self.r1 {
-            let r1_ref_id = self.records[r1_i].reference_sequence_id();
-            let r1_pos = self.records[r1_i].alignment_start();
-            let r1_is_reverse = self.records[r1_i].flags().is_reverse_complemented();
-            let r1_is_unmapped = self.records[r1_i].flags().is_unmapped();
-            let r1_tlen = self.records[r1_i].template_length();
-            let r1_mapq = self.records[r1_i].mapping_quality();
-            let r1_cigar_str = cigar_to_string(self.records[r1_i].cigar())?;
-            let r1_as = self.records[r1_i].data().get(&align_score_tag).and_then(extract_int_value);
-
-            if let Some((start, end)) = self.r2_supplementals {
-                for i in start..end {
-                    // Set mate reference and position
-                    *self.records[i].mate_reference_sequence_id_mut() = r1_ref_id;
-                    *self.records[i].mate_alignment_start_mut() = r1_pos;
-
-                    // Set mate flags (reverse strand and unmapped)
-                    set_mate_flags(&mut self.records[i], r1_is_reverse, r1_is_unmapped);
-
-                    // Set TLEN to negative of mate primary's TLEN
-                    *self.records[i].template_length_mut() = -r1_tlen;
-
-                    // Set MQ tag - use Int8 to match fgbio's tag type encoding
-                    let r1_mapq_value = r1_mapq.map_or(255, |m| i32::from(u8::from(m)));
-                    self.records[i]
-                        .data_mut()
-                        .insert(mapq_tag, to_smallest_signed_int(r1_mapq_value));
-
-                    // Set MC tag if CIGAR is available
-                    if !r1_cigar_str.is_empty() && r1_cigar_str != "*" && !r1_is_unmapped {
-                        self.records[i]
-                            .data_mut()
-                            .insert(mate_cigar_tag, BufValue::from(r1_cigar_str.clone()));
-                    }
-
-                    // Set ms tag if AS is available - use Int8 to match fgbio
-                    if let Some(as_value) = r1_as {
-                        self.records[i]
-                            .data_mut()
-                            .insert(mate_score_tag, to_smallest_signed_int(as_value));
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Fixes mate information for paired-end reads, operating on raw BAM bytes.
-    ///
-    /// This is the raw-byte equivalent of [`fix_mate_info`]. It modifies
-    /// `self.raw_records` in place, setting RNEXT, PNEXT, TLEN, mate flags,
+    /// Modifies `self.records` in place, setting RNEXT, PNEXT, TLEN, mate flags,
     /// MQ, MC, and ms tags for primary pairs and supplementary alignments.
     ///
     /// # Errors
     ///
-    /// Returns an error if `raw_records` is `None`.
+    /// Returns an error if the records are malformed.
     ///
     /// # Panics
     ///
     /// Panics if internal index invariants are violated (should not happen
     /// with well-formed templates).
     #[allow(clippy::too_many_lines)]
-    pub fn fix_mate_info_raw(&mut self) -> Result<()> {
+    pub fn fix_mate_info(&mut self) -> Result<()> {
         use crate::sort::bam_fields;
 
-        let rr = self
-            .raw_records
-            .as_mut()
-            .ok_or_else(|| anyhow!("fix_mate_info_raw requires raw-byte mode"))?;
+        let rr = &mut self.records;
 
         if rr.is_empty() {
             return Ok(());
@@ -1054,17 +429,17 @@ impl Template {
 
             if !r1_is_unmapped && !r2_is_unmapped {
                 // Case 1: Both mapped
-                self.set_mate_info_both_mapped_raw(r1_i, r2_i);
+                self.set_mate_info_both_mapped(r1_i, r2_i);
             } else if r1_is_unmapped && r2_is_unmapped {
                 // Case 2: Both unmapped
-                self.set_mate_info_both_unmapped_raw(r1_i, r2_i);
+                self.set_mate_info_both_unmapped(r1_i, r2_i);
             } else {
                 // Case 3: One mapped, one unmapped
-                self.set_mate_info_one_unmapped_raw(r1_i, r2_i, r1_is_unmapped);
+                self.set_mate_info_one_unmapped(r1_i, r2_i, r1_is_unmapped);
             }
 
             // Set mate score tags (ms) in all cases
-            let rr = self.raw_records.as_mut().unwrap();
+            let rr = &mut self.records;
             if let Some(as_value) = r2_as {
                 if let Ok(v) = i32::try_from(as_value) {
                     bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"ms");
@@ -1081,7 +456,7 @@ impl Template {
 
         // Fix mate info for R1 supplementals (mate is primary R2)
         if let Some((r2_i, _)) = self.r2 {
-            let rr = self.raw_records.as_ref().unwrap();
+            let rr = &self.records;
             let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
             let r2_pos = bam_fields::pos(&rr[r2_i]);
             let r2_flags = RawRecordView::new(&rr[r2_i]).flags();
@@ -1093,11 +468,11 @@ impl Template {
             let r2_as = bam_fields::find_int_tag(bam_fields::aux_data_slice(&rr[r2_i]), b"AS");
 
             if let Some((start, end)) = self.r1_supplementals {
-                let rr = self.raw_records.as_mut().unwrap();
+                let rr = &mut self.records;
                 for rec in &mut rr[start..end] {
                     bam_fields::set_mate_ref_id(rec, r2_ref_id);
                     bam_fields::set_mate_pos(rec, r2_pos);
-                    set_mate_flags_raw(rec, r2_is_reverse, r2_is_unmapped);
+                    set_mate_flags(rec, r2_is_reverse, r2_is_unmapped);
                     bam_fields::set_template_length(rec, -r2_tlen);
 
                     let mq_val = if r2_mapq == 255 { 255 } else { i32::from(r2_mapq) };
@@ -1125,7 +500,7 @@ impl Template {
 
         // Fix mate info for R2 supplementals (mate is primary R1)
         if let Some((r1_i, _)) = self.r1 {
-            let rr = self.raw_records.as_ref().unwrap();
+            let rr = &self.records;
             let r1_ref_id = bam_fields::ref_id(&rr[r1_i]);
             let r1_pos = bam_fields::pos(&rr[r1_i]);
             let r1_flags = RawRecordView::new(&rr[r1_i]).flags();
@@ -1137,11 +512,11 @@ impl Template {
             let r1_as = bam_fields::find_int_tag(bam_fields::aux_data_slice(&rr[r1_i]), b"AS");
 
             if let Some((start, end)) = self.r2_supplementals {
-                let rr = self.raw_records.as_mut().unwrap();
+                let rr = &mut self.records;
                 for rec in &mut rr[start..end] {
                     bam_fields::set_mate_ref_id(rec, r1_ref_id);
                     bam_fields::set_mate_pos(rec, r1_pos);
-                    set_mate_flags_raw(rec, r1_is_reverse, r1_is_unmapped);
+                    set_mate_flags(rec, r1_is_reverse, r1_is_unmapped);
                     bam_fields::set_template_length(rec, -r1_tlen);
 
                     let mq_val = if r1_mapq == 255 { 255 } else { i32::from(r1_mapq) };
@@ -1171,10 +546,10 @@ impl Template {
     }
 
     /// Raw-byte: both reads mapped. Sets mate info, TLEN, MQ, MC.
-    fn set_mate_info_both_mapped_raw(&mut self, r1_i: usize, r2_i: usize) {
+    fn set_mate_info_both_mapped(&mut self, r1_i: usize, r2_i: usize) {
         use crate::sort::bam_fields;
 
-        let rr = self.raw_records.as_ref().unwrap();
+        let rr = &self.records;
 
         // Get R2's info for R1
         let r2_ref_id = bam_fields::ref_id(&rr[r2_i]);
@@ -1195,12 +570,12 @@ impl Template {
         // Compute insert size before mutating
         let insert_size = compute_insert_size_raw(&rr[r1_i], &rr[r2_i]);
 
-        let rr = self.raw_records.as_mut().unwrap();
+        let rr = &mut self.records;
 
         // Set mate info on R1 from R2
         bam_fields::set_mate_ref_id(&mut rr[r1_i], r2_ref_id);
         bam_fields::set_mate_pos(&mut rr[r1_i], r2_pos);
-        set_mate_flags_raw(&mut rr[r1_i], r2_is_reverse, false);
+        set_mate_flags(&mut rr[r1_i], r2_is_reverse, false);
         let r2_mq_val = if r2_mapq == 255 { 255 } else { i32::from(r2_mapq) };
         bam_fields::update_int_tag(rr[r1_i].as_mut_vec(), b"MQ", r2_mq_val);
         if !r2_cigar_str.is_empty() && r2_cigar_str != "*" {
@@ -1212,7 +587,7 @@ impl Template {
         // Set mate info on R2 from R1
         bam_fields::set_mate_ref_id(&mut rr[r2_i], r1_ref_id);
         bam_fields::set_mate_pos(&mut rr[r2_i], r1_pos);
-        set_mate_flags_raw(&mut rr[r2_i], r1_is_reverse, false);
+        set_mate_flags(&mut rr[r2_i], r1_is_reverse, false);
         let r1_mq_val = if r1_mapq == 255 { 255 } else { i32::from(r1_mapq) };
         bam_fields::update_int_tag(rr[r2_i].as_mut_vec(), b"MQ", r1_mq_val);
         if !r1_cigar_str.is_empty() && r1_cigar_str != "*" {
@@ -1227,23 +602,23 @@ impl Template {
     }
 
     /// Raw-byte: both reads unmapped. Clears ref/pos, removes MQ/MC, TLEN=0.
-    fn set_mate_info_both_unmapped_raw(&mut self, r1_i: usize, r2_i: usize) {
+    fn set_mate_info_both_unmapped(&mut self, r1_i: usize, r2_i: usize) {
         use crate::sort::bam_fields;
 
-        let rr = self.raw_records.as_ref().unwrap();
+        let rr = &self.records;
         let r1_is_reverse =
             (RawRecordView::new(&rr[r1_i]).flags() & bam_fields::flags::REVERSE) != 0;
         let r2_is_reverse =
             (RawRecordView::new(&rr[r2_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
-        let rr = self.raw_records.as_mut().unwrap();
+        let rr = &mut self.records;
 
         // R1: set to unmapped coordinates
         bam_fields::set_ref_id(&mut rr[r1_i], -1);
         bam_fields::set_pos(&mut rr[r1_i], -1);
         bam_fields::set_mate_ref_id(&mut rr[r1_i], -1);
         bam_fields::set_mate_pos(&mut rr[r1_i], -1);
-        set_mate_flags_raw(&mut rr[r1_i], r2_is_reverse, true);
+        set_mate_flags(&mut rr[r1_i], r2_is_reverse, true);
         bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"MQ");
         bam_fields::remove_tag(rr[r1_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[r1_i], 0);
@@ -1253,19 +628,19 @@ impl Template {
         bam_fields::set_pos(&mut rr[r2_i], -1);
         bam_fields::set_mate_ref_id(&mut rr[r2_i], -1);
         bam_fields::set_mate_pos(&mut rr[r2_i], -1);
-        set_mate_flags_raw(&mut rr[r2_i], r1_is_reverse, true);
+        set_mate_flags(&mut rr[r2_i], r1_is_reverse, true);
         bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"MQ");
         bam_fields::remove_tag(rr[r2_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[r2_i], 0);
     }
 
     /// Raw-byte: one mapped, one unmapped. Places unmapped at mapped coords.
-    fn set_mate_info_one_unmapped_raw(&mut self, r1_i: usize, r2_i: usize, r1_is_unmapped: bool) {
+    fn set_mate_info_one_unmapped(&mut self, r1_i: usize, r2_i: usize, r1_is_unmapped: bool) {
         use crate::sort::bam_fields;
 
         let (mapped_i, unmapped_i) = if r1_is_unmapped { (r2_i, r1_i) } else { (r1_i, r2_i) };
 
-        let rr = self.raw_records.as_ref().unwrap();
+        let rr = &self.records;
         let mapped_ref_id = bam_fields::ref_id(&rr[mapped_i]);
         let mapped_pos = bam_fields::pos(&rr[mapped_i]);
         let mapped_flags = RawRecordView::new(&rr[mapped_i]).flags();
@@ -1276,7 +651,7 @@ impl Template {
         let unmapped_is_reverse =
             (RawRecordView::new(&rr[unmapped_i]).flags() & bam_fields::flags::REVERSE) != 0;
 
-        let rr = self.raw_records.as_mut().unwrap();
+        let rr = &mut self.records;
 
         // Place unmapped read at mapped read's coordinates
         bam_fields::set_ref_id(&mut rr[unmapped_i], mapped_ref_id);
@@ -1285,7 +660,7 @@ impl Template {
         // Set mate info on mapped read (mate is unmapped)
         bam_fields::set_mate_ref_id(&mut rr[mapped_i], mapped_ref_id);
         bam_fields::set_mate_pos(&mut rr[mapped_i], mapped_pos);
-        set_mate_flags_raw(&mut rr[mapped_i], unmapped_is_reverse, true);
+        set_mate_flags(&mut rr[mapped_i], unmapped_is_reverse, true);
         bam_fields::remove_tag(rr[mapped_i].as_mut_vec(), b"MQ");
         bam_fields::remove_tag(rr[mapped_i].as_mut_vec(), b"MC");
         bam_fields::set_template_length(&mut rr[mapped_i], 0);
@@ -1293,7 +668,7 @@ impl Template {
         // Set mate info on unmapped read (mate is mapped)
         bam_fields::set_mate_ref_id(&mut rr[unmapped_i], mapped_ref_id);
         bam_fields::set_mate_pos(&mut rr[unmapped_i], mapped_pos);
-        set_mate_flags_raw(&mut rr[unmapped_i], mapped_is_reverse, false);
+        set_mate_flags(&mut rr[unmapped_i], mapped_is_reverse, false);
         let mq_val = if mapped_mapq == 255 { 255 } else { i32::from(mapped_mapq) };
         bam_fields::update_int_tag(rr[unmapped_i].as_mut_vec(), b"MQ", mq_val);
         if !mapped_cigar_str.is_empty() && mapped_cigar_str != "*" {
@@ -1307,207 +682,10 @@ impl Template {
         }
         bam_fields::set_template_length(&mut rr[unmapped_i], 0);
     }
-
-    /// Sets mate information when both reads are mapped.
-    /// Following htsjdk's SamPairUtil.setMateInfo case 1.
-    fn set_mate_info_both_mapped(
-        &mut self,
-        r1_i: usize,
-        r2_i: usize,
-        mapq_tag: Tag,
-        mate_cigar_tag: Tag,
-    ) -> Result<()> {
-        // Get R2's info for R1
-        let r2_ref_id = self.records[r2_i].reference_sequence_id();
-        let r2_pos = self.records[r2_i].alignment_start();
-        let r2_is_reverse = self.records[r2_i].flags().is_reverse_complemented();
-        let r2_mapq = self.records[r2_i].mapping_quality();
-        let r2_cigar_str = cigar_to_string(self.records[r2_i].cigar())?;
-
-        // Get R1's info for R2
-        let r1_ref_id = self.records[r1_i].reference_sequence_id();
-        let r1_pos = self.records[r1_i].alignment_start();
-        let r1_is_reverse = self.records[r1_i].flags().is_reverse_complemented();
-        let r1_mapq = self.records[r1_i].mapping_quality();
-        let r1_cigar_str = cigar_to_string(self.records[r1_i].cigar())?;
-
-        // Set mate info on R1 from R2
-        *self.records[r1_i].mate_reference_sequence_id_mut() = r2_ref_id;
-        *self.records[r1_i].mate_alignment_start_mut() = r2_pos;
-        set_mate_flags(&mut self.records[r1_i], r2_is_reverse, false);
-        // Use Int8 for MQ to match fgbio's tag type encoding
-        let r2_mapq_value = r2_mapq.map_or(255, |m| i32::from(u8::from(m)));
-        self.records[r1_i].data_mut().insert(mapq_tag, to_smallest_signed_int(r2_mapq_value));
-        if !r2_cigar_str.is_empty() && r2_cigar_str != "*" {
-            self.records[r1_i].data_mut().insert(mate_cigar_tag, BufValue::from(r2_cigar_str));
-        }
-
-        // Set mate info on R2 from R1
-        *self.records[r2_i].mate_reference_sequence_id_mut() = r1_ref_id;
-        *self.records[r2_i].mate_alignment_start_mut() = r1_pos;
-        set_mate_flags(&mut self.records[r2_i], r1_is_reverse, false);
-        // Use Int8 for MQ to match fgbio's tag type encoding
-        let r1_mapq_value = r1_mapq.map_or(255, |m| i32::from(u8::from(m)));
-        self.records[r2_i].data_mut().insert(mapq_tag, to_smallest_signed_int(r1_mapq_value));
-        if !r1_cigar_str.is_empty() && r1_cigar_str != "*" {
-            self.records[r2_i].data_mut().insert(mate_cigar_tag, BufValue::from(r1_cigar_str));
-        }
-
-        // Compute and set insert size (TLEN)
-        let insert_size = compute_insert_size(&self.records[r1_i], &self.records[r2_i]);
-        *self.records[r1_i].template_length_mut() = insert_size;
-        *self.records[r2_i].template_length_mut() = -insert_size;
-
-        Ok(())
-    }
-
-    /// Sets mate information when both reads are unmapped.
-    /// Following htsjdk's SamPairUtil.setMateInfo case 2.
-    fn set_mate_info_both_unmapped(
-        &mut self,
-        r1_i: usize,
-        r2_i: usize,
-        mapq_tag: Tag,
-        mate_cigar_tag: Tag,
-    ) {
-        // Get strand info before modifying
-        let r1_is_reverse = self.records[r1_i].flags().is_reverse_complemented();
-        let r2_is_reverse = self.records[r2_i].flags().is_reverse_complemented();
-
-        // R1: set to unmapped coordinates
-        *self.records[r1_i].reference_sequence_id_mut() = None;
-        *self.records[r1_i].alignment_start_mut() = None;
-        *self.records[r1_i].mate_reference_sequence_id_mut() = None;
-        *self.records[r1_i].mate_alignment_start_mut() = None;
-        set_mate_flags(&mut self.records[r1_i], r2_is_reverse, true);
-        self.records[r1_i].data_mut().remove(&mapq_tag);
-        self.records[r1_i].data_mut().remove(&mate_cigar_tag);
-        *self.records[r1_i].template_length_mut() = 0;
-
-        // R2: set to unmapped coordinates
-        *self.records[r2_i].reference_sequence_id_mut() = None;
-        *self.records[r2_i].alignment_start_mut() = None;
-        *self.records[r2_i].mate_reference_sequence_id_mut() = None;
-        *self.records[r2_i].mate_alignment_start_mut() = None;
-        set_mate_flags(&mut self.records[r2_i], r1_is_reverse, true);
-        self.records[r2_i].data_mut().remove(&mapq_tag);
-        self.records[r2_i].data_mut().remove(&mate_cigar_tag);
-        *self.records[r2_i].template_length_mut() = 0;
-    }
-
-    /// Sets mate information when one read is mapped and one is unmapped.
-    /// Following htsjdk's SamPairUtil.setMateInfo case 3.
-    fn set_mate_info_one_unmapped(
-        &mut self,
-        r1_i: usize,
-        r2_i: usize,
-        r1_is_unmapped: bool,
-        mapq_tag: Tag,
-        mate_cigar_tag: Tag,
-    ) -> Result<()> {
-        let (mapped_i, unmapped_i) = if r1_is_unmapped { (r2_i, r1_i) } else { (r1_i, r2_i) };
-
-        // Get mapped read's info
-        let mapped_ref_id = self.records[mapped_i].reference_sequence_id();
-        let mapped_pos = self.records[mapped_i].alignment_start();
-        let mapped_is_reverse = self.records[mapped_i].flags().is_reverse_complemented();
-        let mapped_mapq = self.records[mapped_i].mapping_quality();
-        let mapped_cigar_str = cigar_to_string(self.records[mapped_i].cigar())?;
-
-        // Get unmapped read's strand (for mate strand flag on mapped read)
-        let unmapped_is_reverse = self.records[unmapped_i].flags().is_reverse_complemented();
-
-        // Place unmapped read at mapped read's coordinates (htsjdk behavior)
-        *self.records[unmapped_i].reference_sequence_id_mut() = mapped_ref_id;
-        *self.records[unmapped_i].alignment_start_mut() = mapped_pos;
-
-        // Set mate info on mapped read (mate is unmapped)
-        // After placing unmapped at mapped's coords, unmapped's ref/pos = mapped's ref/pos
-        *self.records[mapped_i].mate_reference_sequence_id_mut() = mapped_ref_id;
-        *self.records[mapped_i].mate_alignment_start_mut() = mapped_pos;
-        set_mate_flags(&mut self.records[mapped_i], unmapped_is_reverse, true);
-        self.records[mapped_i].data_mut().remove(&mapq_tag);
-        self.records[mapped_i].data_mut().remove(&mate_cigar_tag);
-        *self.records[mapped_i].template_length_mut() = 0;
-
-        // Set mate info on unmapped read (mate is mapped)
-        *self.records[unmapped_i].mate_reference_sequence_id_mut() = mapped_ref_id;
-        *self.records[unmapped_i].mate_alignment_start_mut() = mapped_pos;
-        set_mate_flags(&mut self.records[unmapped_i], mapped_is_reverse, false);
-        // Use Int8 for MQ to match fgbio's tag type encoding
-        let mapped_mapq_value = mapped_mapq.map_or(255, |m| i32::from(u8::from(m)));
-        self.records[unmapped_i]
-            .data_mut()
-            .insert(mapq_tag, to_smallest_signed_int(mapped_mapq_value));
-        if !mapped_cigar_str.is_empty() && mapped_cigar_str != "*" {
-            self.records[unmapped_i]
-                .data_mut()
-                .insert(mate_cigar_tag, BufValue::from(mapped_cigar_str));
-        }
-        *self.records[unmapped_i].template_length_mut() = 0;
-
-        Ok(())
-    }
-}
-
-/// Computes the insert size (TLEN) for two reads.
-/// Following htsjdk's SamPairUtil.computeInsertSize exactly.
-///
-/// The insert size is computed using 5' positions:
-/// - For forward strand reads: alignment start (leftmost position)
-/// - For reverse strand reads: alignment end (rightmost position)
-///
-/// Returns 0 if either read is unmapped or if reads are on different references.
-fn compute_insert_size(rec1: &RecordBuf, rec2: &RecordBuf) -> i32 {
-    // If either read is unmapped, return 0
-    if rec1.flags().is_unmapped() || rec2.flags().is_unmapped() {
-        return 0;
-    }
-
-    // If reads are on different references, return 0
-    if rec1.reference_sequence_id() != rec2.reference_sequence_id() {
-        return 0;
-    }
-
-    // Get alignment start positions
-    let pos1 = rec1.alignment_start().map_or(0, |p| i32::try_from(usize::from(p)).unwrap_or(0));
-    let pos2 = rec2.alignment_start().map_or(0, |p| i32::try_from(usize::from(p)).unwrap_or(0));
-
-    // Calculate alignment ends (1-based, inclusive)
-    let end1 = pos1 + alignment_length(rec1.cigar()) - 1;
-    let end2 = pos2 + alignment_length(rec2.cigar()) - 1;
-
-    // Use 5' positions: alignment end for reverse strand, alignment start for forward
-    // This matches htsjdk's computeInsertSize exactly
-    let first_5prime = if rec1.flags().is_reverse_complemented() { end1 } else { pos1 };
-    let second_5prime = if rec2.flags().is_reverse_complemented() { end2 } else { pos2 };
-
-    // Compute insert size with adjustment
-    let adjustment = if second_5prime >= first_5prime { 1 } else { -1 };
-    second_5prime - first_5prime + adjustment
-}
-
-/// Calculates the alignment length from a CIGAR (reference-consuming operations).
-fn alignment_length(cigar: &noodles::sam::alignment::record_buf::Cigar) -> i32 {
-    use noodles::sam::alignment::record::cigar::op::Kind;
-    let mut len = 0i32;
-    for op in cigar.iter().flatten() {
-        match op.kind() {
-            Kind::Match
-            | Kind::Deletion
-            | Kind::Skip
-            | Kind::SequenceMatch
-            | Kind::SequenceMismatch => {
-                len += i32::try_from(op.len()).unwrap_or(0);
-            }
-            _ => {}
-        }
-    }
-    len
 }
 
 /// Sets mate flags (`MATE_REVERSE`, `MATE_UNMAPPED`) on a raw BAM record.
-fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped: bool) {
+fn set_mate_flags(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped: bool) {
     use crate::sort::bam_fields;
     let mut f = RawRecordView::new(record).flags();
     f &= !bam_fields::flags::MATE_REVERSE;
@@ -1523,7 +701,6 @@ fn set_mate_flags_raw(record: &mut [u8], mate_is_reverse: bool, mate_is_unmapped
 
 /// Computes insert size (TLEN) from two raw BAM records.
 ///
-/// Same algorithm as `compute_insert_size` but on raw bytes.
 /// Uses 0-based pos from BAM; converts to 1-based for the calculation.
 fn compute_insert_size_raw(rec1: &[u8], rec2: &[u8]) -> i32 {
     use crate::sort::bam_fields;
@@ -1559,52 +736,43 @@ fn compute_insert_size_raw(rec1: &[u8], rec2: &[u8]) -> i32 {
     second_5prime - first_5prime + adjustment
 }
 
-/// Determines the pair orientation for a paired read.
+/// Determines the pair orientation for a paired read using raw BAM bytes.
 ///
 /// This matches htsjdk's `SamPairUtil.getPairOrientation()` algorithm exactly.
 ///
 /// # Arguments
-/// * `record` - A paired, mapped read with a mapped mate on the same reference
+/// * `record` - Raw BAM bytes of a paired, mapped read with a mapped mate on the same reference
 ///
 /// # Returns
 /// The pair orientation (FR, RF, or Tandem)
-///
-/// # Panics
-/// The caller must ensure the record is paired, mapped, has a mapped mate,
-/// and is on the same reference as its mate.
 #[allow(clippy::cast_possible_wrap)]
-fn get_pair_orientation(record: &RecordBuf) -> PairOrientation {
-    let is_reverse = record.flags().is_reverse_complemented();
-    let mate_reverse = record.flags().is_mate_reverse_complemented();
+fn get_pair_orientation_raw(record: &[u8]) -> PairOrientation {
+    use crate::sort::bam_fields;
+    let f = RawRecordView::new(record).flags();
+    let is_reverse = (f & bam_fields::flags::REVERSE) != 0;
+    let mate_reverse = (f & bam_fields::flags::MATE_REVERSE) != 0;
 
     // Same strand = TANDEM
     if is_reverse == mate_reverse {
         return PairOrientation::Tandem;
     }
 
-    // Now determine if FR or RF using htsjdk's logic:
+    // FR vs RF using htsjdk's logic:
     // positiveStrandFivePrimePos = readIsOnReverseStrand ? mateStart : alignmentStart
     // negativeStrandFivePrimePos = readIsOnReverseStrand ? alignmentEnd : alignmentStart + insertSize
     // FR if positiveStrandFivePrimePos < negativeStrandFivePrimePos
-
-    let alignment_start = record.alignment_start().map_or(0, usize::from);
-    let mate_start = record.mate_alignment_start().map_or(0, usize::from);
-    let insert_size = record.template_length();
+    let alignment_start = bam_fields::pos(record) + 1; // 0-based -> 1-based
+    let mate_start = bam_fields::mate_pos(record) + 1;
+    let insert_size = bam_fields::template_length(record);
 
     let (positive_five_prime, negative_five_prime) = if is_reverse {
-        // This read is on reverse strand, mate is on positive strand
-        // positiveStrandFivePrimePos = mateStart
-        // negativeStrandFivePrimePos = alignmentEnd (this read's end)
-        let end = record_utils::alignment_end(record).unwrap_or(alignment_start);
-        (mate_start as i64, end as i64)
+        let ref_len = bam_fields::reference_length_from_raw_bam(record);
+        let end = alignment_start + ref_len - 1;
+        (i64::from(mate_start), i64::from(end))
     } else {
-        // This read is on positive strand, mate is on reverse strand
-        // positiveStrandFivePrimePos = alignmentStart (this read's start)
-        // negativeStrandFivePrimePos = alignmentStart + insertSize
-        (alignment_start as i64, alignment_start as i64 + i64::from(insert_size))
+        (i64::from(alignment_start), i64::from(alignment_start) + i64::from(insert_size))
     };
 
-    // FR if positive strand 5' < negative strand 5'
     if positive_five_prime < negative_five_prime {
         PairOrientation::FR
     } else {
@@ -1612,222 +780,90 @@ fn get_pair_orientation(record: &RecordBuf) -> PairOrientation {
     }
 }
 
-/// Sets the mate flags (`MATE_REVERSE_COMPLEMENTED` and `MATE_UNMAPPED`) on a record
-/// based on the mate's flags.
-///
-/// This follows htsjdk's `setMateInformationOnSupplementalAlignment` behavior:
-/// - Sets `MATE_REVERSE_COMPLEMENTED` (0x20) if mate is reverse complemented
-/// - Sets `MATE_UNMAPPED` (0x8) if mate is unmapped
-fn set_mate_flags(record: &mut RecordBuf, mate_is_reverse: bool, mate_is_unmapped: bool) {
-    use noodles::sam::alignment::record::Flags;
+// ============================================================================
+// TemplateIterator
+// ============================================================================
 
-    let mut flags = record.flags();
-
-    // Clear and then conditionally set MATE_REVERSE_COMPLEMENTED
-    flags.remove(Flags::MATE_REVERSE_COMPLEMENTED);
-    if mate_is_reverse {
-        flags.insert(Flags::MATE_REVERSE_COMPLEMENTED);
-    }
-
-    // Clear and then conditionally set MATE_UNMAPPED
-    flags.remove(Flags::MATE_UNMAPPED);
-    if mate_is_unmapped {
-        flags.insert(Flags::MATE_UNMAPPED);
-    }
-
-    *record.flags_mut() = flags;
-}
-
-/// Extracts an i32 value from any integer `BufValue` variant.
+/// Iterator that groups consecutive raw BAM records by query name into `Template` objects.
 ///
-/// SAM tags can store integers in various sizes (Int8, Int16, Int32, `UInt8`, `UInt16`, `UInt32`).
-/// This function extracts the value as an i32 from any of these variants.
-///
-/// # Arguments
-///
-/// * `value` - The `BufValue` to extract from
-///
-/// # Returns
-///
-/// `Some(i32)` if the value is any integer type, `None` otherwise.
-fn extract_int_value(value: &BufValue) -> Option<i32> {
-    match value {
-        BufValue::Int8(i) => Some(i32::from(*i)),
-        BufValue::Int16(i) => Some(i32::from(*i)),
-        BufValue::Int32(i) => Some(*i),
-        BufValue::UInt8(i) => Some(i32::from(*i)),
-        BufValue::UInt16(i) => Some(i32::from(*i)),
-        BufValue::UInt32(i) => i32::try_from(*i).ok(),
-        _ => None,
-    }
-}
-
-/// Converts a CIGAR operation kind to its SAM character representation.
-///
-/// Maps CIGAR operation types to their single-character SAM format codes:
-/// - M (Match/Mismatch)
-/// - I (Insertion)
-/// - D (Deletion)
-/// - N (Skipped region)
-/// - S (Soft clip)
-/// - H (Hard clip)
-/// - P (Padding)
-/// - = (Sequence match)
-/// - X (Sequence mismatch)
-///
-/// # Arguments
-///
-/// * `kind` - The CIGAR operation kind to convert
-///
-/// # Returns
-///
-/// Single character representing the operation in SAM format
-///
-/// # Panics
-///
-/// This function does not panic. The match is exhaustive over all CIGAR operation kinds.
-fn kind_to_char(kind: noodles::sam::alignment::record::cigar::op::Kind) -> char {
-    use noodles::sam::alignment::record::cigar::op::Kind;
-    match kind {
-        Kind::Match => 'M',
-        Kind::Insertion => 'I',
-        Kind::Deletion => 'D',
-        Kind::Skip => 'N',
-        Kind::SoftClip => 'S',
-        Kind::HardClip => 'H',
-        Kind::Pad => 'P',
-        Kind::SequenceMatch => '=',
-        Kind::SequenceMismatch => 'X',
-    }
-}
-
-/// Converts a CIGAR to its string representation
-///
-/// # Arguments
-///
-/// * `cigar` - The CIGAR to convert
-///
-/// # Returns
-///
-/// String representation of the CIGAR (e.g., "100M5I3D") or "*" if empty
-///
-/// # Errors
-///
-/// Returns an error if the CIGAR operations cannot be parsed (malformed CIGAR data)
-fn cigar_to_string(cigar: &noodles::sam::alignment::record_buf::Cigar) -> Result<String> {
-    if cigar.is_empty() {
-        return Ok(String::from("*"));
-    }
-
-    // Pre-allocate: estimate ~4 chars per op (e.g., "10M" = 3 chars, "100M" = 4 chars)
-    let mut result = String::with_capacity(cigar.as_ref().len() * 4);
-    for op in cigar.iter() {
-        let op = op?;
-        let _ = write!(result, "{}{}", op.len(), kind_to_char(op.kind()));
-    }
-    Ok(result)
-}
-
-/// Iterator that groups consecutive records by query name into `Template` objects.
-///
-/// This iterator consumes a stream of SAM/BAM records and yields complete `Template`
-/// objects. It assumes the input is queryname-sorted or queryname-grouped, meaning all
-/// records with the same query name appear consecutively in the stream.
+/// Reads `RawRecord`s and groups them into `Template` objects using [`Template::from_records`].
+/// The input must be queryname-sorted or queryname-grouped.
 ///
 /// # Requirements
 ///
-/// The input records MUST be queryname-sorted or grouped. If records with the same
-/// name are not consecutive, they will be placed in separate templates.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// let record_iter = bam_reader.records();
-/// let template_iter = TemplateIterator::new(record_iter);
-///
-/// for template in template_iter {
-///     let template = template?;
-///     // Process template
-/// }
-/// ```
-pub struct TemplateIterator<I>
+/// The input records MUST be queryname-sorted or grouped. Records with the same name must
+/// appear consecutively.
+pub struct TemplateIterator<R>
 where
-    I: Iterator<Item = Result<RecordBuf>>,
+    R: std::io::Read,
 {
-    record_iter: I,
-    builder: Builder,
+    reader: fgumi_raw_bam::RawBamReader<R>,
+    /// Lookahead record (peeked from the stream but not yet consumed)
+    pending: Option<RawRecord>,
+    /// Whether the underlying reader has been exhausted
+    exhausted: bool,
 }
 
-impl<I> TemplateIterator<I>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-{
-    /// Creates a new `TemplateIterator`
+impl<R: std::io::Read> TemplateIterator<R> {
+    /// Creates a new `RawTemplateIterator` from a [`RawBamReader`].
     ///
-    /// # Arguments
-    ///
-    /// * `record_iter` - Iterator over records to group into templates
-    ///
-    /// # Returns
-    ///
-    /// A new `TemplateIterator` ready to produce Templates
-    pub fn new(record_iter: I) -> Self {
-        TemplateIterator { record_iter, builder: Builder::new() }
+    /// The reader must already have had its header consumed (e.g., via
+    /// [`create_raw_bam_reader`]).
+    pub fn new(reader: fgumi_raw_bam::RawBamReader<R>) -> Self {
+        TemplateIterator { reader, pending: None, exhausted: false }
     }
 }
 
-impl<I> Iterator for TemplateIterator<I>
-where
-    I: Iterator<Item = Result<RecordBuf>>,
-{
+impl<R: std::io::Read> Iterator for TemplateIterator<R> {
     type Item = Result<Template>;
 
-    /// Returns the next Template from the record iterator
-    ///
-    /// Reads records until the query name changes, then returns the completed
-    /// template. On EOF, returns any remaining template, then None.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Ok(Template))` - Next template successfully read
-    /// * `Some(Err(_))` - Error from underlying iterator
-    /// * `None` - No more templates (EOF reached)
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.record_iter.next() {
-                None => {
-                    // EOF - return any remaining template
-                    if self.builder.is_empty() {
-                        return None;
-                    }
-                    return Some(self.builder.build());
-                }
-                Some(Err(e)) => {
-                    // Error from underlying iterator
-                    return Some(Err(e));
-                }
-                Some(Ok(record)) => {
-                    let name: Vec<u8> = if let Some(n) = record.name() {
-                        Vec::from(<_ as AsRef<[u8]>>::as_ref(n))
-                    } else {
-                        Vec::new()
-                    };
+        if self.exhausted && self.pending.is_none() {
+            return None;
+        }
 
-                    if self.builder.name.iter().any(|n| *n == name) || self.builder.is_empty() {
-                        if let Err(e) = self.builder.push(record) {
-                            return Some(Err(e));
-                        }
+        let mut batch: Vec<RawRecord> = Vec::with_capacity(2);
+
+        // Take any previously-peeked record as the first in this batch
+        if let Some(peeked) = self.pending.take() {
+            batch.push(peeked);
+        }
+
+        // Read records until the query name changes or we exhaust the reader
+        loop {
+            if self.exhausted {
+                break;
+            }
+            let mut rec = RawRecord::new();
+            match self.reader.read_record(&mut rec) {
+                Ok(0) => {
+                    self.exhausted = true;
+                    break;
+                }
+                Ok(_) => {
+                    let name = fgumi_raw_bam::read_name(&rec).to_vec();
+                    if batch.is_empty() {
+                        batch.push(rec);
                     } else {
-                        let template: std::result::Result<Template, anyhow::Error> =
-                            self.builder.build();
-                        if let Err(e) = self.builder.push(record) {
-                            return Some(Err(e));
+                        let first_name = fgumi_raw_bam::read_name(&batch[0]).to_vec();
+                        if name == first_name {
+                            batch.push(rec);
+                        } else {
+                            // Different name — save for the next template
+                            self.pending = Some(rec);
+                            break;
                         }
-                        return Some(template);
                     }
                 }
+                Err(e) => return Some(Err(anyhow::Error::from(e))),
             }
         }
+
+        if batch.is_empty() {
+            return None;
+        }
+
+        Some(Template::from_records(batch))
     }
 }
 
@@ -1840,22 +876,11 @@ impl MemoryEstimate for Template {
         // name: Vec<u8>
         let name_size = self.name.capacity();
 
-        // records: Vec<RecordBuf>
-        // Each RecordBuf contains:
-        // - name: Option<BString> (Vec<u8>)
-        // - sequence: Sequence (Vec<u8>)
-        // - quality_scores: QualityScores (Vec<u8>)
-        // - cigar: Cigar (Vec<Op>)
-        // - data: Data (IndexMap of tags to values)
-        let records_size: usize = self.records.iter().map(estimate_record_buf_heap_size).sum();
-        let records_vec_overhead = self.records.capacity() * std::mem::size_of::<RecordBuf>();
+        // records: Vec<RawRecord>
+        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
+            + self.records.capacity() * std::mem::size_of::<RawRecord>();
 
-        let raw_records_size = self.raw_records.as_ref().map_or(0, |rr| {
-            rr.iter().map(RawRecord::capacity).sum::<usize>()
-                + rr.capacity() * std::mem::size_of::<RawRecord>()
-        });
-
-        name_size + records_size + records_vec_overhead + raw_records_size
+        name_size + records_size
     }
 }
 
@@ -1866,72 +891,11 @@ impl MemoryEstimate for TemplateBatch {
     }
 }
 
-/// Estimate heap size of a `RecordBuf`.
-///
-/// This function estimates the heap memory used by a noodles `RecordBuf`,
-/// including its name, sequence, quality scores, CIGAR, and data fields.
-///
-/// noodles `RecordBuf` layout:
-/// - name: `Option<BString>` (`Vec<u8>`) - heap allocated
-/// - sequence: `Sequence` (`Vec<u8>`, 1 byte per base, unpacked ASCII)
-/// - `quality_scores`: `QualityScores` (`Vec<u8>`)
-/// - cigar: `Cigar` (`Vec<Op>`, each `Op` is 4 bytes)
-/// - data: Data (`IndexMap`<Tag, Value>) - significant overhead from hash table
-#[must_use]
-pub fn estimate_record_buf_heap_size(record: &RecordBuf) -> usize {
-    // Name: Option<BString> which is a Vec<u8>
-    // NB: noodles API returns &BStr, so we can only measure len(), not capacity().
-    // Same constraint applies to sequence and quality_scores below.
-    let name_size = record.name().map_or(0, |n| n.len());
-
-    // Sequence: noodles stores bases as unpacked ASCII (1 byte per base in Vec<u8>)
-    // .len() returns number of bases, which equals the heap allocation in bytes
-    let seq_len = record.sequence().len();
-
-    // Quality scores: Vec<u8>, one byte per base
-    let qual_len = record.quality_scores().len();
-
-    // CIGAR: Vec<Op> where each Op is 4 bytes (u32)
-    let cigar_ops = record.cigar().as_ref().len();
-    let cigar_size = cigar_ops * 4;
-
-    // Data fields: IndexMap<Tag, Value>
-    // IndexMap stores entries in a Vec<Bucket<(K, V)>> plus a hash table Vec<usize>.
-    // - Each entry: Tag (2 bytes) + Value enum (~40 bytes on stack for noodles Value)
-    //   + padding = ~48 bytes per entry in the entries vec
-    // - Hash table: capacity * 8 bytes (indices) + capacity * 8 bytes (hashes)
-    //   With ~87.5% load factor, capacity ~= count * 1.15
-    // - Values with heap allocation (String, Array): add ~24 bytes (Vec header) + data
-    //   Typical BAM tags: RX/QX (string, ~20 bytes), MI (int, no heap), CB/CR (string, ~16 bytes)
-    //   Estimate ~32 bytes average heap per string-type field, ~50% of fields are strings
-    let data_fields = record.data().iter().count();
-    let entry_capacity = (data_fields * 115) / 100 + 1; // ~1.15x for load factor
-    let entries_size = data_fields * 48; // entry vec storage
-    let hash_table_size = entry_capacity * 16; // hash + index arrays
-    let value_heap_size = data_fields * 16; // average heap per field (50% strings × 32 bytes)
-    let data_size = entries_size + hash_table_size + value_heap_size;
-
-    // Note: RecordBuf inline struct overhead (flags, position, etc.) is accounted for
-    // by the caller via `capacity * size_of::<RecordBuf>()`, so we only count heap allocations here.
-    name_size + seq_len + qual_len + cigar_size + data_size
-}
-
 #[cfg(test)]
 #[allow(clippy::similar_names)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
-    use noodles::sam::alignment::record::Flags;
-    use noodles::sam::alignment::record::cigar::Op;
-    use noodles::sam::alignment::record::cigar::op::Kind;
-    use noodles::sam::alignment::record_buf::Cigar as CigarBuf;
-
-    fn create_test_record(name: &[u8], flags: u16) -> RecordBuf {
-        RecordBuilder::new()
-            .name(std::str::from_utf8(name).expect("read name should be valid UTF-8"))
-            .flags(Flags::from(flags))
-            .build()
-    }
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags as raw_flags};
 
     // SAM flag constants
     const FLAG_PAIRED: u16 = 0x1;
@@ -1939,6 +903,74 @@ mod tests {
     const FLAG_READ2: u16 = 0x80;
     const FLAG_SECONDARY: u16 = 0x100;
     const FLAG_SUPPLEMENTARY: u16 = 0x800;
+    const FLAG_REVERSE: u16 = 0x10;
+    const FLAG_MATE_REVERSE: u16 = 0x20;
+    const FLAG_UNMAPPED: u16 = 0x4;
+    const FLAG_MATE_UNMAPPED: u16 = 0x8;
+
+    /// Create a simple test raw record with given name and flags.
+    fn create_test_raw(name: &[u8], flags: u16) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flags);
+        b.build()
+    }
+
+    /// Create a mapped test raw record with position and CIGAR.
+    fn create_mapped_raw(name: &[u8], flags: u16, pos: usize, mapq: u8) -> RawRecord {
+        create_mapped_raw_with_tlen(name, flags, pos, mapq, 0)
+    }
+
+    /// Create a mapped test raw record with position, CIGAR, and TLEN.
+    fn create_mapped_raw_with_tlen(
+        name: &[u8],
+        flags: u16,
+        pos: usize,
+        mapq: u8,
+        tlen: i32,
+    ) -> RawRecord {
+        use fgumi_raw_bam::testutil::encode_op;
+        let mut b = RawSamBuilder::new();
+        b.read_name(name)
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(flags)
+            .ref_id(0)
+            .pos(i32::try_from(pos).expect("pos fits i32") - 1)
+            .mapq(mapq)
+            .template_length(tlen)
+            .cigar_ops(&[encode_op(0, 100)]);
+        b.build()
+    }
+
+    /// Create a mapped test raw record with full fields.
+    fn create_mapped_raw_with_flags(
+        name: &[u8],
+        flags: u16,
+        pos: usize,
+        mapq: u8,
+        tlen: i32,
+        mate_ref_id: Option<usize>,
+        mate_pos: Option<usize>,
+    ) -> RawRecord {
+        use fgumi_raw_bam::testutil::encode_op;
+        let mut b = RawSamBuilder::new();
+        b.read_name(name)
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(flags)
+            .ref_id(0)
+            .pos(i32::try_from(pos).expect("pos fits i32") - 1)
+            .mapq(mapq)
+            .template_length(tlen)
+            .cigar_ops(&[encode_op(0, 100)]);
+        if let Some(mref) = mate_ref_id {
+            b.mate_ref_id(i32::try_from(mref).expect("mate_ref_id fits i32"));
+        }
+        if let Some(mpos) = mate_pos {
+            b.mate_pos(i32::try_from(mpos).expect("mate_pos fits i32") - 1);
+        }
+        b.build()
+    }
 
     #[test]
     fn test_template_new() {
@@ -1948,98 +980,9 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_empty() {
-        let builder = Builder::new();
-        assert!(builder.is_empty());
-        assert_eq!(builder.len(), 0);
-    }
-
-    #[test]
-    fn test_builder_push_r1_only() -> Result<()> {
-        let mut builder = Builder::new();
-        let r1 = create_test_record(b"read1", 0);
-        builder.push(r1)?;
-        assert_eq!(builder.len(), 1);
-        assert!(!builder.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn test_builder_push_paired_end() -> Result<()> {
-        let mut builder = Builder::new();
-        let r1 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2);
-        builder.push(r1)?;
-        builder.push(r2)?;
-        assert_eq!(builder.len(), 2);
-        Ok(())
-    }
-
-    #[test]
-    fn test_builder_push_supplementary() -> Result<()> {
-        let mut builder = Builder::new();
-        let supp = create_test_record(b"read1", FLAG_SUPPLEMENTARY);
-        builder.push(supp)?;
-        assert_eq!(builder.len(), 1);
-        Ok(())
-    }
-
-    #[test]
-    fn test_builder_push_secondary() -> Result<()> {
-        let mut builder = Builder::new();
-        let sec = create_test_record(b"read1", FLAG_SECONDARY);
-        builder.push(sec)?;
-        assert_eq!(builder.len(), 1);
-        Ok(())
-    }
-
-    #[test]
-    fn test_builder_error_on_name_mismatch() {
-        let mut builder = Builder::new();
-        let r1 = create_test_record(b"read1", 0);
-        let r2 = create_test_record(b"read2", 0);
-        builder.push(r1).expect("failed to push record to builder");
-        let result = builder.push(r2);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("mismatch"));
-    }
-
-    #[test]
-    fn test_builder_error_on_multiple_r1() {
-        let mut builder = Builder::new();
-        let r1a = create_test_record(b"read1", 0);
-        let r1b = create_test_record(b"read1", 0);
-        builder.push(r1a).expect("failed to push record to builder");
-        let result = builder.push(r1b);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Multiple non-secondary"));
-    }
-
-    #[test]
-    fn test_builder_error_on_multiple_r2() {
-        let mut builder = Builder::new();
-        let r2a = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let r2b = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2);
-        builder.push(r2a).expect("failed to push record to builder");
-        let result = builder.push(r2b);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Multiple non-secondary"));
-    }
-
-    #[test]
-    fn test_builder_build_empty_error() {
-        let mut builder = Builder::new();
-        let result = builder.build();
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No records"));
-    }
-
-    #[test]
-    fn test_builder_build_success() -> Result<()> {
-        let mut builder = Builder::new();
-        let r1 = create_test_record(b"read1", 0);
-        builder.push(r1)?;
-        let template = builder.build()?;
+    fn test_from_records_single_r1() -> Result<()> {
+        let r1 = create_test_raw(b"read1", 0);
+        let template = Template::from_records(vec![r1])?;
         assert_eq!(template.name, b"read1");
         assert_eq!(template.read_count(), 1);
         assert!(template.r1().is_some());
@@ -2047,12 +990,62 @@ mod tests {
     }
 
     #[test]
-    fn test_template_from_records() -> Result<()> {
-        let records = vec![
-            create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1),
-            create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2),
-        ];
-        let template = Template::from_records(records)?;
+    fn test_from_records_paired() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let template = Template::from_records(vec![r1, r2])?;
+        assert_eq!(template.read_count(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_records_supplementary() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let supp = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let template = Template::from_records(vec![r1, supp])?;
+        assert_eq!(template.read_count(), 2);
+        assert!(template.r1().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_records_error_name_mismatch() {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let supp = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let r2_wrong = create_test_raw(b"read2", FLAG_PAIRED | FLAG_READ2);
+        let result = Template::from_records(vec![r1, supp, r2_wrong]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_records_error_multiple_r1() {
+        let r1a = create_test_raw(b"read1", 0);
+        let r1b = create_test_raw(b"read1", 0);
+        let result = Template::from_records(vec![r1a, r1b]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Multiple non-secondary"));
+    }
+
+    #[test]
+    fn test_from_records_error_multiple_r2() {
+        let r2a = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let r2b = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let result = Template::from_records(vec![r2a, r2b]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Multiple non-secondary"));
+    }
+
+    #[test]
+    fn test_from_records_error_empty() {
+        let result = Template::from_records(vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_template_from_records_basic() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let template = Template::from_records(vec![r1, r2])?;
         assert_eq!(template.read_count(), 2);
         assert!(template.r1().is_some());
         assert!(template.r2().is_some());
@@ -2060,310 +1053,138 @@ mod tests {
     }
 
     #[test]
-    fn test_template_primary_reads() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1))?;
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2))?;
-        let template = builder.build()?;
+    fn test_primary_reads_iter() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let template = Template::from_records(vec![r1, r2])?;
         let primaries: Vec<_> = template.primary_reads().collect();
         assert_eq!(primaries.len(), 2);
         Ok(())
     }
 
     #[test]
-    fn test_template_into_primary_reads() -> Result<()> {
-        let records = vec![
-            create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1),
-            create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2),
-        ];
-        let template = Template::from_records(records)?;
-
-        // Verify we have both reads before consuming
+    fn test_into_records_consumes() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let template = Template::from_records(vec![r1, r2])?;
         assert!(template.r1().is_some());
         assert!(template.r2().is_some());
-
-        // Consume the template and get owned reads
-        let (r1, r2) = template.into_primary_reads();
-
-        // Both should be Some
-        assert!(r1.is_some());
-        assert!(r2.is_some());
-
-        // Verify the records have the expected flags
-        let r1 = r1.expect("R1 record should be present");
-        let r2 = r2.expect("R2 record should be present");
-        assert!(r1.flags().is_first_segment());
-        assert!(r2.flags().is_last_segment());
-
+        let recs = template.into_records();
+        assert_eq!(recs.len(), 2);
         Ok(())
     }
 
     #[test]
-    fn test_template_into_primary_reads_r1_only() -> Result<()> {
-        let records = vec![create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1)];
-        let template = Template::from_records(records)?;
-
-        let (r1, r2) = template.into_primary_reads();
-
-        assert!(r1.is_some());
-        assert!(r2.is_none());
-
+    fn test_read_count_with_supplementals() -> Result<()> {
+        let r1 = create_test_raw(b"read1", 0);
+        let supp = create_test_raw(b"read1", FLAG_SUPPLEMENTARY);
+        let sec = create_test_raw(b"read1", FLAG_SECONDARY);
+        let template = Template::from_records(vec![r1, supp, sec])?;
+        assert_eq!(template.read_count(), 3);
         Ok(())
     }
 
     #[test]
-    fn test_template_all_reads() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", 0))?;
-        builder.push(create_test_record(b"read1", FLAG_SUPPLEMENTARY))?;
-        builder.push(create_test_record(b"read1", FLAG_SECONDARY))?;
-        let template = builder.build()?;
-        let all: Vec<_> = template.all_reads().collect();
-        assert_eq!(all.len(), 3);
+    fn test_r1_supplementals_range() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let supp1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let supp2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let template = Template::from_records(vec![r1, supp1, supp2])?;
+        // r1_supplementals is a range (start, end) into records
+        assert!(template.r1_supplementals.is_some());
+        let (start, end) = template.r1_supplementals.unwrap();
+        assert_eq!(end - start, 2);
         Ok(())
     }
 
     #[test]
-    fn test_template_all_r1s() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1))?;
-        builder
-            .push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))?;
-        let template = builder.build()?;
-        let all_r1s: Vec<_> = template.all_r1s().collect();
-        assert_eq!(all_r1s.len(), 2);
+    fn test_r2_supplementals_range() -> Result<()> {
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let supp = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY);
+        let template = Template::from_records(vec![r1, r2, supp])?;
+        assert!(template.r2_supplementals.is_some());
+        let (start, end) = template.r2_supplementals.unwrap();
+        assert_eq!(end - start, 1);
         Ok(())
     }
 
     #[test]
-    fn test_template_all_r2s() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2))?;
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY))?;
-        let template = builder.build()?;
-        let all_r2s: Vec<_> = template.all_r2s().collect();
-        assert_eq!(all_r2s.len(), 2);
+    fn test_r1_secondaries_range() -> Result<()> {
+        let r1 = create_test_raw(b"read1", 0);
+        let sec = create_test_raw(b"read1", FLAG_SECONDARY);
+        let template = Template::from_records(vec![r1, sec])?;
+        assert!(template.r1_secondaries.is_some());
+        let (start, end) = template.r1_secondaries.unwrap();
+        assert_eq!(end - start, 1);
         Ok(())
     }
 
     #[test]
-    fn test_template_supplementals_and_secondaries() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", 0))?;
-        builder.push(create_test_record(b"read1", FLAG_SUPPLEMENTARY))?;
-        builder.push(create_test_record(b"read1", FLAG_SECONDARY))?;
-        let template = builder.build()?;
-        let non_primary: Vec<_> = template.all_supplementary_and_secondary().collect();
-        assert_eq!(non_primary.len(), 2);
+    fn test_r2_secondaries_range() -> Result<()> {
+        let r2a = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let r2b = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
+        let r2c = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
+        let template = Template::from_records(vec![r2a, r2b, r2c])?;
+        assert!(template.r2_secondaries.is_some());
+        let (start, end) = template.r2_secondaries.unwrap();
+        assert_eq!(end - start, 2);
         Ok(())
     }
 
-    #[test]
-    fn test_cigar_to_string() {
-        use noodles::sam::alignment::record_buf::Cigar;
-        let cigar = Cigar::default();
-        assert_eq!(cigar_to_string(&cigar).expect("cigar_to_string should succeed"), "*");
+    /// Helper to create a mapped record with position and CIGAR for `fix_mate_info` tests.
+    /// Delegates to the raw helper.
+    fn create_mapped_record(name: &[u8], flags: u16, pos: usize, mapq: u8) -> RawRecord {
+        create_mapped_raw(name, flags, pos, mapq)
     }
 
-    #[test]
-    fn test_cigar_to_string_with_ops() {
-        let ops =
-            vec![Op::new(Kind::Match, 10), Op::new(Kind::Deletion, 2), Op::new(Kind::Match, 5)];
-        let cigar = CigarBuf::from(ops);
-        let result = cigar_to_string(&cigar).expect("cigar_to_string should succeed");
-        assert_eq!(result, "10M2D5M");
-    }
-
-    #[test]
-    fn test_template_builder_reuse() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", 0))?;
-        let template1 = builder.build()?;
-        assert_eq!(template1.name, b"read1");
-        builder.push(create_test_record(b"read2", 0))?;
-        let template2 = builder.build()?;
-        assert_eq!(template2.name, b"read2");
-        Ok(())
-    }
-
-    #[test]
-    fn test_template_r1_supplementals() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1))?;
-        builder
-            .push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))?;
-        builder
-            .push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY))?;
-        let template = builder.build()?;
-        let supps = template.r1_supplementals();
-        assert_eq!(supps.len(), 2);
-        Ok(())
-    }
-
-    #[test]
-    fn test_template_r2_supplementals() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2))?;
-        builder
-            .push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY))?;
-        let template = builder.build()?;
-        let supps = template.r2_supplementals();
-        assert_eq!(supps.len(), 1);
-        Ok(())
-    }
-
-    #[test]
-    fn test_template_r1_secondaries() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", 0))?;
-        builder.push(create_test_record(b"read1", FLAG_SECONDARY))?;
-        let template = builder.build()?;
-        let secs = template.r1_secondaries();
-        assert_eq!(secs.len(), 1);
-        Ok(())
-    }
-
-    #[test]
-    fn test_template_r2_secondaries() -> Result<()> {
-        let mut builder = Builder::new();
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2))?;
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY))?;
-        builder.push(create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY))?;
-        let template = builder.build()?;
-        let secs = template.r2_secondaries();
-        assert_eq!(secs.len(), 2);
-        Ok(())
-    }
-
-    // Tests for extract_int_value helper function
-    #[test]
-    fn test_extract_int_value_int8() {
-        let value = BufValue::Int8(42);
-        assert_eq!(extract_int_value(&value), Some(42));
-    }
-
-    #[test]
-    fn test_extract_int_value_int16() {
-        let value = BufValue::Int16(1234);
-        assert_eq!(extract_int_value(&value), Some(1234));
-    }
-
-    #[test]
-    fn test_extract_int_value_int32() {
-        let value = BufValue::Int32(123_456);
-        assert_eq!(extract_int_value(&value), Some(123_456));
-    }
-
-    #[test]
-    fn test_extract_int_value_uint8() {
-        let value = BufValue::UInt8(255);
-        assert_eq!(extract_int_value(&value), Some(255));
-    }
-
-    #[test]
-    fn test_extract_int_value_uint16() {
-        let value = BufValue::UInt16(65535);
-        assert_eq!(extract_int_value(&value), Some(65535));
-    }
-
-    #[test]
-    fn test_extract_int_value_uint32() {
-        let value = BufValue::UInt32(100_000);
-        assert_eq!(extract_int_value(&value), Some(100_000));
-    }
-
-    #[test]
-    fn test_extract_int_value_uint32_overflow() {
-        // Value too large to fit in i32
-        let value = BufValue::UInt32(u32::MAX);
-        assert_eq!(extract_int_value(&value), None);
-    }
-
-    #[test]
-    fn test_extract_int_value_string_returns_none() {
-        let value = BufValue::String("test".into());
-        assert_eq!(extract_int_value(&value), None);
-    }
-
-    #[test]
-    fn test_extract_int_value_negative() {
-        let value = BufValue::Int8(-42);
-        assert_eq!(extract_int_value(&value), Some(-42));
-
-        let value = BufValue::Int16(-1234);
-        assert_eq!(extract_int_value(&value), Some(-1234));
-
-        let value = BufValue::Int32(-123_456);
-        assert_eq!(extract_int_value(&value), Some(-123_456));
-    }
-
-    /// Helper to create a mapped record with position and CIGAR for `fix_mate_info` tests
-    fn create_mapped_record(name: &[u8], flags: u16, pos: usize, mapq: u8) -> RecordBuf {
-        create_mapped_record_with_tlen(name, flags, pos, mapq, 0)
-    }
-
-    /// Helper to create a mapped record with position, CIGAR, and TLEN for `fix_mate_info` tests
+    /// Helper to create a mapped record with position, CIGAR, and TLEN for `fix_mate_info` tests.
+    /// Delegates to the raw helper.
     fn create_mapped_record_with_tlen(
         name: &[u8],
         flags: u16,
         pos: usize,
         mapq: u8,
         tlen: i32,
-    ) -> RecordBuf {
-        let is_read1 = (flags & FLAG_READ1) != 0;
-        let is_paired = (flags & FLAG_PAIRED) != 0;
-
-        let mut builder = RecordBuilder::new()
-            .name(std::str::from_utf8(name).expect("read name should be valid UTF-8"))
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .cigar("100M")
-            .reference_sequence_id(0)
-            .alignment_start(pos)
-            .mapping_quality(mapq)
-            .template_length(tlen);
-
-        if is_paired {
-            builder = builder.first_segment(is_read1);
-        }
-
-        // Handle secondary/supplementary flags - directly set flags for non-standard combinations
-        let mut record = builder.build();
-        // Apply any additional flags not covered by builder methods
-        *record.flags_mut() = Flags::from(flags);
-
-        record
+    ) -> RawRecord {
+        create_mapped_raw_with_tlen(name, flags, pos, mapq, tlen)
     }
 
     /// Tests that `fix_mate_info` correctly sets ms tag when AS is stored as `Int8`.
     /// This was a bug where only `Int32` AS values were recognized.
     #[test]
     fn test_fix_mate_info_sets_ms_tag_with_int8_as() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 55);
+        let r1 = b.build();
 
-        let mut r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
-        r1.data_mut().insert(as_tag, BufValue::Int8(55)); // AS as Int8 (small value)
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 44);
+        let r2 = b.build();
 
-        let mut r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
-        r2.data_mut().insert(as_tag, BufValue::Int8(44)); // AS as Int8 (small value)
-
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
         // R1 should have ms tag with R2's AS value (44)
-        let r1_ms = template.records[0].data().get(&ms_tag);
-        assert!(r1_ms.is_some(), "R1 should have ms tag");
-        assert_eq!(extract_int_value(r1_ms.expect("R1 ms tag should be present")), Some(44));
-
+        assert_eq!(template.records()[0].tags().find_int(b"ms"), Some(44), "R1 ms should be 44");
         // R2 should have ms tag with R1's AS value (55)
-        let r2_ms = template.records[1].data().get(&ms_tag);
-        assert!(r2_ms.is_some(), "R2 should have ms tag");
-        assert_eq!(extract_int_value(r2_ms.expect("R2 ms tag should be present")), Some(55));
+        assert_eq!(template.records()[1].tags().find_int(b"ms"), Some(55), "R2 ms should be 55");
 
         Ok(())
     }
@@ -2371,31 +1192,35 @@ mod tests {
     /// Tests that `fix_mate_info` correctly sets ms tag when AS is stored as `UInt8`
     #[test]
     fn test_fix_mate_info_sets_ms_tag_with_uint8_as() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 77);
+        let r1 = b.build();
 
-        let mut r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
-        r1.data_mut().insert(as_tag, BufValue::UInt8(77)); // AS as UInt8
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 88);
+        let r2 = b.build();
 
-        let mut r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
-        r2.data_mut().insert(as_tag, BufValue::UInt8(88)); // AS as UInt8
-
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // R1 should have ms tag with R2's AS value (88)
-        let r1_ms = template.records[0].data().get(&ms_tag);
-        assert!(r1_ms.is_some(), "R1 should have ms tag");
-        assert_eq!(extract_int_value(r1_ms.expect("R1 ms tag should be present")), Some(88));
-
-        // R2 should have ms tag with R1's AS value (77)
-        let r2_ms = template.records[1].data().get(&ms_tag);
-        assert!(r2_ms.is_some(), "R2 should have ms tag");
-        assert_eq!(extract_int_value(r2_ms.expect("R2 ms tag should be present")), Some(77));
+        assert_eq!(template.records()[0].tags().find_int(b"ms"), Some(88), "R1 ms should be 88");
+        assert_eq!(template.records()[1].tags().find_int(b"ms"), Some(77), "R2 ms should be 77");
 
         Ok(())
     }
@@ -2403,31 +1228,43 @@ mod tests {
     /// Tests that `fix_mate_info` correctly sets ms tag when AS is stored as `Int16`
     #[test]
     fn test_fix_mate_info_sets_ms_tag_with_int16_as() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 1000);
+        let r1 = b.build();
 
-        let mut r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
-        r1.data_mut().insert(as_tag, BufValue::Int16(1000)); // AS as Int16
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 2000);
+        let r2 = b.build();
 
-        let mut r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
-        r2.data_mut().insert(as_tag, BufValue::Int16(2000)); // AS as Int16
-
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // R1 should have ms tag with R2's AS value (2000)
-        let r1_ms = template.records[0].data().get(&ms_tag);
-        assert!(r1_ms.is_some(), "R1 should have ms tag");
-        assert_eq!(extract_int_value(r1_ms.expect("R1 ms tag should be present")), Some(2000));
-
-        // R2 should have ms tag with R1's AS value (1000)
-        let r2_ms = template.records[1].data().get(&ms_tag);
-        assert!(r2_ms.is_some(), "R2 should have ms tag");
-        assert_eq!(extract_int_value(r2_ms.expect("R2 ms tag should be present")), Some(1000));
+        assert_eq!(
+            template.records()[0].tags().find_int(b"ms"),
+            Some(2000),
+            "R1 ms should be 2000"
+        );
+        assert_eq!(
+            template.records()[1].tags().find_int(b"ms"),
+            Some(1000),
+            "R2 ms should be 1000"
+        );
 
         Ok(())
     }
@@ -2435,31 +1272,43 @@ mod tests {
     /// Tests that `fix_mate_info` correctly sets ms tag when AS is stored as `Int32`
     #[test]
     fn test_fix_mate_info_sets_ms_tag_with_int32_as() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 100_000);
+        let r1 = b.build();
 
-        let mut r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
-        r1.data_mut().insert(as_tag, BufValue::Int32(100_000)); // AS as Int32
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 200_000);
+        let r2 = b.build();
 
-        let mut r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
-        r2.data_mut().insert(as_tag, BufValue::Int32(200_000)); // AS as Int32
-
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // R1 should have ms tag with R2's AS value
-        let r1_ms = template.records[0].data().get(&ms_tag);
-        assert!(r1_ms.is_some(), "R1 should have ms tag");
-        assert_eq!(extract_int_value(r1_ms.expect("R1 ms tag should be present")), Some(200_000));
-
-        // R2 should have ms tag with R1's AS value
-        let r2_ms = template.records[1].data().get(&ms_tag);
-        assert!(r2_ms.is_some(), "R2 should have ms tag");
-        assert_eq!(extract_int_value(r2_ms.expect("R2 ms tag should be present")), Some(100_000));
+        assert_eq!(
+            template.records()[0].tags().find_int(b"ms"),
+            Some(200_000),
+            "R1 ms should be 200_000"
+        );
+        assert_eq!(
+            template.records()[1].tags().find_int(b"ms"),
+            Some(100_000),
+            "R2 ms should be 100_000"
+        );
 
         Ok(())
     }
@@ -2467,21 +1316,21 @@ mod tests {
     /// Tests that `fix_mate_info` does not set ms tag when AS is missing
     #[test]
     fn test_fix_mate_info_no_ms_tag_without_as() -> Result<()> {
-        let ms_tag = Tag::from(SamTag::MS);
-
         let r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
         let r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
         // Neither record should have ms tag since AS is missing
-        assert!(template.records[0].data().get(&ms_tag).is_none(), "R1 should not have ms tag");
-        assert!(template.records[1].data().get(&ms_tag).is_none(), "R2 should not have ms tag");
+        assert!(
+            template.records()[0].tags().find_int(b"ms").is_none(),
+            "R1 should not have ms tag"
+        );
+        assert!(
+            template.records()[1].tags().find_int(b"ms").is_none(),
+            "R2 should not have ms tag"
+        );
 
         Ok(())
     }
@@ -2489,33 +1338,41 @@ mod tests {
     /// Tests that `fix_mate_info` sets ms tag on supplementary alignments
     #[test]
     fn test_fix_mate_info_sets_ms_tag_on_supplementals() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 55);
+        let r1 = b.build();
 
-        let mut r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
-        r1.data_mut().insert(as_tag, BufValue::Int8(55));
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .add_int_tag(b"AS", 44);
+        let r2 = b.build();
 
-        let mut r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40);
-        r2.data_mut().insert(as_tag, BufValue::Int8(44));
-
-        let mut r1_supp =
+        let r1_supp =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY, 300, 20);
-        r1_supp.data_mut().insert(as_tag, BufValue::Int8(33));
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
         template.fix_mate_info()?;
 
-        // R1 supplementary should have ms tag with R2's AS value (44)
-        let r1_supp_ms = template.records[2].data().get(&ms_tag);
-        assert!(r1_supp_ms.is_some(), "R1 supplementary should have ms tag");
+        // After from_records: R1[0], R2[1], R1_supp[2]
         assert_eq!(
-            extract_int_value(r1_supp_ms.expect("R1 supplementary ms tag should be present")),
-            Some(44)
+            template.records()[2].tags().find_int(b"ms"),
+            Some(44),
+            "R1 supplementary ms should be R2's AS value (44)"
         );
 
         Ok(())
@@ -2525,11 +1382,8 @@ mod tests {
     /// TLEN should be set to negative of mate primary's (R2) TLEN.
     #[test]
     fn test_fix_mate_info_sets_tlen_on_r1_supplementals() -> Result<()> {
-        // R1 primary with TLEN=200
         let r1 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30, 200);
-        // R2 primary with TLEN=-200
         let r2 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40, -200);
-        // R1 supplementary with original TLEN=0
         let r1_supp = create_mapped_record_with_tlen(
             b"read1",
             FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY,
@@ -2538,18 +1392,13 @@ mod tests {
             0,
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
         template.fix_mate_info()?;
 
-        // R1 supplementary TLEN should be -(-101) = 101 (negative of R2's recalculated TLEN)
-        // R1(pos=100,forward) and R2(pos=200,forward) → 5' positions are 100 and 200 → insert_size = 101
+        // R1(pos=100,forward) and R2(pos=200,forward) → insert_size = 101
+        // R1 supplementary TLEN = -(-101) = 101
         assert_eq!(
-            template.records[2].template_length(),
+            template.records()[2].template_length(),
             101,
             "R1 supplementary TLEN should be negative of R2's TLEN"
         );
@@ -2561,11 +1410,8 @@ mod tests {
     /// TLEN should be set to negative of mate primary's (R1) TLEN.
     #[test]
     fn test_fix_mate_info_sets_tlen_on_r2_supplementals() -> Result<()> {
-        // R1 primary with TLEN=300
         let r1 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30, 300);
-        // R2 primary with TLEN=-300
         let r2 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40, -300);
-        // R2 supplementary with original TLEN=0
         let r2_supp = create_mapped_record_with_tlen(
             b"read1",
             FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY,
@@ -2574,18 +1420,13 @@ mod tests {
             0,
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r2_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r2_supp])?;
         template.fix_mate_info()?;
 
-        // R2 supplementary TLEN should be -(101) = -101 (negative of R1's recalculated TLEN)
-        // R1(pos=100,forward) and R2(pos=200,forward) → 5' positions are 100 and 200 → insert_size = 101
+        // R1(pos=100,forward) and R2(pos=200,forward) → insert_size = 101
+        // R2 supplementary TLEN = -(101) = -101
         assert_eq!(
-            template.records[2].template_length(),
+            template.records()[2].template_length(),
             -101,
             "R2 supplementary TLEN should be negative of R1's TLEN"
         );
@@ -2596,11 +1437,8 @@ mod tests {
     /// Tests that `fix_mate_info` handles multiple supplementary alignments
     #[test]
     fn test_fix_mate_info_sets_tlen_on_multiple_supplementals() -> Result<()> {
-        // R1 primary with TLEN=500
         let r1 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30, 500);
-        // R2 primary with TLEN=-500
         let r2 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40, -500);
-        // Two R1 supplementaries
         let r1_supp1 = create_mapped_record_with_tlen(
             b"read1",
             FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY,
@@ -2615,7 +1453,6 @@ mod tests {
             15,
             0,
         );
-        // Two R2 supplementaries
         let r2_supp1 = create_mapped_record_with_tlen(
             b"read1",
             FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY,
@@ -2631,27 +1468,19 @@ mod tests {
             0,
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp1)?;
-        builder.push(r1_supp2)?;
-        builder.push(r2_supp1)?;
-        builder.push(r2_supp2)?;
-        let mut template = builder.build()?;
-
+        // from_records orders: R1[0], R2[1], r1_supps reversed [2,3], r2_supps reversed [4,5]
+        let mut template =
+            Template::from_records(vec![r1, r2, r1_supp1, r1_supp2, r2_supp1, r2_supp2])?;
         template.fix_mate_info()?;
 
-        // Order: R1[0], R2[1], R1_supp1[2], R1_supp2[3], R2_supp1[4], R2_supp2[5]
-        // R1(pos=100,forward) and R2(pos=200,forward) → 5' positions are 100 and 200 → insert_size = 101
-
+        // R1(pos=100,forward) and R2(pos=200,forward) → insert_size = 101
         // R1 supplementaries should have TLEN = -(-101) = 101
-        assert_eq!(template.records[2].template_length(), 101, "R1 supp1 TLEN");
-        assert_eq!(template.records[3].template_length(), 101, "R1 supp2 TLEN");
+        assert_eq!(template.records()[2].template_length(), 101, "R1 supp1 TLEN");
+        assert_eq!(template.records()[3].template_length(), 101, "R1 supp2 TLEN");
 
         // R2 supplementaries should have TLEN = -(101) = -101
-        assert_eq!(template.records[4].template_length(), -101, "R2 supp1 TLEN");
-        assert_eq!(template.records[5].template_length(), -101, "R2 supp2 TLEN");
+        assert_eq!(template.records()[4].template_length(), -101, "R2 supp1 TLEN");
+        assert_eq!(template.records()[5].template_length(), -101, "R2 supp2 TLEN");
 
         Ok(())
     }
@@ -2659,8 +1488,6 @@ mod tests {
     /// Tests that `fix_mate_info` recalculates TLEN for supplementaries based on primary positions
     #[test]
     fn test_fix_mate_info_tlen_recalculated() -> Result<()> {
-        // Primary reads with TLEN=0 (initial value, will be recalculated)
-        // Note: even if original TLEN is 0, fix_mate_info recalculates based on positions
         let r1 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30, 0);
         let r2 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 40, 0);
         let r1_supp = create_mapped_record_with_tlen(
@@ -2668,21 +1495,15 @@ mod tests {
             FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY,
             300,
             20,
-            999, // Non-zero original TLEN (will be recalculated)
+            999,
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
         template.fix_mate_info()?;
 
-        // R1(pos=100,forward) and R2(pos=200,forward) → 5' positions are 100 and 200 → insert_size = 101
-        // R1 supplementary TLEN = -R2.TLEN = -(-101) = 101
+        // R1(pos=100,forward) and R2(pos=200,forward) → insert_size = 101
         assert_eq!(
-            template.records[2].template_length(),
+            template.records()[2].template_length(),
             101,
             "R1 supplementary TLEN should be recalculated from positions"
         );
@@ -2693,27 +1514,21 @@ mod tests {
     /// Tests that `fix_mate_info` doesn't affect supplementaries when mate primary is missing
     #[test]
     fn test_fix_mate_info_no_mate_primary() -> Result<()> {
-        // Only R1 primary (no R2 primary)
         let r1 = create_mapped_record_with_tlen(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30, 200);
-        // R1 supplementary
         let r1_supp = create_mapped_record_with_tlen(
             b"read1",
             FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY,
             300,
             20,
-            777, // Original TLEN
+            777,
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r1_supp])?;
         template.fix_mate_info()?;
 
-        // R1 supplementary TLEN should remain unchanged since there's no R2 primary
+        // No R2 primary, so R1 supplementary TLEN should remain unchanged
         assert_eq!(
-            template.records[1].template_length(),
+            template.records()[1].template_length(),
             777,
             "R1 supplementary TLEN should be unchanged without R2 primary"
         );
@@ -2721,32 +1536,25 @@ mod tests {
         Ok(())
     }
 
-    /// Tests record ordering in Template matches fgbio's ordering
+    /// Tests record ordering in Template matches fgbio's ordering.
     /// Order should be: R1, R2, `r1_supps`, `r2_supps`, `r1_secondaries`, `r2_secondaries`
     #[test]
     fn test_template_record_ordering() -> Result<()> {
-        let r1 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let r1_supp1 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
-        let r1_supp2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
-        let r2_supp = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY);
-        let r1_sec = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY);
-        let r2_sec1 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
-        let r2_sec2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
+        let r1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1);
+        let r2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2);
+        let r1_supp1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let r1_supp2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY);
+        let r2_supp = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY);
+        let r1_sec = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY);
+        let r2_sec1 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
+        let r2_sec2 = create_test_raw(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SECONDARY);
 
-        // Push in scrambled order
-        let mut builder = Builder::new();
-        builder.push(r2_sec1)?;
-        builder.push(r1_supp2)?;
-        builder.push(r1)?;
-        builder.push(r2_supp)?;
-        builder.push(r1_sec)?;
-        builder.push(r2)?;
-        builder.push(r2_sec2)?;
-        builder.push(r1_supp1)?;
-        let template = builder.build()?;
+        // Pass in scrambled order; from_records sorts into canonical order
+        let template = Template::from_records(vec![
+            r2_sec1, r1_supp2, r1, r2_supp, r1_sec, r2, r2_sec2, r1_supp1,
+        ])?;
 
-        // Verify indices
+        // Verify index ranges
         assert_eq!(template.r1, Some((0, 1)), "R1 should be at index 0");
         assert_eq!(template.r2, Some((1, 2)), "R2 should be at index 1");
         assert_eq!(template.r1_supplementals, Some((2, 4)), "R1 supps should be at indices 2-3");
@@ -2754,21 +1562,19 @@ mod tests {
         assert_eq!(template.r1_secondaries, Some((5, 6)), "R1 secs should be at index 5");
         assert_eq!(template.r2_secondaries, Some((6, 8)), "R2 secs should be at indices 6-7");
 
-        // Verify all_reads() returns in correct order
-        let all_reads: Vec<_> = template.all_reads().collect();
-        assert_eq!(all_reads.len(), 8);
+        // Verify record count
+        assert_eq!(template.read_count(), 8);
 
         // Verify flags match expected ordering
-        assert!(
-            all_reads[0].flags().is_first_segment() && !all_reads[0].flags().is_supplementary()
-        );
-        assert!(all_reads[1].flags().is_last_segment() && !all_reads[1].flags().is_supplementary());
-        assert!(all_reads[2].flags().is_first_segment() && all_reads[2].flags().is_supplementary());
-        assert!(all_reads[3].flags().is_first_segment() && all_reads[3].flags().is_supplementary());
-        assert!(all_reads[4].flags().is_last_segment() && all_reads[4].flags().is_supplementary());
-        assert!(all_reads[5].flags().is_first_segment() && all_reads[5].flags().is_secondary());
-        assert!(all_reads[6].flags().is_last_segment() && all_reads[6].flags().is_secondary());
-        assert!(all_reads[7].flags().is_last_segment() && all_reads[7].flags().is_secondary());
+        let recs = template.records();
+        assert!(recs[0].is_first_segment() && !recs[0].is_supplementary(), "R1 primary");
+        assert!(recs[1].is_last_segment() && !recs[1].is_supplementary(), "R2 primary");
+        assert!(recs[2].is_first_segment() && recs[2].is_supplementary(), "R1 supp[0]");
+        assert!(recs[3].is_first_segment() && recs[3].is_supplementary(), "R1 supp[1]");
+        assert!(recs[4].is_last_segment() && recs[4].is_supplementary(), "R2 supp");
+        assert!(recs[5].is_first_segment() && recs[5].is_secondary(), "R1 sec");
+        assert!(recs[6].is_last_segment() && recs[6].is_secondary(), "R2 sec[0]");
+        assert!(recs[7].is_last_segment() && recs[7].is_secondary(), "R2 sec[1]");
 
         Ok(())
     }
@@ -2777,68 +1583,53 @@ mod tests {
     /// This matches fgbio's behavior which uses Scala List prepend (r :: list).
     #[test]
     fn test_record_ordering_within_groups_is_reversed() -> Result<()> {
-        // Create records with distinct positions so we can verify ordering
         let r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
         let r2 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2, 200, 30);
-
-        // R1 supplementaries with positions 1000, 2000, 3000 (input order)
+        // R1 supplementaries input order: pos 1000, 2000, 3000
         let r1_supp1 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY, 1000, 20);
         let r1_supp2 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY, 2000, 20);
         let r1_supp3 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY, 3000, 20);
-
-        // R2 supplementaries with positions 4000, 5000 (input order)
+        // R2 supplementaries input order: pos 4000, 5000
         let r2_supp1 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY, 4000, 20);
         let r2_supp2 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY, 5000, 20);
-
-        // R1 secondaries with positions 6000, 7000 (input order)
+        // R1 secondaries input order: pos 6000, 7000
         let r1_sec1 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY, 6000, 10);
         let r1_sec2 =
             create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SECONDARY, 7000, 10);
 
-        // Push in input order
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp1)?;
-        builder.push(r1_supp2)?;
-        builder.push(r1_supp3)?;
-        builder.push(r2_supp1)?;
-        builder.push(r2_supp2)?;
-        builder.push(r1_sec1)?;
-        builder.push(r1_sec2)?;
+        let template = Template::from_records(vec![
+            r1, r2, r1_supp1, r1_supp2, r1_supp3, r2_supp1, r2_supp2, r1_sec1, r1_sec2,
+        ])?;
 
-        let template = builder.build()?;
+        let recs = template.records();
+        // Primaries first
+        assert_eq!(recs[0].pos() + 1, 100, "R1 primary");
+        assert_eq!(recs[1].pos() + 1, 200, "R2 primary");
 
-        // Helper to extract position as usize
-        let get_pos = |rec: &RecordBuf| -> usize { rec.alignment_start().map_or(0, |p| p.get()) };
+        // R1 supplementaries reversed: 3000, 2000, 1000
+        assert_eq!(recs[2].pos() + 1, 3000, "R1 supp in reverse order");
+        assert_eq!(recs[3].pos() + 1, 2000, "R1 supp in reverse order");
+        assert_eq!(recs[4].pos() + 1, 1000, "R1 supp in reverse order");
 
-        // Verify R1 and R2 primaries are first
-        assert_eq!(get_pos(&template.records[0]), 100, "R1 primary");
-        assert_eq!(get_pos(&template.records[1]), 200, "R2 primary");
+        // R2 supplementaries reversed: 5000, 4000
+        assert_eq!(recs[5].pos() + 1, 5000, "R2 supp in reverse order");
+        assert_eq!(recs[6].pos() + 1, 4000, "R2 supp in reverse order");
 
-        // Verify R1 supplementaries are in REVERSE input order: 3000, 2000, 1000
-        assert_eq!(get_pos(&template.records[2]), 3000, "R1 supp should be in reverse order");
-        assert_eq!(get_pos(&template.records[3]), 2000, "R1 supp should be in reverse order");
-        assert_eq!(get_pos(&template.records[4]), 1000, "R1 supp should be in reverse order");
-
-        // Verify R2 supplementaries are in REVERSE input order: 5000, 4000
-        assert_eq!(get_pos(&template.records[5]), 5000, "R2 supp should be in reverse order");
-        assert_eq!(get_pos(&template.records[6]), 4000, "R2 supp should be in reverse order");
-
-        // Verify R1 secondaries are in REVERSE input order: 7000, 6000
-        assert_eq!(get_pos(&template.records[7]), 7000, "R1 sec should be in reverse order");
-        assert_eq!(get_pos(&template.records[8]), 6000, "R1 sec should be in reverse order");
+        // R1 secondaries reversed: 7000, 6000
+        assert_eq!(recs[7].pos() + 1, 7000, "R1 sec in reverse order");
+        assert_eq!(recs[8].pos() + 1, 6000, "R1 sec in reverse order");
 
         Ok(())
     }
 
-    /// Helper to create a mapped record with specific flags including reverse strand
+    /// Helper to create a mapped record with specific flags including reverse strand.
+    /// Delegates to the raw helper.
     fn create_mapped_record_with_flags(
         name: &[u8],
         flags: u16,
@@ -2847,139 +1638,76 @@ mod tests {
         tlen: i32,
         mate_ref_id: Option<usize>,
         mate_pos: Option<usize>,
-    ) -> RecordBuf {
-        let is_read1 = (flags & FLAG_READ1) != 0;
-        let is_paired = (flags & FLAG_PAIRED) != 0;
-
-        let mut builder = RecordBuilder::new()
-            .name(std::str::from_utf8(name).expect("read name should be valid UTF-8"))
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .cigar("100M")
-            .reference_sequence_id(0)
-            .alignment_start(pos)
-            .mapping_quality(mapq)
-            .template_length(tlen);
-
-        if is_paired {
-            builder = builder.first_segment(is_read1);
-        }
-
-        if let Some(mate_ref) = mate_ref_id {
-            builder = builder.mate_reference_sequence_id(mate_ref);
-        }
-        if let Some(mate_p) = mate_pos {
-            builder = builder.mate_alignment_start(mate_p);
-        }
-
-        // Build and then override with exact flags
-        let mut record = builder.build();
-        *record.flags_mut() = Flags::from(flags);
-
-        record
+    ) -> RawRecord {
+        create_mapped_raw_with_flags(name, flags, pos, mapq, tlen, mate_ref_id, mate_pos)
     }
-
-    // Flag constants for reverse strand
-    const FLAG_REVERSE: u16 = 0x10;
-    const FLAG_MATE_REVERSE: u16 = 0x20;
-    const FLAG_UNMAPPED: u16 = 0x4;
-    const FLAG_MATE_UNMAPPED: u16 = 0x8;
 
     /// Tests that `fix_mate_info` sets mate info on R1 supplementary alignments correctly.
     /// The mate is R2 primary, so supplementary should get R2's info.
     #[test]
     fn test_fix_mate_info_sets_full_mate_info_on_r1_supplementals() -> Result<()> {
-        let mq_tag = Tag::from(SamTag::MQ);
-        let mc_tag = Tag::from(SamTag::MC);
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(200)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .add_int_tag(b"AS", 100);
+        let r1 = b.build();
 
-        // R1 primary at pos=100, forward strand, TLEN=200
-        let mut r1 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1,
-            100,
-            30,
-            200,
-            Some(0),
-            Some(200),
-        );
-        r1.data_mut().insert(as_tag, BufValue::Int32(100));
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+            .ref_id(0)
+            .pos(199)
+            .mapq(40)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(-200)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .add_int_tag(b"AS", 150);
+        let r2 = b.build();
 
-        // R2 primary at pos=200, reverse strand (0x10), TLEN=-200
-        let mut r2 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            200,
-            40,
-            -200,
-            Some(0),
-            Some(100),
-        );
-        r2.data_mut().insert(as_tag, BufValue::Int32(150));
-
-        // R1 supplementary at pos=500, originally has wrong mate info (will be corrected)
+        // R1 supp has wrong mate info (will be corrected by fix_mate_info)
         let r1_supp = create_mapped_record_with_flags(
             b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE, // has wrong mate_reverse
+            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE,
             500,
             25,
-            0, // wrong TLEN
+            0,
             Some(0),
-            Some(500), // wrong mate pos (points to self)
+            Some(500),
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
         template.fix_mate_info()?;
 
-        // Verify R1 supplementary (at index 2) has correct mate info from R2 primary
-        let supp = &template.records[2];
+        let supp = &template.records()[2];
 
-        // Mate position should be R2's position (200)
-        assert_eq!(
-            supp.mate_alignment_start().map(|p| p.get()),
-            Some(200),
-            "R1 supp should have mate pos from R2"
-        );
-
-        // Mate reference should be R2's reference (0)
-        assert_eq!(
-            supp.mate_reference_sequence_id(),
-            Some(0),
-            "R1 supp should have mate ref from R2"
-        );
-
-        // Mate reverse flag should be set (R2 is reverse)
-        assert!(
-            supp.flags().is_mate_reverse_complemented(),
-            "R1 supp should have mate_reverse set since R2 is reverse"
-        );
-
-        // Mate unmapped flag should NOT be set (R2 is mapped)
-        assert!(
-            !supp.flags().is_mate_unmapped(),
-            "R1 supp should NOT have mate_unmapped since R2 is mapped"
-        );
-
-        // TLEN should be negative of R2's TLEN
+        // Mate position should be R2's position (200 = 0-based 199 + 1)
+        assert_eq!(supp.mate_pos() + 1, 200, "R1 supp should have mate pos from R2");
+        // Mate ref should be 0 (R2's reference)
+        assert_eq!(supp.mate_ref_id(), 0, "R1 supp should have mate ref from R2");
+        // Mate reverse should be set (R2 is reverse)
+        assert!(supp.is_mate_reverse(), "R1 supp should have mate_reverse since R2 is reverse");
+        // Mate unmapped should NOT be set
+        assert!(!supp.is_mate_unmapped(), "R1 supp should NOT have mate_unmapped");
+        // TLEN should be -(-200) = 200
         assert_eq!(supp.template_length(), 200, "R1 supp TLEN should be -(-200) = 200");
-
-        // MQ tag should be R2's mapping quality (40)
-        let mq_value = supp.data().get(&mq_tag).and_then(extract_int_value);
-        assert_eq!(mq_value, Some(40), "R1 supp MQ should be R2's mapq");
-
-        // MC tag should be R2's CIGAR (100M)
-        let mc_value = supp.data().get(&mc_tag);
-        assert!(mc_value.is_some(), "R1 supp should have MC tag");
-
+        // MQ tag should be R2's mapq (40)
+        assert_eq!(supp.tags().find_int(b"MQ"), Some(40), "R1 supp MQ should be R2's mapq");
+        // MC tag should be present
+        assert!(supp.tags().find_string(b"MC").is_some(), "R1 supp should have MC tag");
         // ms tag should be R2's AS value (150)
-        let ms_value = supp.data().get(&ms_tag).and_then(extract_int_value);
-        assert_eq!(ms_value, Some(150), "R1 supp ms should be R2's AS value");
+        assert_eq!(supp.tags().find_int(b"ms"), Some(150), "R1 supp ms should be R2's AS");
 
         Ok(())
     }
@@ -2988,84 +1716,67 @@ mod tests {
     /// The mate is R1 primary, so supplementary should get R1's info.
     #[test]
     fn test_fix_mate_info_sets_full_mate_info_on_r2_supplementals() -> Result<()> {
-        let mq_tag = Tag::from(SamTag::MQ);
-        let mc_tag = Tag::from(SamTag::MC);
-        let as_tag = Tag::from(SamTag::AS);
-        let ms_tag = Tag::from(SamTag::MS);
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(35)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(300)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .add_int_tag(b"AS", 120);
+        let r1 = b.build();
 
-        // R1 primary at pos=100, forward strand, TLEN=300
-        let mut r1 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1,
-            100,
-            35,
-            300,
-            Some(0),
-            Some(200),
-        );
-        r1.data_mut().insert(as_tag, BufValue::Int32(120));
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2)
+            .ref_id(0)
+            .pos(199)
+            .mapq(45)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(-300)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .add_int_tag(b"AS", 180);
+        let r2 = b.build();
 
-        // R2 primary at pos=200, forward strand, TLEN=-300
-        let mut r2 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2,
-            200,
-            45,
-            -300,
-            Some(0),
-            Some(100),
-        );
-        r2.data_mut().insert(as_tag, BufValue::Int32(180));
-
-        // R2 supplementary at pos=600, originally has wrong mate info
         let r2_supp = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ2 | FLAG_SUPPLEMENTARY,
             600,
             20,
-            0, // wrong TLEN
+            0,
             Some(0),
-            Some(600), // wrong mate pos
+            Some(600),
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r2_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r2_supp])?;
         template.fix_mate_info()?;
 
-        // Verify R2 supplementary (at index 2) has correct mate info from R1 primary
-        let supp = &template.records[2];
+        let supp = &template.records()[2];
 
         // Mate position should be R1's position (100)
-        assert_eq!(
-            supp.mate_alignment_start().map(|p| p.get()),
-            Some(100),
-            "R2 supp should have mate pos from R1"
-        );
-
-        // Mate reverse flag should NOT be set (R1 is forward)
+        assert_eq!(supp.mate_pos() + 1, 100, "R2 supp should have mate pos from R1");
+        // Mate reverse should NOT be set (R1 is forward)
         assert!(
-            !supp.flags().is_mate_reverse_complemented(),
+            !supp.is_mate_reverse(),
             "R2 supp should NOT have mate_reverse since R1 is forward"
         );
-
-        // TLEN should be negative of R1's recalculated TLEN
-        // R1(pos=100,forward) and R2(pos=200,forward) → 5' positions are 100 and 200 → insert_size = 101
-        assert_eq!(supp.template_length(), -101, "R2 supp TLEN should be -(101) = -101");
-
-        // MQ tag should be R1's mapping quality (35)
-        let mq_value = supp.data().get(&mq_tag).and_then(extract_int_value);
-        assert_eq!(mq_value, Some(35), "R2 supp MQ should be R1's mapq");
-
+        // TLEN = -(101) = -101
+        // R1(pos=100,forward) and R2(pos=200,forward) → insert_size = 101
+        assert_eq!(supp.template_length(), -101, "R2 supp TLEN should be -101");
+        // MQ tag should be R1's mapq (35)
+        assert_eq!(supp.tags().find_int(b"MQ"), Some(35), "R2 supp MQ should be R1's mapq");
         // MC tag should be present
-        assert!(supp.data().get(&mc_tag).is_some(), "R2 supp should have MC tag");
-
+        assert!(supp.tags().find_string(b"MC").is_some(), "R2 supp should have MC tag");
         // ms tag should be R1's AS value (120)
-        let ms_value = supp.data().get(&ms_tag).and_then(extract_int_value);
-        assert_eq!(ms_value, Some(120), "R2 supp ms should be R1's AS value");
+        assert_eq!(supp.tags().find_int(b"ms"), Some(120), "R2 supp ms should be R1's AS");
 
         Ok(())
     }
@@ -3074,83 +1785,61 @@ mod tests {
     /// When mate is unmapped, `mate_unmapped` flag should be set and MC tag should not be set.
     #[test]
     fn test_fix_mate_info_supplemental_with_unmapped_mate() -> Result<()> {
-        let mc_tag = Tag::from(SamTag::MC);
-
-        // R1 primary at pos=100, forward strand
+        // R1 primary knows its mate is unmapped
         let r1 = create_mapped_record_with_flags(
             b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_MATE_UNMAPPED, // R1 knows mate is unmapped
+            FLAG_PAIRED | FLAG_READ1 | FLAG_MATE_UNMAPPED,
             100,
             30,
-            0, // TLEN=0 when mate unmapped
-            Some(0),
-            Some(100), // unmapped mate placed at R1's position
-        );
-
-        // R2 is unmapped but placed at R1's position (standard convention)
-        let mut r2 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED,
-            100, // same position as R1 (convention for unmapped mate)
-            0,   // mapq 0 for unmapped
-            0,   // TLEN=0
+            0,
             Some(0),
             Some(100),
         );
-        // Clear CIGAR for unmapped read
-        *r2.cigar_mut() = CigarBuf::default();
 
-        // R1 supplementary, originally has incorrect mate_reverse flag set
+        // R2 is unmapped (no CIGAR, placed at R1's position)
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED)
+            .ref_id(0)
+            .pos(99)
+            .mapq(0)
+            .template_length(0)
+            .mate_ref_id(0)
+            .mate_pos(99);
+        let r2 = b.build();
+
+        // R1 supp originally has incorrect MATE_REVERSE and TLEN
         let r1_supp = create_mapped_record_with_flags(
             b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE, // wrong
+            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE,
             500,
             25,
-            999, // wrong TLEN
+            999,
             Some(0),
-            Some(500), // wrong mate pos
+            Some(500),
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
         template.fix_mate_info()?;
 
-        // Verify R1 supplementary has correct flags for unmapped mate
-        let supp = &template.records[2];
+        let supp = &template.records()[2];
 
-        // Mate unmapped flag should be set
+        assert!(supp.is_mate_unmapped(), "R1 supp should have mate_unmapped since R2 is unmapped");
         assert!(
-            supp.flags().is_mate_unmapped(),
-            "R1 supp should have mate_unmapped since R2 is unmapped"
+            !supp.is_mate_reverse(),
+            "R1 supp should NOT have mate_reverse when R2 is unmapped"
         );
-
-        // Mate reverse flag should NOT be set for unmapped mate
-        assert!(
-            !supp.flags().is_mate_reverse_complemented(),
-            "R1 supp should NOT have mate_reverse when R2 is unmapped (unmapped reads have no orientation)"
-        );
-
-        // MC tag should NOT be set for unmapped mate
-        assert!(
-            supp.data().get(&mc_tag).is_none(),
-            "R1 supp should NOT have MC tag when mate is unmapped"
-        );
-
-        // TLEN should be 0 (negative of mate's 0)
+        assert!(supp.tags().find_string(b"MC").is_none(), "R1 supp should NOT have MC tag");
         assert_eq!(supp.template_length(), 0, "TLEN should be 0 when mate is unmapped");
 
         Ok(())
     }
 
     /// Tests that `fix_mate_info` correctly clears `mate_reverse` flag when mate is on forward strand.
-    /// This tests the scenario where supplementary had incorrect `mate_reverse` flag.
     #[test]
     fn test_fix_mate_info_clears_incorrect_mate_reverse_flag() -> Result<()> {
-        // R1 primary at pos=100, forward strand
         let r1 = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ1,
@@ -3160,8 +1849,6 @@ mod tests {
             Some(0),
             Some(200),
         );
-
-        // R2 primary at pos=200, forward strand (NOT reverse)
         let r2 = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ2, // no FLAG_REVERSE
@@ -3171,11 +1858,10 @@ mod tests {
             Some(0),
             Some(100),
         );
-
-        // R1 supplementary incorrectly has MATE_REVERSE set
+        // R1 supp incorrectly has MATE_REVERSE
         let r1_supp = create_mapped_record_with_flags(
             b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE, // incorrectly set
+            FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY | FLAG_MATE_REVERSE,
             500,
             25,
             0,
@@ -3183,15 +1869,11 @@ mod tests {
             Some(500),
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp)?;
-        let mut template = builder.build()?;
+        let mut template = Template::from_records(vec![r1, r2, r1_supp])?;
 
         // Before fix, supplementary has MATE_REVERSE set incorrectly
         assert!(
-            template.records[2].flags().is_mate_reverse_complemented(),
+            template.records()[2].is_mate_reverse(),
             "Before fix: supp incorrectly has mate_reverse"
         );
 
@@ -3199,8 +1881,8 @@ mod tests {
 
         // After fix, MATE_REVERSE should be cleared since R2 is forward
         assert!(
-            !template.records[2].flags().is_mate_reverse_complemented(),
-            "After fix: supp should NOT have mate_reverse since R2 is forward"
+            !template.records()[2].is_mate_reverse(),
+            "After fix: supp should NOT have mate_reverse"
         );
 
         Ok(())
@@ -3209,9 +1891,6 @@ mod tests {
     /// Tests that `fix_mate_info` handles multiple supplementary alignments.
     #[test]
     fn test_fix_mate_info_multiple_supplementals() -> Result<()> {
-        let as_tag = Tag::from(SamTag::AS);
-
-        // R1 primary, forward
         let r1 = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ1,
@@ -3222,19 +1901,21 @@ mod tests {
             Some(300),
         );
 
-        // R2 primary, reverse
-        let mut r2 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            300,
-            50,
-            -400,
-            Some(0),
-            Some(100),
-        );
-        r2.data_mut().insert(as_tag, BufValue::Int32(200));
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+            .ref_id(0)
+            .pos(299)
+            .mapq(50)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(-400)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .add_int_tag(b"AS", 200);
+        let r2 = b.build();
 
-        // Two R1 supplementaries
         let r1_supp1 = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY,
@@ -3254,327 +1935,18 @@ mod tests {
             Some(700),
         );
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        builder.push(r1_supp1)?;
-        builder.push(r1_supp2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2, r1_supp1, r1_supp2])?;
         template.fix_mate_info()?;
 
-        // Both supplementaries should have correct mate info from R2
-        // Note: after build(), supplementaries are at indices 2 and 3 (reversed order)
-        // R1(pos=100,forward) and R2(pos=300,100M,reverse) → 5' positions are 100 and 399 → insert_size = 300
+        // R1(pos=100,forward) and R2(pos=300,100M,reverse) → 5' are 100 and 399 → insert_size = 300
         for i in 2..=3 {
-            let supp = &template.records[i];
-
-            assert_eq!(
-                supp.mate_alignment_start().map(|p| p.get()),
-                Some(300),
-                "Supp {i} should have mate pos 300"
-            );
-            assert!(
-                supp.flags().is_mate_reverse_complemented(),
-                "Supp {i} should have mate_reverse"
-            );
+            let supp = &template.records()[i];
+            assert_eq!(supp.mate_pos() + 1, 300, "Supp {i} should have mate pos 300");
+            assert!(supp.is_mate_reverse(), "Supp {i} should have mate_reverse");
             assert_eq!(supp.template_length(), 300, "Supp {i} TLEN should be 300");
         }
 
         Ok(())
-    }
-
-    // ============================================================================
-    // Tests for compute_insert_size (ported from htsjdk SamPairUtilTest)
-    // ============================================================================
-
-    /// Helper to create a mapped record with specific strand orientation and CIGAR for insert size tests
-    fn create_insert_size_record(
-        name: &[u8],
-        flags: u16,
-        pos: usize,
-        read_length: usize,
-        ref_id: Option<usize>,
-    ) -> RecordBuf {
-        let is_read1 = (flags & FLAG_READ1) != 0;
-        let is_paired = (flags & FLAG_PAIRED) != 0;
-
-        let mut builder = RecordBuilder::new()
-            .name(std::str::from_utf8(name).expect("read name should be valid UTF-8"))
-            .sequence(&"A".repeat(read_length))
-            .qualities(&vec![30u8; read_length])
-            .cigar(&format!("{read_length}M"))
-            .alignment_start(pos)
-            .mapping_quality(30);
-
-        if let Some(rid) = ref_id {
-            builder = builder.reference_sequence_id(rid);
-        }
-
-        if is_paired {
-            builder = builder.first_segment(is_read1);
-        }
-
-        // Build and then override with exact flags
-        let mut record = builder.build();
-        *record.flags_mut() = Flags::from(flags);
-
-        record
-    }
-
-    /// Test `compute_insert_size` for "normal innie" FR pair (htsjdk test case)
-    /// R1: pos=1, length=100, forward
-    /// R2: pos=500, length=100, reverse
-    /// Expected: 5' positions are 1 (forward start) and 599 (reverse end)
-    /// Insert size = 599 - 1 + 1 = 599
-    #[test]
-    fn test_compute_insert_size_normal_innie() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 1, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            500,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 1 (forward, start), R2 5' = 599 (reverse, end = 500+100-1)
-        // second_5prime (599) >= first_5prime (1), so adjustment = +1
-        // 599 - 1 + 1 = 599
-        assert_eq!(insert_size, 599);
-    }
-
-    /// Test `compute_insert_size` for overlapping innie
-    /// R1: pos=1, length=100, forward (ends at 100)
-    /// R2: pos=50, length=100, reverse (ends at 149)
-    #[test]
-    fn test_compute_insert_size_overlapping_innie() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 1, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            50,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 1, R2 5' = 149 (50+100-1)
-        // 149 - 1 + 1 = 149
-        assert_eq!(insert_size, 149);
-    }
-
-    /// Test `compute_insert_size` for completely overlapping innie
-    /// R1: pos=1, length=100, forward
-    /// R2: pos=1, length=100, reverse
-    #[test]
-    fn test_compute_insert_size_completely_overlapping_innie() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 1, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            1,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 1, R2 5' = 100 (1+100-1)
-        // 100 - 1 + 1 = 100
-        assert_eq!(insert_size, 100);
-    }
-
-    /// Test `compute_insert_size` for outie pair (RF orientation)
-    /// R1: pos=1, length=100, reverse
-    /// R2: pos=500, length=100, forward
-    #[test]
-    fn test_compute_insert_size_normal_outie() {
-        let r1 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE,
-            1,
-            100,
-            Some(0),
-        );
-        let r2 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ2, 500, 100, Some(0));
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 100 (reverse, end = 1+100-1), R2 5' = 500 (forward, start)
-        // 500 - 100 + 1 = 401
-        assert_eq!(insert_size, 401);
-    }
-
-    /// Test `compute_insert_size` for forward tandem
-    /// R1: pos=1, length=100, reverse
-    /// R2: pos=500, length=100, reverse
-    #[test]
-    fn test_compute_insert_size_forward_tandem() {
-        let r1 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_REVERSE,
-            1,
-            100,
-            Some(0),
-        );
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            500,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 100 (reverse), R2 5' = 599 (reverse)
-        // 599 - 100 + 1 = 500
-        assert_eq!(insert_size, 500);
-    }
-
-    /// Test `compute_insert_size` for reverse tandem
-    /// R1: pos=1, length=100, forward
-    /// R2: pos=500, length=100, forward
-    #[test]
-    fn test_compute_insert_size_reverse_tandem() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 1, 100, Some(0));
-        let r2 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ2, 500, 100, Some(0));
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 1 (forward), R2 5' = 500 (forward)
-        // 500 - 1 + 1 = 500
-        assert_eq!(insert_size, 500);
-    }
-
-    /// Test `compute_insert_size` when second read is before first (negative insert size)
-    /// R1: pos=500, length=100, forward
-    /// R2: pos=1, length=100, reverse
-    #[test]
-    fn test_compute_insert_size_negative() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 500, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            1,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1 5' = 500 (forward), R2 5' = 100 (reverse)
-        // second_5prime (100) < first_5prime (500), so adjustment = -1
-        // 100 - 500 + (-1) = -401
-        assert_eq!(insert_size, -401);
-    }
-
-    /// Test `compute_insert_size` returns 0 when reads are on different references
-    #[test]
-    fn test_compute_insert_size_different_references() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            200,
-            100,
-            Some(1), // different reference
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        assert_eq!(insert_size, 0, "Insert size should be 0 for different references");
-    }
-
-    /// Test `compute_insert_size` returns 0 when R1 is unmapped
-    #[test]
-    fn test_compute_insert_size_r1_unmapped() {
-        let r1 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED,
-            100,
-            100,
-            Some(0),
-        );
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            200,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        assert_eq!(insert_size, 0, "Insert size should be 0 when R1 is unmapped");
-    }
-
-    /// Test `compute_insert_size` returns 0 when R2 is unmapped
-    #[test]
-    fn test_compute_insert_size_r2_unmapped() {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED,
-            200,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        assert_eq!(insert_size, 0, "Insert size should be 0 when R2 is unmapped");
-    }
-
-    /// Test `compute_insert_size` returns 0 when both reads are unmapped
-    #[test]
-    fn test_compute_insert_size_both_unmapped() {
-        let r1 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED,
-            100,
-            100,
-            Some(0),
-        );
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED,
-            200,
-            100,
-            Some(0),
-        );
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        assert_eq!(insert_size, 0, "Insert size should be 0 when both reads are unmapped");
-    }
-
-    /// Test `compute_insert_size` with complex CIGAR (insertions don't affect reference length)
-    #[test]
-    fn test_compute_insert_size_with_indels() {
-        // CIGAR: 50M10I40M = 90M on reference (insertions don't consume reference)
-        let r1 = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("50M10I40M")
-            .first_segment(true)
-            .build();
-
-        // CIGAR: 50M5D50M = 105 on reference (deletions consume reference)
-        let mut r2 = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .cigar("50M5D50M")
-            .first_segment(false)
-            .reverse_complement(true)
-            .build();
-        // Ensure FLAG_REVERSE is set
-        *r2.flags_mut() = Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE);
-
-        let insert_size = compute_insert_size(&r1, &r2);
-        // R1: alignment length = 50 + 40 = 90, end = 90, 5' = 1 (forward)
-        // R2: alignment length = 50 + 5 + 50 = 105, end = 304, 5' = 304 (reverse)
-        // 304 - 1 + 1 = 304
-        assert_eq!(insert_size, 304);
     }
 
     // ============================================================================
@@ -3584,25 +1956,36 @@ mod tests {
     /// Test `fix_mate_info` correctly sets TLEN for normal innie pair
     #[test]
     fn test_fix_mate_info_sets_tlen_normal_innie() -> Result<()> {
-        let r1 = create_insert_size_record(b"read1", FLAG_PAIRED | FLAG_READ1, 1, 100, Some(0));
-        let r2 = create_insert_size_record(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            500,
-            100,
-            Some(0),
-        );
+        // R1: pos=1, 50M, forward; R2: pos=500, 100M, reverse
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 50])
+            .qualities(&[30u8; 50])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(0)
+            .mapq(30)
+            .cigar_ops(&[50u32 << 4]);
+        let r1 = b.build();
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+            .ref_id(0)
+            .pos(499)
+            .mapq(30)
+            .cigar_ops(&[100u32 << 4]);
+        let r2 = b.build();
 
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // Expected insert size: 599
-        assert_eq!(template.records[0].template_length(), 599, "R1 TLEN");
-        assert_eq!(template.records[1].template_length(), -599, "R2 TLEN");
+        // R1 5' = 1 (forward start), R2 5' = 599 (reverse end = 500+100-1)
+        // insert_size = 599 - 1 + 1 = 599
+        assert_eq!(template.records()[0].template_length(), 599, "R1 TLEN");
+        assert_eq!(template.records()[1].template_length(), -599, "R2 TLEN");
 
         Ok(())
     }
@@ -3610,54 +1993,42 @@ mod tests {
     /// Test `fix_mate_info` correctly sets mate CIGAR (MC tag)
     #[test]
     fn test_fix_mate_info_sets_mate_cigar() -> Result<()> {
-        let mc_tag = Tag::from(SamTag::MC);
-
-        let r1 = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(50))
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 50])
             .qualities(&[30u8; 50])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("50M")
-            .first_segment(true)
-            .build();
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(0)
+            .mapq(30)
+            .cigar_ops(&[50u32 << 4]); // 50M
+        let r1 = b.build();
 
-        // Complex CIGAR for R2: 25M5I20M
-        let mut r2 = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(50))
+        // R2 CIGAR: 25M5I20M
+        let cigar = vec![25u32 << 4, (5u32 << 4) | 1, 20u32 << 4];
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 50])
             .qualities(&[30u8; 50])
-            .reference_sequence_id(0)
-            .alignment_start(500)
-            .cigar("25M5I20M")
-            .first_segment(false)
-            .reverse_complement(true)
-            .build();
-        // Ensure FLAG_REVERSE is set
-        *r2.flags_mut() = Flags::from(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE);
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+            .ref_id(0)
+            .pos(499)
+            .mapq(30)
+            .cigar_ops(&cigar);
+        let r2 = b.build();
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // R1's MC should be R2's CIGAR
-        let r1_mc = template.records[0].data().get(&mc_tag);
+        // R1's MC should be R2's CIGAR (25M5I20M)
+        let r1_mc = template.records()[0].tags().find_string(b"MC");
         assert!(r1_mc.is_some(), "R1 should have MC tag");
-        let Some(BufValue::String(mc)) = r1_mc else {
-            unreachable!("MC tag should be a string");
-        };
-        assert_eq!(&mc[..], b"25M5I20M", "R1 MC should be R2's CIGAR");
+        assert_eq!(r1_mc.unwrap(), b"25M5I20M", "R1 MC should be R2's CIGAR");
 
-        // R2's MC should be R1's CIGAR
-        let r2_mc = template.records[1].data().get(&mc_tag);
+        // R2's MC should be R1's CIGAR (50M)
+        let r2_mc = template.records()[1].tags().find_string(b"MC");
         assert!(r2_mc.is_some(), "R2 should have MC tag");
-        let Some(BufValue::String(mc)) = r2_mc else {
-            unreachable!("MC tag should be a string");
-        };
-        assert_eq!(&mc[..], b"50M", "R2 MC should be R1's CIGAR");
+        assert_eq!(r2_mc.unwrap(), b"50M", "R2 MC should be R1's CIGAR");
 
         Ok(())
     }
@@ -3665,39 +2036,51 @@ mod tests {
     /// Test `fix_mate_info` correctly handles both unmapped case
     #[test]
     fn test_fix_mate_info_both_unmapped() -> Result<()> {
-        let mq_tag = Tag::from(SamTag::MQ);
-        let mc_tag = Tag::from(SamTag::MC);
+        // R1: unmapped, placed at ref 0, has MQ tag
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED)
+            .ref_id(0)
+            .pos(0)
+            .mapq(0)
+            .add_int_tag(b"MQ", 30);
+        let r1 = b.build();
 
-        let mut r1 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_UNMAPPED);
-        *r1.reference_sequence_id_mut() = Some(0); // Originally had a reference
-        *r1.data_mut() = [(mq_tag, BufValue::Int32(30))].into_iter().collect(); // Has MQ tag
+        // R2: unmapped, placed at ref 0, has MC tag
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED)
+            .ref_id(0)
+            .pos(0)
+            .mapq(0)
+            .add_string_tag(b"MC", b"100M");
+        let r2 = b.build();
 
-        let mut r2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED);
-        *r2.reference_sequence_id_mut() = Some(0);
-        *r2.data_mut() = [(mc_tag, BufValue::String("100M".into()))].into_iter().collect();
-
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // Both should have reference cleared (None)
-        assert!(template.records[0].reference_sequence_id().is_none(), "R1 ref should be cleared");
-        assert!(template.records[1].reference_sequence_id().is_none(), "R2 ref should be cleared");
+        // Both should have ref_id = -1 (unmapped)
+        assert_eq!(template.records()[0].ref_id(), -1, "R1 ref should be cleared");
+        assert_eq!(template.records()[1].ref_id(), -1, "R2 ref should be cleared");
 
         // Both should have mate_unmapped flag set
-        assert!(template.records[0].flags().is_mate_unmapped(), "R1 mate_unmapped");
-        assert!(template.records[1].flags().is_mate_unmapped(), "R2 mate_unmapped");
+        assert!(template.records()[0].is_mate_unmapped(), "R1 mate_unmapped");
+        assert!(template.records()[1].is_mate_unmapped(), "R2 mate_unmapped");
 
         // MQ and MC tags should be removed
-        assert!(template.records[0].data().get(&mq_tag).is_none(), "R1 MQ should be removed");
-        assert!(template.records[1].data().get(&mc_tag).is_none(), "R2 MC should be removed");
+        assert!(template.records()[0].tags().find_int(b"MQ").is_none(), "R1 MQ should be removed");
+        assert!(
+            template.records()[1].tags().find_string(b"MC").is_none(),
+            "R2 MC should be removed"
+        );
 
         // TLEN should be 0
-        assert_eq!(template.records[0].template_length(), 0, "R1 TLEN should be 0");
-        assert_eq!(template.records[1].template_length(), 0, "R2 TLEN should be 0");
+        assert_eq!(template.records()[0].template_length(), 0, "R1 TLEN should be 0");
+        assert_eq!(template.records()[1].template_length(), 0, "R2 TLEN should be 0");
 
         Ok(())
     }
@@ -3705,68 +2088,44 @@ mod tests {
     /// Test `fix_mate_info` correctly handles one mapped, one unmapped case
     #[test]
     fn test_fix_mate_info_one_unmapped() -> Result<()> {
-        let mq_tag = Tag::from(SamTag::MQ);
-        let mc_tag = Tag::from(SamTag::MC);
-
         // R1 is mapped
         let r1 = create_mapped_record(b"read1", FLAG_PAIRED | FLAG_READ1, 100, 30);
 
-        // R2 is unmapped
-        let r2 = create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED);
+        // R2 is unmapped (no CIGAR, placed at some position)
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED)
+            .mapq(0);
+        let r2 = b.build();
 
-        let mut builder = Builder::new();
-        builder.push(r1)?;
-        builder.push(r2)?;
-        let mut template = builder.build()?;
-
+        let mut template = Template::from_records(vec![r1, r2])?;
         template.fix_mate_info()?;
 
-        // Unmapped R2 should be placed at R1's position
-        assert_eq!(
-            template.records[1].reference_sequence_id(),
-            Some(0),
-            "R2 should be placed at R1's reference"
-        );
-        assert_eq!(
-            template.records[1].alignment_start().map(|p| p.get()),
-            Some(100),
-            "R2 should be placed at R1's position"
-        );
+        // Unmapped R2 should be placed at R1's ref_id (0) and position (100, i.e. 0-based 99)
+        assert_eq!(template.records()[1].ref_id(), 0, "R2 should be placed at R1's reference");
+        assert_eq!(template.records()[1].pos() + 1, 100, "R2 should be placed at R1's position");
 
         // R1 (mapped) should NOT have MQ tag (mate is unmapped)
-        assert!(
-            template.records[0].data().get(&mq_tag).is_none(),
-            "R1 should NOT have MQ when mate is unmapped"
-        );
+        assert!(template.records()[0].tags().find_int(b"MQ").is_none(), "R1 should NOT have MQ");
 
         // R2 (unmapped) SHOULD have MQ tag (mate is mapped)
-        assert!(
-            template.records[1].data().get(&mq_tag).is_some(),
-            "R2 should have MQ when mate is mapped"
-        );
+        assert!(template.records()[1].tags().find_int(b"MQ").is_some(), "R2 should have MQ");
 
         // R1 should have mate_unmapped flag set
-        assert!(template.records[0].flags().is_mate_unmapped(), "R1 mate_unmapped should be set");
+        assert!(template.records()[0].is_mate_unmapped(), "R1 mate_unmapped should be set");
 
         // R2 should NOT have mate_unmapped flag set (R1 is mapped)
-        assert!(
-            !template.records[1].flags().is_mate_unmapped(),
-            "R2 mate_unmapped should NOT be set"
-        );
+        assert!(!template.records()[1].is_mate_unmapped(), "R2 mate_unmapped should NOT be set");
 
         // TLEN should be 0 for both
-        assert_eq!(template.records[0].template_length(), 0, "R1 TLEN");
-        assert_eq!(template.records[1].template_length(), 0, "R2 TLEN");
+        assert_eq!(template.records()[0].template_length(), 0, "R1 TLEN");
+        assert_eq!(template.records()[1].template_length(), 0, "R2 TLEN");
 
         // MC tag: R1 should not have it (mate unmapped), R2 should have it (mate mapped)
-        assert!(
-            template.records[0].data().get(&mc_tag).is_none(),
-            "R1 should NOT have MC when mate is unmapped"
-        );
-        assert!(
-            template.records[1].data().get(&mc_tag).is_some(),
-            "R2 should have MC when mate is mapped"
-        );
+        assert!(template.records()[0].tags().find_string(b"MC").is_none(), "R1 NOT have MC");
+        assert!(template.records()[1].tags().find_string(b"MC").is_some(), "R2 should have MC");
 
         Ok(())
     }
@@ -3984,29 +2343,30 @@ mod tests {
     /// Test `pair_orientation` returns None when reads are on different chromosomes
     #[test]
     fn test_pair_orientation_different_chromosomes() -> Result<()> {
-        let mut r1 = create_mapped_record_with_flags(
+        // R1 on ref 0, mate_ref_id=1 (different chrom)
+        let r1 = create_mapped_record_with_flags(
             b"read1",
             FLAG_PAIRED | FLAG_READ1 | FLAG_MATE_REVERSE,
             100,
             30,
             200,
-            Some(1), // mate on different chromosome
+            Some(0),
             Some(200),
         );
-        // Override R1's reference to be chr 0
-        *r1.reference_sequence_id_mut() = Some(0);
-
-        let mut r2 = create_mapped_record_with_flags(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE,
-            200,
-            30,
-            -200,
-            Some(0),
-            Some(100),
-        );
-        // R2 is on chr 1
-        *r2.reference_sequence_id_mut() = Some(1);
+        // R2 on ref 1
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_REVERSE)
+            .ref_id(1)
+            .pos(199)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)])
+            .template_length(-200)
+            .mate_ref_id(0)
+            .mate_pos(99);
+        let r2 = b.build();
 
         let template = Template::from_records(vec![r1, r2])?;
         assert_eq!(template.pair_orientation(), None);
@@ -4044,244 +2404,22 @@ mod tests {
     }
 
     // ========================================================================
-    // Tests for RecordBuf accessor panic in raw-byte mode
-    // ========================================================================
-
-    /// Helper to create a minimal raw BAM record for testing raw-byte mode.
-    #[allow(clippy::cast_possible_truncation)]
-    fn make_minimal_raw_bam(name: &[u8], flags: u16) -> Vec<u8> {
-        let l_read_name = (name.len() + 1) as u8; // +1 for null terminator
-        let total = 32 + l_read_name as usize; // minimal: header + name only
-        let mut buf = vec![0u8; total];
-
-        buf[8] = l_read_name;
-        buf[14..16].copy_from_slice(&flags.to_le_bytes());
-
-        let name_start = 32;
-        buf[name_start..name_start + name.len()].copy_from_slice(name);
-        buf[name_start + name.len()] = 0; // null terminator
-
-        buf
-    }
-
-    #[test]
-    fn test_from_raw_records_creates_raw_mode_template() {
-        let raw = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("from_raw_records should succeed");
-
-        // Verify it's in raw-byte mode
-        assert!(template.is_raw_byte_mode());
-        // Verify records vec is empty (all data is in raw_records)
-        assert!(template.records.is_empty());
-        // Verify raw accessors work
-        assert!(template.raw_r1().is_some());
-    }
-
-    #[test]
-    fn test_r1_accessor_returns_none_in_raw_mode() {
-        // After fix: calling r1() on a raw-mode Template returns None instead of panicking
-        let raw = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let template = Template::from_raw_records(vec![raw].into_iter().map(Into::into).collect())
-            .expect("from_raw_records should succeed");
-
-        // r1() should return None in raw mode (use raw_r1() instead)
-        assert!(template.r1().is_none());
-        // raw_r1() should still work
-        assert!(template.raw_r1().is_some());
-    }
-
-    #[test]
-    fn test_r2_accessor_returns_none_in_raw_mode() {
-        // After fix: calling r2() on a raw-mode Template returns None instead of panicking
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template =
-            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
-                .expect("from_raw_records should succeed");
-
-        assert!(template.is_raw_byte_mode());
-
-        // r2() should return None in raw mode (use raw_r2() instead)
-        assert!(template.r2().is_none());
-        // raw_r2() should still work
-        assert!(template.raw_r2().is_some());
-    }
-
-    // ========================================================================
-    // from_raw_records fast path tests
+    // from_records error-path tests
     // ========================================================================
 
     #[test]
-    fn test_from_raw_records_fast_path_normal_order() {
-        // R1 first, R2 second — fast path with no swap
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template =
-            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
-                .expect("from_raw_records should succeed");
-
-        assert!(template.is_raw_byte_mode());
-        assert!(template.raw_r1().is_some());
-        assert!(template.raw_r2().is_some());
-        // Verify R1 is at index 0 (has FIRST_SEGMENT flag)
-        let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = RawRecordView::new(raw_r1).flags();
-        assert_ne!(r1_flags & FLAG_READ1, 0);
-    }
-
-    #[test]
-    fn test_from_raw_records_fast_path_swap() {
-        // R2 first, R1 second — fast path should swap them
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template =
-            Template::from_raw_records(vec![r2, r1].into_iter().map(Into::into).collect())
-                .expect("from_raw_records");
-
-        assert!(template.is_raw_byte_mode());
-        // After swap, R1 should be at index 0
-        let raw_r1 = template.raw_r1().expect("raw_r1 should be present");
-        let r1_flags = RawRecordView::new(raw_r1).flags();
-        assert_ne!(r1_flags & FLAG_READ1, 0);
-        let raw_r2 = template.raw_r2().expect("raw_r2 should be present");
-        let r2_flags = RawRecordView::new(raw_r2).flags();
-        assert_ne!(r2_flags & FLAG_READ2, 0);
-    }
-
-    #[test]
-    fn test_from_raw_records_fast_path_fallthrough_both_r1() {
-        // Both records are R1 — fast path should fall through to general path (error)
-        let r1a = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r1b = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let result =
-            Template::from_raw_records(vec![r1a, r1b].into_iter().map(Into::into).collect());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_from_raw_records_fast_path_rejects_name_mismatch() {
-        // Two primary records (R1 + R2) with *different* QNAMEs must not slip through
-        // the two-record fast path — from_raw_records should bail on the name mismatch.
-        let r1 = make_minimal_raw_bam(b"readA", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"readB", FLAG_PAIRED | FLAG_READ2);
-        let result = Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect());
-        assert!(result.is_err(), "mismatched QNAMEs must not produce a Template");
-    }
-
-    #[test]
-    fn test_from_raw_records_fast_path_with_secondary() {
-        // 2 records but one is secondary — should skip fast path
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let sec = make_minimal_raw_bam(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | crate::sort::bam_fields::flags::SECONDARY,
-        );
-        let template =
-            Template::from_raw_records(vec![r1, sec].into_iter().map(Into::into).collect())
-                .expect("from_raw_records should succeed");
-        assert!(template.is_raw_byte_mode());
-        assert!(template.raw_r1().is_some());
-    }
-
-    #[test]
-    fn test_from_raw_records_with_supplementary() {
-        // R1 primary + R1 supplementary + R2 primary — general path
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r1_supp = make_minimal_raw_bam(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | crate::sort::bam_fields::flags::SUPPLEMENTARY,
-        );
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template =
-            Template::from_raw_records(vec![r1, r1_supp, r2].into_iter().map(Into::into).collect())
-                .expect("value should be present");
-        assert!(template.is_raw_byte_mode());
-        assert!(template.raw_r1().is_some());
-        assert!(template.raw_r2().is_some());
-    }
-
-    #[test]
-    fn test_from_raw_records_single_unpaired() {
-        // Single unpaired record — should be treated as R1
-        let r = make_minimal_raw_bam(b"read1", 0); // no PAIRED flag
-        let template = Template::from_raw_records(vec![r].into_iter().map(Into::into).collect())
-            .expect("from_raw_records should succeed");
-        assert!(template.is_raw_byte_mode());
-        assert!(template.raw_r1().is_some());
-        assert!(template.raw_r2().is_none());
-    }
-
-    #[test]
-    fn test_from_raw_records_empty() {
-        let result = Template::from_raw_records(vec![]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_from_raw_records_name_mismatch() {
-        // Two records with different names — should error in general path
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r1_supp = make_minimal_raw_bam(
-            b"read1",
-            FLAG_PAIRED | FLAG_READ1 | crate::sort::bam_fields::flags::SUPPLEMENTARY,
-        );
-        let r2_wrong = make_minimal_raw_bam(b"read2", FLAG_PAIRED | FLAG_READ2);
-        let result = Template::from_raw_records(
-            vec![r1, r1_supp, r2_wrong].into_iter().map(Into::into).collect(),
-        );
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_from_raw_records_all_raw_records_mut() {
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let mut template =
-            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
-                .expect("from_raw_records should succeed");
-        // Should be able to get mutable access
-        let recs = template.all_raw_records_mut().expect("all_raw_records_mut should succeed");
-        assert_eq!(recs.len(), 2);
-    }
-
-    #[test]
-    fn test_from_raw_records_into_raw_records() {
-        let r1 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ1);
-        let r2 = make_minimal_raw_bam(b"read1", FLAG_PAIRED | FLAG_READ2);
-        let template =
-            Template::from_raw_records(vec![r1, r2].into_iter().map(Into::into).collect())
-                .expect("from_raw_records should succeed");
-        let recs = template.into_raw_records().expect("into_raw_records should succeed");
-        assert_eq!(recs.len(), 2);
-    }
-
-    #[test]
-    fn test_from_raw_records_truncated_header() {
-        // Record too short (< 32 bytes)
-        let short = vec![0u8; 20];
-        let err = Template::from_raw_records(vec![short].into_iter().map(Into::into).collect())
-            .unwrap_err();
+    fn test_from_records_truncated_header() {
+        let short = RawRecord::from(vec![0u8; 20]);
+        let err = Template::from_records(vec![short]).unwrap_err();
         assert!(err.to_string().contains("too short"), "Error: {err}");
     }
 
     #[test]
-    fn test_from_raw_records_truncated_read_name() {
-        // Record has 32 bytes but l_read_name claims more bytes than available
-        let mut buf = vec![0u8; 34]; // 32 header + 2 bytes
-        buf[8] = 10; // l_read_name=10, but only 2 bytes after header
-        let err = Template::from_raw_records(vec![buf].into_iter().map(Into::into).collect())
-            .unwrap_err();
+    fn test_from_records_truncated_read_name() {
+        let mut buf = vec![0u8; 34];
+        buf[8] = 10; // claims 10 bytes for read name, but only 2 available
+        let err = Template::from_records(vec![RawRecord::from(buf)]).unwrap_err();
         assert!(err.to_string().contains("truncated"), "Error: {err}");
-    }
-
-    #[test]
-    fn test_from_raw_records_valid_l_read_name() {
-        // Record with l_read_name that exactly fits
-        let rec = make_minimal_raw_bam(b"test", FLAG_PAIRED | FLAG_READ1);
-        assert!(
-            Template::from_raw_records(vec![rec].into_iter().map(Into::into).collect()).is_ok()
-        );
     }
 
     // ========================================================================
@@ -4349,33 +2487,5 @@ mod tests {
             let result = mi.write_with_offset(100, &mut buf);
             assert_eq!(result, expected.as_bytes(), "Mismatch for {mi:?}");
         }
-    }
-
-    #[test]
-    fn test_records_in_range_invalid_start_gt_end() {
-        let template = Template {
-            name: b"read1".to_vec(),
-            records: vec![
-                create_test_record(b"read1", FLAG_PAIRED | FLAG_READ1),
-                create_test_record(b"read1", FLAG_PAIRED | FLAG_READ2),
-            ],
-            raw_records: None,
-            r1: Some((0, 1)),
-            r2: Some((1, 2)),
-            r1_supplementals: None,
-            r2_supplementals: None,
-            r1_secondaries: None,
-            r2_secondaries: None,
-            mi: MoleculeId::None,
-        };
-
-        // start > end should return empty, not panic
-        assert!(template.records_in_range(Some((2, 1))).is_empty());
-        // valid range
-        assert_eq!(template.records_in_range(Some((0, 2))).len(), 2);
-        // None returns empty
-        assert!(template.records_in_range(None).is_empty());
-        // end > len returns empty
-        assert!(template.records_in_range(Some((0, 10))).is_empty());
     }
 }

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -39,7 +39,7 @@ use super::deadlock::{
     DeadlockAction, DeadlockConfig, DeadlockState, QueueSnapshot, check_deadlock_and_restore,
 };
 use super::scheduler::{BackpressureState, SchedulerStrategy};
-use crate::read_info::{LibraryIndex, compute_group_key};
+use crate::read_info::LibraryIndex;
 use crate::sort::bam_fields;
 use fgumi_raw_bam::RawRecordView;
 
@@ -332,21 +332,20 @@ pub fn decode_records(
 ) -> io::Result<Vec<DecodedRecord>> {
     let num_records = batch.offsets.len().saturating_sub(1);
     let mut records = Vec::with_capacity(num_records);
-    // Reused across records in the noodles decode path below.
-    let default_header = noodles::sam::Header::default();
 
+    let buffer_len = batch.buffer.len();
     for i in 0..num_records {
         let start = batch.offsets[i];
         let end = batch.offsets[i + 1];
 
-        // Validate: end > start + 4 (need at least block_size prefix)
-        if end <= start + 4 {
+        // Validate: ordering, in-bounds, and room for the block_size prefix.
+        // Guards the raw indexes into batch.buffer below against malformed input.
+        if start >= end || end > buffer_len || end - start <= 4 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
                     "Invalid record bounds: start={start}, end={end}, record_index={i}, \
-                     num_records={num_records}, buffer_len={}",
-                    batch.buffer.len()
+                     num_records={num_records}, buffer_len={buffer_len}"
                 ),
             ));
         }
@@ -364,61 +363,40 @@ pub fn decode_records(
                 io::ErrorKind::InvalidData,
                 format!(
                     "Block size mismatch: stored={stored_block_size}, expected={expected_block_size}, \
-                     record_index={i}, start={start}, end={end}, buffer_len={}",
-                    batch.buffer.len()
+                     record_index={i}, start={start}, end={end}, buffer_len={buffer_len}"
                 ),
             ));
         }
 
-        // Skip the 4-byte block_size prefix
-        let record_data = &batch.buffer[start + 4..end];
-
-        if group_key_config.raw_byte_mode {
-            // Raw-byte path: zero-copy GroupKey computation without the noodles RecordBuf
-            // round-trip. Activated only when raw_byte_mode = true (via GroupKeyConfig::new_raw).
-            // Used by `dedup`, `group`, and other commands that opt in via GroupKeyConfig::new_raw;
-            // other commands use the noodles path below via the default config.
-            let raw = record_data.to_vec();
-            if raw.len() < 32 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("BAM record too short: len={}", raw.len()),
-                ));
-            }
-            // Validate l_read_name fits within the record to prevent
-            // panics in read_name() and downstream CIGAR/aux access.
-            let l_rn = raw[8] as usize;
-            if raw.len() < 32 + l_rn {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "BAM record truncated: len={}, l_read_name={l_rn} (need >= {})",
-                        raw.len(),
-                        32 + l_rn
-                    ),
-                ));
-            }
-            let key = compute_group_key_from_raw(
-                &raw,
-                &group_key_config.library_index,
-                group_key_config.cell_tag,
-            );
-            records.push(DecodedRecord::from_raw_bytes(raw, key));
-        } else {
-            // Noodles decode path: retained for commands (e.g. clip) that need typed
-            // RecordBuf access in downstream Template processing (CIGAR edits, flag API).
-            // Uses noodles Reader::from per maintainer recommendation (noodles#364).
-            let mut reader = noodles::bam::io::Reader::from(&batch.buffer[start..end]);
-            let mut record = RecordBuf::default();
-            reader.read_record_buf(&default_header, &mut record)?;
-
-            let key = compute_group_key(
-                &record,
-                &group_key_config.library_index,
-                group_key_config.cell_tag,
-            );
-            records.push(DecodedRecord::new(record, key));
+        // Skip the 4-byte block_size prefix and copy record data.
+        let raw = batch.buffer[start + 4..end].to_vec();
+        if raw.len() < 32 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("BAM record too short: len={}", raw.len()),
+            ));
         }
+        // Validate l_read_name fits within the record to prevent panics in
+        // read_name(). CIGAR, sequence, and aux access still rely on the raw
+        // bytes being a well-formed BAM record produced by the BAM reader;
+        // callers must not feed arbitrary external bytes here.
+        let l_rn = raw[8] as usize;
+        if raw.len() < 32 + l_rn {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "BAM record truncated: len={}, l_read_name={l_rn} (need >= {})",
+                    raw.len(),
+                    32 + l_rn
+                ),
+            ));
+        }
+        let key = compute_group_key_from_raw(
+            &raw,
+            &group_key_config.library_index,
+            group_key_config.cell_tag,
+        );
+        records.push(DecodedRecord::from_raw_bytes(raw, key));
     }
 
     Ok(records)

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1475,93 +1475,60 @@ impl Default for GroupKey {
 /// This is the output of the Decode step and input to the Group step.
 /// The key is computed during the parallel Decode step so that the
 /// serial Group step only needs to do fast integer comparisons.
-///
-/// Uses an enum for the record data to avoid carrying both `RecordBuf` and
-/// `Vec<u8>` — saving ~24 bytes per record in parsed mode and ~200 bytes
-/// in raw mode.
 #[derive(Debug)]
 pub struct DecodedRecord {
     /// Pre-computed grouping key.
     pub key: GroupKey,
-    /// The record data — either a parsed `RecordBuf` or raw bytes.
-    pub(crate) data: DecodedRecordData,
-}
-
-/// Record data: either a parsed noodles `RecordBuf` or raw BAM bytes.
-///
-/// The `Parsed` variant is retained for commands (e.g. `clip`) that require typed
-/// `RecordBuf` access for CIGAR edits and the noodles flag API.
-/// The `Raw` variant uses [`RawRecord`] for zero-overhead byte access and
-/// direct output writes without re-encoding.
-#[derive(Debug)]
-pub enum DecodedRecordData {
-    Parsed(RecordBuf),
-    Raw(RawRecord),
+    /// Raw BAM record bytes.
+    pub(crate) data: RawRecord,
 }
 
 impl DecodedRecord {
-    /// Create a new decoded record with its grouping key.
-    #[must_use]
-    pub fn new(record: RecordBuf, key: GroupKey) -> Self {
-        Self { key, data: DecodedRecordData::Parsed(record) }
-    }
-
     /// Create a decoded record from raw bytes, skipping noodles decode.
     ///
     /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
     /// an already-constructed `RawRecord`).
     #[must_use]
     pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
-        Self { key, data: DecodedRecordData::Raw(raw.into()) }
+        Self { key, data: raw.into() }
     }
 
-    /// Returns a reference to the raw bytes if this is a raw-mode record.
+    /// Returns a reference to the raw bytes.
     #[must_use]
-    pub fn raw_bytes(&self) -> Option<&[u8]> {
-        match &self.data {
-            DecodedRecordData::Raw(v) => Some(v.as_ref()),
-            DecodedRecordData::Parsed(_) => None,
-        }
+    pub fn raw_bytes(&self) -> &[u8] {
+        self.data.as_ref()
     }
 
-    /// Takes the [`RawRecord`] out if this is a raw-mode record.
+    /// Takes the [`RawRecord`] out.
     #[must_use]
-    pub fn into_raw_bytes(self) -> Option<RawRecord> {
-        match self.data {
-            DecodedRecordData::Raw(v) => Some(v),
-            DecodedRecordData::Parsed(_) => None,
-        }
+    pub fn into_raw_bytes(self) -> RawRecord {
+        self.data
     }
+}
 
-    /// Returns a reference to the `RecordBuf` if this is a parsed-mode record.
-    #[must_use]
-    pub fn record(&self) -> Option<&RecordBuf> {
-        match &self.data {
-            DecodedRecordData::Parsed(r) => Some(r),
-            DecodedRecordData::Raw(_) => None,
-        }
-    }
-
-    /// Takes the `RecordBuf` out if this is a parsed-mode record.
-    #[must_use]
-    pub fn into_record(self) -> Option<RecordBuf> {
-        match self.data {
-            DecodedRecordData::Parsed(r) => Some(r),
-            DecodedRecordData::Raw(_) => None,
-        }
-    }
+/// Estimates the heap allocation of a `RecordBuf`.
+///
+/// The inline struct overhead (flags, position, etc.) is accounted for by the caller
+/// via `capacity * size_of::<RecordBuf>()`, so we only count heap allocations here.
+pub(crate) fn estimate_record_buf_heap_size(record: &RecordBuf) -> usize {
+    let name_size = record.name().map_or(0, |n| n.len());
+    let seq_len = record.sequence().len();
+    let qual_len = record.quality_scores().len();
+    let cigar_ops = record.cigar().as_ref().len();
+    let cigar_size = cigar_ops * 4;
+    let data_fields = record.data().iter().count();
+    let entry_capacity = (data_fields * 115) / 100 + 1;
+    let entries_size = data_fields * 48;
+    let hash_table_size = entry_capacity * 16;
+    let value_heap_size = data_fields * 16;
+    let data_size = entries_size + hash_table_size + value_heap_size;
+    name_size + seq_len + qual_len + cigar_size + data_size
 }
 
 impl MemoryEstimate for DecodedRecord {
     fn estimate_heap_size(&self) -> usize {
-        match &self.data {
-            DecodedRecordData::Parsed(record) => {
-                crate::template::estimate_record_buf_heap_size(record)
-            }
-            // RawRecord::capacity() returns the inner Vec<u8> capacity — same semantics
-            // as the previous Vec<u8>::capacity() call.
-            DecodedRecordData::Raw(raw) => raw.capacity(),
-        }
+        // RawRecord::capacity() returns the inner Vec<u8> capacity.
+        self.data.capacity()
     }
 }
 
@@ -1574,8 +1541,7 @@ impl MemoryEstimate for Vec<DecodedRecord> {
 
 impl MemoryEstimate for RecordBuf {
     fn estimate_heap_size(&self) -> usize {
-        // Delegate to the detailed estimation in template.rs (single source of truth)
-        crate::template::estimate_record_buf_heap_size(self)
+        estimate_record_buf_heap_size(self)
     }
 }
 
@@ -1608,35 +1574,19 @@ pub struct GroupKeyConfig {
     pub library_index: Arc<LibraryIndex>,
     /// Tag used for cell barcode extraction. None skips cell extraction.
     pub cell_tag: Option<Tag>,
-    /// When true, skip noodles decode and work with raw BAM bytes.
-    pub raw_byte_mode: bool,
 }
 
 impl GroupKeyConfig {
     /// Create a new `GroupKeyConfig`.
     #[must_use]
     pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
-        Self {
-            library_index: Arc::new(library_index),
-            cell_tag: Some(cell_tag),
-            raw_byte_mode: false,
-        }
+        Self { library_index: Arc::new(library_index), cell_tag: Some(cell_tag) }
     }
 
-    /// Create a `GroupKeyConfig` for raw-byte mode.
-    #[must_use]
-    pub fn new_raw(library_index: LibraryIndex, cell_tag: Tag) -> Self {
-        Self {
-            library_index: Arc::new(library_index),
-            cell_tag: Some(cell_tag),
-            raw_byte_mode: true,
-        }
-    }
-
-    /// Create a `GroupKeyConfig` for raw-byte mode without cell barcode extraction.
+    /// Create a `GroupKeyConfig` without cell barcode extraction.
     #[must_use]
     pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None, raw_byte_mode: true }
+        Self { library_index: Arc::new(library_index), cell_tag: None }
     }
 }
 
@@ -1645,7 +1595,6 @@ impl Default for GroupKeyConfig {
         Self {
             library_index: Arc::new(LibraryIndex::default()),
             cell_tag: Some(Tag::from(SamTag::CB)), // Default cell barcode tag
-            raw_byte_mode: false,
         }
     }
 }
@@ -5999,15 +5948,9 @@ mod tests {
     }
 
     #[test]
-    fn test_decoded_record_record_accessor() {
-        let rec = RecordBuf::default();
-        let parsed = DecodedRecord::new(rec, GroupKey::default());
-        assert!(parsed.record().is_some());
-        assert!(parsed.raw_bytes().is_none());
-
+    fn test_decoded_record_raw_accessor() {
         let raw = DecodedRecord::from_raw_bytes(vec![0u8; 32], GroupKey::default());
-        assert!(raw.record().is_none());
-        assert!(raw.raw_bytes().is_some());
+        assert!(!raw.raw_bytes().is_empty());
     }
 
     #[test]
@@ -6026,10 +5969,14 @@ mod tests {
 
     #[test]
     fn test_memory_estimate_vec_record_buf() {
-        use crate::sam::builder::RecordBuilder;
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, raw_record_to_record_buf};
+        use noodles::sam::Header;
         use noodles::sam::alignment::record_buf::RecordBuf;
 
-        let record = RecordBuilder::new().sequence("ACGT").qualities(&[30, 30, 30, 30]).build();
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30, 30, 30, 30]).flags(0);
+        let record = raw_record_to_record_buf(&b.build(), &Header::default())
+            .expect("raw_record_to_record_buf failed in test");
         let mut records: Vec<RecordBuf> = Vec::with_capacity(10);
         records.push(record);
 

--- a/src/lib/variant_review.rs
+++ b/src/lib/variant_review.rs
@@ -133,70 +133,72 @@ pub fn read_number_suffix(is_first_of_pair: bool) -> &'static str {
 #[must_use]
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub fn format_insert_string(
-    record: &noodles::sam::alignment::RecordBuf,
+    record: &fgumi_raw_bam::RawRecord,
     header: &noodles::sam::Header,
 ) -> String {
-    let flags = record.flags();
-
     // Only generate strings for FR pairs, all other reads get "NA"
     // Must be paired, both reads mapped, and on same reference with FR orientation
-    if !flags.is_segmented() {
+    if !record.is_paired() {
         return "NA".to_string();
     }
 
-    if flags.is_unmapped() || flags.is_mate_unmapped() {
+    if record.is_unmapped() || record.is_mate_unmapped() {
         return "NA".to_string();
     }
 
     // Check that mate is on same reference
-    let Some(ref_idx) = record.reference_sequence_id() else {
+    let ref_id = record.ref_id();
+    let mate_ref_id = record.mate_ref_id();
+    if ref_id < 0 || mate_ref_id < 0 {
         return "NA".to_string();
-    };
-
-    let Some(mate_ref_idx) = record.mate_reference_sequence_id() else {
-        return "NA".to_string();
-    };
-
-    if ref_idx != mate_ref_idx {
+    }
+    if ref_id != mate_ref_id {
         return "NA".to_string();
     }
 
     // Check for FR orientation: one forward, one reverse
-    let is_reverse = flags.is_reverse_complemented();
-    let mate_is_reverse = flags.is_mate_reverse_complemented();
+    let is_reverse = record.is_reverse();
+    let mate_is_reverse = record.is_mate_reverse();
 
     if is_reverse == mate_is_reverse {
         return "NA".to_string(); // Both same orientation (FF or RR)
     }
 
-    // Get reference sequence name
-    let ref_name = match record.reference_sequence(header) {
-        Some(Ok((name, _))) => String::from_utf8_lossy(name).to_string(),
-        _ => return "NA".to_string(),
+    // FR requires the forward read to be leftmost and the reverse read rightmost;
+    // TLEN sign encodes this (positive for the leftmost forward read, negative for
+    // the rightmost reverse read). Reject RF / TLEN-0 layouts up front.
+    let tlen = record.template_length();
+    if tlen == 0 || (!is_reverse && tlen < 0) || (is_reverse && tlen > 0) {
+        return "NA".to_string();
+    }
+
+    // Get reference sequence name by looking up ref_id in the header.
+    // ref_id >= 0 is guaranteed by the check above; the cast is safe.
+    #[allow(clippy::cast_sign_loss)]
+    let ref_name = match header.reference_sequences().get_index(ref_id as usize) {
+        Some((name, _)) => String::from_utf8_lossy(name).to_string(),
+        None => return "NA".to_string(),
     };
 
     // Calculate outer position based on Scala logic:
     // val outer = if (r.negativeStrand) r.end else r.start
     let outer = if is_reverse {
         // If negative strand, use alignment end
-        match record.alignment_end() {
-            Some(pos) => usize::from(pos) as i32,
+        match record.alignment_end_1based() {
+            Some(pos) => pos as i32,
             None => return "NA".to_string(),
         }
     } else {
         // If positive strand, use alignment start
-        match record.alignment_start() {
-            Some(pos) => usize::from(pos) as i32,
+        match record.alignment_start_1based() {
+            Some(pos) => pos as i32,
             None => return "NA".to_string(),
         }
     };
 
-    // Get insert size (signed)
-    let isize = record.template_length();
-
     // Calculate start and end coordinates using Scala logic:
     // val Seq(start, end) = Seq(outer, outer + isize + (if (isize < 0) 1 else -1)).sorted
-    let other_coord = outer + isize + if isize < 0 { 1 } else { -1 };
+    let other_coord = outer + tlen + if tlen < 0 { 1 } else { -1 };
     let (start, end) =
         if outer < other_coord { (outer, other_coord) } else { (other_coord, outer) };
 
@@ -207,7 +209,7 @@ pub fn format_insert_string(
     //   case (false, true)  => "F2R1"
     //   case (false, false) => "F1R2"
     // }
-    let is_first = flags.is_first_segment();
+    let is_first = record.is_first_segment();
     let start_equals_outer = start == outer;
 
     let pairing = match (is_first, start_equals_outer) {
@@ -221,9 +223,8 @@ pub fn format_insert_string(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags as raw_flags};
     use noodles::sam::Header;
-    use noodles::sam::alignment::RecordBuf;
 
     #[test]
     fn test_read_number_suffix() {
@@ -236,8 +237,10 @@ mod tests {
         // Create a simple SAM header
         let header = Header::builder().build();
 
-        // Create an unpaired read (no segmented flag)
-        let record = RecordBuilder::new().sequence("ACGT").build();
+        // Create an unpaired read (no PAIRED flag)
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30; 4]).flags(0);
+        let record: RawRecord = b.build();
 
         let result = format_insert_string(&record, &header);
         assert_eq!(result, "NA");
@@ -332,31 +335,41 @@ mod tests {
         mate_is_reverse: bool,
         is_first: bool,
         template_len: i32,
-    ) -> RecordBuf {
-        RecordBuilder::new()
-            .sequence(&"A".repeat(10))
-            .cigar("10M")
-            .reference_sequence_id(0)
-            .alignment_start(start)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(mate_start)
-            .template_length(template_len)
-            .first_segment(is_first)
-            .reverse_complement(is_reverse)
-            .mate_reverse_complement(mate_is_reverse)
-            .build()
+    ) -> RawRecord {
+        use fgumi_raw_bam::testutil::encode_op;
+        let mut flags: u16 = raw_flags::PAIRED;
+        if is_first {
+            flags |= raw_flags::FIRST_SEGMENT;
+        } else {
+            flags |= raw_flags::LAST_SEGMENT;
+        }
+        if is_reverse {
+            flags |= raw_flags::REVERSE;
+        }
+        if mate_is_reverse {
+            flags |= raw_flags::MATE_REVERSE;
+        }
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"AAAAAAAAAA")
+            .qualities(&[30; 10])
+            .flags(flags)
+            .ref_id(0)
+            .pos(i32::try_from(start).expect("start fits i32") - 1)
+            .cigar_ops(&[encode_op(0, 10)])
+            .mate_ref_id(0)
+            .mate_pos(i32::try_from(mate_start).expect("mate_start fits i32") - 1)
+            .template_length(template_len);
+        b.build()
     }
 
     #[test]
     fn test_format_insert_string_unmapped_returns_na() {
-        use noodles::sam::alignment::record::Flags;
-
         let header = create_test_header();
-        let mut record =
-            RecordBuilder::new().sequence("ACGT").first_segment(true).unmapped(true).build();
-
-        // Ensure SEGMENTED | UNMAPPED flags are set
-        *record.flags_mut() = Flags::SEGMENTED | Flags::UNMAPPED;
+        let mut b = RawSamBuilder::new();
+        b.sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(raw_flags::PAIRED | raw_flags::UNMAPPED | raw_flags::FIRST_SEGMENT);
+        let record: RawRecord = b.build();
 
         let result = format_insert_string(&record, &header);
         assert_eq!(result, "NA");
@@ -367,8 +380,9 @@ mod tests {
         let header = create_test_header();
         let mut record = create_paired_read(100, 200, false, true, true, 101);
 
-        // Set mate as unmapped
-        *record.flags_mut() |= noodles::sam::alignment::record::Flags::MATE_UNMAPPED;
+        // Set mate as unmapped via raw flags
+        let flags = record.flags() | raw_flags::MATE_UNMAPPED;
+        record.set_flags(flags);
 
         let result = format_insert_string(&record, &header);
         assert_eq!(result, "NA");
@@ -394,8 +408,8 @@ mod tests {
         let header = create_test_header();
         let mut record = create_paired_read(100, 200, false, true, true, 101);
 
-        // Set mate on different reference
-        *record.mate_reference_sequence_id_mut() = Some(1);
+        // Set mate on different reference via raw field setter
+        record.set_mate_ref_id(1);
 
         let result = format_insert_string(&record, &header);
         assert_eq!(result, "NA");
@@ -447,5 +461,28 @@ mod tests {
         let record = create_paired_read(191, 100, true, false, false, -101);
         let result = format_insert_string(&record, &header);
         assert_eq!(result, "chr1:100-200 | F1R2");
+    }
+
+    #[test]
+    fn test_format_insert_string_rf_pair_returns_na() {
+        // RF orientation: forward read is rightmost and reverse read is leftmost.
+        // Opposite-strand but TLEN sign disagrees with the FR layout — must be NA.
+        let header = create_test_header();
+
+        // Forward read at start=200 with negative TLEN → this is not FR.
+        let record_fwd = create_paired_read(200, 100, false, true, true, -101);
+        assert_eq!(format_insert_string(&record_fwd, &header), "NA");
+
+        // Reverse read at start=100 with positive TLEN → also not FR.
+        let record_rev = create_paired_read(100, 200, true, false, true, 101);
+        assert_eq!(format_insert_string(&record_rev, &header), "NA");
+    }
+
+    #[test]
+    fn test_format_insert_string_opposite_strand_tlen_zero_returns_na() {
+        // Opposite strands but TLEN = 0 (unpaired on reference) — must be NA.
+        let header = create_test_header();
+        let record = create_paired_read(100, 100, false, true, true, 0);
+        assert_eq!(format_insert_string(&record, &header), "NA");
     }
 }

--- a/tests/integration/test_bam_pipeline.rs
+++ b/tests/integration/test_bam_pipeline.rs
@@ -37,7 +37,7 @@ fn test_bam_pipeline_passthrough() {
         &input_bam,
         &output_bam,
         // Grouper factory
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         // Process function (pass-through)
         |record: RecordBuf| Ok(record),
         // Serialize function
@@ -94,7 +94,7 @@ fn test_bam_pipeline_thread_counts() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             serialize_bam_record_into(&record, header, output)
@@ -125,7 +125,7 @@ fn test_bam_pipeline_with_transform() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         // Transform: return record (already uppercase, just verify it works)
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
@@ -153,7 +153,7 @@ fn test_bam_pipeline_empty_input() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             serialize_bam_record_into(&record, header, output)
@@ -227,7 +227,7 @@ fn test_error_input_file_not_found() {
         config,
         &nonexistent,
         &output_bam,
-        |_| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |r: RecordBuf| Ok(r),
         |r: RecordBuf, h: &Header, output: &mut Vec<u8>| serialize_bam_record_into(&r, h, output),
     );
@@ -256,7 +256,7 @@ fn test_error_output_dir_not_found() {
         config,
         &input_bam,
         output_bam,
-        |_| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |r: RecordBuf| Ok(r),
         |r: RecordBuf, h: &Header, output: &mut Vec<u8>| serialize_bam_record_into(&r, h, output),
     );
@@ -284,7 +284,7 @@ fn test_error_process_fn_fails() {
         config,
         &input_bam,
         &output_bam,
-        |_| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |_record: RecordBuf| Err(io::Error::new(io::ErrorKind::InvalidData, "Process failed")),
         |r: RecordBuf, h: &Header, output: &mut Vec<u8>| serialize_bam_record_into(&r, h, output),
     );
@@ -312,7 +312,7 @@ fn test_error_serialize_fn_fails() {
         config,
         &input_bam,
         &output_bam,
-        |_| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |r: RecordBuf| Ok(r),
         |_r: RecordBuf, _h: &Header, _output: &mut Vec<u8>| {
             Err(io::Error::new(io::ErrorKind::InvalidData, "Serialize failed"))
@@ -389,7 +389,7 @@ fn test_error_corrupted_bgzf() {
         config,
         &corrupted_bam,
         &output_bam,
-        |_| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |r: RecordBuf| Ok(r),
         |r: RecordBuf, h: &Header, output: &mut Vec<u8>| serialize_bam_record_into(&r, h, output),
     );

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -192,3 +192,185 @@ fn test_dedup_command_remove_duplicates() {
     assert!(count < 6, "Remove-duplicates should produce fewer reads than input");
     assert!(count >= 2, "Should keep at least one pair");
 }
+
+/// Regression test for OOM with large position groups in `--no-umi` mode.
+///
+/// WES data can have extreme depth pileups at capture targets, creating positions
+/// with thousands of reads. With `--no-umi` (identity strategy), ALL reads at the
+/// same position form ONE group. This test exercises a 5,000-template position
+/// group to verify the pipeline completes without unbounded memory growth.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn test_dedup_no_umi_large_position_group() {
+    use bstr::BString;
+    use clap::Parser;
+    use fgumi_lib::commands::command::Command as FgumiCommand;
+    use fgumi_lib::commands::dedup::MarkDuplicates;
+    use fgumi_lib::sam::SamTag;
+    use fgumi_raw_bam::raw_record_to_record_buf;
+    use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags, testutil::encode_op};
+    use noodles::sam::Header;
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
+    use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
+    use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
+    use noodles::sam::header::record::value::{
+        Map, map::Header as HeaderRecord, map::ReferenceSequence,
+    };
+    use std::collections::HashSet;
+    use std::num::NonZeroUsize;
+
+    const NUM_TEMPLATES: usize = 5_000;
+    // PROPERLY_PAIRED flag = 0x2 (not exposed as a named constant in flags module).
+    const PROPERLY_PAIRED: u16 = 0x2;
+    // MATE_REVERSE flag = 0x20 (not exposed as a named constant in flags module).
+    // R1 is forward / R2 is reverse; we set MATE_REVERSE on R1 so the pair is FR
+    // self-consistent (mate reverse flag matches mate's REVERSE).
+    const MATE_REVERSE: u16 = 0x20;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Build a template-coordinate sorted header with one reference.
+    let header = {
+        let mut builder = HeaderRecordMap::<HeaderRecord>::builder();
+        for (tag_bytes, value) in
+            [(*b"SO", "unsorted"), (*b"GO", "query"), (*b"SS", "template-coordinate")]
+        {
+            let HeaderTag::Other(tag) = HeaderTag::from(tag_bytes) else { unreachable!() };
+            builder = builder.insert(tag, value);
+        }
+        Header::builder()
+            .set_header(builder.build().expect("valid header map"))
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).expect("non-zero length")),
+            )
+            .build()
+    };
+
+    // Write 5,000 paired-end templates all at position 100 with no UMI tag.
+    // Template-coordinate sort groups by position then name, so we write
+    // R1 and R2 together for each template in name-sorted order.
+    {
+        let mut writer = bam::io::Writer::new(fs::File::create(&input_bam).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+
+        for i in 0..NUM_TEMPLATES {
+            let name = format!("read_{i:05}");
+
+            let r1 = {
+                let mut b = RawSamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | PROPERLY_PAIRED | flags::FIRST_SEGMENT | MATE_REVERSE)
+                    .ref_id(0)
+                    .pos(99)
+                    .mapq(60)
+                    .cigar_ops(&[encode_op(0, 8)])
+                    .mate_ref_id(0)
+                    .mate_pos(199)
+                    .template_length(108);
+                b.add_string_tag(b"MC", b"8M");
+                b.build()
+            };
+
+            let r2 = {
+                let mut b = RawSamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | PROPERLY_PAIRED | flags::REVERSE | flags::LAST_SEGMENT)
+                    .ref_id(0)
+                    .pos(199)
+                    .mapq(60)
+                    .cigar_ops(&[encode_op(0, 8)])
+                    .mate_ref_id(0)
+                    .mate_pos(99)
+                    .template_length(-108);
+                b.add_string_tag(b"MC", b"8M");
+                b.build()
+            };
+
+            let r1_buf = raw_record_to_record_buf(&r1, &header).expect("convert R1");
+            let r2_buf = raw_record_to_record_buf(&r2, &header).expect("convert R2");
+            writer.write_alignment_record(&header, &r1_buf).expect("write R1");
+            writer.write_alignment_record(&header, &r2_buf).expect("write R2");
+        }
+        writer.try_finish().expect("finish BAM");
+    }
+
+    // Run dedup with --no-umi via MarkDuplicates::execute().
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--no-umi",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("dedup --no-umi should succeed with large position group");
+
+    assert!(output_bam.exists(), "output BAM should be created");
+
+    // Read back the output and verify duplicate marking and MI tags.
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).expect("open output BAM"));
+    let out_header = reader.read_header().expect("read output header");
+
+    let mut total_records = 0usize;
+    let mut duplicate_records = 0usize;
+    let mut non_duplicate_records = 0usize;
+    let mut mi_values = HashSet::new();
+    let mut mi_count = 0usize;
+    let mut non_dup_names = HashSet::new();
+
+    let mi_tag = Tag::from(SamTag::MI);
+
+    for result in reader.record_bufs(&out_header) {
+        let record: RecordBuf = result.expect("read record");
+        total_records += 1;
+
+        let is_dup = record.flags().is_duplicate();
+        if is_dup {
+            duplicate_records += 1;
+        } else {
+            non_duplicate_records += 1;
+            if let Some(name) = record.name() {
+                non_dup_names.insert(name.to_owned());
+            }
+        }
+
+        if let Some(DataValue::String(mi)) = record.data().get(&mi_tag) {
+            mi_values.insert(mi.to_owned());
+            mi_count += 1;
+        }
+    }
+
+    // All 10,000 records (5,000 pairs) should be present.
+    assert_eq!(total_records, NUM_TEMPLATES * 2, "all records should be present in output");
+
+    // Exactly one template (2 records) should NOT be marked as duplicate.
+    assert_eq!(
+        non_duplicate_records, 2,
+        "exactly one pair should be non-duplicate (the best-scoring template)"
+    );
+    assert_eq!(
+        duplicate_records,
+        (NUM_TEMPLATES - 1) * 2,
+        "all other pairs should be marked as duplicates"
+    );
+
+    // The two non-duplicate records should share the same read name.
+    assert_eq!(non_dup_names.len(), 1, "non-duplicate records should be from one template");
+
+    // Every record should have an MI tag.
+    assert_eq!(mi_count, NUM_TEMPLATES * 2, "all records should have an MI tag");
+
+    // All templates should share the same MI value (one group in identity strategy).
+    assert_eq!(mi_values.len(), 1, "all records should share a single MI tag value");
+}

--- a/tests/integration/test_pipeline_concurrency.rs
+++ b/tests/integration/test_pipeline_concurrency.rs
@@ -122,7 +122,7 @@ fn run_passthrough_pipeline(
         config,
         input_path,
         output_path,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             serialize_bam_record_into(&record, header, output)
@@ -143,7 +143,7 @@ fn run_passthrough_pipeline_with_config(
         config,
         input_path,
         output_path,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             serialize_bam_record_into(&record, header, output)
@@ -393,7 +393,7 @@ fn test_bam_pipeline_no_dropped_records_under_backpressure() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         move |record: RecordBuf| {
             process_count_clone.fetch_add(1, Ordering::Relaxed);
             // Brief yield to simulate work without excessive delay
@@ -476,7 +476,7 @@ fn test_error_propagation_process_fn_multithreaded() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         move |record: RecordBuf| {
             let n = count_clone.fetch_add(1, Ordering::Relaxed);
             if n == 50 {
@@ -517,7 +517,7 @@ fn test_error_propagation_serialize_fn_multithreaded() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(SingleRecordGrouper::new()),
+        |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
         |record: RecordBuf| Ok(record),
         move |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             let n = count_clone.fetch_add(1, Ordering::Relaxed);
@@ -538,11 +538,12 @@ fn test_error_propagation_serialize_fn_multithreaded() {
 struct FailAfterNGrouper {
     count: usize,
     fail_after: usize,
+    header: Header,
 }
 
 impl FailAfterNGrouper {
-    fn new(fail_after: usize) -> Self {
-        Self { count: 0, fail_after }
+    fn new(fail_after: usize, header: Header) -> Self {
+        Self { count: 0, fail_after, header }
     }
 }
 
@@ -560,9 +561,8 @@ impl Grouper for FailAfterNGrouper {
         records
             .into_iter()
             .map(|d| {
-                d.into_record().ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidData, "Expected parsed record")
-                })
+                fgumi_raw_bam::raw_record_to_record_buf(&d.into_raw_bytes(), &self.header)
+                    .map_err(io::Error::other)
             })
             .collect()
     }
@@ -590,7 +590,7 @@ fn test_error_propagation_grouper_multithreaded() {
         config,
         &input_bam,
         &output_bam,
-        |_header: &Header| Box::new(FailAfterNGrouper::new(50)),
+        |header: &Header| Box::new(FailAfterNGrouper::new(50, header.clone())),
         |record: RecordBuf| Ok(record),
         |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
             serialize_bam_record_into(&record, header, output)
@@ -621,7 +621,7 @@ fn test_error_does_not_cause_hang() {
             config,
             &input_clone,
             &output_bam,
-            |_header: &Header| Box::new(SingleRecordGrouper::new()),
+            |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
             move |record: RecordBuf| {
                 let n = count_clone.fetch_add(1, Ordering::Relaxed);
                 if n == 30 {
@@ -647,7 +647,7 @@ fn test_error_does_not_cause_hang() {
             config,
             &input_clone2,
             &output_bam2,
-            |_header: &Header| Box::new(FailAfterNGrouper::new(30)),
+            |header: &Header| Box::new(FailAfterNGrouper::new(30, header.clone())),
             |record: RecordBuf| Ok(record),
             |record: RecordBuf, header: &Header, output: &mut Vec<u8>| {
                 serialize_bam_record_into(&record, header, output)
@@ -974,7 +974,7 @@ mod stress_tests {
                     config,
                     &input_clone,
                     &output_clone,
-                    |_| Box::new(SingleRecordGrouper::new()),
+                    |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
                     move |record: RecordBuf| {
                         let n = count_clone.fetch_add(1, Ordering::Relaxed);
                         if n == fail_at {
@@ -1017,7 +1017,7 @@ mod stress_tests {
                     config,
                     &input_clone,
                     &output_clone,
-                    |_| Box::new(SingleRecordGrouper::new()),
+                    |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
                     |record: RecordBuf| {
                         // ~10% failure rate using a cheap hash of the record name
                         let hash = record
@@ -1208,7 +1208,7 @@ mod stress_tests {
                 config,
                 &input_clone,
                 &output_clone,
-                |_| Box::new(SingleRecordGrouper::new()),
+                |header: &Header| Box::new(SingleRecordGrouper::with_header(header.clone())),
                 move |record: RecordBuf| {
                     process_count_clone.fetch_add(1, Ordering::Relaxed);
                     // Brief sleep to simulate slow processing, but not enough to trigger deadlock


### PR DESCRIPTION
## Summary

Final pipeline collapse that removes the dual-storage `Template` and `DecodedRecord` enums in favor of raw-byte-only storage, deletes newly-dead `RecordBuf` helpers, and migrates the `clip` / `review` commands to raw-byte APIs. Mostly deletions — see diff shape (~5.9K insertions, ~9.8K deletions).

- **Template dual storage collapsed to raw-only.** In-lib unit tests ported alongside the code they test (`src/lib/template.rs`, `src/lib/mi_group.rs`, `src/lib/grouper.rs`, `src/lib/read_info.rs`, `src/lib/tag_reversal.rs`).
- **DecodedRecord collapsed to a single raw variant.** Drops `record()` / `into_record()` accessors and `GroupKeyConfig::raw_byte_mode` flag (`src/lib/unified_pipeline/bam.rs`, `src/lib/unified_pipeline/base.rs`).
- **Dead RecordBuf helpers removed:** `read_info::compute_group_key`, `get_unclipped_position_for_groupkey`, and `tag_reversal::reverse_per_base_tags` along with their tests.
- **`clip` command migrated to `RawRecordClipper`.** `clip` metrics moved to the shared `fgumi-metrics` crate (`src/lib/commands/clip.rs`, `crates/fgumi-metrics/src/clip.rs`).
- **`review.rs` migrated to `RawRecord` via `IndexedRawBamReader`.** `variant_review.rs` updated to consume `RawRecord`.
- **`zipper`:** unmapped reader swapped to `RawBamReader` + `RawTemplateIterator`, followed by deletion of the `cfg(test)` `RecordBuf` reference implementation of `restore_unconverted_bases` and its oracle tests (raw-byte mirrors already cover every scenario). Preserves main's `tc` / `TC_TAG` naming (#270) and `YD`-based restoration semantics (#274).
- **Cascade updates** across `commands/{codec,dedup,duplex,group,simplex,correct,filter,shared_metrics}` and `grouper` / `mi_group` / `unified_pipeline` to drop the dual paths and match the collapsed `Template` API.

Part 6 of 8 in the series closing #272. Stacks on #292. (Expanded from 7 to 8 PRs — see series comments.)

## Test plan

- [x] `cargo ci-test` — 2450 tests pass
- [x] `cargo ci-fmt` — clean
- [x] `cargo ci-lint` — clean