### PR TITLE
fix(unified-pipeline): suppress deadlock false positive when all queues empty

### DIFF
--- a/src/lib/unified_pipeline/deadlock.rs
+++ b/src/lib/unified_pipeline/deadlock.rs
@@ -414,6 +414,51 @@ pub fn check_deadlock_and_restore(
 
     // Check for deadlock (no progress for timeout period)
     if now.saturating_sub(last_progress) >= timeout {
+        // False-positive guard. The per-queue timestamps only update when a
+        // record is pushed into or popped from one of q1..q7. If every
+        // queue is empty, no push/pop happens even when the pipeline is
+        // fundamentally healthy — the common case is a stdin pipe that
+        // intermittently stalls for longer than `timeout` because the
+        // upstream process is slow (e.g. `fgumi sort` in phase-2 merge
+        // feeding `group | codec | filter`). Absence of queue activity in
+        // that case is starvation, not deadlock.
+        //
+        // Only raise "deadlock detected" when at least one queue still has
+        // items stuck in it. With empty queues we instead bump the progress
+        // timer and return None, so we don't re-fire every monitor tick and
+        // so real pipeline progress — when it resumes — naturally updates
+        // the per-queue timestamps. A genuine upstream hang will leave
+        // every queue empty forever and the pipeline will sit idle until
+        // the user interrupts; the previous behaviour killed the process
+        // in that same scenario, so we do not lose liveness signalling
+        // that we had before.
+        // In-flight work includes both the bounded queues AND the BAM
+        // reorder buffers (FASTQ sets these to 0). Items can sit in a
+        // reorder buffer waiting for a missing sequence number while every
+        // queue.len() reads 0 — treating that as starvation would mask a
+        // real deadlock. For FASTQ, q2b_len already covers Q2.5
+        // (q2_block_parsed for bgzf, q2_5_boundaries otherwise).
+        let has_in_flight_work = snapshot.q1_len > 0
+            || snapshot.q2_len > 0
+            || snapshot.q2b_len > 0
+            || snapshot.q3_len > 0
+            || snapshot.q4_len > 0
+            || snapshot.q5_len > 0
+            || snapshot.q6_len > 0
+            || snapshot.q7_len > 0
+            || snapshot.q2_reorder_mem > 0
+            || snapshot.q3_reorder_mem > 0;
+        if !has_in_flight_work {
+            log::debug!(
+                "Deadlock detector: no queue activity for {}s but all queues \
+                 are empty (read_done={}); treating as upstream starvation, \
+                 not deadlock",
+                timeout,
+                snapshot.read_done
+            );
+            deadlock_state.last_progress_time.store(now, Ordering::Relaxed);
+            return DeadlockAction::None;
+        }
         return handle_deadlock(deadlock_state, snapshot, now);
     }
 
@@ -871,11 +916,14 @@ mod tests {
         let now = now_secs();
         state.last_progress_time.store(now.saturating_sub(5), Ordering::Relaxed);
 
+        // Populate a downstream queue so this is a genuine stuck-items
+        // deadlock, not the starvation (all-queues-empty) case that the
+        // detector now treats as benign.
         let snapshot = QueueSnapshot {
             q1_len: 0,
             q2_len: 0,
             q2b_len: 0,
-            q3_len: 0,
+            q3_len: 1,
             q4_len: 0,
             q5_len: 0,
             q6_len: 0,
@@ -905,11 +953,14 @@ mod tests {
         let now = now_secs();
         state.last_progress_time.store(now.saturating_sub(5), Ordering::Relaxed);
 
+        // Non-empty queue: this represents a genuine "items stuck in queue"
+        // deadlock (a worker is holding progress up) rather than the
+        // starvation case, which the detector now skips.
         let snapshot = QueueSnapshot {
             q1_len: 0,
             q2_len: 0,
             q2b_len: 0,
-            q3_len: 0,
+            q3_len: 1,
             q4_len: 0,
             q5_len: 0,
             q6_len: 0,
@@ -1038,11 +1089,15 @@ mod tests {
         // Set current limit to something that would result in lower stable
         state.current_memory_limit.store(256 * 1024 * 1024, Ordering::Relaxed);
 
+        // Populate q3 so this is a genuine stuck-items deadlock and reaches
+        // `handle_deadlock`, where the anti-decrease stable-limit logic
+        // lives. With all queues empty the new starvation guard returns
+        // early and the anti-oscillation path isn't exercised.
         let snapshot = QueueSnapshot {
             q1_len: 0,
             q2_len: 0,
             q2b_len: 0,
-            q3_len: 0,
+            q3_len: 1,
             q4_len: 0,
             q5_len: 0,
             q6_len: 0,
@@ -1056,7 +1111,8 @@ mod tests {
             extra_state: None,
         };
 
-        check_deadlock_and_restore(&state, &snapshot);
+        let action = check_deadlock_and_restore(&state, &snapshot);
+        assert!(matches!(action, DeadlockAction::Recovered(_)));
 
         // Stable limit should still be 1GB (never decreased)
         let current_stable = state.stable_memory_limit.load(Ordering::Relaxed);
@@ -1092,5 +1148,54 @@ mod tests {
         // Modify and verify
         state.current_memory_limit.store(1024 * 1024 * 1024, Ordering::Relaxed);
         assert_eq!(state.get_memory_limit(), 1024 * 1024 * 1024);
+    }
+
+    /// Regression: detector must NOT fire when all queues are empty, even if
+    /// the last progress timestamp is stale. Empty queues + timeout = stdin
+    /// pipe starvation (upstream is slow), not a genuine deadlock.
+    ///
+    /// Observed pre-fix on a full-depth rep1 run where `fgumi filter` died
+    /// with "pipeline deadlock detected" because `fgumi sort`'s phase-2
+    /// merge was streaming output sporadically into group|codec|filter and
+    /// leaving filter's own queues drained for longer than the 10-second
+    /// timeout even though the pipeline was fundamentally healthy.
+    #[test]
+    fn test_no_deadlock_on_empty_queues_stale_timestamp() {
+        let config = DeadlockConfig::new(1, false);
+        let state = DeadlockState::new(&config, 0);
+        let now = now_secs();
+        // Force last_progress to be well past the 1s timeout.
+        state.last_progress_time.store(now.saturating_sub(5), Ordering::Relaxed);
+        let snapshot = QueueSnapshot {
+            q1_len: 0,
+            q2_len: 0,
+            q2b_len: 0,
+            q3_len: 0,
+            q4_len: 0,
+            q5_len: 0,
+            q6_len: 0,
+            q7_len: 0,
+            q2_reorder_mem: 0,
+            q3_reorder_mem: 0,
+            memory_limit: 0,
+            read_done: false,
+            group_done: false,
+            draining: false,
+            extra_state: None,
+        };
+        let before = state.last_progress_time.load(Ordering::Relaxed);
+        let action = check_deadlock_and_restore(&state, &snapshot);
+        assert_eq!(
+            action,
+            DeadlockAction::None,
+            "empty queues + stale timestamp must be treated as starvation"
+        );
+        // The guard must bump last_progress_time so it doesn't re-fire on
+        // every monitor tick while the pipeline waits on stdin.
+        let after = state.last_progress_time.load(Ordering::Relaxed);
+        assert!(
+            after > before,
+            "empty-queue starvation path should refresh last_progress_time (before={before}, after={after})"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Guard `check_deadlock_and_restore` so it only fires when at least one of the pipeline's `q1..q7` queues still has an item in it.
- When every queue is empty, treat the lack of queue-event activity as upstream starvation (pipe blocked on a slow producer), not a deadlock. Bump `last_progress_time` so we don't re-fire on every monitor tick and return `None`.
- Add regression test `test_no_deadlock_on_empty_queues_stale_timestamp`.
- Repoint the two pre-existing all-queues-empty tests (`test_recovery_disabled_only_logs`, `test_recovery_updates_stable_limit`) to place a single item in `q3_len` so they continue to exercise the genuine stuck-items deadlock path that the detector *should* fire on.

## Why

`check_deadlock_and_restore` declares a deadlock whenever the pipeline's global `last_progress_time` hasn't advanced for `timeout_secs` (default 10 s). That timestamp is only advanced by `record_qN_push` / `record_qN_pop`, so any 10-second window without a queue event trips the detector.

In practice that fires when the pipeline is *blocked on stdin*, not deadlocked. Observed on a full-depth run of

```bash
fgumi extract | fgumi fastq | bwa mem | fgumi zipper | fgumi sort | fgumi group | fgumi codec | fgumi filter
```

on a 552 M-record input: during `fgumi sort`'s phase-2 merge, upstream output to the `group | codec | filter` tail is sporadic. Inside `filter`, all of `q1..q7` drained for longer than `timeout` while the process waited for the next byte from stdin. The detector interpreted that as a deadlock and aborted with a SIGPIPE cascade even though the pipeline was healthy and would have resumed as soon as sort produced more output. The run was lost after ~4 hours of work.

The previous handling offered no way to distinguish starvation from deadlock: any stall that crossed the timeout fired the same code path. `--deadlock-recover` (which doubles the memory limit) does nothing useful for starvation, and a longer `--deadlock-timeout` just delays the false positive.

## What

The fix adds a single pre-check inside `check_deadlock_and_restore`: if `now - last_progress >= timeout` AND every queue is empty, return `DeadlockAction::None` and update `last_progress_time` to `now` so the detector doesn't re-fire on every monitor tick. If real work resumes, the normal per-queue push/pop sites update timestamps and the detector starts fresh; if the pipeline genuinely hangs forever, the process sits idle until the user interrupts — the same liveness guarantee as the pre-detector behaviour, but without the false-positive kill.

### Test plan

- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo test --release --lib --features compare unified_pipeline::deadlock` — **20 passed**, 0 failed
- [x] `cargo test --release --lib --features compare` — **1,974 passed**, 0 failed
- [x] End-to-end: the patched binary completed a 552 M-record `fgumi extract | ... | fgumi filter` pipe to completion where the previous binary aborted at 12% of sort phase-2 merge.

### What's not included

- Genuine-deadlock detection when queues *do* hold items continues to work as before; the stuck-items path `handle_deadlock` is unchanged.
- The `DeadlockConfig::timeout_secs` default and `--deadlock-recover` behaviour are unchanged.
- Per-queue diagnostic logging in `log_queue_state` is unchanged.