### PR TITLE
perf: migrate RecordBuf hot paths to raw-byte accessors

### DIFF
--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -599,9 +599,13 @@ fn start_raw_batch_reader(
 
 /// Deserialize raw BAM record bytes into a noodles `RecordBuf`.
 ///
-/// This is used only when records differ at the raw byte level and we need
-/// human-readable field values for diff reporting. The raw bytes are the BAM
-/// record body WITHOUT the 4-byte length prefix.
+/// **Intentional non-raw decode.** Other production hot paths avoid
+/// `raw_records_to_record_bufs` because it builds a synthetic BAM stream per call;
+/// here it is acceptable because this function only runs *off* the comparison hot
+/// path — after the byte/structured tiers have already flagged a pair as
+/// mismatched and we need typed field values to render a human-readable diff.
+///
+/// The raw bytes are the BAM record body WITHOUT the 4-byte length prefix.
 ///
 /// # Errors
 ///

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -5,18 +5,17 @@
 //!
 //! Requires input BAM to be in template-coordinate order (from group).
 
-use crate::bam_io::{create_bam_reader, create_bam_writer, create_optional_bam_writer};
+use crate::bam_io::{RawBamWriter, create_raw_bam_reader, create_raw_bam_writer};
 use crate::logging::OperationTimer;
 use crate::progress::ProgressTracker;
-use crate::sam::SamTag;
 use crate::sam::is_template_coordinate_sorted;
 use crate::validation::validate_file_exists;
 use anyhow::{Result, bail};
 use clap::Parser;
+use fgumi_raw_bam::{
+    RawBamReader, RawRecord, aux_data_slice, find_int_tag, find_string_tag, read_name,
+};
 use log::info;
-use noodles::sam::alignment::io::Write as AlignmentWrite;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use std::collections::{BTreeMap, HashSet};
@@ -26,9 +25,6 @@ use std::path::PathBuf;
 
 use crate::commands::command::Command;
 use crate::commands::common::{BamIoOptions, CompressionOptions, parse_bool};
-
-/// MI tag for molecular identifier
-const MI_TAG: Tag = SamTag::MI.to_noodles_tag();
 
 /// Downsample a BAM file by UMI family using streaming.
 ///
@@ -125,8 +121,7 @@ impl Command for Downsample {
             None => rand::make_rng(),
         };
 
-        // Open input BAM
-        let (mut reader, header) = create_bam_reader(&self.io.input, 1)?;
+        let (reader, header) = create_raw_bam_reader(&self.io.input, 1)?;
 
         // Validate header - input must be template-coordinate sorted (output from group)
         if !is_template_coordinate_sorted(&header) {
@@ -143,15 +138,14 @@ impl Command for Downsample {
 
         // Create output BAM writer (single-threaded, downsample doesn't have threads parameter)
         let mut writer =
-            create_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
+            create_raw_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
 
         // Create optional rejects writer
-        let mut rejects_writer = create_optional_bam_writer(
-            self.rejects.as_ref(),
-            &header,
-            1,
-            self.compression.compression_level,
-        )?;
+        let mut rejects_writer: Option<RawBamWriter> = self
+            .rejects
+            .as_ref()
+            .map(|path| create_raw_bam_writer(path, &header, 1, self.compression.compression_level))
+            .transpose()?;
 
         // Statistics
         let mut total_families: u64 = 0;
@@ -170,9 +164,7 @@ impl Command for Downsample {
 
         info!("Processing reads...");
 
-        // Process families using streaming iteration
-        let record_iter = reader.record_bufs(&header).map(|r| r.map_err(Into::into));
-        let mut family_iter = FamilyIterator::new(record_iter);
+        let mut family_iter = FamilyIterator::new(raw_record_iter(reader));
 
         while let Some(family_result) = family_iter.next_family()? {
             let (mi, family) = family_result;
@@ -201,7 +193,7 @@ impl Command for Downsample {
                 *hist_kept.entry(family_size).or_insert(0) += 1;
 
                 for record in &family {
-                    writer.write_alignment_record(&header, record)?;
+                    writer.write_raw_record(record.as_ref())?;
                 }
             } else {
                 rejected_reads += family_size as u64;
@@ -209,7 +201,7 @@ impl Command for Downsample {
 
                 if let Some(ref mut rw) = rejects_writer {
                     for record in &family {
-                        rw.write_alignment_record(&header, record)?;
+                        rw.write_raw_record(record.as_ref())?;
                     }
                 }
             }
@@ -227,6 +219,13 @@ impl Command for Downsample {
         if let Some(ref path) = self.histogram_rejected {
             write_histogram(&hist_rejected, path)?;
             info!("Wrote rejected histogram to: {}", path.display());
+        }
+
+        // Finalize writers before summary so any I/O failure surfaces here rather
+        // than silently on drop (flushes buffered records + writes BGZF EOF).
+        writer.finish()?;
+        if let Some(rw) = rejects_writer {
+            rw.finish()?;
         }
 
         // Summary
@@ -261,19 +260,46 @@ fn write_histogram(histogram: &BTreeMap<usize, u64>, path: &PathBuf) -> Result<(
     Ok(())
 }
 
+/// Wrap a [`RawBamReader`] as a streaming iterator of [`RawRecord`]s.
+///
+/// Allocates a fresh `RawRecord` per iteration so downstream code can buffer
+/// records by family without stepping on each other's storage.
+fn raw_record_iter<R: std::io::Read>(
+    mut reader: RawBamReader<R>,
+) -> impl Iterator<Item = Result<RawRecord>> {
+    let mut exhausted = false;
+    std::iter::from_fn(move || {
+        if exhausted {
+            return None;
+        }
+        let mut rec = RawRecord::new();
+        match reader.read_record(&mut rec) {
+            Ok(0) => {
+                exhausted = true;
+                None
+            }
+            Ok(_) => Some(Ok(rec)),
+            Err(e) => {
+                exhausted = true;
+                Some(Err(anyhow::Error::from(e)))
+            }
+        }
+    })
+}
+
 /// Iterator that groups consecutive records by MI tag.
 ///
 /// This provides streaming iteration over UMI families without loading the entire BAM into memory.
 struct FamilyIterator<I>
 where
-    I: Iterator<Item = Result<RecordBuf>>,
+    I: Iterator<Item = Result<RawRecord>>,
 {
     records: std::iter::Peekable<I>,
 }
 
 impl<I> FamilyIterator<I>
 where
-    I: Iterator<Item = Result<RecordBuf>>,
+    I: Iterator<Item = Result<RawRecord>>,
 {
     fn new(records: I) -> Self {
         Self { records: records.peekable() }
@@ -282,7 +308,7 @@ where
     /// Get the next family of records sharing the same MI tag.
     ///
     /// Returns `Ok(Some((mi_tag`, records))) for each family, or Ok(None) when exhausted.
-    fn next_family(&mut self) -> Result<Option<(String, Vec<RecordBuf>)>> {
+    fn next_family(&mut self) -> Result<Option<(String, Vec<RawRecord>)>> {
         // Peek at the first record to get the MI tag
         let mi = match self.records.peek() {
             Some(Ok(record)) => get_mi_tag(record)?,
@@ -317,61 +343,55 @@ where
     }
 }
 
-/// Extract the MI tag value from a record.
-fn get_mi_tag(record: &RecordBuf) -> Result<String> {
-    let mi = record.data().get(&MI_TAG).ok_or_else(|| {
-        let name = record.name().map_or_else(
-            || "<unknown>".to_string(),
-            |n| String::from_utf8_lossy(n.as_ref()).to_string(),
-        );
-        anyhow::anyhow!("Read '{name}' is missing required MI tag")
-    })?;
+/// Extract the MI tag value from a raw BAM record.
+///
+/// MI is Z-typed per SAM spec, but fgbio historically also writes it as an integer.
+/// The raw path supports both: we look for a Z-type first, then fall back to any
+/// integer encoding (c/C/s/S/i/I).
+fn get_mi_tag(record: &RawRecord) -> Result<String> {
+    let aux = aux_data_slice(record.as_ref());
 
-    // MI tag can be an integer or string
-    use noodles::sam::alignment::record_buf::data::field::Value;
-    match mi {
-        Value::Int8(v) => Ok(v.to_string()),
-        Value::UInt8(v) => Ok(v.to_string()),
-        Value::Int16(v) => Ok(v.to_string()),
-        Value::UInt16(v) => Ok(v.to_string()),
-        Value::Int32(v) => Ok(v.to_string()),
-        Value::UInt32(v) => Ok(v.to_string()),
-        Value::String(s) => Ok(s.to_string()),
-        _ => bail!("Unexpected MI tag type"),
+    if let Some(bytes) = find_string_tag(aux, b"MI") {
+        return std::str::from_utf8(bytes)
+            .map(str::to_string)
+            .map_err(|e| anyhow::anyhow!("MI tag is not valid UTF-8: {e}"));
     }
+
+    if let Some(v) = find_int_tag(aux, b"MI") {
+        return Ok(v.to_string());
+    }
+
+    let name = String::from_utf8_lossy(read_name(record.as_ref())).into_owned();
+    let display_name = if name.is_empty() { "<unknown>".to_string() } else { name };
+    bail!("Read '{display_name}' is missing required MI tag")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fgumi_raw_bam::{SamBuilder as RawSamBuilder, raw_record_to_record_buf};
+    use fgumi_raw_bam::SamBuilder as RawSamBuilder;
 
-    fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> RecordBuf {
-        raw_record_to_record_buf(&raw, &noodles::sam::Header::default())
-            .expect("raw_record_to_record_buf failed in test")
-    }
-
-    /// Create a test record with an MI tag
-    fn create_test_record(name: &str, mi: &str) -> RecordBuf {
+    /// Create a test record with a string MI tag.
+    fn create_test_record(name: &str, mi: &str) -> RawRecord {
         let mut b = RawSamBuilder::new();
         b.read_name(name.as_bytes());
         b.add_string_tag(b"MI", mi.as_bytes());
-        to_record_buf(b.build())
+        b.build()
     }
 
-    /// Create a test record with an integer MI tag
-    fn create_test_record_int_mi(name: &str, mi: i32) -> RecordBuf {
+    /// Create a test record with an integer MI tag.
+    fn create_test_record_int_mi(name: &str, mi: i32) -> RawRecord {
         let mut b = RawSamBuilder::new();
         b.read_name(name.as_bytes());
         b.add_int_tag(b"MI", mi);
-        to_record_buf(b.build())
+        b.build()
     }
 
-    /// Create a test record without an MI tag
-    fn create_test_record_no_mi(name: &str) -> RecordBuf {
+    /// Create a test record without an MI tag.
+    fn create_test_record_no_mi(name: &str) -> RawRecord {
         let mut b = RawSamBuilder::new();
         b.read_name(name.as_bytes());
-        to_record_buf(b.build())
+        b.build()
     }
 
     /// Canonical `BamIoOptions` used by `Downsample` test constructors.
@@ -458,7 +478,7 @@ mod tests {
 
     #[test]
     fn test_family_iterator_empty() {
-        let records: Vec<Result<RecordBuf>> = vec![];
+        let records: Vec<Result<RawRecord>> = vec![];
         let mut iter = FamilyIterator::new(records.into_iter());
 
         let family = iter.next_family().expect("next_family should succeed");

--- a/src/lib/commands/merge.rs
+++ b/src/lib/commands/merge.rs
@@ -9,7 +9,9 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 
+#[cfg(test)]
 use crate::bam_io::create_bam_reader;
+use crate::bam_io::create_raw_bam_reader;
 use crate::logging::OperationTimer;
 use crate::sort::RawExternalSorter;
 use crate::validation::validate_file_exists;
@@ -176,11 +178,11 @@ fn merge_headers(input_paths: &[PathBuf]) -> Result<Header> {
         bail!("No input files to merge headers from");
     }
 
-    // Read all headers once
+    // Read all headers once (raw reader; records aren't consumed here).
     let headers: Vec<Header> = input_paths
         .iter()
         .map(|path| {
-            let (_, header) = create_bam_reader(path, 1)?;
+            let (_, header) = create_raw_bam_reader(path, 1)?;
             Ok(header)
         })
         .collect::<Result<Vec<_>>>()?;

--- a/src/lib/commands/shared_metrics.rs
+++ b/src/lib/commands/shared_metrics.rs
@@ -7,17 +7,15 @@
 
 use crate::bam_io::create_raw_bam_reader;
 use crate::progress::ProgressTracker;
-use crate::sam::SamTag;
 use crate::template::TemplateIterator;
 use anyhow::{Context, Result};
-use fgumi_raw_bam::raw_record_to_record_buf;
+use fgumi_raw_bam::{
+    RawRecord, alignment_end_from_raw, aux_data_slice, find_string_tag_in_record, find_tag_type,
+    flags as raw_flags, unclipped_5prime_from_raw_bam,
+};
 
 use log::info;
 use murmur3::murmur3_32;
-use noodles::sam::alignment::record::Cigar;
-use noodles::sam::alignment::record::cigar::op::Kind;
-use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -64,13 +62,13 @@ pub struct TemplateInfo {
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ReadInfoKey {
     /// Reference sequence index for read 1.
-    pub ref_index1: Option<usize>,
+    pub ref_index1: usize,
     /// Unclipped 5' position for read 1.
     pub start1: i32,
     /// `true` if read 1 is reverse-complemented.
     pub strand1: bool,
     /// Reference sequence index for read 2.
-    pub ref_index2: Option<usize>,
+    pub ref_index2: usize,
     /// Unclipped 5' position for read 2.
     pub start2: i32,
     /// `true` if read 2 is reverse-complemented.
@@ -91,40 +89,18 @@ pub struct TemplateMetadata<'a> {
 
 /// Computes the unclipped 5' position for a read, matching fgbio's `positionOf`.
 ///
-/// For forward strand reads: `unclippedStart = alignmentStart - leading soft clips`
-/// For reverse strand reads: `unclippedEnd = alignmentEnd + trailing soft clips`
-pub fn unclipped_five_prime_position(record: &RecordBuf) -> Option<i32> {
-    let is_reverse = record.flags().is_reverse_complemented();
-    let cigar = record.cigar();
-
-    if is_reverse {
-        // For reverse strand, 5' is at the end
-        // unclippedEnd = alignmentEnd + trailing soft clips
-        let alignment_end = record.alignment_end().map(|p| usize::from(p) as i32)?;
-
-        // Count trailing soft clips (last element if it's S)
-        let trailing_clips: i32 = cigar
-            .iter()
-            .filter_map(std::result::Result::ok)
-            .last()
-            .filter(|op| op.kind() == Kind::SoftClip)
-            .map_or(0, |op| op.len() as i32);
-
-        Some(alignment_end + trailing_clips)
-    } else {
-        // For forward strand, 5' is at the start
-        // unclippedStart = alignmentStart - leading soft clips
-        let alignment_start = record.alignment_start().map(|p| usize::from(p) as i32)?;
-
-        // Count leading soft clips (first element if it's S)
-        let leading_clips: i32 = cigar
-            .iter()
-            .find_map(std::result::Result::ok)
-            .filter(|op| op.kind() == Kind::SoftClip)
-            .map_or(0, |op| op.len() as i32);
-
-        Some(alignment_start - leading_clips)
+/// Delegates to [`unclipped_5prime_from_raw_bam`]. Includes both soft- and hard-clip
+/// bases on the 5' side (matching htsjdk / fgbio semantics). Returns `None` for
+/// unmapped records or records missing CIGAR ops.
+fn unclipped_five_prime_position_raw(record: &RawRecord) -> Option<i32> {
+    let flags = record.flags();
+    if flags & raw_flags::UNMAPPED != 0 {
+        return None;
     }
+    if record.n_cigar_op() == 0 {
+        return None;
+    }
+    Some(unclipped_5prime_from_raw_bam(record.as_ref()))
 }
 
 /// Computes a hash value normalized to the [0, 1] range using Murmur3.
@@ -266,11 +242,7 @@ pub fn overlaps_intervals(template: &TemplateInfo, intervals: &[Interval]) -> bo
 ///
 /// Returns an error if the BAM file cannot be read or if it appears to be a consensus BAM.
 pub fn validate_not_consensus_bam(input: &Path) -> Result<()> {
-    use crate::consensus_tags::is_consensus;
-    use crate::sort::bam_fields;
-    use fgumi_raw_bam::{RawRecord, RawRecordView};
-
-    let (mut reader, header) = create_raw_bam_reader(input, 1)?;
+    let (mut reader, _header) = create_raw_bam_reader(input, 1)?;
 
     // Look at the first valid R1 record
     let mut raw = RawRecord::new();
@@ -284,30 +256,33 @@ pub fn validate_not_consensus_bam(input: &Path) -> Result<()> {
         // Do not skip UNMAPPED: consensus BAMs are documented as unaligned, so
         // excluding unmapped records here would let consensus BAMs slip past this
         // guard unchecked.
-        let flags = RawRecordView::new(&raw).flags();
-        if (flags & bam_fields::flags::PAIRED) == 0
-            || (flags & bam_fields::flags::FIRST_SEGMENT) == 0
-            || (flags & bam_fields::flags::SECONDARY) != 0
-            || (flags & bam_fields::flags::SUPPLEMENTARY) != 0
+        let flags = raw.flags();
+        if (flags & raw_flags::PAIRED) == 0
+            || (flags & raw_flags::FIRST_SEGMENT) == 0
+            || (flags & raw_flags::SECONDARY) != 0
+            || (flags & raw_flags::SUPPLEMENTARY) != 0
         {
             continue;
         }
 
-        // Decode to RecordBuf for consensus-tag check and name extraction
-        let record = raw_record_to_record_buf(&raw, &header)?;
-
-        // Check if this is a consensus read
-        if is_consensus(&record) {
+        // Consensus-tag check on raw aux bytes (mirrors
+        // fgumi_consensus::tags::is_consensus: simplex = cD without aD+bD;
+        // duplex = aD and bD). Avoids decoding the record to RecordBuf.
+        let aux = aux_data_slice(raw.as_ref());
+        let has_ad = find_tag_type(aux, b"aD").is_some();
+        let has_bd = find_tag_type(aux, b"bD").is_some();
+        let has_cd = find_tag_type(aux, b"cD").is_some();
+        let is_duplex_consensus = has_ad && has_bd;
+        let is_simplex_consensus = has_cd && !is_duplex_consensus;
+        if is_simplex_consensus || is_duplex_consensus {
+            let name = String::from_utf8_lossy(fgumi_raw_bam::read_name(raw.as_ref())).into_owned();
             anyhow::bail!(
                 "Input BAM file ({}) appears to contain consensus sequences. \
                 This metrics tool cannot run on consensus BAMs, and instead requires \
                 the UMI-grouped BAM generated by group which is run prior to consensus calling.\n\
                 First R1 record '{}' has consensus SAM tags present.",
                 input.display(),
-                record.name().map_or_else(
-                    || "<unnamed>".to_string(),
-                    |n| String::from_utf8_lossy(n.as_ref()).to_string()
-                )
+                name
             );
         }
 
@@ -442,8 +417,18 @@ where
     let mut template_count = 0;
     let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
     let mut fraction_template_counts: Vec<usize> = vec![0; num_fractions];
-    let mi_tag = Tag::from(SamTag::MI);
-    let umi_tag = Tag::from(SamTag::RX);
+
+    // fgbio R1/R2 filter: paired, both mapped, primary.
+    let passes_filter = |r: &RawRecord, is_first: bool| -> bool {
+        let f = r.flags();
+        let seg_mask = if is_first { raw_flags::FIRST_SEGMENT } else { raw_flags::LAST_SEGMENT };
+        (f & raw_flags::PAIRED) != 0
+            && (f & raw_flags::UNMAPPED) == 0
+            && (f & raw_flags::MATE_UNMAPPED) == 0
+            && (f & seg_mask) != 0
+            && (f & raw_flags::SECONDARY) == 0
+            && (f & raw_flags::SUPPLEMENTARY) == 0
+    };
 
     for template in template_iter {
         let template = template?;
@@ -451,133 +436,81 @@ where
             continue;
         }
 
-        // Decode raw records to RecordBuf for flag/tag/position access
-        let record_bufs: Vec<RecordBuf> = template
-            .records()
-            .iter()
-            .map(|r| raw_record_to_record_buf(r, &header))
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        // Find R1 and R2 that pass fgbio's filtering criteria
-        let r1 = record_bufs.iter().find(|r| {
-            let f = r.flags();
-            f.is_segmented()
-                && !f.is_unmapped()
-                && !f.is_mate_unmapped()
-                && f.is_first_segment()
-                && !f.is_secondary()
-                && !f.is_supplementary()
-        });
-        let r2 = record_bufs.iter().find(|r| {
-            let f = r.flags();
-            f.is_segmented()
-                && !f.is_unmapped()
-                && !f.is_mate_unmapped()
-                && f.is_last_segment()
-                && !f.is_secondary()
-                && !f.is_supplementary()
-        });
-
+        let r1 = template.records().iter().find(|r| passes_filter(r, true));
+        let r2 = template.records().iter().find(|r| passes_filter(r, false));
         let (r1, r2) = match (r1, r2) {
             (Some(r1), Some(r2)) => (r1, r2),
             _ => continue,
         };
 
-        // Get read name
-        let read_name =
-            r1.name().map(|n| String::from_utf8_lossy(n.as_ref()).to_string()).unwrap_or_default();
+        let read_name = String::from_utf8_lossy(fgumi_raw_bam::read_name(r1.as_ref())).into_owned();
+        let mi = required_z_tag(r1, *b"MI", &read_name)?;
+        let rx = required_z_tag(r1, *b"RX", &read_name)?;
 
-        // Get MI tag (molecular identifier)
-        let mi = if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(s)) =
-            r1.data().get(&mi_tag)
-        {
-            String::from_utf8(s.iter().copied().collect::<Vec<u8>>())?
+        // Filter already excluded unmapped reads, so tid >= 0 here; skip defensively.
+        let r1_tid = r1.ref_id();
+        let r2_tid = r2.ref_id();
+        if r1_tid < 0 || r2_tid < 0 {
+            continue;
+        }
+        let r1_ref = r1_tid as usize;
+        let r2_ref = r2_tid as usize;
+        let same_ref = r1_ref == r2_ref;
+
+        // `ref_name` is always R1's reference. Interval overlap uses R1's own range
+        // when R1 and R2 are on different chromosomes, matching fgbio
+        // CollectDuplexSeqMetrics: `if (rec.refIndex == rec.mateRefIndex)
+        // Bams.insertCoordinates(rec) else (rec.start, rec.end)`.
+        let ref_name =
+            header.reference_sequences().get_index(r1_ref).map(|(name, _)| name.to_string());
+
+        // None here implies a malformed mapped record (no CIGAR); skip defensively.
+        let (s1, s2) =
+            match (unclipped_five_prime_position_raw(r1), unclipped_five_prime_position_raw(r2)) {
+                (Some(s1), Some(s2)) => (s1, s2),
+                _ => continue,
+            };
+
+        let r1_strand = (r1.flags() & raw_flags::REVERSE) != 0;
+        let r2_strand = (r2.flags() & raw_flags::REVERSE) != 0;
+
+        let r1_start = r1.pos() + 1;
+        let r2_start = r2.pos() + 1;
+        let r1_end = alignment_end_from_raw(r1.as_ref()).map(|e| e as i32);
+        let r2_end = alignment_end_from_raw(r2.as_ref()).map(|e| e as i32);
+
+        let (position, end_position) = if same_ref {
+            match (r1_end, r2_end) {
+                (Some(re1), Some(re2)) => (r1_start.min(r2_start), re1.max(re2)),
+                _ => (r1_start.min(r2_start), r1_start.max(r2_start)),
+            }
         } else {
-            return Err(anyhow::anyhow!(
-                "Read '{}' is missing the required MI tag. \
-                 Metrics commands require standard MI/RX tags.",
-                read_name
-            ));
+            // No single insert interval spans both mates; use R1's own range so
+            // interval filters still evaluate against R1's side of the pair.
+            (r1_start, r1_end.unwrap_or(r1_start))
         };
 
-        // Get UMI tag (raw UMI)
-        let rx = if let Some(noodles::sam::alignment::record_buf::data::field::Value::String(s)) =
-            r1.data().get(&umi_tag)
-        {
-            String::from_utf8(s.iter().copied().collect::<Vec<u8>>())?
+        // ReadInfoKey fields are ordered so the earlier-mapping read comes first.
+        let read_info_key = if (r1_ref, s1) <= (r2_ref, s2) {
+            ReadInfoKey {
+                ref_index1: r1_ref,
+                start1: s1,
+                strand1: r1_strand,
+                ref_index2: r2_ref,
+                start2: s2,
+                strand2: r2_strand,
+            }
         } else {
-            return Err(anyhow::anyhow!(
-                "Read '{}' is missing the required RX tag. \
-                 Metrics commands require standard MI/RX tags.",
-                read_name
-            ));
-        };
-
-        // Get reference position and calculate insert coordinates
-        let ref_name = if let Some(ref_id) = r1.reference_sequence_id() {
-            header.reference_sequences().get_index(ref_id).map(|(name, _)| name.to_string())
-        } else {
-            None
-        };
-
-        // Calculate insert coordinates and ReadInfo key (matching fgbio)
-        let (position, end_position, read_info_key) = {
-            let r1_ref = r1.reference_sequence_id();
-            let r2_ref = r2.reference_sequence_id();
-
-            if r1_ref == r2_ref && r1_ref.is_some() {
-                // Get unclipped 5' positions (matching fgbio's positionOf)
-                let r1_5prime = unclipped_five_prime_position(r1);
-                let r2_5prime = unclipped_five_prime_position(r2);
-                let r1_strand = r1.flags().is_reverse_complemented();
-                let r2_strand = r2.flags().is_reverse_complemented();
-
-                if let (Some(s1), Some(s2)) = (r1_5prime, r2_5prime) {
-                    // For insert coordinates, use alignment positions
-                    let r1_start = r1.alignment_start().map(|p| usize::from(p) as i32);
-                    let r2_start = r2.alignment_start().map(|p| usize::from(p) as i32);
-                    let r1_end = r1.alignment_end().map(|p| usize::from(p) as i32);
-                    let r2_end = r2.alignment_end().map(|p| usize::from(p) as i32);
-
-                    let (pos, end) = match (r1_start, r2_start, r1_end, r2_end) {
-                        (Some(rs1), Some(rs2), Some(re1), Some(re2)) => {
-                            (rs1.min(rs2), re1.max(re2))
-                        }
-                        (Some(rs1), Some(rs2), _, _) => (rs1.min(rs2), rs1.max(rs2)),
-                        _ => continue,
-                    };
-
-                    // Build ReadInfo key: order by (ref, 5' position) so earlier read is first
-                    let key = if (r1_ref, s1) <= (r2_ref, s2) {
-                        ReadInfoKey {
-                            ref_index1: r1_ref,
-                            start1: s1,
-                            strand1: r1_strand,
-                            ref_index2: r2_ref,
-                            start2: s2,
-                            strand2: r2_strand,
-                        }
-                    } else {
-                        ReadInfoKey {
-                            ref_index1: r2_ref,
-                            start1: s2,
-                            strand1: r2_strand,
-                            ref_index2: r1_ref,
-                            start2: s1,
-                            strand2: r1_strand,
-                        }
-                    };
-
-                    (pos, end, key)
-                } else {
-                    continue;
-                }
-            } else {
-                continue;
+            ReadInfoKey {
+                ref_index1: r2_ref,
+                start1: s2,
+                strand1: r2_strand,
+                ref_index2: r1_ref,
+                start2: s1,
+                strand2: r1_strand,
             }
         };
 
-        // Compute hash once for this template
         let hash_fraction = compute_hash_fraction(&read_name);
 
         let template_info = TemplateInfo {
@@ -589,15 +522,15 @@ where
             hash_fraction,
         };
 
-        // Check interval overlap
         if !overlaps_intervals(&template_info, intervals) {
             continue;
         }
 
         template_count += 1;
-        progress.log_if_needed(2); // Each template has R1 and R2
+        progress.log_if_needed(2);
 
-        // Streaming: when ReadInfo key changes, process the accumulated group
+        // Flush the accumulated group when the ReadInfo key changes — input is
+        // assumed to already be consecutively grouped by this key.
         if current_key.as_ref() != Some(&read_info_key) && !current_group.is_empty() {
             process_group(&current_group, &mut fraction_template_counts);
             current_group.clear();
@@ -607,11 +540,139 @@ where
         current_key = Some(read_info_key);
     }
 
-    // Process the final group
     if !current_group.is_empty() {
         process_group(&current_group, &mut fraction_template_counts);
     }
 
     progress.log_final();
     Ok((template_count, fraction_template_counts))
+}
+
+/// Extracts a required Z-typed aux tag from `record`, returning an error that
+/// points at `read_name` when the tag is absent or not UTF-8.
+fn required_z_tag(record: &RawRecord, tag: [u8; 2], read_name: &str) -> Result<String> {
+    let tag_name = std::str::from_utf8(&tag).unwrap_or("??");
+    let bytes = find_string_tag_in_record(record.as_ref(), &tag).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Read '{read_name}' is missing the required {tag_name} tag. \
+             Metrics commands require standard MI/RX tags."
+        )
+    })?;
+    std::str::from_utf8(bytes)
+        .map(str::to_string)
+        .map_err(|e| anyhow::anyhow!("Read '{read_name}' {tag_name} tag is not UTF-8: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags, testutil::encode_op};
+    use noodles::bam;
+    use noodles::sam;
+    use noodles::sam::alignment::io::Write as AlignmentWrite;
+    use noodles::sam::alignment::record_buf::RecordBuf;
+    use std::num::NonZeroUsize;
+    use tempfile::NamedTempFile;
+
+    fn test_header() -> sam::Header {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        sam::Header::builder()
+            .add_reference_sequence(
+                bstr::BString::from("chr1"),
+                Map::<ReferenceSequence>::new(NonZeroUsize::new(248_956_422).expect("non-zero")),
+            )
+            .add_reference_sequence(
+                bstr::BString::from("chr2"),
+                Map::<ReferenceSequence>::new(NonZeroUsize::new(242_193_529).expect("non-zero")),
+            )
+            .build()
+    }
+
+    /// Build an R1/R2 pair with independent refs/positions for each mate.
+    fn build_pair(
+        name: &str,
+        r1_ref: i32,
+        r1_pos: i32,
+        r2_ref: i32,
+        r2_pos: i32,
+        mi: &str,
+    ) -> (RecordBuf, RecordBuf) {
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_REVERSE)
+            .ref_id(r1_ref)
+            .pos(r1_pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(r2_ref)
+            .mate_pos(r2_pos - 1);
+        b1.add_string_tag(b"RX", b"ACGT-TGCA");
+        b1.add_string_tag(b"MI", mi.as_bytes());
+        let r1 = fgumi_raw_bam::raw_record_to_record_buf(&b1.build(), &sam::Header::default())
+            .expect("decode r1");
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+            .ref_id(r2_ref)
+            .pos(r2_pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(r1_ref)
+            .mate_pos(r1_pos - 1);
+        b2.add_string_tag(b"RX", b"ACGT-TGCA");
+        b2.add_string_tag(b"MI", mi.as_bytes());
+        let r2 = fgumi_raw_bam::raw_record_to_record_buf(&b2.build(), &sam::Header::default())
+            .expect("decode r2");
+
+        (r1, r2)
+    }
+
+    fn write_test_bam(records: Vec<RecordBuf>) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("tempfile");
+        let header = test_header();
+        let mut writer =
+            bam::io::writer::Builder.build_from_path(file.path()).expect("open writer");
+        writer.write_header(&header).expect("write header");
+        for r in &records {
+            writer.write_alignment_record(&header, r).expect("write record");
+        }
+        drop(writer);
+        file
+    }
+
+    /// Regression test for fgbio parity: pairs whose mates map to different
+    /// chromosomes must be kept (not silently dropped), matching fgbio's
+    /// `CollectDuplexSeqMetrics` which retains inter-reference pairs and uses
+    /// R1's own range for interval-overlap evaluation.
+    #[test]
+    fn test_inter_reference_pairs_are_retained() {
+        // Two same-ref pairs (chr1:100 / chr1:100) + one inter-ref pair
+        // (chr1:500 / chr2:500).  All three should be counted.
+        let (s1r1, s1r2) = build_pair("same_1", 0, 100, 0, 300, "1");
+        let (s2r1, s2r2) = build_pair("same_2", 0, 100, 0, 300, "2");
+        let (ir1, ir2) = build_pair("inter_1", 0, 500, 1, 500, "3");
+        let bam = write_test_bam(vec![s1r1, s1r2, s2r1, s2r2, ir1, ir2]);
+
+        let mut groups: Vec<Vec<String>> = Vec::new();
+        let (total, _) = process_templates_from_bam(bam.path(), &[], 1, |group, _| {
+            groups.push(group.iter().map(|t| t.mi.clone()).collect());
+        })
+        .expect("process_templates_from_bam");
+
+        assert_eq!(total, 3, "inter-reference pair must not be dropped");
+        let mis: Vec<String> = groups.into_iter().flatten().collect();
+        assert!(mis.contains(&"1".to_string()));
+        assert!(mis.contains(&"2".to_string()));
+        assert!(mis.contains(&"3".to_string()), "inter-ref pair's MI must be in output");
+    }
 }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -20,7 +20,7 @@
 //!
 //! Use `--verify` to check if a BAM file is correctly sorted without writing output.
 
-use crate::bam_io::create_bam_reader;
+use crate::bam_io::create_raw_bam_reader;
 use crate::logging::OperationTimer;
 use crate::sam::SamTag;
 use crate::sort::{QuerynameComparator, RawExternalSorter, SortOrder};
@@ -671,8 +671,8 @@ impl Sort {
             info!("Cell tag: {}{}", ct[0] as char, ct[1] as char);
         }
 
-        // Get header using noodles reader, then use raw reader for records
-        let (_, header) = create_bam_reader(&self.input, 1)?;
+        // Get header via the raw-byte reader, then re-open for raw record iteration.
+        let (_, header) = create_raw_bam_reader(&self.input, 1)?;
 
         let file = File::open(&self.input)?;
         let mut raw_reader = RawBamRecordReader::new(file)?;

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -47,7 +47,7 @@
 //! - `TagInfo`: Holds sets of tags to remove/reverse/revcomp
 //! - `merge_raw()`: Core function that transfers metadata between templates using raw bytes
 use crate::bam_io::{
-    BamReaderAuto, create_bam_reader, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path,
+    RawBamReaderAuto, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path,
 };
 use crate::batched_sam_reader::BatchedSamReader;
 use crate::commands::command::Command;
@@ -943,20 +943,24 @@ impl Zipper {
     }
 }
 
-/// BAM reader for stdin: single-threaded BGZF over a buffered `Box<dyn Read + Send>`.
+/// Raw BAM reader for stdin: single-threaded BGZF over a buffered `Box<dyn Read + Send>`.
 ///
-/// Stdin is non-seekable, so we use a single-threaded BGZF reader (the multi-threaded
-/// variant in [`BamReaderAuto`] requires `Seek`). `BufReader` wraps stdin so we can peek
-/// the BGZF magic bytes for format auto-detection without consuming them.
-type BamStdinReader =
-    noodles::bam::io::Reader<noodles::bgzf::io::Reader<BufReader<Box<dyn Read + Send>>>>;
+/// Stdin is non-seekable, so we use a single-threaded BGZF reader. `BufReader` wraps
+/// stdin so we can peek the BGZF magic bytes for format auto-detection without
+/// consuming them.
+type RawBamStdinReader =
+    fgumi_raw_bam::RawBamReader<noodles::bgzf::io::Reader<BufReader<Box<dyn Read + Send>>>>;
 
 /// Wraps SAM and BAM readers so the mapped-reader thread can handle either format.
-/// Moved into the thread that calls `record_bufs()`, since the iterator borrows `&self`.
+/// Moved into the thread that iterates records, since the iterator owns the reader.
+///
+/// The SAM arm decodes via noodles `RecordBuf` (text-mode SAM has no raw-byte path).
+/// Both BAM arms use `RawBamReader` so records are yielded as raw bytes and fed
+/// directly to `TemplateIterator` without a decode/encode round-trip.
 enum MappedReader {
     Sam(noodles::sam::io::Reader<Box<dyn BufRead + Send>>),
-    Bam(BamReaderAuto),
-    StdinBam(BamStdinReader),
+    Bam(RawBamReaderAuto),
+    StdinBam(RawBamStdinReader),
 }
 
 /// First four bytes of a BGZF stream (gzip magic + extra-flag byte unique to BGZF).
@@ -1060,7 +1064,8 @@ impl Command for Zipper {
                 let bgzf = noodles::bgzf::io::Reader::new(buffered);
                 let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
                 let header = bam_reader.read_header()?;
-                (MappedReader::StdinBam(bam_reader), header)
+                let bgzf = bam_reader.into_inner();
+                (MappedReader::StdinBam(fgumi_raw_bam::RawBamReader::new(bgzf)), header)
             } else {
                 info!(
                     "Reading SAM from stdin with adaptive buffer (bwa -K {})",
@@ -1078,8 +1083,8 @@ impl Command for Zipper {
                 "BAM input detected for --input. For best performance, pipe SAM directly \
                  from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
             );
-            let (bam_reader, header) = create_bam_reader(&self.input, self.threads)?;
-            (MappedReader::Bam(bam_reader), header)
+            let (raw_reader, header) = create_raw_bam_reader(&self.input, self.threads)?;
+            (MappedReader::Bam(raw_reader), header)
         } else {
             // SAM file input
             let reader: Box<dyn BufRead + Send> = Box::new(BufReader::with_capacity(
@@ -1141,8 +1146,8 @@ impl Command for Zipper {
         let (mapped_tx, mapped_rx) = std::sync::mpsc::sync_channel::<Result<Template>>(self.buffer);
         let mapped_header_for_reader = mapped_header.clone();
         std::thread::spawn(move || {
-            // The reader must be owned for the full duration so that the iterator
-            // (which borrows it via record_bufs) remains valid.
+            // The reader is owned by this thread so its record iterator
+            // outlives each iteration.
             match mapped_reader {
                 MappedReader::Sam(mut r) => {
                     let record_iter = r
@@ -1155,23 +1160,15 @@ impl Command for Zipper {
                         }
                     }
                 }
-                MappedReader::Bam(mut r) => {
-                    let record_iter = r
-                        .record_bufs(&mapped_header_for_reader)
-                        .map(|rec| rec.map_err(anyhow::Error::from));
-                    for template in record_bufs_to_templates(record_iter, &mapped_header_for_reader)
-                    {
+                MappedReader::Bam(r) => {
+                    for template in TemplateIterator::new(r) {
                         if mapped_tx.send(template).is_err() {
                             break;
                         }
                     }
                 }
-                MappedReader::StdinBam(mut r) => {
-                    let record_iter = r
-                        .record_bufs(&mapped_header_for_reader)
-                        .map(|rec| rec.map_err(anyhow::Error::from));
-                    for template in record_bufs_to_templates(record_iter, &mapped_header_for_reader)
-                    {
+                MappedReader::StdinBam(r) => {
+                    for template in TemplateIterator::new(r) {
                         if mapped_tx.send(template).is_err() {
                             break;
                         }

--- a/src/lib/sort/keys.rs
+++ b/src/lib/sort/keys.rs
@@ -6,8 +6,9 @@
 //!
 //! # Key Types
 //!
-//! - [`CoordinateKey`]: Standard genomic coordinate (tid, pos, strand)
-//! - [`QuerynameKey`]: Read name with natural numeric ordering
+//! - [`RawCoordinateKey`]: Fixed-size genomic coordinate key (tid, pos, strand)
+//! - [`RawQuerynameKey`]: Read name with natural numeric ordering
+//! - [`RawQuerynameLexKey`]: Read name with lexicographic ordering
 //! - [`TemplateKey`](super::inline_buffer::TemplateKey): Template-level position for UMI grouping
 //!
 //! # Generic Sorting Abstraction
@@ -21,9 +22,7 @@
 //! - fgbio's `SamOrder` trait (Scala)
 //! - samtools' `bam1_tag` union (C)
 
-use anyhow::Result;
 use noodles::sam::Header;
-use noodles::sam::alignment::record_buf::RecordBuf;
 use std::cmp::Ordering;
 
 use crate::sort::bam_fields;
@@ -210,92 +209,6 @@ impl SortOrder {
     }
 }
 
-/// Trait for sort keys that can be extracted from BAM records.
-///
-/// The `Context` associated type allows sort keys to pre-compute data from the header
-/// once (e.g., library index mapping) and reuse it for each record extraction.
-pub trait SortKey: Ord + Clone + Send + Sync {
-    /// Context built once from header (e.g., `LibraryIndex` for template-coordinate).
-    /// Use `()` for keys that don't need context.
-    type Context: Clone + Send + Sync;
-
-    /// Build context from header (called once at sort start).
-    fn build_context(header: &Header) -> Self::Context;
-
-    /// Extract a sort key from a BAM record using pre-built context.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if key extraction fails due to missing or invalid fields.
-    fn from_record(record: &RecordBuf, header: &Header, ctx: &Self::Context) -> Result<Self>;
-}
-
-// ============================================================================
-// Coordinate Sort Key
-// ============================================================================
-
-/// Sort key for coordinate ordering.
-///
-/// Sort order: reference ID → position → reverse strand flag.
-/// Unmapped reads (tid = -1) are sorted to the end.
-///
-/// Note: No read name tie-breaking is used, matching samtools behavior.
-/// Equal records maintain their original input order (stable sort).
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct CoordinateKey {
-    /// Reference sequence ID (tid), or `i32::MAX` for unmapped.
-    pub tid: i32,
-    /// 0-based alignment start position.
-    pub pos: i64,
-    /// True if reverse strand.
-    pub reverse: bool,
-}
-
-impl CoordinateKey {
-    /// Create a coordinate key for an unmapped read.
-    #[must_use]
-    pub fn unmapped() -> Self {
-        Self { tid: i32::MAX, pos: i64::MAX, reverse: false }
-    }
-}
-
-impl Ord for CoordinateKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.tid
-            .cmp(&other.tid)
-            .then_with(|| self.pos.cmp(&other.pos))
-            .then_with(|| self.reverse.cmp(&other.reverse))
-    }
-}
-
-impl PartialOrd for CoordinateKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl SortKey for CoordinateKey {
-    type Context = ();
-
-    fn build_context(_header: &Header) -> Self::Context {}
-
-    fn from_record(record: &RecordBuf, _header: &Header, _ctx: &Self::Context) -> Result<Self> {
-        if record.flags().is_unmapped() {
-            return Ok(Self::unmapped());
-        }
-
-        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
-        let tid = record.reference_sequence_id().map_or(-1, |id| id as i32);
-
-        #[allow(clippy::cast_possible_wrap)]
-        let pos = record.alignment_start().map_or(0, |p| usize::from(p) as i64);
-
-        let reverse = record.flags().is_reverse_complemented();
-
-        Ok(Self { tid, pos, reverse })
-    }
-}
-
 // ============================================================================
 // Raw Coordinate Sort Key (Fixed-size for RawSortKey trait)
 // ============================================================================
@@ -457,60 +370,6 @@ pub const fn queryname_flag_order(flags: u16) -> u16 {
 /// Names are stored with a null terminator so that `natural_compare_nul` can
 /// walk raw pointers without per-byte bounds checks, matching the performance
 /// characteristics of samtools' `strnum_cmp`.
-#[derive(Clone, Debug)]
-pub struct QuerynameKey {
-    /// Read name bytes, null-terminated for `natural_compare_nul`.
-    name: Vec<u8>,
-    /// Read pair flags for ordering R1 before R2.
-    flags: u16,
-}
-
-impl PartialEq for QuerynameKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl Eq for QuerynameKey {}
-
-impl QuerynameKey {
-    /// Returns the read name bytes (including the null terminator).
-    #[must_use]
-    pub fn name(&self) -> &[u8] {
-        &self.name
-    }
-}
-
-impl Ord for QuerynameKey {
-    #[allow(unsafe_code)]
-    fn cmp(&self, other: &Self) -> Ordering {
-        // SAFETY: `name` is always null-terminated (see `from_record`).
-        unsafe { natural_compare_nul(self.name.as_ptr(), other.name.as_ptr()) }
-            .then_with(|| self.flags.cmp(&other.flags))
-    }
-}
-
-impl PartialOrd for QuerynameKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl SortKey for QuerynameKey {
-    type Context = ();
-
-    fn build_context(_header: &Header) -> Self::Context {}
-
-    fn from_record(record: &RecordBuf, _header: &Header, _ctx: &Self::Context) -> Result<Self> {
-        let raw = record.name().map_or(&[] as &[u8], |n| <_ as AsRef<[u8]>>::as_ref(n));
-        let mut name = Vec::with_capacity(raw.len() + 1);
-        name.extend_from_slice(raw);
-        name.push(0); // null-terminate for pointer-walking comparison
-        let flags = queryname_flag_order(u16::from(record.flags()));
-        Ok(Self { name, flags })
-    }
-}
-
 // Re-export natural comparison functions from fgumi-raw-bam where the unsafe
 // implementations live (the main crate enforces `#![deny(unsafe_code)]`).
 pub use fgumi_raw_bam::sort::{natural_compare, natural_compare_nul};
@@ -809,24 +668,6 @@ impl RawSortKey for RawQuerynameLexKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_coordinate_key_ordering() {
-        let k1 = CoordinateKey { tid: 0, pos: 100, reverse: false };
-        let k2 = CoordinateKey { tid: 0, pos: 200, reverse: false };
-        let k3 = CoordinateKey { tid: 1, pos: 50, reverse: false };
-
-        assert!(k1 < k2);
-        assert!(k2 < k3);
-    }
-
-    #[test]
-    fn test_coordinate_key_unmapped_last() {
-        let mapped = CoordinateKey { tid: 0, pos: 100, reverse: false };
-        let unmapped = CoordinateKey::unmapped();
-
-        assert!(mapped < unmapped);
-    }
 
     // ========================================================================
     // queryname_flag_order tests

--- a/src/lib/sort/mod.rs
+++ b/src/lib/sort/mod.rs
@@ -141,9 +141,8 @@ fn create_temp_dir(base: Option<&Path>) -> Result<TempDir> {
 
 pub use inline_buffer::{TemplateKey, extract_coordinate_key_inline};
 pub use keys::{
-    CoordinateKey, QuerynameComparator, QuerynameKey, RawCoordinateKey, RawQuerynameKey,
-    RawQuerynameLexKey, RawSortKey, SortContext, SortKey, SortOrder, natural_compare,
-    normalize_natural_key,
+    QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
+    SortContext, SortOrder, natural_compare, normalize_natural_key,
 };
 pub use pipeline::{ParallelMergeConfig, parallel_merge, parallel_merge_buffered};
 pub use raw::{LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline};


### PR DESCRIPTION
## Summary

- **Fixes the 10× simplex-metrics / duplex-metrics regression** introduced by #294. The per-template round-trip through `raw_record_to_record_buf` was rebuilding a full synthetic BAM stream (prelude + `@SQ` dictionary + framing) for *every* record, so per-record cost scaled with `O(header_size)` instead of `O(record_size)`. Agilent-HS2 (53M records, ~3000 `@SQ` entries) projected 3.4h vs. the 3h AWS batch timeout. Investigation writeup: commit message.
- Same-PR cleanup of the other production `RecordBuf` decoders that missed the 48-commit series migration: **`downsample`** and **`zipper`** (mapped-side BAM and StdinBam arms).
- Header-only `create_bam_reader` callers in **`sort`** and **`merge`** swapped to `create_raw_bam_reader`.
- **`compare::bams::deserialize_raw_record`** comment sharpened to document why its noodles-decode-per-record is intentional (off-hot-path diff rendering only).
- **Deletes the dead `SortKey` trait** and its `CoordinateKey` / `QuerynameKey` impls. Zero production or test callers — the live sort path uses `RawSortKey` / `RawCoordinateKey` / `RawQuerynameKey` exclusively.

The SAM arm of `zipper` retains the existing `RecordBufEncoder` round-trip because text-mode SAM has no raw-byte path.

One commit, 8 files, net **−208 LOC** (+234 / −442; most of the delta is the dead `SortKey` scaffolding).

## Test plan

- [x] `cargo ci-test` — 2451/2451 passing. One unrelated flake (`test_multithreaded_extraction_preserves_order`) under full-suite contention; passes in 31ms in isolation.
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [ ] Re-run the hung agilent-hs2 AWS batch job to confirm simplex-metrics / duplex-metrics now complete well under the 3h timeout.
- [ ] Spot-check simplex-metrics and duplex-metrics numeric output against pre-regression baselines on a grouped BAM (behaviour is preserved but the unclipped-5' calculation now also counts H clips, matching fgbio / htsjdk; negligible impact in practice since H clips are rare in aligner output).
- [ ] \`zipper\`: end-to-end test through `bwa mem ... | fgumi zipper ...` (SAM stdin) and a BAM file input to confirm both paths still produce identical output to the pre-refactor code.
- [ ] `downsample`: round-trip test that output BAM records are byte-identical to the pre-refactor version (no RecordBuf re-encode quirks).