### PR TITLE
fix(ci): exclude non-publishable crates from publish-workflow guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,11 @@ jobs:
             fgumi
           )
 
-          # Verify every workspace crate is in the publish list
+          # Verify every publishable workspace crate is in the publish list.
+          # Crates marked `publish = false` (serialized as `publish: []` by
+          # cargo metadata) are excluded -- e.g. internal xtask tooling.
           WORKSPACE_CRATES=$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[].name' | sort)
+            | jq -r '.packages[] | select(.publish != []) | .name' | sort)
           LISTED_CRATES=$(printf '%s\n' "${CRATES[@]}" | sort)
           MISSING=$(comm -23 <(echo "$WORKSPACE_CRATES") <(echo "$LISTED_CRATES"))
           if [ -n "$MISSING" ]; then


### PR DESCRIPTION
## Summary

The v0.2.0 publish run on main ([failed job](https://github.com/fulcrumgenomics/fgumi/actions/runs/24798332509/job/72573963039)) aborted with:

```
ERROR: workspace crates missing from CRATES publish list:
xtask
```

The guard in `.github/workflows/publish.yml` compared every workspace crate reported by `cargo metadata` against the hardcoded `CRATES` publish list. `xtask` is intentionally marked `publish = false` in `crates/xtask/Cargo.toml` (internal doc-generation tooling), so it should never appear in the publish list — but the guard didn't honor that flag and tripped before any `cargo publish` ran. No crates reached crates.io at 0.2.0.

## Fix

Filter the `cargo metadata` query to exclude crates with `publish: []` (how `publish = false` serializes), so both the `MISSING` and `EXTRA` guards match `cargo publish`'s own behavior:

```diff
-          | jq -r '.packages[].name' | sort)
+          | jq -r '.packages[] | select(.publish != []) | .name' | sort)
```

## Test plan

- [x] Verified locally that the new jq filter produces exactly the 9 publishable crates and drops `xtask`.
- [x] Confirmed no 0.2.0 crates have been published yet, so a re-run after merge will publish all 9 in dependency order (the per-crate `max_version == VERSION` check already makes the loop idempotent).
- [ ] After merge, confirm the publish workflow runs to completion, v0.2.0 tag + GitHub release are created, and `cargo search fgumi` shows 0.2.0.