### PR TITLE
fix(consensus): gate methylation-dependent filter fns behind simplex

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1603,6 +1603,7 @@ mod tests {
 
     // -- mask_strand_methylation_agreement_raw tests --
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_strand_methylation_agreement_concordant() {
         use crate::methylation::tests::TestRef;
@@ -1633,6 +1634,7 @@ mod tests {
         assert_eq!(masked, 0, "Concordant CpG should not be masked");
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_strand_methylation_agreement_discordant() {
         use crate::methylation::tests::TestRef;
@@ -1663,6 +1665,7 @@ mod tests {
         assert_eq!(masked, 2, "Both CpG positions should be masked when strands disagree");
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_strand_methylation_agreement_non_cpg_ignored() {
         use crate::methylation::tests::TestRef;
@@ -1692,6 +1695,7 @@ mod tests {
 
     // -- check_conversion_fraction_raw tests --
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_passes_high_conversion() {
         use crate::methylation::tests::TestRef;
@@ -1728,6 +1732,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_fails_low_conversion() {
         use crate::methylation::tests::TestRef;
@@ -1761,6 +1766,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_skips_cpg() {
         use crate::methylation::tests::TestRef;
@@ -1795,6 +1801,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_no_methylation_tags_passes() {
         use crate::methylation::tests::TestRef;
@@ -1825,6 +1832,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_unmapped_passes() {
         use crate::methylation::tests::TestRef;
@@ -1852,6 +1860,7 @@ mod tests {
 
     // -- TAPs conversion fraction tests --
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_taps_passes_high_non_conversion() {
         use crate::methylation::tests::TestRef;
@@ -1885,6 +1894,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_taps_fails_low_non_conversion() {
         use crate::methylation::tests::TestRef;
@@ -1918,6 +1928,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_taps_vs_emseq_inverted() {
         use crate::methylation::tests::TestRef;
@@ -1964,6 +1975,7 @@ mod tests {
 
     // -- Disabled mode tests --
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_conversion_fraction_disabled_mode_passes() {
         use crate::methylation::tests::TestRef;
@@ -1999,6 +2011,7 @@ mod tests {
 
     // -- resolve_ref_bases_for_record tests --
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_resolve_ref_bases_simple_match() {
         use crate::methylation::tests::TestRef;
@@ -2015,6 +2028,7 @@ mod tests {
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), Some(b'G'), Some(b'T')]);
     }
 
+    #[cfg(feature = "simplex")]
     #[test]
     fn test_resolve_ref_bases_with_insertion() {
         use crate::methylation::tests::TestRef;

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -5,6 +5,7 @@
 
 use ahash::AHashMap;
 use anyhow::Result;
+#[cfg(feature = "simplex")]
 use noodles::sam::alignment::record::cigar::op::Kind;
 
 use crate::phred::{MIN_PHRED, NO_CALL_BASE};
@@ -943,6 +944,7 @@ pub fn mask_methylation_depth_duplex_raw_with_tags(
 /// Returns a vector of `Option<u8>` mapping each query position to its reference base
 /// (uppercased), or `None` for insertions/soft-clips. Returns `None` if the record is
 /// unmapped or the reference cannot be resolved.
+#[cfg(feature = "simplex")]
 #[expect(
     clippy::cast_sign_loss,
     reason = "ref_id and pos are non-negative for mapped records (checked above)"
@@ -1025,6 +1027,7 @@ pub fn resolve_ref_bases_for_record(
 ///
 /// # Errors
 /// Returns an error if the record is too short.
+#[cfg(feature = "simplex")]
 pub fn mask_strand_methylation_agreement_raw(
     record: &mut [u8],
     reference: &dyn crate::methylation::RefBaseProvider,
@@ -1039,7 +1042,7 @@ pub fn mask_strand_methylation_agreement_raw(
     )
 }
 
-/// Like [`mask_strand_methylation_agreement_raw`] but accepts both pre-resolved reference
+/// Like `mask_strand_methylation_agreement_raw` but accepts both pre-resolved reference
 /// bases and pre-parsed methylation tags, avoiding all redundant work.
 ///
 /// # Errors
@@ -1120,6 +1123,7 @@ pub fn mask_strand_methylation_agreement_raw_with_ref_bases_and_tags(
 ///
 /// At non-CpG ref-C positions, the expected behavior is conversion (C->T).
 /// A low conversion rate suggests incomplete enzymatic conversion.
+#[cfg(feature = "simplex")]
 pub fn check_conversion_fraction_raw(
     record: &[u8],
     min_fraction: f64,
@@ -1138,7 +1142,7 @@ pub fn check_conversion_fraction_raw(
     )
 }
 
-/// Like [`check_conversion_fraction_raw`] but accepts both pre-resolved reference bases
+/// Like `check_conversion_fraction_raw` but accepts both pre-resolved reference bases
 /// and pre-parsed methylation tags, avoiding all redundant work.
 ///
 /// For EM-Seq, checks `ct / (cu + ct) >= threshold` at non-CpG ref-C positions.


### PR DESCRIPTION
## Summary

Follow-up to #311 (flagged in that PR's body). The `methylation` module in `fgumi-consensus` is gated behind `#[cfg(feature = "simplex")]` in `lib.rs`, but three public functions in `crates/fgumi-consensus/src/filter.rs` -- compiled unconditionally -- take `&dyn crate::methylation::RefBaseProvider`:

- `resolve_ref_bases_for_record`
- `mask_strand_methylation_agreement_raw`
- `check_conversion_fraction_raw`

The `noodles::...::Kind` import used only inside `resolve_ref_bases_for_record`'s CIGAR match was also ungated, and 14 tests in the same file use either those functions or `crate::methylation::tests::TestRef` without gating.

Result: `cargo check -p fgumi-consensus --no-default-features --all-targets` failed to compile with 29 errors. Not publish-blocking (the workspace enables `simplex` by default, so `cargo publish --verify` compiles fine), but it breaks downstream consumers who want to depend on `fgumi-consensus` with `default-features = false` and enable a bespoke feature set.

## Fix (2 commits)

1. **Library:** gate the three functions and the `noodles::...::Kind` import behind `#[cfg(feature = "simplex")]`, matching the pattern already applied to the adjacent `From` impls.
2. **Tests:** add `#[cfg(feature = "simplex")]` to each of the 14 tests that touch the gated functions or `methylation::tests::TestRef`.

Total diff: 18 lines added across one file.

## Scope decisions

- **Root `fgumi` crate under `--no-default-features`:** separately broken; fixed in the stacked follow-up #314 (rebases onto main after this lands).
- **CI coverage:** #314 adds a `cargo check --workspace --no-default-features --all-targets` job to `check.yml` that would have caught both this class of bug and the one from #311.

## Verification

- [x] `cargo check -p fgumi-consensus --no-default-features --lib` passes cleanly (was 29 errors + 1 warning)
- [x] `cargo check -p fgumi-consensus --no-default-features --all-targets` passes cleanly (was 29 errors)
- [x] `cargo check -p fgumi-consensus --all-targets` (default features) unchanged -- passes
- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test -p fgumi-consensus --no-run` (default features) passes -- all tests still compile