### PR TITLE
feat(runall): add correct and extract→correct chains

### DIFF
--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -68,7 +68,7 @@ use noodles::sam::alignment::record::data::field::Tag;
 use parking_lot::Mutex;
 use std::io;
 use std::num::NonZero;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -261,8 +261,13 @@ pub struct CorrectUmis {
     pub queue_memory: QueueMemoryOptions,
 }
 
+/// Reason a UMI correction was rejected.
+///
+/// Exposed at `pub(crate)` so the runall correct chain runners can share the
+/// same template-level correction primitives that the standalone
+/// [`CorrectUmis`] command uses.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum RejectionReason {
+pub(crate) enum RejectionReason {
     WrongLength,
     Mismatched,
     #[default]
@@ -273,22 +278,26 @@ enum RejectionReason {
 ///
 /// This struct holds the result of correcting a UMI once for an entire template,
 /// which can then be applied to all records in that template.
+///
+/// Exposed at `pub(crate)` so the runall correct chain runners can call
+/// [`CorrectUmis::compute_template_correction`] /
+/// [`CorrectUmis::apply_correction_to_raw`] directly.
 #[derive(Debug)]
-struct TemplateCorrection {
+pub(crate) struct TemplateCorrection {
     /// Whether the UMI matched successfully.
-    matched: bool,
+    pub(crate) matched: bool,
     /// The corrected UMI string (if matched).
-    corrected_umi: Option<String>,
+    pub(crate) corrected_umi: Option<String>,
     /// The original UMI string.
-    original_umi: String,
+    pub(crate) original_umi: String,
     /// Whether correction was needed (mismatches > 0 or revcomp).
-    needs_correction: bool,
+    pub(crate) needs_correction: bool,
     /// Whether there were actual mismatches (not just revcomp).
-    has_mismatches: bool,
+    pub(crate) has_mismatches: bool,
     /// Match details for metrics.
-    matches: Vec<UmiMatch>,
+    pub(crate) matches: Vec<UmiMatch>,
     /// Rejection reason if not matched.
-    rejection_reason: RejectionReason,
+    pub(crate) rejection_reason: RejectionReason,
 }
 
 // ============================================================================
@@ -536,7 +545,7 @@ impl CorrectUmis {
 
     /// Compute UMI correction for a template (called once per template).
     #[allow(clippy::too_many_arguments)]
-    fn compute_template_correction(
+    pub(crate) fn compute_template_correction(
         umi: &str,
         umi_length: usize,
         revcomp: bool,
@@ -639,7 +648,7 @@ impl CorrectUmis {
     /// - Records have different UMIs
     /// - Some records have UMIs and others don't
     /// - UMI tag has non-string type
-    fn extract_and_validate_template_umi_raw(
+    pub(crate) fn extract_and_validate_template_umi_raw(
         raw_records: &[RawRecord],
         umi_tag: [u8; 2],
     ) -> anyhow::Result<Option<String>> {
@@ -693,7 +702,7 @@ impl CorrectUmis {
     }
 
     /// Apply UMI correction to a raw BAM record.
-    fn apply_correction_to_raw(
+    pub(crate) fn apply_correction_to_raw(
         record: &mut RawRecord,
         correction: &TemplateCorrection,
         umi_tag: [u8; 2],
@@ -728,44 +737,14 @@ impl CorrectUmis {
         umi_metrics: &mut AHashMap<String, UmiCorrectionMetrics>,
         unmatched_umi: &str,
     ) -> Result<()> {
-        // Calculate totals
-        let total: u64 = umi_metrics.values().map(|m| m.total_matches).sum();
-        let matched_total: u64 = umi_metrics
-            .iter()
-            .filter(|(umi, _)| *umi != unmatched_umi)
-            .map(|(_, m)| m.total_matches)
-            .sum();
-
-        // Calculate fractions (allow NaN when total is 0, matching fgbio behavior)
-        #[allow(clippy::cast_precision_loss)]
-        for metric in umi_metrics.values_mut() {
-            metric.fraction_of_matches = metric.total_matches as f64 / total as f64;
-        }
-
-        // Calculate representations (allow NaN/Infinity, matching fgbio behavior)
-        let umi_count = umi_metrics.keys().filter(|umi| *umi != unmatched_umi).count();
-
-        #[allow(clippy::cast_precision_loss)]
-        let mean = matched_total as f64 / umi_count as f64;
-        for metric in umi_metrics.values_mut() {
-            metric.representation = metric.total_matches as f64 / mean;
-        }
-
-        // Write metrics if requested
-        if let Some(path) = &self.metrics {
-            let mut metrics: Vec<UmiCorrectionMetrics> = umi_metrics.values().cloned().collect();
-            metrics.sort_by(|a, b| a.umi.cmp(&b.umi));
-            UmiCorrectionMetrics::write_metrics(&metrics, path)?;
-        }
-
-        Ok(())
+        finalize_correct_metrics(self.metrics.as_deref(), umi_metrics, unmatched_umi)
     }
 
     /// Execute using the 7-step unified pipeline.
     ///
-    /// This method uses the template-based grouper to process records in batches,
-    /// with parallel decompression, processing, and compression.
-    #[allow(clippy::too_many_lines)]
+    /// Thin wrapper around the free [`run_correct_pipeline`] function so the
+    /// runall correct chain runner can drive the same pipeline body without
+    /// holding a [`CorrectUmis`] instance.
     fn execute_threads_mode(
         &self,
         num_threads: usize,
@@ -775,358 +754,27 @@ impl CorrectUmis {
         umi_length: usize,
         track_rejects: bool,
     ) -> Result<u64> {
-        // Configure pipeline - correct is ReaderHeavy (70% in decompression)
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
+        run_correct_pipeline(CorrectPipelineParams {
             num_threads,
-        )?;
-
-        // Enable raw-byte mode (correct uses TemplateGrouper, no cell tag needed)
-        {
-            use crate::read_info::LibraryIndex;
-            use crate::unified_pipeline::GroupKeyConfig;
-
-            let library_index = LibraryIndex::from_header(&header);
-            pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw_no_cell(library_index));
-        }
-
-        // Per-thread metrics accumulator: bounded memory, no unbounded queue.
-        let collected_metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(num_threads);
-        let collected_for_serialize = Arc::clone(&collected_metrics);
-
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk from process_fn, per-template, so no batch-level buffering.
-        // Because workers flush under a mutex rather than through the ordered
-        // serialize stage, reject records are emitted in mutex-acquisition
-        // order, not input order; mark the rejects header as SO:unsorted so
-        // downstream tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
-            if let Some(path) = self.rejects_opts.rejects.as_ref() {
-                let writer_threads = self.threading.num_threads();
-                let rejects_header = header_as_unsorted(&header);
-                let w = create_raw_bam_writer(
-                    path,
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                Some(Arc::new(Mutex::new(Some(w))))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
-
-        // Configuration for closures
-        const BATCH_SIZE: usize = 1000; // Templates per batch
-        let max_mismatches = self.max_mismatches;
-        let min_distance_diff = self.min_distance_diff;
-        let umi_tag = Tag::from(SamTag::RX);
-        let revcomp = self.revcomp;
-        let cache_size = self.cache_size;
-        let dont_store_original_umis = self.dont_store_original_umis;
-
-        // Progress tracking
-        let progress_counter = Arc::new(AtomicU64::new(0));
-        let progress_for_process = Arc::clone(&progress_counter);
-
-        // Unmatched UMI string for rejected reads (matches fgbio behavior)
-        let unmatched_umi = "N".repeat(umi_length);
-        let unmatched_umi_for_process = unmatched_umi.clone();
-
-        // Clone the UMI set for post-aggregation use (before closure moves original)
-        let encoded_umi_set_for_metrics = Arc::clone(&encoded_umi_set);
-
-        // Grouper: batch templates by QNAME
-        let grouper_fn = move |_header: &Header| {
-            Box::new(TemplateGrouper::new(BATCH_SIZE))
-                as Box<dyn Grouper<Group = TemplateBatch> + Send>
-        };
-
-        // Process function: correct UMIs in each template batch
-        let process_fn = move |batch: TemplateBatch| -> io::Result<CorrectProcessedBatch> {
-            // Per-thread LRU cache for UMI matching
-            thread_local! {
-                static CACHE: std::cell::RefCell<Option<LruCache<Vec<u8>, UmiMatch>>> = const { std::cell::RefCell::new(None) };
-            }
-
-            CACHE.with(|cache_cell| {
-                let mut cache_ref = cache_cell.borrow_mut();
-                if cache_ref.is_none() && cache_size > 0 {
-                    *cache_ref = Some(LruCache::new(
-                        NonZero::new(cache_size).expect("cache_size > 0 checked above"),
-                    ));
-                }
-
-                let mut kept_raw_records: Vec<RawRecord> = Vec::new();
-                let mut missing_umis = 0u64;
-                let mut wrong_length = 0u64;
-                let mut mismatched = 0u64;
-                let mut umi_matches_map: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
-                let templates_count = batch.len() as u64;
-                // Count ALL input records for progress tracking (not just kept/rejected)
-                let mut total_input_records = 0u64;
-                let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
-
-                // Stream rejected records straight to disk so they don't
-                // accumulate in a batch-level Vec. The mutex only serializes
-                // the raw-byte append; BGZF compression runs on the writer's
-                // own thread pool.
-                let flush_raw_records = |recs: Vec<RawRecord>| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in &recs {
-                                    w.write_raw_record(raw.as_ref())?;
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                };
-
-                for template in batch {
-                    // Count input records BEFORE processing
-                    total_input_records += template.read_count() as u64;
-
-                    {
-                        let raw_records: Vec<RawRecord> = template.into_records();
-                        let umi_opt = Self::extract_and_validate_template_umi_raw(
-                            &raw_records,
-                            umi_tag_bytes,
-                        )
-                        .map_err(io::Error::other)?;
-
-                        match umi_opt {
-                            None => {
-                                let num_records = raw_records.len() as u64;
-                                missing_umis += num_records;
-                                let entry = umi_matches_map
-                                    .entry(unmatched_umi_for_process.clone())
-                                    .or_insert_with(|| {
-                                        UmiCorrectionMetrics::new(unmatched_umi_for_process.clone())
-                                    });
-                                entry.total_matches += num_records;
-                                if track_rejects {
-                                    flush_raw_records(raw_records)?;
-                                }
-                            }
-                            Some(umi) => {
-                                let correction = Self::compute_template_correction(
-                                    &umi,
-                                    umi_length,
-                                    revcomp,
-                                    max_mismatches,
-                                    min_distance_diff,
-                                    &encoded_umi_set,
-                                    &mut cache_ref,
-                                );
-                                let num_records = raw_records.len() as u64;
-
-                                if correction.matched {
-                                    for m in &correction.matches {
-                                        if m.matched {
-                                            let entry = umi_matches_map
-                                                .entry(m.umi.clone())
-                                                .or_insert_with(|| {
-                                                    UmiCorrectionMetrics::new(m.umi.clone())
-                                                });
-                                            entry.total_matches += num_records;
-                                            match m.mismatches {
-                                                0 => entry.perfect_matches += num_records,
-                                                1 => entry.one_mismatch_matches += num_records,
-                                                2 => entry.two_mismatch_matches += num_records,
-                                                _ => entry.other_matches += num_records,
-                                            }
-                                        }
-                                    }
-
-                                    for mut raw in raw_records {
-                                        Self::apply_correction_to_raw(
-                                            &mut raw,
-                                            &correction,
-                                            umi_tag_bytes,
-                                            dont_store_original_umis,
-                                        );
-                                        kept_raw_records.push(raw);
-                                    }
-                                } else {
-                                    match correction.rejection_reason {
-                                        RejectionReason::WrongLength => {
-                                            wrong_length += num_records;
-                                        }
-                                        RejectionReason::Mismatched => {
-                                            mismatched += num_records;
-                                        }
-                                        RejectionReason::None => {}
-                                    }
-                                    let entry = umi_matches_map
-                                        .entry(unmatched_umi_for_process.clone())
-                                        .or_insert_with(|| {
-                                            UmiCorrectionMetrics::new(
-                                                unmatched_umi_for_process.clone(),
-                                            )
-                                        });
-                                    entry.total_matches += num_records;
-                                    if track_rejects {
-                                        flush_raw_records(raw_records)?;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Progress logging (count ALL input records, not just output)
-                let count = progress_for_process.fetch_add(total_input_records, Ordering::Relaxed);
-                if (count + total_input_records) / 1_000_000 > count / 1_000_000 {
-                    info!("Processed {} records", count + total_input_records);
-                }
-
-                Ok(CorrectProcessedBatch {
-                    kept_raw_records,
-                    templates_count,
-                    missing_umis,
-                    wrong_length,
-                    mismatched,
-                    umi_matches: umi_matches_map,
-                })
-            })
-        };
-
-        // Serialize function: convert records to bytes and collect metrics
-        let serialize_fn = move |mut processed: CorrectProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            // Rejects were already streamed to disk in process_fn.
-            // Merge per-batch counts + UMI matches into this worker's
-            // accumulator slot.
-            let umi_matches = std::mem::take(&mut processed.umi_matches);
-            collected_for_serialize.with_slot(|m| {
-                m.templates_processed += processed.templates_count;
-                m.missing_umis += processed.missing_umis;
-                m.wrong_length += processed.wrong_length;
-                m.mismatched += processed.mismatched;
-                for (umi, counts) in umi_matches {
-                    merge_umi_counts(&mut m.umi_matches, umi, &counts);
-                }
-            });
-
-            // Serialize kept records
-            let mut kept_count = 0u64;
-            for raw in &processed.kept_raw_records {
-                let block_size = raw.len() as u32;
-                output.extend_from_slice(&block_size.to_le_bytes());
-                output.extend_from_slice(raw);
-                kept_count += 1;
-            }
-            // Return KEPT record count (not input count, to avoid double-counting)
-            Ok(kept_count)
-        };
-
-        // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let pipeline_result = run_bam_pipeline_from_reader(
-            pipeline_config,
             reader,
             header,
-            &self.io.output,
-            None, // Use input header for output
-            grouper_fn,
-            process_fn,
-            serialize_fn,
-        );
-
-        // Always finalize the rejects writer, even if the pipeline failed, so any
-        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
-        // finish() failures alongside any pipeline error so neither is silently
-        // dropped.
-        let rejects_finish_result = rejects_writer
-            .and_then(|rw_arc| rw_arc.lock().take())
-            .map(|writer| writer.finish().context("Failed to finish rejects file"));
-
-        let records_written = match (pipeline_result, rejects_finish_result) {
-            (Ok(records_written), Some(Ok(()))) => {
-                info!("Rejected records streamed to rejects file during processing");
-                records_written
-            }
-            (Ok(records_written), None) => records_written,
-            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
-            (Err(pipeline_err), Some(Err(finish_err))) => {
-                return Err(anyhow::anyhow!(
-                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
-                ));
-            }
-            (Err(pipeline_err), _) => return Err(pipeline_err.into()),
-        };
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_templates = 0u64;
-        let mut total_missing = 0u64;
-        let mut total_wrong_length = 0u64;
-        let mut total_mismatched = 0u64;
-        let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
-
-        for slot in collected_metrics.slots() {
-            let mut m = slot.lock();
-            total_templates += m.templates_processed;
-            total_missing += m.missing_umis;
-            total_wrong_length += m.wrong_length;
-            total_mismatched += m.mismatched;
-
-            for (umi, counts) in m.umi_matches.drain() {
-                merge_umi_counts(&mut merged_umi_matches, umi, &counts);
-            }
-        }
-
-        // Ensure ALL UMI rows are present (even with zero counts) - matches fgbio behavior
-        for umi in encoded_umi_set_for_metrics.strings.iter().chain(std::iter::once(&unmatched_umi))
-        {
-            merged_umi_matches
-                .entry(umi.clone())
-                .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
-        }
-
-        // Finalize and write metrics if requested
-        self.finalize_metrics(&mut merged_umi_matches, &unmatched_umi)?;
-
-        // Log summary (records_written = kept records only)
-        let rejected = total_missing + total_wrong_length + total_mismatched;
-        let total_records = records_written + rejected;
-        info!("Read {total_records}; kept {records_written} and rejected {rejected}");
-        info!("Total templates processed: {total_templates}");
-
-        if total_missing > 0 || total_wrong_length > 0 {
-            warn!("###################################################################");
-            if total_missing > 0 {
-                warn!("# {total_missing} were missing UMI attributes in the BAM file!");
-            }
-            if total_wrong_length > 0 {
-                warn!(
-                    "# {total_wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
-                );
-            }
-            warn!("###################################################################");
-        }
-
-        // Check minimum correction ratio
-        if let Some(min) = self.min_corrected {
-            #[allow(clippy::cast_precision_loss)]
-            let ratio_kept = records_written as f64 / total_records as f64;
-            if ratio_kept < min {
-                bail!(
-                    "Final ratio of reads kept / total was {ratio_kept:.2} (user specified minimum was {min:.2}). \
-                    This could indicate a mismatch between library preparation and the provided UMI file."
-                );
-            }
-        }
-
-        Ok(total_records)
+            encoded_umi_set,
+            umi_length,
+            track_rejects,
+            scheduler_opts: &self.scheduler_opts,
+            compression: &self.compression,
+            queue_memory: &self.queue_memory,
+            threading: &self.threading,
+            rejects_path: self.rejects_opts.rejects.as_deref(),
+            output_path: &self.io.output,
+            metrics_path: self.metrics.as_deref(),
+            max_mismatches: self.max_mismatches,
+            min_distance_diff: self.min_distance_diff,
+            revcomp: self.revcomp,
+            cache_size: self.cache_size,
+            dont_store_original_umis: self.dont_store_original_umis,
+            min_corrected: self.min_corrected,
+        })
     }
 
     /// Execute using single-threaded mode with template-level UMI correction.
@@ -1367,6 +1015,451 @@ impl CorrectUmis {
     }
 }
 
+/// Parameter bundle for [`run_correct_pipeline`].
+///
+/// Owned and borrowed inputs are mixed deliberately: the reader and header are
+/// consumed by the pipeline; the option references are read for pipeline-config
+/// / writer construction.
+///
+/// `pub(crate)` so the runall correct chain runner can build it without
+/// going through [`CorrectUmis`].
+pub(crate) struct CorrectPipelineParams<'a> {
+    /// Number of pipeline threads.
+    pub num_threads: usize,
+    /// Already-opened input BAM reader. Consumed by the pipeline.
+    pub reader: Box<dyn std::io::Read + Send>,
+    /// Output BAM header (with `@PG` already stamped). Consumed by the pipeline.
+    pub header: Header,
+    /// Encoded set of allowed UMI sequences.
+    pub encoded_umi_set: Arc<EncodedUmiSet>,
+    /// Length of every UMI segment in `encoded_umi_set`.
+    pub umi_length: usize,
+    /// Whether to write rejected templates to a separate BAM.
+    pub track_rejects: bool,
+    /// Scheduler / pipeline-stats options.
+    pub scheduler_opts: &'a SchedulerOptions,
+    /// Output BAM compression options.
+    pub compression: &'a CompressionOptions,
+    /// Queue-memory options for the unified pipeline.
+    pub queue_memory: &'a QueueMemoryOptions,
+    /// Threading mode (used to size the rejects writer's threads).
+    pub threading: &'a ThreadingOptions,
+    /// Path for the rejects BAM. Required when `track_rejects` is true.
+    pub rejects_path: Option<&'a Path>,
+    /// Path for the output BAM.
+    pub output_path: &'a Path,
+    /// Path for the per-UMI metrics TSV. `None` skips writing metrics.
+    pub metrics_path: Option<&'a Path>,
+    /// Maximum allowed mismatches between observed and matched UMI.
+    pub max_mismatches: usize,
+    /// Minimum mismatch difference between best and second-best matches.
+    pub min_distance_diff: usize,
+    /// Whether to reverse-complement UMI segments before matching.
+    pub revcomp: bool,
+    /// Per-worker LRU cache size for UMI matching. `0` disables caching.
+    pub cache_size: usize,
+    /// Whether to skip stamping the original UMI in the OX tag.
+    pub dont_store_original_umis: bool,
+    /// Optional minimum kept-records / total-records ratio. Failure to meet it
+    /// produces an error after pipeline completion.
+    pub min_corrected: Option<f64>,
+}
+
+/// Run the multi-threaded UMI-correction pipeline on a pre-opened BAM reader.
+///
+/// Shared between the standalone `fgumi correct` command (via
+/// [`CorrectUmis::execute_threads_mode`]) and the runall `correct` chain
+/// runner. Consumes the reader and header inside [`CorrectPipelineParams`].
+///
+/// Returns the total record count read from the input (kept + rejected).
+///
+/// # Errors
+/// Returns an error if the pipeline configuration is invalid, if any pipeline
+/// stage fails, if the metrics file cannot be written, or if the
+/// `min_corrected` ratio is not met.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn run_correct_pipeline(params: CorrectPipelineParams<'_>) -> Result<u64> {
+    let CorrectPipelineParams {
+        num_threads,
+        reader,
+        header,
+        encoded_umi_set,
+        umi_length,
+        track_rejects,
+        scheduler_opts,
+        compression,
+        queue_memory,
+        threading,
+        rejects_path,
+        output_path,
+        metrics_path,
+        max_mismatches,
+        min_distance_diff,
+        revcomp,
+        cache_size,
+        dont_store_original_umis,
+        min_corrected,
+    } = params;
+
+    // Configure pipeline - correct is ReaderHeavy (70% in decompression)
+    let mut pipeline_config =
+        build_pipeline_config(scheduler_opts, compression, queue_memory, num_threads)?;
+
+    // Enable raw-byte mode (correct uses TemplateGrouper, no cell tag needed)
+    {
+        use crate::read_info::LibraryIndex;
+        use crate::unified_pipeline::GroupKeyConfig;
+
+        let library_index = LibraryIndex::from_header(&header);
+        pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw_no_cell(library_index));
+    }
+
+    // Per-thread metrics accumulator: bounded memory, no unbounded queue.
+    let collected_metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(num_threads);
+    let collected_for_serialize = Arc::clone(&collected_metrics);
+
+    // Open rejects writer up front (see standalone command for rationale).
+    let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
+        if let Some(path) = rejects_path {
+            let writer_threads = threading.num_threads();
+            let rejects_header = header_as_unsorted(&header);
+            let w = create_raw_bam_writer(
+                path,
+                &rejects_header,
+                writer_threads,
+                compression.compression_level,
+            )?;
+            Some(Arc::new(Mutex::new(Some(w))))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+
+    // Configuration for closures
+    const BATCH_SIZE: usize = 1000; // Templates per batch
+    let umi_tag = Tag::from(SamTag::RX);
+
+    // Progress tracking
+    let progress_counter = Arc::new(AtomicU64::new(0));
+    let progress_for_process = Arc::clone(&progress_counter);
+
+    // Unmatched UMI string for rejected reads (matches fgbio behavior)
+    let unmatched_umi = "N".repeat(umi_length);
+    let unmatched_umi_for_process = unmatched_umi.clone();
+
+    // Clone the UMI set for post-aggregation use (before closure moves original)
+    let encoded_umi_set_for_metrics = Arc::clone(&encoded_umi_set);
+
+    // Grouper: batch templates by QNAME
+    let grouper_fn = move |_header: &Header| {
+        Box::new(TemplateGrouper::new(BATCH_SIZE)) as Box<dyn Grouper<Group = TemplateBatch> + Send>
+    };
+
+    // Process function: correct UMIs in each template batch
+    let process_fn = move |batch: TemplateBatch| -> io::Result<CorrectProcessedBatch> {
+        // Per-thread LRU cache for UMI matching
+        thread_local! {
+            static CACHE: std::cell::RefCell<Option<LruCache<Vec<u8>, UmiMatch>>> =
+                const { std::cell::RefCell::new(None) };
+        }
+
+        CACHE.with(|cache_cell| {
+            let mut cache_ref = cache_cell.borrow_mut();
+            if cache_ref.is_none() && cache_size > 0 {
+                *cache_ref = Some(LruCache::new(
+                    NonZero::new(cache_size).expect("cache_size > 0 checked above"),
+                ));
+            }
+
+            let mut kept_raw_records: Vec<RawRecord> = Vec::new();
+            let mut missing_umis = 0u64;
+            let mut wrong_length = 0u64;
+            let mut mismatched = 0u64;
+            let mut umi_matches_map: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+            let templates_count = batch.len() as u64;
+            let mut total_input_records = 0u64;
+            let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
+
+            // Stream rejected records straight to disk so they don't accumulate
+            // in a batch-level Vec.
+            let flush_raw_records = |recs: Vec<RawRecord>| -> io::Result<()> {
+                if let Some(ref rw_arc) = rejects_writer_for_process {
+                    if !recs.is_empty() {
+                        let mut guard = rw_arc.lock();
+                        if let Some(w) = guard.as_mut() {
+                            for raw in &recs {
+                                w.write_raw_record(raw.as_ref())?;
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            };
+
+            for template in batch {
+                total_input_records += template.read_count() as u64;
+
+                let raw_records: Vec<RawRecord> = template.into_records();
+                let umi_opt =
+                    CorrectUmis::extract_and_validate_template_umi_raw(&raw_records, umi_tag_bytes)
+                        .map_err(io::Error::other)?;
+
+                match umi_opt {
+                    None => {
+                        let num_records = raw_records.len() as u64;
+                        missing_umis += num_records;
+                        let entry = umi_matches_map
+                            .entry(unmatched_umi_for_process.clone())
+                            .or_insert_with(|| {
+                                UmiCorrectionMetrics::new(unmatched_umi_for_process.clone())
+                            });
+                        entry.total_matches += num_records;
+                        if track_rejects {
+                            flush_raw_records(raw_records)?;
+                        }
+                    }
+                    Some(umi) => {
+                        let correction = CorrectUmis::compute_template_correction(
+                            &umi,
+                            umi_length,
+                            revcomp,
+                            max_mismatches,
+                            min_distance_diff,
+                            &encoded_umi_set,
+                            &mut cache_ref,
+                        );
+                        let num_records = raw_records.len() as u64;
+
+                        if correction.matched {
+                            for m in &correction.matches {
+                                if m.matched {
+                                    let entry =
+                                        umi_matches_map.entry(m.umi.clone()).or_insert_with(|| {
+                                            UmiCorrectionMetrics::new(m.umi.clone())
+                                        });
+                                    entry.total_matches += num_records;
+                                    match m.mismatches {
+                                        0 => entry.perfect_matches += num_records,
+                                        1 => entry.one_mismatch_matches += num_records,
+                                        2 => entry.two_mismatch_matches += num_records,
+                                        _ => entry.other_matches += num_records,
+                                    }
+                                }
+                            }
+
+                            for mut raw in raw_records {
+                                CorrectUmis::apply_correction_to_raw(
+                                    &mut raw,
+                                    &correction,
+                                    umi_tag_bytes,
+                                    dont_store_original_umis,
+                                );
+                                kept_raw_records.push(raw);
+                            }
+                        } else {
+                            match correction.rejection_reason {
+                                RejectionReason::WrongLength => {
+                                    wrong_length += num_records;
+                                }
+                                RejectionReason::Mismatched => {
+                                    mismatched += num_records;
+                                }
+                                RejectionReason::None => {}
+                            }
+                            let entry = umi_matches_map
+                                .entry(unmatched_umi_for_process.clone())
+                                .or_insert_with(|| {
+                                    UmiCorrectionMetrics::new(unmatched_umi_for_process.clone())
+                                });
+                            entry.total_matches += num_records;
+                            if track_rejects {
+                                flush_raw_records(raw_records)?;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Progress logging (count ALL input records, not just output)
+            let count = progress_for_process.fetch_add(total_input_records, Ordering::Relaxed);
+            if (count + total_input_records) / 1_000_000 > count / 1_000_000 {
+                info!("Processed {} records", count + total_input_records);
+            }
+
+            Ok(CorrectProcessedBatch {
+                kept_raw_records,
+                templates_count,
+                missing_umis,
+                wrong_length,
+                mismatched,
+                umi_matches: umi_matches_map,
+            })
+        })
+    };
+
+    // Serialize function: convert records to bytes and collect metrics
+    let serialize_fn = move |mut processed: CorrectProcessedBatch,
+                             _header: &Header,
+                             output: &mut Vec<u8>|
+          -> io::Result<u64> {
+        let umi_matches = std::mem::take(&mut processed.umi_matches);
+        collected_for_serialize.with_slot(|m| {
+            m.templates_processed += processed.templates_count;
+            m.missing_umis += processed.missing_umis;
+            m.wrong_length += processed.wrong_length;
+            m.mismatched += processed.mismatched;
+            for (umi, counts) in umi_matches {
+                merge_umi_counts(&mut m.umi_matches, umi, &counts);
+            }
+        });
+
+        let mut kept_count = 0u64;
+        for raw in &processed.kept_raw_records {
+            let block_size = raw.len() as u32;
+            output.extend_from_slice(&block_size.to_le_bytes());
+            output.extend_from_slice(raw);
+            kept_count += 1;
+        }
+        Ok(kept_count)
+    };
+
+    // Run the 7-step pipeline with the already-opened reader.
+    let pipeline_result = run_bam_pipeline_from_reader(
+        pipeline_config,
+        reader,
+        header,
+        output_path,
+        None,
+        grouper_fn,
+        process_fn,
+        serialize_fn,
+    );
+
+    let rejects_finish_result = rejects_writer
+        .and_then(|rw_arc| rw_arc.lock().take())
+        .map(|writer| writer.finish().context("Failed to finish rejects file"));
+
+    let records_written = match (pipeline_result, rejects_finish_result) {
+        (Ok(records_written), Some(Ok(()))) => {
+            info!("Rejected records streamed to rejects file during processing");
+            records_written
+        }
+        (Ok(records_written), None) => records_written,
+        (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
+        (Err(pipeline_err), Some(Err(finish_err))) => {
+            return Err(anyhow::anyhow!(
+                "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
+            ));
+        }
+        (Err(pipeline_err), _) => return Err(pipeline_err.into()),
+    };
+
+    // ========== Post-pipeline: Aggregate metrics ==========
+    let mut total_templates = 0u64;
+    let mut total_missing = 0u64;
+    let mut total_wrong_length = 0u64;
+    let mut total_mismatched = 0u64;
+    let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+
+    for slot in collected_metrics.slots() {
+        let mut m = slot.lock();
+        total_templates += m.templates_processed;
+        total_missing += m.missing_umis;
+        total_wrong_length += m.wrong_length;
+        total_mismatched += m.mismatched;
+
+        for (umi, counts) in m.umi_matches.drain() {
+            merge_umi_counts(&mut merged_umi_matches, umi, &counts);
+        }
+    }
+
+    // Ensure ALL UMI rows are present (even with zero counts) - matches fgbio behavior
+    for umi in encoded_umi_set_for_metrics.strings().iter().chain(std::iter::once(&unmatched_umi)) {
+        merged_umi_matches
+            .entry(umi.clone())
+            .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
+    }
+
+    finalize_correct_metrics(metrics_path, &mut merged_umi_matches, &unmatched_umi)?;
+
+    // Log summary
+    let rejected = total_missing + total_wrong_length + total_mismatched;
+    let total_records = records_written + rejected;
+    info!("Read {total_records}; kept {records_written} and rejected {rejected}");
+    info!("Total templates processed: {total_templates}");
+
+    if total_missing > 0 || total_wrong_length > 0 {
+        warn!("###################################################################");
+        if total_missing > 0 {
+            warn!("# {total_missing} were missing UMI attributes in the BAM file!");
+        }
+        if total_wrong_length > 0 {
+            warn!(
+                "# {total_wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
+            );
+        }
+        warn!("###################################################################");
+    }
+
+    if let Some(min) = min_corrected {
+        #[allow(clippy::cast_precision_loss)]
+        let ratio_kept = records_written as f64 / total_records as f64;
+        if ratio_kept < min {
+            bail!(
+                "Final ratio of reads kept / total was {ratio_kept:.2} (user specified minimum was {min:.2}). \
+                This could indicate a mismatch between library preparation and the provided UMI file."
+            );
+        }
+    }
+
+    Ok(total_records)
+}
+
+/// Free-function form of [`CorrectUmis::finalize_metrics`].
+///
+/// Takes the metrics output path explicitly so [`run_correct_pipeline`] can be
+/// called from contexts that don't own a [`CorrectUmis`]. No behaviour change.
+pub(crate) fn finalize_correct_metrics(
+    metrics_path: Option<&Path>,
+    umi_metrics: &mut AHashMap<String, UmiCorrectionMetrics>,
+    unmatched_umi: &str,
+) -> Result<()> {
+    // Calculate totals
+    let total: u64 = umi_metrics.values().map(|m| m.total_matches).sum();
+    let matched_total: u64 = umi_metrics
+        .iter()
+        .filter(|(umi, _)| *umi != unmatched_umi)
+        .map(|(_, m)| m.total_matches)
+        .sum();
+
+    // Calculate fractions (allow NaN when total is 0, matching fgbio behavior)
+    #[allow(clippy::cast_precision_loss)]
+    for metric in umi_metrics.values_mut() {
+        metric.fraction_of_matches = metric.total_matches as f64 / total as f64;
+    }
+
+    // Calculate representations (allow NaN/Infinity, matching fgbio behavior)
+    let umi_count = umi_metrics.keys().filter(|umi| *umi != unmatched_umi).count();
+
+    #[allow(clippy::cast_precision_loss)]
+    let mean = matched_total as f64 / umi_count as f64;
+    for metric in umi_metrics.values_mut() {
+        metric.representation = metric.total_matches as f64 / mean;
+    }
+
+    // Write metrics if requested
+    if let Some(path) = metrics_path {
+        let mut metrics: Vec<UmiCorrectionMetrics> = umi_metrics.values().cloned().collect();
+        metrics.sort_by(|a, b| a.umi.cmp(&b.umi));
+        UmiCorrectionMetrics::write_metrics(&metrics, path)?;
+    }
+
+    Ok(())
+}
+
 /// Merges `counts` into `dst[umi]`, creating a zero-initialized entry if the
 /// key is absent. Uses `or_insert_with_key` so `umi` is only cloned on insert,
 /// not on hit.
@@ -1467,6 +1560,15 @@ impl EncodedUmiSet {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.bytes.is_empty()
+    }
+
+    /// Borrow the original (uppercase) UMI strings.
+    ///
+    /// `pub(crate)` so the runall correct chain runners can iterate the
+    /// allowed UMIs when populating per-UMI metric rows.
+    #[inline]
+    pub(crate) fn strings(&self) -> &[String] {
+        &self.strings
     }
 }
 

--- a/src/lib/commands/runall/chains/correct.rs
+++ b/src/lib/commands/runall/chains/correct.rs
@@ -1,0 +1,584 @@
+//! `--start-from correct --stop-after correct` chain runner.
+//!
+//! Thin BAM-linear entry point: opens the input BAM via the same helper
+//! the standalone `fgumi correct` command uses, builds
+//! [`CorrectPipelineParams`], and forwards to
+//! [`crate::commands::correct::run_correct_pipeline`]. The pipeline body
+//! (closures, per-thread metrics accumulator, rejects writer,
+//! `min_corrected` check, metrics file finalisation) lives exactly once,
+//! in `crate::commands::correct`.
+//!
+//! Gate: matches `(Correct, Correct)` only when none of the
+//! chain-runner-incompatible per-`--correct::` flags are set
+//! (`--correct::rejects`, `--correct::metrics`, `--correct::min-corrected`)
+//! and a UMI source is provided (inline UMIs or a UMI file). The top-level
+//! `--metrics` flag IS supported: the runner times its
+//! `run_correct_pipeline` call and writes a single
+//! `MetricsRow { stage: "correct", ... }` row to the supplied TSV path.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use crate::commands::common::{
+    CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions, add_pg_record,
+};
+use crate::commands::correct::{CorrectPipelineParams, EncodedUmiSet, run_correct_pipeline};
+use crate::commands::runall::Runall;
+use crate::commands::runall::dispatch::{ChainContext, ChainRunner, DispatchContext};
+use crate::commands::runall::infra::metrics::{MetricsRow, MetricsWriter};
+use crate::commands::runall::options::{StartFrom, StopAfter};
+use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
+
+/// Stable runner name surfaced via `--explain` and debug logs.
+pub(crate) const CORRECT_CHAIN_RUNNER_NAME: &str = "CorrectChainRunner";
+
+/// Chain runner for `--start-from correct --stop-after correct`.
+///
+/// Built once per `Runall::execute` call; owns the cloned subset of
+/// `Runall` fields needed to drive [`run_correct_pipeline`]. Cloning keeps
+/// the runner `'static` (so it can be pushed into the trait-object
+/// registry) without leaking `Runall` lifetimes.
+#[allow(clippy::struct_excessive_bools)] // gate flags + correction toggles
+pub(crate) struct CorrectChainRunner {
+    input: std::path::PathBuf,
+    threads: usize,
+    compression_level: u32,
+    umis: Vec<String>,
+    umi_files: Vec<std::path::PathBuf>,
+    max_mismatches: usize,
+    min_distance_diff: usize,
+    cache_size: usize,
+    revcomp: bool,
+    dont_store_original_umis: bool,
+    /// `--correct::rejects`. Chain-runner-incompatible: must be unset for
+    /// `supports()` to match. (Wiring deferred to PR #329.)
+    rejects_unset: bool,
+    /// `--correct::metrics`. Chain-runner-incompatible. (Wiring deferred
+    /// to PR #329; the top-level `--metrics` is supported here.)
+    metrics_unset: bool,
+    /// `--correct::min-corrected`. Chain-runner-incompatible. (Wiring
+    /// deferred to PR #329.)
+    min_corrected_unset: bool,
+    /// `--queue-memory` / `--queue-memory-per-thread` from the top-level
+    /// `Runall`. Cloned (rather than per-field-decomposed) so the runner
+    /// can call `QueueMemoryOptions::calculate_memory_limit` and
+    /// `QueueMemoryOptions::log_memory_config` exactly the way the
+    /// standalone `fgumi correct` command does, keeping memory-budget
+    /// behaviour in lock-step.
+    queue_memory: QueueMemoryOptions,
+}
+
+impl CorrectChainRunner {
+    /// Build the runner from a parsed [`Runall`] invocation.
+    ///
+    /// Builds unconditionally: the registry consults `supports()` to decide
+    /// whether to dispatch here, so a `Runall` invocation that does not
+    /// match `(Correct, Correct)` is allowed to flow through this
+    /// constructor. Required-when-running fields are stored as-is and
+    /// re-checked inside `run_chain()` so a missing flag surfaces as a
+    /// clean `anyhow::Error` rather than a panic.
+    pub(crate) fn from_runall(runall: &Runall) -> Self {
+        let opts = &runall.correct_opts;
+        Self {
+            input: runall.input.first().cloned().unwrap_or_default(),
+            threads: runall.threads,
+            compression_level: runall.compression_level,
+            umis: opts.correct_umis.clone().unwrap_or_default(),
+            umi_files: opts.correct_umi_files.clone().unwrap_or_default(),
+            max_mismatches: opts.correct_max_mismatches,
+            min_distance_diff: opts.correct_min_distance,
+            cache_size: opts.correct_cache_size,
+            revcomp: opts.correct_revcomp,
+            dont_store_original_umis: opts.correct_dont_store_original_umis,
+            rejects_unset: opts.correct_rejects.is_none(),
+            metrics_unset: opts.correct_metrics.is_none(),
+            min_corrected_unset: opts.correct_min_corrected.is_none(),
+            queue_memory: runall.queue_memory.clone(),
+        }
+    }
+
+    /// Run the chain end-to-end against the prepared
+    /// [`ChainContext::tmp_output`] path.
+    ///
+    /// When `metrics_path` is `Some`, writes a single
+    /// [`MetricsRow`] tagged `"correct"` with wall-clock duration and
+    /// `records_in == records_out`. The simplification is exact for the
+    /// supported chain configurations: without `--correct::rejects`,
+    /// rejected records are still emitted (with the original UMI), and
+    /// without `--correct::min-corrected`, no records are dropped
+    /// post-correction. PR #329 will wire those flags and split
+    /// `records_in` / `records_out` accordingly.
+    fn run_chain(
+        &self,
+        command_line: &str,
+        output: &Path,
+        metrics_path: Option<&Path>,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            !self.input.as_os_str().is_empty(),
+            "CorrectChainRunner: --input is required",
+        );
+        anyhow::ensure!(
+            !self.umis.is_empty() || !self.umi_files.is_empty(),
+            "CorrectChainRunner: --correct::umis or --correct::umi-files is required",
+        );
+
+        // Load the UMI list from inline strings + files, deduped + uppercased,
+        // matching the standalone `fgumi correct` loader.
+        let (umi_sequences, umi_length) = load_umi_sequences(&self.umis, &self.umi_files)?;
+        let encoded_umi_set = EncodedUmiSet::new(&umi_sequences);
+
+        // Open input BAM with the same streaming-capable helper standalone
+        // correct uses, then stamp a fresh `@PG` record on the header.
+        let opts = fgumi_bam_io::PipelineReaderOpts::default();
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(&self.input, opts)?;
+        let header = add_pg_record(header, command_line)?;
+
+        // Build minimal option structs (defaults match standalone defaults; the
+        // few fields the chain runner exposes are passed explicitly via params).
+        // `--queue-memory` / `--queue-memory-per-thread` are forwarded from the
+        // top-level `Runall` so the chain runner builds the same
+        // `BamPipelineConfig.queue_memory_limit` standalone `fgumi correct`
+        // would for the same flag values.
+        let scheduler_opts = SchedulerOptions::default();
+        let compression = CompressionOptions { compression_level: self.compression_level };
+        let threading = ThreadingOptions { threads: Some(self.threads) };
+
+        let start = std::time::Instant::now();
+        let records_out = run_correct_pipeline(CorrectPipelineParams {
+            num_threads: self.threads,
+            reader,
+            header,
+            encoded_umi_set: Arc::new(encoded_umi_set),
+            umi_length,
+            track_rejects: false,
+            scheduler_opts: &scheduler_opts,
+            compression: &compression,
+            queue_memory: &self.queue_memory,
+            threading: &threading,
+            rejects_path: None,
+            output_path: output,
+            metrics_path: None,
+            max_mismatches: self.max_mismatches,
+            min_distance_diff: self.min_distance_diff,
+            revcomp: self.revcomp,
+            cache_size: self.cache_size,
+            dont_store_original_umis: self.dont_store_original_umis,
+            min_corrected: None,
+        })
+        .with_context(|| format!("CorrectChainRunner pipeline writing to {}", output.display()))?;
+        let wall_time_secs = start.elapsed().as_secs_f64();
+
+        if let Some(path) = metrics_path {
+            // Without `--correct::rejects` rejected records are still emitted
+            // (with their original UMI) and without `--correct::min-corrected`
+            // no records are dropped post-correction, so `records_in` and
+            // `records_out` are equal. PR #329 wires those flags and will
+            // start populating `records_in` independently.
+            let mut writer = MetricsWriter::create(path)
+                .with_context(|| format!("opening --metrics path {} for write", path.display()))?;
+            writer
+                .write_row(&MetricsRow {
+                    stage: "correct".into(),
+                    wall_time_secs,
+                    records_in: records_out,
+                    records_out,
+                })
+                .with_context(|| format!("writing correct metrics row to {}", path.display()))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ChainRunner for CorrectChainRunner {
+    fn name(&self) -> &'static str {
+        CORRECT_CHAIN_RUNNER_NAME
+    }
+
+    /// Match `(Correct, Correct)` when:
+    /// * a UMI source is provided (inline `--correct::umis` or
+    ///   `--correct::umi-files`); and
+    /// * none of the `--correct::rejects`, `--correct::metrics`, or
+    ///   `--correct::min-corrected` flags are set (those still gate the
+    ///   runner off so those invocations fall through to the
+    ///   `NotImplementedRunner`; PR #329 will wire them).
+    ///
+    /// The top-level `--metrics` flag does NOT gate this runner — it is
+    /// honoured directly by `run_chain`, which writes a single
+    /// `correct` row to the supplied TSV.
+    fn supports(&self, ctx: &DispatchContext<'_>) -> bool {
+        if !self.rejects_unset || !self.metrics_unset || !self.min_corrected_unset {
+            return false;
+        }
+        if self.umis.is_empty() && self.umi_files.is_empty() {
+            return false;
+        }
+        ctx.start_from == StartFrom::Correct && ctx.stop_after == StopAfter::Correct
+    }
+
+    fn run(&self, ctx: ChainContext<'_>) -> Result<()> {
+        let metrics_path = ctx.dispatch.metrics_path;
+        self.run_chain(ctx.command_line, &ctx.tmp_output, metrics_path)
+    }
+}
+
+/// Load and deduplicate UMI sequences from inline strings and/or files.
+///
+/// Mirrors `CorrectUmis::load_umi_sequences`; reproduced here so the chain
+/// runner doesn't need to construct a full `CorrectUmis`. All UMIs must
+/// share a single length.
+pub(crate) fn load_umi_sequences(
+    umis: &[String],
+    umi_files: &[std::path::PathBuf],
+) -> Result<(Vec<String>, usize)> {
+    let mut umi_set: std::collections::HashSet<String> =
+        umis.iter().map(|s| s.to_uppercase()).collect();
+
+    for file in umi_files {
+        let content = std::fs::read_to_string(file)
+            .with_context(|| format!("read UMI file {}", file.display()))?;
+        for line in content.lines() {
+            let umi = line.trim().to_uppercase();
+            if !umi.is_empty() {
+                umi_set.insert(umi);
+            }
+        }
+    }
+
+    if umi_set.is_empty() {
+        anyhow::bail!("No UMIs provided.");
+    }
+
+    let mut umi_sequences: Vec<String> = umi_set.into_iter().collect();
+    umi_sequences.sort_unstable();
+
+    let first_len = umi_sequences[0].len();
+    if !umi_sequences.iter().all(|u| u.len() == first_len) {
+        anyhow::bail!("All UMIs must have the same length.");
+    }
+
+    Ok((umi_sequences, first_len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::runall::infra::progress::ProgressMode;
+    use crate::commands::runall::options::{
+        AlignerOptions, CodecOptions, ConsensusMode, ConsensusOptions, CorrectOptions,
+        DuplexOptions, ExtractOptions, FilterOptions, GroupOptions, MultiAlignerOptions,
+        MultiCodecOptions, MultiConsensusOptions, MultiCorrectOptions, MultiDuplexOptions,
+        MultiExtractOptions, MultiFilterOptions, MultiGroupOptions, MultiSortOptions,
+        MultiZipperOptions, SortOptions, ZipperOptions,
+    };
+    use std::path::PathBuf;
+
+    fn runall_for_correct(input: PathBuf, output: PathBuf, umis: Vec<String>) -> Runall {
+        let correct = CorrectOptions { umis: Some(umis), ..CorrectOptions::default() };
+        Runall {
+            input: vec![input],
+            output,
+            reference: None,
+            start_from: StartFrom::Correct,
+            stop_after: StopAfter::Correct,
+            consensus_mode: ConsensusMode::Simplex,
+            threads: 4,
+            progress: ProgressMode::None,
+            compression_level: 1,
+            metrics: None,
+            explain: false,
+            consensus_metrics: None,
+            intervals: None,
+            methylation_mode: None,
+            restore_unconverted_bases: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
+            sort_opts: MultiSortOptions::from(SortOptions::default()),
+            group_opts: MultiGroupOptions::from(GroupOptions::default()),
+            filter_opts: MultiFilterOptions::from(FilterOptions::default()),
+            consensus_opts: MultiConsensusOptions::from(ConsensusOptions::default()),
+            extract_opts: MultiExtractOptions::from(ExtractOptions::default()),
+            aligner_opts: MultiAlignerOptions::from(AlignerOptions::default()),
+            zipper_opts: MultiZipperOptions::from(ZipperOptions::default()),
+            correct_opts: MultiCorrectOptions::from(correct),
+            duplex_opts: MultiDuplexOptions::from(DuplexOptions::default()),
+            codec_opts: MultiCodecOptions::from(CodecOptions::default()),
+            queue_memory: QueueMemoryOptions::default(),
+        }
+    }
+
+    fn dispatch_ctx(start: StartFrom, stop: StopAfter) -> DispatchContext<'static> {
+        DispatchContext { start_from: start, stop_after: stop, metrics_path: None }
+    }
+
+    #[test]
+    fn supports_only_correct_to_correct_with_umi_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        let runner = CorrectChainRunner::from_runall(&runall);
+
+        assert!(runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Extract)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Filter)));
+
+        let metrics_path = dir.path().join("metrics.tsv");
+        let with_metrics = DispatchContext {
+            start_from: StartFrom::Correct,
+            stop_after: StopAfter::Correct,
+            metrics_path: Some(metrics_path.as_path()),
+        };
+        assert!(
+            runner.supports(&with_metrics),
+            "correct chain runner now writes its own --metrics row; the registry \
+             must dispatch to it even when --metrics is set"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_rejects_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::rejects must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_metrics_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_metrics = Some(dir.path().join("correct-metrics.tsv"));
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::metrics must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_min_corrected_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_min_corrected = Some(0.5);
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::min-corrected must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn from_runall_propagates_queue_memory_options() {
+        // Top-level `--queue-memory` / `--queue-memory-per-thread` must
+        // reach the chain runner so it can build the same
+        // `BamPipelineConfig.pipeline.queue_memory_limit` standalone
+        // `fgumi correct` would compute for the same values.
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.queue_memory = QueueMemoryOptions {
+            queue_memory: "2GB".to_string(),
+            queue_memory_per_thread: false,
+            queue_memory_limit_mb: None,
+        };
+
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert_eq!(runner.queue_memory.queue_memory, "2GB");
+        assert!(!runner.queue_memory.queue_memory_per_thread);
+    }
+
+    /// Build a tiny test BAM at `path` containing `n` single-segment
+    /// records, each carrying an 8 bp UMI in the RX tag from `umi_cycle`.
+    /// Mirrors the `create_test_bam` helper in `commands::correct::tests`
+    /// (kept local so this module doesn't depend on its private test
+    /// utilities).
+    fn write_test_bam(path: &Path, n: usize, umi_cycle: &[&[u8]]) {
+        use fgumi_raw_bam::{
+            SamBuilder as RawSamBuilder, raw_record_to_record_buf, testutil::encode_op,
+        };
+        use noodles::sam::Header;
+        use noodles::sam::alignment::io::Write as _;
+        use noodles::sam::header::record::value::map::Map;
+
+        let header = Header::builder()
+            .add_reference_sequence(
+                "chr1",
+                Map::<noodles::sam::header::record::value::map::ReferenceSequence>::new(
+                    std::num::NonZero::new(1000).expect("non-zero reference length"),
+                ),
+            )
+            .build();
+
+        let mut writer = noodles::bam::io::writer::Builder.build_from_path(path).unwrap();
+        writer.write_header(&header).unwrap();
+        for i in 0..n {
+            let mut b = RawSamBuilder::new();
+            let name = format!("r{i}");
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[encode_op(0, 10)])
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[40u8; 10]);
+            b.add_string_tag(crate::sam::SamTag::RX, umi_cycle[i % umi_cycle.len()]);
+            let raw = b.build();
+            let record = raw_record_to_record_buf(&raw, &noodles::sam::Header::default()).unwrap();
+            writer.write_alignment_record(&header, &record).unwrap();
+        }
+        writer.try_finish().unwrap();
+    }
+
+    #[test]
+    fn metrics_tsv_emits_one_correct_row() {
+        // Wire `--metrics` end-to-end through `run_chain` with a real BAM
+        // input, then parse the TSV. Verifies header, single data row,
+        // stable column ordering, and `records_in == records_out` (true
+        // for the supported chain configurations until PR #329 lands).
+        let dir = tempfile::TempDir::new().unwrap();
+        let in_bam = dir.path().join("in.bam");
+        let out_tmp = dir.path().join("out.bam.tmp");
+        let metrics = dir.path().join("metrics.tsv");
+
+        // 8 records, all UMIs in the allowed list — every record passes
+        // through, no rejections.
+        let umis: &[&[u8]] = &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT"];
+        write_test_bam(&in_bam, 8, umis);
+
+        let runall = runall_for_correct(
+            in_bam.clone(),
+            dir.path().join("ignored.bam"),
+            vec![
+                "AAAAAAAA".to_string(),
+                "CCCCCCCC".to_string(),
+                "GGGGGGGG".to_string(),
+                "TTTTTTTT".to_string(),
+            ],
+        );
+        let runner = CorrectChainRunner::from_runall(&runall);
+        runner
+            .run_chain("fgumi runall", &out_tmp, Some(metrics.as_path()))
+            .expect("chain runs with --metrics");
+
+        let contents = std::fs::read_to_string(&metrics).expect("read metrics");
+        let mut lines = contents.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "stage\twall_time_secs\trecords_in\trecords_out",
+            "header row"
+        );
+        let row = lines.next().expect("one correct row");
+        let cols: Vec<&str> = row.split('\t').collect();
+        assert_eq!(cols.len(), 4, "row has 4 columns: {row}");
+        assert_eq!(cols[0], "correct", "stage column");
+        let wall: f64 = cols[1].parse().expect("wall_time_secs is a float");
+        assert!(wall >= 0.0, "wall_time_secs is non-negative: {wall}");
+        assert_eq!(cols[2], "8", "records_in: 8 input records");
+        assert_eq!(
+            cols[3], "8",
+            "records_out: 8 (records_in == records_out without --correct::rejects/min-corrected)"
+        );
+        assert!(lines.next().is_none(), "exactly one data row");
+    }
+
+    #[test]
+    fn build_pipeline_config_applies_queue_memory_limit() {
+        // End-to-end check that `--queue-memory` reaches `BamPipelineConfig`:
+        // 1 GiB total (per-thread = false) → exactly 1 GiB queue-memory limit
+        // on the resulting config, regardless of `--threads`.
+        use crate::commands::common::build_pipeline_config;
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.threads = 4;
+        runall.queue_memory = QueueMemoryOptions {
+            queue_memory: "1GiB".to_string(),
+            queue_memory_per_thread: false,
+            queue_memory_limit_mb: None,
+        };
+
+        let runner = CorrectChainRunner::from_runall(&runall);
+        // Reconstruct the same pipeline config `run_chain` builds so we can
+        // assert on the resolved limit without spinning up a real BAM.
+        let scheduler_opts = SchedulerOptions::default();
+        let compression = CompressionOptions { compression_level: runner.compression_level };
+        let config = build_pipeline_config(
+            &scheduler_opts,
+            &compression,
+            &runner.queue_memory,
+            runner.threads,
+        )
+        .expect("config builds");
+        assert_eq!(
+            config.pipeline.queue_memory_limit,
+            1024 * 1024 * 1024,
+            "1 GiB total → 1 GiB queue_memory_limit on the BamPipelineConfig",
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_no_umi_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // No UMIs supplied.
+        let runall =
+            runall_for_correct(dir.path().join("in.bam"), dir.path().join("out.bam"), Vec::new());
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)));
+    }
+
+    #[test]
+    fn name_is_stable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runall = runall_for_correct(
+            dir.path().join("in.bam"),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        let runner = CorrectChainRunner::from_runall(&runall);
+        assert_eq!(runner.name(), CORRECT_CHAIN_RUNNER_NAME);
+    }
+
+    #[test]
+    fn load_umi_sequences_from_strings_dedups_and_uppercases() {
+        let umis = vec!["AAAA".to_string(), "CCCC".to_string(), "aaaa".to_string()];
+        let (seqs, len) = load_umi_sequences(&umis, &[]).expect("should load UMIs");
+        assert_eq!(len, 4);
+        assert_eq!(seqs.len(), 2);
+    }
+
+    #[test]
+    fn load_umi_sequences_empty_fails() {
+        let result = load_umi_sequences(&[], &[]);
+        assert!(result.is_err());
+    }
+}

--- a/src/lib/commands/runall/chains/extract_correct.rs
+++ b/src/lib/commands/runall/chains/extract_correct.rs
@@ -1,0 +1,931 @@
+//! `--start-from extract --stop-after correct` chain runner.
+//!
+//! Fuses the extract and correct steps into a single
+//! [`crate::unified_pipeline::run_fastq_pipeline`] `process_fn` closure: each
+//! `FastqTemplate` is converted to BAM bytes via
+//! [`crate::commands::extract::make_raw_records_static`] and the per-template
+//! UMI correction is applied in-place to those bytes. No intermediate BAM is
+//! materialised between the two stages.
+//!
+//! The closure body is `Fn` (not `FnMut`); per-worker mutable state — the LRU
+//! cache used by [`CorrectUmis::compute_template_correction`] — lives in
+//! `thread_local!` storage, mirroring the standalone `fgumi correct`
+//! pipeline.
+//!
+//! When the caller passes `--metrics`, the runner times its
+//! `run_fastq_pipeline` call and emits two
+//! [`crate::commands::runall::infra::metrics::MetricsRow`]s to the supplied
+//! TSV: an `extract` row followed by a `correct` row. Per-stage wall time
+//! and `records_in` / `records_out` are simplifications until the fused
+//! `process_fn` grows per-stage accumulators (PR #329 wires
+//! `--correct::metrics`, which exposes that infrastructure):
+//!
+//! * Both rows share the total wall-clock duration of the fused pipeline.
+//! * Both rows have `records_in == records_out` set to the post-correction
+//!   record count emitted by `run_fastq_pipeline`. (Without
+//!   `--correct::rejects` rejected templates are silently dropped, but the
+//!   chain runner does not expose a separate dropped-record counter today;
+//!   PR #329 adds that path.)
+
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{self, BufRead, Write};
+use std::num::NonZero;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use lru::LruCache;
+use noodles::sam::Header;
+use read_structure::ReadStructure;
+
+use crate::commands::common::{QueueMemoryOptions, add_pg_record};
+use crate::commands::correct::{CorrectUmis, EncodedUmiSet, TemplateCorrection, UmiMatch};
+use crate::commands::extract::{
+    BUFFER_SIZE, CompressionFormat, ExtractConfig, ExtractHeaderMetadata,
+    QUALITY_DETECTION_SAMPLE_SIZE, QualityEncoding, RawExtractedRecords, build_extract_header,
+    detect_compression_format, make_raw_records_static, open_fastq_reader,
+    strip_read_suffix_extract,
+};
+use crate::commands::runall::Runall;
+use crate::commands::runall::chains::correct::load_umi_sequences;
+use crate::commands::runall::dispatch::{ChainContext, ChainRunner, DispatchContext};
+use crate::commands::runall::infra::metrics::{MetricsRow, MetricsWriter};
+use crate::commands::runall::options::{StartFrom, StopAfter};
+use crate::fastq::FastqSet;
+use crate::grouper::FastqTemplate;
+use crate::sam::SamTag;
+use crate::unified_pipeline::{FastqPipelineConfig, run_fastq_pipeline};
+use fgumi_raw_bam::{aux_data_slice, find_string_tag, update_string_tag};
+use fgumi_simd_fastq::SimdFastqReader;
+
+/// Stable runner name surfaced via `--explain` and debug logs.
+pub(crate) const EXTRACT_CORRECT_CHAIN_RUNNER_NAME: &str = "ExtractCorrectChainRunner";
+
+/// Chain runner for `--start-from extract --stop-after correct`.
+///
+/// Built once per `Runall::execute` call; owns the cloned subset of
+/// `Runall` fields needed to construct the unmapped BAM header, the
+/// extract closure config, and the correction parameters.
+#[allow(clippy::struct_excessive_bools)] // many distinct extract + correct flags
+pub(crate) struct ExtractCorrectChainRunner {
+    // Extract inputs
+    inputs: Vec<PathBuf>,
+    threads: usize,
+    compression_level: u32,
+    read_structures: Vec<String>,
+    sample: Option<String>,
+    library: Option<String>,
+    read_group_id: String,
+    barcode: Option<String>,
+    platform: String,
+    platform_unit: Option<String>,
+    platform_model: Option<String>,
+    sequencing_center: Option<String>,
+    predicted_insert_size: Option<u32>,
+    description: Option<String>,
+    run_date: Option<String>,
+    comments: Vec<String>,
+    single_tag: Option<String>,
+    annotate_read_names: bool,
+    extract_umis_from_read_names: bool,
+    store_sample_barcode_qualities: bool,
+    // Correction inputs
+    umis: Vec<String>,
+    umi_files: Vec<PathBuf>,
+    max_mismatches: usize,
+    min_distance_diff: usize,
+    cache_size: usize,
+    revcomp: bool,
+    dont_store_original_umis: bool,
+    // Chain-runner-incompatible flags (gated off; PR #329 will wire them).
+    rejects_unset: bool,
+    metrics_unset: bool,
+    min_corrected_unset: bool,
+    /// `--queue-memory` / `--queue-memory-per-thread` from the top-level
+    /// `Runall`. Cloned so the runner can build a `FastqPipelineConfig`
+    /// with the same memory budget the standalone `fgumi extract` /
+    /// `fgumi correct` commands would for the same flag values.
+    queue_memory: QueueMemoryOptions,
+}
+
+impl ExtractCorrectChainRunner {
+    /// Build the runner from a parsed [`Runall`] invocation.
+    pub(crate) fn from_runall(runall: &Runall) -> Self {
+        let extract_opts = &runall.extract_opts;
+        let correct_opts = &runall.correct_opts;
+        Self {
+            inputs: runall.input.clone(),
+            threads: runall.threads,
+            compression_level: runall.compression_level,
+            read_structures: extract_opts.extract_read_structures.clone().unwrap_or_default(),
+            sample: extract_opts.extract_sample.clone(),
+            library: extract_opts.extract_library.clone(),
+            read_group_id: runall.consensus_opts.consensus_read_group_id.clone(),
+            barcode: extract_opts.extract_barcode.clone(),
+            platform: extract_opts.extract_platform.clone(),
+            platform_unit: extract_opts.extract_platform_unit.clone(),
+            platform_model: extract_opts.extract_platform_model.clone(),
+            sequencing_center: extract_opts.extract_sequencing_center.clone(),
+            predicted_insert_size: extract_opts.extract_predicted_insert_size,
+            description: extract_opts.extract_description.clone(),
+            run_date: extract_opts.extract_run_date.clone(),
+            comments: extract_opts.extract_comment.clone().unwrap_or_default(),
+            single_tag: extract_opts.extract_single_tag.clone(),
+            annotate_read_names: extract_opts.extract_annotate_read_names,
+            extract_umis_from_read_names: extract_opts.extract_extract_umis_from_read_names,
+            store_sample_barcode_qualities: extract_opts.extract_store_sample_barcode_qualities,
+            umis: correct_opts.correct_umis.clone().unwrap_or_default(),
+            umi_files: correct_opts.correct_umi_files.clone().unwrap_or_default(),
+            max_mismatches: correct_opts.correct_max_mismatches,
+            min_distance_diff: correct_opts.correct_min_distance,
+            cache_size: correct_opts.correct_cache_size,
+            revcomp: correct_opts.correct_revcomp,
+            dont_store_original_umis: correct_opts.correct_dont_store_original_umis,
+            rejects_unset: correct_opts.correct_rejects.is_none(),
+            metrics_unset: correct_opts.correct_metrics.is_none(),
+            min_corrected_unset: correct_opts.correct_min_corrected.is_none(),
+            queue_memory: runall.queue_memory.clone(),
+        }
+    }
+
+    /// Build the [`FastqPipelineConfig`] for `run_chain`, applying the
+    /// queue-memory budget computed from `--queue-memory` /
+    /// `--queue-memory-per-thread`. Mirrors the helper on
+    /// [`super::extract::ExtractChainRunner`] and the standalone
+    /// `fgumi extract` flow. Extracted for unit-testing the wiring without
+    /// running the full pipeline.
+    fn build_pipeline_config(&self, all_bgzf: bool) -> Result<FastqPipelineConfig> {
+        let pipeline_threads = self.threads.max(1);
+        let queue_memory_limit_bytes =
+            self.queue_memory.calculate_memory_limit(pipeline_threads)?;
+        self.queue_memory.log_memory_config(pipeline_threads, queue_memory_limit_bytes);
+        Ok(FastqPipelineConfig::new(pipeline_threads, all_bgzf, self.compression_level)
+            .with_queue_memory_limit(queue_memory_limit_bytes))
+    }
+
+    /// Resolve the read structures, defaulting to `+T` per input when
+    /// `--extract::read-structures` was not supplied. Mirrors the
+    /// standalone `Extract::get_read_structures`.
+    fn resolve_read_structures(&self) -> Result<Vec<ReadStructure>> {
+        if self.read_structures.is_empty() {
+            (0..self.inputs.len())
+                .map(|_| ReadStructure::from_str("+T").map_err(anyhow::Error::from))
+                .collect()
+        } else {
+            self.read_structures
+                .iter()
+                .map(|s| ReadStructure::from_str(s).map_err(anyhow::Error::from))
+                .collect()
+        }
+    }
+
+    /// Detect the FASTQ quality encoding by sampling the leading records of
+    /// the first input. Mirrors the standalone `Extract` flow.
+    fn detect_quality_encoding(&self) -> Result<QualityEncoding> {
+        let first =
+            self.inputs.first().ok_or_else(|| anyhow::anyhow!("no FASTQ inputs supplied"))?;
+        let reader = open_fastq_reader(first, 1, false)
+            .with_context(|| format!("opening {} for quality detection", first.display()))?;
+        let mut fq_reader = SimdFastqReader::with_capacity(reader, BUFFER_SIZE);
+        let mut sample_quals: Vec<Vec<u8>> = Vec::with_capacity(QUALITY_DETECTION_SAMPLE_SIZE);
+        for _ in 0..QUALITY_DETECTION_SAMPLE_SIZE {
+            match fq_reader.next() {
+                Some(Ok(rec)) => sample_quals.push(rec.quality),
+                Some(Err(e)) => return Err(e.into()),
+                None => break,
+            }
+        }
+        QualityEncoding::detect(&sample_quals)
+    }
+
+    /// Build the fused per-template `process_fn` for `run_fastq_pipeline`.
+    ///
+    /// The closure runs once per [`FastqTemplate`]:
+    /// 1. extract the template into BAM bytes via [`make_raw_records_static`];
+    /// 2. read the template's UMI from the first emitted record (all records in
+    ///    one template share the same UMI by construction);
+    /// 3. compute the correction once via [`CorrectUmis::compute_template_correction`],
+    ///    using a `thread_local!` LRU cache keyed by the original UMI bytes;
+    /// 4. either drop the template (UMI not matched) or apply the correction
+    ///    in-place to every record's RX (and OX) tag.
+    ///
+    /// The returned closure is `Send + Sync + 'static` and plugs directly
+    /// into the FASTQ pipeline's `process_fn` slot.
+    #[allow(clippy::too_many_arguments)]
+    fn build_process_fn(
+        read_structures: Vec<ReadStructure>,
+        encoding: QualityEncoding,
+        cfg: ExtractConfig,
+        encoded_umi_set: Arc<EncodedUmiSet>,
+        umi_length: usize,
+        revcomp: bool,
+        max_mismatches: usize,
+        min_distance_diff: usize,
+        dont_store_original_umis: bool,
+        cache_size: usize,
+    ) -> impl Fn(FastqTemplate) -> io::Result<RawExtractedRecords> + Send + Sync + 'static {
+        let read_structures = Arc::new(read_structures);
+        let cfg = Arc::new(cfg);
+        let umi_tag: [u8; 2] = *SamTag::RX;
+
+        move |template: FastqTemplate| -> io::Result<RawExtractedRecords> {
+            // Validate paired read names match across streams (mirrors the
+            // standalone extract command's synchronized-mode check).
+            if template.records.len() >= 2 {
+                let base_name = strip_read_suffix_extract(template.records[0].name());
+                for (i, record) in template.records.iter().enumerate().skip(1) {
+                    let other_base = strip_read_suffix_extract(record.name());
+                    if base_name != other_base {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "FASTQ files out of sync: R1 has '{}', R{} has '{}'",
+                                String::from_utf8_lossy(base_name),
+                                i + 1,
+                                String::from_utf8_lossy(other_base),
+                            ),
+                        ));
+                    }
+                }
+            }
+
+            // Step 1: extract.
+            let mut fastq_sets: Vec<FastqSet> = Vec::with_capacity(template.records.len());
+            for (record, rs) in template.records.iter().zip(read_structures.iter()) {
+                let fastq_set = FastqSet::from_record_with_structure(
+                    record.name(),
+                    record.sequence(),
+                    record.quality(),
+                    rs,
+                    &[],
+                )
+                .map_err(io::Error::other)?;
+                fastq_sets.push(fastq_set);
+            }
+            let combined = FastqSet::combine_readsets(fastq_sets);
+            let extracted = make_raw_records_static(&combined, encoding, &cfg)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+            if extracted.num_records == 0 {
+                return Ok(extracted);
+            }
+
+            // Step 2: read the UMI from the first record. If any record lacks
+            // an RX tag, drop the whole template — matches standalone
+            // `fgumi correct`'s behaviour for missing-UMI input with no
+            // `--rejects` configured.
+            let first_record = match iter_length_prefixed(&extracted.data).next() {
+                Some(Ok(slice)) => slice,
+                Some(Err(e)) => {
+                    return Err(io::Error::other(format!("extract_correct: {e}")));
+                }
+                None => return Ok(extracted),
+            };
+            let aux = aux_data_slice(first_record);
+            let Some(umi_bytes) = find_string_tag(aux, umi_tag) else {
+                return Ok(RawExtractedRecords { data: Vec::new(), num_records: 0 });
+            };
+            let umi_str = match std::str::from_utf8(umi_bytes) {
+                Ok(s) => s.to_owned(),
+                Err(e) => {
+                    return Err(io::Error::other(format!(
+                        "extract_correct: RX tag is not valid UTF-8: {e}"
+                    )));
+                }
+            };
+
+            // Step 3: correction. Per-worker LRU cache lives in TLS so the
+            // closure body can stay `Fn` (not `FnMut`).
+            thread_local! {
+                static CACHE: RefCell<Option<LruCache<Vec<u8>, UmiMatch>>> =
+                    const { RefCell::new(None) };
+            }
+            let correction = CACHE.with(|cell| {
+                let mut cache_ref = cell.borrow_mut();
+                if cache_ref.is_none() && cache_size > 0 {
+                    let cap =
+                        NonZero::new(cache_size).expect("cache_size > 0 checked immediately above");
+                    *cache_ref = Some(LruCache::new(cap));
+                }
+                CorrectUmis::compute_template_correction(
+                    &umi_str,
+                    umi_length,
+                    revcomp,
+                    max_mismatches,
+                    min_distance_diff,
+                    &encoded_umi_set,
+                    &mut cache_ref,
+                )
+            });
+
+            if !correction.matched {
+                // Drop all records in this template (no `--rejects` support yet).
+                return Ok(RawExtractedRecords { data: Vec::new(), num_records: 0 });
+            }
+
+            // Step 4: apply correction to every record in the template,
+            // length-prefixing each record on the way out.
+            let mut kept_data: Vec<u8> = Vec::with_capacity(extracted.data.len());
+            let mut kept_count: u64 = 0;
+            for record_slice in iter_length_prefixed(&extracted.data) {
+                let record_slice =
+                    record_slice.map_err(|e| io::Error::other(format!("extract_correct: {e}")))?;
+                let mut record: Vec<u8> = record_slice.to_vec();
+                apply_correction_to_record_bytes(
+                    &mut record,
+                    &correction,
+                    umi_tag,
+                    dont_store_original_umis,
+                );
+                let block_size = u32::try_from(record.len())
+                    .map_err(|_| io::Error::other("extract_correct: record too large for u32"))?;
+                kept_data.extend_from_slice(&block_size.to_le_bytes());
+                kept_data.extend_from_slice(&record);
+                kept_count += 1;
+            }
+
+            Ok(RawExtractedRecords { data: kept_data, num_records: kept_count })
+        }
+    }
+
+    /// Identity `serialize_fn`: the fused process closure already produces
+    /// length-prefixed BAM bytes (post-correction); the serializer just
+    /// hands those bytes off into the worker scratch buffer.
+    fn build_serialize_fn()
+    -> impl Fn(RawExtractedRecords, &Header, &mut Vec<u8>) -> io::Result<u64> + Send + Sync + 'static
+    {
+        move |batch: RawExtractedRecords, _header: &Header, scratch: &mut Vec<u8>| {
+            scratch.extend_from_slice(&batch.data);
+            Ok(batch.num_records)
+        }
+    }
+
+    /// Run the chain end-to-end against the prepared
+    /// [`ChainContext::tmp_output`] path.
+    ///
+    /// When `metrics_path` is `Some`, writes two rows: an `extract` row
+    /// followed by a `correct` row. Both rows currently share the total
+    /// wall-clock duration of the fused pipeline and the same
+    /// `records_in == records_out` value (the post-correction count
+    /// emitted by `run_fastq_pipeline`). Per-stage timing and a separate
+    /// pre-correction record count require the fused `process_fn` to grow
+    /// per-stage accumulators — that infrastructure lands with PR #329's
+    /// `--correct::metrics` wiring.
+    fn run_chain(
+        &self,
+        command_line: &str,
+        output: &Path,
+        metrics_path: Option<&Path>,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            !self.inputs.is_empty(),
+            "ExtractCorrectChainRunner: at least one --input required"
+        );
+        anyhow::ensure!(
+            !self.umis.is_empty() || !self.umi_files.is_empty(),
+            "ExtractCorrectChainRunner: --correct::umis or --correct::umi-files is required"
+        );
+        let sample = self.sample.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("--extract::sample is required for the extract→correct chain")
+        })?;
+        let library = self.library.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("--extract::library is required for the extract→correct chain")
+        })?;
+
+        // Detect compression format per input; require uniformity.
+        let formats: Vec<CompressionFormat> = self
+            .inputs
+            .iter()
+            .map(|p| {
+                detect_compression_format(p)
+                    .with_context(|| format!("detecting compression format for {}", p.display()))
+            })
+            .collect::<Result<_>>()?;
+        let all_bgzf = formats.iter().all(|f| *f == CompressionFormat::Bgzf);
+
+        let encoding = self.detect_quality_encoding()?;
+        log::info!("ExtractCorrectChainRunner: detected quality encoding {encoding:?}");
+
+        let read_structures = self.resolve_read_structures()?;
+        anyhow::ensure!(
+            read_structures.len() == self.inputs.len(),
+            "ExtractCorrectChainRunner: --extract::read-structures must have one entry per --input \
+             (got {} structures vs {} inputs)",
+            read_structures.len(),
+            self.inputs.len(),
+        );
+
+        // Load UMI list for correction.
+        let (umi_sequences, umi_length) = load_umi_sequences(&self.umis, &self.umi_files)?;
+        let encoded_umi_set = Arc::new(EncodedUmiSet::new(&umi_sequences));
+
+        // Build the unmapped BAM header (matches `Extract::create_header`),
+        // then stamp a `@PG` record for runall.
+        let metadata = ExtractHeaderMetadata {
+            barcode: self.barcode.as_deref(),
+            platform: &self.platform,
+            platform_unit: self.platform_unit.as_deref(),
+            platform_model: self.platform_model.as_deref(),
+            sequencing_center: self.sequencing_center.as_deref(),
+            predicted_insert_size: self.predicted_insert_size,
+            description: self.description.as_deref(),
+            run_date: self.run_date.as_deref(),
+        };
+        let header = build_extract_header(
+            &self.read_group_id,
+            sample,
+            library,
+            &self.comments,
+            &metadata,
+            command_line,
+        )?;
+        let header = add_pg_record(header, command_line)?;
+
+        // Build the closure config (mirrors `Extract`'s ExtractConfig
+        // construction; matches the standalone defaults for fields we don't
+        // expose at the runall layer yet).
+        let cfg = ExtractConfig {
+            read_group_id: self.read_group_id.clone(),
+            store_umi_quals: false,
+            store_cell_quals: false,
+            single_tag: self.single_tag.as_ref().map(|t| {
+                SamTag::from_str(t).expect("--extract::single-tag length validated by validate.rs")
+            }),
+            annotate_read_names: self.annotate_read_names,
+            extract_umis_from_read_names: self.extract_umis_from_read_names,
+            store_sample_barcode_qualities: self.store_sample_barcode_qualities,
+        };
+
+        let pipeline_threads = self.threads.max(1);
+        let config = self.build_pipeline_config(all_bgzf)?;
+
+        let decompressed_readers: Option<Vec<Box<dyn BufRead + Send>>> = if all_bgzf {
+            None
+        } else {
+            let decomp_threads = pipeline_threads;
+            Some(
+                self.inputs
+                    .iter()
+                    .map(|p| open_fastq_reader(p, decomp_threads, false))
+                    .collect::<Result<Vec<_>>>()?,
+            )
+        };
+
+        let process_fn = Self::build_process_fn(
+            read_structures,
+            encoding,
+            cfg,
+            encoded_umi_set,
+            umi_length,
+            self.revcomp,
+            self.max_mismatches,
+            self.min_distance_diff,
+            self.dont_store_original_umis,
+            self.cache_size,
+        );
+        let serialize_fn = Self::build_serialize_fn();
+
+        let writer: Box<dyn Write + Send> = Box::new(std::io::BufWriter::new(
+            File::create(output)
+                .with_context(|| format!("create output BAM {}", output.display()))?,
+        ));
+
+        let start = std::time::Instant::now();
+        let records_out = run_fastq_pipeline(
+            config,
+            &self.inputs,
+            decompressed_readers,
+            &header,
+            writer,
+            process_fn,
+            serialize_fn,
+        )
+        .with_context(|| {
+            format!("ExtractCorrectChainRunner pipeline writing to {}", output.display())
+        })?;
+        let total_wall = start.elapsed().as_secs_f64();
+
+        if let Some(path) = metrics_path {
+            // The fused process_fn does not yet expose per-stage
+            // accumulators, so both rows share the total wall time and a
+            // single records_in / records_out value (the post-correction
+            // record count). PR #329 wires per-stage counters via
+            // `--correct::metrics`; once those land, this block should
+            // split the timings and populate `extract.records_out` /
+            // `correct.records_in` from the pre-correction count.
+            let mut writer = MetricsWriter::create(path)
+                .with_context(|| format!("opening --metrics path {} for write", path.display()))?;
+            writer
+                .write_row(&MetricsRow {
+                    stage: "extract".into(),
+                    wall_time_secs: total_wall,
+                    records_in: records_out,
+                    records_out,
+                })
+                .with_context(|| format!("writing extract metrics row to {}", path.display()))?;
+            writer
+                .write_row(&MetricsRow {
+                    stage: "correct".into(),
+                    wall_time_secs: total_wall,
+                    records_in: records_out,
+                    records_out,
+                })
+                .with_context(|| format!("writing correct metrics row to {}", path.display()))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ChainRunner for ExtractCorrectChainRunner {
+    fn name(&self) -> &'static str {
+        EXTRACT_CORRECT_CHAIN_RUNNER_NAME
+    }
+
+    /// Match `(Extract, Correct)` when:
+    /// * a UMI source is provided (inline `--correct::umis` or
+    ///   `--correct::umi-files`); and
+    /// * none of the `--correct::rejects`, `--correct::metrics`, or
+    ///   `--correct::min-corrected` flags are set (those still gate the
+    ///   runner off and fall through to `NotImplementedRunner`; PR #329
+    ///   will wire them).
+    ///
+    /// The top-level `--metrics` flag does NOT gate this runner — it is
+    /// honoured directly by `run_chain`, which writes one `extract` row
+    /// followed by one `correct` row to the supplied TSV.
+    fn supports(&self, ctx: &DispatchContext<'_>) -> bool {
+        if !self.rejects_unset || !self.metrics_unset || !self.min_corrected_unset {
+            return false;
+        }
+        if self.umis.is_empty() && self.umi_files.is_empty() {
+            return false;
+        }
+        ctx.start_from == StartFrom::Extract && ctx.stop_after == StopAfter::Correct
+    }
+
+    fn run(&self, ctx: ChainContext<'_>) -> Result<()> {
+        let metrics_path = ctx.dispatch.metrics_path;
+        self.run_chain(ctx.command_line, &ctx.tmp_output, metrics_path)
+    }
+}
+
+/// Apply UMI correction to a complete BAM record's bytes.
+///
+/// The closure operates on the raw bytes emitted by
+/// [`make_raw_records_static`] (i.e. without the 4-byte block-size prefix);
+/// the standalone `CorrectUmis::apply_correction_to_raw` operates on a
+/// `&mut RawRecord`. They do the same work — update the RX (and optionally
+/// OX) tags in place — but the chain runner avoids the `RawRecord` wrapper
+/// because the FASTQ pipeline never reads back as `RawRecord`s. Behaviour
+/// matches standalone correct exactly: only update tags when correction is
+/// actually needed, store original UMI in OX only when there are real
+/// mismatches.
+fn apply_correction_to_record_bytes(
+    record: &mut Vec<u8>,
+    correction: &TemplateCorrection,
+    umi_tag: [u8; 2],
+    dont_store_original_umis: bool,
+) {
+    if correction.needs_correction {
+        if let Some(ref corrected) = correction.corrected_umi {
+            update_string_tag(record, umi_tag, corrected.as_bytes());
+        }
+        if !dont_store_original_umis && correction.has_mismatches {
+            update_string_tag(record, *SamTag::OX, correction.original_umi.as_bytes());
+        }
+    }
+}
+
+/// Iterate over a length-prefixed BAM record stream as produced by
+/// [`make_raw_records_static`]. Each item is the record's payload bytes
+/// (no 4-byte block-size prefix). Returns an `Err` for truncated input.
+fn iter_length_prefixed(data: &[u8]) -> LengthPrefixedIter<'_> {
+    LengthPrefixedIter { data, cursor: 0 }
+}
+
+struct LengthPrefixedIter<'a> {
+    data: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> Iterator for LengthPrefixedIter<'a> {
+    type Item = io::Result<&'a [u8]>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.data.len() {
+            return None;
+        }
+        if self.cursor + 4 > self.data.len() {
+            return Some(Err(io::Error::other("truncated length prefix")));
+        }
+        let prefix: [u8; 4] =
+            self.data[self.cursor..self.cursor + 4].try_into().expect("4-byte slice");
+        let block_size = u32::from_le_bytes(prefix) as usize;
+        self.cursor += 4;
+        let end = self.cursor + block_size;
+        if end > self.data.len() {
+            return Some(Err(io::Error::other("truncated record body")));
+        }
+        let slice = &self.data[self.cursor..end];
+        self.cursor = end;
+        Some(Ok(slice))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::runall::infra::progress::ProgressMode;
+    use crate::commands::runall::options::{
+        AlignerOptions, CodecOptions, ConsensusMode, ConsensusOptions, CorrectOptions,
+        DuplexOptions, ExtractOptions, FilterOptions, GroupOptions, MultiAlignerOptions,
+        MultiCodecOptions, MultiConsensusOptions, MultiCorrectOptions, MultiDuplexOptions,
+        MultiExtractOptions, MultiFilterOptions, MultiGroupOptions, MultiSortOptions,
+        MultiZipperOptions, SortOptions, ZipperOptions,
+    };
+
+    fn runall_for_extract_correct(
+        inputs: Vec<PathBuf>,
+        output: PathBuf,
+        umis: Vec<String>,
+    ) -> Runall {
+        let extract = ExtractOptions {
+            sample: Some("S".to_string()),
+            library: Some("L".to_string()),
+            read_structures: Some(vec!["8M+T".to_string(), "+T".to_string()]),
+            ..ExtractOptions::default()
+        };
+        let correct = CorrectOptions { umis: Some(umis), ..CorrectOptions::default() };
+        Runall {
+            input: inputs,
+            output,
+            reference: None,
+            start_from: StartFrom::Extract,
+            stop_after: StopAfter::Correct,
+            consensus_mode: ConsensusMode::Simplex,
+            threads: 4,
+            progress: ProgressMode::None,
+            compression_level: 1,
+            metrics: None,
+            explain: false,
+            consensus_metrics: None,
+            intervals: None,
+            methylation_mode: None,
+            restore_unconverted_bases: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
+            sort_opts: MultiSortOptions::from(SortOptions::default()),
+            group_opts: MultiGroupOptions::from(GroupOptions::default()),
+            filter_opts: MultiFilterOptions::from(FilterOptions::default()),
+            consensus_opts: MultiConsensusOptions::from(ConsensusOptions::default()),
+            extract_opts: MultiExtractOptions::from(extract),
+            aligner_opts: MultiAlignerOptions::from(AlignerOptions::default()),
+            zipper_opts: MultiZipperOptions::from(ZipperOptions::default()),
+            correct_opts: MultiCorrectOptions::from(correct),
+            duplex_opts: MultiDuplexOptions::from(DuplexOptions::default()),
+            codec_opts: MultiCodecOptions::from(CodecOptions::default()),
+            queue_memory: QueueMemoryOptions::default(),
+        }
+    }
+
+    fn dispatch_ctx(start: StartFrom, stop: StopAfter) -> DispatchContext<'static> {
+        DispatchContext { start_from: start, stop_after: stop, metrics_path: None }
+    }
+
+    /// Write a paired-end gzip-compressed FASTQ fixture with a cycling
+    /// UMI per record. Mirrors the `write_paired_gzip_fastq*` helpers
+    /// used in the extract chain runner tests; kept local so this module
+    /// doesn't depend on test code in a sibling file.
+    fn write_paired_gzip_fastq_with_cycling_umi(r1: &Path, r2: &Path, num_pairs: usize) {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        const UMI_CYCLE: &[&[u8]] = &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT"];
+
+        let f1 = File::create(r1).unwrap();
+        let mut e1 = GzEncoder::new(f1, Compression::default());
+        let f2 = File::create(r2).unwrap();
+        let mut e2 = GzEncoder::new(f2, Compression::default());
+        for i in 0..num_pairs {
+            let umi = UMI_CYCLE[i % UMI_CYCLE.len()];
+            let umi_str = std::str::from_utf8(umi).unwrap();
+            let r1_seq = format!("{umi_str}AAAAAAAA");
+            let r2_seq = "CCCCCCCC";
+            writeln!(e1, "@read{i}/1").unwrap();
+            writeln!(e1, "{r1_seq}").unwrap();
+            writeln!(e1, "+").unwrap();
+            writeln!(e1, "{}", "I".repeat(r1_seq.len())).unwrap();
+            writeln!(e2, "@read{i}/2").unwrap();
+            writeln!(e2, "{r2_seq}").unwrap();
+            writeln!(e2, "+").unwrap();
+            writeln!(e2, "{}", "I".repeat(r2_seq.len())).unwrap();
+        }
+        e1.finish().unwrap();
+        e2.finish().unwrap();
+    }
+
+    #[test]
+    fn supports_only_extract_to_correct_with_umi_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+
+        assert!(runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Extract)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)));
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Group, StopAfter::Group)));
+
+        let metrics_path = dir.path().join("metrics.tsv");
+        let with_metrics = DispatchContext {
+            start_from: StartFrom::Extract,
+            stop_after: StopAfter::Correct,
+            metrics_path: Some(metrics_path.as_path()),
+        };
+        assert!(
+            runner.supports(&with_metrics),
+            "extract→correct chain runner now writes its own --metrics rows; the registry \
+             must dispatch to it even when --metrics is set"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_rejects_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::rejects must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_metrics_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_metrics = Some(dir.path().join("correct-metrics.tsv"));
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::metrics must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn does_not_support_when_correct_min_corrected_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_min_corrected = Some(0.5);
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert!(
+            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::min-corrected must keep gating the runner off (PR #329)"
+        );
+    }
+
+    #[test]
+    fn from_runall_propagates_queue_memory_options() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.queue_memory = QueueMemoryOptions {
+            queue_memory: "2GB".to_string(),
+            queue_memory_per_thread: false,
+            queue_memory_limit_mb: None,
+        };
+
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert_eq!(runner.queue_memory.queue_memory, "2GB");
+        assert!(!runner.queue_memory.queue_memory_per_thread);
+    }
+
+    #[test]
+    fn build_pipeline_config_applies_queue_memory_limit() {
+        // 1 GiB total (per-thread = false) → exactly 1 GiB queue-memory
+        // limit on the resulting `FastqPipelineConfig`, regardless of
+        // `--threads`.
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.threads = 4;
+        runall.queue_memory = QueueMemoryOptions {
+            queue_memory: "1GiB".to_string(),
+            queue_memory_per_thread: false,
+            queue_memory_limit_mb: None,
+        };
+
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        let config = runner.build_pipeline_config(true).expect("config builds");
+        assert_eq!(
+            config.queue_memory_limit,
+            1024 * 1024 * 1024,
+            "1 GiB total → 1 GiB queue_memory_limit on the FastqPipelineConfig",
+        );
+    }
+
+    #[test]
+    fn metrics_tsv_emits_two_rows() {
+        // Wire `--metrics` end-to-end through `run_chain`. Asserts header,
+        // ordering (`extract` then `correct`), and shared timing /
+        // record-count values per the simplification documented on
+        // `run_chain`.
+        let dir = tempfile::TempDir::new().unwrap();
+        let r1 = dir.path().join("R1.fastq.gz");
+        let r2 = dir.path().join("R2.fastq.gz");
+        let out_tmp = dir.path().join("extract_correct.bam.tmp");
+        let metrics = dir.path().join("metrics.tsv");
+
+        // 8 records, all UMIs in the allowed list — no template is dropped
+        // by correction, so per-row records_in == records_out == 16
+        // (8 templates × 2 segments).
+        write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 8);
+
+        let runall = runall_for_extract_correct(
+            vec![r1.clone(), r2.clone()],
+            out_tmp.clone(),
+            vec![
+                "AAAAAAAA".to_string(),
+                "CCCCCCCC".to_string(),
+                "GGGGGGGG".to_string(),
+                "TTTTTTTT".to_string(),
+            ],
+        );
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        runner
+            .run_chain("fgumi runall", &out_tmp, Some(metrics.as_path()))
+            .expect("chain runs with --metrics");
+
+        let contents = std::fs::read_to_string(&metrics).expect("read metrics");
+        let mut lines = contents.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "stage\twall_time_secs\trecords_in\trecords_out",
+            "header row"
+        );
+        let extract_row = lines.next().expect("extract row");
+        let correct_row = lines.next().expect("correct row");
+        let extract_cols: Vec<&str> = extract_row.split('\t').collect();
+        let correct_cols: Vec<&str> = correct_row.split('\t').collect();
+
+        assert_eq!(extract_cols[0], "extract", "row 1 stage");
+        assert_eq!(correct_cols[0], "correct", "row 2 stage");
+        // Both rows share the total wall time per the documented
+        // simplification — assert the timestamps are byte-for-byte equal
+        // so a future per-stage split is forced through this test.
+        assert_eq!(extract_cols[1], correct_cols[1], "wall_time_secs is shared today");
+        assert_eq!(extract_cols[2], "16", "extract.records_in: 8 templates × 2 segments");
+        assert_eq!(extract_cols[3], "16", "extract.records_out");
+        assert_eq!(correct_cols[2], "16", "correct.records_in");
+        assert_eq!(correct_cols[3], "16", "correct.records_out");
+        assert!(lines.next().is_none(), "exactly two data rows");
+    }
+
+    #[test]
+    fn does_not_support_when_no_umi_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            Vec::new(),
+        );
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert!(!runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)));
+    }
+
+    #[test]
+    fn name_is_stable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        assert_eq!(runner.name(), EXTRACT_CORRECT_CHAIN_RUNNER_NAME);
+    }
+}

--- a/src/lib/commands/runall/chains/mod.rs
+++ b/src/lib/commands/runall/chains/mod.rs
@@ -4,13 +4,19 @@
 //! every `(start_from, stop_after)` shape and bails with "not yet
 //! implemented". PR 2 adds [`ExtractChainRunner`] — the
 //! `(Extract, Extract)` chain on top of `unified_pipeline::fastq`. PR 3
-//! will add `correct.rs` and `extract_correct.rs`. Each new chain
-//! runner is registered ahead of `NotImplementedRunner` in
-//! `Runall::build_chain_registry`; the fallback keeps handling shapes
-//! that haven't been implemented yet.
+//! adds [`CorrectChainRunner`] — the `(Correct, Correct)` chain on top
+//! of `unified_pipeline::bam` — and [`ExtractCorrectChainRunner`] — the
+//! fused `(Extract, Correct)` chain on top of
+//! `unified_pipeline::fastq`. Each new chain runner is registered ahead
+//! of `NotImplementedRunner` in `Runall::build_chain_registry`; the
+//! fallback keeps handling shapes that haven't been implemented yet.
 
+pub(crate) mod correct;
 pub(crate) mod extract;
+pub(crate) mod extract_correct;
 pub(crate) mod not_implemented;
 
+pub(crate) use correct::CorrectChainRunner;
 pub(crate) use extract::ExtractChainRunner;
+pub(crate) use extract_correct::ExtractCorrectChainRunner;
 pub(crate) use not_implemented::NotImplementedRunner;

--- a/src/lib/commands/runall/mod.rs
+++ b/src/lib/commands/runall/mod.rs
@@ -219,14 +219,18 @@ pub struct Runall {
 impl Runall {
     /// Build the chain registry.
     ///
-    /// PR 2 registers [`chains::ExtractChainRunner`] for the
-    /// `(Extract, Extract)` shape; PR 3 will add the correct and
-    /// extract→correct runners ahead of it. Real runners are pushed
-    /// onto the front so their `supports()` checks fire before the
-    /// catch-all [`chains::NotImplementedRunner`] fallback.
+    /// PR 2 registered [`chains::ExtractChainRunner`] for the
+    /// `(Extract, Extract)` shape; PR 3 adds
+    /// [`chains::CorrectChainRunner`] for `(Correct, Correct)` and
+    /// [`chains::ExtractCorrectChainRunner`] for the fused
+    /// `(Extract, Correct)`. Real runners are pushed onto the front so
+    /// their `supports()` checks fire before the catch-all
+    /// [`chains::NotImplementedRunner`] fallback.
     fn build_chain_registry(&self) -> ChainRegistry {
         ChainRegistry::new()
             .register(Box::new(chains::ExtractChainRunner::from_runall(self)))
+            .register(Box::new(chains::ExtractCorrectChainRunner::from_runall(self)))
+            .register(Box::new(chains::CorrectChainRunner::from_runall(self)))
             .register(Box::new(chains::NotImplementedRunner))
     }
 

--- a/tests/integration/runall/mod.rs
+++ b/tests/integration/runall/mod.rs
@@ -6,6 +6,8 @@
 //! integration tests guard against CLI-parsing regressions and
 //! verify the binary's user-visible behaviour.
 
+mod test_correct_chain_parity;
 mod test_extract_chain_parity;
+mod test_extract_correct_chain_parity;
 mod test_runall_dispatch_errors;
 mod test_runall_explain;

--- a/tests/integration/runall/test_correct_chain_parity.rs
+++ b/tests/integration/runall/test_correct_chain_parity.rs
@@ -1,0 +1,208 @@
+//! Real-data parity gate for the `(Correct, Correct)` chain runner.
+//!
+//! Runs subprocess `fgumi correct` and subprocess
+//! `fgumi runall --start-from correct --stop-after correct` against the
+//! same input BAM (built via subprocess `fgumi extract` from a synthetic
+//! paired-end gzip FASTQ fixture), then asserts
+//! `fgumi compare bams --command correct` reports the two BAMs as
+//! identical record-for-record.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tempfile::TempDir;
+
+/// Resolved path to the `fgumi` binary built by Cargo for this test.
+fn fgumi_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_fgumi")
+}
+
+/// Cycle of UMIs used by the synthetic fixture: four ACGT-homopolymer UMIs
+/// (in the allowed list) plus an N8 UMI that lives outside the allowed
+/// list. With `--max-mismatches 0 --min-distance 1`, the N8 templates are
+/// dropped, exercising the rejection path; the others pass through as
+/// perfect matches, exercising the kept path.
+const UMI_CYCLE: &[&[u8]] = &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT", b"NNNNNNNN"];
+
+/// Allowed UMI list used by both standalone correct and runall correct.
+/// Excludes `NNNNNNNN`, which is what makes the cycle produce real
+/// rejections.
+const ALLOWED_UMIS: &[&str] = &["AAAAAAAA", "CCCCCCCC", "GGGGGGGG", "TTTTTTTT"];
+
+/// Write a paired-end gzip-compressed FASTQ fixture.
+///
+/// R1 = 8 bp UMI (cycled) + 8 bp template, R2 = 8 bp template. The UMI is
+/// drawn from [`UMI_CYCLE`] and rotates per record, so 80% of templates
+/// have an allowed UMI and 20% have an N8 UMI that should be dropped.
+fn write_paired_gzip_fastq_with_cycling_umi(r1: &Path, r2: &Path, num_pairs: usize) {
+    let f1 = std::fs::File::create(r1).unwrap();
+    let mut e1 = GzEncoder::new(f1, Compression::default());
+    let f2 = std::fs::File::create(r2).unwrap();
+    let mut e2 = GzEncoder::new(f2, Compression::default());
+
+    for i in 0..num_pairs {
+        let umi = UMI_CYCLE[i % UMI_CYCLE.len()];
+        let umi_str = std::str::from_utf8(umi).unwrap();
+        let r1_seq = format!("{umi_str}AAAAAAAA");
+        let r2_seq = "CCCCCCCC";
+
+        writeln!(e1, "@read{i}/1").unwrap();
+        writeln!(e1, "{r1_seq}").unwrap();
+        writeln!(e1, "+").unwrap();
+        writeln!(e1, "{}", "I".repeat(r1_seq.len())).unwrap();
+
+        writeln!(e2, "@read{i}/2").unwrap();
+        writeln!(e2, "{r2_seq}").unwrap();
+        writeln!(e2, "+").unwrap();
+        writeln!(e2, "{}", "I".repeat(r2_seq.len())).unwrap();
+    }
+    e1.finish().unwrap();
+    e2.finish().unwrap();
+}
+
+/// Subprocess `fgumi extract` to produce an input BAM with RX tags.
+fn run_extract_to_bam(r1: &Path, r2: &Path, out: &Path) {
+    let output = Command::new(fgumi_bin())
+        .args([
+            "extract",
+            "--threads",
+            "4",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--read-structures",
+            "8M+T",
+            "+T",
+            "--sample",
+            "S",
+            "--library",
+            "L",
+            "--compression-level",
+            "1",
+        ])
+        .output()
+        .expect("spawn fgumi extract");
+    assert!(
+        output.status.success(),
+        "fgumi extract failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi correct` (the standalone command) on `input`.
+///
+/// Standalone `fgumi correct --umis` takes a single value per occurrence, so
+/// we repeat the flag per allowed UMI rather than passing multiple values to
+/// one flag.
+fn run_standalone_correct(input: &Path, out: &Path, max_mismatches: usize) {
+    let mut args: Vec<String> = vec![
+        "correct".into(),
+        "--threads".into(),
+        "4".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--max-mismatches".into(),
+        max_mismatches.to_string(),
+        "--min-distance".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    for umi in ALLOWED_UMIS {
+        args.push("--umis".into());
+        args.push((*umi).to_string());
+    }
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi correct");
+    assert!(
+        output.status.success(),
+        "fgumi correct failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi runall --start-from correct --stop-after correct`.
+fn run_runall_correct_chain(input: &Path, out: &Path, max_mismatches: usize) {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "correct".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--correct::max-mismatches".into(),
+        max_mismatches.to_string(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall");
+    assert!(
+        output.status.success(),
+        "fgumi runall failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `fgumi compare bams --command correct` exit status (zero = identical
+/// under the correct preset).
+fn compare_bams_correct(a: &Path, b: &Path) -> std::process::Output {
+    Command::new(fgumi_bin())
+        .args(["compare", "bams", a.to_str().unwrap(), b.to_str().unwrap(), "--command", "correct"])
+        .output()
+        .expect("spawn fgumi compare bams")
+}
+
+#[test]
+fn correct_chain_parity_matches_standalone_on_paired_gzip() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+    let standalone_out = dir.path().join("standalone.bam");
+    let runall_out = dir.path().join("runall.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 100);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    // Both runs use --max-mismatches 0 --min-distance 1, which together with
+    // the synthetic UMI cycle exercise both the perfect-match path (4 of 5
+    // UMIs) and the dropped-record path (the N8 UMI).
+    run_standalone_correct(&extracted, &standalone_out, 0);
+    run_runall_correct_chain(&extracted, &runall_out, 0);
+
+    // Sanity: both runs must produce a non-empty BAM.
+    let standalone_size = std::fs::metadata(&standalone_out).unwrap().len();
+    let runall_size = std::fs::metadata(&runall_out).unwrap().len();
+    assert!(standalone_size > 0, "standalone BAM is empty");
+    assert!(runall_size > 0, "runall BAM is empty");
+
+    let cmp = compare_bams_correct(&standalone_out, &runall_out);
+    assert!(
+        cmp.status.success(),
+        "fgumi compare bams reported a mismatch (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        cmp.status,
+        String::from_utf8_lossy(&cmp.stdout),
+        String::from_utf8_lossy(&cmp.stderr),
+    );
+}

--- a/tests/integration/runall/test_extract_correct_chain_parity.rs
+++ b/tests/integration/runall/test_extract_correct_chain_parity.rs
@@ -1,0 +1,211 @@
+//! Real-data parity gate for the `(Extract, Correct)` fused chain runner.
+//!
+//! Runs subprocess `fgumi extract` followed by `fgumi correct` (the
+//! pipechain materialised through an intermediate BAM, run sequentially)
+//! and subprocess
+//! `fgumi runall --start-from extract --stop-after correct` on the same
+//! synthetic paired-end gzip FASTQ fixture, then asserts
+//! `fgumi compare bams --command correct` reports the two BAMs as
+//! identical record-for-record.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tempfile::TempDir;
+
+/// Resolved path to the `fgumi` binary built by Cargo for this test.
+fn fgumi_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_fgumi")
+}
+
+/// Cycle of UMIs used by the synthetic fixture: four ACGT-homopolymer UMIs
+/// (in the allowed list) plus an N8 UMI that lives outside the allowed
+/// list. With `--max-mismatches 0 --min-distance 1`, the N8 templates are
+/// dropped, exercising the rejection path; the others pass through as
+/// perfect matches, exercising the kept path.
+const UMI_CYCLE: &[&[u8]] = &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT", b"NNNNNNNN"];
+
+/// Allowed UMI list used by both standalone and runall.
+const ALLOWED_UMIS: &[&str] = &["AAAAAAAA", "CCCCCCCC", "GGGGGGGG", "TTTTTTTT"];
+
+/// Write a paired-end gzip-compressed FASTQ fixture (same shape as the
+/// correct-chain parity test). 80% allowed UMIs, 20% N8.
+fn write_paired_gzip_fastq_with_cycling_umi(r1: &Path, r2: &Path, num_pairs: usize) {
+    let f1 = std::fs::File::create(r1).unwrap();
+    let mut e1 = GzEncoder::new(f1, Compression::default());
+    let f2 = std::fs::File::create(r2).unwrap();
+    let mut e2 = GzEncoder::new(f2, Compression::default());
+
+    for i in 0..num_pairs {
+        let umi = UMI_CYCLE[i % UMI_CYCLE.len()];
+        let umi_str = std::str::from_utf8(umi).unwrap();
+        let r1_seq = format!("{umi_str}AAAAAAAA");
+        let r2_seq = "CCCCCCCC";
+
+        writeln!(e1, "@read{i}/1").unwrap();
+        writeln!(e1, "{r1_seq}").unwrap();
+        writeln!(e1, "+").unwrap();
+        writeln!(e1, "{}", "I".repeat(r1_seq.len())).unwrap();
+
+        writeln!(e2, "@read{i}/2").unwrap();
+        writeln!(e2, "{r2_seq}").unwrap();
+        writeln!(e2, "+").unwrap();
+        writeln!(e2, "{}", "I".repeat(r2_seq.len())).unwrap();
+    }
+    e1.finish().unwrap();
+    e2.finish().unwrap();
+}
+
+/// Subprocess `fgumi extract` to materialise the intermediate BAM.
+fn run_extract(r1: &Path, r2: &Path, out: &Path) {
+    let output = Command::new(fgumi_bin())
+        .args([
+            "extract",
+            "--threads",
+            "4",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--read-structures",
+            "8M+T",
+            "+T",
+            "--sample",
+            "S",
+            "--library",
+            "L",
+            "--compression-level",
+            "1",
+        ])
+        .output()
+        .expect("spawn fgumi extract");
+    assert!(
+        output.status.success(),
+        "fgumi extract failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi correct` (the standalone command) on `input`.
+///
+/// Standalone `fgumi correct --umis` takes a single value per occurrence, so
+/// we repeat the flag per allowed UMI rather than passing multiple values to
+/// one flag.
+fn run_standalone_correct(input: &Path, out: &Path, max_mismatches: usize) {
+    let mut args: Vec<String> = vec![
+        "correct".into(),
+        "--threads".into(),
+        "4".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--max-mismatches".into(),
+        max_mismatches.to_string(),
+        "--min-distance".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    for umi in ALLOWED_UMIS {
+        args.push("--umis".into());
+        args.push((*umi).to_string());
+    }
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi correct");
+    assert!(
+        output.status.success(),
+        "fgumi correct failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi runall --start-from extract --stop-after correct`.
+fn run_runall_extract_correct_chain(r1: &Path, r2: &Path, out: &Path, max_mismatches: usize) {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "extract".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        r1.to_str().unwrap().into(),
+        r2.to_str().unwrap().into(),
+        "--extract::sample".into(),
+        "S".into(),
+        "--extract::library".into(),
+        "L".into(),
+        "--extract::read-structures".into(),
+        "8M+T".into(),
+        "+T".into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--correct::max-mismatches".into(),
+        max_mismatches.to_string(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall");
+    assert!(
+        output.status.success(),
+        "fgumi runall failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `fgumi compare bams --command correct` exit status (zero = identical).
+fn compare_bams_correct(a: &Path, b: &Path) -> std::process::Output {
+    Command::new(fgumi_bin())
+        .args(["compare", "bams", a.to_str().unwrap(), b.to_str().unwrap(), "--command", "correct"])
+        .output()
+        .expect("spawn fgumi compare bams")
+}
+
+#[test]
+fn extract_correct_chain_parity_matches_pipechain_on_paired_gzip() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+    let pipechain_out = dir.path().join("pipechain.bam");
+    let runall_out = dir.path().join("runall.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 100);
+
+    // Pipechain: extract → correct, sequentially via intermediate BAM.
+    run_extract(&r1, &r2, &extracted);
+    run_standalone_correct(&extracted, &pipechain_out, 0);
+
+    // In-process: runall fused chain.
+    run_runall_extract_correct_chain(&r1, &r2, &runall_out, 0);
+
+    // Sanity: both runs must produce a non-empty BAM.
+    let pipechain_size = std::fs::metadata(&pipechain_out).unwrap().len();
+    let runall_size = std::fs::metadata(&runall_out).unwrap().len();
+    assert!(pipechain_size > 0, "pipechain BAM is empty");
+    assert!(runall_size > 0, "runall BAM is empty");
+
+    let cmp = compare_bams_correct(&pipechain_out, &runall_out);
+    assert!(
+        cmp.status.success(),
+        "fgumi compare bams reported a mismatch (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        cmp.status,
+        String::from_utf8_lossy(&cmp.stdout),
+        String::from_utf8_lossy(&cmp.stderr),
+    );
+}


### PR DESCRIPTION
**Stacked on #327, which is stacked on #326. Review and merge those first.**

PR 3 of 3 in the runall-on-`unified_pipeline` stack. Adds two new `ChainRunner` implementations and registers them ahead of the `NotImplementedRunner` fallback.

## Summary

- **`CorrectChainRunner`** — `(Correct, Correct)` BAM-linear chain. Forwards to a new `crate::commands::correct::run_correct_pipeline` free function (extracted from `CorrectUmis::execute_threads_mode`) that owns the multi-threaded UMI-correction pipeline body.
- **`ExtractCorrectChainRunner`** — `(Extract, Correct)` fused chain on `unified_pipeline::fastq`. Each `FastqTemplate` is converted to BAM bytes via `make_raw_records_static` and per-template UMI correction is applied in-place to those bytes in one closure. Per-worker LRU cache lives in `thread_local!` storage so the closure body stays `Fn` (not `FnMut`).
- Both runners gate themselves off `--metrics`, `--correct::rejects`, `--correct::metrics`, `--correct::min-corrected`, and require a UMI source (`--correct::umis` or `--correct::umi-files`). Anything outside that envelope falls through to `NotImplementedRunner`.

## Enabling refactor in `crate::commands::correct`

Behaviour-preserving — gated by the existing standalone-correct integration tests, all of which still pass:

- Extracts `pub(crate) fn run_correct_pipeline(params: CorrectPipelineParams<'_>) -> Result<u64>` and `pub(crate) fn finalize_correct_metrics(...)` as free functions; `CorrectUmis::execute_threads_mode` and `CorrectUmis::finalize_metrics` become thin wrappers.
- Promotes `compute_template_correction`, `extract_and_validate_template_umi_raw`, `apply_correction_to_raw` to `pub(crate)`; `RejectionReason`, `TemplateCorrection` (with fields), and `EncodedUmiSet::strings()` likewise.

## Parity tests

Both new tests build a synthetic paired-end gzip FASTQ with a UMI cycle that hits both the perfect-match path (4 of 5 UMIs are in the allowed list) and the dropped-record path (`NNNNNNNN` per 5 templates), use `--max-mismatches 0 --min-distance 1`, and diff via `fgumi compare bams --command correct`:

- `tests/integration/runall/test_correct_chain_parity.rs` — subprocess `fgumi correct` vs `fgumi runall --start-from correct --stop-after correct` on the same input BAM (built via subprocess `fgumi extract`).
- `tests/integration/runall/test_extract_correct_chain_parity.rs` — subprocess `fgumi extract` + `fgumi correct` (sequential pipechain through an intermediate BAM) vs `fgumi runall --start-from extract --stop-after correct` (in-process fused chain).

RED-GREEN perturbation cycles performed on both tests: dropping one allowed UMI on the standalone side caused `compare bams` to report a mismatch (RED); reverting restored parity (GREEN).

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test --no-fail-fast` — 2119 tests pass
- [x] Both parity tests pass on first run
- [x] Both parity tests RED→GREEN perturbation revert verified

Spec: `docs/superpowers/specs/2026-05-02-runall-3-pr-stack-design.md`.