### PR TITLE
fix(raw-bam): gate cigar_op_kind behind noodles feature

### DIFF
--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -8,6 +8,7 @@ use crate::fields::{
 ///
 /// Extracts the 4-bit op type from the raw u32 and maps it to the corresponding
 /// `Kind` variant. Returns `Kind::Pad` for unknown op types.
+#[cfg(feature = "noodles")]
 #[inline]
 #[must_use]
 pub fn cigar_op_kind(raw_op: u32) -> noodles::sam::alignment::record::cigar::op::Kind {
@@ -2218,6 +2219,7 @@ mod tests {
         assert_eq!(cigar_to_string_from_raw(&rec), "");
     }
 
+    #[cfg(feature = "noodles")]
     #[test]
     fn test_cigar_op_kind_all_ops() {
         use noodles::sam::alignment::record::cigar::op::Kind;
@@ -2235,6 +2237,7 @@ mod tests {
         assert_eq!(cigar_op_kind(15), Kind::Pad);
     }
 
+    #[cfg(feature = "noodles")]
     #[test]
     fn test_cigar_op_kind_with_length_bits() {
         use noodles::sam::alignment::record::cigar::op::Kind;

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -61,13 +61,14 @@ pub use fields::{
 pub use builder::{SamBuilder, UnmappedSamBuilder};
 
 // -- cigar --
+#[cfg(feature = "noodles")]
+pub use cigar::cigar_op_kind;
 pub use cigar::{
     // -- typed CIGAR iteration --
     CigarKind,
     CigarOp,
     alignment_end_from_raw,
     alignment_start_from_raw,
-    cigar_op_kind,
     cigar_to_string_from_raw,
     clip_cigar_ops_raw,
     consumes_query,


### PR DESCRIPTION
## Summary

The v0.2.0 publish run ([failed job](https://github.com/fulcrumgenomics/fgumi/actions/runs/24798559716/job/72574752406)) got past the workflow guard (thanks to #310) and successfully published `fgumi-dna`, `fgumi-bgzf`, and `fgumi-simd-fastq`, then aborted when `cargo publish --verify` of `fgumi-raw-bam` failed:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `noodles`
  --> src/cigar.rs:14:9
```

`pub fn cigar_op_kind` returns `noodles::sam::alignment::record::cigar::op::Kind` but wasn't gated behind the optional `noodles` feature, while its sibling `From<CigarKind> for noodles::...::Kind` / `From<noodles::...::Kind> for CigarKind` impls in the same file already are. `cargo publish --verify` builds the packaged tarball with default features only, so the ungated function failed to compile against a manifest that declares `noodles` as `optional = true`.

Workspace builds didn't surface this because `fgumi-consensus` depends on `fgumi-raw-bam` with `features = ["noodles"]`, transparently propagating the feature.

## Fix

Gate `cigar_op_kind`, its re-export in `lib.rs`, and the two tests that reference `noodles::...::Kind` with `#[cfg(feature = "noodles")]` -- matching the pattern used by the adjacent `From` impls.

## Verification

Reproduced locally with `cargo publish --workspace --dry-run --allow-dirty` and confirmed the fix lets `fgumi-raw-bam` verify cleanly. No other crate has optional dependencies, so this bug class cannot exist elsewhere.

## Post-merge behaviour

The publish workflow is idempotent (publish.yml:120-134 -- skip if crate's crates.io `max_version` already matches target). On merge it will:

1. Skip `fgumi-dna`, `fgumi-bgzf`, `fgumi-simd-fastq` (already at 0.2.0 on crates.io)
2. Publish `fgumi-raw-bam`, `fgumi-umi`, `fgumi-sam`, `fgumi-metrics`, `fgumi-consensus`, `fgumi` at 0.2.0
3. Create the `v0.2.0` tag + GitHub release

## Follow-ups (separate PRs)

- Add a `cargo publish --workspace --dry-run --allow-dirty --no-verify` step (plus `cargo check -p fgumi-raw-bam --no-default-features` for verify-like coverage of optional-dep gating) to `check.yml`, so future release PRs catch these issues pre-merge.
- `crate::methylation::RefBaseProvider` is used unconditionally in `crates/fgumi-consensus/src/filter.rs` but the `methylation` module is gated behind `feature = "simplex"`. Not publish-blocking (default features include `simplex`) but breaks `default-features = false` consumers.

## Test plan

- [x] `cargo publish --workspace --dry-run --allow-dirty` passes for `fgumi-raw-bam` locally
- [x] `cargo check -p fgumi-raw-bam --no-default-features` compiles cleanly with the fix
- [ ] After merge, publish workflow completes and creates the `v0.2.0` tag + release