### PR TITLE
fix(group,dedup): deterministic MoleculeId numbering across runs

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -541,7 +541,16 @@ fn assign_umi_groups(
     no_umi: bool,
 ) -> Result<()> {
     if assigner.split_templates_by_pair_orientation() {
-        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
+        // Group by pair orientation. Use BTreeMap (not AHashMap) so subgroup
+        // iteration order is deterministic across processes — `AHashMap`'s
+        // per-process random hasher seed would otherwise make
+        // `assigner.assign()` see orientation subgroups in different orders
+        // between two runs of `fgumi dedup` on the same input, which produces
+        // identical molecule groupings but different `MoleculeId` numbering
+        // (and therefore different `MI:Z` tags). Mirrors the same fix in
+        // `src/lib/commands/group.rs`.
+        let mut subgroups: std::collections::BTreeMap<(bool, bool), Vec<usize>> =
+            std::collections::BTreeMap::new();
         for (idx, template) in templates.iter().enumerate() {
             let orientation = get_pair_orientation(template);
             subgroups.entry(orientation).or_default().push(idx);
@@ -991,8 +1000,16 @@ impl Command for MarkDuplicates {
         let library_index = LibraryIndex::from_header(&header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
-        // Counter for contiguous MI assignment (incremented in the serial serialize step).
-        let next_mi_base = std::sync::atomic::AtomicU64::new(0);
+        // Serial-ordered counter for contiguous MI assignment. See the
+        // matching comment in `src/lib/commands/group.rs` for the full
+        // rationale; in short, `SerialOrderedArrayQueue` makes the serialize
+        // step pop batches in pipeline serial order, and
+        // `OrderedMiAllocator` serializes the cumulative-offset advance on
+        // that serial so that two runs of `fgumi dedup` on the same input
+        // assign identical `MI:Z` numbering even though serialize workers
+        // can run concurrently across batches.
+        let next_mi_base =
+            std::sync::Arc::new(crate::ordered_mi_allocator::OrderedMiAllocator::new());
 
         // Run the pipeline
         let _records_processed = run_bam_pipeline_from_reader(
@@ -1034,13 +1051,15 @@ impl Command for MarkDuplicates {
 
                 let input_record_count = processed.input_record_count;
 
-                // Assign contiguous base_mi from serial counter. Use the distinct MI
-                // count (number of families) so base_mi advances once per emitted MI,
-                // not once per template — families with multiple templates would
-                // otherwise create gaps in MI IDs.
+                // Assign contiguous base_mi from the serial-ordered allocator.
+                // Use the distinct MI count (number of families) so base_mi
+                // advances once per emitted MI, not once per template —
+                // families with multiple templates would otherwise create
+                // gaps in MI IDs.
+                let serialize_ctx = crate::unified_pipeline::serialize_context::current()
+                    .expect("serialize_fn called outside of pipeline serialize step");
                 let distinct_mi_count: u64 = processed.family_sizes.values().copied().sum();
-                let base_mi =
-                    next_mi_base.fetch_add(distinct_mi_count, std::sync::atomic::Ordering::Relaxed);
+                let base_mi = next_mi_base.allocate(serialize_ctx.serial, distinct_mi_count);
                 // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
                 output.reserve(processed.templates.len() * 2 * 400);
                 // Serialize templates
@@ -1076,6 +1095,15 @@ impl Command for MarkDuplicates {
                             output.extend_from_slice(raw);
                         }
                     }
+                }
+
+                // Finalize the per-batch MoleculeId allocation on the last
+                // item so the cumulative cursor advances and waiters on later
+                // serials wake up. The pipeline guarantees we see every item
+                // in a batch before the batch is dropped, so this fires
+                // exactly once per serial.
+                if serialize_ctx.is_last() {
+                    next_mi_base.finalize(serialize_ctx.serial);
                 }
 
                 Ok(input_record_count)

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -378,8 +378,16 @@ fn assign_umi_groups_impl(
     // All templates are in raw-byte mode (Template always uses RawRecord)
 
     if assigner.split_templates_by_pair_orientation() {
-        // Group by pair orientation
-        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
+        // Group by pair orientation. Use BTreeMap (not AHashMap) so subgroup
+        // iteration order is deterministic across processes — `AHashMap`'s
+        // per-process random hasher seed would otherwise make
+        // `assigner.assign()` see orientation subgroups in different orders
+        // between two runs of `fgumi group` on the same input, which produces
+        // identical molecule groupings but different `MoleculeId` numbering
+        // (and therefore different `MI:Z` tags and downstream consensus
+        // QNAMEs). See `tests/integration/test_group_determinism.rs`.
+        let mut subgroups: std::collections::BTreeMap<(bool, bool), Vec<usize>> =
+            std::collections::BTreeMap::new();
         for (idx, template) in templates.iter().enumerate() {
             let orientation = get_pair_orientation_raw(template);
             subgroups.entry(orientation).or_default().push(idx);
@@ -945,10 +953,28 @@ impl Command for GroupReadsByUmi {
         #[cfg(feature = "memory-debug")]
         let short_circuit_compress = short_circuit == "compress";
 
-        // Counter for contiguous MI assignment (incremented in the serial serialize step).
-        // AtomicU64 satisfies the Fn + Sync bound; Relaxed ordering is fine because
-        // the serialize step is serial and ordered.
-        let next_mi_base = std::sync::atomic::AtomicU64::new(0);
+        // Serial-ordered counter for contiguous MI assignment. Two
+        // pieces are needed for cross-run determinism:
+        //
+        // 1. `SerialOrderedArrayQueue` (the `processed` queue) makes the
+        //    serialize step pop batches in pipeline serial order rather
+        //    than completion order.
+        //
+        // 2. `OrderedMiAllocator` serializes the cumulative-offset advance
+        //    on the batch's pipeline serial. This is necessary because
+        //    serialize workers can still run concurrently — one worker can
+        //    pop serial S+1 and start `serialize_fn` while another worker
+        //    is still inside `serialize_fn` for serial S — and the
+        //    `MoleculeId` numbering must reflect serial order, not
+        //    completion order.
+        //
+        // Together these guarantee identical `MI:Z` numbering across runs of
+        // `fgumi group` on the same input. See
+        // `src/lib/unified_pipeline/serial_ordered_array_queue.rs`,
+        // `src/lib/ordered_mi_allocator.rs`, and
+        // `tests/integration/test_group_determinism.rs`.
+        let next_mi_base =
+            std::sync::Arc::new(crate::ordered_mi_allocator::OrderedMiAllocator::new());
 
         // Run the 7-step unified pipeline with the already-opened reader (supports streaming)
         let records_processed = run_bam_pipeline_from_reader(
@@ -1193,16 +1219,17 @@ impl Command for GroupReadsByUmi {
                 // Save input record count for progress tracking
                 let input_record_count = processed.input_record_count;
 
-                // Assign contiguous base_mi from the global counter. Advance by the
-                // number of distinct numeric MoleculeId IDs actually assigned in this
-                // group (not the template count), because multiple templates can share
-                // the same MoleculeId and because PairedA/PairedB share a numeric id.
-                // This ensures emitted MI integers are consecutive 0..N-1, matching
-                // fgbio's `GroupReadsByUmi` (see issue #269).
-                let base_mi = next_mi_base.fetch_add(
-                    processed.distinct_mi_count,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
+                // Assign contiguous base_mi from the serial-ordered allocator.
+                // Advance by the number of distinct numeric MoleculeId IDs
+                // actually assigned in this group (not the template count),
+                // because multiple templates can share the same MoleculeId and
+                // because PairedA/PairedB share a numeric id. This keeps
+                // emitted MI integers consecutive `0..N-1`, matching fgbio's
+                // `GroupReadsByUmi` (see issue #269).
+                let serialize_ctx = crate::unified_pipeline::serialize_context::current()
+                    .expect("serialize_fn called outside of pipeline serialize step");
+                let base_mi =
+                    next_mi_base.allocate(serialize_ctx.serial, processed.distinct_mi_count);
 
                 // Track template memory deallocation (templates are consumed here)
                 #[cfg(feature = "memory-debug")]
@@ -1234,6 +1261,14 @@ impl Command for GroupReadsByUmi {
                 #[cfg(feature = "memory-debug")]
                 if short_circuit_compress {
                     output.clear();
+                }
+                // Finalize the per-batch MoleculeId allocation on the last
+                // item so the cumulative cursor advances and waiters on later
+                // serials wake up. The pipeline guarantees we see every item
+                // in a batch before the batch is dropped, so this fires
+                // exactly once per serial.
+                if serialize_ctx.is_last() {
+                    next_mi_base.finalize(serialize_ctx.serial);
                 }
                 // Return INPUT record count for progress tracking (not output count)
                 Ok(input_record_count)

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -144,6 +144,7 @@ pub mod header;
 pub mod logging;
 pub mod metrics;
 pub mod mi_group;
+pub mod ordered_mi_allocator;
 pub mod os_hints;
 pub mod per_thread_accumulator;
 pub mod prefetch_reader;

--- a/src/lib/ordered_mi_allocator.rs
+++ b/src/lib/ordered_mi_allocator.rs
@@ -1,0 +1,204 @@
+//! Serial-ordered allocator for cumulative `MoleculeId` numbering.
+//!
+//! `fgumi group` and `fgumi dedup` allocate contiguous blocks of integer
+//! `MoleculeId`s, one block per item within a pipeline batch, by advancing a
+//! shared cumulative counter. Even though
+//! [`crate::unified_pipeline::serial_ordered_array_queue::SerialOrderedArrayQueue`]
+//! makes the pipeline pop processed batches in pipeline-serial order, the
+//! `serialize_fn` invocations can still run concurrently across worker
+//! threads — one worker can be writing batch `S+1`'s bytes while another is
+//! still inside batch `S`'s `serialize_fn`. A naive `AtomicU64::fetch_add`
+//! would therefore observe `S+1` advancing the counter before `S` does,
+//! producing identical molecule groupings but different integer `MI:Z`
+//! numbering across runs.
+//!
+//! [`OrderedMiAllocator`] serializes the cumulative-offset advance on the
+//! pipeline's per-batch serial number. Callers invoke
+//! [`allocate`](OrderedMiAllocator::allocate) once per item in a batch with
+//! the batch's `serial` and the item's `count`. Multiple items within the
+//! same `serial` get back-to-back base values that share the in-progress
+//! per-serial offset. Once the last item in batch `serial` is allocated, the
+//! caller invokes [`finalize`](OrderedMiAllocator::finalize) to fold the
+//! per-serial offset into the cumulative counter and advance the cursor to
+//! `serial + 1`. The pipeline guarantees monotonically increasing serials
+//! with no gaps, so the cursor always eventually reaches every requested
+//! serial — there is no risk of permanent waiting.
+
+use parking_lot::{Condvar, Mutex};
+use std::collections::BTreeMap;
+
+/// Allocator that hands out contiguous `MoleculeId` blocks in serial order.
+///
+/// See the [module docs][self] for the contract callers must follow.
+#[derive(Debug, Default)]
+pub struct OrderedMiAllocator {
+    inner: Mutex<Inner>,
+    cv: Condvar,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    /// Next batch serial that may begin allocating.
+    cursor: u64,
+    /// Total count consumed by serials strictly less than `cursor`.
+    cumulative: u64,
+    /// Per-serial in-progress offset for batches whose `finalize` has not yet
+    /// been called. `BTreeMap` rather than `HashMap` so iteration is
+    /// trivially deterministic in tests; in production we only ever look up,
+    /// insert, and remove by exact key.
+    in_progress: BTreeMap<u64, u64>,
+}
+
+impl OrderedMiAllocator {
+    /// Create a fresh allocator with cursor and cumulative both at 0.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate the next `count` IDs for an item belonging to batch `serial`.
+    ///
+    /// Blocks until the cursor reaches `serial`, then returns
+    /// `cumulative + per_serial_offset` and advances the per-serial offset
+    /// by `count`. Subsequent items within the same `serial` can call
+    /// `allocate(serial, _)` again — they will not block because the cursor
+    /// is already at `serial`, and they will receive bases that pack onto
+    /// the earlier ones in the batch.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `serial` is strictly less than the
+    /// allocator's cursor, which would mean an item from an already-finalized
+    /// batch is trying to allocate — a pipeline ordering bug.
+    pub fn allocate(&self, serial: u64, count: u64) -> u64 {
+        let mut g = self.inner.lock();
+        while g.cursor < serial {
+            self.cv.wait(&mut g);
+        }
+        debug_assert!(
+            g.cursor == serial,
+            "OrderedMiAllocator::allocate called for stale serial {serial} (cursor={})",
+            g.cursor,
+        );
+        let cumulative = g.cumulative;
+        let offset = g.in_progress.entry(serial).or_insert(0);
+        let base = cumulative + *offset;
+        *offset += count;
+        base
+    }
+
+    /// Mark batch `serial` complete.
+    ///
+    /// Folds the per-serial offset into `cumulative`, advances the cursor,
+    /// and wakes any threads waiting on later serials. Must be called
+    /// exactly once per serial, after all items in that batch have called
+    /// [`allocate`].
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `serial` does not equal the cursor, which
+    /// would indicate a missing or extra finalize.
+    pub fn finalize(&self, serial: u64) {
+        let mut g = self.inner.lock();
+        debug_assert_eq!(
+            g.cursor, serial,
+            "OrderedMiAllocator::finalize called out of order (cursor={}, serial={serial})",
+            g.cursor,
+        );
+        let folded = g.in_progress.remove(&serial).unwrap_or(0);
+        g.cumulative += folded;
+        g.cursor += 1;
+        drop(g);
+        self.cv.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn single_item_per_batch_is_consecutive() {
+        let alloc = OrderedMiAllocator::new();
+        assert_eq!(alloc.allocate(0, 3), 0);
+        alloc.finalize(0);
+        assert_eq!(alloc.allocate(1, 5), 3);
+        alloc.finalize(1);
+        assert_eq!(alloc.allocate(2, 2), 8);
+        alloc.finalize(2);
+    }
+
+    #[test]
+    fn multiple_items_share_serial_and_pack_together() {
+        let alloc = OrderedMiAllocator::new();
+        // Three items in batch 0, each adding 4 IDs.
+        assert_eq!(alloc.allocate(0, 4), 0);
+        assert_eq!(alloc.allocate(0, 4), 4);
+        assert_eq!(alloc.allocate(0, 4), 8);
+        alloc.finalize(0);
+        // Next batch starts at 12.
+        assert_eq!(alloc.allocate(1, 1), 12);
+        alloc.finalize(1);
+    }
+
+    #[test]
+    fn out_of_order_allocate_blocks_until_finalize() {
+        let alloc = Arc::new(OrderedMiAllocator::new());
+
+        let alloc_late = Arc::clone(&alloc);
+        let late = thread::spawn(move || {
+            // Batch 1 wants to allocate; should block until batch 0 finalizes.
+            let base = alloc_late.allocate(1, 7);
+            alloc_late.finalize(1);
+            base
+        });
+
+        // Give the late thread a chance to park on the condvar.
+        thread::sleep(std::time::Duration::from_millis(50));
+
+        let early_base = alloc.allocate(0, 3);
+        alloc.finalize(0);
+        assert_eq!(early_base, 0);
+
+        let late_base = late.join().expect("late thread");
+        assert_eq!(late_base, 3, "batch 1 must start after batch 0 finalizes");
+    }
+
+    #[test]
+    fn many_concurrent_batches_get_contiguous_ranges() {
+        const N: usize = 64;
+        let alloc = Arc::new(OrderedMiAllocator::new());
+        let counts: Vec<u64> =
+            (0..N).map(|i| u64::try_from(i + 1).expect("count fits u64")).collect();
+
+        // Spawn one thread per batch. They contend on the condvar; the
+        // allocator must hand out [0..1), [1..3), [3..6), ... in order.
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let alloc = Arc::clone(&alloc);
+                let count = counts[i];
+                let serial = u64::try_from(i).expect("serial fits u64");
+                thread::spawn(move || {
+                    let base = alloc.allocate(serial, count);
+                    alloc.finalize(serial);
+                    (serial, base, count)
+                })
+            })
+            .collect();
+
+        let mut results: Vec<(u64, u64, u64)> =
+            handles.into_iter().map(|h| h.join().expect("worker")).collect();
+        results.sort_by_key(|(s, _, _)| *s);
+
+        let mut expected_base = 0u64;
+        for (serial, base, count) in results {
+            assert_eq!(
+                base, expected_base,
+                "serial {serial} got base {base}, expected {expected_base}"
+            );
+            expected_base += count;
+        }
+    }
+}

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -2668,12 +2668,28 @@ fn try_step_serialize<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
     worker.core.serialization_buffer.clear();
     worker.core.secondary_serialization_buffer.clear();
 
-    // Serialize all items into worker's buffer
+    // Serialize all items into worker's buffer.
+    //
+    // Publish a per-thread `SerializeContext` for each item so closures
+    // needing serial-ordered global state (notably `fgumi group` /
+    // `fgumi dedup`'s `MoleculeId` numbering via `OrderedMiAllocator`) can
+    // read the batch's pipeline serial and detect the last item via
+    // `SerializeContext::is_last()`. Combined with `SerialOrderedArrayQueue`
+    // ensuring pops happen in serial order, this gives the closure a stable
+    // serial to anchor its global counter advance against, even though
+    // `serialize_fn` itself runs in parallel across worker threads.
     let mut total_record_count: u64 = 0;
-    for item in batch {
+    let batch_len = batch.len();
+    for (item_idx, item) in batch.into_iter().enumerate() {
+        super::serialize_context::set(super::serialize_context::SerializeContext {
+            serial,
+            item_idx,
+            batch_len,
+        });
         // Secondary serialize (borrows item) — must run before primary consumes it
         if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
             if let Err(e) = (secondary_fn)(&item, &mut worker.core.secondary_serialization_buffer) {
+                super::serialize_context::clear();
                 state.set_error(e);
                 return false;
             }
@@ -2684,11 +2700,13 @@ fn try_step_serialize<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
                 total_record_count += record_count;
             }
             Err(e) => {
+                super::serialize_context::clear();
                 state.set_error(e);
                 return false;
             }
         }
     }
+    super::serialize_context::clear();
 
     // Swap buffer into batch, replace with fresh pre-allocated buffer
     let combined_data = std::mem::replace(
@@ -3014,7 +3032,7 @@ impl SingleThreadedBuffers {
 /// This avoids the overhead of thread spawning, queues, and atomic
 /// operations when only one thread is requested. Significantly faster
 /// for small inputs or when parallelization overhead exceeds the benefit.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 fn run_bam_pipeline_single_threaded<G, P>(
     config: &PipelineConfig,
     mut input: Box<dyn Read + Send>,
@@ -3046,6 +3064,12 @@ where
 
     // Progress tracking
     let progress = ProgressTracker::new("Processed records").with_interval(PROGRESS_LOG_INTERVAL);
+
+    // Serial counter for the SerializeContext so single-threaded callers see
+    // the same serial-ordered API as the parallel pipeline. Each call to
+    // (fns.serialize_fn) is a one-batch-per-serial step and we increment the
+    // serial after every call.
+    let mut next_serial: u64 = 0;
 
     // Main loop: read -> decompress -> find_boundaries -> decode -> group -> process -> serialize -> compress -> write
     loop {
@@ -3090,7 +3114,15 @@ where
 
                 // Step 7b: Primary serialize (consumes processed, reuse buffer)
                 buffers.serialized.clear();
-                let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
+                super::serialize_context::set(super::serialize_context::SerializeContext {
+                    serial: next_serial,
+                    item_idx: 0,
+                    batch_len: 1,
+                });
+                let serialize_result = (fns.serialize_fn)(processed, &mut buffers.serialized);
+                super::serialize_context::clear();
+                next_serial += 1;
+                let record_count = serialize_result?;
 
                 // Step 8: Compress (only when buffer reaches 64KB)
                 compressor.write_all(&buffers.serialized)?;
@@ -3126,7 +3158,15 @@ where
                 }
 
                 buffers.serialized.clear();
-                let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
+                super::serialize_context::set(super::serialize_context::SerializeContext {
+                    serial: next_serial,
+                    item_idx: 0,
+                    batch_len: 1,
+                });
+                let serialize_result = (fns.serialize_fn)(processed, &mut buffers.serialized);
+                super::serialize_context::clear();
+                next_serial += 1;
+                let record_count = serialize_result?;
                 compressor.write_all(&buffers.serialized)?;
                 compressor.maybe_compress()?;
                 compressor.write_blocks_to(output.as_mut())?;
@@ -3155,7 +3195,17 @@ where
 
         // Step 7b: Primary serialize (consumes processed, reuse buffer)
         buffers.serialized.clear();
-        let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
+        super::serialize_context::set(super::serialize_context::SerializeContext {
+            serial: next_serial,
+            item_idx: 0,
+            batch_len: 1,
+        });
+        let serialize_result = (fns.serialize_fn)(processed, &mut buffers.serialized);
+        super::serialize_context::clear();
+        // No further iterations after the final-group block; this assignment
+        // is purely for symmetry with the in-loop case.
+        let _ = next_serial + 1;
+        let record_count = serialize_result?;
 
         // Step 8: Compress (only when buffer reaches 64KB)
         compressor.write_all(&buffers.serialized)?;

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1698,7 +1698,13 @@ pub struct OutputPipelineQueues<G, P: MemoryEstimate> {
 
     // ========== Queue: Process → Serialize ==========
     /// Batches of processed data waiting for serialization.
-    pub processed: ArrayQueue<(u64, Vec<P>)>,
+    ///
+    /// Uses [`SerialOrderedArrayQueue`] (rather than `ArrayQueue`) so the
+    /// serialize step pops batches in pipeline-serial order, not in completion
+    /// order. This is required for any global counter advanced inside
+    /// `serialize_fn` to be deterministic across runs — most notably the
+    /// per-batch `MoleculeId` base in `fgumi group` and `fgumi dedup`.
+    pub processed: super::serial_ordered_array_queue::SerialOrderedArrayQueue<Vec<P>>,
     /// Current heap bytes in processed queue.
     pub processed_heap_bytes: AtomicU64,
 
@@ -1766,7 +1772,9 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
         Self {
             groups: ArrayQueue::new(queue_capacity),
             groups_heap_bytes: AtomicU64::new(0),
-            processed: ArrayQueue::new(queue_capacity),
+            processed: super::serial_ordered_array_queue::SerialOrderedArrayQueue::new(
+                queue_capacity,
+            ),
             processed_heap_bytes: AtomicU64::new(0),
             serialized: ArrayQueue::new(queue_capacity),
             serialized_heap_bytes: AtomicU64::new(0),

--- a/src/lib/unified_pipeline/mod.rs
+++ b/src/lib/unified_pipeline/mod.rs
@@ -111,6 +111,8 @@ mod fastq;
 pub mod queue;
 pub mod rebalancer;
 pub mod scheduler;
+pub mod serial_ordered_array_queue;
+pub mod serialize_context;
 
 // Re-export everything from base
 pub use base::*;

--- a/src/lib/unified_pipeline/serial_ordered_array_queue.rs
+++ b/src/lib/unified_pipeline/serial_ordered_array_queue.rs
@@ -1,0 +1,240 @@
+//! `crossbeam_queue::ArrayQueue`-compatible queue that pops items in the
+//! order of their pipeline serial, not their arrival order.
+//!
+//! The BAM pipeline's `Q5` (process step output) historically used
+//! `ArrayQueue<(u64, Vec<P>)>` so that serialize workers popped in completion
+//! (arrival) order. That made any global counter advanced inside `serialize_fn`
+//! — notably the `MoleculeId` counter in `fgumi group` and `fgumi dedup` —
+//! non-deterministic across runs because the parallel process step finishes
+//! batches in an arbitrary order.
+//!
+//! [`SerialOrderedArrayQueue`] keeps the existing ArrayQueue-like surface
+//! (`push`, `pop`, `is_full`, `is_empty`, `len`) so it can be dropped in for
+//! `Q5` with no other call-site changes, but internally it is a
+//! `BTreeMap` keyed by serial:
+//!
+//! - `push((serial, item))` inserts the entry into the map (until full).
+//! - `pop()` returns the entry with the smallest serial **only when that
+//!   serial is the next expected one**, advancing an internal cursor on
+//!   success. If the smallest serial currently buffered is greater than the
+//!   cursor (because earlier serials are still in the process step), `pop`
+//!   returns `None` and the worker is free to do other work.
+//!
+//! Because the pipeline's group step assigns serials monotonically with no
+//! gaps, the cursor always eventually catches up — the queue can stall
+//! serialize workers but it cannot deadlock the pipeline. The deadlock-
+//! avoidance logic in [`SerialOrderedArrayQueue::push`] also lets producers
+//! exceed the configured capacity when the cursor's expected serial has not
+//! yet been buffered, so the missing serial can always reach the queue.
+
+use parking_lot::Mutex;
+use std::collections::BTreeMap;
+
+/// Capacity-bounded, serial-ordered FIFO with an `ArrayQueue`-compatible API.
+#[derive(Debug)]
+pub struct SerialOrderedArrayQueue<T> {
+    inner: Mutex<Inner<T>>,
+    capacity: usize,
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    buf: BTreeMap<u64, T>,
+    /// Next serial that is allowed to be popped. The pipeline only ever
+    /// pushes monotonically increasing serials with no gaps starting from 0,
+    /// so the cursor is always equal to "smallest serial that has not yet
+    /// been popped or skipped".
+    cursor: u64,
+}
+
+impl<T> SerialOrderedArrayQueue<T> {
+    /// Create an empty queue with the given capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner { buf: BTreeMap::new(), cursor: 0 }),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Insert an `(serial, item)` pair. Returns the input back as `Err` if
+    /// the queue is at capacity AND the cursor's expected serial is already
+    /// buffered (so the consumer can drain).
+    ///
+    /// **Deadlock avoidance:** if the cursor's expected serial is **not** yet
+    /// buffered, the consumer cannot make progress and the producers must be
+    /// allowed to push the missing serial through. In that case the push
+    /// always succeeds, even if the buffer is over capacity. This mirrors
+    /// the same safety net used by [`crate::unified_pipeline::queue::OrderedQueue`]
+    /// — without it, a transient burst of out-of-order completions can fill
+    /// the queue and trap the worker holding the next-expected serial in its
+    /// `held_processed` slot, deadlocking the pipeline.
+    ///
+    /// # Errors
+    ///
+    /// Returns the input pair as `Err` when the queue is at capacity and
+    /// the consumer can drain (so backpressure should kick in at the
+    /// caller).
+    pub fn push(&self, item: (u64, T)) -> Result<(), (u64, T)> {
+        let mut g = self.inner.lock();
+        // Defensive: cursor is monotonic, items with serial < cursor have
+        // already been popped and must not appear again. Convert this into a
+        // panic in debug builds — silently dropping the item would mask a
+        // pipeline ordering bug.
+        debug_assert!(
+            item.0 >= g.cursor,
+            "SerialOrderedArrayQueue: stale serial {} pushed (cursor={})",
+            item.0,
+            g.cursor,
+        );
+        let consumer_can_drain = g
+            .buf
+            .first_key_value()
+            .is_some_and(|(&k, _)| k == g.cursor);
+        if g.buf.len() >= self.capacity && consumer_can_drain {
+            return Err(item);
+        }
+        // Always accept when we don't have the cursor's expected serial yet,
+        // even if over capacity, so the missing serial can arrive and unblock
+        // the consumer.
+        g.buf.insert(item.0, item.1);
+        Ok(())
+    }
+
+    /// Pop the entry with the smallest serial **iff** that serial is the
+    /// next expected one. Returns `None` if the queue is empty or if the
+    /// smallest buffered serial is ahead of the cursor (i.e. some earlier
+    /// batch is still in flight).
+    pub fn pop(&self) -> Option<(u64, T)> {
+        let mut g = self.inner.lock();
+        let cursor = g.cursor;
+        // Peek: only pop if the smallest key matches the cursor.
+        let take = matches!(g.buf.first_key_value(), Some((&k, _)) if k == cursor);
+        if !take {
+            return None;
+        }
+        let (serial, item) = g.buf.pop_first()?;
+        debug_assert_eq!(serial, cursor);
+        g.cursor += 1;
+        Some((serial, item))
+    }
+
+    /// True when the queue is at capacity AND the consumer can drain (i.e.
+    /// the cursor's expected serial is buffered). When the cursor's serial
+    /// is **not** yet buffered, the queue advertises that it has space —
+    /// otherwise producer backpressure would block all workers from pushing
+    /// the missing serial through, deadlocking the pipeline. See [`push`]
+    /// for the matching deadlock-avoidance logic.
+    pub fn is_full(&self) -> bool {
+        let g = self.inner.lock();
+        let consumer_can_drain = g
+            .buf
+            .first_key_value()
+            .is_some_and(|(&k, _)| k == g.cursor);
+        g.buf.len() >= self.capacity && consumer_can_drain
+    }
+
+    /// True when the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        let g = self.inner.lock();
+        g.buf.is_empty()
+    }
+
+    /// Current number of buffered items.
+    pub fn len(&self) -> usize {
+        let g = self.inner.lock();
+        g.buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn pops_in_serial_order_regardless_of_push_order() {
+        let q: SerialOrderedArrayQueue<&'static str> = SerialOrderedArrayQueue::new(8);
+        q.push((3, "three")).unwrap();
+        q.push((1, "one")).unwrap();
+        q.push((0, "zero")).unwrap();
+        q.push((2, "two")).unwrap();
+
+        assert_eq!(q.pop(), Some((0, "zero")));
+        assert_eq!(q.pop(), Some((1, "one")));
+        assert_eq!(q.pop(), Some((2, "two")));
+        assert_eq!(q.pop(), Some((3, "three")));
+        assert_eq!(q.pop(), None);
+    }
+
+    #[test]
+    fn pop_returns_none_when_smallest_is_ahead_of_cursor() {
+        let q: SerialOrderedArrayQueue<u64> = SerialOrderedArrayQueue::new(8);
+        // Push out-of-order serials, but never push 0 yet.
+        q.push((1, 100)).unwrap();
+        q.push((2, 200)).unwrap();
+        // Cursor is 0 but the smallest buffered serial is 1, so pop must
+        // wait — returning None means "do other work".
+        assert!(q.pop().is_none());
+        assert_eq!(q.len(), 2);
+        // Once the missing serial 0 arrives, pops drain in order.
+        q.push((0, 10)).unwrap();
+        assert_eq!(q.pop(), Some((0, 10)));
+        assert_eq!(q.pop(), Some((1, 100)));
+        assert_eq!(q.pop(), Some((2, 200)));
+    }
+
+    #[test]
+    fn push_returns_err_when_full_and_consumer_can_drain() {
+        let q: SerialOrderedArrayQueue<u8> = SerialOrderedArrayQueue::new(2);
+        q.push((0, 0)).unwrap();
+        q.push((1, 1)).unwrap();
+        assert!(q.is_full());
+        let pushed_back = q.push((2, 2));
+        assert_eq!(pushed_back, Err((2, 2)));
+    }
+
+    #[test]
+    fn push_succeeds_over_capacity_when_consumer_is_starved() {
+        let q: SerialOrderedArrayQueue<u8> = SerialOrderedArrayQueue::new(2);
+        // Cursor is 0 but only out-of-order serials are buffered.
+        q.push((1, 1)).unwrap();
+        q.push((2, 2)).unwrap();
+        assert!(!q.is_full(), "must not advertise full while consumer is starved");
+        // Going over capacity is allowed when the cursor's serial is missing
+        // — otherwise the producer holding serial 0 deadlocks waiting for
+        // queue space that the consumer cannot create.
+        q.push((3, 3)).unwrap();
+        assert_eq!(q.len(), 3);
+        // Once serial 0 arrives the consumer can drain.
+        q.push((0, 0)).unwrap();
+        assert_eq!(q.pop(), Some((0, 0)));
+        assert_eq!(q.pop(), Some((1, 1)));
+        assert_eq!(q.pop(), Some((2, 2)));
+        assert_eq!(q.pop(), Some((3, 3)));
+    }
+
+    #[test]
+    fn many_concurrent_producers_pop_in_serial_order() {
+        const N: u64 = 64;
+        let q: Arc<SerialOrderedArrayQueue<u64>> = Arc::new(SerialOrderedArrayQueue::new(256));
+        let mut handles = Vec::new();
+        for s in 0..N {
+            let q = Arc::clone(&q);
+            handles.push(thread::spawn(move || {
+                // Spread the pushes apart so they finish in arbitrary order.
+                thread::yield_now();
+                q.push((s, s * 10)).expect("push");
+            }));
+        }
+        for h in handles {
+            h.join().expect("producer");
+        }
+        for s in 0..N {
+            // Pop must always return the next expected serial.
+            assert_eq!(q.pop(), Some((s, s * 10)), "expected to pop serial {s} next");
+        }
+        assert!(q.pop().is_none());
+    }
+}

--- a/src/lib/unified_pipeline/serialize_context.rs
+++ b/src/lib/unified_pipeline/serialize_context.rs
@@ -1,0 +1,106 @@
+//! Per-thread context published by the BAM pipeline's serialize step.
+//!
+//! When `try_step_serialize` invokes the user-supplied `serialize_fn` for each
+//! item in a popped batch, it stores the batch's pipeline serial number in
+//! this thread-local cell. Closures that need to allocate IDs in serial order
+//! — notably `fgumi group` and `fgumi dedup`, via
+//! [`crate::ordered_mi_allocator::OrderedMiAllocator`] — read the cell to
+//! know which serial they belong to. Combined with
+//! [`crate::unified_pipeline::serial_ordered_array_queue::SerialOrderedArrayQueue`],
+//! which makes popping happen in serial order, this gives the closure a
+//! deterministic serial to anchor its global counter advance against.
+//!
+//! The harness clears the cell to `None` after each `serialize_fn` call so
+//! reads outside a serialize call get `None` and any closure that requires
+//! the context can panic loudly rather than silently ignoring missing data.
+
+use std::cell::Cell;
+
+/// Per-batch serialize context: the batch's pipeline serial plus the item's
+/// position within the batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SerializeContext {
+    /// Pipeline serial number of the batch currently being serialized.
+    pub serial: u64,
+    /// Zero-based index of this item within the batch.
+    pub item_idx: usize,
+    /// Total number of items in the batch.
+    pub batch_len: usize,
+}
+
+impl SerializeContext {
+    /// True when this is the final item in the batch and any per-batch
+    /// finalization (e.g. folding per-batch state into a global counter)
+    /// should run before the closure returns.
+    #[must_use]
+    pub fn is_last(&self) -> bool {
+        self.item_idx + 1 == self.batch_len
+    }
+}
+
+thread_local! {
+    static CURRENT: Cell<Option<SerializeContext>> = const { Cell::new(None) };
+}
+
+/// Stash the serialize context for the calling thread. The harness must call
+/// this immediately before invoking `serialize_fn` for each item in a batch
+/// and must call [`clear`] after the for-loop completes (success or error).
+pub fn set(ctx: SerializeContext) {
+    CURRENT.with(|c| c.set(Some(ctx)));
+}
+
+/// Clear the serialize context. Read by tests and by the harness on cleanup.
+pub fn clear() {
+    CURRENT.with(|c| c.set(None));
+}
+
+/// Returns the current serialize context for this thread, if any.
+///
+/// Closures that require the context to be set should `.expect(...)` with a
+/// descriptive message.
+#[must_use]
+pub fn current() -> Option<SerializeContext> {
+    CURRENT.with(Cell::get)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_returns_none() {
+        clear();
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn set_and_clear_round_trip() {
+        let ctx = SerializeContext { serial: 3, item_idx: 1, batch_len: 4 };
+        set(ctx);
+        assert_eq!(current(), Some(ctx));
+        assert!(!ctx.is_last());
+        clear();
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn is_last_is_true_for_final_item() {
+        assert!(SerializeContext { serial: 7, item_idx: 2, batch_len: 3 }.is_last());
+        assert!(!SerializeContext { serial: 7, item_idx: 1, batch_len: 3 }.is_last());
+    }
+
+    #[test]
+    fn thread_local_is_isolated_per_thread() {
+        clear();
+        let other = std::thread::spawn(|| {
+            // Thread starts with cleared cell.
+            assert!(current().is_none());
+            set(SerializeContext { serial: 99, item_idx: 0, batch_len: 1 });
+            current()
+        });
+        // Main thread is unaffected by the child thread's set().
+        assert!(current().is_none());
+        let other_ctx = other.join().expect("worker");
+        assert_eq!(other_ctx.map(|c| c.serial), Some(99));
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,7 @@ mod test_extract_command;
 mod test_fastq_command;
 mod test_filter_command;
 mod test_group_command;
+mod test_group_determinism;
 mod test_pipeline_concurrency;
 mod test_review_command;
 #[cfg(feature = "simplex")]

--- a/tests/integration/test_group_determinism.rs
+++ b/tests/integration/test_group_determinism.rs
@@ -1,0 +1,288 @@
+//! Determinism regression tests for the `group` and `dedup` commands.
+//!
+//! These tests guard against a class of non-determinism caused by iterating
+//! `AHashMap`-keyed orientation subgroups (`(bool, bool) -> Vec<usize>`)
+//! without sorting before assigning `MoleculeId`s. With Rust's per-process
+//! random hasher, two runs of the same command on the same input would walk
+//! orientation subgroups in different orders and produce identical molecule
+//! groupings but mismatched `MI:Z` numbering across runs — which then
+//! propagates into downstream consensus QNAMEs.
+//!
+//! The failing case requires multiple distinct orientations so that
+//! `subgroups` has more than one entry; otherwise iteration order is trivially
+//! stable.
+//!
+//! Both tests build a small paired-end BAM containing several UMI families
+//! distributed across both FR (R1 forward, R2 reverse) and RF (R1 reverse,
+//! R2 forward) orientations, run the command twice on the same input, and
+//! assert that the per-record `MI:Z` tags are identical across runs.
+
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use noodles::bam;
+use noodles::sam::alignment::io::Write as AlignmentWrite;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
+
+/// Build a paired-end template for `--strategy paired` with explicit orientation.
+///
+/// `is_rf = false` produces FR orientation: R1 forward at `r1_pos`, R2 reverse
+/// at `r2_pos`. `is_rf = true` flips the strand bits for both reads.
+fn build_paired_template(
+    name: &str,
+    umi: &str,
+    sequence: &str,
+    quality: u8,
+    r1_pos: i32,
+    r2_pos: i32,
+    is_rf: bool,
+) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let cigar_op = u32::try_from(seq.len()).expect("seq len fits u32") << 4;
+    let cigar_str = format!("{}M", seq.len());
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "small synthetic positions fit in i32"
+    )]
+    let tlen = (r2_pos - r1_pos + seq.len() as i32).abs();
+
+    let r1_flags = flags::PAIRED
+        | flags::FIRST_SEGMENT
+        | if is_rf { flags::REVERSE } else { 0 }
+        | if is_rf { 0 } else { flags::MATE_REVERSE };
+    let r2_flags = flags::PAIRED
+        | flags::LAST_SEGMENT
+        | if is_rf { 0 } else { flags::REVERSE }
+        | if is_rf { flags::MATE_REVERSE } else { 0 };
+
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(r1_pos - 1)
+            .mapq(60)
+            .flags(r1_flags)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r2_pos - 1)
+            .template_length(if is_rf { -tlen } else { tlen })
+            .sequence(seq)
+            .qualities(&vec![quality; seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, cigar_str.as_bytes());
+        b.build()
+    };
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(r2_pos - 1)
+            .mapq(60)
+            .flags(r2_flags)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r1_pos - 1)
+            .template_length(if is_rf { tlen } else { -tlen })
+            .sequence(seq)
+            .qualities(&vec![quality; seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, cigar_str.as_bytes());
+        b.build()
+    };
+    (r1, r2)
+}
+
+/// Write a BAM containing the given templates against a minimal `chr1` header.
+fn write_bam(path: &Path, templates: &[(RawRecord, RawRecord)]) {
+    let header = create_minimal_header("chr1", 100_000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for (r1, r2) in templates {
+        writer.write_alignment_record(&header, &to_record_buf(r1)).expect("Failed to write R1");
+        writer.write_alignment_record(&header, &to_record_buf(r2)).expect("Failed to write R2");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Build a BAM with paired-end UMI families spread across multiple
+/// orientations, multiple UMIs per orientation, and multiple positions.
+///
+/// The combination of distinct orientations and distinct paired UMIs is what
+/// triggers the bug: the assigner sees more than one orientation subgroup,
+/// and within each subgroup more than one UMI family, so `MoleculeId`
+/// numbering depends on subgroup iteration order.
+///
+/// We materialize a large number of distinct molecules per subgroup so that
+/// even small variances in `AHashMap::values()` iteration order become
+/// observable as different `MoleculeId` numbering across runs.
+fn build_mixed_orientation_bam(path: &Path) {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut umis: Vec<String> = Vec::new();
+    for &a in &bases {
+        for &b in &bases {
+            for &c in &bases {
+                for &d in &bases {
+                    let prefix = format!("{}{}{}{}", a as char, b as char, c as char, d as char,);
+                    let suffix = format!("{}{}{}{}", d as char, c as char, b as char, a as char,);
+                    umis.push(format!("{prefix}{prefix}-{suffix}{suffix}"));
+                }
+            }
+        }
+    }
+
+    let mut templates = Vec::new();
+    let mut counter = 0;
+    let mut emit = |name: String, umi: &str, pos: i32, is_rf: bool| {
+        templates.push(build_paired_template(
+            &name,
+            umi,
+            "ACGTACGTACGTACGT",
+            30,
+            pos,
+            pos + 100,
+            is_rf,
+        ));
+    };
+
+    // Many position groups, each carrying templates from BOTH orientations.
+    // Position-grouping is per-coordinate, so distinct positions form
+    // independent subgroup AHashMaps in the assigner — each one a separate
+    // chance for iteration order to vary.
+    for group_idx in 0..40 {
+        let base_pos = 1_000 + group_idx * 1_000;
+        for (u_idx, umi) in umis.iter().enumerate() {
+            for is_rf in [false, true] {
+                counter += 1;
+                let name = format!("read_g{group_idx}_u{u_idx}_{is_rf}_{counter}");
+                emit(name, umi, base_pos, is_rf);
+            }
+        }
+    }
+    write_bam(path, &templates);
+}
+
+/// Read all `(QNAME, flags, MI:Z)` tuples from a BAM in input order.
+///
+/// Returning the tuple lets the test compare both per-output-position (which
+/// catches sort-order differences induced by re-numbered MIs) and
+/// per-(QNAME, flags) (which catches MI re-numbering on the same record).
+fn read_qname_mi(path: &Path) -> Vec<(String, u16, String)> {
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open output BAM"));
+    let _header = reader.read_header().expect("read header");
+    let mi = SamTag::MI.to_noodles_tag();
+    reader
+        .records()
+        .map(|r| {
+            let r = r.expect("read record");
+            let qname = r.name().expect("missing name").to_string();
+            let flags = u16::from(r.flags());
+            let mi_val = r.data().get(&mi).map(|v| format!("{v:?}")).unwrap_or_default();
+            (qname, flags, mi_val)
+        })
+        .collect()
+}
+
+/// Run a fgumi subcommand `n_runs` times on the same input and assert that
+/// the per-record MI tags are byte-identical across every pair of runs.
+///
+/// Each run is a fresh process invocation so `AHashMap`'s per-process random
+/// hasher seed varies between runs; this is exactly the property that exposes
+/// the orientation-subgroup iteration bug. Running more than two times and
+/// comparing pairwise raises the probability of catching the variance even
+/// when only a handful of subgroup keys are present.
+fn assert_mi_deterministic(subcommand: &str, threads: &str, n_runs: usize) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    build_mixed_orientation_bam(&input_bam);
+
+    let mut all_runs: Vec<Vec<(String, u16, String)>> = Vec::with_capacity(n_runs);
+    for run in 0..n_runs {
+        let out = temp_dir.path().join(format!("out_{run}.bam"));
+        let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+            .args([
+                subcommand,
+                "--input",
+                input_bam.to_str().unwrap(),
+                "--output",
+                out.to_str().unwrap(),
+                "--strategy",
+                "paired",
+                "--threads",
+                threads,
+                "--compression-level",
+                "1",
+            ])
+            .status()
+            .expect("Failed to run command");
+        assert!(status.success(), "{subcommand} run {run} failed");
+        all_runs.push(read_qname_mi(&out));
+    }
+
+    let baseline = &all_runs[0];
+    let baseline_by_key: std::collections::HashMap<(String, u16), &str> =
+        baseline.iter().map(|(q, f, m)| ((q.clone(), *f), m.as_str())).collect();
+
+    for (run, run_records) in all_runs.iter().enumerate().skip(1) {
+        assert_eq!(
+            baseline.len(),
+            run_records.len(),
+            "{subcommand} produced different record counts across runs",
+        );
+
+        // Per-(QNAME, flags) comparison: catches MI tag re-numbering on the
+        // same logical record, even if the output is re-sorted by MI.
+        let mut keyed_mismatches = 0usize;
+        let mut sample_diffs: Vec<String> = Vec::new();
+        for (qname, flags, mi_run) in run_records {
+            let mi_base = baseline_by_key.get(&(qname.clone(), *flags));
+            let Some(mi_base) = mi_base else {
+                continue;
+            };
+            if *mi_base != mi_run.as_str() {
+                keyed_mismatches += 1;
+                if sample_diffs.len() < 5 {
+                    sample_diffs
+                        .push(format!("{qname} flags={flags}: run0={mi_base} run{run}={mi_run}",));
+                }
+            }
+        }
+
+        // Positional comparison: catches re-sorting that occurs because
+        // templates are sorted by MI on the way out.
+        let pos_mismatches =
+            baseline.iter().zip(run_records.iter()).filter(|(x, y)| x != y).count();
+
+        assert_eq!(
+            keyed_mismatches,
+            0,
+            "{subcommand} --threads {threads}: per-(QNAME,flags) MI tags differ between run 0 and run {run} ({keyed_mismatches}/{} records). Positional mismatches: {pos_mismatches}. Examples: {sample_diffs:?}",
+            baseline.len(),
+        );
+    }
+}
+
+/// Repeated runs of `fgumi group --strategy paired` must assign identical
+/// `MI:Z` tags to every record.
+#[test]
+fn test_group_paired_mi_deterministic_threads_4() {
+    assert_mi_deterministic("group", "4", 6);
+}
+
+/// Same as above for the single-threaded path.
+#[test]
+fn test_group_paired_mi_deterministic_threads_1() {
+    assert_mi_deterministic("group", "1", 6);
+}
+
+/// Repeated runs of `fgumi dedup --strategy paired` must assign identical
+/// `MI:Z` tags to every accepted record.
+#[test]
+fn test_dedup_paired_mi_deterministic_threads_4() {
+    assert_mi_deterministic("dedup", "4", 6);
+}


### PR DESCRIPTION
## Summary

- Fix `fgumi group` and `fgumi dedup` `--threads N>1` non-determinism: two runs on the same input were producing identical molecule groupings but mismatched `MI:Z` numbering on ~10–15% of records (verified end-to-end on the SRR6109255 paired-UMI smoke), which then propagates into downstream `simplex`/`duplex`/`codec` consensus QNAMEs and breaks `fgumi compare bams` correspondence.
- Add a serial-ordered Q5 (`SerialOrderedArrayQueue`) plus an `OrderedMiAllocator` to advance the cumulative MI counter in pipeline-input order even when serialize workers run concurrently.
- Add an integration regression suite that reproduces the bug deterministically and now passes after the fix.

## Root cause

The unified BAM pipeline's `Q5` (process → serialize) is an unordered FIFO. Worker threads finish position groups in parallel and push completions in arrival order, not pipeline-serial order. The serialize step then advances a shared `AtomicU64::fetch_add` inside `serialize_fn`, so two runs see different completion orders → different cumulative offsets → different `MI:Z` numbers, even though the per-group molecule sets are identical. The single-threaded fast path was not affected because it only ever has one in-flight serialize.

The user-visible report attributed the bug to `fgumi duplex`, but `simplex`/`duplex`/`codec` themselves were already deterministic — they preserve the input `MI:Z` rather than minting new IDs, so they inherit the upstream non-determinism through the QNAME format `prefix:input_mi`. Fixing `group` and `dedup` removes the non-determinism at the source for the whole consensus pipeline.

## Fix

1. **`SerialOrderedArrayQueue<T>`** (`src/lib/unified_pipeline/serial_ordered_array_queue.rs`) — drop-in replacement for `crossbeam_queue::ArrayQueue<(u64, T)>` used as Q5. Pop returns the smallest buffered serial only when it equals the cursor; push exceeds capacity when the cursor's serial isn't yet buffered to avoid producer/consumer deadlock (mirroring the existing `OrderedQueue` safety net).
2. **`OrderedMiAllocator`** (`src/lib/ordered_mi_allocator.rs`) — hands out contiguous `MoleculeId` blocks in serial order. `allocate(serial, count)` blocks via condvar until the cursor reaches `serial`, then packs onto the per-serial offset; `finalize(serial)` folds the per-serial offset into the cumulative counter and advances the cursor.
3. **`serialize_context`** thread-local (`src/lib/unified_pipeline/serialize_context.rs`) — published by `try_step_serialize` (and the single-threaded fast path) so closures can read `(serial, item_idx, batch_len)` without changing the public `serialize_fn` signature. Used by `group`/`dedup`'s closures to call `allocate` with the right serial and `finalize` on the last item of each batch.

`fgumi group` and `fgumi dedup` swap their `AtomicU64::fetch_add` for the new allocator. No other BAM pipeline command needs changes (none mint MI integers themselves).

## Test plan

- [x] `cargo ci-test` (full nextest suite, 2510 tests, 23 skipped, 0 failures)
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint` (clippy `-D warnings -W clippy::pedantic` clean)
- [x] New `tests/integration/test_group_determinism.rs` — three regression tests for `group --threads 1`, `group --threads 4`, `dedup --threads 4`. Each runs the command 6× on the same multi-orientation paired-UMI BAM and asserts byte-identical per-`(QNAME, flags)` `MI:Z` across all runs. Without the fix the threads-4 cases reproduce the bug deterministically (~30k/40k records mismatching); with the fix all 6 runs are identical.
- [x] Real-data smoke: `fgumi zipper → sort → group --threads 8` on SRR6109255 (1.7M records). Pre-fix: 100% of MI tags differed across two runs. Post-fix: byte-identical SAM body across two runs. Also verified `fgumi duplex --threads 8` on the (now stable) grouped output is byte-identical across runs.
- [x] Existing `test_pipeline_concurrency` suite (13 tests) still passes — `SerialOrderedArrayQueue`'s deadlock-avoidance branch (push exceeds capacity when cursor's serial is missing) keeps the multi-threaded contention tests from deadlocking even with the new ordering invariants.