### PR TITLE
fix(fgumi): make root crate build cleanly with --no-default-features

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,3 +128,27 @@ jobs:
         # dep. Current members:
         #   - fgumi-raw-bam: default = [], `noodles`/`anyhow` behind feature
         run: cargo check -p fgumi-raw-bam --no-default-features --all-targets
+
+  no-default-features-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: cargo check --workspace --no-default-features --all-targets
+        # The regular test/lint jobs run with default features enabled, which
+        # pulls in every optional dependency transitively. That hides two
+        # classes of bug from CI:
+        #   1. Optional deps used unconditionally (library behind a feature
+        #      gate referenced from non-gated code).
+        #   2. Modules behind a non-default feature referenced from
+        #      always-compiled code.
+        # Both manifest as compile failures only under
+        # `default-features = false`, which is exactly what downstream
+        # consumers can opt into. This job compiles every workspace crate
+        # (lib + tests + benches) with no default features to surface
+        # regressions at PR time.
+        run: cargo check --workspace --no-default-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,11 @@ nix = { version = "0.29", default-features = false, features = ["fs"] }
 [features]
 default = ["simplex", "duplex", "codec"]
 simplex = ["fgumi-consensus/simplex"]
-duplex = ["fgumi-consensus/duplex"]
-codec = ["fgumi-consensus/codec"]
+# duplex and codec depend on simplex (mirrors fgumi-consensus: `duplex = ["simplex"]`
+# and `codec = ["simplex"]`), and their commands share methylation/filter paths
+# that live behind the `simplex` feature in this crate.
+duplex = ["simplex", "fgumi-consensus/duplex"]
+codec = ["simplex", "fgumi-consensus/codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
 memory-debug = []
@@ -122,6 +125,8 @@ noodles = { version = "0.106.0", features = ["bam", "sam"] }
 [[bench]]
 name = "core_functions"
 harness = false
+# Exercises vanilla consensus / overlap helpers that live behind `simplex`.
+required-features = ["simplex"]
 
 [[bench]]
 name = "raw_bam_accessors"

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -4,15 +4,19 @@
 //! command structs using `#[command(flatten)]`.
 
 use std::path::PathBuf;
+#[cfg(feature = "simplex")]
 use std::sync::Arc;
 
 use crate::bam_io::is_stdin_path;
+#[cfg(feature = "simplex")]
 use crate::logging::OperationTimer;
 use crate::unified_pipeline::{BamPipelineConfig, SchedulerStrategy};
 use crate::validation::validate_file_exists;
 use bytesize::ByteSize;
 use clap::Args;
+#[cfg(feature = "simplex")]
 use fgumi_consensus::methylation::RefBaseProvider;
+#[cfg(feature = "simplex")]
 use log::info;
 use noodles::sam::Header;
 
@@ -53,6 +57,7 @@ pub fn resolve_methylation_mode(
 }
 
 /// Methylation reference pair: reference base provider + contig name mapping.
+#[cfg(feature = "simplex")]
 pub type MethylationRef = Option<(
     Arc<dyn fgumi_consensus::methylation::RefBaseProvider + Send + Sync>,
     Arc<Vec<String>>,
@@ -61,6 +66,7 @@ pub type MethylationRef = Option<(
 /// Loads the reference FASTA and builds contig name mapping for methylation-aware modes.
 ///
 /// Returns `None` if methylation mode is disabled. Errors if enabled but `reference` is `None`.
+#[cfg(feature = "simplex")]
 pub fn load_methylation_reference(
     methylation_mode: fgumi_consensus::MethylationMode,
     reference: &Option<PathBuf>,

--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -3,6 +3,7 @@
 //! This module provides shared traits and utilities used by simplex, duplex, and codec
 //! consensus calling commands to reduce code duplication.
 
+#[cfg(feature = "codec")]
 use crate::consensus::codec_caller::CodecConsensusStats;
 use crate::consensus_caller::ConsensusCallingStats;
 use crate::metrics::consensus::ConsensusMetrics;
@@ -46,6 +47,7 @@ impl ConsensusStatsOps for ConsensusCallingStats {
     }
 }
 
+#[cfg(feature = "codec")]
 impl ConsensusStatsOps for CodecConsensusStats {
     fn merge(&mut self, other: &Self) {
         self.total_input_reads += other.total_input_reads;

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -10,13 +10,14 @@
 
 use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::bam_io::create_bam_reader_for_pipeline_with_opts;
+#[cfg(feature = "simplex")]
+use crate::consensus_filter::resolve_ref_bases_for_record;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
     check_conversion_fraction_raw_with_ref_bases_and_tags, compute_read_stats, filter_duplex_read,
     filter_read, is_duplex_consensus, mask_bases, mask_duplex_bases,
     mask_methylation_depth_duplex_raw_with_tags, mask_methylation_depth_simplex_raw_with_tags,
-    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, resolve_ref_bases_for_record,
-    template_passes,
+    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, template_passes,
 };
 use crate::grouper::{SingleRawRecordGrouper, TemplateGrouper};
 use crate::logging::OperationTimer;
@@ -750,6 +751,10 @@ impl Filter {
         methylation_mode: fgumi_consensus::MethylationMode,
         ref_names: &[String],
     ) -> Result<(u64, bool)> {
+        // `ref_names` is only consumed by the `simplex`-gated ref-base resolver below.
+        #[cfg(not(feature = "simplex"))]
+        let _ = ref_names;
+
         // Fail fast if we encounter a mapped read without a reference, since masking
         // can invalidate NM/UQ/MD tags and we have no way to regenerate them.
         if reference.is_none() {
@@ -808,12 +813,29 @@ impl Filter {
             };
         }
 
-        // Resolve reference bases once for all reference-dependent filters
-        let needs_ref_bases = (require_strand_methylation_agreement && is_duplex)
-            || min_conversion_fraction.is_some();
-        let ref_base_map = if needs_ref_bases {
-            reference.and_then(|r| resolve_ref_bases_for_record(record, r, ref_names))
-        } else {
+        // Resolve reference bases once for all reference-dependent filters.
+        // The resolver lives in the `simplex`-gated `methylation` module, so the
+        // reference-dependent methylation filters below are only available when
+        // `simplex` is enabled. Without `simplex` we skip the lookup entirely.
+        #[cfg(feature = "simplex")]
+        let ref_base_map = {
+            let needs_ref_bases = (require_strand_methylation_agreement && is_duplex)
+                || min_conversion_fraction.is_some();
+            if needs_ref_bases {
+                reference.and_then(|r| resolve_ref_bases_for_record(record, r, ref_names))
+            } else {
+                None
+            }
+        };
+        #[cfg(not(feature = "simplex"))]
+        let ref_base_map: Option<Vec<Option<u8>>> = {
+            if (require_strand_methylation_agreement && is_duplex)
+                || min_conversion_fraction.is_some()
+            {
+                bail!(
+                    "reference-dependent methylation filters require building fgumi with the `simplex` feature"
+                );
+            }
             None
         };
 

--- a/src/lib/commands/mod.rs
+++ b/src/lib/commands/mod.rs
@@ -51,6 +51,7 @@
 )]
 
 pub mod clip;
+#[cfg(feature = "codec")]
 pub mod codec;
 pub mod command;
 pub mod common;
@@ -60,7 +61,9 @@ pub mod consensus_runner;
 pub mod correct;
 pub mod dedup;
 pub mod downsample;
+#[cfg(feature = "duplex")]
 pub mod duplex;
+#[cfg(feature = "duplex")]
 pub mod duplex_metrics;
 pub mod extract;
 pub mod fastq;
@@ -69,7 +72,9 @@ pub mod group;
 pub mod merge;
 pub mod review;
 pub mod shared_metrics;
+#[cfg(feature = "simplex")]
 pub mod simplex;
+#[cfg(feature = "simplex")]
 pub mod simplex_metrics;
 #[cfg(feature = "simulate")]
 pub mod simulate;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -179,9 +179,11 @@ pub use umi::assigner;
 
 // Re-export consensus items for backward compatibility
 pub use consensus::caller as consensus_caller;
+#[cfg(feature = "duplex")]
 pub use consensus::duplex_caller as duplex_consensus_caller;
 pub use consensus::filter as consensus_filter;
 pub use consensus::overlapping as overlapping_consensus;
 pub use consensus::simple_umi as simple_umi_consensus;
 pub use consensus::tags as consensus_tags;
+#[cfg(feature = "simplex")]
 pub use consensus::vanilla_caller as vanilla_consensus_caller;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ const STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Cyan.on_default());
 use env_logger::Env;
 use fgumi_lib::commands::clip::Clip;
+#[cfg(feature = "codec")]
 use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command;
 #[cfg(feature = "compare")]
@@ -19,7 +20,9 @@ use fgumi_lib::commands::compare::Compare;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::commands::downsample::Downsample;
+#[cfg(feature = "duplex")]
 use fgumi_lib::commands::duplex::Duplex;
+#[cfg(feature = "duplex")]
 use fgumi_lib::commands::duplex_metrics::DuplexMetrics;
 use fgumi_lib::commands::extract::Extract;
 use fgumi_lib::commands::fastq::Fastq;
@@ -27,7 +30,9 @@ use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::commands::merge::Merge;
 use fgumi_lib::commands::review::Review;
+#[cfg(feature = "simplex")]
 use fgumi_lib::commands::simplex::Simplex;
+#[cfg(feature = "simplex")]
 use fgumi_lib::commands::simplex_metrics::SimplexMetrics;
 #[cfg(feature = "simulate")]
 use fgumi_lib::commands::simulate::Simulate;
@@ -38,6 +43,16 @@ use log::info;
 /// Commands that require feature flags to be enabled.
 /// Format: (`command_name`, `feature_name`)
 const FEATURE_GATED_COMMANDS: &[(&str, &str)] = &[
+    #[cfg(not(feature = "simplex"))]
+    ("simplex", "simplex"),
+    #[cfg(not(feature = "simplex"))]
+    ("simplex-metrics", "simplex"),
+    #[cfg(not(feature = "duplex"))]
+    ("duplex", "duplex"),
+    #[cfg(not(feature = "duplex"))]
+    ("duplex-metrics", "duplex"),
+    #[cfg(not(feature = "codec"))]
+    ("codec", "codec"),
     #[cfg(not(feature = "compare"))]
     ("compare", "compare"),
     #[cfg(not(feature = "simulate"))]
@@ -91,10 +106,13 @@ enum Subcommand {
     Dedup(MarkDuplicates),
 
     // Consensus Calling
+    #[cfg(feature = "simplex")]
     #[command(display_order = 9)]
     Simplex(Simplex),
+    #[cfg(feature = "duplex")]
     #[command(display_order = 10)]
     Duplex(Duplex),
+    #[cfg(feature = "codec")]
     #[command(display_order = 11)]
     Codec(Codec),
 
@@ -103,8 +121,10 @@ enum Subcommand {
     Filter(Filter),
     #[command(display_order = 13)]
     Clip(Clip),
+    #[cfg(feature = "duplex")]
     #[command(display_order = 14)]
     DuplexMetrics(DuplexMetrics),
+    #[cfg(feature = "simplex")]
     #[command(display_order = 15)]
     SimplexMetrics(SimplexMetrics),
     #[command(display_order = 16)]
@@ -132,12 +152,17 @@ impl Subcommand {
             Self::Merge(cmd) => cmd.execute(command_line),
             Self::Group(cmd) => cmd.execute(command_line),
             Self::Dedup(cmd) => cmd.execute(command_line),
+            #[cfg(feature = "simplex")]
             Self::Simplex(cmd) => cmd.execute(command_line),
+            #[cfg(feature = "duplex")]
             Self::Duplex(cmd) => cmd.execute(command_line),
+            #[cfg(feature = "codec")]
             Self::Codec(cmd) => cmd.execute(command_line),
             Self::Filter(cmd) => cmd.execute(command_line),
             Self::Clip(cmd) => cmd.execute(command_line),
+            #[cfg(feature = "duplex")]
             Self::DuplexMetrics(cmd) => cmd.execute(command_line),
+            #[cfg(feature = "simplex")]
             Self::SimplexMetrics(cmd) => cmd.execute(command_line),
             Self::Review(cmd) => cmd.execute(command_line),
             Self::Downsample(cmd) => cmd.execute(command_line),

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -1,4 +1,11 @@
 //! Helper utilities for integration tests.
+//!
+//! Individual helpers are used by different subsets of the test modules
+//! (some of which are feature-gated), so some helpers appear unused under
+//! certain feature combinations. Silence the resulting warnings wholesale
+//! so `--no-default-features` stays clean.
+
+#![allow(dead_code, unused_imports)]
 
 pub mod assertions;
 pub mod bam_generator;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -10,14 +10,18 @@ mod test_async_reader;
 mod test_bam_pipeline;
 mod test_bgzf_eof;
 mod test_clip_command;
+#[cfg(feature = "codec")]
 mod test_codec_command;
+#[cfg(feature = "codec")]
 mod test_codec_pipeline;
 #[cfg(feature = "compare")]
 mod test_compare_bams;
 mod test_correct_command;
 mod test_dedup_command;
 mod test_downsample_command;
+#[cfg(feature = "duplex")]
 mod test_duplex_command;
+#[cfg(feature = "duplex")]
 mod test_duplex_metrics_command;
 #[cfg(all(feature = "compare", feature = "simulate"))]
 mod test_e2e_regression;
@@ -28,8 +32,11 @@ mod test_filter_command;
 mod test_group_command;
 mod test_pipeline_concurrency;
 mod test_review_command;
+#[cfg(feature = "simplex")]
 mod test_simplex_command;
+#[cfg(feature = "simplex")]
 mod test_simplex_metrics_command;
+#[cfg(feature = "simplex")]
 mod test_simplex_pipeline;
 mod test_simulate_sort;
 mod test_sort_correctness;


### PR DESCRIPTION
## Summary

Follow-up scope-completion to #313 (flagged there as an explicitly-deferred item). Makes the root `fgumi` crate build cleanly under `cargo check --workspace --no-default-features --all-targets`, and adds a CI job so future regressions are caught at PR time.

**Stacked on #313** -- the fgumi-consensus gates that land there are a prerequisite for these fixes to compile.

## What was broken

`cargo check -p fgumi --no-default-features` failed with ~6 unresolved-import errors across the root lib target -- plus more under `--all-targets` from benches and integration tests -- because:

- Command modules `codec` / `duplex` / `simplex` / `duplex_metrics` / `simplex_metrics` were declared unconditionally in `src/lib/commands/mod.rs` even though they depend on matching features.
- Backward-compat re-exports in `src/lib/mod.rs` referenced `duplex_caller` and `vanilla_caller` unconditionally.
- `src/lib/commands/common.rs`'s `MethylationRef` / `load_methylation_reference` / their transitive imports assumed `fgumi_consensus::methylation` (a `simplex`-gated module).
- `src/main.rs`'s `Subcommand` enum, `use` statements, and `execute` dispatch listed the consensus commands unconditionally.
- `benches/core_functions.rs` imports `vanilla_caller`; `tests/integration/main.rs` pulls in `test_codec_*`, `test_duplex_*`, `test_simplex_*` modules unconditionally.
- `Cargo.toml`'s `duplex` / `codec` features didn't pull in `simplex`, even though fgumi-consensus's equivalent features do (`duplex = ["simplex"]`, `codec = ["simplex"]`) and the consensus commands share `simplex`-gated methylation/filter code.

## Fix

Apply the same `#[cfg(feature = "...")]` discipline that the adjacent `compare`/`simulate` modules already use, and add the matching feature-dependency edges in `Cargo.toml`. See the commit message for a file-by-file walkthrough.

No production behaviour change under default features. Default builds, workspace builds, default `cargo test`, default `cargo clippy`, and `cargo publish --verify` are all unchanged.

## CI addition

New `no-default-features-check` job in `check.yml`:

```yaml
cargo check --workspace --no-default-features --all-targets
```

The regular test/lint jobs run with default features enabled, which transparently enables every optional dependency and default-on feature across the graph, so feature-gating bugs (optional dep used unconditionally; default-off module referenced from always-compiled code) don't fail CI. This new job compiles every workspace crate under `default-features = false` to surface them.

Intentionally a separate job from the `publish-dry-run` job being added in #312 -- no file conflict, and they catch overlapping but distinct bug classes.

## Verification (all green locally)

- `cargo check -p fgumi --no-default-features --all-targets`
- `cargo check -p fgumi --all-targets` (default)
- `cargo check -p fgumi --no-default-features --features simplex`
- `cargo check -p fgumi --no-default-features --features duplex`
- `cargo check -p fgumi --no-default-features --features codec`
- `cargo check --workspace --all-targets` (default)
- `cargo check --workspace --no-default-features --all-targets`
- `cargo clippy -p fgumi --no-default-features --all-targets`
- `cargo test -p fgumi --no-run` (default)

## Merge order

1. #313 (fgumi-consensus methylation + test gates) -- prerequisite.
2. This PR -- rebase onto main after #313 lands.
3. #312 (CI publish dry-run) -- orthogonal; can merge before or after.