### PR TITLE
feat(os_hints): hint compute workers with Apple Silicon QoS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,11 @@ The following external FFI calls are approved because they back core infrastruct
 - **`mach2`** (`src/lib/sort/memory_probe.rs`, macOS only) — `task_info(TASK_VM_INFO)`
   is the only way to read `phys_footprint` (the RSS metric mimalloc reports accurately).
   Isolated to the same sub-module as the mimalloc FFI.
+- **`libc::pthread_set_qos_class_self_np`** (`src/lib/os_hints.rs`, macOS only) —
+  Darwin public API for hinting the scheduler that the calling thread is
+  compute-bound interactive work. The FFI wrapper is isolated to a single
+  `#[allow(unsafe_code)]` sub-module. The call affects only the calling thread
+  and is safe to invoke concurrently across threads.
 
 ## Benchmarking Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "fs4",
  "indexmap",
  "itertools 0.14.0",
+ "libc",
  "libdeflater",
  "libmimalloc-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ fgumi-consensus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.6"
+libc = "0.2.135"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.29", default-features = false, features = ["fs"] }

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -1343,6 +1343,7 @@ impl CompareBams {
         // This controls BOTH rayon parallelism and BGZF decompression
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
+            .start_handler(|_| crate::os_hints::set_current_thread_compute_qos())
             .build()
             .map_err(|e| anyhow!("Failed to create thread pool: {e}"))?;
 

--- a/src/lib/os_hints.rs
+++ b/src/lib/os_hints.rs
@@ -65,6 +65,25 @@ pub fn hint_fd(_file: &File) -> Option<i32> {
     None
 }
 
+/// Hint to the Darwin scheduler that the current thread is compute-bound
+/// interactive work, preferring placement on performance (P) cores on Apple
+/// Silicon. No-op on non-macOS targets and on Intel Macs (where the OS has no
+/// P/E distinction to route).
+///
+/// Call this once at the top of a long-running compute worker thread's
+/// closure. Do NOT call from I/O-bound writer or reader threads — those
+/// should remain at default `QoS` so the scheduler is free to place them on
+/// efficiency cores, keeping P-cores hot for compute.
+///
+/// Best-effort: if the underlying `pthread_set_qos_class_self_np` call fails,
+/// the failure is logged at `debug` level and otherwise ignored. The thread
+/// remains usable at its default `QoS`.
+pub fn set_current_thread_compute_qos() {
+    #[cfg(target_os = "macos")]
+    macos_qos::set_user_initiated();
+    // Non-macOS: intentionally empty.
+}
+
 #[cfg(target_os = "linux")]
 mod linux {
     use std::fs::File;
@@ -84,6 +103,23 @@ mod linux {
     pub(super) fn advise_willneed_raw(fd: i32, offset: i64, len: i64) {
         if let Err(e) = posix_fadvise(fd, offset, len, PosixFadviseAdvice::POSIX_FADV_WILLNEED) {
             log::debug!("posix_fadvise(POSIX_FADV_WILLNEED) failed on fd {fd}: {e}");
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+mod macos_qos {
+    use libc::qos_class_t::QOS_CLASS_USER_INITIATED;
+
+    pub(super) fn set_user_initiated() {
+        // SAFETY: pthread_set_qos_class_self_np affects only the calling
+        // thread. The `override` argument of 0 requests the default relative
+        // priority within the class. The libc binding is a thin wrapper over
+        // a stable Darwin public API and takes no pointer arguments.
+        let rc = unsafe { libc::pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0) };
+        if rc != 0 {
+            log::debug!("pthread_set_qos_class_self_np failed: rc={rc}");
         }
     }
 }
@@ -110,5 +146,56 @@ mod tests {
         for _ in 0..16 {
             advise_sequential(&f);
         }
+    }
+
+    #[test]
+    fn set_current_thread_compute_qos_does_not_panic() {
+        // The function is a no-op on non-macOS and a best-effort pthread call
+        // on macOS. It must not panic on any supported platform.
+        set_current_thread_compute_qos();
+    }
+
+    #[test]
+    fn set_current_thread_compute_qos_is_callable_repeatedly() {
+        for _ in 0..16 {
+            set_current_thread_compute_qos();
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn set_current_thread_compute_qos_round_trip_on_macos() {
+        use libc::qos_class_t::{QOS_CLASS_UNSPECIFIED, QOS_CLASS_USER_INITIATED};
+
+        // Run on a freshly spawned thread so we don't mutate the test runner's
+        // QoS (which could affect subsequent tests on the same worker thread).
+        let actual_class = std::thread::spawn(|| {
+            set_current_thread_compute_qos();
+
+            #[allow(unsafe_code)]
+            // SAFETY: pthread_get_qos_class_np with two out-pointers to
+            // locally-owned storage. Both pointers are valid for the duration
+            // of the call.
+            unsafe {
+                let mut class: libc::qos_class_t = QOS_CLASS_UNSPECIFIED;
+                let mut relpri: std::os::raw::c_int = 0;
+                let rc = libc::pthread_get_qos_class_np(
+                    libc::pthread_self(),
+                    std::ptr::addr_of_mut!(class),
+                    std::ptr::addr_of_mut!(relpri),
+                );
+                assert_eq!(rc, 0, "pthread_get_qos_class_np failed: rc={rc}");
+                class
+            }
+        })
+        .join()
+        .expect("spawned thread should not panic");
+
+        // `qos_class_t` does not implement `PartialEq` in the libc bindings,
+        // so match on the variant instead.
+        assert!(
+            matches!(actual_class, QOS_CLASS_USER_INITIATED),
+            "expected QOS_CLASS_USER_INITIATED, got {actual_class:?}",
+        );
     }
 }

--- a/src/lib/sort/raw.rs
+++ b/src/lib/sort/raw.rs
@@ -1366,6 +1366,7 @@ impl RawExternalSorter {
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads.max(1))
             .thread_name(|i| format!("fgumi-sort-rayon-{i}"))
+            .start_handler(|_| crate::os_hints::set_current_thread_compute_qos())
             .build()
             .map_err(|e| anyhow::anyhow!("failed to build rayon sort pool: {e}"))
     }

--- a/src/lib/sort/worker_pool.rs
+++ b/src/lib/sort/worker_pool.rs
@@ -887,6 +887,7 @@ impl SortWorkerPool {
                 let shared = Arc::clone(&shared);
 
                 thread::spawn(move || {
+                    crate::os_hints::set_current_thread_compute_qos();
                     let mut worker = SortWorkerState {
                         worker_id,
                         compressor: InlineBgzfCompressor::new(temp_compression),

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -3301,6 +3301,7 @@ where
             thread::spawn(move || {
                 // Wrap worker logic in catch_unwind to handle panics gracefully
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    crate::os_hints::set_current_thread_compute_qos();
                     let mut worker = WorkerState::new(
                         compression_level,
                         thread_id,

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -3754,6 +3754,7 @@ where
             thread::spawn(move || {
                 // Wrap worker logic in catch_unwind to handle panics gracefully
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    crate::os_hints::set_current_thread_compute_qos();
                     log::debug!("Worker thread {thread_id} starting");
                     let mut worker = FastqWorkerState::new(
                         compression_level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,16 @@ fn main() -> Result<()> {
     let default_level = if args.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(Env::default().default_filter_or(default_level)).init();
 
+    // Initialize the rayon global thread pool so every rayon worker receives
+    // the Apple Silicon compute-QoS hint on first activation. This call MUST
+    // run before any rayon work is submitted; once rayon auto-initializes the
+    // global pool, `build_global` returns an error that we treat as fatal
+    // rather than silently dropping the hint.
+    rayon::ThreadPoolBuilder::new()
+        .start_handler(|_| fgumi_lib::os_hints::set_current_thread_compute_qos())
+        .build_global()
+        .expect("rayon global thread pool already initialized");
+
     info!("Running fgumi version {}", fgumi_lib::version::VERSION.as_str());
     args.subcommand.execute(&command_line)
 }


### PR DESCRIPTION
## Summary

- Add `set_current_thread_compute_qos()` in `os_hints`, a best-effort hint backed by `pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED)` that tells the Darwin scheduler to prefer performance cores on Apple Silicon. No-op on non-macOS and Intel Macs.
- Call the hint at compute-worker entry points — unified-pipeline BAM/FASTQ workers, the sort worker pool, the rayon global pool in `main`, and the scoped sort/compare rayon pools — so both hand-rolled `thread::spawn` workers and rayon-backed parallelism pick up the hint.
- Leave I/O-bound threads (BGZF writers, chunk readers, prefetchers, monitor threads) at default QoS so the scheduler is free to park them on efficiency cores, keeping P-cores hot for compute.
- Add `libc` as a macOS-only dependency for the FFI and document the new unsafe exception in `CLAUDE.md`.

Reference implementation: bwa-mem2's `src/kthread.cpp` applies the same hint at `pthread_create` time. This PR uses `pthread_set_qos_class_self_np` from inside the thread instead, which composes transparently with `std::thread::spawn`, crossbeam, and rayon — no need to touch every spawn site.

## Why QoS and not Linux affinity

QoS is a scheduler *hint* that expresses intent ("interactive compute") and lets the kernel route — the right abstraction for hybrid P/E topologies like Apple Silicon. Linux CPU affinity is a *directive* that overrides kernel knowledge with user assumptions, interacts poorly with container cpusets, fights work-stealing, and offers weak cache benefits for streaming bioinformatics workloads. Not worth adding.

## Performance

Benchmarked across sort and simplex-consensus workloads at 2/4/8/12 threads on an M-series Mac (40+ trials total). **No measurable speedup and no regression** on a quiet dev machine — see [this comment](https://github.com/fulcrumgenomics/fgumi/pull/301#issuecomment-4278437183) for the full matrix. The hint is a correctness/intent statement; its value shows up under contention (other processes fighting for P-cores, thermal throttling) which a quiet benchmark cannot reproduce. Landing on principle, not as a performance win.

## Test plan

- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo ci-test` (2569 passed, 0 failed; includes three new `os_hints::tests::set_current_thread_compute_qos*` tests, one of which round-trips through `pthread_get_qos_class_np` on macOS to confirm the FFI constant survives)
- [x] Local benchmark on M-series Mac (sort + simplex, 2/4/8/12 threads, 40+ trials) — no regression anywhere; no measurable uplift on uncontested hardware.
- [ ] Staying in draft pending reviewer decision on whether to merge as a correctness/intent change without a demonstrated perf win, or defer until a contended-machine benchmark is available.