### PR TITLE
docs(readme): use absolute URLs for logo images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Fulcrum Genomics Unique Molecular Indexing (UMI) Tools - a suite of high-perform
 <p>
 <a href="https://fulcrumgenomics.com">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset=".github/logos/fulcrumgenomics-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset=".github/logos/fulcrumgenomics-light.svg">
-  <img alt="Fulcrum Genomics" src=".github/logos/fulcrumgenomics-light.svg" height="100">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fulcrumgenomics/fgumi/main/.github/logos/fulcrumgenomics-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fulcrumgenomics/fgumi/main/.github/logos/fulcrumgenomics-light.svg">
+  <img alt="Fulcrum Genomics" src="https://raw.githubusercontent.com/fulcrumgenomics/fgumi/main/.github/logos/fulcrumgenomics-light.svg" height="100">
 </picture>
 </a>
 </p>


### PR DESCRIPTION
## Why

crates.io strips relative image paths from rendered READMEs, so the logo at the top of [`fgumi`'s crate page](https://crates.io/crates/fgumi) is broken. Switching to absolute `raw.githubusercontent.com` URLs renders correctly on both GitHub and crates.io.

## What changed

- Replaced relative `srcset`/`src` paths with absolute raw URLs pinned to `main`.
- GitHub continues to honor `<picture>` dark/light switching; crates.io ignores `<source>` and falls back to the `<img>` (light variant), which is the same behavior as before, just no longer broken.

## Note

The crate page itself only updates on the next published version — this PR prevents future releases from being broken, but doesn't refresh the existing crate page.