### PR TITLE
refactor(test): migrate workspace tests to fgumi_raw_bam SamBuilder

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -146,7 +146,7 @@
 //!
 //! // Process reads - should include both /A and /B MI tags
 //! // Example: "AAAA-CCCC/A" and "CCCC-AAAA/B" for same molecule
-//! let duplex_consensus = caller.consensus_reads_from_sam_records(reads)?;
+//! let duplex_consensus = caller.consensus_reads(reads)?;
 //!
 //! // Check statistics
 //! caller.log_statistics();
@@ -197,7 +197,7 @@ use bstr::BString;
 use bstr::ByteSlice;
 use log::{debug, info};
 use noodles::sam::alignment::record::data::field::Tag;
-// Used by #[cfg(test)] functions (call_duplex_from_ss_pair) and tests
+// Used by call_duplex_from_ss_pair and extract_int_tag (both #[cfg(test)])
 #[cfg(test)]
 use noodles::sam::alignment::record_buf::RecordBuf;
 
@@ -472,40 +472,6 @@ impl DuplexConsensusCaller {
         self.ss_caller.clear();
     }
 
-    /// Test helper: accepts `Vec<RecordBuf>`, encodes to raw bytes, and delegates to `consensus_reads`.
-    #[cfg(test)]
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "test helper takes ownership for convenience"
-    )]
-    pub(crate) fn consensus_reads_from_sam_records(
-        &mut self,
-        records: Vec<noodles::sam::alignment::RecordBuf>,
-    ) -> anyhow::Result<ConsensusOutput> {
-        use noodles::sam::header::record::value::Map;
-        use noodles::sam::header::record::value::map::ReferenceSequence;
-        use std::num::NonZeroUsize;
-        // Build header with a reference sequence for mapped records
-        let header = noodles::sam::Header::builder()
-            .add_reference_sequence(
-                "chr1",
-                Map::<ReferenceSequence>::new(
-                    NonZeroUsize::new(1_000_000).expect("1_000_000 is non-zero"),
-                ),
-            )
-            .build();
-        let raw: Vec<RawRecord> = records
-            .iter()
-            .map(|rec| {
-                let mut buf = Vec::new();
-                crate::vendored::bam_codec::encode_record_buf(&mut buf, &header, rec)
-                    .map_err(|e| anyhow::anyhow!("Failed to encode RecordBuf: {e}"))?;
-                Ok(RawRecord::from(buf))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        self.consensus_reads(raw)
-    }
-
     /// Parses MI tag to extract base UMI and strand (/A or /B)
     ///
     /// Returns (`base_umi`, strand) where strand is 'A', 'B', or None if no suffix
@@ -566,19 +532,16 @@ impl DuplexConsensusCaller {
     /// strands are found.
     #[cfg(test)]
     #[must_use]
-    pub fn has_both_strands(reads: &[RecordBuf]) -> bool {
+    pub fn has_both_strands(reads: &[RawRecord]) -> bool {
         if reads.len() < 2 {
             return false;
         }
 
-        let mi_tag = Tag::from([b'M', b'I']);
         let mut has_a = false;
         let mut has_b = false;
 
         for read in reads {
-            if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(mi_bytes)) =
-                read.data().get(&mi_tag)
-            {
+            if let Some(mi_bytes) = RawRecordView::new(read).tags().find_string(b"MI") {
                 match Self::extract_strand_from_mi_bytes(mi_bytes) {
                     Some('A') => {
                         has_a = true;
@@ -678,24 +641,21 @@ impl DuplexConsensusCaller {
         reason = "tuple return type is clearer than a one-off struct for test grouping"
     )]
     fn group_by_mi_and_strand(
-        reads: Vec<RecordBuf>,
-    ) -> Result<AHashMap<String, (Vec<RecordBuf>, Vec<RecordBuf>)>> {
-        let mut groups: AHashMap<String, (Vec<RecordBuf>, Vec<RecordBuf>)> = AHashMap::new();
+        reads: Vec<RawRecord>,
+    ) -> Result<AHashMap<String, (Vec<RawRecord>, Vec<RawRecord>)>> {
+        let mut groups: AHashMap<String, (Vec<RawRecord>, Vec<RawRecord>)> = AHashMap::new();
 
         for read in reads {
-            // Get MI tag
-            let mi_tag = noodles::sam::alignment::record::data::field::Tag::from([b'M', b'I']);
-            let mi =
-                if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(s)) =
-                    read.data().get(&mi_tag)
-                {
-                    String::from_utf8(s.iter().copied().collect::<Vec<u8>>())
-                        .context("MI tag is not valid UTF-8")?
-                } else {
-                    // No MI tag, skip this read
-                    continue;
+            // Extract MI tag bytes from the raw record. Missing MI on duplex input is a
+            // fatal error: the input must be grouped with `fgumi group --strategy paired`.
+            let mi = {
+                let view = RawRecordView::new(&read);
+                let Some(mi_bytes) = view.tags().find_string(b"MI") else {
+                    let read_name = String::from_utf8_lossy(view.read_name());
+                    bail!("Read '{read_name}' is missing MI tag");
                 };
-
+                String::from_utf8(mi_bytes.to_vec()).context("MI tag is not valid UTF-8")?
+            };
             let (base_mi, strand) = Self::parse_mi_tag(&mi);
 
             let entry = groups.entry(base_mi).or_insert_with(|| (Vec::new(), Vec::new()));
@@ -1362,7 +1322,19 @@ impl DuplexConsensusCaller {
         use noodles::sam::alignment::record_buf::data::field::Value;
         use noodles::sam::alignment::record_buf::{QualityScores, Sequence};
 
-        use fgumi_sam::to_smallest_signed_int;
+        /// Encode `value` as the smallest signed integer `BufValue` type.
+        fn to_smallest_signed_int(
+            value: i32,
+        ) -> noodles::sam::alignment::record_buf::data::field::Value {
+            use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+            if let Ok(v) = i8::try_from(value) {
+                BufValue::Int8(v)
+            } else if let Ok(v) = i16::try_from(value) {
+                BufValue::Int16(v)
+            } else {
+                BufValue::Int32(value)
+            }
+        }
 
         // Get sequences and qualities from both single-strand consensuses
         let seq_a = ss_a.sequence();
@@ -2277,17 +2249,8 @@ impl ConsensusCaller for DuplexConsensusCaller {
 )]
 mod tests {
     use super::*;
-    use fgumi_raw_bam::ParsedBamRecord;
-    use fgumi_sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{ParsedBamRecord, SamBuilder, testutil::encode_op};
     use noodles::sam::alignment::record_buf::data::field::Value;
-
-    fn encode_to_raw(rec: &noodles::sam::alignment::RecordBuf) -> RawRecord {
-        let header = noodles::sam::Header::default();
-        let mut buf = Vec::new();
-        crate::vendored::bam_codec::encode_record_buf(&mut buf, &header, rec)
-            .expect("encode_record_buf should succeed");
-        RawRecord::from(buf)
-    }
 
     #[test]
     fn test_parse_mi_tag() {
@@ -2305,83 +2268,38 @@ mod tests {
         );
     }
 
+    /// Build a minimal raw record with the given MI tag value.
+    fn raw_with_mi(name: &[u8], mi: &[u8]) -> RawRecord {
+        let mut b = SamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30u8; 4]);
+        b.add_string_tag(b"MI", mi);
+        b.build()
+    }
+
     #[test]
     fn test_has_both_strands() {
         // Empty - no strands
-        let empty: Vec<RecordBuf> = vec![];
+        let empty: Vec<RawRecord> = vec![];
         assert!(!DuplexConsensusCaller::has_both_strands(&empty));
 
         // Single read - not enough
-        let single_a = vec![
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-        ];
+        let single_a = vec![raw_with_mi(b"read1", b"UMI1/A")];
         assert!(!DuplexConsensusCaller::has_both_strands(&single_a));
 
         // Two reads, same strand - no duplex
-        let two_a = vec![
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-            RecordBuilder::new()
-                .name("read2")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-        ];
+        let two_a = vec![raw_with_mi(b"read1", b"UMI1/A"), raw_with_mi(b"read2", b"UMI1/A")];
         assert!(!DuplexConsensusCaller::has_both_strands(&two_a));
 
         // Two reads, both strands - duplex possible
-        let both_strands = vec![
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-            RecordBuilder::new()
-                .name("read2")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/B")
-                .build(),
-        ];
+        let both_strands = vec![raw_with_mi(b"read1", b"UMI1/A"), raw_with_mi(b"read2", b"UMI1/B")];
         assert!(DuplexConsensusCaller::has_both_strands(&both_strands));
 
         // Many reads, A strand first, B found later
         let many_a_one_b = vec![
-            RecordBuilder::new()
-                .name("read1")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-            RecordBuilder::new()
-                .name("read2")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-            RecordBuilder::new()
-                .name("read3")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/A")
-                .build(),
-            RecordBuilder::new()
-                .name("read4")
-                .sequence("ACGT")
-                .qualities(&[30, 30, 30, 30])
-                .tag("MI", "UMI1/B")
-                .build(),
+            raw_with_mi(b"read1", b"UMI1/A"),
+            raw_with_mi(b"read2", b"UMI1/A"),
+            raw_with_mi(b"read3", b"UMI1/A"),
+            raw_with_mi(b"read4", b"UMI1/B"),
         ];
         assert!(DuplexConsensusCaller::has_both_strands(&many_a_one_b));
     }
@@ -2448,13 +2366,10 @@ mod tests {
     #[test]
     fn test_group_by_mi_and_strand() -> Result<()> {
         // Create test reads with different MI tags
-        let read1 = RecordBuilder::new().sequence("ACGT").tag("MI", "UMI1/A").build();
-
-        let read2 = RecordBuilder::new().sequence("ACGT").tag("MI", "UMI1/B").build();
-
-        let read3 = RecordBuilder::new().sequence("ACGT").tag("MI", "UMI1/A").build();
-
-        let read4 = RecordBuilder::new().sequence("ACGT").tag("MI", "UMI2/A").build();
+        let read1 = raw_with_mi(b"r1", b"UMI1/A");
+        let read2 = raw_with_mi(b"r2", b"UMI1/B");
+        let read3 = raw_with_mi(b"r3", b"UMI1/A");
+        let read4 = raw_with_mi(b"r4", b"UMI2/A");
 
         let reads = vec![read1, read2, read3, read4];
         let groups = DuplexConsensusCaller::group_by_mi_and_strand(reads)?;
@@ -2472,6 +2387,22 @@ mod tests {
         assert_eq!(b_reads.len(), 0);
 
         Ok(())
+    }
+
+    /// Regression: a read without an MI tag must be a fatal error (not silently skipped),
+    /// so malformed input is surfaced rather than quietly dropping records.
+    #[test]
+    fn test_group_by_mi_and_strand_missing_mi_errors() {
+        let raw_without_mi = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r_no_mi").sequence(b"ACGT").qualities(&[30u8; 4]);
+            b.build()
+        };
+        let err = DuplexConsensusCaller::group_by_mi_and_strand(vec![raw_without_mi])
+            .expect_err("missing MI must be an error, not a silent skip");
+        let msg = format!("{err}");
+        assert!(msg.contains("r_no_mi"), "error should identify the offending read: {msg}");
+        assert!(msg.contains("MI"), "error should mention the missing MI tag: {msg}");
     }
 
     // Helper function to create a test VanillaUmiConsensusCaller
@@ -2496,28 +2427,32 @@ mod tests {
         )
     }
 
-    // Helper function to create a test single-strand consensus record
+    // Helper function to create a test single-strand consensus RecordBuf.
+    //
+    // Builds the record as raw bytes via SamBuilder, then decodes to RecordBuf so that
+    // call_duplex_from_ss_pair (which still accepts RecordBuf) can consume it.
     fn create_ss_consensus(
-        seq: &str,
+        seq: &[u8],
         qual: &[u8],
         depth_max: i32,
         depth_min: i32,
         error_rate: f32,
     ) -> RecordBuf {
-        RecordBuilder::new()
-            .sequence(seq)
-            .qualities(qual)
-            .tag("cD", depth_max)
-            .tag("cM", depth_min)
-            .tag("cE", error_rate)
-            .build()
+        let mut b = SamBuilder::new();
+        b.sequence(seq).qualities(qual);
+        b.add_int_tag(b"cD", depth_max);
+        b.add_int_tag(b"cM", depth_min);
+        b.add_float_tag(b"cE", error_rate);
+        let raw = b.build();
+        fgumi_raw_bam::raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+            .expect("raw_record_to_record_buf should succeed")
     }
 
     #[test]
     fn test_duplex_consensus_quality_scores_agreement() -> Result<()> {
         // Test that agreeing bases sum their qualities (capped at 93)
-        let ss_a = create_ss_consensus("AAAA", &[20, 30, 40, 50], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("AAAA", &[20, 30, 40, 50], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"AAAA", &[20, 30, 40, 50], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"AAAA", &[20, 30, 40, 50], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2544,8 +2479,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_quality_scores_disagreement_unequal() -> Result<()> {
         // Test that disagreeing bases with unequal qualities subtract lower from higher
-        let ss_a = create_ss_consensus("ACGT", &[30, 30, 30, 30], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("TGCA", &[10, 15, 20, 25], 2, 2, 0.0); // Different bases
+        let ss_a = create_ss_consensus(b"ACGT", &[30, 30, 30, 30], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"TGCA", &[10, 15, 20, 25], 2, 2, 0.0); // Different bases
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2572,8 +2507,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_quality_scores_disagreement_equal() -> Result<()> {
         // Test that disagreeing bases with equal qualities produce N with Q=2
-        let ss_a = create_ss_consensus("ACGT", &[20, 20, 20, 20], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("TGCA", &[20, 20, 20, 20], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"ACGT", &[20, 20, 20, 20], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"TGCA", &[20, 20, 20, 20], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2602,8 +2537,8 @@ mod tests {
         // Test that all per-read tags are generated correctly
         use noodles::sam::alignment::record::data::field::Tag;
 
-        let ss_a = create_ss_consensus("AAAA", &[20, 20, 20, 20], 3, 2, 0.05);
-        let ss_b = create_ss_consensus("AAAA", &[20, 20, 20, 20], 2, 1, 0.10);
+        let ss_a = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 3, 2, 0.05);
+        let ss_b = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 2, 1, 0.10);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2681,8 +2616,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_n_bases() -> Result<()> {
         // Test that N bases in either strand produce N in duplex with Q=2
-        let ss_a = create_ss_consensus("ANAA", &[20, 20, 20, 20], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("AANA", &[20, 20, 20, 20], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"ANAA", &[20, 20, 20, 20], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"AANA", &[20, 20, 20, 20], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2711,8 +2646,8 @@ mod tests {
     fn test_duplex_consensus_length_mismatch() -> Result<()> {
         // Test that length mismatches are handled by truncating to minimum length
         // This matches fgbio's behavior
-        let ss_a = create_ss_consensus("AAAA", &[20, 20, 20, 20], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("AAA", &[20, 20, 20], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"AAA", &[20, 20, 20], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2736,8 +2671,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_quality_capping() -> Result<()> {
         // Test that summed qualities are capped at 93
-        let ss_a = create_ss_consensus("AAA", &[50, 60, 93], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("AAA", &[50, 60, 93], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"AAA", &[50, 60, 93], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"AAA", &[50, 60, 93], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2761,8 +2696,8 @@ mod tests {
     fn test_duplex_consensus_quality_difference_at_threshold() -> Result<()> {
         // Test that quality differences of 2 or less mask to N
         // This tests the edge case where subtraction results in Q=2 or Q=1
-        let ss_a = create_ss_consensus("ACGT", &[5, 4, 3, 10], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("TGCA", &[3, 2, 2, 8], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"ACGT", &[5, 4, 3, 10], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"TGCA", &[3, 2, 2, 8], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2791,8 +2726,8 @@ mod tests {
     fn test_duplex_consensus_with_deep_coverage() -> Result<()> {
         // Test that qualities with deep coverage on one strand don't saturate incorrectly
         // AB strand has very high depth, BA strand has low depth
-        let ss_a = create_ss_consensus("AAAA", &[45, 45, 45, 45], 50, 50, 0.01);
-        let ss_b = create_ss_consensus("AAAA", &[20, 20, 20, 20], 1, 1, 0.0);
+        let ss_a = create_ss_consensus(b"AAAA", &[45, 45, 45, 45], 50, 50, 0.01);
+        let ss_b = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 1, 1, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -2835,8 +2770,8 @@ mod tests {
         use noodles::sam::alignment::record::data::field::Tag;
 
         // Create single-strand consensuses with per-base tags
-        let mut ss_a = create_ss_consensus("AAAA", &[20, 20, 20, 20], 3, 2, 0.05);
-        let mut ss_b = create_ss_consensus("AAAA", &[20, 20, 20, 20], 2, 1, 0.10);
+        let mut ss_a = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 3, 2, 0.05);
+        let mut ss_b = create_ss_consensus(b"AAAA", &[20, 20, 20, 20], 2, 1, 0.10);
 
         // Add per-base depth tags (cd) for both strands
         let cd_tag = Tag::from([b'c', b'd']);
@@ -2990,8 +2925,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_mixed_bases_and_n() -> Result<()> {
         // Test complex scenario with mixture of N bases and disagreements
-        let ss_a = create_ss_consensus("ANGT", &[30, 30, 30, 30], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("TNCG", &[25, 25, 25, 25], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"ANGT", &[30, 30, 30, 30], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"TNCG", &[25, 25, 25, 25], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -3025,8 +2960,8 @@ mod tests {
     #[test]
     fn test_duplex_consensus_zero_quality_difference() -> Result<()> {
         // Test that bases with same quality but different calls become N
-        let ss_a = create_ss_consensus("AAAA", &[25, 25, 25, 25], 3, 3, 0.0);
-        let ss_b = create_ss_consensus("TTTT", &[25, 25, 25, 25], 2, 2, 0.0);
+        let ss_a = create_ss_consensus(b"AAAA", &[25, 25, 25, 25], 3, 3, 0.0);
+        let ss_b = create_ss_consensus(b"TTTT", &[25, 25, 25, 25], 2, 2, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -3108,8 +3043,8 @@ mod tests {
         // At position 1: A vs G - disagreement, but one is N → no error
         // At position 2: A vs N - one is N → no error
 
-        let ss_a = create_ss_consensus("ANAA", &[30, 30, 30, 30], 1, 1, 0.0);
-        let ss_b = create_ss_consensus("GGNG", &[30, 30, 30, 30], 1, 1, 0.0);
+        let ss_a = create_ss_consensus(b"ANAA", &[30, 30, 30, 30], 1, 1, 0.0);
+        let ss_b = create_ss_consensus(b"GGNG", &[30, 30, 30, 30], 1, 1, 0.0);
 
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
             ss_a,
@@ -3141,8 +3076,8 @@ mod tests {
     #[test]
     fn test_duplex_n_base_propagation() -> Result<()> {
         // AB strand has data, BA has N's
-        let ss_ab = create_ss_consensus("AAAA", &[30, 30, 30, 30], 3, 3, 0.0);
-        let ss_ba_n = create_ss_consensus("NNNN", &[2, 2, 2, 2], 0, 0, 0.0);
+        let ss_ab = create_ss_consensus(b"AAAA", &[30, 30, 30, 30], 3, 3, 0.0);
+        let ss_ba_n = create_ss_consensus(b"NNNN", &[2, 2, 2, 2], 0, 0, 0.0);
 
         // When one strand has N, fgbio outputs N with NoCallQual (2)
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
@@ -3172,9 +3107,9 @@ mod tests {
     #[test]
     fn test_duplex_n_base_propagation_reverse() -> Result<()> {
         // Create AB with N's
-        let ss_ab_n = create_ss_consensus("NNNN", &[2, 2, 2, 2], 0, 0, 0.0);
+        let ss_ab_n = create_ss_consensus(b"NNNN", &[2, 2, 2, 2], 0, 0, 0.0);
         // Create BA with actual data
-        let ss_ba = create_ss_consensus("TTTT", &[30, 30, 30, 30], 3, 3, 0.0);
+        let ss_ba = create_ss_consensus(b"TTTT", &[30, 30, 30, 30], 3, 3, 0.0);
 
         // When one strand has N, fgbio outputs N
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
@@ -3201,8 +3136,128 @@ mod tests {
     }
 
     // ==========================================================================
-    // Integration tests using consensus_reads_from_sam_records
+    // Integration tests using consensus_reads() directly
     // ==========================================================================
+
+    /// Build an AB-strand R1 (fwd at pos1, mate at pos2).
+    /// flags: `PAIRED` | `FIRST_SEGMENT` | `MATE_REVERSE`
+    fn ab_r1(
+        b: &mut SamBuilder,
+        name: &[u8],
+        seq: &[u8],
+        qual: &[u8],
+        cigar: &[u32],
+        mi: &[u8],
+        extra_tags: &[(&[u8; 2], &[u8])],
+    ) -> RawRecord {
+        b.clear();
+        b.ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .read_name(name)
+            .cigar_ops(cigar)
+            .sequence(seq)
+            .qualities(qual);
+        b.add_string_tag(b"MI", mi);
+        b.add_string_tag(b"RG", b"A");
+        for (tag, val) in extra_tags {
+            b.add_string_tag(tag, val);
+        }
+        b.build()
+    }
+
+    /// Build an AB-strand R2 (rev at pos2, mate at pos1).
+    /// flags: `PAIRED` | `LAST_SEGMENT` | `REVERSE`
+    fn ab_r2(
+        b: &mut SamBuilder,
+        name: &[u8],
+        seq: &[u8],
+        qual: &[u8],
+        cigar: &[u32],
+        mi: &[u8],
+        extra_tags: &[(&[u8; 2], &[u8])],
+    ) -> RawRecord {
+        b.clear();
+        b.ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .read_name(name)
+            .cigar_ops(cigar)
+            .sequence(seq)
+            .qualities(qual);
+        b.add_string_tag(b"MI", mi);
+        b.add_string_tag(b"RG", b"A");
+        for (tag, val) in extra_tags {
+            b.add_string_tag(tag, val);
+        }
+        b.build()
+    }
+
+    /// Build a BA-strand R1 (rev at pos2, mate at pos1).
+    /// flags: `PAIRED` | `FIRST_SEGMENT` | `REVERSE`
+    fn ba_r1(
+        b: &mut SamBuilder,
+        name: &[u8],
+        seq: &[u8],
+        qual: &[u8],
+        cigar: &[u32],
+        mi: &[u8],
+        extra_tags: &[(&[u8; 2], &[u8])],
+    ) -> RawRecord {
+        b.clear();
+        b.ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .read_name(name)
+            .cigar_ops(cigar)
+            .sequence(seq)
+            .qualities(qual);
+        b.add_string_tag(b"MI", mi);
+        b.add_string_tag(b"RG", b"A");
+        for (tag, val) in extra_tags {
+            b.add_string_tag(tag, val);
+        }
+        b.build()
+    }
+
+    /// Build a BA-strand R2 (fwd at pos1, mate at pos2).
+    /// flags: `PAIRED` | `LAST_SEGMENT` | `MATE_REVERSE`
+    fn ba_r2(
+        b: &mut SamBuilder,
+        name: &[u8],
+        seq: &[u8],
+        qual: &[u8],
+        cigar: &[u32],
+        mi: &[u8],
+        extra_tags: &[(&[u8; 2], &[u8])],
+    ) -> RawRecord {
+        b.clear();
+        b.ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::MATE_REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .read_name(name)
+            .cigar_ops(cigar)
+            .sequence(seq)
+            .qualities(qual);
+        b.add_string_tag(b"MI", mi);
+        b.add_string_tag(b"RG", b"A");
+        for (tag, val) in extra_tags {
+            b.add_string_tag(tag, val);
+        }
+        b.build()
+    }
 
     /// Port of fgbio test: "not create records from fragments"
     /// Tests that fragment reads (unpaired) are rejected
@@ -3222,26 +3277,38 @@ mod tests {
             40,
         )?;
 
-        // Create fragment (unpaired) reads with MI tags
-        let frag_a = RecordBuilder::new()
-            .name("frag1")
-            .sequence("AAAAAAAAAA")
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .build();
+        // Fragment reads: no PAIRED flag
+        let cigar_10m = &[encode_op(0, 10)];
+        let mut b = SamBuilder::new();
 
-        let frag_b = RecordBuilder::new()
-            .name("frag2")
-            .sequence("AAAAAAAAAA")
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .build();
+        let frag_a = {
+            b.clear();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .flags(0) // unpaired
+                .read_name(b"frag1")
+                .cigar_ops(cigar_10m)
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[30u8; 10]);
+            b.add_string_tag(b"MI", b"foo/A");
+            b.build()
+        };
+        let frag_b = {
+            b.clear();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .flags(0) // unpaired
+                .read_name(b"frag2")
+                .cigar_ops(cigar_10m)
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[30u8; 10]);
+            b.add_string_tag(b"MI", b"foo/B");
+            b.build()
+        };
 
-        let result = caller.consensus_reads_from_sam_records(vec![frag_a, frag_b])?;
+        let result = caller.consensus_reads(vec![frag_a, frag_b])?;
 
         // Fragments should be rejected - no consensus output
         assert_eq!(
@@ -3271,73 +3338,18 @@ mod tests {
             40,
         )?;
 
-        // Create AB pair: R1 at pos 100 (+), R2 at pos 200 (-)
-        let ab_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RG", "A")
-            .build();
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
 
-        let ab_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RG", "A")
-            .build();
+        let reads = vec![
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", &[]),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", &[]),
+            ba_r1(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", &[]),
+            ba_r2(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", &[]),
+        ];
 
-        // Create BA pair: R1 at pos 200 (-), R2 at pos 100 (+)
-        let ba_r1 = RecordBuilder::new()
-            .name("q2")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RG", "A")
-            .build();
-
-        let ba_r2 = RecordBuilder::new()
-            .name("q2")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RG", "A")
-            .build();
-
-        let result = caller.consensus_reads_from_sam_records(vec![ab_r1, ab_r2, ba_r1, ba_r2])?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce 2 consensus reads (R1 and R2)
         assert_eq!(
@@ -3370,77 +3382,19 @@ mod tests {
             40,
         )?;
 
-        // Create AB pair with CB tag
-        let ab_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("CB", "ACGT")
-            .tag("RG", "A")
-            .build();
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+        let cb_extra: &[(&[u8; 2], &[u8])] = &[(b"CB", b"ACGT")];
 
-        let ab_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("CB", "ACGT")
-            .tag("RG", "A")
-            .build();
+        let reads = vec![
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", cb_extra),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", cb_extra),
+            ba_r1(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", cb_extra),
+            ba_r2(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", cb_extra),
+        ];
 
-        // Create BA pair with CB tag
-        let ba_r1 = RecordBuilder::new()
-            .name("q2")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("CB", "ACGT")
-            .tag("RG", "A")
-            .build();
-
-        let ba_r2 = RecordBuilder::new()
-            .name("q2")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("CB", "ACGT")
-            .tag("RG", "A")
-            .build();
-
-        let result = caller.consensus_reads_from_sam_records(vec![ab_r1, ab_r2, ba_r1, ba_r2])?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce consensus reads with CB tag preserved
         assert_eq!(result.count, 2, "Should produce 2 consensus reads");
@@ -3474,77 +3428,20 @@ mod tests {
             40,
         )?;
 
-        // Create AB pair with RX="ACT-" (right UMI absent)
-        let ab_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RX", "ACT-")
-            .tag("RG", "A")
-            .build();
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+        let rx_a: &[(&[u8; 2], &[u8])] = &[(b"RX", b"ACT-")];
+        let rx_b: &[(&[u8; 2], &[u8])] = &[(b"RX", b"-ACT")];
 
-        let ab_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RX", "ACT-")
-            .tag("RG", "A")
-            .build();
+        let reads = vec![
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", rx_a),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", rx_a),
+            ba_r1(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", rx_b),
+            ba_r2(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", rx_b),
+        ];
 
-        // Create BA pair with RX="-ACT" (left UMI absent)
-        let ba_r1 = RecordBuilder::new()
-            .name("q2")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RX", "-ACT")
-            .tag("RG", "A")
-            .build();
-
-        let ba_r2 = RecordBuilder::new()
-            .name("q2")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RX", "-ACT")
-            .tag("RG", "A")
-            .build();
-
-        let result = caller.consensus_reads_from_sam_records(vec![ab_r1, ab_r2, ba_r1, ba_r2])?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce 2 consensus reads
         assert_eq!(result.count, 2, "Should produce 2 duplex consensus reads");
@@ -3577,77 +3474,20 @@ mod tests {
             40,
         )?;
 
-        // Create AB pair with RX="-ACT" (left UMI absent)
-        let ab_r1 = RecordBuilder::new()
-            .name("q1")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RX", "-ACT")
-            .tag("RG", "A")
-            .build();
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+        let rx_a: &[(&[u8; 2], &[u8])] = &[(b"RX", b"-ACT")];
+        let rx_b: &[(&[u8; 2], &[u8])] = &[(b"RX", b"ACT-")];
 
-        let ab_r2 = RecordBuilder::new()
-            .name("q1")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/A")
-            .tag("RX", "-ACT")
-            .tag("RG", "A")
-            .build();
+        let reads = vec![
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", rx_a),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", rx_a),
+            ba_r1(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", rx_b),
+            ba_r2(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", rx_b),
+        ];
 
-        // Create BA pair with RX="ACT-" (right UMI absent)
-        let ba_r1 = RecordBuilder::new()
-            .name("q2")
-            .sequence("CCCCCCCCCC")
-            .qualities(&[20; 10])
-            .first_segment(true)
-            .reverse_complement(true)
-            .mate_reverse_complement(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RX", "ACT-")
-            .tag("RG", "A")
-            .build();
-
-        let ba_r2 = RecordBuilder::new()
-            .name("q2")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[20; 10])
-            .first_segment(false)
-            .reverse_complement(false)
-            .mate_reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(200)
-            .cigar("10M")
-            .tag("MI", "foo/B")
-            .tag("RX", "ACT-")
-            .tag("RG", "A")
-            .build();
-
-        let result = caller.consensus_reads_from_sam_records(vec![ab_r1, ab_r2, ba_r1, ba_r2])?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce 2 consensus reads
         assert_eq!(result.count, 2, "Should produce 2 duplex consensus reads");
@@ -3682,45 +3522,22 @@ mod tests {
             40,
         )?;
 
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+
         // Create 3 A-strand pairs (no B-strand)
-        let reads: Vec<RecordBuf> = (1..=3)
+        let reads: Vec<RawRecord> = (1..=3_u8)
             .flat_map(|i| {
+                let name = [b'q', i];
                 vec![
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("AAAAAAAAAA")
-                        .qualities(&[20; 10])
-                        .first_segment(true)
-                        .reverse_complement(false)
-                        .mate_reverse_complement(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(200)
-                        .cigar("10M")
-                        .tag("MI", "foo/A")
-                        .tag("RG", "A")
-                        .build(),
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("CCCCCCCCCC")
-                        .qualities(&[20; 10])
-                        .first_segment(false)
-                        .reverse_complement(true)
-                        .mate_reverse_complement(false)
-                        .reference_sequence_id(0)
-                        .alignment_start(200)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/A")
-                        .tag("RG", "A")
-                        .build(),
+                    ab_r1(&mut b, &name, b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", &[]),
+                    ab_r2(&mut b, &name, b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", &[]),
                 ]
             })
             .collect();
 
-        let result = caller.consensus_reads_from_sam_records(reads)?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce 2 consensus reads (R1 and R2) from single strand
         assert_eq!(result.count, 2, "Should produce 2 consensus reads from single A strand");
@@ -3761,45 +3578,22 @@ mod tests {
             40,
         )?;
 
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+
         // Create 3 B-strand pairs (no A-strand)
-        let reads: Vec<RecordBuf> = (1..=3)
+        let reads: Vec<RawRecord> = (1..=3_u8)
             .flat_map(|i| {
+                let name = [b'q', i];
                 vec![
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("CCCCCCCCCC")
-                        .qualities(&[20; 10])
-                        .first_segment(true)
-                        .reverse_complement(true)
-                        .mate_reverse_complement(false)
-                        .reference_sequence_id(0)
-                        .alignment_start(200)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("AAAAAAAAAA")
-                        .qualities(&[20; 10])
-                        .first_segment(false)
-                        .reverse_complement(false)
-                        .mate_reverse_complement(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(200)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
+                    ba_r1(&mut b, &name, b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", &[]),
+                    ba_r2(&mut b, &name, b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", &[]),
                 ]
             })
             .collect();
 
-        let result = caller.consensus_reads_from_sam_records(reads)?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce 2 consensus reads (R1 and R2) from single strand
         assert_eq!(result.count, 2, "Should produce 2 consensus reads from single B strand");
@@ -3836,45 +3630,22 @@ mod tests {
             40,
         )?;
 
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+
         // Create 3 A-strand pairs only (no B-strand)
-        let reads: Vec<RecordBuf> = (1..=3)
+        let reads: Vec<RawRecord> = (1..=3_u8)
             .flat_map(|i| {
+                let name = [b'q', i];
                 vec![
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("AAAAAAAAAA")
-                        .qualities(&[20; 10])
-                        .first_segment(true)
-                        .reverse_complement(false)
-                        .mate_reverse_complement(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(200)
-                        .cigar("10M")
-                        .tag("MI", "foo/A")
-                        .tag("RG", "A")
-                        .build(),
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("CCCCCCCCCC")
-                        .qualities(&[20; 10])
-                        .first_segment(false)
-                        .reverse_complement(true)
-                        .mate_reverse_complement(false)
-                        .reference_sequence_id(0)
-                        .alignment_start(200)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/A")
-                        .tag("RG", "A")
-                        .build(),
+                    ab_r1(&mut b, &name, b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", &[]),
+                    ab_r2(&mut b, &name, b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", &[]),
                 ]
             })
             .collect();
 
-        let result = caller.consensus_reads_from_sam_records(reads)?;
+        let result = caller.consensus_reads(reads)?;
 
         // Should produce empty result since BA=0 doesn't meet minReads[2]=1
         assert_eq!(
@@ -3919,125 +3690,36 @@ mod tests {
             40,
         )?;
 
-        // Create reads: 3 AB pairs + 2 BA pairs
-        let mut reads = Vec::new();
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
 
-        // 3 AB pairs
-        for i in 1..=3 {
-            reads.push(
-                RecordBuilder::new()
-                    .name(&format!("ab{i}"))
-                    .sequence("AAAAAAAAAA")
-                    .qualities(&[20; 10])
-                    .first_segment(true)
-                    .reverse_complement(false)
-                    .mate_reverse_complement(true)
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(200)
-                    .cigar("10M")
-                    .tag("MI", "foo/A")
-                    .tag("RG", "A")
-                    .build(),
-            );
-            reads.push(
-                RecordBuilder::new()
-                    .name(&format!("ab{i}"))
-                    .sequence("CCCCCCCCCC")
-                    .qualities(&[20; 10])
-                    .first_segment(false)
-                    .reverse_complement(true)
-                    .mate_reverse_complement(false)
-                    .reference_sequence_id(0)
-                    .alignment_start(200)
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(100)
-                    .cigar("10M")
-                    .tag("MI", "foo/A")
-                    .tag("RG", "A")
-                    .build(),
-            );
+        // Build 3 AB pairs + 2 BA pairs
+        let mut reads: Vec<RawRecord> = Vec::new();
+        for i in 1..=3_u8 {
+            let name = [b'a', b'b', i];
+            reads.push(ab_r1(&mut b, &name, b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", &[]));
+            reads.push(ab_r2(&mut b, &name, b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", &[]));
         }
-
-        // 2 BA pairs
-        for i in 4..=5 {
-            reads.push(
-                RecordBuilder::new()
-                    .name(&format!("ba{i}"))
-                    .sequence("CCCCCCCCCC")
-                    .qualities(&[20; 10])
-                    .first_segment(true)
-                    .reverse_complement(true)
-                    .mate_reverse_complement(false)
-                    .reference_sequence_id(0)
-                    .alignment_start(200)
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(100)
-                    .cigar("10M")
-                    .tag("MI", "foo/B")
-                    .tag("RG", "A")
-                    .build(),
-            );
-            reads.push(
-                RecordBuilder::new()
-                    .name(&format!("ba{i}"))
-                    .sequence("AAAAAAAAAA")
-                    .qualities(&[20; 10])
-                    .first_segment(false)
-                    .reverse_complement(false)
-                    .mate_reverse_complement(true)
-                    .reference_sequence_id(0)
-                    .alignment_start(100)
-                    .mate_reference_sequence_id(0)
-                    .mate_alignment_start(200)
-                    .cigar("10M")
-                    .tag("MI", "foo/B")
-                    .tag("RG", "A")
-                    .build(),
-            );
+        for i in 4..=5_u8 {
+            let name = [b'b', b'a', i];
+            reads.push(ba_r1(&mut b, &name, b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", &[]));
+            reads.push(ba_r2(&mut b, &name, b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", &[]));
         }
 
         // With minReads=3: should fail (BA only has 2 reads)
-        let result_3 = caller_3.consensus_reads_from_sam_records(reads.clone())?;
+        let result_3 = caller_3.consensus_reads(reads.clone())?;
         assert_eq!(result_3.count, 0, "minReads=3 should fail with only 2 BA reads");
 
         // With minReads=2: should pass
-        let result_2 = caller_2.consensus_reads_from_sam_records(reads.clone())?;
+        let result_2 = caller_2.consensus_reads(reads.clone())?;
         assert_eq!(result_2.count, 2, "minReads=2 should produce 2 consensus reads");
 
         // Now add a BA read with different CIGAR (will be filtered out)
+        let cigar_dissimilar = &[encode_op(0, 5), encode_op(2, 1), encode_op(0, 5)]; // 5M1D5M
         let dissimilar = vec![
-            RecordBuilder::new()
-                .name("ba6")
-                .sequence("CCCCCCCCCC")
-                .qualities(&[20; 10])
-                .first_segment(true)
-                .reverse_complement(true)
-                .mate_reverse_complement(false)
-                .reference_sequence_id(0)
-                .alignment_start(200)
-                .mate_reference_sequence_id(0)
-                .mate_alignment_start(100)
-                .cigar("5M1D5M") // Different CIGAR - will be filtered
-                .tag("MI", "foo/B")
-                .tag("RG", "A")
-                .build(),
-            RecordBuilder::new()
-                .name("ba6")
-                .sequence("AAAAAAAAAA")
-                .qualities(&[20; 10])
-                .first_segment(false)
-                .reverse_complement(false)
-                .mate_reverse_complement(true)
-                .reference_sequence_id(0)
-                .alignment_start(100)
-                .mate_reference_sequence_id(0)
-                .mate_alignment_start(200)
-                .cigar("10M")
-                .tag("MI", "foo/B")
-                .tag("RG", "A")
-                .build(),
+            ba_r1(&mut b, b"ba6", b"CCCCCCCCCC", quals, cigar_dissimilar, b"foo/B", &[]),
+            ba_r2(&mut b, b"ba6", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", &[]),
         ];
 
         let mut reads_with_dissimilar = reads.clone();
@@ -4060,8 +3742,7 @@ mod tests {
 
         // With dissimilar read (filtered): still only 2 BA reads pass filtering
         // minReads=3 should still fail
-        let result_dissimilar =
-            caller_3_new.consensus_reads_from_sam_records(reads_with_dissimilar)?;
+        let result_dissimilar = caller_3_new.consensus_reads(reads_with_dissimilar)?;
         assert_eq!(
             result_dissimilar.count, 0,
             "minReads=3 should still fail when dissimilar read is filtered out"
@@ -4075,8 +3756,8 @@ mod tests {
     #[test]
     fn test_swap_ab_ba_when_ab_has_zero_depth() -> Result<()> {
         // Create SS consensuses where AB has zero depth
-        let ss_ab_zero = create_ss_consensus("NNN", &[2, 2, 2], 0, 0, 0.0);
-        let ss_ba = create_ss_consensus("AAA", &[30, 30, 30], 3, 3, 0.0);
+        let ss_ab_zero = create_ss_consensus(b"NNN", &[2, 2, 2], 0, 0, 0.0);
+        let ss_ba = create_ss_consensus(b"AAA", &[30, 30, 30], 3, 3, 0.0);
 
         // Call duplex consensus - should swap AB and BA
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
@@ -4106,8 +3787,8 @@ mod tests {
     #[test]
     fn test_swap_ba_ab_when_ba_has_zero_depth() -> Result<()> {
         // Create SS consensuses where BA has zero depth
-        let ss_ab = create_ss_consensus("AAA", &[30, 30, 30], 3, 3, 0.0);
-        let ss_ba_zero = create_ss_consensus("NNN", &[2, 2, 2], 0, 0, 0.0);
+        let ss_ab = create_ss_consensus(b"AAA", &[30, 30, 30], 3, 3, 0.0);
+        let ss_ba_zero = create_ss_consensus(b"NNN", &[2, 2, 2], 0, 0, 0.0);
 
         // Call duplex consensus
         let duplex = DuplexConsensusCaller::call_duplex_from_ss_pair(
@@ -4204,7 +3885,7 @@ mod tests {
     */
     #[test]
     fn test_tie_breaking_for_simplex_consensus() -> Result<()> {
-        use fgumi_sam::builder::{SamBuilder, Strand};
+        use fgumi_raw_bam::SamBuilder;
 
         // This test reproduces the tie-breaking scenario:
         // 8 BA read pairs with 4 having 'A' at position 5 and 4 having 'C' at position 5
@@ -4212,147 +3893,112 @@ mod tests {
         // With Kahan summation for numeric stability (matching fgbio PR #1120),
         // the likelihoods are exactly equal, so we correctly return 'N' (no-call).
         // Previously, numerical instability would incorrectly break the tie.
-        let mut builder = SamBuilder::with_single_ref("chr1", 10000);
 
         // Quality array for 10 bases, all quality 38
         let quals = vec![38u8; 10];
+        // CIGAR for 10bp: 10M encoded as BAM u32 = (10 << 4) | op_code_for_M(0)
+        let cigar_10m: &[u32] = &[10u32 << 4];
 
-        // Create 8 BA read pairs (strand B): 4 with 'A' at position 5, 4 with 'C' at position 5
-        let _ = builder
-            .add_pair()
-            .name("ba1")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAACAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+        // Build a mapped FR pair using SamBuilder.
+        //
+        // Flag constants (BAM spec):
+        //   R1 of BA pair (R1=Plus/fwd, R2=Minus/rev):
+        //     PAIRED(0x1) | FIRST_SEGMENT(0x40) | MATE_REVERSE(0x20) = 0x61
+        //   R2 of BA pair:
+        //     PAIRED(0x1) | LAST_SEGMENT(0x80) | REVERSE(0x10)       = 0x91
+        //   R1 of AB pair (R1=Minus/rev, R2=Plus/fwd):
+        //     PAIRED(0x1) | FIRST_SEGMENT(0x40) | REVERSE(0x10)      = 0x51
+        //   R2 of AB pair:
+        //     PAIRED(0x1) | LAST_SEGMENT(0x80) | MATE_REVERSE(0x20)  = 0xa1
+        //
+        // Positions are 0-based in BAM (start1=100 → pos=99, start2=200 → pos=199).
+        let mut b = SamBuilder::new();
 
-        let _ = builder
-            .add_pair()
-            .name("ba2")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAAAAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+        /// Build one BA-strand read pair and append both records to `out`.
+        fn ba_pair(
+            b: &mut SamBuilder,
+            name: &[u8],
+            bases1: &[u8],
+            bases2: &[u8],
+            quals: &[u8],
+            cigar: &[u32],
+            out: &mut Vec<RawRecord>,
+        ) {
+            // R1: forward at pos 99, mate at pos 199
+            b.clear();
+            b.ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(199)
+                .read_name(name)
+                .cigar_ops(cigar)
+                .sequence(bases1)
+                .qualities(quals);
+            b.add_string_tag(b"RG", b"A");
+            b.add_string_tag(b"MI", b"test/B");
+            out.push(b.build());
 
-        let _ = builder
-            .add_pair()
-            .name("ba3")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAACAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+            // R2: reverse at pos 199, mate at pos 99
+            b.clear();
+            b.ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .read_name(name)
+                .cigar_ops(cigar)
+                .sequence(bases2)
+                .qualities(quals);
+            b.add_string_tag(b"RG", b"A");
+            b.add_string_tag(b"MI", b"test/B");
+            out.push(b.build());
+        }
 
-        let _ = builder
-            .add_pair()
-            .name("ba4")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAAAAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+        let mut raw_records: Vec<RawRecord> = Vec::new();
 
-        let _ = builder
-            .add_pair()
-            .name("ba5")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAACAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+        // 8 BA read pairs (strand B): 4 with 'A' at position 5, 4 with 'C' at position 5
+        ba_pair(&mut b, b"ba1", b"AAAAACAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba2", b"AAAAAAAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba3", b"AAAAACAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba4", b"AAAAAAAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba5", b"AAAAACAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba6", b"AAAAAAAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba7", b"AAAAACAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
+        ba_pair(&mut b, b"ba8", b"AAAAAAAAAA", b"TTTTTTTTTT", &quals, cigar_10m, &mut raw_records);
 
-        let _ = builder
-            .add_pair()
-            .name("ba6")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAAAAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
+        // 1 AB read pair (strand A): R1=Minus/rev at pos 199, R2=Plus/fwd at pos 99
+        b.clear();
+        b.ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .read_name(b"ab1")
+            .cigar_ops(cigar_10m)
+            .sequence(b"TTTTTTTTTT")
+            .qualities(&quals);
+        b.add_string_tag(b"RG", b"A");
+        b.add_string_tag(b"MI", b"test/A");
+        raw_records.push(b.build());
 
-        let _ = builder
-            .add_pair()
-            .name("ba7")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAACAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
-
-        let _ = builder
-            .add_pair()
-            .name("ba8")
-            .contig(0)
-            .start1(100)
-            .start2(200)
-            .strand1(Strand::Plus)
-            .strand2(Strand::Minus)
-            .bases1("AAAAAAAAAA")
-            .bases2("TTTTTTTTTT")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/B")
-            .build();
-
-        // Add 1 AB read pair (strand A)
-        let _ = builder
-            .add_pair()
-            .name("ab1")
-            .contig(0)
-            .start1(200)
-            .start2(100)
-            .strand1(Strand::Minus)
-            .strand2(Strand::Plus)
-            .bases1("TTTTTTTTTT")
-            .bases2("AAAAAAAAAA")
-            .quals1(&quals)
-            .quals2(&quals)
-            .attr("MI", "test/A")
-            .build();
+        b.clear();
+        b.ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::MATE_REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .read_name(b"ab1")
+            .cigar_ops(cigar_10m)
+            .sequence(b"AAAAAAAAAA")
+            .qualities(&quals);
+        b.add_string_tag(b"RG", b"A");
+        b.add_string_tag(b"MI", b"test/A");
+        raw_records.push(b.build());
 
         // Create a duplex consensus caller with minimum thresholds
         let mut caller = DuplexConsensusCaller::new(
@@ -4369,9 +4015,8 @@ mod tests {
             45,                 // error_rate_post_umi
         )?;
 
-        // Call consensus on these reads
-        let consensus_output =
-            caller.consensus_reads_from_sam_records(builder.records().to_vec())?;
+        // Call consensus directly on raw records (no RecordBuf bridge needed)
+        let consensus_output = caller.consensus_reads(raw_records)?;
 
         assert_eq!(consensus_output.count, 2, "Should generate 2 consensus records (R1 and R2)");
 
@@ -4722,26 +4367,22 @@ mod tests {
         // Create 3 AB R1 reads
         let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
-                encode_to_raw(
-                    &RecordBuilder::new()
-                        .sequence("ACGT")
-                        .first_segment(true)
-                        .tag("MI", "test/A")
-                        .build(),
-                )
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT")
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                    .add_string_tag(b"MI", b"test/A");
+                b.build()
             })
             .collect();
 
         // Create 2 BA R1 reads
         let b_reads: Vec<RawRecord> = (0..2)
             .map(|_| {
-                encode_to_raw(
-                    &RecordBuilder::new()
-                        .sequence("ACGT")
-                        .first_segment(true)
-                        .tag("MI", "test/B")
-                        .build(),
-                )
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT")
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                    .add_string_tag(b"MI", b"test/B");
+                b.build()
             })
             .collect();
 
@@ -4765,20 +4406,22 @@ mod tests {
         // Create 3 AB R1 reads
         let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
-                encode_to_raw(
-                    &RecordBuilder::new()
-                        .sequence("ACGT")
-                        .first_segment(true)
-                        .tag("MI", "test/A")
-                        .build(),
-                )
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT")
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                    .add_string_tag(b"MI", b"test/A");
+                b.build()
             })
             .collect();
 
         // Create 1 BA R1 read
-        let b_reads = vec![encode_to_raw(
-            &RecordBuilder::new().sequence("ACGT").first_segment(true).tag("MI", "test/B").build(),
-        )];
+        let b_reads = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT")
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .add_string_tag(b"MI", b"test/B");
+            vec![b.build()]
+        };
 
         // [3, 2, 1]: min_total=3, min_xy=2, min_yx=1
         // A=3, B=1, xy=max(3,1)=3, yx=min(3,1)=1
@@ -4814,10 +4457,17 @@ mod tests {
     #[test]
     fn test_are_all_same_strand() {
         // Create test records
-        let fwd_raw = encode_to_raw(&RecordBuilder::new().sequence("ACGT").build());
+        let fwd_raw = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT");
+            b.build()
+        };
 
-        let rev_raw =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").reverse_complement(true).build());
+        let rev_raw = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags::REVERSE);
+            b.build()
+        };
 
         // Empty collection
         assert!(DuplexConsensusCaller::are_all_same_strand(std::iter::empty::<&RawRecord>()));
@@ -4923,7 +4573,7 @@ mod tests {
             is_ba_only: false,
         };
 
-        let cell_tag = Tag::from(fgumi_sam::SamTag::CB);
+        let cell_tag = Tag::from([b'C', b'B']);
         let cell_barcode = "ACGTACGT-1";
 
         let mut builder = UnmappedSamBuilder::new();
@@ -5147,10 +4797,17 @@ mod tests {
     #[test]
     fn test_are_all_same_strand_mixed() {
         // Test are_all_same_strand with mixed strands
-        let fwd_raw = encode_to_raw(&RecordBuilder::new().sequence("ACGT").build());
+        let fwd_raw = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT");
+            b.build()
+        };
 
-        let rev_raw =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").reverse_complement(true).build());
+        let rev_raw = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags::REVERSE);
+            b.build()
+        };
 
         // All forward
         assert!(DuplexConsensusCaller::are_all_same_strand([&fwd_raw, &fwd_raw].into_iter()));
@@ -5474,13 +5131,17 @@ mod tests {
         // Create mock reads with paired + first segment flags for R1 counting
         let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
-                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT").flags(flags::PAIRED | flags::FIRST_SEGMENT);
+                b.build()
             })
             .collect();
 
         let b_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
-                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT").flags(flags::PAIRED | flags::FIRST_SEGMENT);
+                b.build()
             })
             .collect();
 
@@ -5505,7 +5166,9 @@ mod tests {
         // Create 3 A reads
         let a_reads: Vec<RawRecord> = (0..3)
             .map(|_| {
-                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
+                let mut b = SamBuilder::new();
+                b.sequence(b"ACGT").flags(flags::PAIRED | flags::FIRST_SEGMENT);
+                b.build()
             })
             .collect();
 
@@ -5531,43 +5194,46 @@ mod tests {
 
     #[test]
     fn test_is_paired_r1_and_r2_predicates() {
+        let build = |flags_val: u16| -> RawRecord {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags_val);
+            b.build()
+        };
+
         // Paired R1: PAIRED | FIRST_SEGMENT.
-        let paired_r1 =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build());
+        let paired_r1 = build(flags::PAIRED | flags::FIRST_SEGMENT);
         assert!(DuplexConsensusCaller::is_paired_r1(&paired_r1));
         assert!(!DuplexConsensusCaller::is_paired_r2(&paired_r1));
 
         // Paired R2: PAIRED | LAST_SEGMENT.
-        let paired_r2 =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(false).build());
+        let paired_r2 = build(flags::PAIRED | flags::LAST_SEGMENT);
         assert!(!DuplexConsensusCaller::is_paired_r1(&paired_r2));
         assert!(DuplexConsensusCaller::is_paired_r2(&paired_r2));
 
         // Unpaired fragment: neither PAIRED nor any segment bit. Must not be
         // classified as R1 or R2 — this is the regression guarded by fix.
-        let fragment = encode_to_raw(&RecordBuilder::new().sequence("ACGT").build());
+        let fragment = build(0);
         assert!(!DuplexConsensusCaller::is_paired_r1(&fragment));
         assert!(!DuplexConsensusCaller::is_paired_r2(&fragment));
     }
 
     #[test]
     fn test_has_minimum_number_of_reads_ignores_unpaired_fragments() {
+        let build = |flags_val: u16| -> RawRecord {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags_val);
+            b.build()
+        };
+
         // Three R1s plus two unpaired fragments on the A strand: fragments
         // must not contribute to the R1 count.
-        let a_r1s: Vec<RawRecord> = (0..3)
-            .map(|_| {
-                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
-            })
-            .collect();
-        let a_fragments: Vec<RawRecord> =
-            (0..2).map(|_| encode_to_raw(&RecordBuilder::new().sequence("ACGT").build())).collect();
+        let a_r1s: Vec<RawRecord> =
+            (0..3).map(|_| build(flags::PAIRED | flags::FIRST_SEGMENT)).collect();
+        let a_fragments: Vec<RawRecord> = (0..2).map(|_| build(0)).collect();
         let a_reads: Vec<RawRecord> = a_r1s.into_iter().chain(a_fragments).collect();
 
-        let b_reads: Vec<RawRecord> = (0..3)
-            .map(|_| {
-                encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build())
-            })
-            .collect();
+        let b_reads: Vec<RawRecord> =
+            (0..3).map(|_| build(flags::PAIRED | flags::FIRST_SEGMENT)).collect();
 
         // With fragments excluded: total R1s = 3 + 3 = 6 -> passes min_total=6.
         assert!(DuplexConsensusCaller::has_minimum_number_of_reads(
@@ -5586,20 +5252,25 @@ mod tests {
     #[test]
     fn test_has_minimum_number_of_reads_only_counts_r1() {
         // Create R1 and R2 reads for A strand
-        let a_r1 =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build());
+        let a_r1 = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
 
-        let a_r2 = encode_to_raw(
-            &RecordBuilder::new()
-                .sequence("ACGT")
-                .first_segment(false) // R2, should not be counted
-                .build(),
-        );
+        let a_r2 = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags::PAIRED | flags::LAST_SEGMENT); // R2, should not be counted
+            b.build()
+        };
 
         let a_reads = vec![a_r1, a_r2]; // Only 1 R1
 
-        let b_r1 =
-            encode_to_raw(&RecordBuilder::new().sequence("ACGT").first_segment(true).build());
+        let b_r1 = {
+            let mut b = SamBuilder::new();
+            b.sequence(b"ACGT").flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
 
         let b_reads = vec![b_r1]; // 1 R1
 
@@ -5713,30 +5384,30 @@ mod tests {
 
     #[test]
     fn test_partition_records_by_strand_basic() {
-        let a1 = encode_to_raw(
-            &RecordBuilder::new()
-                .name("r1")
-                .sequence("ACGT")
+        let a1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r1")
+                .sequence(b"ACGT")
                 .qualities(&[30; 4])
-                .tag("MI", "UMI1/A")
-                .build(),
-        );
-        let a2 = encode_to_raw(
-            &RecordBuilder::new()
-                .name("r2")
-                .sequence("ACGT")
+                .add_string_tag(b"MI", b"UMI1/A");
+            b.build()
+        };
+        let a2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r2")
+                .sequence(b"ACGT")
                 .qualities(&[30; 4])
-                .tag("MI", "UMI1/A")
-                .build(),
-        );
-        let b1 = encode_to_raw(
-            &RecordBuilder::new()
-                .name("r3")
-                .sequence("ACGT")
+                .add_string_tag(b"MI", b"UMI1/A");
+            b.build()
+        };
+        let b1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r3")
+                .sequence(b"ACGT")
                 .qualities(&[30; 4])
-                .tag("MI", "UMI1/B")
-                .build(),
-        );
+                .add_string_tag(b"MI", b"UMI1/B");
+            b.build()
+        };
 
         let records = vec![a1, a2, b1];
         let (base_mi, a_records, b_records) =
@@ -5761,14 +5432,11 @@ mod tests {
 
     #[test]
     fn test_partition_records_by_strand_missing_suffix() {
-        let rec = encode_to_raw(
-            &RecordBuilder::new()
-                .name("r1")
-                .sequence("ACGT")
-                .qualities(&[30; 4])
-                .tag("MI", "UMI1") // No /A or /B suffix
-                .build(),
-        );
+        let rec = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r1").sequence(b"ACGT").qualities(&[30; 4]).add_string_tag(b"MI", b"UMI1"); // No /A or /B suffix
+            b.build()
+        };
 
         let result = DuplexConsensusCaller::partition_records_by_strand(vec![rec]);
         assert!(result.is_err(), "Should error on MI tag without /A or /B suffix");
@@ -5776,14 +5444,14 @@ mod tests {
 
     #[test]
     fn test_partition_records_by_strand_a_only() {
-        let a1 = encode_to_raw(
-            &RecordBuilder::new()
-                .name("r1")
-                .sequence("ACGT")
+        let a1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"r1")
+                .sequence(b"ACGT")
                 .qualities(&[30; 4])
-                .tag("MI", "UMI1/A")
-                .build(),
-        );
+                .add_string_tag(b"MI", b"UMI1/A");
+            b.build()
+        };
 
         let (base_mi, a_records, b_records) =
             DuplexConsensusCaller::partition_records_by_strand(vec![a1])
@@ -6194,44 +5862,47 @@ mod tests {
         // 3 B-strand pairs: R1 reverse-complemented (fgbio BA-R1 convention),
         // R2 forward. Both sequences become CCCCCCCCCC in the query-sequence field
         // such that the aligned BA-strand view produces unconverted-C evidence.
-        let reads: Vec<RecordBuf> = (1..=3)
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[30u8; 10];
+        let mut b = SamBuilder::new();
+        let reads: Vec<RawRecord> = (1..=3_u8)
             .flat_map(|i| {
-                vec![
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("GGGGGGGGGG")
-                        .qualities(&[30; 10])
-                        .first_segment(true)
-                        .reverse_complement(true)
-                        .mate_reverse_complement(false)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("CCCCCCCCCC")
-                        .qualities(&[30; 10])
-                        .first_segment(false)
-                        .reverse_complement(false)
-                        .mate_reverse_complement(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
-                ]
+                let name = [b'q', i];
+                let ba_r1 = {
+                    b.clear();
+                    b.ref_id(0)
+                        .pos(99)
+                        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE)
+                        .mate_ref_id(0)
+                        .mate_pos(99)
+                        .read_name(&name)
+                        .cigar_ops(cigar_10m)
+                        .sequence(b"GGGGGGGGGG")
+                        .qualities(quals);
+                    b.add_string_tag(b"MI", b"foo/B");
+                    b.add_string_tag(b"RG", b"A");
+                    b.build()
+                };
+                let ba_r2 = {
+                    b.clear();
+                    b.ref_id(0)
+                        .pos(99)
+                        .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::MATE_REVERSE)
+                        .mate_ref_id(0)
+                        .mate_pos(99)
+                        .read_name(&name)
+                        .cigar_ops(cigar_10m)
+                        .sequence(b"CCCCCCCCCC")
+                        .qualities(quals);
+                    b.add_string_tag(b"MI", b"foo/B");
+                    b.add_string_tag(b"RG", b"A");
+                    b.build()
+                };
+                vec![ba_r1, ba_r2]
             })
             .collect();
 
-        let result = caller.consensus_reads_from_sam_records(reads)?;
+        let result = caller.consensus_reads(reads)?;
         assert_eq!(result.count, 2, "Should produce 2 consensus reads from B-only");
 
         let records = ParsedBamRecord::parse_all(&result.data);
@@ -6286,44 +5957,47 @@ mod tests {
         // BA-R2 (reverse_complement=false) stored "AAAAAAAAAA" → aligned "AAAAAAAAAA".
         // Distinguishable sequences let us verify which BA read each output slot
         // derives from.
-        let reads: Vec<RecordBuf> = (1..=3)
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[30u8; 10];
+        let mut b = SamBuilder::new();
+        let reads: Vec<RawRecord> = (1..=3_u8)
             .flat_map(|i| {
-                vec![
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("GGGGGGGGGG")
-                        .qualities(&[30; 10])
-                        .first_segment(true)
-                        .reverse_complement(true)
-                        .mate_reverse_complement(false)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
-                    RecordBuilder::new()
-                        .name(&format!("q{i}"))
-                        .sequence("AAAAAAAAAA")
-                        .qualities(&[30; 10])
-                        .first_segment(false)
-                        .reverse_complement(false)
-                        .mate_reverse_complement(true)
-                        .reference_sequence_id(0)
-                        .alignment_start(100)
-                        .mate_reference_sequence_id(0)
-                        .mate_alignment_start(100)
-                        .cigar("10M")
-                        .tag("MI", "foo/B")
-                        .tag("RG", "A")
-                        .build(),
-                ]
+                let name = [b'q', i];
+                let ba_r1 = {
+                    b.clear();
+                    b.ref_id(0)
+                        .pos(99)
+                        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE)
+                        .mate_ref_id(0)
+                        .mate_pos(99)
+                        .read_name(&name)
+                        .cigar_ops(cigar_10m)
+                        .sequence(b"GGGGGGGGGG")
+                        .qualities(quals);
+                    b.add_string_tag(b"MI", b"foo/B");
+                    b.add_string_tag(b"RG", b"A");
+                    b.build()
+                };
+                let ba_r2 = {
+                    b.clear();
+                    b.ref_id(0)
+                        .pos(99)
+                        .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::MATE_REVERSE)
+                        .mate_ref_id(0)
+                        .mate_pos(99)
+                        .read_name(&name)
+                        .cigar_ops(cigar_10m)
+                        .sequence(b"AAAAAAAAAA")
+                        .qualities(quals);
+                    b.add_string_tag(b"MI", b"foo/B");
+                    b.add_string_tag(b"RG", b"A");
+                    b.build()
+                };
+                vec![ba_r1, ba_r2]
             })
             .collect();
 
-        let result = caller.consensus_reads_from_sam_records(reads)?;
+        let result = caller.consensus_reads(reads)?;
         assert_eq!(result.count, 2, "Should produce 2 consensus reads from B-only");
 
         let records = ParsedBamRecord::parse_all(&result.data);

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1216,8 +1216,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fgumi_sam::builder::RecordBuilder;
-    use noodles::sam::alignment::record_buf::RecordBuf;
+    use fgumi_raw_bam::SamBuilder as RawSamBuilder;
 
     #[test]
     fn test_filter_result_to_rejection_reason() {
@@ -1490,40 +1489,6 @@ mod tests {
     // Methylation filter tests
     // ========================================================================
 
-    /// Helper: build a raw BAM record with methylation tags from a `RecordBuf`.
-    fn build_raw_with_methylation_tags(
-        header: &noodles::sam::Header,
-        record: &RecordBuf,
-    ) -> Vec<u8> {
-        fgumi_raw_bam::encode_record_buf_to_raw(record, header)
-            .expect("encode_record_buf_to_raw should succeed")
-            .into_inner()
-    }
-
-    /// Helper: create a SAM header with a single reference sequence for mapped record tests.
-    fn header_for_methylation_tests() -> noodles::sam::Header {
-        //                  0123456789
-        // Reference:       ACGTCGATCG
-        use noodles::sam::header::record::value::Map;
-        use noodles::sam::header::record::value::map::ReferenceSequence;
-        use std::num::NonZeroUsize;
-        noodles::sam::Header::builder()
-            .add_reference_sequence(
-                "chr1",
-                Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("1000 is non-zero")),
-            )
-            .build()
-    }
-
-    /// Helper: add an i16 array tag to a `RecordBuf`.
-    fn add_i16_array_tag(record: &mut RecordBuf, tag_str: &str, values: &[i16]) {
-        use noodles::sam::alignment::record::data::field::Tag;
-        use noodles::sam::alignment::record_buf::data::field::Value;
-        use noodles::sam::alignment::record_buf::data::field::value::Array;
-        let tag = Tag::from([tag_str.as_bytes()[0], tag_str.as_bytes()[1]]);
-        record.data_mut().insert(tag, Value::Array(Array::Int16(values.to_vec())));
-    }
-
     // -- MethylationDepthThresholds tests --
 
     #[test]
@@ -1554,60 +1519,41 @@ mod tests {
 
     #[test]
     fn test_mask_methylation_depth_simplex_all_pass() {
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
         // cu+ct = 5+3=8 at each position, min_depth=5 -> all pass
-        add_i16_array_tag(&mut record, "cu", &[5, 5, 5, 5]);
-        add_i16_array_tag(&mut record, "ct", &[3, 3, 3, 3]);
-
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.add_array_i16(b"cu", &[5, 5, 5, 5]).add_array_i16(b"ct", &[3, 3, 3, 3]);
+            b.build()
+        };
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 0);
     }
 
     #[test]
     fn test_mask_methylation_depth_simplex_some_fail() {
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
         // Position 0: cu+ct = 5+3=8 -> pass
         // Position 1: cu+ct = 1+1=2 -> fail (< 5)
         // Position 2: cu+ct = 0+0=0 -> fail
         // Position 3: cu+ct = 10+0=10 -> pass
-        add_i16_array_tag(&mut record, "cu", &[5, 1, 0, 10]);
-        add_i16_array_tag(&mut record, "ct", &[3, 1, 0, 0]);
-
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.add_array_i16(b"cu", &[5, 1, 0, 10]).add_array_i16(b"ct", &[3, 1, 0, 0]);
+            b.build()
+        };
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 2, "Positions 1 and 2 should be masked");
     }
 
     #[test]
     fn test_mask_methylation_depth_simplex_no_tags_no_masking() {
-        let header = header_for_methylation_tests();
-        let record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
         // No cu/ct tags
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.build()
+        };
         let masked = mask_methylation_depth_simplex_raw(&mut raw, 5).unwrap();
         assert_eq!(masked, 0, "No methylation tags should mean no masking");
     }
@@ -1616,49 +1562,37 @@ mod tests {
 
     #[test]
     fn test_mask_methylation_depth_duplex_all_pass() {
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
-        add_i16_array_tag(&mut record, "cu", &[10, 10, 10, 10]);
-        add_i16_array_tag(&mut record, "ct", &[2, 2, 2, 2]);
-        add_i16_array_tag(&mut record, "au", &[5, 5, 5, 5]);
-        add_i16_array_tag(&mut record, "at", &[1, 1, 1, 1]);
-        add_i16_array_tag(&mut record, "bu", &[5, 5, 5, 5]);
-        add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.add_array_i16(b"cu", &[10, 10, 10, 10])
+                .add_array_i16(b"ct", &[2, 2, 2, 2])
+                .add_array_i16(b"au", &[5, 5, 5, 5])
+                .add_array_i16(b"at", &[1, 1, 1, 1])
+                .add_array_i16(b"bu", &[5, 5, 5, 5])
+                .add_array_i16(b"bt", &[1, 1, 1, 1]);
+            b.build()
+        };
         let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
         assert_eq!(masked, 0);
     }
 
     #[test]
     fn test_mask_methylation_depth_duplex_ab_fails() {
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
         // Duplex passes (cu+ct=12), but AB fails at position 1 (au+at=1 < 3)
-        add_i16_array_tag(&mut record, "cu", &[10, 10, 10, 10]);
-        add_i16_array_tag(&mut record, "ct", &[2, 2, 2, 2]);
-        add_i16_array_tag(&mut record, "au", &[5, 0, 5, 5]);
-        add_i16_array_tag(&mut record, "at", &[1, 1, 1, 1]);
-        add_i16_array_tag(&mut record, "bu", &[5, 5, 5, 5]);
-        add_i16_array_tag(&mut record, "bt", &[1, 1, 1, 1]);
-
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.add_array_i16(b"cu", &[10, 10, 10, 10])
+                .add_array_i16(b"ct", &[2, 2, 2, 2])
+                .add_array_i16(b"au", &[5, 0, 5, 5])
+                .add_array_i16(b"at", &[1, 1, 1, 1])
+                .add_array_i16(b"bu", &[5, 5, 5, 5])
+                .add_array_i16(b"bt", &[1, 1, 1, 1]);
+            b.build()
+        };
         let thresholds = MethylationDepthThresholds { duplex: 5, ab: 3, ba: 3 };
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
         let masked = mask_methylation_depth_duplex_raw(&mut raw, &thresholds).unwrap();
         assert_eq!(masked, 1, "Position 1 should be masked (AB depth too low)");
     }
@@ -1674,23 +1608,22 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("AAAAACGAAAA")
-            .qualities(&[30; 11])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("11M")
-            .build();
         // au/at at position 5 (C): methylated (au=10, at=1)
         // bu/bt at position 6 (G): methylated (bu=10, bt=1)
-        add_i16_array_tag(&mut record, "au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
-
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[11 << 4])
+                .sequence(b"AAAAACGAAAA")
+                .qualities(&[30; 11]);
+            b.add_array_i16(b"au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0])
+                .add_array_i16(b"at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+                .add_array_i16(b"bu", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0])
+                .add_array_i16(b"bt", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
+            b.build()
+        };
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 0, "Concordant CpG should not be masked");
@@ -1705,23 +1638,22 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("AAAAACGAAAA")
-            .qualities(&[30; 11])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("11M")
-            .build();
         // au/at at position 5 (C): methylated (au=10, at=1)
         // bu/bt at position 6 (G): unmethylated (bu=1, bt=10)
-        add_i16_array_tag(&mut record, "au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "bu", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "bt", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
-
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[11 << 4])
+                .sequence(b"AAAAACGAAAA")
+                .qualities(&[30; 11]);
+            b.add_array_i16(b"au", &[0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0])
+                .add_array_i16(b"at", &[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+                .add_array_i16(b"bu", &[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0])
+                .add_array_i16(b"bt", &[0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0]);
+            b.build()
+        };
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 2, "Both CpG positions should be masked when strands disagree");
@@ -1735,21 +1667,20 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACAGTGCATGA")
-            .qualities(&[30; 11])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("11M")
-            .build();
-        add_i16_array_tag(&mut record, "au", &[0; 11]);
-        add_i16_array_tag(&mut record, "at", &[0; 11]);
-        add_i16_array_tag(&mut record, "bu", &[0; 11]);
-        add_i16_array_tag(&mut record, "bt", &[0; 11]);
-
-        let mut raw = build_raw_with_methylation_tags(&header, &record);
+        let mut raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[11 << 4])
+                .sequence(b"ACAGTGCATGA")
+                .qualities(&[30; 11]);
+            b.add_array_i16(b"au", &[0; 11])
+                .add_array_i16(b"at", &[0; 11])
+                .add_array_i16(b"bu", &[0; 11])
+                .add_array_i16(b"bt", &[0; 11]);
+            b.build()
+        };
         let masked =
             mask_strand_methylation_agreement_raw(&mut raw, &reference, &ref_names).unwrap();
         assert_eq!(masked, 0, "Non-CpG sites should not be masked");
@@ -1766,21 +1697,20 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Non-CpG C at positions 1 and 5: high conversion (ct >> cu)
         // cu: unconverted count, ct: converted count
-        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+            b.build()
+        };
         // 18 converted out of 20 = 90% conversion (positions 1 and 5)
         assert!(
             check_conversion_fraction_raw(
@@ -1801,20 +1731,19 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Non-CpG C at positions 1 and 5: low conversion (cu >> ct)
-        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+            b.build()
+        };
         // 2 converted out of 20 = 10% conversion (positions 1 and 5)
         assert!(
             !check_conversion_fraction_raw(
@@ -1836,21 +1765,20 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("AAAACGAAA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // CpG C at position 4: high unconverted (methylated) -- should be EXCLUDED
         // No non-CpG C positions -> should pass vacuously
-        add_i16_array_tag(&mut record, "cu", &[0, 0, 0, 0, 10, 0, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 0, 0, 0, 0, 0, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"AAAACGAAA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 0, 0, 0, 10, 0, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 0, 0, 0, 0, 0, 0, 0, 0]);
+            b.build()
+        };
         assert!(
             check_conversion_fraction_raw(
                 &raw,
@@ -1870,17 +1798,17 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // No cu/ct tags
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.build()
+        };
         assert!(
             check_conversion_fraction_raw(
                 &raw,
@@ -1900,9 +1828,12 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let record = RecordBuilder::new().sequence("ACATACATA").qualities(&[30; 9]).build();
         // Unmapped record (no ref_id, no cigar)
-        let raw = build_raw_with_methylation_tags(&noodles::sam::Header::default(), &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.sequence(b"ACATACATA").qualities(&[30; 9]);
+            b.build()
+        };
         assert!(
             check_conversion_fraction_raw(
                 &raw,
@@ -1924,20 +1855,19 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Non-CpG C at positions 1 and 5: high unconverted (cu >> ct) = good TAPs specificity
-        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+            b.build()
+        };
         // TAPs numerator = cu: 18 out of 20 = 90%
         assert!(
             check_conversion_fraction_raw(
@@ -1958,20 +1888,19 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Non-CpG C at positions 1 and 5: low unconverted (ct >> cu) = poor TAPs specificity
-        add_i16_array_tag(&mut record, "cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 1, 0, 0, 0, 1, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
+            b.build()
+        };
         // TAPs numerator = cu: 2 out of 20 = 10%
         assert!(
             !check_conversion_fraction_raw(
@@ -1992,21 +1921,20 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Non-CpG C at positions 1 and 5: cu=9, ct=1 at each
         // EM-Seq numerator = ct: 2/20 = 10%, TAPs numerator = cu: 18/20 = 90%
-        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+            b.build()
+        };
         // EM-Seq should fail (10% < 80%), TAPs should pass (90% >= 80%)
         assert!(
             !check_conversion_fraction_raw(
@@ -2039,20 +1967,19 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let mut record = RecordBuilder::new()
-            .sequence("ACATACATA")
-            .qualities(&[30; 9])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("9M")
-            .build();
         // Data that would fail EM-Seq at 80% threshold
-        add_i16_array_tag(&mut record, "cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0]);
-        add_i16_array_tag(&mut record, "ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
-
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[9 << 4])
+                .sequence(b"ACATACATA")
+                .qualities(&[30; 9]);
+            b.add_array_i16(b"cu", &[0, 9, 0, 0, 0, 9, 0, 0, 0])
+                .add_array_i16(b"ct", &[0, 1, 0, 0, 0, 1, 0, 0, 0]);
+            b.build()
+        };
         // Disabled mode should always pass regardless of data
         assert!(
             check_conversion_fraction_raw(
@@ -2075,16 +2002,11 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let record = RecordBuilder::new()
-            .sequence("ACGT")
-            .qualities(&[30; 4])
-            .reference_sequence_id(0)
-            .alignment_start(1) // 1-based -> 0-based pos=0
-            .mapping_quality(60)
-            .cigar("4M")
-            .build();
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+            b.build()
+        };
         let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')]);
     }
@@ -2096,16 +2018,17 @@ mod tests {
         let reference = TestRef::new(&[("chr1", ref_seq)]);
         let ref_names = vec!["chr1".to_string()];
 
-        let header = header_for_methylation_tests();
-        let record = RecordBuilder::new()
-            .sequence("ACNNGT") // 2M2I2M -> positions 2,3 are insertions
-            .qualities(&[30; 6])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .mapping_quality(60)
-            .cigar("2M2I2M")
-            .build();
-        let raw = build_raw_with_methylation_tags(&header, &record);
+        let raw = {
+            let mut b = RawSamBuilder::new();
+            // 2M2I2M -> positions 2,3 are insertions
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[2 << 4, 2 << 4 | 1, 2 << 4])
+                .sequence(b"ACNNGT")
+                .qualities(&[30; 6]);
+            b.build()
+        };
         let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, None, Some(b'G'), Some(b'T')]);
     }

--- a/crates/fgumi-consensus/src/tags.rs
+++ b/crates/fgumi-consensus/src/tags.rs
@@ -285,7 +285,32 @@ pub fn is_consensus(rec: &impl noodles::sam::alignment::Record) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fgumi_sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{RawRecord, SamBuilder, raw_record_to_record_buf};
+
+    /// Build a minimal `RawRecord` with the given integer tags, then decode to
+    /// `RecordBuf` so that `is_*_consensus` (which takes `&impl Record`) can be tested.
+    fn make_record_with_int_tags(tags: &[(&[u8; 2], i32)]) -> impl noodles::sam::alignment::Record {
+        let mut b = SamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30u8; 4]);
+        for (tag, value) in tags {
+            b.add_int_tag(tag, *value);
+        }
+        let raw: RawRecord = b.build();
+        raw_record_to_record_buf(&raw, &noodles::sam::Header::default()).expect("decode failed")
+    }
+
+    /// Build a minimal `RawRecord` with the given string tags, then decode to `RecordBuf`.
+    fn make_record_with_str_tags(
+        tags: &[(&[u8; 2], &[u8])],
+    ) -> impl noodles::sam::alignment::Record {
+        let mut b = SamBuilder::new();
+        b.sequence(b"ACGT").qualities(&[30u8; 4]);
+        for (tag, value) in tags {
+            b.add_string_tag(tag, value);
+        }
+        let raw: RawRecord = b.build();
+        raw_record_to_record_buf(&raw, &noodles::sam::Header::default()).expect("decode failed")
+    }
 
     #[test]
     fn test_tag_constants() {
@@ -328,7 +353,7 @@ mod tests {
     #[test]
     fn test_is_simplex_consensus() {
         // Create a record with cD tag (simplex consensus)
-        let rec = RecordBuilder::new().sequence("ACGT").tag("cD", 10_i32).build();
+        let rec = make_record_with_int_tags(&[(b"cD", 10)]);
 
         assert!(is_simplex_consensus(&rec));
         assert!(!is_duplex_consensus(&rec));
@@ -338,7 +363,7 @@ mod tests {
     #[test]
     fn test_is_duplex_consensus() {
         // Create a record with aD and bD tags (duplex consensus)
-        let rec = RecordBuilder::new().sequence("ACGT").tag("aD", 10_i32).tag("bD", 5_i32).build();
+        let rec = make_record_with_int_tags(&[(b"aD", 10), (b"bD", 5)]);
 
         assert!(!is_simplex_consensus(&rec));
         assert!(is_duplex_consensus(&rec));
@@ -348,7 +373,7 @@ mod tests {
     #[test]
     fn test_is_not_consensus() {
         // Create a record without consensus tags (raw read)
-        let rec = RecordBuilder::new().sequence("ACGT").tag("RX", "ACGT").build();
+        let rec = make_record_with_str_tags(&[(b"RX", b"ACGT")]);
 
         assert!(!is_simplex_consensus(&rec));
         assert!(!is_duplex_consensus(&rec));
@@ -513,12 +538,7 @@ mod tests {
     #[test]
     fn test_is_consensus_with_all_tags() {
         // Record with cD, aD, and bD is duplex, not simplex
-        let rec = RecordBuilder::new()
-            .sequence("ACGT")
-            .tag("cD", 10_i32)
-            .tag("aD", 5_i32)
-            .tag("bD", 3_i32)
-            .build();
+        let rec = make_record_with_int_tags(&[(b"cD", 10), (b"aD", 5), (b"bD", 3)]);
 
         assert!(!is_simplex_consensus(&rec));
         assert!(is_duplex_consensus(&rec));
@@ -528,7 +548,7 @@ mod tests {
     #[test]
     fn test_is_not_duplex_with_only_one_strand() {
         // Record with only aD (no bD) is not duplex
-        let rec = RecordBuilder::new().sequence("ACGT").tag("aD", 5_i32).build();
+        let rec = make_record_with_int_tags(&[(b"aD", 5)]);
 
         assert!(!is_simplex_consensus(&rec));
         assert!(!is_duplex_consensus(&rec));

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -16,8 +16,6 @@ use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::{RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
-#[cfg(test)]
-use noodles::sam::alignment::record_buf::RecordBuf;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -535,7 +533,7 @@ impl VanillaUmiConsensusCaller {
     #[cfg(test)]
     pub(crate) fn to_source_read_from_record(
         &self,
-        read: &RecordBuf,
+        read: &noodles::sam::alignment::record_buf::RecordBuf,
         original_idx: usize,
     ) -> Option<SourceRead> {
         use fgumi_sam::clipper::cigar_utils;
@@ -880,6 +878,13 @@ impl VanillaUmiConsensusCaller {
         let read_len = bases.len();
 
         if quals.is_empty() || quals.len() != read_len {
+            return None;
+        }
+
+        // Per the BAM spec, absent quality scores are encoded as 0xFF per base. Reject
+        // such reads rather than treating 0xFF as genuine very-high-quality evidence
+        // (which would let unqualified reads dominate consensus).
+        if quals.iter().all(|&q| q == 0xFF) {
             return None;
         }
 
@@ -1535,54 +1540,23 @@ pub(crate) enum ReadType {
 
 #[cfg(test)]
 #[expect(
-    clippy::needless_pass_by_value,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
-    reason = "test helpers use owned values and numeric casts for quality score math"
+    reason = "test helpers use numeric casts for quality score math"
 )]
 mod tests {
     use super::*;
-    use bstr::BString;
-    use fgumi_raw_bam::ParsedBamRecord;
-    use fgumi_sam::builder::{RecordBuilder, RecordPairBuilder};
-    use fgumi_sam::record_utils;
-    use noodles::core::Position;
-    use noodles::sam::alignment::record::Flags as NoodlesFlags;
-    use noodles::sam::alignment::record::cigar::op::Op;
-    use noodles::sam::alignment::record::data::field::Tag;
-    use noodles::sam::alignment::record_buf::{Cigar, QualityScores, Sequence, data::field::Value};
+    use fgumi_raw_bam::{
+        ParsedBamRecord, SamBuilder, encode_op, num_bases_extending_past_mate_raw,
+    };
 
-    /// Build a SAM header with a dummy reference sequence so that records
-    /// with `reference_sequence_id(0)` or `mate_reference_sequence_id(0)` can be encoded.
-    fn test_header() -> noodles::sam::Header {
-        use noodles::sam::header::record::value::Map;
-        use noodles::sam::header::record::value::map::ReferenceSequence;
-        use std::num::NonZeroUsize;
-        let ref_seq = Map::<ReferenceSequence>::new(
-            NonZeroUsize::new(1_000_000).expect("1_000_000 is non-zero"),
-        );
-        noodles::sam::Header::builder().add_reference_sequence("chr1", ref_seq).build()
-    }
-
-    /// Encode a `RecordBuf` into raw BAM bytes for use with the raw-byte API.
-    fn encode_to_raw(rec: &RecordBuf) -> Vec<u8> {
-        let header = test_header();
-        let mut buf = Vec::new();
-        crate::vendored::bam_codec::encode_record_buf(&mut buf, &header, rec)
-            .expect("encode_record_buf should succeed");
-        buf
-    }
-
-    /// Encode a batch of `RecordBuf` records and run `consensus_reads` directly,
-    /// bypassing the bridge function that uses a headerless default.
-    fn consensus_reads_from_records(
+    /// Call `consensus_reads` with a batch of already-built [`RawRecord`]s.
+    fn consensus_reads_from_raw(
         caller: &mut VanillaUmiConsensusCaller,
-        records: Vec<RecordBuf>,
+        records: Vec<RawRecord>,
     ) -> anyhow::Result<ConsensusOutput> {
-        let raw: Vec<RawRecord> =
-            records.iter().map(|r| RawRecord::from(encode_to_raw(r))).collect();
-        caller.consensus_reads(raw)
+        caller.consensus_reads(records)
     }
 
     fn create_test_read(
@@ -1591,16 +1565,25 @@ mod tests {
         qual: &[u8],
         is_paired: bool,
         is_first: bool,
-    ) -> RecordBuf {
-        let seq_str = String::from_utf8_lossy(seq);
-        let mut builder =
-            RecordBuilder::new().name(name).sequence(&seq_str).qualities(qual).tag("MI", "UMI123");
-
+    ) -> RawRecord {
+        let n = seq.len();
+        let mut flg = 0u16;
         if is_paired {
-            builder = builder.first_segment(is_first);
+            flg |= flags::PAIRED;
+            if is_first {
+                flg |= flags::FIRST_SEGMENT;
+            } else {
+                flg |= flags::LAST_SEGMENT;
+            }
         }
-
-        builder.build()
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .flags(flg)
+            .sequence(seq)
+            .qualities(qual)
+            .cigar_ops(&[encode_op(0, n)])
+            .add_string_tag(b"MI", b"UMI123");
+        b.build()
     }
 
     #[test]
@@ -1730,13 +1713,19 @@ mod tests {
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
         let read1 = create_test_read("read1", b"ACGT", b"####", false, false);
-        let mut read2 = create_test_read("read2", b"ACGT", b"####", false, false);
+        // Build read2 with the SECONDARY flag set directly
+        let read2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .flags(flags::SECONDARY)
+                .sequence(b"ACGT")
+                .qualities(b"####")
+                .cigar_ops(&[encode_op(0, 4)])
+                .add_string_tag(b"MI", b"UMI123");
+            b.build()
+        };
 
-        // Mark read2 as secondary
-        *read2.flags_mut() = NoodlesFlags::SECONDARY;
-
-        let filtered =
-            caller.filter_reads(vec![encode_to_raw(&read1).into(), encode_to_raw(&read2).into()]);
+        let filtered = caller.filter_reads(vec![read1, read2]);
         assert_eq!(filtered.len(), 1);
     }
 
@@ -1750,11 +1739,7 @@ mod tests {
         let r1 = create_test_read("r1", b"ACGT", b"####", true, true);
         let r2 = create_test_read("r2", b"ACGT", b"####", true, false);
 
-        let (frag_reads, r1_reads, r2_reads) = caller.subgroup_reads(vec![
-            encode_to_raw(&fragment).into(),
-            encode_to_raw(&r1).into(),
-            encode_to_raw(&r2).into(),
-        ]);
+        let (frag_reads, r1_reads, r2_reads) = caller.subgroup_reads(vec![fragment, r1, r2]);
 
         // Should have one read in each subgroup
         assert_eq!(frag_reads.len(), 1, "Should have 1 fragment read");
@@ -1773,8 +1758,8 @@ mod tests {
         let read2 = create_test_read("r2", b"ACGT", b"####", false, false);
         let read3 = create_test_read("r3", b"ACGT", b"####", false, false);
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -1796,8 +1781,8 @@ mod tests {
         let read1 = create_test_read("r1", b"ACGT", b"####", false, false);
         let read2 = create_test_read("r2", b"ACGT", b"####", false, false);
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 0);
     }
@@ -1817,8 +1802,7 @@ mod tests {
         let mut reads: Vec<RawRecord> = Vec::new();
         for i in 0..10 {
             let name = format!("read{i}");
-            let read = create_test_read(&name, b"ACGT", b"####", false, false);
-            reads.push(encode_to_raw(&read).into());
+            reads.push(create_test_read(&name, b"ACGT", b"####", false, false));
         }
 
         // Create two callers with the same seed
@@ -1861,8 +1845,7 @@ mod tests {
         let mut reads: Vec<RawRecord> = Vec::new();
         for i in 0..10 {
             let name = format!("read{i}");
-            let read = create_test_read(&name, b"ACGT", b"####", false, false);
-            reads.push(encode_to_raw(&read).into());
+            reads.push(create_test_read(&name, b"ACGT", b"####", false, false));
         }
 
         let mut caller =
@@ -1874,24 +1857,48 @@ mod tests {
         assert_eq!(downsampled.len(), 3);
     }
 
-    /// Creates a test read with a specific CIGAR string.
-    /// Sequence and qualities are auto-generated from CIGAR length.
-    fn create_test_read_with_cigar(name: &str, cigar: &str) -> RecordBuf {
-        RecordBuilder::new().name(name).cigar(cigar).tag("MI", "UMI123").build()
+    /// Parse a CIGAR string into BAM-encoded `u32` ops for use with [`SamBuilder::cigar_ops`].
+    ///
+    /// BAM op codes: 0=M, 1=I, 2=D, 3=N, 4=S, 5=H, 6=P, 7==, 8=X
+    fn parse_cigar_str(cigar: &str) -> Vec<u32> {
+        let mut ops = Vec::new();
+        let mut num_str = String::new();
+        for c in cigar.chars() {
+            if c.is_ascii_digit() {
+                num_str.push(c);
+            } else {
+                let len: u32 = num_str.parse().expect("failed to parse CIGAR length");
+                num_str.clear();
+                let op_code: u32 = match c {
+                    'M' => 0,
+                    'I' => 1,
+                    'D' => 2,
+                    'N' => 3,
+                    'S' => 4,
+                    'H' => 5,
+                    'P' => 6,
+                    '=' => 7,
+                    'X' => 8,
+                    _ => panic!("Unknown CIGAR op: {c}"),
+                };
+                ops.push((len << 4) | op_code);
+            }
+        }
+        ops
     }
 
     #[test]
     fn test_simplify_cigar_all_matches() {
-        let read = create_test_read_with_cigar("read1", "50M");
-        let simplified = cigar_utils::simplify_cigar(read.cigar());
+        let ops = parse_cigar_str("50M");
+        let simplified = fgumi_raw_bam::simplify_cigar_from_raw(&ops);
         assert_eq!(simplified.len(), 1);
         assert_eq!(simplified[0], (Kind::Match, 50));
     }
 
     #[test]
     fn test_simplify_cigar_with_soft_clips() {
-        let read = create_test_read_with_cigar("read1", "5S40M5S");
-        let simplified = cigar_utils::simplify_cigar(read.cigar());
+        let ops = parse_cigar_str("5S40M5S");
+        let simplified = fgumi_raw_bam::simplify_cigar_from_raw(&ops);
         // S converts to M and coalesces: 5M + 40M + 5M = 50M
         assert_eq!(simplified.len(), 1);
         assert_eq!(simplified[0], (Kind::Match, 50));
@@ -1899,8 +1906,8 @@ mod tests {
 
     #[test]
     fn test_simplify_cigar_with_indels() {
-        let read = create_test_read_with_cigar("read1", "25M1D25M");
-        let simplified = cigar_utils::simplify_cigar(read.cigar());
+        let ops = parse_cigar_str("25M1D25M");
+        let simplified = fgumi_raw_bam::simplify_cigar_from_raw(&ops);
         assert_eq!(simplified.len(), 3);
         assert_eq!(simplified[0], (Kind::Match, 25));
         assert_eq!(simplified[1], (Kind::Deletion, 1));
@@ -1909,8 +1916,8 @@ mod tests {
 
     #[test]
     fn test_simplify_cigar_complex() {
-        let read = create_test_read_with_cigar("read1", "5S20M1D25M5H");
-        let simplified = cigar_utils::simplify_cigar(read.cigar());
+        let ops = parse_cigar_str("5S20M1D25M5H");
+        let simplified = fgumi_raw_bam::simplify_cigar_from_raw(&ops);
         // 5S->5M + 20M = 25M, then 1D, then 25M, then 5H->5M coalesces with previous 25M = 30M
         assert_eq!(simplified.len(), 3);
         assert_eq!(simplified[0], (Kind::Match, 25));
@@ -2054,17 +2061,19 @@ mod tests {
     // Tests ported from fgbio's VanillaUmiConsensusCallerTest.scala
     // =====================================================================
 
-    /// Helper to create a test read with specific bases, quals, and UMI tag
-    /// This is the Rust equivalent of fgbio's SamBuilder.addFrag
-    fn create_consensus_test_read(name: &str, bases: &[u8], quals: &[u8], umi: &str) -> RecordBuf {
-        let seq_str = String::from_utf8_lossy(bases);
-        RecordBuilder::mapped_read()
-            .name(name)
-            .sequence(&seq_str)
+    /// Helper to create a mapped test read with specific bases, quals, and UMI tag.
+    /// Equivalent to fgbio's SamBuilder.addFrag: mapped, positive strand, `alignment_start=100`.
+    fn create_consensus_test_read(name: &str, bases: &[u8], quals: &[u8], umi: &str) -> RawRecord {
+        let n = bases.len();
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(99) // 0-based pos = alignment_start(100) - 1
+            .sequence(bases)
             .qualities(quals)
-            .alignment_start(100)
-            .tag("MI", umi)
-            .build()
+            .cigar_ops(&[encode_op(0, n)])
+            .add_string_tag(b"MI", umi.as_bytes());
+        b.build()
     }
 
     /// Port of fgbio test: "produce a consensus from two reads"
@@ -2084,8 +2093,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
         let read2 = create_consensus_test_read("r2", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2120,8 +2129,8 @@ mod tests {
         let read2 = create_consensus_test_read("r2", b"GATTACA", &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", b"GATTTCA", &quals, "UMI1"); // T instead of A at pos 4
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2159,8 +2168,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", b"GATTACA", &quals7, "UMI1");
         let read2 = create_consensus_test_read("r2", b"GATTAC", &quals6, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2194,8 +2203,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", &[b'A'; 10], &quals10, "UMI1");
         let read2 = create_consensus_test_read("r2", &[b'A'; 20], &quals20, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2229,8 +2238,8 @@ mod tests {
         let quals: Vec<u8> = vec![10, 10, 10, 10, 10, 10, 5];
         let read = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2261,8 +2270,8 @@ mod tests {
         let quals = vec![10u8; 7];
         let read = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2296,8 +2305,8 @@ mod tests {
         let quals = vec![10u8; 7];
         let read = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2329,8 +2338,8 @@ mod tests {
         let quals = vec![10u8; 7];
         let read = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2364,8 +2373,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", b"GATTACA", &quals_low, "UMI1");
         let read2 = create_consensus_test_read("r2", b"GATTACA", &quals_high, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2404,8 +2413,8 @@ mod tests {
         bases4[5] = b'C';
         let read4 = create_consensus_test_read("r4", &bases4, &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3, read4])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3, read4])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2480,8 +2489,8 @@ mod tests {
         let read3 = create_consensus_test_read("r3", b"GATGACAG", &quals, "UMI1"); // G at pos 3
         let read4 = create_consensus_test_read("r4", b"GATTACAG", &quals, "UMI1"); // T at pos 3
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3, read4])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3, read4])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2528,8 +2537,8 @@ mod tests {
         let read3 = create_consensus_test_read("r3", b"GATTACA", &quals_low, "UMI1");
         let read4 = create_consensus_test_read("r4", b"CTAATGT", &quals_high, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3, read4])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3, read4])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2569,8 +2578,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", &[b'A'; 10], &quals, "UMI1");
         let read2 = create_consensus_test_read("r2", &[b'A'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -2846,18 +2855,19 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create a read with mixed quality scores
         // fgbio: bases="AAAAAAAAAA", quals=[2,30,19,21,18,20,0,30,2,30]
-        let record = RecordBuilder::new()
-            .name("test")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[2, 30, 19, 21, 18, 20, 0, 30, 2, 30])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .build();
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[2, 30, 19, 21, 18, 20, 0, 30, 2, 30])
+                .cigar_ops(&[encode_op(0, 10)]);
+            b.build()
+        };
 
-        let source = caller.create_source_read(&encode_to_raw(&record), 0, 0);
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -2882,18 +2892,19 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create a read with low quality at the end
         // fgbio: bases="AAAAAAAAAA", quals=[30,30,30,30,30,30,2,2,2,2]
-        let record = RecordBuilder::new()
-            .name("test")
-            .sequence("AAAAAAAAAA")
-            .qualities(&[30, 30, 30, 30, 30, 30, 2, 2, 2, 2])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .build();
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[30, 30, 30, 30, 30, 30, 2, 2, 2, 2])
+                .cigar_ops(&[encode_op(0, 10)]);
+            b.build()
+        };
 
-        let source = caller.create_source_read(&encode_to_raw(&record), 0, 0);
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -2911,18 +2922,19 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create a read with Ns at the end
         // fgbio: bases="AAAAAANNNN", quals=[30,30,30,30,30,30,30,30,30,30]
-        let record = RecordBuilder::new()
-            .name("test")
-            .sequence("AAAAAANNNN")
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .build();
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"AAAAAANNNN")
+                .qualities(&[30; 10])
+                .cigar_ops(&[encode_op(0, 10)]);
+            b.build()
+        };
 
-        let source = caller.create_source_read(&encode_to_raw(&record), 0, 0);
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -2941,19 +2953,20 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create a read on negative strand with leading Ns
         // fgbio: bases="NNNNAAAAAA", strand=Minus, cigar="4S1M1D5M"
-        let record = RecordBuilder::new()
-            .name("test")
-            .sequence("NNNNAAAAAA")
-            .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("4S1M1D5M")
-            .reverse_complement(true)
-            .build();
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .flags(flags::REVERSE) // negative strand
+                .sequence(b"NNNNAAAAAA")
+                .qualities(&[30; 10])
+                .cigar_ops(&[encode_op(4, 4), encode_op(0, 1), encode_op(2, 1), encode_op(0, 5)]);
+            b.build()
+        };
 
-        let source = caller.create_source_read(&encode_to_raw(&record), 0, 0);
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -2976,18 +2989,19 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create a read where all bases are N or low quality
         // fgbio: bases="NANANANANA", quals=[30,2,30,2,30,2,30,2,30,2]
-        let record = RecordBuilder::new()
-            .name("test")
-            .sequence("NANANANANA")
-            .qualities(&[30, 2, 30, 2, 30, 2, 30, 2, 30, 2])
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("10M")
-            .build();
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"NANANANANA")
+                .qualities(&[30, 2, 30, 2, 30, 2, 30, 2, 30, 2])
+                .cigar_ops(&[encode_op(0, 10)]);
+            b.build()
+        };
 
-        let source = caller.create_source_read(&encode_to_raw(&record), 0, 0);
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
         // fgbio expected: None
         assert!(source.is_none(), "Should return None when all bases are masked or N");
     }
@@ -3001,29 +3015,30 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create R1 on positive strand with mate also on positive strand (FF pair, not FR)
+        // R1 on positive strand with mate also on positive strand (FF pair, not FR)
         // fgbio: addPair(start1=11, start2=1, strand1=Plus, strand2=Plus), bases="A"*50
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(50))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(11)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1)
-            .template_length(50)
-            // mate on positive strand (no MATE_REVERSE flag)
-            .tag("MC", "50M")
-            .build();
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(10) // 0-based = alignment_start(11) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                // mate on positive strand: no MATE_REVERSE flag
+                .mate_ref_id(0)
+                .mate_pos(0) // mate_alignment_start(1) - 1
+                .template_length(50)
+                .sequence(&[b'A'; 50])
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(0, 50)])
+                .add_string_tag(b"MC", b"50M");
+            b.build()
+        };
 
         // For FF pair, num_bases_extending_past_mate should return 0
-        let clip = record_utils::num_bases_extending_past_mate(&r1);
+        let clip = num_bases_extending_past_mate_raw(r1.as_ref());
         assert_eq!(clip, 0, "FF pair should not trigger mate overlap clipping");
 
-        let source = caller.create_source_read(&encode_to_raw(&r1), 0, clip);
+        let source = caller.create_source_read(r1.as_ref(), 0, clip);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -3040,27 +3055,27 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create FR pair where both reads have insertions
+        // FR pair where both reads have insertions
         // fgbio: addPair(start1=1, start2=1, strand1=Plus, strand2=Minus, cigar1="40M20I40M", cigar2="40M20I40M")
         // bases="A"*100
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30; 100])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("40M20I40M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1)
-            .template_length(80) // Reference span is 80bp due to insertion
-            .mate_reverse_complement(true)
-            .tag("MC", "40M20I40M")
-            .build();
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(0)
+                .template_length(80)
+                .sequence(&[b'A'; 100])
+                .qualities(&[30; 100])
+                .cigar_ops(&[encode_op(0, 40), encode_op(1, 20), encode_op(0, 40)])
+                .add_string_tag(b"MC", b"40M20I40M");
+            b.build()
+        };
 
-        let clip = record_utils::num_bases_extending_past_mate(&r1);
-        let source = caller.create_source_read(&encode_to_raw(&r1), 0, clip);
+        let clip = num_bases_extending_past_mate_raw(r1.as_ref());
+        let source = caller.create_source_read(r1.as_ref(), 0, clip);
         assert!(source.is_some(), "Should produce a SourceRead");
 
         let sr = source.expect("source read should be Some");
@@ -3077,32 +3092,30 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create R1 (positive strand) that extends past the mate's unclipped end
-        // R1: pos=100, cigar=50M → alignment_end = 149
-        // R2 (mate): pos=120, cigar=50M → mate_unclipped_end = 169
-        // R1 aligned portion (149) < mate unclipped end (169), so check soft clip excess
-        // With 50M (no soft clips), gap = 169 - 149 = 20, trailing_clip = 0, so clip = max(0, 0-20) = 0
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(50))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(120)
-            .template_length(70) // positive = FR
-            .mate_reverse_complement(true)
-            .tag("MC", "50M")
-            .build();
+        // R1 (positive strand): pos=100 (0-based=99), cigar=50M → alignment_end = 148 (0-based)
+        // R2 (mate): pos=120 (0-based=119), cigar=50M → mate_unclipped_end = 168 (0-based)
+        // R1 doesn't extend past mate → clip = 0
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(119)
+                .template_length(70)
+                .sequence(&[b'A'; 50])
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(0, 50)])
+                .add_string_tag(b"MC", b"50M");
+            b.build()
+        };
 
-        let clip = record_utils::num_bases_extending_past_mate(&r1);
-        // R1 ends at 149, mate ends at 169, so R1 doesn't extend past mate
+        let clip = num_bases_extending_past_mate_raw(r1.as_ref());
+        // R1 ends at 148, mate ends at 168, so R1 doesn't extend past mate
         assert_eq!(clip, 0, "R1 should not extend past mate");
 
-        let source = caller.create_source_read(&encode_to_raw(&r1), 0, clip);
+        let source = caller.create_source_read(r1.as_ref(), 0, clip);
         assert!(source.is_some());
         assert_eq!(source.expect("source should be Some").bases.len(), 50);
     }
@@ -3115,33 +3128,30 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
-        // Create R1 that extends past mate's unclipped end
-        // R1: pos=100, cigar=50M → alignment_end = 149
-        // R2 (mate): pos=100, cigar=30M → mate_unclipped_end = 129
-        // R1 alignment_end (149) >= mate_unclipped_end (129)
-        // readPosAtRefPos(129, false) → position 30 (1-based)
-        // clip = read_length - pos = 50 - 30 = 20
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(50))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .template_length(30) // positive = FR
-            .mate_reverse_complement(true)
-            .tag("MC", "30M")
-            .build();
+        // R1: pos=100 (0-based=99), cigar=50M → alignment_end = 148 (0-based)
+        // R2 (mate): pos=100 (0-based=99), cigar=30M → mate_unclipped_end = 128 (0-based)
+        // R1 extends 20 bases past mate
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .template_length(30)
+                .sequence(&[b'A'; 50])
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(0, 50)])
+                .add_string_tag(b"MC", b"30M");
+            b.build()
+        };
 
-        let clip = record_utils::num_bases_extending_past_mate(&r1);
-        // R1 ends at 149, mate ends at 129, so R1 extends 20 bases past mate
+        let clip = num_bases_extending_past_mate_raw(r1.as_ref());
+        // R1 ends at 148, mate ends at 128, so R1 extends 20 bases past mate
         assert_eq!(clip, 20, "R1 should extend 20 bases past mate");
 
-        let source = caller.create_source_read(&encode_to_raw(&r1), 0, clip);
+        let source = caller.create_source_read(r1.as_ref(), 0, clip);
         assert!(source.is_some());
         let sr = source.expect("source read should be Some");
         assert_eq!(sr.bases.len(), 30, "Should be trimmed to 30 bases");
@@ -3231,62 +3241,69 @@ mod tests {
         // R1 extends 10 bases past R2's unclipped end (50)
         // R2 extends 10 bases before R1's unclipped start (11)
 
-        // Create R1 (positive strand, at position 11)
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&("A".repeat(10) + &"C".repeat(30) + &"G".repeat(10)))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(11)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1)
-            .template_length(50) // positive = FR
-            .mate_reverse_complement(true)
-            .tag("MC", "50M")
-            .build();
+        // R1 (positive strand, at position 11, 0-based=10)
+        let mut seq_r1 = vec![b'A'; 10];
+        seq_r1.extend_from_slice(&[b'C'; 30]);
+        seq_r1.extend_from_slice(&[b'G'; 10]);
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(10) // alignment_start(11) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(0) // mate_alignment_start(1) - 1
+                .template_length(50)
+                .sequence(&seq_r1)
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(0, 50)])
+                .add_string_tag(b"MC", b"50M");
+            b.build()
+        };
 
         // Calculate clip for R1
-        let clip_r1 = record_utils::num_bases_extending_past_mate(&r1);
+        let clip_r1 = num_bases_extending_past_mate_raw(r1.as_ref());
         // R1 ends at position 60 (11+50-1), mate ends at position 50 (1+50-1)
         // R1 extends 10 bases past mate's end
         assert_eq!(clip_r1, 10, "R1 should extend 10 bases past mate");
 
-        let source_r1 = caller.create_source_read(&encode_to_raw(&r1), 0, clip_r1);
+        let source_r1 = caller.create_source_read(r1.as_ref(), 0, clip_r1);
         assert!(source_r1.is_some(), "R1 should produce SourceRead");
         let sr1 = source_r1.expect("failed to get sr1");
 
         // fgbio expected: "A"*10 + "C"*30 (last 10 G's trimmed)
         assert_eq!(sr1.bases.len(), 40, "R1 should be trimmed to 40 bases");
         assert_eq!(&sr1.bases[..10], b"AAAAAAAAAA", "R1 first 10 bases should be A");
-        assert_eq!(&sr1.bases[10..40], &vec![b'C'; 30][..], "R1 next 30 bases should be C");
+        assert_eq!(&sr1.bases[10..40], &[b'C'; 30], "R1 next 30 bases should be C");
 
-        // Create R2 (negative strand, at position 1)
-        let r2 = RecordBuilder::new()
-            .name("test")
-            .sequence(&("A".repeat(10) + &"C".repeat(30) + &"G".repeat(10)))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(11)
-            .template_length(-50) // negative = still FR from R2's perspective
-            .reverse_complement(true) // R2 is on negative strand
-            .tag("MC", "50M")
-            .build();
+        // R2 (negative strand, at position 1, 0-based=0)
+        let mut seq_r2 = vec![b'A'; 10];
+        seq_r2.extend_from_slice(&[b'C'; 30]);
+        seq_r2.extend_from_slice(&[b'G'; 10]);
+        let r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                // mate (R1) is not reversed
+                .mate_ref_id(0)
+                .mate_pos(10) // mate_alignment_start(11) - 1
+                .template_length(-50)
+                .sequence(&seq_r2)
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(0, 50)])
+                .add_string_tag(b"MC", b"50M");
+            b.build()
+        };
 
         // Calculate clip for R2
-        let clip_r2 = record_utils::num_bases_extending_past_mate(&r2);
+        let clip_r2 = num_bases_extending_past_mate_raw(r2.as_ref());
         // R2 starts at position 1, mate starts at position 11 (unclipped)
         // R2's first 10 bases (positions 1-10) extend before mate's start (11)
         assert_eq!(clip_r2, 10, "R2 should extend 10 bases before mate start");
 
-        let source_r2 = caller.create_source_read(&encode_to_raw(&r2), 0, clip_r2);
+        let source_r2 = caller.create_source_read(r2.as_ref(), 0, clip_r2);
         assert!(source_r2.is_some(), "R2 should produce SourceRead");
         let sr2 = source_r2.expect("failed to get sr2");
 
@@ -3308,26 +3325,27 @@ mod tests {
         // fgbio: addPair(start1=545, start2=493, strand1=Minus, strand2=Plus, cigar1="47S72M23S", cigar2="46S96M")
         // This is a -/+ pair which should not trigger mate overlap trimming in typical cases
 
-        // R1 on negative strand at position 545
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(142))
-            .qualities(&[30; 142])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(545)
-            .cigar("47S72M23S")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(493)
-            .template_length(-124) // negative for -/+ orientation
-            .reverse_complement(true)
-            .tag("MC", "46S96M")
-            .build();
+        // R1 on negative strand at position 545 (0-based=544)
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(544) // alignment_start(545) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE)
+                // mate on positive strand: no MATE_REVERSE flag
+                .mate_ref_id(0)
+                .mate_pos(492) // mate_alignment_start(493) - 1
+                .template_length(-124)
+                .sequence(&[b'A'; 142])
+                .qualities(&[30; 142])
+                .cigar_ops(&[encode_op(4, 47), encode_op(0, 72), encode_op(4, 23)])
+                .add_string_tag(b"MC", b"46S96M");
+            b.build()
+        };
 
-        let clip_r1 = record_utils::num_bases_extending_past_mate(&r1);
+        let clip_r1 = num_bases_extending_past_mate_raw(r1.as_ref());
 
-        let source_r1 = caller.create_source_read(&encode_to_raw(&r1), 0, clip_r1);
+        let source_r1 = caller.create_source_read(r1.as_ref(), 0, clip_r1);
         assert!(source_r1.is_some(), "R1 should produce SourceRead");
         let sr1 = source_r1.expect("failed to get sr1");
 
@@ -3349,26 +3367,26 @@ mod tests {
         // fgbio: addPair(start2=545, start1=493, strand2=Minus, strand1=Plus, cigar2="47S72M23S", cigar1="46S96M")
         // This is a +/- pair (R1 positive, R2 negative)
 
-        // R1 on positive strand at position 493
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&"A".repeat(142))
-            .qualities(&[30; 142])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(493)
-            .cigar("46S96M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(545)
-            .template_length(124) // positive for +/- orientation
-            .mate_reverse_complement(true)
-            .tag("MC", "47S72M23S")
-            .build();
+        // R1 on positive strand at position 493 (0-based=492)
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(492) // alignment_start(493) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(544) // mate_alignment_start(545) - 1
+                .template_length(124)
+                .sequence(&[b'A'; 142])
+                .qualities(&[30; 142])
+                .cigar_ops(&[encode_op(4, 46), encode_op(0, 96)])
+                .add_string_tag(b"MC", b"47S72M23S");
+            b.build()
+        };
 
-        let clip_r1 = record_utils::num_bases_extending_past_mate(&r1);
+        let clip_r1 = num_bases_extending_past_mate_raw(r1.as_ref());
 
-        let source_r1 = caller.create_source_read(&encode_to_raw(&r1), 0, clip_r1);
+        let source_r1 = caller.create_source_read(r1.as_ref(), 0, clip_r1);
         assert!(source_r1.is_some(), "R1 should produce SourceRead");
         let sr1 = source_r1.expect("failed to get sr1");
 
@@ -3391,38 +3409,36 @@ mod tests {
         // R1: 10S35M5S (unclipped start=10, unclipped end=60)
         // R2: 12S30M8S (unclipped start=8, unclipped end=58)
 
-        // R1: positive strand, 10S35M5S at position 20
-        // Unclipped range: 10 to 60 (reference positions)
-        let r1 = RecordBuilder::new()
-            .name("test")
-            .sequence(&("A".repeat(2) + &"C".repeat(46) + &"G".repeat(2)))
-            .qualities(&[30; 50])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(20)
-            .cigar("10S35M5S")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(20)
-            .template_length(39) // positive = FR, rough estimate
-            .mate_reverse_complement(true)
-            .tag("MC", "12S30M8S")
-            .build();
+        // R1: positive strand, 10S35M5S at position 20 (0-based=19)
+        let mut seq_r1_sc = vec![b'A'; 2];
+        seq_r1_sc.extend_from_slice(&[b'C'; 46]);
+        seq_r1_sc.extend_from_slice(&[b'G'; 2]);
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(19) // alignment_start(20) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(19) // mate_alignment_start(20) - 1
+                .template_length(39)
+                .sequence(&seq_r1_sc)
+                .qualities(&[30; 50])
+                .cigar_ops(&[encode_op(4, 10), encode_op(0, 35), encode_op(4, 5)])
+                .add_string_tag(b"MC", b"12S30M8S");
+            b.build()
+        };
 
-        let clip_r1 = record_utils::num_bases_extending_past_mate(&r1);
+        let clip_r1 = num_bases_extending_past_mate_raw(r1.as_ref());
         // R1 unclipped end is 59 (20+35-1+5=59)
         // R2 unclipped end is 57 (20+30-1+8=57)
         // R1 extends 2 bases past R2's end
 
-        let source_r1 = caller.create_source_read(&encode_to_raw(&r1), 0, clip_r1);
+        let source_r1 = caller.create_source_read(r1.as_ref(), 0, clip_r1);
         assert!(source_r1.is_some(), "R1 should produce SourceRead");
         let sr1 = source_r1.expect("failed to get sr1");
 
-        // fgbio expected: all 50 bases minus 2 at end = 48 bases
-        // Actually fgbio says "A"*2 + "C"*46 which is all 50 bases
-        // The test says "trim 2bp off the end of r1" but the expected string shows all bases
-        // Let me re-check: the expected baseString is "A"*2 + "C"*46 which is 48 bases
-        // So 2 G's at the end are trimmed
+        // fgbio expected: "A"*2 + "C"*46 = 48 bases (2 G's at end trimmed)
         if clip_r1 > 0 {
             assert!(sr1.bases.len() < 50, "R1 should be trimmed when extending past mate");
         }
@@ -3468,8 +3484,8 @@ mod tests {
         let read1 = create_consensus_test_read("r1", b"GATTACA", &quals, "UMI1");
         let read2 = create_consensus_test_read("r2", b"GATTACA", &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -3513,8 +3529,8 @@ mod tests {
         let read2 = create_consensus_test_read("r2", b"GATTACA", &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", b"GATTTCA", &quals, "UMI1"); // disagreement at pos 4
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3])
-            .expect("consensus_reads_from_records should succeed");
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3])
+            .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
@@ -3548,22 +3564,13 @@ mod tests {
     /// In Rust we handle this gracefully rather than panicking
     #[test]
     fn test_bases_quals_length_mismatch_handled() {
-        // Note: In fgumi, mismatched lengths are handled at the BAM parsing level
-        // or by noodles. This test verifies the code doesn't panic if it somehow
-        // receives mismatched data (though it would be caught earlier in practice).
+        // Note: In fgumi, mismatched lengths are handled at the BAM parsing level.
+        // This test verifies that the SamBuilder enforces matching sequence/quality lengths.
 
-        // The test effectively verifies our implementation is robust - we don't need
-        // to explicitly test for exceptions like fgbio does since Rust prevents this
-        // at the type level when using proper BAM records.
-
-        // Verify that creating a valid RecordBuf always has matching lengths
-        // (this is enforced by the type system, but we verify here for documentation)
+        // Verify that creating a valid RawRecord always has matching lengths
         let record = create_consensus_test_read("test", b"GATTACA", &[30u8; 7], "UMI1");
-        assert_eq!(
-            record.sequence().as_ref().len(),
-            record.quality_scores().as_ref().len(),
-            "Bases and quals must always have same length"
-        );
+        let view = RawRecordView::new(record.as_ref());
+        assert_eq!(view.l_seq() as usize, 7, "Sequence length should be 7 (GATTACA)");
     }
 
     /// Test that reads can be added to multiple CIGAR groups when their CIGAR
@@ -3686,44 +3693,68 @@ mod tests {
 
     /// Helper to create a fragment read with UMI tag for grouping tests
     fn create_fragment_read_with_umi(
-        name: &str,
-        umi: &str,
+        name: &[u8],
+        umi: &[u8],
         bases: &[u8],
         quals: &[u8],
-    ) -> RecordBuf {
-        RecordBuilder::new()
-            .name(name)
-            .sequence(&String::from_utf8_lossy(bases))
+    ) -> RawRecord {
+        let len = bases.len();
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .ref_id(0)
+            .pos(0)
+            .sequence(bases)
             .qualities(quals)
-            .reference_sequence_id(0)
-            .alignment_start(1)
-            .cigar(&format!("{}M", bases.len()))
-            .tag("MI", umi)
-            .build()
+            .cigar_ops(&[encode_op(0, len)])
+            .add_string_tag(b"MI", umi);
+        b.build()
     }
 
     /// Helper to create paired reads with UMI tag for grouping tests
+    ///
+    /// `start1` and `start2` are 1-based alignment start positions (converted internally to
+    /// 0-based for the raw BAM API).
     fn create_paired_reads_with_umi(
-        name: &str,
-        umi: &str,
+        name: &[u8],
+        umi: &[u8],
         bases: &[u8],
         quals: &[u8],
-        start1: usize,
-        start2: usize,
-    ) -> (RecordBuf, RecordBuf) {
-        let seq = String::from_utf8_lossy(bases);
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&seq)
-            .r2_sequence(&seq)
-            .r1_qualities(quals)
-            .r2_qualities(quals)
-            .r1_start(start1)
-            .r2_start(start2)
-            .r1_reverse(false)
-            .r2_reverse(false)
-            .tag("MI", umi)
-            .build()
+        start1: i32,
+        start2: i32,
+    ) -> (RawRecord, RawRecord) {
+        let len = bases.len();
+        let cigar = [encode_op(0, len)];
+        // Convert 1-based input positions to 0-based BAM positions.
+        let pos1 = start1 - 1;
+        let pos2 = start2 - 1;
+
+        let mut b1 = SamBuilder::new();
+        b1.read_name(name)
+            .ref_id(0)
+            .pos(pos1)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .sequence(bases)
+            .qualities(quals)
+            .cigar_ops(&cigar)
+            .mate_ref_id(0)
+            .mate_pos(pos2)
+            .add_string_tag(b"MI", umi);
+        let r1 = b1.build();
+
+        let mut b2 = SamBuilder::new();
+        b2.read_name(name)
+            .ref_id(0)
+            .pos(pos2)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .sequence(bases)
+            .qualities(quals)
+            .cigar_ops(&cigar)
+            .mate_ref_id(0)
+            .mate_pos(pos1)
+            .add_string_tag(b"MI", umi);
+        let r2 = b2.build();
+
+        (r1, r2)
     }
 
     /// Port of fgbio test: "should create two consensus for two UMI groups"
@@ -3735,10 +3766,10 @@ mod tests {
         let quals = vec![60u8; len]; // High quality
 
         // Create 4 fragment reads: 2 with UMI "GATTACA", 2 with UMI "ACATTAG"
-        let read1 = create_fragment_read_with_umi("READ1", "GATTACA", &bases, &quals);
-        let read2 = create_fragment_read_with_umi("READ2", "GATTACA", &bases, &quals);
-        let read3 = create_fragment_read_with_umi("READ3", "ACATTAG", &bases, &quals);
-        let read4 = create_fragment_read_with_umi("READ4", "ACATTAG", &bases, &quals);
+        let read1 = create_fragment_read_with_umi(b"READ1", b"GATTACA", &bases, &quals);
+        let read2 = create_fragment_read_with_umi(b"READ2", b"GATTACA", &bases, &quals);
+        let read3 = create_fragment_read_with_umi(b"READ3", b"ACATTAG", &bases, &quals);
+        let read4 = create_fragment_read_with_umi(b"READ4", b"ACATTAG", &bases, &quals);
 
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
@@ -3756,9 +3787,9 @@ mod tests {
         let mut caller2 =
             VanillaUmiConsensusCaller::new("c2".to_string(), "ACATTAG".to_string(), options);
 
-        let consensus1 = consensus_reads_from_records(&mut caller1, vec![read1, read2])
+        let consensus1 = consensus_reads_from_raw(&mut caller1, vec![read1, read2])
             .expect("consensus should succeed");
-        let consensus2 = consensus_reads_from_records(&mut caller2, vec![read3, read4])
+        let consensus2 = consensus_reads_from_raw(&mut caller2, vec![read3, read4])
             .expect("consensus should succeed");
 
         // Should have 1 consensus per UMI group (fragment reads only produce 1 consensus)
@@ -3774,7 +3805,7 @@ mod tests {
         let bases = vec![b'A'; len];
         let quals = vec![60u8; len];
 
-        let (r1, r2) = create_paired_reads_with_umi("READ1", "GATTACA", &bases, &quals, 1, 1000);
+        let (r1, r2) = create_paired_reads_with_umi(b"READ1", b"GATTACA", &bases, &quals, 1, 1000);
 
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
@@ -3786,8 +3817,8 @@ mod tests {
         let mut caller =
             VanillaUmiConsensusCaller::new("c".to_string(), "GATTACA".to_string(), options);
 
-        let output = consensus_reads_from_records(&mut caller, vec![r1, r2])
-            .expect("consensus should succeed");
+        let output =
+            consensus_reads_from_raw(&mut caller, vec![r1, r2]).expect("consensus should succeed");
 
         // Should have 2 consensus reads: one for R1, one for R2
         assert_eq!(output.count, 2, "Read pair should produce 2 consensus reads");
@@ -3817,8 +3848,10 @@ mod tests {
         let bases = vec![b'A'; len];
         let quals = vec![60u8; len];
 
-        let (r1a, r2a) = create_paired_reads_with_umi("READ1", "GATTACA", &bases, &quals, 1, 1000);
-        let (r1b, r2b) = create_paired_reads_with_umi("READ2", "ACATTAG", &bases, &quals, 1, 1000);
+        let (r1a, r2a) =
+            create_paired_reads_with_umi(b"READ1", b"GATTACA", &bases, &quals, 1, 1000);
+        let (r1b, r2b) =
+            create_paired_reads_with_umi(b"READ2", b"ACATTAG", &bases, &quals, 1, 1000);
 
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
@@ -3836,9 +3869,9 @@ mod tests {
         let mut caller2 =
             VanillaUmiConsensusCaller::new("c2".to_string(), "ACATTAG".to_string(), options);
 
-        let consensus1 = consensus_reads_from_records(&mut caller1, vec![r1a, r2a])
+        let consensus1 = consensus_reads_from_raw(&mut caller1, vec![r1a, r2a])
             .expect("consensus should succeed");
-        let consensus2 = consensus_reads_from_records(&mut caller2, vec![r1b, r2b])
+        let consensus2 = consensus_reads_from_raw(&mut caller2, vec![r1b, r2b])
             .expect("consensus should succeed");
 
         // Each pair should produce 2 consensus reads (R1 + R2)
@@ -3881,22 +3914,17 @@ mod tests {
         // Input: "AGCACGACGT" with quals [30,30,30,2,5,2,3,20,2,6]
         // With minBaseQuality=15 and qualityTrim=true
         // Expected: "AGC" (first 3 bases are good, phred-style trim cuts there)
-        let bases = b"AGCACGACGT";
-        let quals: Vec<u8> = vec![30, 30, 30, 2, 5, 2, 3, 20, 2, 6];
-
-        let mut rec = RecordBuf::builder()
-            .set_name(BString::from("test"))
-            .set_sequence(Sequence::from(bases.to_vec()))
-            .set_quality_scores(QualityScores::from(quals))
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![Op::new(Kind::Match, bases.len())]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-
-        // Add MI tag
-        let mi_tag = Tag::from([b'M', b'I']);
-        rec.data_mut().insert(mi_tag, Value::from("UMI1"));
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"AGCACGACGT")
+                .qualities(&[30, 30, 30, 2, 5, 2, 3, 20, 2, 6])
+                .cigar_ops(&[encode_op(0, 10)])
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions {
             min_input_base_quality: 15,
@@ -3907,7 +3935,7 @@ mod tests {
         let caller =
             VanillaUmiConsensusCaller::new("test".to_string(), "UMI1".to_string(), options);
 
-        let source = caller.to_source_read_from_record(&rec, 0); // 0 is original_idx
+        let source = caller.create_source_read(record.as_ref(), 0, 0);
 
         assert!(source.is_some(), "Should produce a source read");
         let sr = source.expect("source read should be Some");
@@ -3925,39 +3953,30 @@ mod tests {
     /// Tests that reads without quality scores are handled appropriately
     #[test]
     fn test_reads_without_base_qualities() {
-        // Create a read without quality scores (empty quals)
-        let bases = b"AAAAAAAAAA";
-
-        let mut rec = RecordBuf::builder()
-            .set_name(BString::from("test"))
-            .set_sequence(Sequence::from(bases.to_vec()))
-            // Note: NOT setting quality_scores leaves them empty/missing
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![Op::new(Kind::Match, bases.len())]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-
-        let mi_tag = Tag::from([b'M', b'I']);
-        rec.data_mut().insert(mi_tag, Value::from("UMI1"));
+        // The BAM spec represents absent quality scores as 0xFF per base. SamBuilder
+        // emits 0xFF when qualities are not set. create_source_read must reject such
+        // records rather than treating 0xFF as usable very-high-quality evidence.
+        let record = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .ref_id(0)
+                .pos(0)
+                .sequence(b"AAAAAAAAAA")
+                // Not setting qualities → SamBuilder encodes 0xFF (absent) per BAM spec
+                .cigar_ops(&[encode_op(0, 10)])
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions::default();
         let caller =
             VanillaUmiConsensusCaller::new("test".to_string(), "UMI1".to_string(), options);
 
-        // Calling to_source_read on a read without qualities should return None
-        // (fgbio throws an exception, but in Rust we can handle it gracefully)
-        let result = caller.to_source_read_from_record(&rec, 0); // 0 is original_idx
-
-        // The read has empty qualities, so it should return None or an empty/masked read
-        if let Some(sr) = result {
-            // If somehow we got a source read, it should have proper handling
-            // The qualities would be empty which means all bases would be masked
-            assert!(
-                sr.bases.is_empty() || sr.bases.iter().all(|&b| b == b'N'),
-                "Without qualities, all bases should be masked or read should be empty"
-            );
-        }
+        let result = caller.create_source_read(record.as_ref(), 0, 0);
+        assert!(
+            result.is_none(),
+            "reads without base qualities should be rejected, not treated as usable qualities"
+        );
     }
 
     // =========================================================================
@@ -3969,16 +3988,39 @@ mod tests {
     #[test]
     fn test_mate_cigar_handling() {
         let len = 10;
-        let bases = vec![b'A'; len];
-        let quals = vec![30u8; len];
-
-        let (mut r1, mut r2) =
-            create_paired_reads_with_umi("READ1", "GATTACA", &bases, &quals, 1, 100);
-
-        // Remove MC tag if present (ensure it's not there)
-        let mc_tag = Tag::from([b'M', b'C']);
-        r1.data_mut().remove(&mc_tag);
-        r2.data_mut().remove(&mc_tag);
+        // Build R1 and R2 without MC tag (to test that missing MC is handled gracefully)
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ1")
+                .ref_id(0)
+                .pos(0) // alignment_start(1) - 1
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(99) // alignment_start(100) - 1
+                .template_length(109)
+                .sequence(&vec![b'A'; len])
+                .qualities(&[30; 10])
+                .cigar_ops(&[encode_op(0, len)])
+                // No MC tag intentionally
+                .add_string_tag(b"MI", b"GATTACA");
+            b.build()
+        };
+        let r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ1")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .mate_ref_id(0)
+                .mate_pos(0)
+                .template_length(-109)
+                .sequence(&vec![b'A'; len])
+                .qualities(&[30; 10])
+                .cigar_ops(&[encode_op(0, len)])
+                // No MC tag intentionally
+                .add_string_tag(b"MI", b"GATTACA");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
@@ -3990,7 +4032,7 @@ mod tests {
             VanillaUmiConsensusCaller::new("c".to_string(), "GATTACA".to_string(), options);
 
         // Should succeed even without MC tag
-        let output = consensus_reads_from_records(&mut caller, vec![r1, r2])
+        let output = consensus_reads_from_raw(&mut caller, vec![r1, r2])
             .expect("consensus should succeed without MC tag");
 
         assert_eq!(output.count, 2, "Should produce 2 consensus reads even without MC tag");
@@ -4016,68 +4058,61 @@ mod tests {
         // After filtering to most common alignment (10M), only READ1 and READ3 remain
         // Consensus UMI should be "TNT" (T at pos 0, N at pos 1 due to disagreement, T at pos 2)
 
-        let rx_tag = Tag::from([b'R', b'X']);
-        let mi_tag = Tag::from([b'M', b'I']);
-
         // READ1: 10M, RX=TTT
-        let mut read1 = RecordBuf::builder()
-            .set_name(BString::from("READ1"))
-            .set_sequence(Sequence::from(bases.clone()))
-            .set_quality_scores(QualityScores::from(quals.clone()))
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![Op::new(Kind::Match, 10)]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-        read1.data_mut().insert(mi_tag, Value::from("AAA"));
-        read1.data_mut().insert(rx_tag, Value::from("TTT"));
+        let read1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ1")
+                .ref_id(0)
+                .pos(0)
+                .sequence(&bases)
+                .qualities(&quals)
+                .cigar_ops(&[encode_op(0, 10)])
+                .add_string_tag(b"MI", b"AAA")
+                .add_string_tag(b"RX", b"TTT");
+            b.build()
+        };
 
         // READ2: 5M5D5M, RX=ATT (different alignment, will be filtered)
-        let mut read2 = RecordBuf::builder()
-            .set_name(BString::from("READ2"))
-            .set_sequence(Sequence::from(bases.clone()))
-            .set_quality_scores(QualityScores::from(quals.clone()))
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![
-                Op::new(Kind::Match, 5),
-                Op::new(Kind::Deletion, 5),
-                Op::new(Kind::Match, 5),
-            ]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-        read2.data_mut().insert(mi_tag, Value::from("AAA"));
-        read2.data_mut().insert(rx_tag, Value::from("ATT"));
+        let read2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ2")
+                .ref_id(0)
+                .pos(0)
+                .sequence(&bases)
+                .qualities(&quals)
+                .cigar_ops(&[encode_op(0, 5), encode_op(2, 5), encode_op(0, 5)])
+                .add_string_tag(b"MI", b"AAA")
+                .add_string_tag(b"RX", b"ATT");
+            b.build()
+        };
 
         // READ3: 10M, RX=TAT
-        let mut read3 = RecordBuf::builder()
-            .set_name(BString::from("READ3"))
-            .set_sequence(Sequence::from(bases.clone()))
-            .set_quality_scores(QualityScores::from(quals.clone()))
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![Op::new(Kind::Match, 10)]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-        read3.data_mut().insert(mi_tag, Value::from("AAA"));
-        read3.data_mut().insert(rx_tag, Value::from("TAT"));
+        let read3 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ3")
+                .ref_id(0)
+                .pos(0)
+                .sequence(&bases)
+                .qualities(&quals)
+                .cigar_ops(&[encode_op(0, 10)])
+                .add_string_tag(b"MI", b"AAA")
+                .add_string_tag(b"RX", b"TAT");
+            b.build()
+        };
 
         // READ4: 4M2I4M, RX=TTA (different alignment, will be filtered)
-        let mut read4 = RecordBuf::builder()
-            .set_name(BString::from("READ4"))
-            .set_sequence(Sequence::from(bases.clone()))
-            .set_quality_scores(QualityScores::from(quals.clone()))
-            .set_reference_sequence_id(0)
-            .set_alignment_start(Position::try_from(1).expect("failed to set alignment_start"))
-            .set_cigar(Cigar::from(vec![
-                Op::new(Kind::Match, 4),
-                Op::new(Kind::Insertion, 2),
-                Op::new(Kind::Match, 4),
-            ]))
-            .set_flags(NoodlesFlags::empty())
-            .build();
-        read4.data_mut().insert(mi_tag, Value::from("AAA"));
-        read4.data_mut().insert(rx_tag, Value::from("TTA"));
+        let read4 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"READ4")
+                .ref_id(0)
+                .pos(0)
+                .sequence(&bases)
+                .qualities(&quals)
+                .cigar_ops(&[encode_op(0, 4), encode_op(1, 2), encode_op(0, 4)])
+                .add_string_tag(b"MI", b"AAA")
+                .add_string_tag(b"RX", b"TTA");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions {
             min_reads: 1,
@@ -4088,7 +4123,7 @@ mod tests {
         let mut caller =
             VanillaUmiConsensusCaller::new("c".to_string(), "AAA".to_string(), options);
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3, read4])
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3, read4])
             .expect("consensus should succeed");
 
         assert_eq!(output.count, 1, "Should produce 1 consensus");
@@ -4220,23 +4255,30 @@ mod tests {
     /// - `consensus_reads` in `consensus_call()` via `record_consensus()`
     #[test]
     fn test_stats_no_double_counting() {
-        // Helper to create a test read with a specific UMI
-        fn create_test_read_with_umi(name: &str, is_first: bool, umi: &str) -> RecordBuf {
-            RecordBuilder::new()
-                .name(name)
-                .sequence("ACGT")
+        // Helper to create a paired test read with a specific UMI
+        fn create_test_read_with_umi(name: &[u8], is_first: bool, umi: &[u8]) -> RawRecord {
+            let pair_flags = if is_first {
+                flags::PAIRED | flags::FIRST_SEGMENT
+            } else {
+                flags::PAIRED | flags::LAST_SEGMENT
+            };
+            let mut b = SamBuilder::new();
+            b.read_name(name)
+                .ref_id(0)
+                .pos(0)
+                .flags(pair_flags)
+                .sequence(b"ACGT")
                 .qualities(&[30, 30, 30, 30])
-                .paired(true)
-                .first_segment(is_first)
-                .tag("MI", umi)
-                .build()
+                .cigar_ops(&[encode_op(0, 4)])
+                .add_string_tag(b"MI", umi);
+            b.build()
         }
 
         // Create 2 pairs of reads for 2 UMI groups (4 total reads)
-        let r1_umi1 = create_test_read_with_umi("read1", true, "1");
-        let r2_umi1 = create_test_read_with_umi("read1", false, "1");
-        let r1_umi2 = create_test_read_with_umi("read2", true, "2");
-        let r2_umi2 = create_test_read_with_umi("read2", false, "2");
+        let r1_umi1 = create_test_read_with_umi(b"read1", true, b"1");
+        let r2_umi1 = create_test_read_with_umi(b"read1", false, b"1");
+        let r1_umi2 = create_test_read_with_umi(b"read2", true, b"2");
+        let r2_umi2 = create_test_read_with_umi(b"read2", false, b"2");
 
         let options = VanillaUmiConsensusOptions {
             tag: "MI".to_string(),
@@ -4248,13 +4290,13 @@ mod tests {
             VanillaUmiConsensusCaller::new("test".to_string(), "A".to_string(), options);
 
         // Process first UMI group (2 reads -> 2 consensus reads: R1 and R2)
-        let output1 = consensus_reads_from_records(&mut caller, vec![r1_umi1, r2_umi1])
-            .expect("consensus_reads_from_records should succeed");
+        let output1 = consensus_reads_from_raw(&mut caller, vec![r1_umi1, r2_umi1])
+            .expect("consensus_reads_from_raw should succeed");
         assert_eq!(output1.count, 2, "Should produce 2 consensus reads (R1 and R2)");
 
         // Process second UMI group (2 reads -> 2 consensus reads: R1 and R2)
-        let output2 = consensus_reads_from_records(&mut caller, vec![r1_umi2, r2_umi2])
-            .expect("consensus_reads_from_records should succeed");
+        let output2 = consensus_reads_from_raw(&mut caller, vec![r1_umi2, r2_umi2])
+            .expect("consensus_reads_from_raw should succeed");
         assert_eq!(output2.count, 2, "Should produce 2 consensus reads (R1 and R2)");
 
         // Check statistics
@@ -4290,85 +4332,99 @@ mod tests {
         let good_quals = vec![30u8; 50];
         let bad_quals = vec![2u8; 50]; // Below default min_input_base_quality (10)
 
+        let bases = seq_50.as_bytes();
+
         // Build 3 R1 reads: 2 with 50M, 1 with 25M25I (minority alignment)
-        let r1_a = RecordBuilder::new()
-            .name("read_a")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_a = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_a")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r1_b = RecordBuilder::new()
-            .name("read_b")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_b = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_b")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r1_c = RecordBuilder::new()
-            .name("read_c")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("25M25I")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_c = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_c")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 25), encode_op(1, 25)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         // Build 3 R2 reads: all with low quality → ZeroLengthAfterTrimming
-        let r2_a = RecordBuilder::new()
-            .name("read_a")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(false) // R2
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_a = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_a")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r2_b = RecordBuilder::new()
-            .name("read_b")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_b = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_b")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r2_c = RecordBuilder::new()
-            .name("read_c")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_c = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_c")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions {
             tag: "MI".to_string(),
@@ -4380,8 +4436,8 @@ mod tests {
             VanillaUmiConsensusCaller::new("test".to_string(), "A".to_string(), options);
 
         let output =
-            consensus_reads_from_records(&mut caller, vec![r1_a, r1_b, r1_c, r2_a, r2_b, r2_c])
-                .expect("consensus_reads_from_records should succeed");
+            consensus_reads_from_raw(&mut caller, vec![r1_a, r1_b, r1_c, r2_a, r2_b, r2_c])
+                .expect("consensus_reads_from_raw should succeed");
 
         // No consensus should be produced (R1 built one but it's orphaned)
         assert_eq!(output.count, 0, "Orphan R1 consensus should be discarded");
@@ -4436,85 +4492,99 @@ mod tests {
         let good_quals = vec![30u8; 50];
         let bad_quals = vec![2u8; 50];
 
+        let bases = seq_50.as_bytes();
+
         // Build 3 R1 reads: all with low quality → ZeroLengthAfterTrimming
-        let r1_a = RecordBuilder::new()
-            .name("read_a")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_a = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_a")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r1_b = RecordBuilder::new()
-            .name("read_b")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_b = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_b")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r1_c = RecordBuilder::new()
-            .name("read_c")
-            .sequence(&seq_50)
-            .qualities(&bad_quals)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(1000)
-            .tag("MI", "UMI1")
-            .build();
+        let r1_c = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_c")
+                .ref_id(0)
+                .pos(99)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .sequence(bases)
+                .qualities(&bad_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(999)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         // Build 3 R2 reads: 2 with 50M, 1 with 25M25I (minority alignment)
-        let r2_a = RecordBuilder::new()
-            .name("read_a")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_a = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_a")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r2_b = RecordBuilder::new()
-            .name("read_b")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("50M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_b = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_b")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 50)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
-        let r2_c = RecordBuilder::new()
-            .name("read_c")
-            .sequence(&seq_50)
-            .qualities(&good_quals)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(1000)
-            .cigar("25M25I")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(100)
-            .tag("MI", "UMI1")
-            .build();
+        let r2_c = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read_c")
+                .ref_id(0)
+                .pos(999)
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .sequence(bases)
+                .qualities(&good_quals)
+                .cigar_ops(&[encode_op(0, 25), encode_op(1, 25)])
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .add_string_tag(b"MI", b"UMI1");
+            b.build()
+        };
 
         let options = VanillaUmiConsensusOptions {
             tag: "MI".to_string(),
@@ -4526,8 +4596,8 @@ mod tests {
             VanillaUmiConsensusCaller::new("test".to_string(), "A".to_string(), options);
 
         let output =
-            consensus_reads_from_records(&mut caller, vec![r1_a, r1_b, r1_c, r2_a, r2_b, r2_c])
-                .expect("consensus_reads_from_records should succeed");
+            consensus_reads_from_raw(&mut caller, vec![r1_a, r1_b, r1_c, r2_a, r2_b, r2_c])
+                .expect("consensus_reads_from_raw should succeed");
 
         assert_eq!(output.count, 0, "Orphan R2 consensus should be discarded");
 
@@ -4606,7 +4676,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'C'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4649,7 +4719,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4686,7 +4756,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4719,7 +4789,7 @@ mod tests {
         let read1 = create_consensus_test_read("r1", &[b'A'; 10], &quals, "UMI1");
         let read2 = create_consensus_test_read("r2", &[b'A'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4753,7 +4823,7 @@ mod tests {
         let read1 = create_consensus_test_read("r1", &[b'T'; 10], &quals, "UMI1");
         let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4784,7 +4854,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'C'; 10], &[30u8; 10], "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'C'; 10], &[30u8; 10], "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4835,7 +4905,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'C'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4873,7 +4943,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'T'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4909,7 +4979,7 @@ mod tests {
         let read2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let read3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
 
-        let output = consensus_reads_from_records(&mut caller, vec![read1, read2, read3]).unwrap();
+        let output = consensus_reads_from_raw(&mut caller, vec![read1, read2, read3]).unwrap();
         assert_eq!(output.count, 1);
         let records = ParsedBamRecord::parse_all(&output.data);
         let consensus = &records[0];
@@ -4942,7 +5012,7 @@ mod tests {
         let r1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
         let r2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let r3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
-        let em_output = consensus_reads_from_records(&mut em_caller, vec![r1, r2, r3]).unwrap();
+        let em_output = consensus_reads_from_raw(&mut em_caller, vec![r1, r2, r3]).unwrap();
         let em_records = ParsedBamRecord::parse_all(&em_output.data);
         let em_ml = em_records[0].get_u8_array_tag(b"ML").unwrap();
 
@@ -4951,7 +5021,7 @@ mod tests {
         let r1 = create_consensus_test_read("r1", &[b'C'; 10], &quals, "UMI1");
         let r2 = create_consensus_test_read("r2", &[b'C'; 10], &quals, "UMI1");
         let r3 = create_consensus_test_read("r3", &[b'T'; 10], &quals, "UMI1");
-        let taps_output = consensus_reads_from_records(&mut taps_caller, vec![r1, r2, r3]).unwrap();
+        let taps_output = consensus_reads_from_raw(&mut taps_caller, vec![r1, r2, r3]).unwrap();
         let taps_records = ParsedBamRecord::parse_all(&taps_output.data);
         let taps_ml = taps_records[0].get_u8_array_tag(b"ML").unwrap();
 

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -174,10 +174,6 @@ pub struct ProcessedDedupGroup {
     pub dedup_metrics: DedupMetrics,
     /// Total input records processed (for progress tracking).
     pub input_record_count: u64,
-    /// Number of distinct numeric molecule IDs assigned in this group. See
-    /// [`fgumi_lib::grouper::ProcessedPositionGroup::distinct_mi_count`] for
-    /// rationale; ensures emitted MI tag integers are consecutive 0..N-1.
-    pub distinct_mi_count: u64,
 }
 
 impl BatchWeight for ProcessedDedupGroup {
@@ -689,7 +685,6 @@ fn process_position_group(
             family_sizes: AHashMap::new(),
             dedup_metrics,
             input_record_count,
-            distinct_mi_count: 0,
         });
     }
 
@@ -751,7 +746,7 @@ fn process_position_group(
         }
     }
 
-    // Count reads and check for missing tc tags
+    // Count reads and check for missing pa tags
     let tc_tag_bytes: [u8; 2] = *TC_TAG.as_ref();
     for template in &templates {
         dedup_metrics.total_templates += 1;
@@ -778,18 +773,7 @@ fn process_position_group(
 
     dedup_metrics.unique_reads = dedup_metrics.total_reads - dedup_metrics.duplicate_reads;
 
-    // Compute distinct numeric MoleculeId count for the global MI counter block
-    // size; see issue #269 / ProcessedPositionGroup::distinct_mi_count rationale.
-    let distinct_mi_count: u64 =
-        templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
-
-    Ok(ProcessedDedupGroup {
-        templates,
-        family_sizes,
-        dedup_metrics,
-        input_record_count,
-        distinct_mi_count,
-    })
+    Ok(ProcessedDedupGroup { templates, family_sizes, dedup_metrics, input_record_count })
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1050,12 +1034,13 @@ impl Command for MarkDuplicates {
 
                 let input_record_count = processed.input_record_count;
 
-                // Assign contiguous base_mi from the global counter. Advance by the
-                // number of distinct numeric MoleculeId IDs actually assigned in this
-                // group, not the template count, so the emitted MI integers are
-                // consecutive 0..N-1 (see issue #269).
-                let base_mi = next_mi_base
-                    .fetch_add(processed.distinct_mi_count, std::sync::atomic::Ordering::Relaxed);
+                // Assign contiguous base_mi from serial counter. Use the distinct MI
+                // count (number of families) so base_mi advances once per emitted MI,
+                // not once per template — families with multiple templates would
+                // otherwise create gaps in MI IDs.
+                let distinct_mi_count: u64 = processed.family_sizes.values().copied().sum();
+                let base_mi =
+                    next_mi_base.fetch_add(distinct_mi_count, std::sync::atomic::Ordering::Relaxed);
                 // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
                 output.reserve(processed.templates.len() * 2 * 400);
                 // Serialize templates
@@ -2544,7 +2529,6 @@ mod tests {
             family_sizes: AHashMap::new(),
             dedup_metrics: DedupMetrics::default(),
             input_record_count: 1,
-            distinct_mi_count: 0,
         };
 
         let estimate = batch.estimate_heap_size();

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -344,21 +344,34 @@ fn get_mi_tag(record: &RecordBuf) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sam::builder::RecordBuilder;
+    use fgumi_raw_bam::{SamBuilder as RawSamBuilder, raw_record_to_record_buf};
+
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> RecordBuf {
+        raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
 
     /// Create a test record with an MI tag
     fn create_test_record(name: &str, mi: &str) -> RecordBuf {
-        RecordBuilder::new().name(name).tag("MI", mi).build()
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes());
+        b.add_string_tag(b"MI", mi.as_bytes());
+        to_record_buf(b.build())
     }
 
     /// Create a test record with an integer MI tag
     fn create_test_record_int_mi(name: &str, mi: i32) -> RecordBuf {
-        RecordBuilder::new().name(name).tag("MI", mi).build()
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes());
+        b.add_int_tag(b"MI", mi);
+        to_record_buf(b.build())
     }
 
     /// Create a test record without an MI tag
     fn create_test_record_no_mi(name: &str) -> RecordBuf {
-        RecordBuilder::new().name(name).build()
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes());
+        to_record_buf(b.build())
     }
 
     #[test]

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -610,9 +610,11 @@ mod tests {
     };
     use crate::metrics::duplex::{DuplexFamilySizeMetric, DuplexUmiMetric, FamilySizeMetric};
     use crate::metrics::shared::UmiMetric;
-    use crate::sam::builder::{RecordBuilder, RecordPairBuilder};
     use anyhow::Result;
     use fgoxide::io::DelimFile;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+    };
     use noodles::bam;
     use noodles::sam;
     use noodles::sam::alignment::io::Write;
@@ -644,8 +646,13 @@ mod tests {
         builder.build()
     }
 
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> sam::alignment::RecordBuf {
+        raw_record_to_record_buf(&raw, &sam::Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
+
     /// Builds a pair of reads with proper mate information
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::cast_sign_loss)]
     fn build_test_pair(
         name: &str,
         ref_id: usize,
@@ -656,18 +663,50 @@ mod tests {
         strand1_plus: bool,
         strand2_plus: bool,
     ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(ref_id)
-            .r1_start(pos1 as usize)
-            .r2_start(pos2 as usize)
-            .r1_reverse(!strand1_plus)
-            .r2_reverse(!strand2_plus)
-            .tag("RX", rx_umi)
-            .tag("MI", mi_tag)
-            .build()
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        let r1_flags = flags::PAIRED
+            | flags::FIRST_SEGMENT
+            | if strand1_plus { 0 } else { flags::REVERSE }
+            | if strand2_plus { 0 } else { flags::MATE_REVERSE };
+        let r2_flags = flags::PAIRED
+            | flags::LAST_SEGMENT
+            | if strand2_plus { 0 } else { flags::REVERSE }
+            | if strand1_plus { 0 } else { flags::MATE_REVERSE };
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(r1_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos2 - 1);
+        b1.add_string_tag(b"RX", rx_umi.as_bytes());
+        b1.add_string_tag(b"MI", mi_tag.as_bytes());
+        let r1 = to_record_buf(b1.build());
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(r2_flags)
+            .ref_id(ref_id as i32)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos1 - 1);
+        b2.add_string_tag(b"RX", rx_umi.as_bytes());
+        b2.add_string_tag(b"MI", mi_tag.as_bytes());
+        let r2 = to_record_buf(b2.build());
+
+        (r1, r2)
     }
 
     /// Writes records to a temporary BAM file in template-coordinate order
@@ -1585,17 +1624,17 @@ mod tests {
             .build();
 
         // Create a simplex consensus record (has cD tag)
-        let rec = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("100M")
-            .first_segment(true)
-            .tag("cD", 10_i32)
-            .build();
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[encode_op(0, 100)])
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100]);
+        b.add_int_tag(b"cD", 10_i32);
+        let rec = to_record_buf(b.build());
 
         // Write BAM
         let mut writer = noodles::bam::io::Writer::new(std::fs::File::create(&bam_path)?);

--- a/src/lib/commands/simplex_metrics.rs
+++ b/src/lib/commands/simplex_metrics.rs
@@ -344,9 +344,11 @@ impl SimplexMetrics {
 mod tests {
     use super::*;
     use crate::metrics::simplex::{SimplexFamilySizeMetric, SimplexMetricsCollector};
-    use crate::sam::builder::RecordPairBuilder;
     use anyhow::Result;
     use fgoxide::io::DelimFile;
+    use fgumi_raw_bam::{
+        SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
+    };
     use noodles::bam;
     use noodles::sam;
     use noodles::sam::alignment::io::Write;
@@ -373,6 +375,12 @@ mod tests {
         builder.build()
     }
 
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> sam::alignment::RecordBuf {
+        raw_record_to_record_buf(&raw, &sam::Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
+
+    #[allow(clippy::cast_sign_loss)]
     fn build_test_pair(
         name: &str,
         ref_id: usize,
@@ -381,18 +389,41 @@ mod tests {
         rx_umi: &str,
         mi_tag: &str,
     ) -> (sam::alignment::RecordBuf, sam::alignment::RecordBuf) {
-        RecordPairBuilder::new()
-            .name(name)
-            .r1_sequence(&"A".repeat(100))
-            .r2_sequence(&"A".repeat(100))
-            .reference_sequence_id(ref_id)
-            .r1_start(pos1 as usize)
-            .r2_start(pos2 as usize)
-            .r1_reverse(false)
-            .r2_reverse(true)
-            .tag("RX", rx_umi)
-            .tag("MI", mi_tag)
-            .build()
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos2 - 1);
+        b1.add_string_tag(b"RX", rx_umi.as_bytes());
+        b1.add_string_tag(b"MI", mi_tag.as_bytes());
+        let r1 = to_record_buf(b1.build());
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(ref_id as i32)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(pos1 - 1);
+        b2.add_string_tag(b"RX", rx_umi.as_bytes());
+        b2.add_string_tag(b"MI", mi_tag.as_bytes());
+        let r2 = to_record_buf(b2.build());
+
+        (r1, r2)
     }
 
     fn create_test_bam(records: Vec<sam::alignment::RecordBuf>) -> Result<NamedTempFile> {
@@ -570,24 +601,22 @@ mod tests {
 
     #[test]
     fn test_reject_consensus_bam() -> Result<()> {
-        use crate::sam::builder::RecordBuilder;
-
         let temp_file = NamedTempFile::new()?;
         let header = create_test_header();
         let mut writer = bam::io::writer::Builder.build_from_path(temp_file.path())?;
         writer.write_header(&header)?;
 
-        let record = RecordBuilder::new()
-            .name("read1")
-            .sequence(&"A".repeat(100))
-            .qualities(&[30u8; 100])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .tag("cD", "5")
-            .build();
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[encode_op(0, 100)])
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100]);
+        b.add_int_tag(b"cD", 5);
+        let record = to_record_buf(b.build());
         writer.write_alignment_record(&header, &record)?;
         drop(writer);
 

--- a/src/lib/commands/simulate/correct_reads.rs
+++ b/src/lib/commands/simulate/correct_reads.rs
@@ -619,19 +619,28 @@ mod tests {
         }
     }
 
-    // Tests for paired read generation using RecordBuilder
+    // Tests for paired read generation using RawSamBuilder
+    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> noodles::sam::alignment::RecordBuf {
+        fgumi_raw_bam::raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+            .expect("raw_record_to_record_buf failed in test")
+    }
+
     #[test]
     fn test_paired_read_r1_flags() {
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
         // R1 should have flag 77: UNMAPPED | SEGMENTED | FIRST_SEGMENT | MATE_UNMAPPED
-        let r1 = RecordBuilder::new()
-            .name("test_read")
-            .sequence("ACGT")
-            .paired(true)
-            .first_segment(true)
-            .unmapped(true)
-            .mate_unmapped(true)
-            .tag("RX", "AAAAAAAA")
-            .build();
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"test_read")
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::FIRST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::MATE_UNMAPPED,
+            )
+            .sequence(b"ACGT");
+        b.add_string_tag(b"RX", b"AAAAAAAA");
+        let r1 = to_record_buf(b.build());
 
         assert!(r1.flags().is_unmapped());
         assert!(r1.flags().is_segmented());
@@ -646,16 +655,20 @@ mod tests {
 
     #[test]
     fn test_paired_read_r2_flags() {
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
         // R2 should have flag 141: UNMAPPED | SEGMENTED | LAST_SEGMENT | MATE_UNMAPPED
-        let r2 = RecordBuilder::new()
-            .name("test_read")
-            .sequence("ACGT")
-            .paired(true)
-            .first_segment(false)
-            .unmapped(true)
-            .mate_unmapped(true)
-            .tag("RX", "AAAAAAAA")
-            .build();
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"test_read")
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::LAST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::MATE_UNMAPPED,
+            )
+            .sequence(b"ACGT");
+        b.add_string_tag(b"RX", b"AAAAAAAA");
+        let r2 = to_record_buf(b.build());
 
         assert!(r2.flags().is_unmapped());
         assert!(r2.flags().is_segmented());
@@ -670,52 +683,63 @@ mod tests {
 
     #[test]
     fn test_paired_reads_same_name_and_umi() {
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
         let read_name = "test_pair";
         let umi = "ACGTACGT";
 
-        let r1 = RecordBuilder::new()
-            .name(read_name)
-            .sequence("AAAA")
-            .paired(true)
-            .first_segment(true)
-            .unmapped(true)
-            .mate_unmapped(true)
-            .tag("RX", umi)
-            .build();
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(read_name.as_bytes())
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::FIRST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::MATE_UNMAPPED,
+            )
+            .sequence(b"AAAA");
+        b1.add_string_tag(b"RX", umi.as_bytes());
+        let r1 = to_record_buf(b1.build());
 
-        let r2 = RecordBuilder::new()
-            .name(read_name)
-            .sequence("CCCC")
-            .paired(true)
-            .first_segment(false)
-            .unmapped(true)
-            .mate_unmapped(true)
-            .tag("RX", umi)
-            .build();
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(read_name.as_bytes())
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::LAST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::MATE_UNMAPPED,
+            )
+            .sequence(b"CCCC");
+        b2.add_string_tag(b"RX", umi.as_bytes());
+        let r2 = to_record_buf(b2.build());
 
         // Both should have the same read name
         assert_eq!(r1.name(), r2.name());
 
-        // Both should have the same RX tag
+        // Both should have the same RX tag with the same value.
         let rx_tag: Tag = Tag::from(SamTag::RX);
         assert!(r1.data().get(&rx_tag).is_some());
         assert!(r2.data().get(&rx_tag).is_some());
+        assert_eq!(r1.data().get(&rx_tag), r2.data().get(&rx_tag));
     }
 
     #[test]
     fn test_paired_read_qualities() {
-        let quality: u8 = 35;
-        let seq = "ACGTACGT";
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
 
-        let r1 = RecordBuilder::new()
-            .name("read")
+        let quality: u8 = 35;
+        let seq = b"ACGTACGT";
+
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read")
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::FIRST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::MATE_UNMAPPED,
+            )
             .sequence(seq)
-            .qualities(&vec![quality; seq.len()])
-            .paired(true)
-            .first_segment(true)
-            .unmapped(true)
-            .mate_unmapped(true)
-            .build();
+            .qualities(&vec![quality; seq.len()]);
+        let r1 = to_record_buf(b.build());
 
         let quals: Vec<u8> = r1.quality_scores().iter().collect();
         assert_eq!(quals.len(), 8);

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -1199,10 +1199,11 @@ impl Command for Zipper {
 mod tests {
     use super::*;
     use crate::sam::SamTag;
+    use crate::sam::TC_TAG;
     use crate::sam::builder::{
         MAPPED_PG_ID, REFERENCE_LENGTH, SamBuilder as FgSamBuilder, create_ref_dict,
     };
-    use crate::sam::{TC_TAG, TemplateCoordinateInfo};
+
     use anyhow::Result;
     use bstr::ByteSlice;
     use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags, testutil::encode_op};
@@ -2712,11 +2713,11 @@ mod tests {
             .expect("Should have supplementary in output");
 
         // Check pa tag was added
-        let pa_value =
+        let tc_value =
             supp_record.data().get(&TC_TAG).expect("Supplementary should have pa tag after merge");
 
         // Parse and verify the pa tag
-        let tc_info = TemplateCoordinateInfo::from_tag_value(pa_value)
+        let tc_info = TemplateCoordinateInfo::from_tag_value(tc_value)
             .expect("Should be able to parse pa tag");
 
         // pa tag should contain both primaries' unclipped 5' positions

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -163,31 +163,58 @@ pub fn assert_different_molecule_ids(family1: &[RecordBuf], family2: &[RecordBuf
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fgumi_lib::sam::builder::RecordBuilder;
+    use crate::helpers::bam_generator::to_record_buf;
+    use fgumi_raw_bam::{SamBuilder, flags};
 
     #[test]
     fn test_assert_mi_tag() {
-        let record =
-            RecordBuilder::new().name("test").sequence("ACGT").tag("MI", "molecule_123").build();
-
+        let raw = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .add_string_tag(b"MI", b"molecule_123");
+            b.build()
+        };
+        let record = to_record_buf(&raw);
         assert_mi_tag(&record, "molecule_123");
     }
 
     #[test]
     #[should_panic(expected = "MI tag mismatch")]
     fn test_assert_mi_tag_mismatch() {
-        let record =
-            RecordBuilder::new().name("test").sequence("ACGT").tag("MI", "molecule_123").build();
-
+        let raw = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"test")
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .add_string_tag(b"MI", b"molecule_123");
+            b.build()
+        };
+        let record = to_record_buf(&raw);
         assert_mi_tag(&record, "wrong_id");
     }
 
     #[test]
     fn test_assert_proper_pairing() {
-        let r1 = RecordBuilder::new().name("pair1").sequence("ACGT").first_segment(true).build();
-
-        let r2 = RecordBuilder::new().name("pair1").sequence("TGCA").first_segment(false).build();
-
+        let raw_r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"pair1")
+                .sequence(b"ACGT")
+                .qualities(&[30; 4])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+            b.build()
+        };
+        let raw_r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(b"pair1")
+                .sequence(b"TGCA")
+                .qualities(&[30; 4])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT);
+            b.build()
+        };
+        let r1 = to_record_buf(&raw_r1);
+        let r2 = to_record_buf(&raw_r2);
         assert_proper_pairing(&r1, &r2);
     }
 }

--- a/tests/integration/helpers/bam_generator.rs
+++ b/tests/integration/helpers/bam_generator.rs
@@ -1,8 +1,17 @@
 //! Utilities for generating test BAM data programmatically.
 
-use fgumi_lib::sam::builder::{ConsensusTagsBuilder, RecordBuilder};
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::sam::Header;
 use noodles::sam::alignment::record_buf::RecordBuf;
+
+/// Convert a `RawRecord` to a noodles `RecordBuf` using the default (empty) header.
+///
+/// Used to bridge the raw-byte builder API with the noodles BAM writer for test
+/// file creation.
+pub fn to_record_buf(raw: &RawRecord) -> RecordBuf {
+    fgumi_raw_bam::raw_record_to_record_buf(raw, &noodles::sam::Header::default())
+        .expect("raw_record_to_record_buf should succeed in test")
+}
 
 /// Creates a UMI family with specified parameters.
 ///
@@ -20,25 +29,30 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 ///
 /// # Returns
 ///
-/// Vector of `RecordBuf` representing the UMI family
+/// Vector of `RawRecord` representing the UMI family
 pub fn create_umi_family(
     umi: &str,
     depth: usize,
     base_name: &str,
     sequence: &str,
     quality: u8,
-) -> Vec<RecordBuf> {
+) -> Vec<RawRecord> {
+    let seq = sequence.as_bytes();
+    let cigar_op = u32::try_from(seq.len()).expect("seq.len() fits u32") << 4; // NM
     (0..depth)
         .map(|i| {
-            RecordBuilder::new()
-                .name(&format!("{base_name}_{i}"))
-                .sequence(sequence)
-                .qualities(&vec![quality; sequence.len()])
-                .reference_sequence_id(0)
-                .alignment_start(100)
-                .mapping_quality(60)
-                .tag("RX", umi)
-                .build()
+            let name = format!("{base_name}_{i}");
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .flags(0)
+                .cigar_ops(&[cigar_op])
+                .sequence(seq)
+                .qualities(&vec![quality; seq.len()])
+                .add_string_tag(b"RX", umi.as_bytes());
+            b.build()
         })
         .collect()
 }
@@ -59,7 +73,7 @@ pub fn create_umi_family(
 ///
 /// # Returns
 ///
-/// Vector of `RecordBuf` with R1 and R2 reads properly flagged
+/// Vector of `RawRecord` with R1 and R2 reads properly flagged
 pub fn create_paired_umi_family(
     umi: &str,
     depth: usize,
@@ -67,39 +81,52 @@ pub fn create_paired_umi_family(
     r1_sequence: &str,
     r2_sequence: &str,
     quality: u8,
-) -> Vec<RecordBuf> {
+) -> Vec<RawRecord> {
+    let r1_seq = r1_sequence.as_bytes();
+    let r2_seq = r2_sequence.as_bytes();
+    let r1_cigar = u32::try_from(r1_seq.len()).expect("r1_seq.len() fits u32") << 4;
+    let r2_cigar = u32::try_from(r2_seq.len()).expect("r2_seq.len() fits u32") << 4;
+
+    // R1 at pos 99 (0-based); R2 at pos 199. Template spans from R1 start through end
+    // of R2 — 100bp gap + R2 length — and R2 carries the negated length.
+    let template_len = i32::try_from(100 + r2_seq.len()).expect("template length fits i32");
+
     let mut records = Vec::new();
 
     for i in 0..depth {
         let read_name = format!("{base_name}_{i}");
 
-        // R1
-        let r1 = RecordBuilder::new()
-            .name(&read_name)
-            .sequence(r1_sequence)
-            .qualities(&vec![quality; r1_sequence.len()])
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .tag("RX", umi)
-            .build();
-        records.push(r1);
+        // R1: paired + first segment
+        let mut b1 = SamBuilder::new();
+        b1.read_name(read_name.as_bytes())
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .template_length(template_len)
+            .cigar_ops(&[r1_cigar])
+            .sequence(r1_seq)
+            .qualities(&vec![quality; r1_seq.len()])
+            .add_string_tag(b"RX", umi.as_bytes());
+        records.push(b1.build());
 
-        // R2
-        let r2 = RecordBuilder::new()
-            .name(&read_name)
-            .sequence(r2_sequence)
-            .qualities(&vec![quality; r2_sequence.len()])
-            .paired(true)
-            .first_segment(false)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .tag("RX", umi)
-            .build();
-        records.push(r2);
+        // R2: paired + last segment
+        let mut b2 = SamBuilder::new();
+        b2.read_name(read_name.as_bytes())
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-template_len)
+            .cigar_ops(&[r2_cigar])
+            .sequence(r2_seq)
+            .qualities(&vec![quality; r2_seq.len()])
+            .add_string_tag(b"RX", umi.as_bytes());
+        records.push(b2.build());
     }
 
     records
@@ -118,7 +145,7 @@ pub fn create_paired_umi_family(
 ///
 /// # Returns
 ///
-/// `RecordBuf` representing a consensus read
+/// `RawRecord` representing a consensus read
 pub fn create_consensus_read(
     name: &str,
     sequence: &str,
@@ -126,18 +153,16 @@ pub fn create_consensus_read(
     depth_min: i32,
     error_rate: f32,
     mean_quality: u8,
-) -> RecordBuf {
-    RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![mean_quality; sequence.len()])
-        .consensus_tags(
-            ConsensusTagsBuilder::new()
-                .depth_max(depth_max)
-                .depth_min(depth_min)
-                .error_rate(error_rate),
-        )
-        .build()
+) -> RawRecord {
+    let seq = sequence.as_bytes();
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![mean_quality; seq.len()])
+        .add_int_tag(b"cD", depth_max)
+        .add_int_tag(b"cM", depth_min)
+        .add_float_tag(b"cE", error_rate);
+    b.build()
 }
 
 /// Builds a SAM header with the given header tags and one reference sequence.
@@ -225,7 +250,7 @@ pub fn create_umi_family_with_errors(
     base_depth: usize,
     error_depth: usize,
     sequence: &str,
-) -> Vec<RecordBuf> {
+) -> Vec<RawRecord> {
     let mut records = Vec::new();
 
     // Add base UMI reads
@@ -288,11 +313,12 @@ mod tests {
         assert_eq!(family.len(), 5);
 
         for (i, record) in family.iter().enumerate() {
+            let buf = to_record_buf(record);
             assert_eq!(
-                record.name().map(std::convert::AsRef::as_ref),
+                buf.name().map(std::convert::AsRef::as_ref),
                 Some(format!("test_{i}").as_bytes())
             );
-            assert_eq!(record.sequence().as_ref(), b"AAAA");
+            assert_eq!(buf.sequence().as_ref(), b"AAAA");
         }
     }
 
@@ -304,18 +330,21 @@ mod tests {
         assert_eq!(family.len(), 6);
 
         // Check R1/R2 flags
-        assert!(family[0].flags().is_first_segment());
-        assert!(!family[1].flags().is_first_segment());
-        assert!(family[1].flags().is_last_segment());
+        let r1_flags = family[0].flags();
+        let r2_flags = family[1].flags();
+        assert_ne!(r1_flags & flags::FIRST_SEGMENT, 0, "R1 should have FIRST_SEGMENT flag");
+        assert_eq!(r2_flags & flags::FIRST_SEGMENT, 0, "R2 should not have FIRST_SEGMENT flag");
+        assert_ne!(r2_flags & flags::LAST_SEGMENT, 0, "R2 should have LAST_SEGMENT flag");
     }
 
     #[test]
     fn test_create_consensus_read() {
         let consensus = create_consensus_read("cons1", "ACGT", 10, 5, 0.01, 35);
+        let buf = to_record_buf(&consensus);
 
-        assert_eq!(consensus.name().map(std::convert::AsRef::as_ref), Some(b"cons1".as_ref()));
-        assert_eq!(consensus.sequence().as_ref(), b"ACGT");
-        assert_eq!(consensus.quality_scores().as_ref(), &[35, 35, 35, 35]);
+        assert_eq!(buf.name().map(std::convert::AsRef::as_ref), Some(b"cons1".as_ref()));
+        assert_eq!(buf.sequence().as_ref(), b"ACGT");
+        assert_eq!(buf.quality_scores().as_ref(), &[35, 35, 35, 35]);
     }
 
     #[test]

--- a/tests/integration/test_async_reader.rs
+++ b/tests/integration/test_async_reader.rs
@@ -22,7 +22,7 @@ use noodles::sam::alignment::record_buf::data::field::Value;
 use noodles_bgzf::io::Writer as BgzfWriter;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
 
 // ============================================================================
 // Helpers
@@ -197,7 +197,9 @@ fn create_test_bam(path: &Path) {
     let family3 = create_umi_family("GGGGGGGG", 4, "family3", "TTTTAAAA", 30);
 
     for record in family1.iter().chain(family2.iter()).chain(family3.iter()) {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
@@ -211,12 +213,14 @@ fn create_grouped_bam(path: &Path) {
 
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
 
+    // MI is a string tag — emit string literals so consumers reading via `find_string`
+    // (vanilla/duplex/codec callers) can parse them.
     for (mi, umi, depth, base) in
-        [(1, "AAAAAAAA", 5, "mol1"), (2, "CCCCCCCC", 3, "mol2"), (3, "GGGGGGGG", 4, "mol3")]
+        [("1", "AAAAAAAA", 5, "mol1"), ("2", "CCCCCCCC", 3, "mol2"), ("3", "GGGGGGGG", 4, "mol3")]
     {
         let records = create_umi_family(umi, depth, base, "ACGTACGT", 30);
         for record in records {
-            let mut rec = record.clone();
+            let mut rec = to_record_buf(&record);
             rec.data_mut().insert(mi_tag, Value::from(mi));
             writer.write_alignment_record(&header, &rec).expect("Failed to write record");
         }

--- a/tests/integration/test_bam_pipeline.rs
+++ b/tests/integration/test_bam_pipeline.rs
@@ -182,8 +182,9 @@ fn create_test_bam(path: &std::path::Path, header: &Header) -> Vec<RecordBuf> {
     let family3 = create_umi_family("GGGGGGGG", 15, "family3", "ATCGATCG", 30);
 
     for record in family1.iter().chain(family2.iter()).chain(family3.iter()) {
-        writer.write_alignment_record(header, record).expect("Failed to write record");
-        records.push(record.clone());
+        let record_buf = crate::helpers::bam_generator::to_record_buf(record);
+        writer.write_alignment_record(header, &record_buf).expect("Failed to write record");
+        records.push(record_buf);
     }
 
     writer.finish(header).expect("Failed to finish BAM");

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -4,11 +4,10 @@
 //! GitHub issue #125: BAM files written by pipeline-based commands were missing
 //! the BGZF EOF block, causing `samtools quickcheck` to fail.
 
-use fgumi_lib::sam::builder::{ConsensusTagsBuilder, RecordBuilder};
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::alignment::record_buf::data::field::Value;
 use std::fs;
 use std::path::Path;
@@ -17,23 +16,25 @@ use tempfile::TempDir;
 
 use crate::helpers::assertions::assert_has_bgzf_eof;
 use crate::helpers::bam_generator::{
-    create_minimal_header, create_test_reference, create_umi_family,
+    create_minimal_header, create_test_reference, create_umi_family, to_record_buf,
 };
 
 /// Write a BAM file with the given records using the standard test header.
-fn write_test_bam(path: &Path, records: &[RecordBuf]) {
+fn write_test_bam(path: &Path, records: &[RawRecord]) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
     for record in records {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Write a BAM file with MI-tagged records (grouped input for consensus callers).
-fn write_grouped_bam(path: &Path, families: &[(&str, &[RecordBuf])]) {
+fn write_grouped_bam(path: &Path, families: &[(&str, &[RawRecord])]) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
@@ -42,68 +43,65 @@ fn write_grouped_bam(path: &Path, families: &[(&str, &[RecordBuf])]) {
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
     for &(mi, records) in families {
         for record in records {
-            let mut rec = record.clone();
-            rec.data_mut().insert(mi_tag, Value::from(mi));
-            writer.write_alignment_record(&header, &rec).expect("Failed to write record");
+            let mut buf = to_record_buf(record);
+            buf.data_mut().insert(mi_tag, Value::from(mi));
+            writer.write_alignment_record(&header, &buf).expect("Failed to write record");
         }
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create paired-end duplicate reads at a given position with MC tags.
-fn create_dedup_reads(name: &str, umi: &str, start: usize) -> Vec<RecordBuf> {
-    let cigar = "8M";
-    let r1 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .properly_paired(true)
-        .reference_sequence_id(0)
-        .alignment_start(start)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(start + 100)
-        .template_length(108)
-        .tag("RX", umi)
-        .tag("MC", cigar)
-        .build();
+fn create_dedup_reads(name: &[u8], umi: &str, start: i32) -> Vec<RawRecord> {
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(start - 1)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(start + 99)
+            .template_length(108)
+            .add_string_tag(b"RX", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .properly_paired(true)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(start + 100)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(start)
-        .template_length(-108)
-        .tag("RX", umi)
-        .tag("MC", cigar)
-        .build();
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(start + 99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(start - 1)
+            .template_length(-108)
+            .add_string_tag(b"RX", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
     vec![r1, r2]
 }
 
 /// Create a duplex read pair with /A or /B strand MI suffix.
 fn create_duplex_pair(
-    name: &str,
+    name: &[u8],
     mi_tag: &str,
-    sequence: &str,
-    ref_start: usize,
+    sequence: &[u8],
+    ref_start: i32,
     is_b_strand: bool,
-) -> (RecordBuf, RecordBuf) {
+) -> (RawRecord, RawRecord) {
     let read_len = sequence.len();
-    let cigar = format!("{read_len}M");
-
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4; // NM
     let (r1_start, r2_start, r1_rev, r2_rev) = if is_b_strand {
         (ref_start + 100, ref_start, true, false)
     } else {
@@ -117,137 +115,131 @@ fn create_duplex_pair(
     )]
     let tlen: i32 = if is_b_strand { -((read_len + 100) as i32) } else { (read_len + 100) as i32 };
 
-    let mi = Tag::from(fgumi_lib::sam::SamTag::MI);
+    let r1_flags = flags::PAIRED
+        | flags::FIRST_SEGMENT
+        | if r1_rev { flags::REVERSE } else { 0 }
+        | if r2_rev { flags::MATE_REVERSE } else { 0 };
 
-    let mut r1 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![30; read_len])
-        .paired(true)
-        .first_segment(true)
-        .reverse_complement(r1_rev)
-        .mate_reverse_complement(r2_rev)
-        .reference_sequence_id(0)
-        .alignment_start(r1_start)
-        .mapping_quality(60)
-        .cigar(&cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(r2_start)
-        .template_length(tlen)
-        .build();
-    r1.data_mut().insert(mi, Value::from(mi_tag));
+    let r2_flags = flags::PAIRED
+        | flags::LAST_SEGMENT
+        | if r2_rev { flags::REVERSE } else { 0 }
+        | if r1_rev { flags::MATE_REVERSE } else { 0 };
 
-    let mut r2 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![30; read_len])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(r2_rev)
-        .mate_reverse_complement(r1_rev)
-        .reference_sequence_id(0)
-        .alignment_start(r2_start)
-        .mapping_quality(60)
-        .cigar(&cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(r1_start)
-        .template_length(-tlen)
-        .build();
-    r2.data_mut().insert(mi, Value::from(mi_tag));
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(sequence)
+            .qualities(&vec![30; read_len])
+            .flags(r1_flags)
+            .ref_id(0)
+            .pos(r1_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r2_start - 1)
+            .template_length(tlen)
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
+
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(sequence)
+            .qualities(&vec![30; read_len])
+            .flags(r2_flags)
+            .ref_id(0)
+            .pos(r2_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r1_start - 1)
+            .template_length(-tlen)
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
 
     (r1, r2)
 }
 
 /// Create a single-template family (will be rejected by --min-reads > 1).
-fn create_rejected_family(name: &str, umi: &str, start: usize) -> Vec<RecordBuf> {
-    let cigar = "8M";
-    let r1 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .properly_paired(true)
-        .reference_sequence_id(0)
-        .alignment_start(start)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(start + 100)
-        .template_length(108)
-        .tag("RX", umi)
-        .tag("MC", cigar)
-        .build();
+fn create_rejected_family(name: &[u8], umi: &str, start: i32) -> Vec<RawRecord> {
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(start - 1)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(start + 99)
+            .template_length(108)
+            .add_string_tag(b"RX", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .properly_paired(true)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(start + 100)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(start)
-        .template_length(-108)
-        .tag("RX", umi)
-        .tag("MC", cigar)
-        .build();
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(start + 99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(start - 1)
+            .template_length(-108)
+            .add_string_tag(b"RX", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
     vec![r1, r2]
 }
 
 /// Create a CODEC read pair (FR orientation, same position).
-fn create_codec_pair(name: &str, umi: &str, ref_start: usize) -> (RecordBuf, RecordBuf) {
-    let cigar = "8M";
+fn create_codec_pair(name: &[u8], umi: &str, ref_start: i32) -> (RawRecord, RawRecord) {
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(ref_start - 1)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(ref_start - 1)
+            .template_length(8)
+            .add_string_tag(b"MI", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
-    let mut r1 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .mate_reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(ref_start)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(ref_start)
-        .tag("MI", umi)
-        .tag("MC", cigar)
-        .build();
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    {
-        *r1.template_length_mut() = 8;
-    }
-
-    let mut r2 = RecordBuilder::new()
-        .name(name)
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(ref_start)
-        .mapping_quality(60)
-        .cigar(cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(ref_start)
-        .tag("MI", umi)
-        .tag("MC", cigar)
-        .build();
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    {
-        *r2.template_length_mut() = -8;
-    }
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(ref_start - 1)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(ref_start - 1)
+            .template_length(-8)
+            .add_string_tag(b"MI", umi.as_bytes())
+            .add_string_tag(b"MC", b"8M");
+        b.build()
+    };
 
     (r1, r2)
 }
@@ -294,8 +286,8 @@ fn test_dedup_output_has_bgzf_eof() {
     let input_bam = temp_dir.path().join("input.bam");
     let output_bam = temp_dir.path().join("output.bam");
 
-    let mut records = create_dedup_reads("dup_0", "ACGTACGT", 100);
-    records.extend(create_dedup_reads("dup_1", "ACGTACGT", 100));
+    let mut records = create_dedup_reads(b"dup_0", "ACGTACGT", 100);
+    records.extend(create_dedup_reads(b"dup_1", "ACGTACGT", 100));
     write_test_bam(&input_bam, &records);
 
     let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
@@ -356,12 +348,14 @@ fn test_duplex_output_has_bgzf_eof() {
     // Create a duplex molecule: 3 /A pairs and 3 /B pairs
     let mut records = Vec::new();
     for i in 0..3 {
-        let (r1, r2) = create_duplex_pair(&format!("a_{i}"), "1/A", "ACGTACGT", 100, false);
+        let (r1, r2) =
+            create_duplex_pair(format!("a_{i}").as_bytes(), "1/A", b"ACGTACGT", 100, false);
         records.push(r1);
         records.push(r2);
     }
     for i in 0..3 {
-        let (r1, r2) = create_duplex_pair(&format!("b_{i}"), "1/B", "ACGTACGT", 100, true);
+        let (r1, r2) =
+            create_duplex_pair(format!("b_{i}").as_bytes(), "1/B", b"ACGTACGT", 100, true);
         records.push(r1);
         records.push(r2);
     }
@@ -396,7 +390,7 @@ fn test_codec_output_has_bgzf_eof() {
 
     let mut records = Vec::new();
     for i in 0..3 {
-        let (r1, r2) = create_codec_pair(&format!("read{i}"), "1", 100);
+        let (r1, r2) = create_codec_pair(format!("read{i}").as_bytes(), "1", 100);
         records.push(r1);
         records.push(r2);
     }
@@ -430,18 +424,19 @@ fn test_filter_output_has_bgzf_eof() {
     let output_bam = temp_dir.path().join("output.bam");
     let ref_path = create_test_reference(temp_dir.path());
 
-    let record = RecordBuilder::new()
-        .name("cons1")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let record = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"cons1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8])
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .add_array_u16(b"cd", &[10; 8])
+            .add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     write_test_bam(&input_bam, &[record]);
 
@@ -475,36 +470,37 @@ fn test_clip_output_has_bgzf_eof() {
     let output_bam = temp_dir.path().join("output.bam");
     let ref_path = create_test_reference(temp_dir.path());
 
-    let r1 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(104)
-        .template_length(12)
-        .build();
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(103)
+            .template_length(12);
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(104)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(100)
-        .template_length(-12)
-        .build();
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(103)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-12);
+        b.build()
+    };
 
     write_test_bam(&input_bam, &[r1, r2]);
 
@@ -647,7 +643,7 @@ fn test_simplex_rejects_has_bgzf_eof() {
 
     // One family with 3 reads (kept) and one singleton family (rejected by --min-reads 2)
     let kept = create_umi_family("ACGT", 3, "kept", "ACGTACGT", 30);
-    let rejected = create_rejected_family("reject", "TTTT", 500);
+    let rejected = create_rejected_family(b"reject", "TTTT", 500);
     write_grouped_bam(&input_bam, &[("1", &kept), ("2", &rejected)]);
 
     let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
@@ -684,17 +680,19 @@ fn test_duplex_rejects_has_bgzf_eof() {
     // 3 /A pairs and 3 /B pairs (kept), plus a singleton /A pair (rejected by --min-reads 2)
     let mut records = Vec::new();
     for i in 0..3 {
-        let (r1, r2) = create_duplex_pair(&format!("a_{i}"), "1/A", "ACGTACGT", 100, false);
+        let (r1, r2) =
+            create_duplex_pair(format!("a_{i}").as_bytes(), "1/A", b"ACGTACGT", 100, false);
         records.push(r1);
         records.push(r2);
     }
     for i in 0..3 {
-        let (r1, r2) = create_duplex_pair(&format!("b_{i}"), "1/B", "ACGTACGT", 100, true);
+        let (r1, r2) =
+            create_duplex_pair(format!("b_{i}").as_bytes(), "1/B", b"ACGTACGT", 100, true);
         records.push(r1);
         records.push(r2);
     }
     // Singleton family that will be rejected
-    let (r1, r2) = create_duplex_pair("reject_a", "2/A", "ACGTACGT", 500, false);
+    let (r1, r2) = create_duplex_pair(b"reject_a", "2/A", b"ACGTACGT", 500, false);
     records.push(r1);
     records.push(r2);
     write_test_bam(&input_bam, &records);
@@ -733,11 +731,11 @@ fn test_codec_rejects_has_bgzf_eof() {
     // One family with 3 reads (kept) and one singleton (rejected by --min-reads 2)
     let mut records = Vec::new();
     for i in 0..3 {
-        let (r1, r2) = create_codec_pair(&format!("read{i}"), "1", 100);
+        let (r1, r2) = create_codec_pair(format!("read{i}").as_bytes(), "1", 100);
         records.push(r1);
         records.push(r2);
     }
-    let (r1, r2) = create_codec_pair("reject", "2", 500);
+    let (r1, r2) = create_codec_pair(b"reject", "2", 500);
     records.push(r1);
     records.push(r2);
     write_test_bam(&input_bam, &records);

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -5,27 +5,26 @@
 //! 2. Fixed clipping (5' and 3' ends)
 //! 3. Metrics output
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
+use crate::helpers::bam_generator::{create_minimal_header, create_test_reference, to_record_buf};
 
 /// Create a BAM with paired reads.
-fn create_paired_bam(path: &Path, pairs: Vec<(RecordBuf, RecordBuf)>) {
+fn create_paired_bam(path: &Path, pairs: Vec<(RawRecord, RawRecord)>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
     for (r1, r2) in pairs {
-        writer.write_alignment_record(&header, &r1).expect("Failed to write R1");
-        writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
+        writer.write_alignment_record(&header, &to_record_buf(&r1)).expect("Failed to write R1");
+        writer.write_alignment_record(&header, &to_record_buf(&r2)).expect("Failed to write R2");
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
@@ -39,36 +38,37 @@ fn test_clip_command_basic() {
     let ref_path = create_test_reference(temp_dir.path());
 
     // Create a paired-end read
-    let r1 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(104)
-        .template_length(12)
-        .build();
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(103)
+            .template_length(12);
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(104)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(100)
-        .template_length(-12)
-        .build();
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(103)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-12);
+        b.build()
+    };
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 
@@ -110,36 +110,37 @@ fn test_clip_command_with_metrics() {
     let metrics_path = temp_dir.path().join("metrics.txt");
     let ref_path = create_test_reference(temp_dir.path());
 
-    let r1 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(true)
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(200)
-        .template_length(108)
-        .build();
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .template_length(108);
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name("read1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(true)
-        .reference_sequence_id(0)
-        .alignment_start(200)
-        .mapping_quality(60)
-        .cigar("8M")
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(100)
-        .template_length(-108)
-        .build();
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-108);
+        b.build()
+    };
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -6,12 +6,9 @@
 //! 3. Rejected reads output
 //! 4. Quality filtering options
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_lib::bam_io::create_raw_bam_writer;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
 use noodles::bam;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
-use noodles::sam::alignment::record_buf::data::field::Value;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -23,6 +20,7 @@ use crate::helpers::bam_generator::create_minimal_header;
 ///
 /// In CODEC sequencing, R1 and R2 come from opposite strands of the same molecule,
 /// so a single read pair can produce duplex consensus.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::too_many_arguments)]
 fn create_codec_read_pair(
     name: &str,
     r1_seq: &[u8],
@@ -31,76 +29,67 @@ fn create_codec_read_pair(
     r2_qual: &[u8],
     ref_start: usize,
     umi: &str,
-) -> (RecordBuf, RecordBuf) {
-    let read_len = r1_seq.len();
-    let cigar = format!("{read_len}M");
+    cell_barcode: Option<&str>,
+) -> (RawRecord, RawRecord) {
+    let r1_len = r1_seq.len();
+    let r2_len = r2_seq.len();
+    let r1_cigar_op = u32::try_from(r1_len).expect("r1_len fits u32") << 4; // nM
+    let r2_cigar_op = u32::try_from(r2_len).expect("r2_len fits u32") << 4; // nM
+    // SamBuilder pos is 0-based; ref_start is 1-based
+    let pos = i32::try_from(ref_start).expect("ref_start fits i32") - 1;
+    // MC is the mate's CIGAR, so b1 carries R2's tag and vice versa.
+    let r1_mc_tag = format!("{r1_len}M");
+    let r2_mc_tag = format!("{r2_len}M");
 
-    // R1: forward read
-    let mut r1 = RecordBuilder::new()
-        .name(name)
-        .sequence(&String::from_utf8_lossy(r1_seq))
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(r1_seq)
         .qualities(r1_qual)
-        .cigar(&cigar)
-        .reference_sequence_id(0)
-        .alignment_start(ref_start)
-        .mapping_quality(60)
-        .paired(true)
-        .first_segment(true)
-        .mate_reverse_complement(true)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(ref_start)
-        .tag("MI", umi)
-        .tag("MC", cigar.clone())
-        .build();
-
-    // Set template length for FR pair
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    {
-        *r1.template_length_mut() = read_len as i32;
+        .cigar_ops(&[r1_cigar_op])
+        .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_REVERSE)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(r1_len as i32)
+        .add_string_tag(b"MI", umi.as_bytes())
+        .add_string_tag(b"MC", r2_mc_tag.as_bytes());
+    if let Some(cb) = cell_barcode {
+        b1.add_string_tag(b"CB", cb.as_bytes());
     }
 
-    // R2: reverse read (from opposite strand)
-    let mut r2 = RecordBuilder::new()
-        .name(name)
-        .sequence(&String::from_utf8_lossy(r2_seq))
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(r2_seq)
         .qualities(r2_qual)
-        .cigar(&cigar)
-        .reference_sequence_id(0)
-        .alignment_start(ref_start)
-        .mapping_quality(60)
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(true)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(ref_start)
-        .tag("MI", umi)
-        .tag("MC", cigar)
-        .build();
-
-    // Set template length for FR pair (negative for R2)
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    {
-        *r2.template_length_mut() = -(read_len as i32);
+        .cigar_ops(&[r2_cigar_op])
+        .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(-(r2_len as i32))
+        .add_string_tag(b"MI", umi.as_bytes())
+        .add_string_tag(b"MC", r1_mc_tag.as_bytes());
+    if let Some(cb) = cell_barcode {
+        b2.add_string_tag(b"CB", cb.as_bytes());
     }
 
-    (r1, r2)
+    (b1.build(), b2.build())
 }
 
 /// Helper to create a test BAM file with CODEC read pairs.
-fn create_codec_test_bam(path: &PathBuf, pairs: Vec<(RecordBuf, RecordBuf)>) {
+fn create_codec_test_bam(path: &PathBuf, pairs: Vec<(RawRecord, RawRecord)>) {
     let header = create_minimal_header("chr1", 10000);
-
     let mut writer =
-        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
-
-    writer.write_header(&header).expect("Failed to write header");
-
+        create_raw_bam_writer(path, &header, 1, 6).expect("Failed to create raw BAM writer");
     for (r1, r2) in pairs {
-        writer.write_alignment_record(&header, &r1).expect("Failed to write R1");
-        writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
+        writer.write_raw_record(r1.as_ref()).expect("Failed to write R1");
+        writer.write_raw_record(r2.as_ref()).expect("Failed to write R2");
     }
-
-    writer.try_finish().expect("Failed to finish BAM");
+    writer.finish().expect("Failed to finish BAM");
 }
 
 /// Test basic CODEC consensus calling.
@@ -121,6 +110,7 @@ fn test_codec_command_basic_consensus() {
             &[30; 8],
             100,
             "UMI001",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -183,6 +173,7 @@ fn test_codec_command_with_stats() {
             &[30; 8],
             100,
             "UMI001",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -195,6 +186,7 @@ fn test_codec_command_with_stats() {
             &[30; 8],
             200,
             "UMI002",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -249,6 +241,7 @@ fn test_codec_command_with_rejects() {
             &[30; 8],
             100,
             "UMI_PASS",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -262,6 +255,7 @@ fn test_codec_command_with_rejects() {
         &[30; 8],
         200,
         "UMI_FAIL",
+        None,
     );
     pairs.push((r1, r2));
 
@@ -322,6 +316,7 @@ fn test_codec_command_min_duplex_length() {
             &[30; 8],
             100,
             "UMI001",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -373,6 +368,7 @@ fn test_codec_command_per_base_tags() {
             &[30; 8],
             100,
             "UMI001",
+            None,
         );
         pairs.push((r1, r2));
     }
@@ -415,31 +411,6 @@ fn test_codec_command_per_base_tags() {
     }
 }
 
-/// Creates a CODEC read pair with an optional cell barcode tag.
-#[allow(clippy::too_many_arguments)]
-fn create_codec_read_pair_with_cell_tag(
-    name: &str,
-    r1_seq: &[u8],
-    r2_seq: &[u8],
-    r1_qual: &[u8],
-    r2_qual: &[u8],
-    ref_start: usize,
-    umi: &str,
-    cell_barcode: Option<&str>,
-) -> (RecordBuf, RecordBuf) {
-    let (mut r1, mut r2) =
-        create_codec_read_pair(name, r1_seq, r2_seq, r1_qual, r2_qual, ref_start, umi);
-
-    // Add cell barcode if provided
-    if let Some(cell_bc) = cell_barcode {
-        let cb_tag = Tag::from([b'C', b'B']);
-        r1.data_mut().insert(cb_tag, Value::from(cell_bc.to_string()));
-        r2.data_mut().insert(cb_tag, Value::from(cell_bc.to_string()));
-    }
-
-    (r1, r2)
-}
-
 /// Test CODEC command preserves cell barcode tag.
 #[test]
 fn test_codec_command_cell_barcode_preservation() {
@@ -450,7 +421,7 @@ fn test_codec_command_cell_barcode_preservation() {
     // Create 3 read pairs with cell barcode
     let mut pairs = Vec::new();
     for i in 0..3 {
-        let (r1, r2) = create_codec_read_pair_with_cell_tag(
+        let (r1, r2) = create_codec_read_pair(
             &format!("read{i}"),
             b"ACGTACGT",
             b"ACGTACGT",

--- a/tests/integration/test_codec_pipeline.rs
+++ b/tests/integration/test_codec_pipeline.rs
@@ -13,13 +13,29 @@
 //! 4. Handling of strand orientation
 //! 5. Overlap region computation
 
+use fgumi_lib::consensus::caller::ConsensusCaller;
 use fgumi_lib::consensus::codec_caller::{CodecConsensusCaller, CodecConsensusOptions};
-use fgumi_lib::sam::builder::RecordBuilder;
-use noodles::sam::alignment::record::cigar::Op;
+use fgumi_raw_bam::RawRecord;
 use noodles::sam::alignment::record::cigar::op::Kind;
-use noodles::sam::alignment::record_buf::{Cigar, RecordBuf};
 
-/// Helper function to create a test paired read with proper CIGAR
+/// Map a noodles CIGAR `Kind` to its BAM op code (bits 3:0 of each cigar word).
+const fn kind_to_op_code(k: Kind) -> u32 {
+    match k {
+        Kind::Match => 0,
+        Kind::Insertion => 1,
+        Kind::Deletion => 2,
+        Kind::Skip => 3,
+        Kind::SoftClip => 4,
+        Kind::HardClip => 5,
+        Kind::Pad => 6,
+        Kind::SequenceMatch => 7,
+        Kind::SequenceMismatch => 8,
+    }
+}
+
+/// Helper function to create a test paired read with proper CIGAR.
+///
+/// Returns a `RawRecord` built directly via `fgumi_raw_bam::SamBuilder`.
 #[allow(clippy::too_many_arguments, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 fn create_codec_read(
     name: &str,
@@ -32,54 +48,68 @@ fn create_codec_read(
     mate_start: usize,
     cigar_ops: &[(Kind, usize)],
     umi: &str,
-) -> RecordBuf {
-    // Build CIGAR and calculate reference length
-    let mut cigar = Cigar::default();
-    let mut ref_len = 0usize;
-    for &(kind, len) in cigar_ops {
-        cigar.as_mut().push(Op::new(kind, len));
-        match kind {
-            Kind::Match
-            | Kind::SequenceMatch
-            | Kind::SequenceMismatch
-            | Kind::Deletion
-            | Kind::Skip => {
-                ref_len += len;
-            }
-            _ => {}
-        }
-    }
+) -> RawRecord {
+    use fgumi_raw_bam::flags as raw_flags;
 
-    // Calculate template length for FR pair detection
+    // Encode CIGAR as BAM u32 words and compute reference length
+    let mut ref_len = 0usize;
+    let encoded_cigar: Vec<u32> = cigar_ops
+        .iter()
+        .map(|&(kind, len)| {
+            match kind {
+                Kind::Match
+                | Kind::SequenceMatch
+                | Kind::SequenceMismatch
+                | Kind::Deletion
+                | Kind::Skip => {
+                    ref_len += len;
+                }
+                _ => {}
+            }
+            (u32::try_from(len).expect("cigar len fits u32") << 4) | kind_to_op_code(kind)
+        })
+        .collect();
+
+    // Compute template length for FR pair detection
     let insert_size: i32 = if ref_start <= mate_start {
         (mate_start + ref_len - ref_start) as i32
     } else {
         -((ref_start + ref_len - mate_start) as i32)
     };
 
-    let mut record = RecordBuilder::new()
-        .name(name)
-        .sequence(&String::from_utf8_lossy(seq))
+    // Build flags
+    let mut flags = raw_flags::PAIRED;
+    if is_first {
+        flags |= raw_flags::FIRST_SEGMENT;
+    } else {
+        flags |= raw_flags::LAST_SEGMENT;
+    }
+    if is_reverse {
+        flags |= raw_flags::REVERSE;
+    }
+    if mate_is_reverse {
+        flags |= raw_flags::MATE_REVERSE;
+    }
+
+    let mut b = fgumi_raw_bam::SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(seq)
         .qualities(qual)
-        .reference_sequence_id(0)
-        .alignment_start(ref_start)
-        .paired(true)
-        .first_segment(is_first)
-        .reverse_complement(is_reverse)
-        .mate_reverse_complement(mate_is_reverse)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(mate_start)
-        .tag("MI", umi)
-        .build();
-
-    // Set CIGAR (built from ops) and template length
-    *record.cigar_mut() = cigar;
-    *record.template_length_mut() = insert_size;
-
-    record
+        .flags(flags)
+        .ref_id(0)
+        .pos(i32::try_from(ref_start).expect("ref_start fits i32") - 1) // 0-based
+        .mapq(60)
+        .cigar_ops(&encoded_cigar)
+        .mate_ref_id(0)
+        .mate_pos(i32::try_from(mate_start).expect("mate_start fits i32") - 1) // 0-based
+        .template_length(insert_size)
+        .add_string_tag(b"MI", umi.as_bytes());
+    b.build()
 }
 
-/// Creates a CODEC read pair (R1 forward, R2 reverse - FR orientation)
+/// Creates a CODEC read pair (R1 forward, R2 reverse - FR orientation).
+///
+/// Returns raw BAM records directly without an intermediate `RecordBuf`.
 #[allow(clippy::too_many_arguments)]
 fn create_codec_read_pair(
     name: &str,
@@ -90,7 +120,7 @@ fn create_codec_read_pair(
     r1_start: usize,
     r2_start: usize,
     umi: &str,
-) -> (RecordBuf, RecordBuf) {
+) -> (RawRecord, RawRecord) {
     let r1 = create_codec_read(
         name,
         r1_seq,
@@ -145,7 +175,7 @@ fn test_codec_single_pair_consensus() {
     );
 
     let reads = vec![r1, r2];
-    let output = caller.consensus_reads_from_sam_records(reads).unwrap();
+    let output = caller.consensus_reads(reads).unwrap();
 
     // Should produce exactly 1 consensus read
     assert_eq!(output.count, 1, "Single read pair should produce 1 consensus");
@@ -184,7 +214,7 @@ fn test_codec_multiple_pairs_consensus() {
         reads.push(r2);
     }
 
-    let output = caller.consensus_reads_from_sam_records(reads).unwrap();
+    let output = caller.consensus_reads(reads).unwrap();
 
     assert_eq!(output.count, 1, "Multiple pairs should produce 1 consensus");
 
@@ -220,7 +250,7 @@ fn test_codec_insufficient_reads_rejection() {
         reads.push(r2);
     }
 
-    let output = caller.consensus_reads_from_sam_records(reads).unwrap();
+    let output = caller.consensus_reads(reads).unwrap();
 
     assert_eq!(output.count, 0, "Should reject when fewer than min_reads_per_strand pairs");
 
@@ -240,17 +270,21 @@ fn test_codec_fragment_reads_rejection() {
     let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
 
     // Create a fragment read (not paired - no SEGMENTED flag)
-    let record = RecordBuilder::new()
-        .name("fragment1")
-        .sequence("ACGTACGT")
-        .qualities(&[30; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .cigar("8M")
-        .tag("MI", "UMI004")
-        .build();
+    let record = {
+        let mut b = fgumi_raw_bam::SamBuilder::new();
+        b.read_name(b"fragment1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(0) // not paired
+            .ref_id(0)
+            .pos(99) // 0-based (alignment_start 100)
+            .mapq(60)
+            .cigar_ops(&[8u32 << 4]) // 8M
+            .add_string_tag(b"MI", b"UMI004");
+        b.build()
+    };
 
-    let output = caller.consensus_reads_from_sam_records(vec![record]).unwrap();
+    let output = caller.consensus_reads(vec![record]).unwrap();
 
     assert_eq!(output.count, 0, "Fragment reads should be rejected");
 
@@ -282,7 +316,7 @@ fn test_codec_consensus_has_required_tags() {
         "UMI005",
     );
 
-    let output = caller.consensus_reads_from_sam_records(vec![r1, r2]).unwrap();
+    let output = caller.consensus_reads(vec![r1, r2]).unwrap();
     assert_eq!(output.count, 1);
 
     // Verify raw bytes are present (detailed tag validation is covered by unit tests)
@@ -294,7 +328,7 @@ fn test_codec_empty_input() {
     let options = CodecConsensusOptions::default();
     let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
 
-    let output = caller.consensus_reads_from_sam_records(Vec::new()).unwrap();
+    let output = caller.consensus_reads(Vec::new()).unwrap();
 
     assert_eq!(output.count, 0, "Empty input should produce empty output");
     assert_eq!(caller.statistics().total_input_reads, 0);
@@ -333,7 +367,7 @@ fn test_codec_rejected_reads_tracking() {
         reads.push(r2);
     }
 
-    let output = caller.consensus_reads_from_sam_records(reads).unwrap();
+    let output = caller.consensus_reads(reads).unwrap();
     assert_eq!(output.count, 0);
 
     // With reject tracking enabled, rejected reads should be stored
@@ -365,7 +399,7 @@ fn test_codec_min_duplex_length_filter() {
         "UMI007",
     );
 
-    let output = caller.consensus_reads_from_sam_records(vec![r1, r2]).unwrap();
+    let output = caller.consensus_reads(vec![r1, r2]).unwrap();
 
     assert_eq!(output.count, 0, "Should reject reads with insufficient duplex length");
 }
@@ -392,7 +426,7 @@ fn test_codec_statistics_tracking() {
             100,
             &format!("UMI{mol_idx:03}"),
         );
-        let _ = caller.consensus_reads_from_sam_records(vec![r1, r2]).unwrap();
+        let _ = caller.consensus_reads(vec![r1, r2]).unwrap();
     }
 
     let stats = caller.statistics();

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -12,21 +12,21 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
+use fgumi_raw_bam::RawRecord;
 
 /// Write a BAM with UMI-tagged reads.
-fn create_umi_bam(
-    path: &PathBuf,
-    families: Vec<Vec<noodles::sam::alignment::record_buf::RecordBuf>>,
-) {
+fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
     for family in families {
-        for record in family {
-            writer.write_alignment_record(&header, &record).expect("Failed to write record");
+        for record in &family {
+            writer
+                .write_alignment_record(&header, &to_record_buf(record))
+                .expect("Failed to write record");
         }
     }
     writer.try_finish().expect("Failed to finish BAM");

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -5,80 +5,76 @@
 //! 2. Metrics output
 //! 3. Remove duplicates mode
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::create_minimal_header;
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 
 /// Create a template-coordinate sorted BAM with UMI-tagged reads.
 ///
 /// Template-coordinate sort groups reads by position, then by name within each position.
 /// The header must have SO:unsorted GO:query SS:template-coordinate tags.
-fn create_sorted_bam(path: &PathBuf, records: Vec<RecordBuf>) {
+fn create_sorted_bam(path: &PathBuf, records: Vec<RawRecord>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
     for record in records {
-        writer.write_alignment_record(&header, &record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(&record))
+            .expect("Failed to write record");
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
 
 /// Create a group of paired-end reads at the same position with the same UMI
 /// (simulating PCR duplicates).
-fn create_duplicate_group(
-    base_name: &str,
-    umi: &str,
-    count: usize,
-    start: usize,
-) -> Vec<RecordBuf> {
+fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) -> Vec<RawRecord> {
     let mut records = Vec::new();
     for i in 0..count {
         let name = format!("{base_name}_{i}");
-        let r1 = RecordBuilder::new()
-            .name(&name)
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .paired(true)
-            .first_segment(true)
-            .properly_paired(true)
-            .reference_sequence_id(0)
-            .alignment_start(start)
-            .mapping_quality(60)
-            .cigar("8M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(start + 100)
-            .template_length(108)
-            .tag("RX", umi)
-            .tag("MC", "8M")
-            .build();
 
-        let r2 = RecordBuilder::new()
-            .name(&name)
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .paired(true)
-            .first_segment(false)
-            .properly_paired(true)
-            .reverse_complement(true)
-            .reference_sequence_id(0)
-            .alignment_start(start + 100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .mate_reference_sequence_id(0)
-            .mate_alignment_start(start)
-            .template_length(-108)
-            .tag("RX", umi)
-            .tag("MC", "8M")
-            .build();
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(start - 1)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(start + 99)
+                .template_length(108)
+                .add_string_tag(b"RX", umi.as_bytes())
+                .add_string_tag(b"MC", b"8M");
+            b.build()
+        };
+
+        let r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(0)
+                .pos(start + 99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(start - 1)
+                .template_length(-108)
+                .add_string_tag(b"RX", umi.as_bytes())
+                .add_string_tag(b"MC", b"8M");
+            b.build()
+        };
 
         records.push(r1);
         records.push(r2);
@@ -211,6 +207,7 @@ fn test_dedup_no_umi_large_position_group() {
     use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags, testutil::encode_op};
     use noodles::sam::Header;
     use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::RecordBuf;
     use noodles::sam::alignment::record_buf::data::field::value::Value as DataValue;
     use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
     use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;

--- a/tests/integration/test_downsample_command.rs
+++ b/tests/integration/test_downsample_command.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the downsample command.
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::SamBuilder;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -28,14 +28,21 @@ fn create_grouped_bam(path: &PathBuf, families: Vec<(&str, usize)>) {
     let mut read_idx = 0;
     for (mi, count) in families {
         for _ in 0..count {
-            let record = RecordBuilder::new()
-                .name(&format!("read_{read_idx}"))
-                .sequence("ACGT") // Minimal sequence
-                .reference_sequence_id(0)
-                .alignment_start(100)
-                .mapping_quality(60)
-                .tag("MI", mi)
-                .build();
+            let raw = {
+                let mut b = SamBuilder::new();
+                b.read_name(format!("read_{read_idx}").as_bytes())
+                    .sequence(b"ACGT")
+                    .qualities(&[30; 4])
+                    .ref_id(0)
+                    .pos(99) // 0-based (alignment_start 100)
+                    .mapq(60)
+                    .cigar_ops(&[4u32 << 4]) // 4M
+                    .add_string_tag(b"MI", mi.as_bytes());
+                b.build()
+            };
+            let record =
+                fgumi_raw_bam::raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
+                    .expect("raw_record_to_record_buf failed in test");
 
             writer.write_alignment_record(&header, &record).expect("Failed to write record");
             read_idx += 1;

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -5,18 +5,15 @@
 //! 2. Statistics output
 //! 3. Rejected reads output
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
-use noodles::sam::alignment::record_buf::data::field::Value;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::create_minimal_header;
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 
 /// Create a paired-end read pair for duplex consensus testing.
 ///
@@ -28,11 +25,12 @@ fn create_duplex_read_pair(
     mi_tag: &str,
     sequence: &str,
     quality: u8,
-    ref_start: usize,
+    ref_start: i32,
     is_b_strand: bool,
-) -> (RecordBuf, RecordBuf) {
-    let read_len = sequence.len();
-    let cigar = format!("{read_len}M");
+) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let read_len = seq.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
 
     let (r1_start, r2_start, r1_rev, r2_rev) = if is_b_strand {
         // B strand: RF orientation — R1 reverse at far position, R2 forward at near
@@ -49,50 +47,55 @@ fn create_duplex_read_pair(
     )]
     let tlen: i32 = if is_b_strand { -((read_len + 100) as i32) } else { (read_len + 100) as i32 };
 
-    let mut r1 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; read_len])
-        .paired(true)
-        .first_segment(true)
-        .reverse_complement(r1_rev)
-        .mate_reverse_complement(r2_rev)
-        .reference_sequence_id(0)
-        .alignment_start(r1_start)
-        .mapping_quality(60)
-        .cigar(&cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(r2_start)
-        .template_length(tlen)
-        .build();
+    let r1_flags = flags::PAIRED
+        | flags::FIRST_SEGMENT
+        | if r1_rev { flags::REVERSE } else { 0 }
+        | if r2_rev { flags::MATE_REVERSE } else { 0 };
 
-    let mut r2 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; read_len])
-        .paired(true)
-        .first_segment(false)
-        .reverse_complement(r2_rev)
-        .mate_reverse_complement(r1_rev)
-        .reference_sequence_id(0)
-        .alignment_start(r2_start)
-        .mapping_quality(60)
-        .cigar(&cigar)
-        .mate_reference_sequence_id(0)
-        .mate_alignment_start(r1_start)
-        .template_length(-tlen)
-        .build();
+    let r2_flags = flags::PAIRED
+        | flags::LAST_SEGMENT
+        | if r2_rev { flags::REVERSE } else { 0 }
+        | if r1_rev { flags::MATE_REVERSE } else { 0 };
 
-    // Add MI tag
-    let mi = Tag::from(fgumi_lib::sam::SamTag::MI);
-    r1.data_mut().insert(mi, Value::from(mi_tag));
-    r2.data_mut().insert(mi, Value::from(mi_tag));
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(seq)
+            .qualities(&vec![quality; read_len])
+            .flags(r1_flags)
+            .ref_id(0)
+            .pos(r1_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r2_start - 1)
+            .template_length(tlen)
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
+
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(seq)
+            .qualities(&vec![quality; read_len])
+            .flags(r2_flags)
+            .ref_id(0)
+            .pos(r2_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r1_start - 1)
+            .template_length(-tlen)
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
 
     (r1, r2)
 }
 
 /// Create a BAM with duplex-grouped reads (MI tags with /A and /B strand suffixes).
-fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RecordBuf, RecordBuf)>>) {
+fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RawRecord, RawRecord)>>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
@@ -100,8 +103,12 @@ fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RecordBuf, RecordBuf)>>) {
 
     for pairs in molecules {
         for (r1, r2) in pairs {
-            writer.write_alignment_record(&header, &r1).expect("Failed to write R1");
-            writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
+            writer
+                .write_alignment_record(&header, &to_record_buf(&r1))
+                .expect("Failed to write R1");
+            writer
+                .write_alignment_record(&header, &to_record_buf(&r2))
+                .expect("Failed to write R2");
         }
     }
     writer.try_finish().expect("Failed to finish BAM");
@@ -112,9 +119,9 @@ fn create_duplex_molecule(
     mi_id: &str,
     sequence: &str,
     quality: u8,
-    ref_start: usize,
+    ref_start: i32,
     depth: usize,
-) -> Vec<(RecordBuf, RecordBuf)> {
+) -> Vec<(RawRecord, RawRecord)> {
     let mut molecule = Vec::new();
     for i in 0..depth {
         let (r1, r2) = create_duplex_read_pair(

--- a/tests/integration/test_duplex_metrics_command.rs
+++ b/tests/integration/test_duplex_metrics_command.rs
@@ -3,17 +3,16 @@
 use fgoxide::io::DelimFile;
 use fgumi_lib::metrics::duplex::{DuplexFamilySizeMetric, FamilySizeMetric};
 use fgumi_lib::metrics::shared::UmiMetric;
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::create_minimal_header;
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 
 /// Creates a paired-end read pair for duplex-metrics testing.
 ///
@@ -21,8 +20,8 @@ use crate::helpers::bam_generator::create_minimal_header;
 ///
 /// * `name` - Read name
 /// * `ref_id` - Reference sequence ID
-/// * `pos1` - R1 alignment start position
-/// * `pos2` - R2 alignment start position
+/// * `pos1` - R1 alignment start position (1-based)
+/// * `pos2` - R2 alignment start position (1-based)
 /// * `rx_umi` - Raw UMI (RX tag) in format "AAA-TTT"
 /// * `mi_tag` - Molecule identifier (MI tag) with strand suffix, e.g., "1/A" or "1/B"
 /// * `strand1_forward` - If true, R1 is on forward strand
@@ -30,44 +29,64 @@ use crate::helpers::bam_generator::create_minimal_header;
 #[allow(clippy::too_many_arguments)]
 fn create_duplex_pair(
     name: &str,
-    ref_id: usize,
-    pos1: usize,
-    pos2: usize,
+    ref_id: i32,
+    pos1: i32,
+    pos2: i32,
     rx_umi: &str,
     mi_tag: &str,
     strand1_forward: bool,
     strand2_forward: bool,
-) -> (RecordBuf, RecordBuf) {
-    let sequence = "ACGTACGTACGTACGT";
+) -> (RawRecord, RawRecord) {
+    let sequence = b"ACGTACGTACGTACGT";
     let quality = 30u8;
+    let cigar_op = u32::try_from(sequence.len()).expect("sequence.len() fits u32") << 4;
 
-    let r1 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; sequence.len()])
-        .paired(true)
-        .first_segment(true)
-        .reference_sequence_id(ref_id)
-        .alignment_start(pos1)
-        .mapping_quality(60)
-        .reverse_complement(!strand1_forward)
-        .tag("RX", rx_umi)
-        .tag("MI", mi_tag)
-        .build();
+    let r1_flags = flags::PAIRED
+        | flags::FIRST_SEGMENT
+        | if strand1_forward { 0 } else { flags::REVERSE }
+        | if strand2_forward { 0 } else { flags::MATE_REVERSE };
+    let r2_flags = flags::PAIRED
+        | flags::LAST_SEGMENT
+        | if strand2_forward { 0 } else { flags::REVERSE }
+        | if strand1_forward { 0 } else { flags::MATE_REVERSE };
 
-    let r2 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; sequence.len()])
-        .paired(true)
-        .first_segment(false)
-        .reference_sequence_id(ref_id)
-        .alignment_start(pos2)
-        .mapping_quality(60)
-        .reverse_complement(!strand2_forward)
-        .tag("RX", rx_umi)
-        .tag("MI", mi_tag)
-        .build();
+    let tlen = pos2 - pos1 + i32::try_from(sequence.len()).expect("sequence.len() fits i32");
+
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(sequence)
+            .qualities(&vec![quality; sequence.len()])
+            .flags(r1_flags)
+            .ref_id(ref_id)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(ref_id)
+            .mate_pos(pos2 - 1)
+            .template_length(tlen)
+            .add_string_tag(b"RX", rx_umi.as_bytes())
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
+
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(sequence)
+            .qualities(&vec![quality; sequence.len()])
+            .flags(r2_flags)
+            .ref_id(ref_id)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(ref_id)
+            .mate_pos(pos1 - 1)
+            .template_length(-tlen)
+            .add_string_tag(b"RX", rx_umi.as_bytes())
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
 
     (r1, r2)
 }
@@ -151,7 +170,9 @@ fn create_duplex_test_bam(path: &PathBuf, header: &Header) {
     }
 
     for record in &records {
-        writer.write_alignment_record(header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
 
     writer.finish(header).expect("Failed to finish BAM");

--- a/tests/integration/test_fastq_command.rs
+++ b/tests/integration/test_fastq_command.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the fastq command.
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::create_minimal_header;
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 
 /// Create a BAM file with paired-end reads for testing.
 fn create_paired_bam(path: &PathBuf, read_pairs: Vec<(&str, &str, &str, &str, &str, bool)>) {
@@ -22,34 +22,40 @@ fn create_paired_bam(path: &PathBuf, read_pairs: Vec<(&str, &str, &str, &str, &s
 
     // Create paired-end records
     for (name, seq1, qual1, seq2, qual2, r2_reverse) in read_pairs {
-        // R1 (forward strand)
-        let r1 = RecordBuilder::new()
-            .name(name)
-            .sequence(seq1)
-            .qualities(&qual1.bytes().map(|b| b - 33).collect::<Vec<u8>>())
-            .paired(true)
-            .first_segment(true)
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .build();
+        let q1: Vec<u8> = qual1.bytes().map(|b| b - 33).collect();
+        let q2: Vec<u8> = qual2.bytes().map(|b| b - 33).collect();
 
-        writer.write_alignment_record(&header, &r1).expect("Failed to write R1");
+        // R1 (forward strand)
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(seq1.as_bytes())
+                .qualities(&q1)
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60);
+            b.build()
+        };
+
+        writer.write_alignment_record(&header, &to_record_buf(&r1)).expect("Failed to write R1");
 
         // R2 (optionally reverse complemented)
-        let r2 = RecordBuilder::new()
-            .name(name)
-            .sequence(seq2)
-            .qualities(&qual2.bytes().map(|b| b - 33).collect::<Vec<u8>>())
-            .paired(true)
-            .first_segment(false)
-            .reverse_complement(r2_reverse)
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .build();
+        let r2_flags =
+            flags::PAIRED | flags::LAST_SEGMENT | if r2_reverse { flags::REVERSE } else { 0 };
+        let r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(seq2.as_bytes())
+                .qualities(&q2)
+                .flags(r2_flags)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60);
+            b.build()
+        };
 
-        writer.write_alignment_record(&header, &r2).expect("Failed to write R2");
+        writer.write_alignment_record(&header, &to_record_buf(&r2)).expect("Failed to write R2");
     }
 
     writer.try_finish().expect("Failed to finish BAM");
@@ -129,10 +135,8 @@ fn test_fastq_reverse_complement() {
     let output_fq = temp_dir.path().join("output.fq");
 
     // Create input BAM with R2 reverse complemented
-    // The stored sequence is "ACGT", but since it's reverse complemented,
-    // the output should be "ACGT" (reverse complement of "ACGT" = "ACGT")
-    // Actually, reverse complement of "ACGT" = reverse("TGCA") = "ACGT"
-    // Let me use a more obvious example: "AAAA" -> reverse complement = "TTTT"
+    // The stored sequence is "AAAA", but since it's reverse complemented,
+    // the output should be reverse complement: "TTTT"
     create_paired_bam(
         &input_bam,
         vec![
@@ -234,39 +238,51 @@ fn create_bam_with_flags(path: &PathBuf) {
     writer.write_header(&header).expect("Failed to write header");
 
     // Create a primary read
-    let primary = RecordBuilder::new()
-        .name("primary")
-        .sequence("ACGT")
-        .qualities(&[30, 30, 30, 30])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .build();
-    writer.write_alignment_record(&header, &primary).expect("Failed to write primary");
+    let primary = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"primary")
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .ref_id(0)
+            .pos(99)
+            .mapq(60);
+        b.build()
+    };
+    writer
+        .write_alignment_record(&header, &to_record_buf(&primary))
+        .expect("Failed to write primary");
 
     // Create a secondary read (flag 0x100)
-    let secondary = RecordBuilder::new()
-        .name("secondary")
-        .sequence("TGCA")
-        .qualities(&[30, 30, 30, 30])
-        .secondary(true)
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .build();
-    writer.write_alignment_record(&header, &secondary).expect("Failed to write secondary");
+    let secondary = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"secondary")
+            .sequence(b"TGCA")
+            .qualities(&[30, 30, 30, 30])
+            .flags(flags::SECONDARY)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60);
+        b.build()
+    };
+    writer
+        .write_alignment_record(&header, &to_record_buf(&secondary))
+        .expect("Failed to write secondary");
 
     // Create a supplementary read (flag 0x800)
-    let supplementary = RecordBuilder::new()
-        .name("supplementary")
-        .sequence("GGGG")
-        .qualities(&[30, 30, 30, 30])
-        .supplementary(true)
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .build();
-    writer.write_alignment_record(&header, &supplementary).expect("Failed to write supplementary");
+    let supplementary = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"supplementary")
+            .sequence(b"GGGG")
+            .qualities(&[30, 30, 30, 30])
+            .flags(flags::SUPPLEMENTARY)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60);
+        b.build()
+    };
+    writer
+        .write_alignment_record(&header, &to_record_buf(&supplementary))
+        .expect("Failed to write supplementary");
 
     writer.try_finish().expect("Failed to finish BAM");
 }

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -5,10 +5,9 @@
 //! 2. Rejected reads output
 //! 3. Statistics output
 
-use fgumi_lib::sam::builder::{ConsensusTagsBuilder, RecordBuilder};
+use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -16,15 +15,30 @@ use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
 
+/// Convert a raw BAM record to a `RecordBuf` using the given header.
+///
+/// Used to bridge the raw-byte builder API with the noodles BAM writer for test
+/// file creation. Mapped records reference the header's sequence dictionary by
+/// index, so callers must pass the same header they use to write the BAM.
+fn to_record_buf(
+    raw: &RawRecord,
+    header: &noodles::sam::Header,
+) -> noodles::sam::alignment::RecordBuf {
+    fgumi_raw_bam::raw_record_to_record_buf(raw, header)
+        .expect("raw_record_to_record_buf should succeed in test")
+}
+
 /// Create a consensus BAM with records that have consensus tags.
-fn create_consensus_bam(path: &Path, records: Vec<RecordBuf>) {
+fn create_consensus_bam(path: &Path, records: Vec<RawRecord>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
     for record in records {
-        writer.write_alignment_record(&header, &record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(&record, &header))
+            .expect("Failed to write record");
     }
     writer.try_finish().expect("Failed to finish BAM");
 }
@@ -38,31 +52,31 @@ fn test_filter_command_basic() {
     let ref_path = create_test_reference(temp_dir.path());
 
     // Create consensus reads with good quality and per-base tags (cd/ce).
-    let r1 = RecordBuilder::new()
-        .name("cons1")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let r1 = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"cons1")
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name("cons2")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(200)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[5; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let r2 = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"cons2")
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[5; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
@@ -109,32 +123,32 @@ fn test_filter_command_rejects_low_depth() {
     let ref_path = create_test_reference(temp_dir.path());
 
     // Good read: per-base depth 10 (all above min-reads=3), no bases masked
-    let good = RecordBuilder::new()
-        .name("good")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let good = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"good")
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     // Low-depth read: per-base depth 1 (all below min-reads=3), all bases masked
-    let low_depth = RecordBuilder::new()
-        .name("low_depth")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(200)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[1; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let low_depth = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"low_depth")
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[1; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
@@ -182,16 +196,18 @@ fn test_filter_command_with_stats() {
     let stats_path = temp_dir.path().join("stats.txt");
     let ref_path = create_test_reference(temp_dir.path());
 
-    let record = RecordBuilder::new()
-        .name("cons1")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(ConsensusTagsBuilder::new().depth_max(10).depth_min(8).error_rate(0.005))
-        .build();
+    let record = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"cons1")
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_int_tag(b"cD", 10).add_int_tag(b"cM", 8).add_float_tag(b"cE", 0.005_f32);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![record]);
 
@@ -232,25 +248,19 @@ fn test_filter_command_no_ref_unmapped_reads() {
     let output_bam = temp_dir.path().join("output.bam");
 
     // Create unmapped consensus reads with good per-base tags
-    let r1 = RecordBuilder::new()
-        .name("cons1")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .unmapped(true)
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let r1 = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"cons1").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
-    let r2 = RecordBuilder::new()
-        .name("cons2")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .unmapped(true)
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[5; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let r2 = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"cons2").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[5; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
@@ -293,26 +303,20 @@ fn test_filter_command_no_ref_with_rejects() {
     let rejects_bam = temp_dir.path().join("rejects.bam");
 
     // Good unmapped read: per-base depth 10 (above min-reads=3)
-    let good = RecordBuilder::new()
-        .name("good")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .unmapped(true)
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let good = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"good").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     // Low-depth unmapped read: per-base depth 1 (below min-reads=3), all bases masked
-    let low_depth = RecordBuilder::new()
-        .name("low_depth")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .unmapped(true)
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[1; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let low_depth = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"low_depth").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[1; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
@@ -362,18 +366,18 @@ fn test_filter_command_no_ref_mapped_reads_fails() {
     let output_bam = temp_dir.path().join("output.bam");
 
     // Create a mapped consensus read (has ref_id, alignment_start, cigar)
-    let mapped = RecordBuilder::new()
-        .name("mapped_read")
-        .sequence("ACGTACGT")
-        .qualities(&[35; 8])
-        .reference_sequence_id(0)
-        .alignment_start(100)
-        .mapping_quality(60)
-        .cigar("8M")
-        .consensus_tags(
-            ConsensusTagsBuilder::new().per_base_depths(&[10; 8]).per_base_errors(&[0; 8]),
-        )
-        .build();
+    let mapped = {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"mapped_read")
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        b.add_array_u16(b"cd", &[10; 8]).add_array_u16(b"ce", &[0; 8]);
+        b.build()
+    };
 
     create_consensus_bam(&input_bam, vec![mapped]);
 

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
 
 /// Test that the group command properly writes metrics in the new format.
 #[test]
@@ -127,7 +127,9 @@ fn create_test_input_bam(path: &PathBuf) {
     let family3 = create_umi_family("GGGGGGGG", 15, "family3", "ATCGATCG", 30);
 
     for record in family1.iter().chain(family2.iter()).chain(family3.iter()) {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
 
     writer.try_finish().expect("Failed to finish BAM");
@@ -147,7 +149,9 @@ fn create_test_bam_with_n_umis(path: &PathBuf) {
     let bad_family = create_umi_family("NNNNNNNN", 3, "bad", "TGCATGCA", 30);
 
     for record in good_family.iter().chain(bad_family.iter()) {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
 
     writer.try_finish().expect("Failed to finish BAM");

--- a/tests/integration/test_pipeline_concurrency.rs
+++ b/tests/integration/test_pipeline_concurrency.rs
@@ -31,7 +31,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
 use fgumi_lib::grouper::SingleRecordGrouper;
 use fgumi_lib::unified_pipeline::{
     BamPipelineConfig, DecodedRecord, Grouper, OrderedQueue, run_bam_pipeline_with_grouper,
@@ -58,8 +58,9 @@ fn create_test_bam_with_families(
     for &(umi, depth, base_name, sequence) in families {
         let family = create_umi_family(umi, depth, base_name, sequence, 30);
         for record in &family {
-            writer.write_alignment_record(header, record).expect("Failed to write record");
-            records.push(record.clone());
+            let record_buf = to_record_buf(record);
+            writer.write_alignment_record(header, &record_buf).expect("Failed to write record");
+            records.push(record_buf);
         }
     }
 

--- a/tests/integration/test_review_command.rs
+++ b/tests/integration/test_review_command.rs
@@ -4,7 +4,7 @@
 //! 1. Missing required arguments produce a clear error
 //! 2. Basic execution with minimal valid inputs
 
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
@@ -13,10 +13,12 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_coordinate_sorted_header, create_test_reference};
+use crate::helpers::bam_generator::{
+    create_coordinate_sorted_header, create_test_reference, to_record_buf,
+};
 
 /// Create a coordinate-sorted, indexed BAM file.
-fn create_indexed_bam(path: &Path, records: &[noodles::sam::alignment::record_buf::RecordBuf]) {
+fn create_indexed_bam(path: &Path, records: &[RawRecord]) {
     let header = create_coordinate_sorted_header("chr1", 10000);
 
     // Write BAM and drop to flush
@@ -25,7 +27,9 @@ fn create_indexed_bam(path: &Path, records: &[noodles::sam::alignment::record_bu
             bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
         writer.write_header(&header).expect("Failed to write header");
         for record in records {
-            writer.write_alignment_record(&header, record).expect("Failed to write record");
+            writer
+                .write_alignment_record(&header, &to_record_buf(record))
+                .expect("Failed to write record");
         }
     }
 
@@ -107,42 +111,46 @@ fn test_review_basic_execution() {
 
     // Create a consensus BAM with a read spanning the variant position,
     // with MI tag for molecule identifier
-    let consensus_records = vec![
-        RecordBuilder::new()
-            .name("cons1")
-            .sequence("ACGTACGT")
+    let consensus_records = vec![{
+        let mut b = SamBuilder::new();
+        b.read_name(b"cons1")
+            .sequence(b"ACGTACGT")
             .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(97)
-            .mapping_quality(60)
-            .cigar("8M")
-            .tag("MI", "1")
-            .build(),
-    ];
+            .ref_id(0)
+            .pos(96) // 0-based for 1-based pos 97
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .add_string_tag(b"MI", b"1");
+        b.build()
+    }];
     create_indexed_bam(&consensus_bam, &consensus_records);
 
     // Create a grouped BAM with raw reads (MI tag matches consensus)
     let grouped_records = vec![
-        RecordBuilder::new()
-            .name("raw1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(97)
-            .mapping_quality(60)
-            .cigar("8M")
-            .tag("MI", "1")
-            .build(),
-        RecordBuilder::new()
-            .name("raw2")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(97)
-            .mapping_quality(60)
-            .cigar("8M")
-            .tag("MI", "1")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"raw1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(96)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .add_string_tag(b"MI", b"1");
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"raw2")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(96)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .add_string_tag(b"MI", b"1");
+            b.build()
+        },
     ];
     create_indexed_bam(&grouped_bam, &grouped_records);
 

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -9,7 +9,6 @@ use bstr::BString;
 use noodles::bam;
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use noodles::sam::header::record::value::Map;
 use noodles::sam::header::record::value::map::ReadGroup;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
@@ -19,20 +18,21 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
 
 /// Write grouped BAM file (reads grouped by MI tag).
-fn create_grouped_bam(path: &Path, families: Vec<(&str, Vec<RecordBuf>)>) {
+fn create_grouped_bam(path: &Path, families: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
     for (mi, records) in families {
-        for mut record in records {
-            // Add MI tag for molecule identity (simplex expects grouped reads with MI)
+        for raw in &records {
+            // Convert to RecordBuf, add MI tag, write
             use noodles::sam::alignment::record::data::field::Tag;
             use noodles::sam::alignment::record_buf::data::field::Value;
+            let mut record = to_record_buf(raw);
             let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
             record.data_mut().insert(mi_tag, Value::from(mi));
             writer.write_alignment_record(&header, &record).expect("Failed to write record");
@@ -199,16 +199,17 @@ fn create_header_with_read_groups(ref_name: &str, ref_len: usize) -> Header {
 fn create_grouped_bam_with_header(
     path: &Path,
     header: &Header,
-    families: Vec<(&str, Vec<RecordBuf>)>,
+    families: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)>,
 ) {
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(header).expect("Failed to write header");
 
     for (mi, records) in families {
-        for mut record in records {
+        for raw in &records {
             use noodles::sam::alignment::record::data::field::Tag;
             use noodles::sam::alignment::record_buf::data::field::Value;
+            let mut record = to_record_buf(raw);
             let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
             record.data_mut().insert(mi_tag, Value::from(mi));
             writer.write_alignment_record(header, &record).expect("Failed to write record");

--- a/tests/integration/test_simplex_metrics_command.rs
+++ b/tests/integration/test_simplex_metrics_command.rs
@@ -3,56 +3,70 @@
 use fgoxide::io::DelimFile;
 use fgumi_lib::metrics::shared::UmiMetric;
 use fgumi_lib::metrics::simplex::{SimplexFamilySizeMetric, SimplexYieldMetric};
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::create_minimal_header;
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 
 /// Creates a paired-end read pair for simplex-metrics testing.
+///
+/// `pos1`/`pos2` are SAM-style 1-based positions; both must be `>= 1`.
 fn create_simplex_pair(
     name: &str,
-    ref_id: usize,
-    pos1: usize,
-    pos2: usize,
+    ref_id: i32,
+    pos1: i32,
+    pos2: i32,
     rx_umi: &str,
     mi_tag: &str,
-) -> (RecordBuf, RecordBuf) {
-    let sequence = "ACGTACGTACGTACGT";
-    let quality = 30u8;
+) -> (RawRecord, RawRecord) {
+    const SEQUENCE: &[u8; 16] = b"ACGTACGTACGTACGT";
+    const QUALS: [u8; 16] = [30; 16];
 
-    let r1 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; sequence.len()])
-        .paired(true)
-        .first_segment(true)
-        .reference_sequence_id(ref_id)
-        .alignment_start(pos1)
-        .mapping_quality(60)
-        .tag("RX", rx_umi)
-        .tag("MI", mi_tag)
-        .build();
+    assert!(pos1 >= 1 && pos2 >= 1, "pos1 and pos2 must be 1-based SAM positions (>= 1)");
+    let cigar_op = u32::try_from(SEQUENCE.len()).expect("sequence.len() fits u32") << 4;
+    let tlen = pos2 - pos1 + i32::try_from(SEQUENCE.len()).expect("sequence.len() fits i32");
 
-    let r2 = RecordBuilder::new()
-        .name(name)
-        .sequence(sequence)
-        .qualities(&vec![quality; sequence.len()])
-        .paired(true)
-        .first_segment(false)
-        .reference_sequence_id(ref_id)
-        .alignment_start(pos2)
-        .mapping_quality(60)
-        .reverse_complement(true)
-        .tag("RX", rx_umi)
-        .tag("MI", mi_tag)
-        .build();
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(SEQUENCE)
+            .qualities(&QUALS)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(ref_id)
+            .pos(pos1 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(ref_id)
+            .mate_pos(pos2 - 1)
+            .template_length(tlen)
+            .add_string_tag(b"RX", rx_umi.as_bytes())
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
+
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(SEQUENCE)
+            .qualities(&QUALS)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(ref_id)
+            .pos(pos2 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(ref_id)
+            .mate_pos(pos1 - 1)
+            .template_length(-tlen)
+            .add_string_tag(b"RX", rx_umi.as_bytes())
+            .add_string_tag(b"MI", mi_tag.as_bytes());
+        b.build()
+    };
 
     (r1, r2)
 }
@@ -90,7 +104,9 @@ fn create_simplex_test_bam(path: &PathBuf, header: &Header) {
     }
 
     for record in &records {
-        writer.write_alignment_record(header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
     writer.finish(header).expect("Failed to finish BAM");
 }

--- a/tests/integration/test_simplex_pipeline.rs
+++ b/tests/integration/test_simplex_pipeline.rs
@@ -14,9 +14,6 @@ use std::collections::HashSet;
 
 #[test]
 fn test_identity_assigner_basic_workflow() {
-    use noodles::sam::alignment::record::data::field::Tag;
-    use noodles::sam::alignment::record_buf::data::field::Value;
-
     // Create test data: 3 UMI families with 5, 3, and 2 reads respectively
     let mut all_reads = Vec::new();
 
@@ -29,11 +26,10 @@ fn test_identity_assigner_basic_workflow() {
     // Family 3: GGGGGGGG - 2 reads
     all_reads.extend(create_umi_family("GGGGGGGG", 2, "family3", "CCCCCCCCCC", 30));
 
-    let rx_tag = Tag::from([b'R', b'X']);
     let umis: Vec<String> = all_reads
         .iter()
-        .map(|record| match record.data().get(&rx_tag).expect("RX tag should exist") {
-            Value::String(s) => String::from_utf8_lossy(s.as_ref()).to_string(),
+        .map(|record| match record.tags().get(b"RX").expect("RX tag should exist") {
+            fgumi_raw_bam::TagValue::String(s) => String::from_utf8_lossy(s).to_string(),
             _ => panic!("RX should be string"),
         })
         .collect();
@@ -68,9 +64,6 @@ fn test_identity_assigner_basic_workflow() {
 
 #[test]
 fn test_adjacency_assigner_with_error_correction() {
-    use noodles::sam::alignment::record::data::field::Tag;
-    use noodles::sam::alignment::record_buf::data::field::Value;
-
     // Create test data with intentional sequencing errors
     // Base UMI: AAAAAAAA (50 reads)
     // Error UMI: AAAAAAAC (5 reads, 1bp error)
@@ -82,11 +75,10 @@ fn test_adjacency_assigner_with_error_correction() {
     // Add another distinct UMI family that should NOT be merged
     all_reads.extend(create_umi_family("TTTTTTTT", 30, "distinct", "TGCATGCATGCA", 30));
 
-    let rx_tag = Tag::from([b'R', b'X']);
     let umis: Vec<String> = all_reads
         .iter()
-        .map(|record| match record.data().get(&rx_tag).expect("RX tag") {
-            Value::String(s) => String::from_utf8_lossy(s.as_ref()).to_string(),
+        .map(|record| match record.tags().get(b"RX").expect("RX tag") {
+            fgumi_raw_bam::TagValue::String(s) => String::from_utf8_lossy(s).to_string(),
             _ => panic!("RX should be string"),
         })
         .collect();
@@ -126,9 +118,6 @@ fn test_adjacency_assigner_with_error_correction() {
 
 #[test]
 fn test_adjacency_respects_count_gradient() {
-    use noodles::sam::alignment::record::data::field::Tag;
-    use noodles::sam::alignment::record_buf::data::field::Value;
-
     // Test that adjacency method does NOT merge UMIs when count gradient prevents it
     // Base UMI: GGGGGGGG (30 reads)
     // Similar UMI: GGGGGGGC (20 reads, 1bp error)
@@ -137,11 +126,10 @@ fn test_adjacency_respects_count_gradient() {
 
     all_reads.extend(create_umi_family_with_errors("GGGGGGGG", "GGGGGGGC", 30, 20, "ACGTACGT"));
 
-    let rx_tag = Tag::from([b'R', b'X']);
     let umis: Vec<String> = all_reads
         .iter()
-        .map(|record| match record.data().get(&rx_tag).expect("RX tag") {
-            Value::String(s) => String::from_utf8_lossy(s.as_ref()).to_string(),
+        .map(|record| match record.tags().get(b"RX").expect("RX tag") {
+            fgumi_raw_bam::TagValue::String(s) => String::from_utf8_lossy(s).to_string(),
             _ => panic!("RX should be string"),
         })
         .collect();
@@ -169,9 +157,6 @@ fn test_adjacency_respects_count_gradient() {
 
 #[test]
 fn test_paired_end_umi_workflow() {
-    use noodles::sam::alignment::record::data::field::Tag;
-    use noodles::sam::alignment::record_buf::data::field::Value;
-
     // Create paired-end reads with UMIs
     let family1 = create_paired_umi_family(
         "AAAA-CCCC",
@@ -192,13 +177,13 @@ fn test_paired_end_umi_workflow() {
     );
 
     // Verify proper pairing
-    assert_proper_pairing(&family1[0], &family1[1]);
-    assert_proper_pairing(&family2[0], &family2[1]);
+    assert_proper_pairing(&to_record_buf(&family1[0]), &to_record_buf(&family1[1]));
+    assert_proper_pairing(&to_record_buf(&family2[0]), &to_record_buf(&family2[1]));
 
     // Verify R1 and R2 have different sequences
     assert_ne!(
-        family1[0].sequence().as_ref(),
-        family1[1].sequence().as_ref(),
+        family1[0].sequence_vec(),
+        family1[1].sequence_vec(),
         "R1 and R2 should have different sequences"
     );
 
@@ -206,11 +191,10 @@ fn test_paired_end_umi_workflow() {
     all_reads.extend(family1);
     all_reads.extend(family2);
 
-    let rx_tag = Tag::from([b'R', b'X']);
     let umis: Vec<String> = all_reads
         .iter()
-        .map(|record| match record.data().get(&rx_tag).expect("RX tag") {
-            Value::String(s) => String::from_utf8_lossy(s.as_ref()).to_string(),
+        .map(|record| match record.tags().get(b"RX").expect("RX tag") {
+            fgumi_raw_bam::TagValue::String(s) => String::from_utf8_lossy(s).to_string(),
             _ => panic!("RX should be string"),
         })
         .collect();

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -13,7 +13,7 @@ use std::process::{Command, Stdio};
 
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
 
 /// Test that the group command works correctly with piped input.
 #[test]
@@ -238,7 +238,9 @@ fn create_test_input_bam(path: &PathBuf) {
     let family2 = create_umi_family("CCCCCCCC", 3, "family2", "TGCATGCA", 30);
 
     for record in family1.iter().chain(family2.iter()) {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
 
     writer.try_finish().expect("Failed to finish BAM");
@@ -259,23 +261,20 @@ fn create_grouped_test_bam(path: &PathBuf) {
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
     let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
 
-    // Add MI tag to each record
+    // Add MI tag to each record (convert to RecordBuf first to enable tag mutation)
     let mi_value = 1;
-    for record in records {
-        let mut rec = record.clone();
-        // Get existing data and add MI tag
-        let data = rec.data_mut();
-        data.insert(mi_tag, Value::from(mi_value));
+    for raw in &records {
+        let mut rec = to_record_buf(raw);
+        rec.data_mut().insert(mi_tag, Value::from(mi_value));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
     // Second family with different MI
     let mi_value2 = 2;
     let records2 = create_umi_family("CCCCCCCC", 3, "mol2", "TGCATGCA", 30);
-    for record in records2 {
-        let mut rec = record.clone();
-        let data = rec.data_mut();
-        data.insert(mi_tag, Value::from(mi_value2));
+    for raw in &records2 {
+        let mut rec = to_record_buf(raw);
+        rec.data_mut().insert(mi_tag, Value::from(mi_value2));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 

--- a/tests/integration/test_zipper_command.rs
+++ b/tests/integration/test_zipper_command.rs
@@ -6,7 +6,7 @@
 //! 3. Error on missing input files
 
 use fgumi_lib::sam::SamTag;
-use fgumi_lib::sam::builder::RecordBuilder;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
@@ -18,37 +18,43 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
+use crate::helpers::bam_generator::{create_minimal_header, create_test_reference, to_record_buf};
 
 /// Create a queryname-sorted unmapped BAM with UMI tags (RX/QX).
-fn create_unmapped_bam(path: &Path, records: &[RecordBuf]) {
+fn create_unmapped_bam(path: &Path, records: &[RawRecord]) {
     let header = sam::Header::default();
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create unmapped BAM"));
     writer.write_header(&header).expect("Failed to write header");
     for record in records {
-        writer.write_alignment_record(&header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
     writer.finish(&header).expect("Failed to finish BAM");
 }
 
 /// Create a mapped SAM file with aligned reads (same read names as unmapped).
-fn create_mapped_sam(path: &Path, header: &sam::Header, records: &[RecordBuf]) {
+fn create_mapped_sam(path: &Path, header: &sam::Header, records: &[RawRecord]) {
     let file = fs::File::create(path).expect("Failed to create mapped SAM");
     let mut writer = sam::io::Writer::new(file);
     writer.write_header(header).expect("Failed to write header");
     for record in records {
-        writer.write_alignment_record(header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
 }
 
 /// Create a mapped BAM file with aligned reads (same read names as unmapped).
-fn create_mapped_bam(path: &Path, header: &sam::Header, records: &[RecordBuf]) {
+fn create_mapped_bam(path: &Path, header: &sam::Header, records: &[RawRecord]) {
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create mapped BAM"));
     writer.write_header(header).expect("Failed to write header");
     for record in records {
-        writer.write_alignment_record(header, record).expect("Failed to write record");
+        writer
+            .write_alignment_record(header, &to_record_buf(record))
+            .expect("Failed to write record");
     }
     writer.finish(header).expect("Failed to finish BAM");
 }
@@ -64,46 +70,54 @@ fn test_zipper_basic_merge() {
 
     // Unmapped reads with RX/QX tags
     let unmapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "AACCGGTT")
-            .tag("QX", "IIIIIIII")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "GGTTCCAA")
-            .tag("QX", "IIIIIIII")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"AACCGGTT")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"GGTTCCAA")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
     ];
     create_unmapped_bam(&unmapped_bam, &unmapped_records);
 
     // Mapped reads (same names, aligned to chr1)
     let mapped_header = create_minimal_header("chr1", 10000);
     let mapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
     ];
     create_mapped_sam(&mapped_sam, &mapped_header, &mapped_records);
 
@@ -149,30 +163,30 @@ fn test_zipper_tag_removal() {
     let ref_path = create_test_reference(temp_dir.path());
 
     // Unmapped read with RX and a custom tag XY
-    let unmapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
+    let unmapped_records = vec![{
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
             .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "AACCGGTT")
-            .tag("XY", "REMOVE_ME")
-            .build(),
-    ];
+            .flags(flags::UNMAPPED)
+            .add_string_tag(b"RX", b"AACCGGTT")
+            .add_string_tag(b"XY", b"REMOVE_ME");
+        b.build()
+    }];
     create_unmapped_bam(&unmapped_bam, &unmapped_records);
 
     let mapped_header = create_minimal_header("chr1", 10000);
-    let mapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
+    let mapped_records = vec![{
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGTACGT")
             .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
-    ];
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]); // 8M
+        b.build()
+    }];
     create_mapped_sam(&mapped_sam, &mapped_header, &mapped_records);
 
     let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
@@ -246,45 +260,53 @@ fn test_zipper_bam_mapped_input() {
     let ref_path = create_test_reference(temp_dir.path());
 
     let unmapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "AACCGGTT")
-            .tag("QX", "IIIIIIII")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "GGTTCCAA")
-            .tag("QX", "IIIIIIII")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"AACCGGTT")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"GGTTCCAA")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
     ];
     create_unmapped_bam(&unmapped_bam, &unmapped_records);
 
     let mapped_header = create_minimal_header("chr1", 10000);
     let mapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
     ];
     create_mapped_bam(&mapped_bam, &mapped_header, &mapped_records);
 
@@ -344,45 +366,53 @@ fn test_zipper_bam_stdin_input() {
     let ref_path = create_test_reference(temp_dir.path());
 
     let unmapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "AACCGGTT")
-            .tag("QX", "IIIIIIII")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .unmapped(true)
-            .tag("RX", "GGTTCCAA")
-            .tag("QX", "IIIIIIII")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"AACCGGTT")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(b"RX", b"GGTTCCAA")
+                .add_string_tag(b"QX", b"IIIIIIII");
+            b.build()
+        },
     ];
     create_unmapped_bam(&unmapped_bam, &unmapped_records);
 
     let mapped_header = create_minimal_header("chr1", 10000);
     let mapped_records = vec![
-        RecordBuilder::new()
-            .name("read1")
-            .sequence("ACGTACGT")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(100)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
-        RecordBuilder::new()
-            .name("read2")
-            .sequence("TGCATGCA")
-            .qualities(&[30; 8])
-            .reference_sequence_id(0)
-            .alignment_start(200)
-            .mapping_quality(60)
-            .cigar("8M")
-            .build(),
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read1")
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(b"read2")
+                .sequence(b"TGCATGCA")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            b.build()
+        },
     ];
     create_mapped_bam(&mapped_bam, &mapped_header, &mapped_records);
 


### PR DESCRIPTION
## Summary

Migrates all remaining workspace tests from legacy test scaffolding
(`fgumi_sam::RecordBuilder` / `RecordPairBuilder` / `SamBuilder`, noodles
`RecordBuf` fixtures) to the new `fgumi_raw_bam::SamBuilder`. Tests now
drive production code paths (`Vec<RawRecord>`) directly instead of
bridging through noodles record construction and encode-to-raw.

Part 7 of 8 in the series closing #272. Stacks on #294.

## Scope

**Migrated test modules:**
- `zipper.rs` - full test suite rebuilt on `RawSamBuilder`; adapted to
  main's `tc` tag / `TemplateCoordinateInfo` naming
- `consensus/duplex_caller.rs` - drop `consensus_reads_from_sam_records`
  bridge; tests now call `consensus_reads(Vec<RawRecord>)` directly
- `consensus/vanilla_caller.rs` - replace `RecordBuilder` /
  `RecordPairBuilder` with `SamBuilder`
- `consensus/filter.rs` - methylation filter tests use `SamBuilder`
- `commands/dedup.rs`, `commands/filter.rs` - unit + integration filter
  tests migrated
- `commands/downsample.rs`, `duplex_metrics.rs`, `simplex_metrics.rs`,
  `simulate/correct_reads.rs` - test-only migrations

**Integration helpers updated:**
- `helpers/bam_generator.rs` - `create_umi_family` returns
  `Vec<RawRecord>`; new `to_record_buf()` adapter for noodles
  `write_alignment_record` paths
- `helpers/assertions.rs` - adapted to `RawRecord` fixtures

**Integration test files migrated:**
`test_async_reader`, `test_bam_pipeline`, `test_bgzf_eof`,
`test_clip_command`, `test_codec_command`, `test_codec_pipeline`,
`test_compare_bams`, `test_correct_command`, `test_dedup_command`,
`test_downsample_command`, `test_duplex_command`,
`test_duplex_metrics_command`, `test_fastq_command`, `test_filter_command`,
`test_group_command`, `test_pipeline_concurrency`, `test_review_command`,
`test_simplex_command`, `test_simplex_metrics_command`,
`test_simplex_pipeline`, `test_streaming_input`, `test_zipper_command`.

`test_codec_command.rs` now writes raw records directly via
`create_raw_bam_writer` + `write_raw_record`, eliminating the
`SamBuilder`→`RecordBuf`→noodles writer detour.

## Not included

- `src/lib/commands/simulate/` (scope: PR 13)
- `src/lib/vendored/` (scope: PR 13)

## Test plan

- [x] `cargo ci-test` - 2450 tests pass, 23 skipped
- [x] `cargo ci-fmt` - clean
- [x] `cargo ci-lint` - clean

Refs #272