### PR TITLE
ci: add publish dry-run to catch release-blocking bugs pre-merge

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,3 +96,35 @@ jobs:
           tool: cargo-audit
       - name: Audit dependencies for known vulnerabilities
         run: cargo audit
+
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: Package every workspace crate (dry-run)
+        # Validates manifest health for every publishable crate: declared
+        # dependency versions on path deps, include = [...] paths, features
+        # referring to real deps/features, no-publish flags, etc. Uses
+        # --no-verify because cargo's workspace dry-run with --verify hits
+        # an internal "no hash listed" error (cargo 1.93) when a later
+        # crate transitively depends on an earlier crate's freshly packaged
+        # tarball. Real-CI publish doesn't hit this -- each predecessor
+        # resolves from crates.io with a real hash before the next verify.
+        run: cargo publish --workspace --dry-run --allow-dirty --no-verify
+      - name: Simulate publish-verify for crates with default-off optional deps
+        # `cargo publish --verify` compiles the packaged tarball with DEFAULT
+        # features only. For crates whose default feature set does NOT enable
+        # every optional dependency, that build path is not exercised by the
+        # regular workspace build (other crates often enable the optional
+        # feature transitively), so "optional dep used unconditionally" bugs
+        # can ship unnoticed and break publish mid-release.
+        #
+        # Add a crate to this list whenever it gains a default-off optional
+        # dep. Current members:
+        #   - fgumi-raw-bam: default = [], `noodles`/`anyhow` behind feature
+        run: cargo check -p fgumi-raw-bam --no-default-features --all-targets


### PR DESCRIPTION
## Summary

Follow-up to #311. Adds a `publish-dry-run` job to `check.yml` that runs on every PR and push to main, catching two classes of publish-blocking bugs before they trip the release pipeline:

1. **Manifest/packaging issues** -- `cargo publish --workspace --dry-run --allow-dirty --no-verify` validates every workspace crate can be packaged: declared path-dep versions, `include = [...]` paths, feature references to real deps, `publish` flags, etc.

2. **Default-features feature-gating bugs** -- `cargo check -p fgumi-raw-bam --no-default-features --all-targets` simulates the compile path that `cargo publish --verify` uses (default features only). For crates whose defaults don't enable every optional dep, this surfaces "optional dep used unconditionally" bugs that workspace builds mask because other crates enable the feature transitively. Would have caught the `cigar_op_kind` noodles bug that broke today's v0.2.0 publish.

## Why `--no-verify` on the workspace dry-run

Cargo 1.93's workspace dry-run has an internal bug (`no hash listed for <crate> v<version>`) that fires whenever a later crate transitively depends on an earlier crate's freshly packaged tarball. Real-CI publish doesn't hit this -- each predecessor is published to crates.io with a real hash before the next `--verify` runs. So for the dry-run we skip verify on the workspace pass and get verify-equivalent coverage for the one crate that actually needs it via the explicit `cargo check --no-default-features` step.

## Maintenance

The `cargo check -p <crate> --no-default-features` list is currently hardcoded to `fgumi-raw-bam` (the only crate whose default features don't enable all its optional deps). Comment in the workflow notes: add to the list when a new crate ships a default-off optional dependency.

## Base branch

Stacked on `nh/fix-publish-verify-errors` (#311) so CI exercises the new job against a branch where the raw-bam fix is applied. Once #311 merges, this branch will rebase onto main cleanly.

## Test plan

- [x] `cargo publish --workspace --dry-run --allow-dirty --no-verify` passes locally on this branch
- [x] `cargo check -p fgumi-raw-bam --no-default-features --all-targets` passes locally on this branch (thanks to #311's fix)
- [ ] Verified CI `publish-dry-run` job goes green on this PR