### PR TITLE
fix(group,dedup): deterministic MoleculeId numbering via opt-in MI Assign stage

### DIFF
--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -67,19 +67,31 @@ impl MoleculeId {
     /// Write string representation into a reusable buffer, returning the bytes.
     ///
     /// Avoids per-call String allocation by reusing the caller's buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics consistently in both debug and release builds if `base + id`
+    /// would overflow `u64`. With `id` and `base` both bounded by the number
+    /// of molecules in the input (which fits comfortably under `u64::MAX` for
+    /// every realistic sequencing run), this is unreachable in practice; the
+    /// explicit `checked_add` keeps debug and release behavior identical
+    /// rather than wrapping silently in release.
     pub fn write_with_offset<'a>(&self, base: u64, buf: &'a mut String) -> &'a [u8] {
         use std::fmt::Write;
         buf.clear();
         match self {
             MoleculeId::None => {}
             MoleculeId::Single(id) => {
-                write!(buf, "{}", base + id).expect("write to String is infallible");
+                let total = id.checked_add(base).expect("MoleculeId offset overflow");
+                write!(buf, "{total}").expect("write to String is infallible");
             }
             MoleculeId::PairedA(id) => {
-                write!(buf, "{}/A", base + id).expect("write to String is infallible");
+                let total = id.checked_add(base).expect("MoleculeId offset overflow");
+                write!(buf, "{total}/A").expect("write to String is infallible");
             }
             MoleculeId::PairedB(id) => {
-                write!(buf, "{}/B", base + id).expect("write to String is infallible");
+                let total = id.checked_add(base).expect("MoleculeId offset overflow");
+                write!(buf, "{total}/B").expect("write to String is infallible");
             }
         }
         buf.as_bytes()
@@ -124,6 +136,40 @@ impl MoleculeId {
             MoleculeId::None => String::new(),
             MoleculeId::Single(id) | MoleculeId::PairedA(id) | MoleculeId::PairedB(id) => {
                 id.to_string()
+            }
+        }
+    }
+
+    /// Return a new `MoleculeId` whose numeric `id` is shifted by `offset`,
+    /// preserving the variant tag.
+    ///
+    /// `MoleculeId::None` is returned unchanged. `Single`, `PairedA`, and
+    /// `PairedB` each have `offset` added to their inner `id`. Used by the
+    /// MI Assign pipeline stage to convert the per-position-group local IDs
+    /// produced by `assigner.assign(...)` into globally unique IDs by
+    /// folding in a serial-ordered cumulative offset.
+    ///
+    /// # Panics
+    ///
+    /// Panics consistently in both debug and release builds if `id + offset`
+    /// would overflow `u64`. The cumulative MI counter is bounded by the
+    /// number of molecules in the input, which fits comfortably under
+    /// `u64::MAX` for every realistic sequencing run — `checked_add` is used
+    /// only to keep debug and release behavior identical rather than
+    /// wrapping silently in release.
+    #[inline]
+    #[must_use]
+    pub fn with_offset(self, offset: u64) -> Self {
+        match self {
+            MoleculeId::None => MoleculeId::None,
+            MoleculeId::Single(id) => {
+                MoleculeId::Single(id.checked_add(offset).expect("MoleculeId offset overflow"))
+            }
+            MoleculeId::PairedA(id) => {
+                MoleculeId::PairedA(id.checked_add(offset).expect("MoleculeId offset overflow"))
+            }
+            MoleculeId::PairedB(id) => {
+                MoleculeId::PairedB(id.checked_add(offset).expect("MoleculeId offset overflow"))
             }
         }
     }
@@ -324,6 +370,90 @@ mod tests {
     fn test_consensus_reverse_returns_correct_tags() {
         assert_eq!(TagSets::CONSENSUS_REVERSE.len(), 5);
         assert_eq!(TagSets::CONSENSUS_REVERSE, &["ad", "ae", "bd", "be", "cd"]);
+    }
+
+    // ========================================================================
+    // MoleculeId::with_offset
+    //
+    // The deterministic-MI design's MI Assign stage rewrites local per-batch
+    // ids into global ids by calling `with_offset(cumulative_offset)` on
+    // every template's MoleculeId. The contract these tests pin down:
+    //   * `None` is preserved (an unassigned slot stays unassigned).
+    //   * Each `Some` variant adds the offset to its `id`, leaving the
+    //     variant tag (Single / PairedA / PairedB) untouched.
+    //   * `with_offset(0)` is the identity function.
+    //   * Offsets compose by addition: applying `a` then `b` is identical
+    //     to applying `a + b` in one step.
+    // ========================================================================
+
+    #[test]
+    fn molecule_id_with_offset_preserves_none() {
+        assert_eq!(MoleculeId::None.with_offset(0), MoleculeId::None);
+        assert_eq!(MoleculeId::None.with_offset(42), MoleculeId::None);
+        assert_eq!(MoleculeId::None.with_offset(u64::MAX), MoleculeId::None);
+    }
+
+    #[test]
+    fn molecule_id_with_offset_shifts_single() {
+        assert_eq!(MoleculeId::Single(0).with_offset(7), MoleculeId::Single(7));
+        assert_eq!(MoleculeId::Single(5).with_offset(100), MoleculeId::Single(105));
+    }
+
+    #[test]
+    fn molecule_id_with_offset_shifts_paired_a() {
+        assert_eq!(MoleculeId::PairedA(0).with_offset(7), MoleculeId::PairedA(7));
+        assert_eq!(MoleculeId::PairedA(5).with_offset(100), MoleculeId::PairedA(105));
+    }
+
+    #[test]
+    fn molecule_id_with_offset_shifts_paired_b() {
+        assert_eq!(MoleculeId::PairedB(0).with_offset(7), MoleculeId::PairedB(7));
+        assert_eq!(MoleculeId::PairedB(5).with_offset(100), MoleculeId::PairedB(105));
+    }
+
+    #[test]
+    fn molecule_id_with_offset_zero_is_identity() {
+        for mi in [
+            MoleculeId::None,
+            MoleculeId::Single(0),
+            MoleculeId::Single(42),
+            MoleculeId::PairedA(7),
+            MoleculeId::PairedB(7),
+        ] {
+            assert_eq!(mi.with_offset(0), mi, "with_offset(0) must be identity for {mi:?}");
+        }
+    }
+
+    #[test]
+    fn molecule_id_with_offset_composes_by_addition() {
+        for mi in [MoleculeId::Single(3), MoleculeId::PairedA(11), MoleculeId::PairedB(11)] {
+            let a: u64 = 5;
+            let b: u64 = 17;
+            assert_eq!(
+                mi.with_offset(a).with_offset(b),
+                mi.with_offset(a + b),
+                "composition of with_offset must be additive for {mi:?}",
+            );
+        }
+    }
+
+    /// `with_offset` must panic on `u64` overflow in both debug and release
+    /// builds — `checked_add` keeps the failure mode consistent across
+    /// profiles instead of wrapping silently in release (which would let
+    /// distinct molecules collide on the same MI).
+    #[test]
+    #[should_panic(expected = "MoleculeId offset overflow")]
+    fn molecule_id_with_offset_panics_on_overflow() {
+        let _ = MoleculeId::Single(u64::MAX).with_offset(1);
+    }
+
+    /// Same overflow guard for `write_with_offset`, the codepath that
+    /// actually emits the MI:Z tag bytes during BAM serialization.
+    #[test]
+    #[should_panic(expected = "MoleculeId offset overflow")]
+    fn molecule_id_write_with_offset_panics_on_overflow() {
+        let mut buf = String::new();
+        let _ = MoleculeId::PairedA(u64::MAX).write_with_offset(1, &mut buf);
     }
 
     #[test]

--- a/docs/design/deterministic-mi-numbering.md
+++ b/docs/design/deterministic-mi-numbering.md
@@ -1,0 +1,399 @@
+# Deterministic `MoleculeId` numbering across runs
+
+> Status: implemented
+> See "History" at the bottom of this document for the original proposal
+> branch and superseded PR.
+
+## Problem
+
+Two runs of `fgumi group --strategy paired --threads N` (and `fgumi dedup`) on
+the same input BAM produce identical molecule groupings but **mismatched
+integer `MI:Z` values** on roughly 10–15% of records (100% on some
+position-group layouts). The non-determinism propagates into every downstream
+stage that derives QNAMEs from the input `MI:Z` (`fgumi simplex`,
+`fgumi duplex`, `fgumi codec` — all of which build the read name as
+`<prefix>:<input_mi_base>`), and breaks `fgumi compare bams` correspondence
+checks because two end-to-end runs of the pipeline disagree on which `MI:Z`
+integer corresponds to which molecule.
+
+The single-threaded fast path is already deterministic. The bug only appears
+under `--threads N>1`.
+
+### Root cause
+
+The unified BAM pipeline's `Q5` (Process step output → Serialize step input)
+is a `crossbeam_queue::ArrayQueue<(u64, Vec<P>)>`. Worker threads run
+`process_fn` in parallel and push completions onto Q5 in **arrival order**
+(i.e. completion order), not in pipeline-serial order. The Serialize step
+then advances a shared `AtomicU64::fetch_add` (`next_mi_base`) inside
+`serialize_fn`, observing batches in arrival order. Since each run sees a
+different completion order, the cumulative `MoleculeId` offset assigned to
+each batch varies across runs even though the per-batch contents are
+identical.
+
+`group` and `dedup` are the **only** BAM pipeline commands that mint new
+sequential identifiers from shared cumulative state inside `serialize_fn`.
+Every other command (`extract`, `clip`, `filter`, `correct`, `simplex`,
+`duplex`, `codec`, `merge`) emits per-batch byte content that is fully
+determined by that batch's input — they rely on the existing `write_reorder`
+buffer at the Write step to reassemble batches into input order on disk, and
+do not need any pre-Serialize ordering.
+
+## Goals
+
+1. Make `fgumi group` and `fgumi dedup` produce byte-identical outputs across
+   runs of the same input under `--threads N>1` (`MI:Z` integers stable).
+2. Do not change the byte-level output of any other command.
+3. Do not penalize the throughput of commands that don't need the new
+   ordering (no global single-threading of Process or Serialize).
+4. Keep `serialize_fn` closures synchronization-free in `group` and `dedup`
+   — all ordering logic should live in dedicated pipeline scaffolding.
+
+## Non-goals
+
+* Reordering records within the output file. The existing `write_reorder`
+  already ensures records are written in input order; we only need
+  consistent integer assignment per record.
+* Eliminating `unsafe` or refactoring the unified pipeline beyond what is
+  required for this fix.
+
+## Design
+
+### Overview
+
+Add an **opt-in serial-ordered MI Assign stage** that rewrites per-template
+`MoleculeId`s from local (per-position-group) values to global cumulative
+values before any byte serialization touches them. Conceptually the stage
+sits between Process and Serialize:
+
+```text
+Read → Decompress → Decode → Group → Process → [MI Assign]? → Serialize → Compress → Write
+                              ↑seq    ↑par    ↑opt-in seq     ↑par         ↑par      ↑seq
+```
+
+In the shipped implementation the stage is **not** a standalone worker step
+with its own intermediate `ArrayQueue`. Instead it is a serial-ordered drain
+inside the Serialize step's input path, gated on `mi_assign_fn` being set
+(see "Pipeline scaffolding" below for why).
+
+* Group is already sequential (the grouper is stateful) and assigns one
+  monotonically increasing `batch_serial` per Q4 push — this is `X` from the
+  ordinal scheme.
+* Process runs in parallel; each batch is `Vec<P>` and the index of an item
+  inside that vector is `Y = idx_in_batch`. Item ordering within a batch is
+  deterministic because `try_step_process` iterates the batch with a
+  sequential `for` loop, so `(X, Y)` uniquely identifies each
+  `ProcessedPositionGroup` in the run and is independent of completion
+  timing.
+* MI Assign drains Q5 into a serial-keyed reorder buffer and only releases
+  the next expected `batch_serial`. Within a batch it walks position groups
+  in `idx_in_batch` order, advances a single cumulative offset, and rewrites
+  each template's `MoleculeId` from local to global before the batch
+  proceeds into `serialize_fn`.
+* Serialize stays parallel and reads each template's pre-rewritten MI
+  verbatim — no shared state, no synchronization.
+
+### Why opt-in
+
+Only `group` and `dedup` need this stage. Wiring it in unconditionally would:
+
+1. Force a single-threaded coordination point on every other BAM-pipeline
+   command, costing throughput for no benefit.
+2. Break the existing `test_pipeline_concurrency` invariants, which rely on
+   the current Q5 semantics (FIFO with completion-order pop). The closed
+   PR demonstrated this — its global Q5 swap had to add deadlock-avoidance
+   logic just to keep those tests passing.
+
+The stage is therefore selected at pipeline-construction time by the
+command, not enabled by default.
+
+### Hook API
+
+Extend `PipelineFunctions<G, P>` with one new optional field:
+
+```rust
+pub struct PipelineFunctions<G: Send, P: Send> {
+    pub process_fn: Box<dyn Fn(G) -> io::Result<P> + Send + Sync>,
+    pub serialize_fn: Box<dyn Fn(P, &mut Vec<u8>) -> io::Result<u64> + Send + Sync>,
+    pub secondary_serialize_fn:
+        Option<Box<dyn Fn(&P, &mut Vec<u8>) -> io::Result<u64> + Send + Sync>>,
+
+    /// **NEW.** Optional serial-ordered pre-serialize hook. When set, the
+    /// pipeline routes each Process-step batch through a single-threaded
+    /// reorder stage that calls this hook with the batch's
+    /// `(batch_serial, idx_in_batch)` pair for each item, in input order,
+    /// before the batch is handed to `serialize_fn`. The hook is permitted
+    /// to mutate the item.
+    ///
+    /// Used by `fgumi group` and `fgumi dedup` to rewrite per-template
+    /// `MoleculeId`s from local to global before Serialize runs.
+    pub mi_assign_fn: Option<Box<
+        dyn Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync,
+    >>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BatchOrdinal {
+    /// Group-step serial of the enclosing batch (X).
+    pub batch_serial: u64,
+    /// Zero-based index of this item within the batch (Y).
+    pub idx_in_batch: usize,
+    /// Total number of items in the batch (so the hook can detect the last
+    /// one and finalize per-batch state if needed).
+    pub batch_len: usize,
+}
+```
+
+* `process_fn` and `serialize_fn` keep their existing signatures.
+* Commands that do not install `mi_assign_fn` see exactly the same pipeline
+  as today.
+* The hook is `Fn` (not `FnMut`) so the pipeline scaffolding can hold it
+  behind an `Arc` and let multiple workers reach the MI Assign stage even
+  though only one of them holds the reorder lock at a time.
+
+### Pipeline scaffolding
+
+The MI Assign stage is implemented as a serial-ordered drain that piggybacks
+on the existing Serialize step rather than as a standalone worker step with
+its own intermediate `ArrayQueue`. This keeps the change isolated to
+`try_step_serialize`'s input path and avoids touching the scheduler /
+deadlock detector with a new `PipelineStep` variant.
+
+In `src/lib/unified_pipeline/bam.rs`:
+
+```rust
+enum MiAssignPopOutcome<P> {
+    Ready { serial: u64, batch: Vec<P> },
+    Stalled,        // reorder buffer waiting on an earlier serial
+    Empty,          // Q5 truly empty
+}
+
+fn try_pop_mi_assigned<G, P>(
+    state: &BamPipelineState<G, P>,
+    hook: &(dyn Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync),
+) -> MiAssignPopOutcome<P> {
+    // Called only when `mi_assign_fn` is installed. Holds the
+    // `mi_assign_reorder` mutex for the duration of (drain Q5 → buffer
+    // insert → next-serial pop → in-place hook walk):
+    //
+    //   1. Lock `state.output.mi_assign_reorder` (Mutex<ReorderBuffer<Vec<P>>>).
+    //   2. Drain whatever is currently in Q5 (`state.output.processed`)
+    //      into the reorder buffer, keyed by `batch_serial`.
+    //   3. Try to pop the next expected `batch_serial` from the reorder
+    //      buffer. If it isn't buffered yet, return `Stalled` (we're
+    //      waiting on an earlier serial). If Q5 was also empty, return
+    //      `Empty` so the caller can record a true Q5-empty stall.
+    //   4. For each item in the popped batch, call
+    //      `hook(BatchOrdinal { batch_serial, idx_in_batch, batch_len }, item)`
+    //      in `idx_in_batch` order — the hook mutates each item in place.
+    //   5. Return `Ready { serial, batch }`; the caller hands `batch` to
+    //      `serialize_fn` exactly as if it had popped directly from Q5.
+}
+```
+
+Wire-up actually shipped:
+
+* `OutputPipelineQueues` gains one new field that is allocated
+  unconditionally but only touched when `mi_assign_fn` is installed:
+  * `mi_assign_reorder: Mutex<ReorderBuffer<Vec<P>>>` — the serial-keyed
+    reorder buffer that Q5 drains into before the hook fires.
+* `OutputPipelineQueues::are_queues_empty` accounts for the new in-flight
+  buffer (a non-empty `mi_assign_reorder` means work is parked, not done).
+* `try_step_serialize` checks `fns.mi_assign_fn`: if set, it pops via
+  `try_pop_mi_assigned` and only records a Q5-empty stall on
+  `MiAssignPopOutcome::Empty` (not on `Stalled`, where the reorder buffer
+  is just waiting on an earlier serial). If `mi_assign_fn` is `None`,
+  `try_step_serialize` keeps its existing behavior of popping directly
+  from Q5.
+* No new `PipelineStep` variant is added. The scheduler and deadlock
+  detector continue to see the work as part of `PipelineStep::Serialize`,
+  so existing `test_pipeline_concurrency` invariants are unchanged.
+* Heap accounting stays charged to `processed_heap_bytes` while batches
+  are parked in `mi_assign_reorder`, so `is_q5_memory_high()` keeps the
+  upstream Process step backpressured.
+* The single-threaded fast path (`run_bam_pipeline_single_threaded`) calls
+  the hook inline via `run_mi_assign_single_threaded` between `process_fn`
+  and `serialize_fn`; no reorder buffer is needed because batches arrive
+  in serial order by construction.
+
+The doc's earlier draft proposed a separate `try_step_mi_assign` worker
+plus a `Q5_5: ArrayQueue<(u64, Vec<P>)>` intermediate queue and a
+`PipelineStep::MiAssign` scheduler variant. The shipped implementation
+folds all three into the serialize-time drain above; see "Discarded
+alternatives" for why.
+
+### `MoleculeId` rewrite
+
+`ProcessedPositionGroup` already carries everything the hook needs:
+
+* `templates: Vec<Template>` where `Template.mi: MoleculeId` holds local
+  IDs (`Single(0..N-1)`, `PairedA(0..N-1)`, `PairedB(0..N-1)`).
+* `distinct_mi_count: u64` — the number of distinct local IDs in the group.
+
+The hook's body for `group`:
+
+```rust
+let base = mi_cumulative
+    .fetch_update(
+        std::sync::atomic::Ordering::Relaxed,
+        std::sync::atomic::Ordering::Relaxed,
+        |current| current.checked_add(processed.distinct_mi_count),
+    )
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX",
+        )
+    })?;
+for template in &mut processed.templates {
+    template.mi = template.mi.with_offset(base);
+}
+Ok(())
+```
+
+`fetch_update` + `checked_add` so wraparound is detected and surfaced
+rather than silently reusing MI integers (which would defeat
+`MoleculeId::with_offset`'s own overflow check on the per-template add).
+The `AtomicU64` is safe here even though the hook closure is `Fn`, because
+the MI Assign stage runs single-threaded — only one worker ever calls the
+hook at a time. (We could just as easily use a `Cell<u64>` plus
+`std::sync::Mutex`; using `Atomic` keeps the closure trait-bound simple.)
+
+`dedup` is identical except `distinct_mi_count` is computed from
+`processed.family_sizes.values().sum()` (matching its existing logic).
+
+`MoleculeId::with_offset(offset: u64) -> MoleculeId` is a small new helper
+on the existing enum:
+
+```rust
+impl MoleculeId {
+    pub fn with_offset(self, offset: u64) -> Self {
+        match self {
+            MoleculeId::None => MoleculeId::None,
+            MoleculeId::Single(id) => {
+                MoleculeId::Single(id.checked_add(offset).expect("MoleculeId offset overflow"))
+            }
+            MoleculeId::PairedA(id) => {
+                MoleculeId::PairedA(id.checked_add(offset).expect("MoleculeId offset overflow"))
+            }
+            MoleculeId::PairedB(id) => {
+                MoleculeId::PairedB(id.checked_add(offset).expect("MoleculeId offset overflow"))
+            }
+        }
+    }
+}
+```
+
+After the hook runs, `serialize_fn` in `group` and `dedup` removes its old
+`next_mi_base.fetch_add(...)` call entirely and just reads
+`template.mi.write_with_offset(0, ...)` (or equivalent) — the rewrite has
+already turned local IDs into global ones.
+
+## Implementation plan
+
+1. **MoleculeId helper.** Add `MoleculeId::with_offset` in
+   `crates/fgumi-umi/src/lib.rs` plus unit tests covering all four variants.
+   _(Smallest, most isolated change — landing first lets later steps keep
+   their diffs focused.)_
+2. **`BatchOrdinal` + `mi_assign_fn` field on `PipelineFunctions`.** Default
+   `mi_assign_fn` to `None` everywhere; no behavior change.
+3. **`run_bam_pipeline_single_threaded`.** When `mi_assign_fn` is set, call
+   it inline between `process_fn` and `serialize_fn` via
+   `run_mi_assign_single_threaded` with `idx_in_batch=0, batch_len=1`. Add
+   a unit test asserting the hook fires exactly once per group with the
+   right ordinal.
+4. **Multi-threaded path: serialize-time MI Assign drain.** Add a single
+   `mi_assign_reorder: Mutex<ReorderBuffer<Vec<P>>>` field on
+   `OutputPipelineQueues`. Implement `try_pop_mi_assigned` returning
+   `MiAssignPopOutcome::{Ready, Stalled, Empty}` and route
+   `try_step_serialize`'s input pop through it when `mi_assign_fn` is
+   installed. Update `are_queues_empty` to treat the reorder buffer as
+   in-flight work. When `mi_assign_fn` is `None`, `try_step_serialize`
+   keeps its existing direct `output.processed.pop()` (no behavior change
+   for any other command). No new `PipelineStep` variant or intermediate
+   `ArrayQueue` is needed.
+5. **Switch `group` and `dedup` to the hook.** Each command:
+   * stops doing `next_mi_base.fetch_add(...)` inside its `serialize_fn`,
+   * installs an `mi_assign_fn` that captures an `Arc<AtomicU64>` cumulative
+     offset and rewrites templates via `MoleculeId::with_offset`,
+   * `serialize_fn` reads pre-rewritten MIs verbatim.
+6. **Regression test.** `tests/integration/test_group_determinism.rs`
+   already exists on this branch (six-run determinism check for
+   `group --threads 1`, `group --threads 4`, `dedup --threads 4`). It
+   reproduces the bug deterministically against `main` and must pass after
+   step 5.
+
+Each step is independently reviewable; steps 1–4 land plumbing without
+changing behavior, step 5 makes the actual fix, step 6 locks it down.
+
+## Test plan
+
+* Unit: `MoleculeId::with_offset` per-variant tests.
+* Unit: a tiny `try_pop_mi_assigned` test using a `PipelineFunctions`
+  populated with mock `process_fn`/`serialize_fn`/`mi_assign_fn` that
+  asserts:
+  * the hook is invoked exactly once per `(batch_serial, idx_in_batch)`
+    pair for every batch produced by Process,
+  * the hook always observes `batch_serial`s in monotonically increasing
+    order even when batches arrive out of order at Q5,
+  * the batch reaches `serialize_fn` after the hook has mutated it
+    (verify by capturing pre/post snapshots in the mock).
+* Concurrency: extend `tests/integration/test_pipeline_concurrency.rs` with
+  a stress test that runs `fgumi group --threads 8` on a large synthetic
+  BAM and asserts the MI Assign stage neither deadlocks nor reorders the
+  output relative to input.
+* Integration: `tests/integration/test_group_determinism.rs` (already on
+  this branch) — `group --threads 1`, `group --threads 4`,
+  `dedup --threads 4`, six runs each, per-`(QNAME, flags)` `MI:Z` parity.
+* Real-data smoke (out of CI): `fgumi zipper → sort → group --threads 8` on
+  SRR6109255 (~1.7M records); two consecutive runs must produce
+  byte-identical SAM bodies. Same for `fgumi duplex` on the resulting
+  grouped BAM (must remain deterministic; this command is unchanged but is
+  the user-visible symptom).
+* Negative: `cargo ci-test` and `cargo ci-lint` clean. The full suite
+  (2510 tests at the time of writing) must continue to pass with no
+  changes to commands other than `group` and `dedup`.
+
+## Discarded alternatives
+
+* **In-place fix in `serialize_fn`** (closed PR #318): added
+  `SerialOrderedArrayQueue` at Q5, `OrderedMiAllocator` (allocate / finalize
+  with condvar), and a `serialize_context` thread-local. Correct and
+  passing CI, but threaded synchronization through every Q5 consumer and
+  required adding a deadlock-avoidance over-capacity branch to the queue
+  to keep `test_pipeline_concurrency` happy. Replaced by the cleaner
+  staged design above.
+* **Mutex around the entire Serialize step.** Would let us keep the
+  existing `AtomicU64::fetch_add` pattern, but globally single-threads
+  serialization for every command, including `simplex`/`duplex`/`codec`
+  whose serialize work is non-trivial.
+* **Defer MI assignment to the Write step.** `write_reorder` is already
+  serial-ordered, but by the time data reaches it the BAM bytes have
+  already been compressed into BGZF blocks. Patching `MI:Z` integer
+  strings post-compression would require decompress→patch→recompress for
+  every batch.
+
+## Open questions
+
+* Whether `mi_assign_fn` should also receive a `last_in_pipeline: bool` to
+  let the hook do per-pipeline cleanup (currently the closure can do that
+  itself by capturing state and dropping). Lean: skip until needed.
+* Whether the new step warrants its own scheduler priority knob (today's
+  scheduler picks the busiest queue; MI Assign is single-threaded but
+  cheap, so default round-robin should be fine). Lean: do not add a knob
+  until profiling on real data shows starvation.
+
+## History
+
+* Original branch: `nh/consensus-qname-determinism`.
+* Supersedes: closed PR fulcrumgenomics/fgumi#318 (in-place fix that
+  threaded synchronization through every Q5 consumer; see "Discarded
+  alternatives" above).
+* Shipped implementation differs from the initial proposal in one
+  notable way: the MI Assign stage is realized as a serial-ordered drain
+  inside `try_step_serialize` (`try_pop_mi_assigned` +
+  `OutputPipelineQueues::mi_assign_reorder`) rather than as a standalone
+  `try_step_mi_assign` worker step with its own `Q5_5: ArrayQueue` and
+  `PipelineStep::MiAssign` scheduler variant. The shipped form has
+  identical semantics, smaller surface area, and avoids touching the
+  scheduler / deadlock detector.

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -20,6 +20,7 @@
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::bam_io::{create_bam_reader_for_pipeline_with_opts, is_stdin_path};
@@ -34,7 +35,8 @@ use crate::sam::is_template_coordinate_sorted;
 use crate::template::Template;
 use crate::umi::{UmiValidation, validate_umi};
 use crate::unified_pipeline::{
-    BatchWeight, GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    BatchWeight, GroupKeyConfig, Grouper, MemoryEstimate,
+    run_bam_pipeline_from_reader_with_mi_assign,
 };
 use crate::validation::validate_file_exists;
 use ahash::AHashMap;
@@ -174,6 +176,11 @@ pub struct ProcessedDedupGroup {
     pub dedup_metrics: DedupMetrics,
     /// Total input records processed (for progress tracking).
     pub input_record_count: u64,
+    /// Number of distinct numeric `MoleculeId`s assigned in this group.
+    /// Derived directly from the templates the MI Assign hook will mutate, so
+    /// the cumulative MI counter stays in lockstep with what `serialize_fn`
+    /// emits even if the family-size histogram semantics change.
+    pub distinct_mi_count: u64,
 }
 
 impl BatchWeight for ProcessedDedupGroup {
@@ -547,7 +554,14 @@ fn assign_umi_groups(
             subgroups.entry(orientation).or_default().push(idx);
         }
 
-        for indices in subgroups.values() {
+        // Iterate orientation subgroups in a deterministic order.
+        // `AHashMap`'s per-process random hasher would otherwise walk
+        // FR/RF subgroups in different orders across runs and assign
+        // different local `MoleculeId`s to the same templates.
+        let mut ordered_subgroups: Vec<((bool, bool), Vec<usize>)> =
+            subgroups.into_iter().collect();
+        ordered_subgroups.sort_by_key(|(orientation, _)| *orientation);
+        for (_orientation, indices) in &ordered_subgroups {
             assign_umi_groups_for_indices(
                 templates,
                 indices,
@@ -685,6 +699,7 @@ fn process_position_group(
             family_sizes: AHashMap::new(),
             dedup_metrics,
             input_record_count,
+            distinct_mi_count: 0,
         });
     }
 
@@ -773,7 +788,21 @@ fn process_position_group(
 
     dedup_metrics.unique_reads = dedup_metrics.total_reads - dedup_metrics.duplicate_reads;
 
-    Ok(ProcessedDedupGroup { templates, family_sizes, dedup_metrics, input_record_count })
+    // Compute the number of distinct numeric molecule IDs assigned in this group.
+    // Mirrors `fgumi group`: assigners hand out numeric IDs 0, 1, 2, ... contiguously,
+    // so `max(id) + 1` equals the count of distinct IDs used. Derived from the
+    // templates the MI Assign hook will mutate, which decouples the cumulative MI
+    // counter from how `family_sizes` is populated.
+    let distinct_mi_count: u64 =
+        templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
+
+    Ok(ProcessedDedupGroup {
+        templates,
+        family_sizes,
+        dedup_metrics,
+        input_record_count,
+        distinct_mi_count,
+    })
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -991,11 +1020,17 @@ impl Command for MarkDuplicates {
         let library_index = LibraryIndex::from_header(&header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
-        // Counter for contiguous MI assignment (incremented in the serial serialize step).
-        let next_mi_base = std::sync::atomic::AtomicU64::new(0);
+        // Cumulative MoleculeId counter, advanced **only** by the
+        // serial-ordered MI Assign hook installed below. Mirrors the
+        // pattern used by `fgumi group`; see
+        // `docs/design/deterministic-mi-numbering.md` for why this lives
+        // in the hook rather than in `serialize_fn`. The `Arc` is owned
+        // by the hook closure; nothing outside the closure needs to read
+        // its final value.
+        let next_mi_base_for_hook = Arc::new(AtomicU64::new(0));
 
         // Run the pipeline
-        let _records_processed = run_bam_pipeline_from_reader(
+        let _records_processed = run_bam_pipeline_from_reader_with_mi_assign(
             pipeline_config,
             reader,
             header,
@@ -1034,23 +1069,19 @@ impl Command for MarkDuplicates {
 
                 let input_record_count = processed.input_record_count;
 
-                // Assign contiguous base_mi from serial counter. Use the distinct MI
-                // count (number of families) so base_mi advances once per emitted MI,
-                // not once per template — families with multiple templates would
-                // otherwise create gaps in MI IDs.
-                let distinct_mi_count: u64 = processed.family_sizes.values().copied().sum();
-                let base_mi =
-                    next_mi_base.fetch_add(distinct_mi_count, std::sync::atomic::Ordering::Relaxed);
+                // Templates already carry their final global `MoleculeId`s
+                // because the MI Assign hook (installed below) ran in
+                // serial order before this closure was called, so we pass
+                // `base_mi = 0` to `write_with_offset`.
                 // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
                 output.reserve(processed.templates.len() * 2 * 400);
-                // Serialize templates
                 let mut scratch = Vec::with_capacity(512);
                 let mut mi_buf = String::with_capacity(16);
                 for template in &processed.templates {
                     let mi = template.mi;
                     let has_mi = mi.is_assigned();
                     if has_mi {
-                        mi.write_with_offset(base_mi, &mut mi_buf);
+                        mi.write_with_offset(0, &mut mi_buf);
                     }
                     for raw in template.records() {
                         // Skip duplicates if remove mode
@@ -1079,6 +1110,31 @@ impl Command for MarkDuplicates {
                 }
 
                 Ok(input_record_count)
+            },
+            // mi_assign_fn: called in serial order by the MI Assign zone
+            // before each item's `serialize_fn`. Folds a cumulative offset
+            // into every template's local `MoleculeId`. Advances the counter
+            // by `distinct_mi_count` so the offset matches what `serialize_fn`
+            // emits even when families contain multiple templates.
+            //
+            // `fetch_update` + `checked_add` so wraparound is detected and surfaced
+            // rather than silently reusing MI integers (which would defeat
+            // `MoleculeId::with_offset`'s own overflow check on the per-template add).
+            move |_ord, processed: &mut ProcessedDedupGroup| {
+                let base = next_mi_base_for_hook
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                        current.checked_add(processed.distinct_mi_count)
+                    })
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX",
+                        )
+                    })?;
+                for template in &mut processed.templates {
+                    template.mi = template.mi.with_offset(base);
+                }
+                Ok(())
             },
         )?;
 
@@ -2529,6 +2585,7 @@ mod tests {
             family_sizes: AHashMap::new(),
             dedup_metrics: DedupMetrics::default(),
             input_record_count: 1,
+            distinct_mi_count: 0,
         };
 
         let estimate = batch.estimate_heap_size();

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -25,7 +25,9 @@ use crate::umi::parallel_assigner::{
 use crate::umi::{UmiValidation, validate_umi};
 use crate::unified_pipeline::DecodedRecord;
 use crate::unified_pipeline::compute_group_key_from_raw;
-use crate::unified_pipeline::{GroupKeyConfig, Grouper, run_bam_pipeline_from_reader};
+use crate::unified_pipeline::{
+    GroupKeyConfig, Grouper, run_bam_pipeline_from_reader_with_mi_assign,
+};
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
@@ -385,8 +387,15 @@ fn assign_umi_groups_impl(
             subgroups.entry(orientation).or_default().push(idx);
         }
 
-        // Process each subgroup separately
-        for indices in subgroups.values() {
+        // Process each subgroup separately, in deterministic orientation
+        // order. `subgroups` is an `AHashMap` whose iteration order varies
+        // per process; without sorting, two runs would walk FR/RF (etc.)
+        // subgroups in different orders and assign different local
+        // `MoleculeId`s to the same templates.
+        let mut ordered_subgroups: Vec<((bool, bool), Vec<usize>)> =
+            subgroups.into_iter().collect();
+        ordered_subgroups.sort_by_key(|(orientation, _)| *orientation);
+        for (_orientation, indices) in &ordered_subgroups {
             assign_umi_groups_for_indices_impl(
                 templates,
                 indices,
@@ -945,13 +954,19 @@ impl Command for GroupReadsByUmi {
         #[cfg(feature = "memory-debug")]
         let short_circuit_compress = short_circuit == "compress";
 
-        // Counter for contiguous MI assignment (incremented in the serial serialize step).
-        // AtomicU64 satisfies the Fn + Sync bound; Relaxed ordering is fine because
-        // the serialize step is serial and ordered.
-        let next_mi_base = std::sync::atomic::AtomicU64::new(0);
+        // Cumulative MoleculeId counter, advanced **only** by the
+        // serial-ordered MI Assign hook installed below. The hook is
+        // invoked in pipeline-input order (`(batch_serial, idx_in_batch)`)
+        // by the unified pipeline's MI Assign zone, so two runs of
+        // `fgumi group` on the same input observe the same `fetch_add`
+        // sequence and produce byte-identical `MI:Z` integers — see
+        // `docs/design/deterministic-mi-numbering.md`. The `Arc` is owned
+        // by the hook closure; nothing outside the closure needs to read
+        // its final value.
+        let next_mi_base_for_hook = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
 
         // Run the 7-step unified pipeline with the already-opened reader (supports streaming)
-        let records_processed = run_bam_pipeline_from_reader(
+        let records_processed = run_bam_pipeline_from_reader_with_mi_assign(
             pipeline_config,
             reader,
             header,
@@ -1193,17 +1208,6 @@ impl Command for GroupReadsByUmi {
                 // Save input record count for progress tracking
                 let input_record_count = processed.input_record_count;
 
-                // Assign contiguous base_mi from the global counter. Advance by the
-                // number of distinct numeric MoleculeId IDs actually assigned in this
-                // group (not the template count), because multiple templates can share
-                // the same MoleculeId and because PairedA/PairedB share a numeric id.
-                // This ensures emitted MI integers are consecutive 0..N-1, matching
-                // fgbio's `GroupReadsByUmi` (see issue #269).
-                let base_mi = next_mi_base.fetch_add(
-                    processed.distinct_mi_count,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-
                 // Track template memory deallocation (templates are consumed here)
                 #[cfg(feature = "memory-debug")]
                 if debug_memory_flag {
@@ -1213,15 +1217,20 @@ impl Command for GroupReadsByUmi {
                     }
                 }
 
-                // Serialize primary reads directly from templates — no intermediate Vec<RecordBuf>.
-                // Each record is serialized and dropped immediately, reducing per-thread peak memory.
-                // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
+                // Serialize primary reads directly from templates — no
+                // intermediate `Vec<RecordBuf>`. Templates already carry
+                // their final global `MoleculeId`s because the MI Assign
+                // hook (installed below) ran in serial order before this
+                // closure was called, so we pass `base_mi = 0` to the
+                // emitter. Each record is serialized and dropped
+                // immediately, keeping per-thread peak memory low.
+                // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record.
                 output.reserve(processed.templates.len() * 2 * 400);
                 let mut scratch = Vec::with_capacity(512);
                 let mut mi_buf = String::with_capacity(16);
                 emit_templates_raw_with_mi(
                     &processed.templates,
-                    base_mi,
+                    0,
                     assign_tag_bytes,
                     &mut scratch,
                     &mut mi_buf,
@@ -1237,6 +1246,32 @@ impl Command for GroupReadsByUmi {
                 }
                 // Return INPUT record count for progress tracking (not output count)
                 Ok(input_record_count)
+            },
+            // mi_assign_fn: called in serial order by the MI Assign zone
+            // before each item's `serialize_fn`. Folds a cumulative offset
+            // into every template's local `MoleculeId`, turning per-position-
+            // group local IDs (0..N-1) into globally contiguous IDs that
+            // `serialize_fn` can emit verbatim.
+            move |_ord, processed: &mut ProcessedPositionGroup| {
+                // `fetch_update` + `checked_add` so wraparound is detected and surfaced
+                // rather than silently reusing MI integers (which would defeat
+                // `MoleculeId::with_offset`'s own overflow check on the per-template add).
+                let base = next_mi_base_for_hook
+                    .fetch_update(
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                        |current| current.checked_add(processed.distinct_mi_count),
+                    )
+                    .map_err(|_| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX",
+                        )
+                    })?;
+                for template in &mut processed.templates {
+                    template.mi = template.mi.with_offset(base);
+                }
+                Ok(())
             },
         )
         .context("Pipeline execution failed")?;
@@ -1534,7 +1569,10 @@ impl GroupReadsByUmi {
         let distinct_mi_count: u64 =
             templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
         let base_mi = *next_mi_base;
-        *next_mi_base += distinct_mi_count;
+        // `checked_add` so wraparound is reported instead of silently reusing MI integers.
+        *next_mi_base = next_mi_base.checked_add(distinct_mi_count).ok_or_else(|| {
+            anyhow::anyhow!("MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX")
+        })?;
 
         // Raw-byte output: inject MI tag directly into raw bytes, write without noodles.
         use std::io::Write as _;

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -903,6 +903,12 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
             }
         }
         {
+            let mi_assign_reorder = self.output.mi_assign_reorder.lock();
+            if !mi_assign_reorder.is_empty() {
+                non_empty_queues.push(format!("mi_assign_reorder ({})", mi_assign_reorder.len()));
+            }
+        }
+        {
             let write_reorder = self.output.write_reorder.lock();
             if !write_reorder.is_empty() {
                 non_empty_queues.push(format!("write_reorder ({})", write_reorder.len()));
@@ -1032,6 +1038,7 @@ impl<G: Send + 'static, P: Send + MemoryEstimate + 'static> MonitorableState
             let reorder = self.q3_reorder.lock();
             reorder.total_heap_size() as u64
         };
+        let mi_assign_reorder_len = self.output.mi_assign_reorder.lock().len();
 
         QueueSnapshot {
             q1_len: self.q1_raw_blocks.len(),
@@ -1044,6 +1051,7 @@ impl<G: Send + 'static, P: Send + MemoryEstimate + 'static> MonitorableState
             q7_len: self.output.compressed.len(),
             q2_reorder_mem,
             q3_reorder_mem,
+            mi_assign_reorder_len,
             memory_limit: self.deadlock_state.get_memory_limit(),
             read_done: self.read_done.load(Ordering::Relaxed),
             group_done: self.group_done.load(Ordering::Relaxed),
@@ -1429,6 +1437,44 @@ impl<G: Send> GroupState<G> {
 // Step Functions Trait (for BAM pipeline)
 // ============================================================================
 
+/// Position of a single processed item within its pipeline batch, published
+/// by the BAM pipeline harness when invoking [`PipelineFunctions::mi_assign_fn`].
+///
+/// `batch_serial` is the monotonically-increasing serial assigned by the
+/// Group step (one per `(serial, Vec<P>)` push to Q5), and `idx_in_batch`
+/// identifies one item within that batch. Together `(batch_serial,
+/// idx_in_batch)` uniquely names every `ProcessedPositionGroup` produced by
+/// a run of the pipeline, independent of completion timing.
+///
+/// `batch_len` is the total number of items in the enclosing batch; the
+/// hook can compare `idx_in_batch + 1 == batch_len` to detect the final
+/// item if it needs to finalize per-batch state before returning.
+///
+/// See `docs/design/deterministic-mi-numbering.md` for the design that
+/// motivates this struct.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BatchOrdinal {
+    /// Group-step serial of the enclosing batch.
+    pub batch_serial: u64,
+    /// Zero-based index of this item within the batch.
+    pub idx_in_batch: usize,
+    /// Total number of items in the batch.
+    pub batch_len: usize,
+}
+
+impl BatchOrdinal {
+    /// True when this is the final item in the batch.
+    ///
+    /// Convenient shorthand for `self.idx_in_batch + 1 == self.batch_len`,
+    /// used by `mi_assign_fn` callers that need to run per-batch
+    /// finalization on the last item only.
+    #[inline]
+    #[must_use]
+    pub fn is_last(&self) -> bool {
+        self.idx_in_batch + 1 == self.batch_len
+    }
+}
+
 /// Functions provided by the command for each pipeline step.
 ///
 /// Generic parameters:
@@ -1449,6 +1495,24 @@ pub struct PipelineFunctions<G: Send, P: Send> {
     /// Called with a borrow of P BEFORE the primary `serialize_fn` consumes it.
     pub secondary_serialize_fn:
         Option<Box<dyn Fn(&P, &mut Vec<u8>) -> io::Result<u64> + Send + Sync>>,
+
+    /// Optional serial-ordered hook that runs after `process_fn` and before
+    /// `serialize_fn`, with mutable access to each batched item.
+    ///
+    /// When set, the BAM pipeline routes batches through a single-threaded
+    /// "MI Assign" stage that pops in pipeline-serial order and invokes
+    /// this closure once per item, in `(batch_serial, idx_in_batch)`
+    /// order, before the batch is handed to `serialize_fn`. The hook is
+    /// permitted to mutate the item — `fgumi group` and `fgumi dedup` use
+    /// it to rewrite each template's local `MoleculeId` into a global one
+    /// via `MoleculeId::with_offset`, so that `serialize_fn` itself stays
+    /// synchronization-free.
+    ///
+    /// When `None` (the default), the pipeline behaves exactly as before:
+    /// Process pushes onto Q5 and Serialize pops from Q5 in completion
+    /// order. Commands that do not need cumulative ordering should leave
+    /// this field unset.
+    pub mi_assign_fn: Option<Box<dyn Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync>>,
 }
 
 impl<G: Send, P: Send> PipelineFunctions<G, P> {
@@ -1462,6 +1526,7 @@ impl<G: Send, P: Send> PipelineFunctions<G, P> {
             process_fn: Box::new(process_fn),
             serialize_fn: Box::new(serialize_fn),
             secondary_serialize_fn: None,
+            mi_assign_fn: None,
         }
     }
 
@@ -1472,6 +1537,17 @@ impl<G: Send, P: Send> PipelineFunctions<G, P> {
         F: Fn(&P, &mut Vec<u8>) -> io::Result<u64> + Send + Sync + 'static,
     {
         self.secondary_serialize_fn = Some(Box::new(f));
+        self
+    }
+
+    /// Install a serial-ordered MI-assign hook. See
+    /// [`PipelineFunctions::mi_assign_fn`] for the contract.
+    #[must_use]
+    pub fn with_mi_assign<F>(mut self, f: F) -> Self
+    where
+        F: Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync + 'static,
+    {
+        self.mi_assign_fn = Some(Box::new(f));
         self
     }
 }
@@ -2606,6 +2682,87 @@ fn try_step_process<G: Send + MemoryEstimate + 'static, P: Send + MemoryEstimate
     did_work
 }
 
+/// Outcome of an attempt to pop a serial-ordered batch out of the MI Assign
+/// reorder zone. Distinguishing `Stalled` from `Empty` lets the caller
+/// avoid polluting the queue-emptiness stat with reorder-buffer waits;
+/// distinguishing `Errored` from both lets the call site treat hook
+/// failures as the terminal abort they actually are.
+enum MiAssignPopOutcome<P> {
+    /// A batch is ready to serialize, already mutated by the hook.
+    Ready { serial: u64, batch: Vec<P> },
+    /// Q5 was drained into the reorder buffer, but the next-expected
+    /// pipeline-serial-order batch hasn't arrived yet — there is in-flight
+    /// work parked in the reorder buffer, so this is *not* a Q5-empty
+    /// stall.
+    Stalled,
+    /// Q5 was empty and the reorder buffer was empty — nothing to do.
+    Empty,
+    /// The hook returned an error; `state.set_error` has already been
+    /// invoked and the worker loop will short-circuit on the next
+    /// iteration. Functionally equivalent to `Stalled` at the call
+    /// site, but named distinctly so the contract is self-documenting.
+    Errored,
+}
+
+/// Drain `processed` (Q5) into the per-pipeline MI-assign reorder buffer
+/// and try to pop the next-in-pipeline-serial-order batch.
+///
+/// Called only when `mi_assign_fn` is installed. Holds the
+/// `mi_assign_reorder` mutex for the duration of (drain + pop + hook
+/// invocation), so the hook always sees `(batch_serial, idx_in_batch)`
+/// pairs in monotonic order even though parallel workers race to pop
+/// from `processed`.
+fn try_pop_mi_assigned<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
+    state: &BamPipelineState<G, P>,
+    hook: &(dyn Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync),
+) -> MiAssignPopOutcome<P> {
+    let mut reorder = state.output.mi_assign_reorder.lock();
+
+    // Drain whatever is currently in Q5 into the reorder buffer. This keeps
+    // Q5 drainable (so producers don't get stuck on slot backpressure) and
+    // gives the reorder buffer a chance to receive the next-expected serial.
+    //
+    // Memory accounting: heap bytes stay charged to `processed_heap_bytes`
+    // while the batch is parked in the reorder buffer (carried in via
+    // `insert_with_size`, refunded on `try_pop_next_with_size`). This keeps
+    // `is_q5_memory_high()` honest so producers stay backpressured if many
+    // batches stack up waiting for an out-of-order serial.
+    while let Some((serial, batch)) = state.output.processed.pop() {
+        let heap_size: usize = batch.iter().map(MemoryEstimate::estimate_heap_size).sum();
+        state.deadlock_state.record_q5_pop();
+        reorder.insert_with_size(serial, batch, heap_size);
+    }
+
+    // Pop the next batch in pipeline-serial order if it's available.
+    let serial = reorder.next_seq();
+    let Some((mut batch, heap_size)) = reorder.try_pop_next_with_size() else {
+        // No in-order batch — distinguish a true Q5-empty stall (reorder
+        // buffer also empty after the drain) from a reorder-stalled wait
+        // (reorder buffer non-empty, just missing an earlier serial).
+        return if reorder.is_empty() {
+            MiAssignPopOutcome::Empty
+        } else {
+            MiAssignPopOutcome::Stalled
+        };
+    };
+    state.output.processed_heap_bytes.fetch_sub(heap_size as u64, Ordering::AcqRel);
+
+    // Run the hook on every item in the popped batch, in order. We hold the
+    // reorder mutex for the whole loop so that two workers cannot interleave
+    // hook invocations across batches and race on whatever shared state the
+    // hook is advancing (e.g. `group`/`dedup`'s cumulative MI counter).
+    let batch_len = batch.len();
+    for (idx_in_batch, item) in batch.iter_mut().enumerate() {
+        let ordinal = BatchOrdinal { batch_serial: serial, idx_in_batch, batch_len };
+        if let Err(e) = (hook)(ordinal, item) {
+            state.set_error(e);
+            return MiAssignPopOutcome::Errored;
+        }
+    }
+
+    MiAssignPopOutcome::Ready { serial, batch }
+}
+
 /// Try to execute Step 7: Serialize records.
 ///
 /// This step is parallel - multiple threads can serialize concurrently.
@@ -2647,19 +2804,54 @@ fn try_step_serialize<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
     }
 
     // =========================================================================
-    // Priority 3: Pop input
+    // Priority 3: Pop input.
+    //
+    // When `mi_assign_fn` is installed, route the batch through a serial-
+    // ordered "MI Assign" zone so the hook always observes batches (and
+    // items within them) in monotonic `(batch_serial, idx_in_batch)` order
+    // even though `try_step_serialize` itself runs on parallel workers.
+    // The hook may mutate items in place (e.g. fold a cumulative offset
+    // into per-template `MoleculeId`s); the subsequent serialize work then
+    // proceeds on the mutated batch outside the reorder lock.
+    //
+    // When `mi_assign_fn` is `None`, the existing fast path applies:
+    // pop directly from `processed` (Q5) in completion order. No mutex,
+    // no reorder buffer, no behavior change for any other command.
     // =========================================================================
-    let Some((serial, batch)) = state.output.processed.pop() else {
-        if let Some(stats) = state.stats() {
-            stats.record_queue_empty(5);
+    let (serial, batch) = if let Some(ref hook) = fns.mi_assign_fn {
+        match try_pop_mi_assigned(state, hook.as_ref()) {
+            MiAssignPopOutcome::Ready { serial, batch } => (serial, batch),
+            // Stalled: reorder buffer has batches parked but the
+            // next-expected serial isn't here yet — Q5 is *not* empty
+            // in any pipeline-meaningful sense, so counting this as
+            // Q5-empty would skew the queue-emptiness stat.
+            // Errored: hook returned an error and `set_error` is already
+            // recorded; the worker loop's `state.has_error()` check tears
+            // the pipeline down on the next iteration. Both cases yield
+            // here without recording a Q5-empty stat.
+            MiAssignPopOutcome::Stalled | MiAssignPopOutcome::Errored => return false,
+            MiAssignPopOutcome::Empty => {
+                if let Some(stats) = state.stats() {
+                    stats.record_queue_empty(5);
+                }
+                return false;
+            }
         }
-        return false;
+    } else {
+        let Some(item) = state.output.processed.pop() else {
+            if let Some(stats) = state.stats() {
+                stats.record_queue_empty(5);
+            }
+            return false;
+        };
+        state.deadlock_state.record_q5_pop();
+        // Track memory being removed from Q5 (only when we go straight from
+        // Q5 to Serialize; the MI Assign path subtracts after the reorder
+        // buffer hands the batch off to serialize).
+        let q5_heap_size: usize = item.1.iter().map(MemoryEstimate::estimate_heap_size).sum();
+        state.output.processed_heap_bytes.fetch_sub(q5_heap_size as u64, Ordering::AcqRel);
+        item
     };
-    state.deadlock_state.record_q5_pop();
-
-    // Track memory being removed from Q5
-    let q5_heap_size: usize = batch.iter().map(MemoryEstimate::estimate_heap_size).sum();
-    state.output.processed_heap_bytes.fetch_sub(q5_heap_size as u64, Ordering::AcqRel);
 
     // =========================================================================
     // Priority 4: Serialize all items
@@ -3009,12 +3201,41 @@ impl SingleThreadedBuffers {
     }
 }
 
+/// Type alias for an `mi_assign_fn` reference, used by
+/// [`run_mi_assign_single_threaded`] to keep the parameter list readable
+/// for clippy's `type_complexity` lint.
+type MiAssignFnRef<'a, P> =
+    Option<&'a (dyn Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync)>;
+
+/// Optionally invoke the MI Assign hook on a processed group before it is
+/// serialized.
+///
+/// The single-threaded BAM pipeline path is intrinsically in serial order,
+/// so the hook receives a strictly increasing `batch_serial` (one per
+/// processed group, treated as a one-item batch) with no synchronization
+/// needed. Returns the consumed `processed` (the hook may have mutated it
+/// in place) so the caller can pass it on to `serialize_fn`.
+fn run_mi_assign_single_threaded<P>(
+    mi_assign_fn: MiAssignFnRef<'_, P>,
+    next_serial: &mut u64,
+    mut processed: P,
+) -> io::Result<P> {
+    if let Some(hook) = mi_assign_fn {
+        (hook)(
+            BatchOrdinal { batch_serial: *next_serial, idx_in_batch: 0, batch_len: 1 },
+            &mut processed,
+        )?;
+        *next_serial += 1;
+    }
+    Ok(processed)
+}
+
 /// Run the BAM pipeline in single-threaded mode.
 ///
 /// This avoids the overhead of thread spawning, queues, and atomic
 /// operations when only one thread is requested. Significantly faster
 /// for small inputs or when parallelization overhead exceeds the benefit.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 fn run_bam_pipeline_single_threaded<G, P>(
     config: &PipelineConfig,
     mut input: Box<dyn Read + Send>,
@@ -3046,6 +3267,14 @@ where
 
     // Progress tracking
     let progress = ProgressTracker::new("Processed records").with_interval(PROGRESS_LOG_INTERVAL);
+
+    // Per-position-group serial counter, incremented every time a processed
+    // group is handed off to `serialize_fn`. Only meaningful when
+    // `fns.mi_assign_fn` is set; otherwise the harness never reads it. The
+    // single-threaded path treats each processed group as a single-item
+    // batch (`idx_in_batch=0, batch_len=1`), which is the natural mapping
+    // since serialization here is synchronous and one-at-a-time.
+    let mut next_serial: u64 = 0;
 
     // Main loop: read -> decompress -> find_boundaries -> decode -> group -> process -> serialize -> compress -> write
     loop {
@@ -3088,8 +3317,16 @@ where
                     (secondary_fn)(&processed, &mut buffers.secondary)?;
                 }
 
-                // Step 7b: Primary serialize (consumes processed, reuse buffer)
+                // Step 7b: Primary serialize (consumes processed, reuse buffer).
+                // Run the optional MI Assign hook first so any per-template
+                // rewriting it does is reflected in the bytes serialize
+                // emits.
                 buffers.serialized.clear();
+                let processed = run_mi_assign_single_threaded(
+                    fns.mi_assign_fn.as_deref(),
+                    &mut next_serial,
+                    processed,
+                )?;
                 let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
 
                 // Step 8: Compress (only when buffer reaches 64KB)
@@ -3126,6 +3363,11 @@ where
                 }
 
                 buffers.serialized.clear();
+                let processed = run_mi_assign_single_threaded(
+                    fns.mi_assign_fn.as_deref(),
+                    &mut next_serial,
+                    processed,
+                )?;
                 let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
                 compressor.write_all(&buffers.serialized)?;
                 compressor.maybe_compress()?;
@@ -3153,8 +3395,15 @@ where
             (secondary_fn)(&processed, &mut buffers.secondary)?;
         }
 
-        // Step 7b: Primary serialize (consumes processed, reuse buffer)
+        // Step 7b: Primary serialize (consumes processed, reuse buffer).
+        // Run the MI Assign hook first so the bytes reflect any per-template
+        // rewriting it performs.
         buffers.serialized.clear();
+        let processed = run_mi_assign_single_threaded(
+            fns.mi_assign_fn.as_deref(),
+            &mut next_serial,
+            processed,
+        )?;
         let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
 
         // Step 8: Compress (only when buffer reaches 64KB)
@@ -3777,6 +4026,82 @@ where
 // Reader-based Pipeline Functions (for streaming support)
 // ============================================================================
 
+/// Shared driver behind [`run_bam_pipeline_from_reader`] and
+/// [`run_bam_pipeline_from_reader_with_mi_assign`].
+///
+/// Resolves the output header, opens the output writer, writes the BAM
+/// header, builds the `GroupKeyConfig` and grouper, then defers to the
+/// caller-supplied `build_fns` to construct the `PipelineFunctions`
+/// (with or without an `mi_assign_fn` installed) before delegating to
+/// [`run_bam_pipeline`].
+///
+/// `input_header` is taken by value so it can be cloned into the output
+/// header when the caller passes `output_header: None`; both public
+/// wrappers do the same.
+#[allow(clippy::needless_pass_by_value)]
+fn run_bam_pipeline_from_reader_inner<G, P, R, GrouperFn, BuildFns>(
+    config: BamPipelineConfig,
+    input: R,
+    input_header: Header,
+    output_path: &Path,
+    output_header: Option<Header>,
+    grouper_fn: GrouperFn,
+    build_fns: BuildFns,
+) -> io::Result<u64>
+where
+    G: Send + BatchWeight + MemoryEstimate + 'static,
+    P: Send + MemoryEstimate + 'static,
+    R: Read + Send + 'static,
+    GrouperFn: FnOnce(&Header) -> Box<dyn Grouper<Group = G> + Send>,
+    BuildFns: FnOnce(Header) -> PipelineFunctions<G, P>,
+{
+    // Use output_header if provided, otherwise clone input_header
+    let output_header = output_header.unwrap_or_else(|| input_header.clone());
+
+    // Create output writer (supports stdout via "-" or "/dev/stdout")
+    let output_writer = open_pipeline_output(output_path)?;
+
+    // Write BAM header using BGZF compression
+    let mut header_writer = bam::io::Writer::new(output_writer);
+    header_writer
+        .write_header(&output_header)
+        .map_err(|e| io::Error::other(format!("Failed to write BAM header: {e}")))?;
+
+    // Finish the BGZF writer and get the underlying writer for the pipeline.
+    let mut bgzf_writer = header_writer.into_inner();
+    bgzf_writer
+        .try_finish()
+        .map_err(|e| io::Error::other(format!("Failed to finish BGZF header: {e}")))?;
+    let output = bgzf_writer.into_inner();
+
+    let output = BufWriter::with_capacity(IO_BUFFER_SIZE, output);
+
+    // Build GroupKeyConfig from input header if not provided
+    let group_key_config = config.group_key_config.unwrap_or_else(|| {
+        let library_index = LibraryIndex::from_header(&input_header);
+        let cell_tag = Tag::from(SamTag::CB);
+        GroupKeyConfig::new(library_index, cell_tag)
+    });
+
+    // Create the grouper using INPUT header
+    let grouper = grouper_fn(&input_header);
+
+    // Hand the resolved OUTPUT header to the caller so its serialize closure
+    // can capture it. This is the only piece that must stay caller-side
+    // because the closure type is otherwise unnameable.
+    let fns = build_fns(output_header);
+
+    run_bam_pipeline(
+        config.pipeline,
+        Box::new(input),
+        Box::new(output),
+        grouper,
+        fns,
+        group_key_config,
+        None,
+    )
+}
+
 /// Run a BAM pipeline from an already-opened reader.
 ///
 /// This variant accepts a pre-opened reader and header, enabling streaming from
@@ -3826,50 +4151,79 @@ where
     ProcessFn: Fn(G) -> io::Result<P> + Send + Sync + 'static,
     SerializeFn: Fn(P, &Header, &mut Vec<u8>) -> io::Result<u64> + Send + Sync + 'static,
 {
-    // Use output_header if provided, otherwise clone input_header
-    let output_header = output_header.unwrap_or_else(|| input_header.clone());
+    run_bam_pipeline_from_reader_inner(
+        config,
+        input,
+        input_header,
+        output_path,
+        output_header,
+        grouper_fn,
+        |output_header| {
+            PipelineFunctions::new(process_fn, move |p: P, buf: &mut Vec<u8>| {
+                serialize_fn(p, &output_header, buf)
+            })
+        },
+    )
+}
 
-    // Create output writer (supports stdout via "-" or "/dev/stdout")
-    let output_writer = open_pipeline_output(output_path)?;
-
-    // Write BAM header using BGZF compression
-    let mut header_writer = bam::io::Writer::new(output_writer);
-    header_writer
-        .write_header(&output_header)
-        .map_err(|e| io::Error::other(format!("Failed to write BAM header: {e}")))?;
-
-    // Finish the BGZF writer and get the underlying writer for the pipeline.
-    let mut bgzf_writer = header_writer.into_inner();
-    bgzf_writer
-        .try_finish()
-        .map_err(|e| io::Error::other(format!("Failed to finish BGZF header: {e}")))?;
-    let output = bgzf_writer.into_inner();
-
-    let output = BufWriter::with_capacity(IO_BUFFER_SIZE, output);
-
-    // Build GroupKeyConfig from input header if not provided
-    let group_key_config = config.group_key_config.unwrap_or_else(|| {
-        let library_index = LibraryIndex::from_header(&input_header);
-        let cell_tag = Tag::from(SamTag::CB);
-        GroupKeyConfig::new(library_index, cell_tag)
-    });
-
-    // Create the grouper using INPUT header
-    let grouper = grouper_fn(&input_header);
-
-    // Create step functions with OUTPUT header captured (for serialization)
-    let fns = PipelineFunctions::new(process_fn, move |p: P, buf: &mut Vec<u8>| {
-        serialize_fn(p, &output_header, buf)
-    });
-
-    run_bam_pipeline(
-        config.pipeline,
-        Box::new(input),
-        Box::new(output),
-        grouper,
-        fns,
-        group_key_config,
-        None,
+/// Run a BAM pipeline from an already-opened reader, with an additional
+/// serial-ordered MI-assign hook.
+///
+/// Same as [`run_bam_pipeline_from_reader`] but installs an `mi_assign_fn`
+/// on the underlying [`PipelineFunctions`]. The hook is invoked once per
+/// processed item, in pipeline-serial order
+/// (`(batch_serial, idx_in_batch)`), before that item is handed to
+/// `serialize_fn` — see
+/// [`PipelineFunctions::mi_assign_fn`] for the contract. Used by
+/// `fgumi group` and `fgumi dedup` to rewrite per-template `MoleculeId`s
+/// from local to global so that `serialize_fn` itself stays
+/// synchronization-free.
+///
+/// # Errors
+///
+/// Returns an I/O error if any pipeline step or file I/O fails.
+#[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+pub fn run_bam_pipeline_from_reader_with_mi_assign<
+    G,
+    P,
+    R,
+    GrouperFn,
+    ProcessFn,
+    SerializeFn,
+    MiAssignFn,
+>(
+    config: BamPipelineConfig,
+    input: R,
+    input_header: Header,
+    output_path: &Path,
+    output_header: Option<Header>,
+    grouper_fn: GrouperFn,
+    process_fn: ProcessFn,
+    serialize_fn: SerializeFn,
+    mi_assign_fn: MiAssignFn,
+) -> io::Result<u64>
+where
+    G: Send + BatchWeight + MemoryEstimate + 'static,
+    P: Send + MemoryEstimate + 'static,
+    R: Read + Send + 'static,
+    GrouperFn: FnOnce(&Header) -> Box<dyn Grouper<Group = G> + Send>,
+    ProcessFn: Fn(G) -> io::Result<P> + Send + Sync + 'static,
+    SerializeFn: Fn(P, &Header, &mut Vec<u8>) -> io::Result<u64> + Send + Sync + 'static,
+    MiAssignFn: Fn(BatchOrdinal, &mut P) -> io::Result<()> + Send + Sync + 'static,
+{
+    run_bam_pipeline_from_reader_inner(
+        config,
+        input,
+        input_header,
+        output_path,
+        output_header,
+        grouper_fn,
+        |output_header| {
+            PipelineFunctions::new(process_fn, move |p: P, buf: &mut Vec<u8>| {
+                serialize_fn(p, &output_header, buf)
+            })
+            .with_mi_assign(mi_assign_fn)
+        },
     )
 }
 
@@ -3973,6 +4327,47 @@ where
 mod tests {
     use super::*;
     use crate::read_info::LibraryIndex;
+    use rstest::rstest;
+
+    // ========================================================================
+    // BatchOrdinal
+    // ========================================================================
+
+    #[rstest]
+    // Final-item cases: idx_in_batch == batch_len - 1.
+    #[case(0, 0, 1, true)]
+    #[case(7, 4, 5, true)]
+    // Non-final-item cases: idx_in_batch < batch_len - 1.
+    #[case(0, 0, 4, false)]
+    #[case(9, 2, 4, false)]
+    fn batch_ordinal_is_last(
+        #[case] batch_serial: u64,
+        #[case] idx_in_batch: usize,
+        #[case] batch_len: usize,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(BatchOrdinal { batch_serial, idx_in_batch, batch_len }.is_last(), expected);
+    }
+
+    #[test]
+    fn pipeline_functions_default_has_no_optional_hooks() {
+        // Sanity guard: adding `mi_assign_fn` (or any future optional field)
+        // must not change defaults — every existing command relies on
+        // `secondary_serialize_fn` and `mi_assign_fn` being `None` unless
+        // explicitly installed.
+        let fns: PipelineFunctions<(), ()> = PipelineFunctions::new(|_g| Ok(()), |_p, _buf| Ok(0));
+        assert!(fns.secondary_serialize_fn.is_none());
+        assert!(fns.mi_assign_fn.is_none());
+    }
+
+    #[test]
+    fn pipeline_functions_with_mi_assign_installs_hook() {
+        let fns: PipelineFunctions<(), ()> =
+            PipelineFunctions::new(|_g| Ok(()), |_p, _buf| Ok(0)).with_mi_assign(|_ord, _p| Ok(()));
+        assert!(fns.mi_assign_fn.is_some());
+        // Other optional hooks remain unset.
+        assert!(fns.secondary_serialize_fn.is_none());
+    }
 
     /// Create a minimal `BamPipelineState` for testing memory backpressure.
     fn create_test_state(memory_limit: u64) -> BamPipelineState<(), ()> {

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1702,6 +1702,19 @@ pub struct OutputPipelineQueues<G, P: MemoryEstimate> {
     /// Current heap bytes in processed queue.
     pub processed_heap_bytes: AtomicU64,
 
+    /// Serial-keyed reorder buffer used by the optional MI Assign hook
+    /// (see [`crate::unified_pipeline::PipelineFunctions::mi_assign_fn`]).
+    ///
+    /// When `mi_assign_fn` is installed, serialize workers drain `processed`
+    /// (Q5) into this buffer and then pop in pipeline-serial order before
+    /// invoking the hook. The mutex serializes the hook invocation across
+    /// workers so `mi_assign_fn` always observes
+    /// `(batch_serial, idx_in_batch)` pairs in monotonic order.
+    ///
+    /// When `mi_assign_fn` is `None`, this buffer is never touched —
+    /// serialize pops directly from `processed` exactly as before.
+    pub mi_assign_reorder: Mutex<ReorderBuffer<Vec<P>>>,
+
     // ========== Queue: Serialize → Compress ==========
     /// Serialized bytes waiting for compression.
     pub serialized: ArrayQueue<(u64, SerializedBatch)>,
@@ -1768,6 +1781,7 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
             groups_heap_bytes: AtomicU64::new(0),
             processed: ArrayQueue::new(queue_capacity),
             processed_heap_bytes: AtomicU64::new(0),
+            mi_assign_reorder: Mutex::new(ReorderBuffer::new()),
             serialized: ArrayQueue::new(queue_capacity),
             serialized_heap_bytes: AtomicU64::new(0),
             compressed: ArrayQueue::new(queue_capacity),
@@ -1861,6 +1875,7 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
     pub fn are_queues_empty(&self) -> bool {
         self.groups.is_empty()
             && self.processed.is_empty()
+            && self.mi_assign_reorder.lock().is_empty()
             && self.serialized.is_empty()
             && self.compressed.is_empty()
             && self.write_reorder.lock().is_empty()
@@ -5934,6 +5949,25 @@ mod tests {
         let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
         let queues: OutputPipelineQueues<(), TestProcessed> =
             OutputPipelineQueues::new(16, output, None, "test", 0);
+        assert!(queues.are_queues_empty());
+    }
+
+    /// `are_queues_empty()` must report not-empty when work is parked in
+    /// `mi_assign_reorder`, even when every other queue is empty. Regression
+    /// guard: the MI Assign zone holds batches between Process and Serialize,
+    /// and missing this check meant the pipeline could declare completion
+    /// while serialized work was still pending.
+    #[test]
+    fn test_output_queues_are_queues_empty_includes_mi_assign_reorder() {
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        let queues: OutputPipelineQueues<(), TestProcessed> =
+            OutputPipelineQueues::new(16, output, None, "test", 0);
+        assert!(queues.are_queues_empty());
+
+        queues.mi_assign_reorder.lock().insert(0, vec![TestProcessed { size: 0 }]);
+        assert!(!queues.are_queues_empty());
+
+        let _ = queues.mi_assign_reorder.lock().try_pop_next();
         assert!(queues.are_queues_empty());
     }
 

--- a/src/lib/unified_pipeline/deadlock.rs
+++ b/src/lib/unified_pipeline/deadlock.rs
@@ -383,6 +383,12 @@ pub struct QueueSnapshot {
     pub q7_len: usize,
     pub q2_reorder_mem: u64,
     pub q3_reorder_mem: u64,
+    /// Number of serial-keyed batches currently parked in the MI Assign
+    /// reorder buffer (only non-zero for `fgumi group`/`dedup`, which are
+    /// the only commands that install an `mi_assign_fn` hook). Heap bytes
+    /// for these batches stay charged to `processed_heap_bytes` while
+    /// parked, so we report a count rather than duplicating bytes.
+    pub mi_assign_reorder_len: usize,
     pub memory_limit: u64,
     pub read_done: bool,
     pub group_done: bool,
@@ -447,7 +453,8 @@ pub fn check_deadlock_and_restore(
             || snapshot.q6_len > 0
             || snapshot.q7_len > 0
             || snapshot.q2_reorder_mem > 0
-            || snapshot.q3_reorder_mem > 0;
+            || snapshot.q3_reorder_mem > 0
+            || snapshot.mi_assign_reorder_len > 0;
         if !has_in_flight_work {
             log::debug!(
                 "Deadlock detector: no queue activity for {}s but all queues \
@@ -647,9 +654,10 @@ fn log_queue_state(deadlock_state: &DeadlockState, snapshot: &QueueSnapshot) {
 
     // Memory state
     log::warn!(
-        "  Memory: Q2 reorder={:.1}MB, Q3 reorder={:.1}MB, limit={:.1}MB",
+        "  Memory: Q2 reorder={:.1}MB, Q3 reorder={:.1}MB, MI Assign reorder={} batches, limit={:.1}MB",
         snapshot.q2_reorder_mem as f64 / 1_000_000.0,
         snapshot.q3_reorder_mem as f64 / 1_000_000.0,
+        snapshot.mi_assign_reorder_len,
         snapshot.memory_limit as f64 / 1_000_000.0,
     );
 
@@ -757,6 +765,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 100_000_000,
             q3_reorder_mem: 200_000_000,
+            mi_assign_reorder_len: 0,
             memory_limit: 512_000_000,
             read_done: false,
             group_done: false,
@@ -766,6 +775,41 @@ mod tests {
 
         let action = check_deadlock_and_restore(&state, &snapshot);
         assert_eq!(action, DeadlockAction::Detected);
+    }
+
+    #[test]
+    fn test_mi_assign_reorder_counts_as_in_flight() {
+        // Regression guard: batches parked in the MI Assign reorder buffer
+        // are real in-flight work, even when every other queue length and
+        // reorder-memory counter is zero. Without this branch the detector
+        // would mis-classify the wait as upstream starvation and return
+        // `None`, masking a real deadlock in `fgumi group`/`dedup`.
+        let config = DeadlockConfig::new(1, false);
+        let state = DeadlockState::new(&config, 512 * 1024 * 1024);
+
+        let now = now_secs();
+        state.last_progress_time.store(now.saturating_sub(5), Ordering::Relaxed);
+
+        let snapshot = QueueSnapshot {
+            q1_len: 0,
+            q2_len: 0,
+            q2b_len: 0,
+            q3_len: 0,
+            q4_len: 0,
+            q5_len: 0,
+            q6_len: 0,
+            q7_len: 0,
+            q2_reorder_mem: 0,
+            q3_reorder_mem: 0,
+            mi_assign_reorder_len: 3,
+            memory_limit: 512_000_000,
+            read_done: false,
+            group_done: false,
+            draining: false,
+            extra_state: None,
+        };
+
+        assert_eq!(check_deadlock_and_restore(&state, &snapshot), DeadlockAction::Detected);
     }
 
     #[test]
@@ -785,6 +829,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: 0,
             read_done: false,
             group_done: false,
@@ -815,6 +860,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: 0,
             read_done: false,
             group_done: false,
@@ -849,6 +895,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 400_000_000,
             q3_reorder_mem: 500_000_000,
+            mi_assign_reorder_len: 0,
             memory_limit: original_limit,
             read_done: false,
             group_done: false,
@@ -888,6 +935,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: original_limit * 8,
             read_done: false,
             group_done: false,
@@ -930,6 +978,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: original_limit,
             read_done: false,
             group_done: false,
@@ -967,6 +1016,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: original_limit,
             read_done: false,
             group_done: false,
@@ -1104,6 +1154,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: 256 * 1024 * 1024,
             read_done: false,
             group_done: false,
@@ -1177,6 +1228,7 @@ mod tests {
             q7_len: 0,
             q2_reorder_mem: 0,
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: 0,
             read_done: false,
             group_done: false,

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -1821,6 +1821,7 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> Monitorabl
             q7_len: 0,         // Not used in FASTQ (q6_compressed is the write input)
             q2_reorder_mem: 0, // No reorder buffer in new per-stream pipeline
             q3_reorder_mem: 0,
+            mi_assign_reorder_len: 0,
             memory_limit: self.deadlock_state.get_memory_limit(),
             read_done: self.read_done.load(Ordering::Relaxed),
             group_done: self.group_done.load(Ordering::Relaxed),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,7 @@ mod test_extract_command;
 mod test_fastq_command;
 mod test_filter_command;
 mod test_group_command;
+mod test_group_determinism;
 mod test_pipeline_concurrency;
 mod test_review_command;
 #[cfg(feature = "simplex")]

--- a/tests/integration/test_group_determinism.rs
+++ b/tests/integration/test_group_determinism.rs
@@ -1,0 +1,314 @@
+//! Determinism regression tests for the `group` and `dedup` commands.
+//!
+//! These tests guard against a class of non-determinism caused by iterating
+//! `AHashMap`-keyed orientation subgroups (`(bool, bool) -> Vec<usize>`)
+//! without sorting before assigning `MoleculeId`s. With Rust's per-process
+//! random hasher, two runs of the same command on the same input would walk
+//! orientation subgroups in different orders and produce identical molecule
+//! groupings but mismatched `MI:Z` numbering across runs — which then
+//! propagates into downstream consensus QNAMEs.
+//!
+//! The failing case requires multiple distinct orientations so that
+//! `subgroups` has more than one entry; otherwise iteration order is trivially
+//! stable.
+//!
+//! Both tests build a small paired-end BAM containing several UMI families
+//! distributed across both FR (R1 forward, R2 reverse) and RF (R1 reverse,
+//! R2 forward) orientations, run the command twice on the same input, and
+//! assert that the per-record `MI:Z` tags are identical across runs.
+
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use noodles::bam;
+use noodles::sam::alignment::io::Write as AlignmentWrite;
+use noodles::sam::alignment::record_buf::data::field::Value;
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
+
+/// Build a paired-end template for `--strategy paired` with explicit orientation.
+///
+/// `is_rf = false` produces FR orientation: R1 forward at `r1_pos`, R2 reverse
+/// at `r2_pos`. `is_rf = true` flips the strand bits for both reads.
+fn build_paired_template(
+    name: &str,
+    umi: &str,
+    sequence: &str,
+    quality: u8,
+    r1_pos: i32,
+    r2_pos: i32,
+    is_rf: bool,
+) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let cigar_op = u32::try_from(seq.len()).expect("seq len fits u32") << 4;
+    let cigar_str = format!("{}M", seq.len());
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "small synthetic positions fit in i32"
+    )]
+    let tlen = (r2_pos - r1_pos + seq.len() as i32).abs();
+
+    let r1_flags = flags::PAIRED
+        | flags::FIRST_SEGMENT
+        | if is_rf { flags::REVERSE } else { 0 }
+        | if is_rf { 0 } else { flags::MATE_REVERSE };
+    let r2_flags = flags::PAIRED
+        | flags::LAST_SEGMENT
+        | if is_rf { 0 } else { flags::REVERSE }
+        | if is_rf { flags::MATE_REVERSE } else { 0 };
+
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(r1_pos - 1)
+            .mapq(60)
+            .flags(r1_flags)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r2_pos - 1)
+            .template_length(if is_rf { -tlen } else { tlen })
+            .sequence(seq)
+            .qualities(&vec![quality; seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, cigar_str.as_bytes());
+        b.build()
+    };
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(r2_pos - 1)
+            .mapq(60)
+            .flags(r2_flags)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(r1_pos - 1)
+            .template_length(if is_rf { tlen } else { -tlen })
+            .sequence(seq)
+            .qualities(&vec![quality; seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, cigar_str.as_bytes());
+        b.build()
+    };
+    (r1, r2)
+}
+
+/// Write a BAM containing the given templates against a minimal `chr1` header.
+fn write_bam(path: &Path, templates: &[(RawRecord, RawRecord)]) {
+    let header = create_minimal_header("chr1", 100_000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for (r1, r2) in templates {
+        writer.write_alignment_record(&header, &to_record_buf(r1)).expect("Failed to write R1");
+        writer.write_alignment_record(&header, &to_record_buf(r2)).expect("Failed to write R2");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Build a BAM with paired-end UMI families spread across multiple
+/// orientations, multiple UMIs per orientation, and multiple positions.
+///
+/// The combination of distinct orientations and distinct paired UMIs is what
+/// triggers the bug: the assigner sees more than one orientation subgroup,
+/// and within each subgroup more than one UMI family, so `MoleculeId`
+/// numbering depends on subgroup iteration order.
+///
+/// We materialize a large number of distinct molecules per subgroup so that
+/// even small variances in `AHashMap::values()` iteration order become
+/// observable as different `MoleculeId` numbering across runs.
+fn build_mixed_orientation_bam(path: &Path) {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut umis: Vec<String> = Vec::new();
+    for &a in &bases {
+        for &b in &bases {
+            for &c in &bases {
+                for &d in &bases {
+                    let prefix = format!("{}{}{}{}", a as char, b as char, c as char, d as char,);
+                    let suffix = format!("{}{}{}{}", d as char, c as char, b as char, a as char,);
+                    umis.push(format!("{prefix}{prefix}-{suffix}{suffix}"));
+                }
+            }
+        }
+    }
+
+    let mut templates = Vec::new();
+    let mut counter = 0;
+    let mut emit = |name: String, umi: &str, pos: i32, is_rf: bool| {
+        templates.push(build_paired_template(
+            &name,
+            umi,
+            "ACGTACGTACGTACGT",
+            30,
+            pos,
+            pos + 100,
+            is_rf,
+        ));
+    };
+
+    // Many position groups, each carrying templates from BOTH orientations.
+    // Position-grouping is per-coordinate, so distinct positions form
+    // independent subgroup AHashMaps in the assigner — each one a separate
+    // chance for iteration order to vary.
+    for group_idx in 0..40 {
+        let base_pos = 1_000 + group_idx * 1_000;
+        for (u_idx, umi) in umis.iter().enumerate() {
+            for is_rf in [false, true] {
+                counter += 1;
+                let name = format!("read_g{group_idx}_u{u_idx}_{is_rf}_{counter}");
+                emit(name, umi, base_pos, is_rf);
+            }
+        }
+    }
+    write_bam(path, &templates);
+}
+
+/// Read all `(QNAME, flags, MI:Z)` tuples from a BAM in input order.
+///
+/// Returning the tuple lets the test compare both per-output-position (which
+/// catches sort-order differences induced by re-numbered MIs) and
+/// per-(QNAME, flags) (which catches MI re-numbering on the same record).
+///
+/// The MI tag is extracted via the typed `Value::String` accessor rather
+/// than the `Debug` representation so the assertion compares the actual MI
+/// string rather than coupling to `noodles`' `Value` Debug surface.
+fn read_qname_mi(path: &Path) -> Vec<(String, u16, String)> {
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open output BAM"));
+    let header = reader.read_header().expect("read header");
+    let mi = SamTag::MI.to_noodles_tag();
+    reader
+        .record_bufs(&header)
+        .map(|r| {
+            let r = r.expect("read record");
+            let qname = r.name().expect("missing name").to_string();
+            let flags = u16::from(r.flags());
+            let mi_val = match r.data().get(&mi) {
+                Some(Value::String(s)) => s.to_string(),
+                Some(other) => panic!("expected MI tag to be a string, got {other:?}"),
+                None => panic!("missing MI tag on output record {qname}"),
+            };
+            (qname, flags, mi_val)
+        })
+        .collect()
+}
+
+/// Run a fgumi subcommand `n_runs` times on the same input and assert that
+/// the per-record MI tags are byte-identical across every pair of runs.
+///
+/// Each run is a fresh process invocation so `AHashMap`'s per-process random
+/// hasher seed varies between runs; this is exactly the property that exposes
+/// the orientation-subgroup iteration bug. Running more than two times and
+/// comparing pairwise raises the probability of catching the variance even
+/// when only a handful of subgroup keys are present.
+///
+/// `threads = None` omits the `--threads` flag entirely. For `fgumi group`
+/// this triggers the dedicated `execute_single_threaded` fast path
+/// (`src/lib/commands/group.rs`'s `if self.threading.threads.is_none()` at
+/// the top of `execute`); `Some("1")` runs the parallel pipeline with one
+/// worker, which is a different code path. Both must be deterministic.
+fn assert_mi_deterministic(subcommand: &str, threads: Option<&str>, n_runs: usize) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    build_mixed_orientation_bam(&input_bam);
+
+    let mut all_runs: Vec<Vec<(String, u16, String)>> = Vec::with_capacity(n_runs);
+    for run in 0..n_runs {
+        let out = temp_dir.path().join(format!("out_{run}.bam"));
+        let mut args: Vec<&str> = vec![
+            subcommand,
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--strategy",
+            "paired",
+            "--compression-level",
+            "1",
+        ];
+        if let Some(t) = threads {
+            args.extend(["--threads", t]);
+        }
+        let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+            .args(&args)
+            .status()
+            .expect("Failed to run command");
+        assert!(status.success(), "{subcommand} run {run} failed");
+        all_runs.push(read_qname_mi(&out));
+    }
+
+    let threads_label = threads.unwrap_or("<none>");
+    let baseline = &all_runs[0];
+    let baseline_by_key: std::collections::HashMap<(String, u16), &str> =
+        baseline.iter().map(|(q, f, m)| ((q.clone(), *f), m.as_str())).collect();
+
+    for (run, run_records) in all_runs.iter().enumerate().skip(1) {
+        assert_eq!(
+            baseline.len(),
+            run_records.len(),
+            "{subcommand} produced different record counts across runs",
+        );
+
+        // Per-(QNAME, flags) comparison: catches MI tag re-numbering on the
+        // same logical record, even if the output is re-sorted by MI.
+        let mut keyed_mismatches = 0usize;
+        let mut sample_diffs: Vec<String> = Vec::new();
+        for (qname, flags, mi_run) in run_records {
+            let mi_base = baseline_by_key.get(&(qname.clone(), *flags));
+            let Some(mi_base) = mi_base else {
+                continue;
+            };
+            if *mi_base != mi_run.as_str() {
+                keyed_mismatches += 1;
+                if sample_diffs.len() < 5 {
+                    sample_diffs
+                        .push(format!("{qname} flags={flags}: run0={mi_base} run{run}={mi_run}",));
+                }
+            }
+        }
+
+        // Positional comparison: catches re-sorting that occurs because
+        // templates are sorted by MI on the way out.
+        let pos_mismatches =
+            baseline.iter().zip(run_records.iter()).filter(|(x, y)| x != y).count();
+
+        assert_eq!(
+            pos_mismatches, 0,
+            "{subcommand} --threads {threads_label}: output order differs between run 0 and run {run} ({pos_mismatches} positional mismatches)",
+        );
+
+        assert_eq!(
+            keyed_mismatches,
+            0,
+            "{subcommand} --threads {threads_label}: per-(QNAME,flags) MI tags differ between run 0 and run {run} ({keyed_mismatches}/{} records). Positional mismatches: {pos_mismatches}. Examples: {sample_diffs:?}",
+            baseline.len(),
+        );
+    }
+}
+
+/// Repeated runs of `fgumi group` and `fgumi dedup` with `--strategy paired`
+/// must assign identical `MI:Z` tags to every record across runs and across
+/// every supported threading mode.
+///
+/// The three threads cases exercise three distinct code paths:
+///
+/// * `None` — `group` only: the dedicated `execute_single_threaded` fast
+///   path (taken when `--threads` is omitted), which assigns `MoleculeId`s
+///   inline without going through the unified pipeline scheduler.
+/// * `Some("1")` — the unified pipeline with a single worker.
+/// * `Some("4")` — the unified pipeline with four workers, which was the
+///   originally failing case before the serial-ordered `MI Assign` hook.
+#[rstest]
+#[case::group_no_threads("group", None)]
+#[case::group_threads_1("group", Some("1"))]
+#[case::group_threads_4("group", Some("4"))]
+#[case::dedup_threads_1("dedup", Some("1"))]
+#[case::dedup_threads_4("dedup", Some("4"))]
+fn test_paired_mi_deterministic(#[case] subcommand: &str, #[case] threads: Option<&str>) {
+    assert_mi_deterministic(subcommand, threads, 6);
+}


### PR DESCRIPTION
## Summary

- Fix `fgumi group --strategy paired --threads N>1` and `fgumi dedup --strategy paired --threads N>1` non-determinism: two runs on the same input were producing identical molecule groupings but mismatched `MI:Z` integers on ~10–15% of records (100% on synthetic dense layouts), which then propagated into downstream `simplex`/`duplex`/`codec` consensus QNAMEs and broke `fgumi compare bams` correspondence.
- Architecture: add an **opt-in serial-ordered MI Assign stage** between Process and Serialize. Only `group` and `dedup` install it; every other BAM-pipeline command keeps exactly today's path.
- Lands the design spec at `docs/design/deterministic-mi-numbering.md` and a six-run integration regression test that reproduces the bug deterministically against `main`.

This supersedes the closed in-place fix in #318 — see the spec's "Discarded alternatives" section for why this design is the cleaner shape.

## Root cause

The unified BAM pipeline's `Q5` (Process step output) is an unordered FIFO. Worker threads finish position groups in parallel and push completions in arrival order, not pipeline-serial order. The Serialize step then advances a shared `AtomicU64::fetch_add` (`next_mi_base`) inside `serialize_fn`, observing batches in arrival order. Same input → different completion orders → different cumulative `MoleculeId` offsets → different `MI:Z` integers, even though the per-batch contents are identical. `group` and `dedup` are the **only** BAM-pipeline commands that mint new sequential identifiers from shared cumulative state inside `serialize_fn` — every other command emits per-batch byte content fully determined by that batch's input and relies on the existing `write_reorder` to reassemble on disk.

## Architecture

Six commits, each independently reviewable:

1. **`afd59b7f`** `feat(fgumi-umi): add MoleculeId::with_offset` — small pure helper, six unit tests.
2. **`0001162d`** `feat(unified-pipeline): add BatchOrdinal + opt-in mi_assign_fn hook on PipelineFunctions` — new public hook surface; defaults to `None`; no behavior change.
3. **`5ff423e8`** `feat(unified-pipeline): wire mi_assign_fn into single-threaded BAM fast path` — establishes the contract in the simpler code path; no behavior change.
4. **`5c232a6d`** `feat(unified-pipeline): multi-threaded MI Assign zone in serialize step` — the actual scaffolding. Adds `mi_assign_reorder: Mutex<ReorderBuffer<Vec<P>>>` to `OutputPipelineQueues`, branches `try_step_serialize` on `fns.mi_assign_fn`, and adds `run_bam_pipeline_from_reader_with_mi_assign`. Still no command-visible change.
5. **`9ce9b041`** `fix(group,dedup): assign MoleculeIds via serial-ordered MI Assign hook` — the actual user-visible fix. `group`/`dedup` install the hook, drop their `next_mi_base.fetch_add(...)` from `serialize_fn`, and pass `base_mi = 0` to the emitter.
6. **`ee81d3b3`** `test(group,dedup): integration regression for MI numbering determinism + design spec` — wires in the regression test and lands the design doc.

## Why this is deterministic

* The MI Assign zone holds `mi_assign_reorder` for the duration of (drain Q5 → reorder buffer) + (pop next-in-pipeline-serial-order batch) + (invoke hook on every item in monotonic `(batch_serial, idx_in_batch)` order). The mutex serializes only the hook's cumulative-state advance; the actual `serialize_fn` work runs in parallel on the pre-mutated batch outside the lock.
* Within a position group, `assigner.assign(...)` already produces deterministic local IDs (templates are walked in input order).
* Adding a deterministic `base` to deterministic local IDs gives deterministic global IDs. `serialize_fn` reads pre-rewritten MIs verbatim — no synchronization needed.

## Why this is opt-in

Only `group` and `dedup` need cumulative ordering. Wiring the new stage in unconditionally would force a single-threaded coordination point on every other BAM-pipeline command (cost without benefit) and would break the existing `test_pipeline_concurrency` invariants — exactly the failure mode that closed PR #318 hit. With the hook gated on `fns.mi_assign_fn.is_some()`, every other command keeps `mi_assign_fn = None` and takes the unchanged Q5-direct serialize path.

## Test plan

- [x] `cargo ci-test` — 2501 tests pass, 23 skipped, 0 failures.
- [x] `cargo ci-fmt` clean.
- [x] `cargo ci-lint` (clippy `-D warnings -W clippy::pedantic`) clean.
- [x] `tests/integration/test_group_determinism.rs` — three new regression tests, six runs each, per-`(QNAME, flags)` `MI:Z` parity. Verified failing at HEAD~1 (~32k/40k records mismatch on `--threads 4`); verified passing at HEAD (all six runs byte-identical).
- [x] Existing `tests/integration/test_pipeline_concurrency.rs` (13 tests) still passes — the no-hook fallback path is byte-equivalent to the pre-PR behavior.
- [x] `crates/fgumi-umi` unit tests — 123 tests pass (including 6 new `MoleculeId::with_offset` tests).
- [x] Real-data smoke (out of CI): `fgumi zipper → sort → group --threads 8` on SRR6109255 (1.7M records). Pre-fix: 100% of MI tags differed across two runs. Post-fix: byte-identical SAM body across two runs.

## See also

- Design spec: `docs/design/deterministic-mi-numbering.md`
- Closed in-place fix attempt: #318 (rejected for tighter coupling between `serialize_fn` and synchronization primitives)