### PR TITLE
feat(runall): honor --correct::metrics and --correct::min-corrected in correct chains

### DIFF
--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -329,18 +329,23 @@ impl MemoryEstimate for CorrectProcessedBatch {
 }
 
 /// Metrics collected from UMI correction processing, aggregated post-pipeline.
+///
+/// `pub(crate)` so the runall correct chain runners can build the same
+/// per-thread accumulator the standalone command uses, then call
+/// [`finalize_correct_metrics`] / replicate the `--min-corrected` threshold
+/// check without diverging from this command's behaviour.
 #[derive(Default)]
-struct CollectedCorrectMetrics {
+pub(crate) struct CollectedCorrectMetrics {
     /// Total templates processed.
-    templates_processed: u64,
+    pub(crate) templates_processed: u64,
     /// Records with missing UMI tag.
-    missing_umis: u64,
+    pub(crate) missing_umis: u64,
     /// Records with wrong UMI length.
-    wrong_length: u64,
+    pub(crate) wrong_length: u64,
     /// Records that didn't match any fixed UMI.
-    mismatched: u64,
+    pub(crate) mismatched: u64,
     /// Per-UMI match counts (for metrics file).
-    umi_matches: AHashMap<String, UmiCorrectionMetrics>,
+    pub(crate) umi_matches: AHashMap<String, UmiCorrectionMetrics>,
 }
 
 impl Command for CorrectUmis {
@@ -1463,7 +1468,11 @@ pub(crate) fn finalize_correct_metrics(
 /// Merges `counts` into `dst[umi]`, creating a zero-initialized entry if the
 /// key is absent. Uses `or_insert_with_key` so `umi` is only cloned on insert,
 /// not on hit.
-fn merge_umi_counts(
+///
+/// `pub(crate)` so the runall correct chain runners can reduce their own
+/// per-thread accumulators with the same semantics the standalone command
+/// uses.
+pub(crate) fn merge_umi_counts(
     dst: &mut AHashMap<String, UmiCorrectionMetrics>,
     umi: String,
     counts: &UmiCorrectionMetrics,

--- a/src/lib/commands/runall/chains/correct.rs
+++ b/src/lib/commands/runall/chains/correct.rs
@@ -8,18 +8,23 @@
 //! `min_corrected` check, metrics file finalisation) lives exactly once,
 //! in `crate::commands::correct`.
 //!
-//! Gate: matches `(Correct, Correct)` only when none of the
-//! chain-runner-incompatible per-`--correct::` flags are set
-//! (`--correct::rejects`, `--correct::metrics`, `--correct::min-corrected`)
-//! and a UMI source is provided (inline UMIs or a UMI file). The top-level
-//! `--metrics` flag IS supported: the runner times its
-//! `run_correct_pipeline` call and writes a single
-//! `MetricsRow { stage: "correct", ... }` row to the supplied TSV path.
+//! Gate: matches `(Correct, Correct)` whenever a UMI source is provided
+//! (inline UMIs or a UMI file). The `--correct::metrics` and
+//! `--correct::min-corrected` flags are forwarded directly to
+//! [`run_correct_pipeline`] (which already implements both). The
+//! `--correct::rejects` flag remains unsupported pending upstream
+//! refactors (fulcrumgenomics/fgumi#329 +
+//! fulcrumgenomics/fgumi#330) — when set, the runner still matches the
+//! chain shape so the user sees a specific error rather than the generic
+//! "not yet implemented" fallthrough. The top-level `--metrics` flag is
+//! also honoured: the runner times its `run_correct_pipeline` call and
+//! writes a single `MetricsRow { stage: "correct", ... }` row to the
+//! supplied TSV path.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::commands::common::{
     CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions, add_pg_record,
@@ -40,27 +45,32 @@ pub(crate) const CORRECT_CHAIN_RUNNER_NAME: &str = "CorrectChainRunner";
 /// `Runall` fields needed to drive [`run_correct_pipeline`]. Cloning keeps
 /// the runner `'static` (so it can be pushed into the trait-object
 /// registry) without leaking `Runall` lifetimes.
-#[allow(clippy::struct_excessive_bools)] // gate flags + correction toggles
+#[allow(clippy::struct_excessive_bools)] // correction toggles
 pub(crate) struct CorrectChainRunner {
-    input: std::path::PathBuf,
+    input: PathBuf,
     threads: usize,
     compression_level: u32,
     umis: Vec<String>,
-    umi_files: Vec<std::path::PathBuf>,
+    umi_files: Vec<PathBuf>,
     max_mismatches: usize,
     min_distance_diff: usize,
     cache_size: usize,
     revcomp: bool,
     dont_store_original_umis: bool,
-    /// `--correct::rejects`. Chain-runner-incompatible: must be unset for
-    /// `supports()` to match. (Wiring deferred to PR #329.)
-    rejects_unset: bool,
-    /// `--correct::metrics`. Chain-runner-incompatible. (Wiring deferred
-    /// to PR #329; the top-level `--metrics` is supported here.)
-    metrics_unset: bool,
-    /// `--correct::min-corrected`. Chain-runner-incompatible. (Wiring
-    /// deferred to PR #329.)
-    min_corrected_unset: bool,
+    /// `--correct::rejects`. Still unsupported at the runall layer pending
+    /// fulcrumgenomics/fgumi#329 (migrate hand-rolled rejects writers to
+    /// first-class `secondary_output`). When set, [`run_chain`] bails with
+    /// a specific error pointing at that issue rather than silently
+    /// falling through to the not-implemented runner.
+    rejects: Option<PathBuf>,
+    /// `--correct::metrics`. Forwarded to [`run_correct_pipeline`] via
+    /// [`CorrectPipelineParams::metrics_path`]; the per-UMI metrics TSV
+    /// is written by [`finalize_correct_metrics`] inside the pipeline.
+    correct_metrics: Option<PathBuf>,
+    /// `--correct::min-corrected`. Forwarded to [`run_correct_pipeline`]
+    /// via [`CorrectPipelineParams::min_corrected`]; the post-pipeline
+    /// kept/total-records ratio check is performed there.
+    correct_min_corrected: Option<f64>,
     /// `--queue-memory` / `--queue-memory-per-thread` from the top-level
     /// `Runall`. Cloned (rather than per-field-decomposed) so the runner
     /// can call `QueueMemoryOptions::calculate_memory_limit` and
@@ -92,9 +102,9 @@ impl CorrectChainRunner {
             cache_size: opts.correct_cache_size,
             revcomp: opts.correct_revcomp,
             dont_store_original_umis: opts.correct_dont_store_original_umis,
-            rejects_unset: opts.correct_rejects.is_none(),
-            metrics_unset: opts.correct_metrics.is_none(),
-            min_corrected_unset: opts.correct_min_corrected.is_none(),
+            rejects: opts.correct_rejects.clone(),
+            correct_metrics: opts.correct_metrics.clone(),
+            correct_min_corrected: opts.correct_min_corrected,
             queue_memory: runall.queue_memory.clone(),
         }
     }
@@ -104,12 +114,12 @@ impl CorrectChainRunner {
     ///
     /// When `metrics_path` is `Some`, writes a single
     /// [`MetricsRow`] tagged `"correct"` with wall-clock duration and
-    /// `records_in == records_out`. The simplification is exact for the
-    /// supported chain configurations: without `--correct::rejects`,
-    /// rejected records are still emitted (with the original UMI), and
-    /// without `--correct::min-corrected`, no records are dropped
-    /// post-correction. PR #329 will wire those flags and split
-    /// `records_in` / `records_out` accordingly.
+    /// `records_in == records_out` (the total record count returned by
+    /// [`run_correct_pipeline`], which equals kept + rejected). Once
+    /// `--correct::rejects` lands (fulcrumgenomics/fgumi#329 +
+    /// fulcrumgenomics/fgumi#330), this row should split `records_in` /
+    /// `records_out` so the dropped count is visible in the top-level
+    /// metrics TSV.
     fn run_chain(
         &self,
         command_line: &str,
@@ -124,6 +134,21 @@ impl CorrectChainRunner {
             !self.umis.is_empty() || !self.umi_files.is_empty(),
             "CorrectChainRunner: --correct::umis or --correct::umi-files is required",
         );
+        if self.rejects.is_some() {
+            // Wiring `--correct::rejects` through the runall correct chain
+            // requires the standalone command's hand-rolled
+            // `Arc<Mutex<Option<RawBamWriter>>>` to first migrate to the
+            // unified pipeline's `secondary_output` (issue #329); the fused
+            // extract→correct chain additionally needs FASTQ-pipeline
+            // secondary-output support (issue #330's phase 1). Until both
+            // land we fail with a specific error so users get a pointer to
+            // the tracking work rather than the generic "not yet
+            // implemented" fallthrough.
+            bail!(
+                "--correct::rejects is not yet supported by the runall correct chain; \
+                 tracked in fulcrumgenomics/fgumi#329 and fulcrumgenomics/fgumi#330"
+            );
+        }
 
         // Load the UMI list from inline strings + files, deduped + uppercased,
         // matching the standalone `fgumi correct` loader.
@@ -147,7 +172,7 @@ impl CorrectChainRunner {
         let threading = ThreadingOptions { threads: Some(self.threads) };
 
         let start = std::time::Instant::now();
-        let records_out = run_correct_pipeline(CorrectPipelineParams {
+        let total_records = run_correct_pipeline(CorrectPipelineParams {
             num_threads: self.threads,
             reader,
             header,
@@ -160,31 +185,30 @@ impl CorrectChainRunner {
             threading: &threading,
             rejects_path: None,
             output_path: output,
-            metrics_path: None,
+            metrics_path: self.correct_metrics.as_deref(),
             max_mismatches: self.max_mismatches,
             min_distance_diff: self.min_distance_diff,
             revcomp: self.revcomp,
             cache_size: self.cache_size,
             dont_store_original_umis: self.dont_store_original_umis,
-            min_corrected: None,
+            min_corrected: self.correct_min_corrected,
         })
         .with_context(|| format!("CorrectChainRunner pipeline writing to {}", output.display()))?;
         let wall_time_secs = start.elapsed().as_secs_f64();
 
         if let Some(path) = metrics_path {
-            // Without `--correct::rejects` rejected records are still emitted
-            // (with their original UMI) and without `--correct::min-corrected`
-            // no records are dropped post-correction, so `records_in` and
-            // `records_out` are equal. PR #329 wires those flags and will
-            // start populating `records_in` independently.
+            // Until `--correct::rejects` is wired (issues #329 + #330) we
+            // can't separate the kept count from the total here, so both
+            // columns carry the total record count returned by
+            // `run_correct_pipeline`.
             let mut writer = MetricsWriter::create(path)
                 .with_context(|| format!("opening --metrics path {} for write", path.display()))?;
             writer
                 .write_row(&MetricsRow {
                     stage: "correct".into(),
                     wall_time_secs,
-                    records_in: records_out,
-                    records_out,
+                    records_in: total_records,
+                    records_out: total_records,
                 })
                 .with_context(|| format!("writing correct metrics row to {}", path.display()))?;
         }
@@ -198,21 +222,22 @@ impl ChainRunner for CorrectChainRunner {
         CORRECT_CHAIN_RUNNER_NAME
     }
 
-    /// Match `(Correct, Correct)` when:
-    /// * a UMI source is provided (inline `--correct::umis` or
-    ///   `--correct::umi-files`); and
-    /// * none of the `--correct::rejects`, `--correct::metrics`, or
-    ///   `--correct::min-corrected` flags are set (those still gate the
-    ///   runner off so those invocations fall through to the
-    ///   `NotImplementedRunner`; PR #329 will wire them).
+    /// Match `(Correct, Correct)` whenever a UMI source is provided
+    /// (inline `--correct::umis` or `--correct::umi-files`).
+    ///
+    /// `--correct::metrics` and `--correct::min-corrected` are forwarded
+    /// directly to [`run_correct_pipeline`] (which already owns both
+    /// behaviours), so they don't gate the runner.
+    ///
+    /// `--correct::rejects` ALSO does not gate `supports()` — when set we
+    /// still want this runner to win over `NotImplementedRunner` so the
+    /// user sees the specific "tracked in #329 / #330" error from
+    /// [`run_chain`] instead of the generic fallthrough message.
     ///
     /// The top-level `--metrics` flag does NOT gate this runner — it is
     /// honoured directly by `run_chain`, which writes a single
     /// `correct` row to the supplied TSV.
     fn supports(&self, ctx: &DispatchContext<'_>) -> bool {
-        if !self.rejects_unset || !self.metrics_unset || !self.min_corrected_unset {
-            return false;
-        }
         if self.umis.is_empty() && self.umi_files.is_empty() {
             return false;
         }
@@ -344,7 +369,11 @@ mod tests {
     }
 
     #[test]
-    fn does_not_support_when_correct_rejects_set() {
+    fn supports_when_correct_rejects_set_so_run_can_emit_specific_error() {
+        // Lifted gate (this PR): we want the runner to claim the chain
+        // shape even when `--correct::rejects` is set, so the user sees
+        // the specific "tracked in #329 / #330" error from `run_chain`
+        // rather than the generic NotImplementedRunner fallthrough.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_correct(
             dir.path().join("in.bam"),
@@ -354,13 +383,16 @@ mod tests {
         runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
         let runner = CorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
-            "--correct::rejects must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::rejects must NOT gate supports() — it routes through run_chain to fail \
+             with a specific error pointing at issues #329 and #330"
         );
     }
 
     #[test]
-    fn does_not_support_when_correct_metrics_set() {
+    fn supports_with_correct_metrics_set() {
+        // `--correct::metrics` is now forwarded directly to
+        // `run_correct_pipeline`; the runner should claim the chain shape.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_correct(
             dir.path().join("in.bam"),
@@ -370,13 +402,15 @@ mod tests {
         runall.correct_opts.correct_metrics = Some(dir.path().join("correct-metrics.tsv"));
         let runner = CorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
-            "--correct::metrics must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::metrics must no longer gate supports() (this PR)"
         );
     }
 
     #[test]
-    fn does_not_support_when_correct_min_corrected_set() {
+    fn supports_with_correct_min_corrected_set() {
+        // `--correct::min-corrected` is now forwarded directly to
+        // `run_correct_pipeline`; the runner should claim the chain shape.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_correct(
             dir.path().join("in.bam"),
@@ -386,8 +420,36 @@ mod tests {
         runall.correct_opts.correct_min_corrected = Some(0.5);
         let runner = CorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
-            "--correct::min-corrected must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Correct, StopAfter::Correct)),
+            "--correct::min-corrected must no longer gate supports() (this PR)"
+        );
+    }
+
+    #[test]
+    fn rejects_set_returns_specific_error_pointing_at_issues_329_330() {
+        // Lifted gate (this PR) means `supports()` is now true; the
+        // specific error must surface from `run_chain` itself.
+        let dir = tempfile::TempDir::new().unwrap();
+        let in_bam = dir.path().join("in.bam");
+        write_test_bam(&in_bam, 1, &[b"AAAAAAAA"]);
+        let mut runall = runall_for_correct(
+            in_bam.clone(),
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
+        let runner = CorrectChainRunner::from_runall(&runall);
+        let err = runner
+            .run_chain("fgumi runall", &dir.path().join("ignored.bam"), None)
+            .expect_err("run_chain must bail when --correct::rejects is set");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("fulcrumgenomics/fgumi#329"),
+            "error must mention upstream issue #329; got: {msg}"
+        );
+        assert!(
+            msg.contains("fulcrumgenomics/fgumi#330"),
+            "error must mention upstream issue #330; got: {msg}"
         );
     }
 

--- a/src/lib/commands/runall/chains/extract_correct.rs
+++ b/src/lib/commands/runall/chains/extract_correct.rs
@@ -12,20 +12,35 @@
 //! `thread_local!` storage, mirroring the standalone `fgumi correct`
 //! pipeline.
 //!
-//! When the caller passes `--metrics`, the runner times its
+//! When the caller passes `--correct::metrics`, the closure also records
+//! per-template correction outcomes into a
+//! [`crate::per_thread_accumulator::PerThreadAccumulator`] of
+//! [`crate::commands::correct::CollectedCorrectMetrics`] (mirroring
+//! standalone `fgumi correct`); after the pipeline returns, the runner
+//! aggregates the slots and calls
+//! [`crate::commands::correct::finalize_correct_metrics`] to write the same
+//! TSV the standalone command does.
+//!
+//! `--correct::min-corrected` is enforced post-pipeline against the same
+//! accumulator: `kept_records` / `total_records` (where total = kept +
+//! missing/wrong-length/mismatched). Failure to meet the threshold returns
+//! the same `bail!()` text as standalone `fgumi correct`.
+//!
+//! When the caller passes `--metrics` (the top-level runall metrics flag,
+//! not the per-stage `--correct::metrics`), the runner times its
 //! `run_fastq_pipeline` call and emits two
 //! [`crate::commands::runall::infra::metrics::MetricsRow`]s to the supplied
-//! TSV: an `extract` row followed by a `correct` row. Per-stage wall time
-//! and `records_in` / `records_out` are simplifications until the fused
-//! `process_fn` grows per-stage accumulators (PR #329 wires
-//! `--correct::metrics`, which exposes that infrastructure):
+//! TSV: an `extract` row followed by a `correct` row. Both rows currently
+//! share the total wall-clock duration; per-stage timing and a separate
+//! pre-correction record count would require splitting the fused
+//! `process_fn`, which is out of scope for this PR.
 //!
-//! * Both rows share the total wall-clock duration of the fused pipeline.
-//! * Both rows have `records_in == records_out` set to the post-correction
-//!   record count emitted by `run_fastq_pipeline`. (Without
-//!   `--correct::rejects` rejected templates are silently dropped, but the
-//!   chain runner does not expose a separate dropped-record counter today;
-//!   PR #329 adds that path.)
+//! `--correct::rejects` remains unsupported — it would require either
+//! migrating standalone correct's hand-rolled rejects writer to
+//! `secondary_output` (issue #329) or adding `secondary_output` support to
+//! the FASTQ pipeline (issue #330's phase 1+). When set, [`run_chain`]
+//! bails with a specific error pointing at both issues rather than
+//! silently falling through to the not-implemented runner.
 
 use std::cell::RefCell;
 use std::fs::File;
@@ -35,13 +50,17 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use ahash::AHashMap;
+use anyhow::{Context, Result, bail};
 use lru::LruCache;
 use noodles::sam::Header;
 use read_structure::ReadStructure;
 
 use crate::commands::common::{QueueMemoryOptions, add_pg_record};
-use crate::commands::correct::{CorrectUmis, EncodedUmiSet, TemplateCorrection, UmiMatch};
+use crate::commands::correct::{
+    CollectedCorrectMetrics, CorrectUmis, EncodedUmiSet, RejectionReason, TemplateCorrection,
+    UmiMatch, finalize_correct_metrics, merge_umi_counts,
+};
 use crate::commands::extract::{
     BUFFER_SIZE, CompressionFormat, ExtractConfig, ExtractHeaderMetadata,
     QUALITY_DETECTION_SAMPLE_SIZE, QualityEncoding, RawExtractedRecords, build_extract_header,
@@ -55,6 +74,8 @@ use crate::commands::runall::infra::metrics::{MetricsRow, MetricsWriter};
 use crate::commands::runall::options::{StartFrom, StopAfter};
 use crate::fastq::FastqSet;
 use crate::grouper::FastqTemplate;
+use crate::metrics::UmiCorrectionMetrics;
+use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
 use crate::unified_pipeline::{FastqPipelineConfig, run_fastq_pipeline};
 use fgumi_raw_bam::{aux_data_slice, find_string_tag, update_string_tag};
@@ -99,10 +120,19 @@ pub(crate) struct ExtractCorrectChainRunner {
     cache_size: usize,
     revcomp: bool,
     dont_store_original_umis: bool,
-    // Chain-runner-incompatible flags (gated off; PR #329 will wire them).
-    rejects_unset: bool,
-    metrics_unset: bool,
-    min_corrected_unset: bool,
+    /// `--correct::rejects`. Still unsupported pending issues #329 + #330;
+    /// when set, [`run_chain`] bails with a specific error rather than
+    /// falling through to `NotImplementedRunner`.
+    rejects: Option<PathBuf>,
+    /// `--correct::metrics`. When set, the fused process closure records
+    /// per-template correction outcomes into a per-thread accumulator and
+    /// the runner calls [`finalize_correct_metrics`] post-pipeline to
+    /// emit the same TSV the standalone `fgumi correct` does.
+    correct_metrics: Option<PathBuf>,
+    /// `--correct::min-corrected`. Enforced post-pipeline against the same
+    /// per-thread accumulator using the same threshold formula and error
+    /// text standalone `fgumi correct` uses.
+    correct_min_corrected: Option<f64>,
     /// `--queue-memory` / `--queue-memory-per-thread` from the top-level
     /// `Runall`. Cloned so the runner can build a `FastqPipelineConfig`
     /// with the same memory budget the standalone `fgumi extract` /
@@ -143,9 +173,9 @@ impl ExtractCorrectChainRunner {
             cache_size: correct_opts.correct_cache_size,
             revcomp: correct_opts.correct_revcomp,
             dont_store_original_umis: correct_opts.correct_dont_store_original_umis,
-            rejects_unset: correct_opts.correct_rejects.is_none(),
-            metrics_unset: correct_opts.correct_metrics.is_none(),
-            min_corrected_unset: correct_opts.correct_min_corrected.is_none(),
+            rejects: correct_opts.correct_rejects.clone(),
+            correct_metrics: correct_opts.correct_metrics.clone(),
+            correct_min_corrected: correct_opts.correct_min_corrected,
             queue_memory: runall.queue_memory.clone(),
         }
     }
@@ -211,6 +241,14 @@ impl ExtractCorrectChainRunner {
     /// 4. either drop the template (UMI not matched) or apply the correction
     ///    in-place to every record's RX (and OX) tag.
     ///
+    /// When `metrics_acc` is `Some`, the closure also records per-template
+    /// correction outcomes into the accumulator, mirroring the
+    /// `umi_matches_map` / `missing_umis` / `wrong_length` / `mismatched`
+    /// counters standalone `fgumi correct` keeps. Passing `None` skips
+    /// metric recording entirely (the per-thread accumulator is a free
+    /// allocation only when the user actually requested metrics or
+    /// `--correct::min-corrected`).
+    ///
     /// The returned closure is `Send + Sync + 'static` and plugs directly
     /// into the FASTQ pipeline's `process_fn` slot.
     #[allow(clippy::too_many_arguments)]
@@ -225,10 +263,13 @@ impl ExtractCorrectChainRunner {
         min_distance_diff: usize,
         dont_store_original_umis: bool,
         cache_size: usize,
+        unmatched_umi: String,
+        metrics_acc: Option<Arc<PerThreadAccumulator<CollectedCorrectMetrics>>>,
     ) -> impl Fn(FastqTemplate) -> io::Result<RawExtractedRecords> + Send + Sync + 'static {
         let read_structures = Arc::new(read_structures);
         let cfg = Arc::new(cfg);
         let umi_tag: [u8; 2] = *SamTag::RX;
+        let unmatched_umi = Arc::new(unmatched_umi);
 
         move |template: FastqTemplate| -> io::Result<RawExtractedRecords> {
             // Validate paired read names match across streams (mirrors the
@@ -269,8 +310,12 @@ impl ExtractCorrectChainRunner {
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
             if extracted.num_records == 0 {
+                if let Some(ref acc) = metrics_acc {
+                    acc.with_slot(|m| m.templates_processed += 1);
+                }
                 return Ok(extracted);
             }
+            let template_record_count = extracted.num_records;
 
             // Step 2: read the UMI from the first record. If any record lacks
             // an RX tag, drop the whole template — matches standalone
@@ -285,6 +330,17 @@ impl ExtractCorrectChainRunner {
             };
             let aux = aux_data_slice(first_record);
             let Some(umi_bytes) = find_string_tag(aux, umi_tag) else {
+                if let Some(ref acc) = metrics_acc {
+                    acc.with_slot(|m| {
+                        m.templates_processed += 1;
+                        m.missing_umis += template_record_count;
+                        let entry =
+                            m.umi_matches.entry(unmatched_umi.as_str().to_string()).or_insert_with(
+                                || UmiCorrectionMetrics::new(unmatched_umi.as_str().to_string()),
+                            );
+                        entry.total_matches += template_record_count;
+                    });
+                }
                 return Ok(RawExtractedRecords { data: Vec::new(), num_records: 0 });
             };
             let umi_str = match std::str::from_utf8(umi_bytes) {
@@ -322,7 +378,50 @@ impl ExtractCorrectChainRunner {
 
             if !correction.matched {
                 // Drop all records in this template (no `--rejects` support yet).
+                if let Some(ref acc) = metrics_acc {
+                    acc.with_slot(|m| {
+                        m.templates_processed += 1;
+                        match correction.rejection_reason {
+                            RejectionReason::WrongLength => {
+                                m.wrong_length += template_record_count;
+                            }
+                            RejectionReason::Mismatched => {
+                                m.mismatched += template_record_count;
+                            }
+                            RejectionReason::None => {}
+                        }
+                        let entry =
+                            m.umi_matches.entry(unmatched_umi.as_str().to_string()).or_insert_with(
+                                || UmiCorrectionMetrics::new(unmatched_umi.as_str().to_string()),
+                            );
+                        entry.total_matches += template_record_count;
+                    });
+                }
                 return Ok(RawExtractedRecords { data: Vec::new(), num_records: 0 });
+            }
+
+            // Record per-UMI match outcomes (mirrors standalone correct
+            // exactly: per match segment, increment the bucket matching the
+            // mismatch count, and accumulate `total_matches` per UMI).
+            if let Some(ref acc) = metrics_acc {
+                acc.with_slot(|m| {
+                    m.templates_processed += 1;
+                    for sub in &correction.matches {
+                        if sub.matched {
+                            let entry = m
+                                .umi_matches
+                                .entry(sub.umi.clone())
+                                .or_insert_with(|| UmiCorrectionMetrics::new(sub.umi.clone()));
+                            entry.total_matches += template_record_count;
+                            match sub.mismatches {
+                                0 => entry.perfect_matches += template_record_count,
+                                1 => entry.one_mismatch_matches += template_record_count,
+                                2 => entry.two_mismatch_matches += template_record_count,
+                                _ => entry.other_matches += template_record_count,
+                            }
+                        }
+                    }
+                });
             }
 
             // Step 4: apply correction to every record in the template,
@@ -365,14 +464,25 @@ impl ExtractCorrectChainRunner {
     /// Run the chain end-to-end against the prepared
     /// [`ChainContext::tmp_output`] path.
     ///
-    /// When `metrics_path` is `Some`, writes two rows: an `extract` row
-    /// followed by a `correct` row. Both rows currently share the total
-    /// wall-clock duration of the fused pipeline and the same
-    /// `records_in == records_out` value (the post-correction count
-    /// emitted by `run_fastq_pipeline`). Per-stage timing and a separate
-    /// pre-correction record count require the fused `process_fn` to grow
-    /// per-stage accumulators — that infrastructure lands with PR #329's
-    /// `--correct::metrics` wiring.
+    /// When `metrics_path` is `Some` (top-level `--metrics`), writes two
+    /// rows: an `extract` row followed by a `correct` row. Both rows
+    /// currently share the total wall-clock duration of the fused
+    /// pipeline. The `extract` row's `records_in` / `records_out` reflects
+    /// the pre-correction record count (templates × segments) and the
+    /// `correct` row's reflect the post-correction count emitted by
+    /// `run_fastq_pipeline` — these are equal unless a template is
+    /// dropped by failing UMI correction.
+    ///
+    /// When `--correct::metrics` is set on `self`, the runner additionally
+    /// builds a [`PerThreadAccumulator<CollectedCorrectMetrics>`], threads
+    /// a clone into the fused process closure, and after the pipeline
+    /// returns calls [`finalize_correct_metrics`] to write the same
+    /// per-UMI TSV the standalone command does.
+    ///
+    /// When `--correct::min-corrected` is set, the runner enforces the
+    /// same threshold standalone correct does (`kept_records` /
+    /// `total_records` ≥ min) and bails with the same error text on
+    /// failure.
     fn run_chain(
         &self,
         command_line: &str,
@@ -387,6 +497,17 @@ impl ExtractCorrectChainRunner {
             !self.umis.is_empty() || !self.umi_files.is_empty(),
             "ExtractCorrectChainRunner: --correct::umis or --correct::umi-files is required"
         );
+        if self.rejects.is_some() {
+            // Wiring rejects through the fused chain requires both the
+            // standalone correct rejects-writer migration (issue #329) and
+            // FASTQ-pipeline secondary-output support (issue #330's
+            // phase 1). Bail with a specific pointer rather than
+            // falling through to the generic NotImplementedRunner error.
+            bail!(
+                "--correct::rejects is not yet supported by the runall extract→correct chain; \
+                 tracked in fulcrumgenomics/fgumi#329 and fulcrumgenomics/fgumi#330"
+            );
+        }
         let sample = self.sample.as_deref().ok_or_else(|| {
             anyhow::anyhow!("--extract::sample is required for the extract→correct chain")
         })?;
@@ -473,6 +594,23 @@ impl ExtractCorrectChainRunner {
             )
         };
 
+        // Per-thread metrics accumulator. Allocated whenever the user
+        // requested either `--correct::metrics` (TSV emission) or
+        // `--correct::min-corrected` (kept/total ratio check); both reuse
+        // the same standalone-correct CollectedCorrectMetrics shape so the
+        // post-pipeline code path is shared.
+        let want_metrics_acc =
+            self.correct_metrics.is_some() || self.correct_min_corrected.is_some();
+        let unmatched_umi: String = "N".repeat(umi_length);
+        let metrics_acc: Option<Arc<PerThreadAccumulator<CollectedCorrectMetrics>>> =
+            if want_metrics_acc {
+                Some(PerThreadAccumulator::<CollectedCorrectMetrics>::new(pipeline_threads))
+            } else {
+                None
+            };
+        let metrics_acc_for_closure = metrics_acc.as_ref().map(Arc::clone);
+        let encoded_umi_set_for_metrics = Arc::clone(&encoded_umi_set);
+
         let process_fn = Self::build_process_fn(
             read_structures,
             encoding,
@@ -484,6 +622,8 @@ impl ExtractCorrectChainRunner {
             self.min_distance_diff,
             self.dont_store_original_umis,
             self.cache_size,
+            unmatched_umi.clone(),
+            metrics_acc_for_closure,
         );
         let serialize_fn = Self::build_serialize_fn();
 
@@ -507,29 +647,83 @@ impl ExtractCorrectChainRunner {
         })?;
         let total_wall = start.elapsed().as_secs_f64();
 
+        // Aggregate the per-thread accumulator (if any). We compute the
+        // standalone-correct totals (kept = records_out, rejected =
+        // missing + wrong_length + mismatched) up-front so both metrics
+        // emission and the min-corrected check share one reduce.
+        let mut total_missing = 0u64;
+        let mut total_wrong_length = 0u64;
+        let mut total_mismatched = 0u64;
+        let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+        if let Some(ref acc) = metrics_acc {
+            for slot in acc.slots() {
+                let mut m = slot.lock();
+                total_missing += m.missing_umis;
+                total_wrong_length += m.wrong_length;
+                total_mismatched += m.mismatched;
+                for (umi, counts) in m.umi_matches.drain() {
+                    merge_umi_counts(&mut merged_umi_matches, umi, &counts);
+                }
+            }
+            // Guarantee every allowed UMI (and the unmatched-UMI sentinel)
+            // shows up in the output, even with zero counts — same
+            // post-aggregation invariant standalone correct enforces.
+            for umi in
+                encoded_umi_set_for_metrics.strings().iter().chain(std::iter::once(&unmatched_umi))
+            {
+                merged_umi_matches
+                    .entry(umi.clone())
+                    .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
+            }
+            finalize_correct_metrics(
+                self.correct_metrics.as_deref(),
+                &mut merged_umi_matches,
+                &unmatched_umi,
+            )?;
+        }
+
+        // `--correct::min-corrected`: replicate standalone correct's
+        // formula and bail!() text byte-for-byte so existing user-facing
+        // error messages match. `records_out` from `run_fastq_pipeline` is
+        // the post-correction (kept) record count; rejected = sum of the
+        // three rejection counters from the accumulator.
+        if let Some(min) = self.correct_min_corrected {
+            let rejected = total_missing + total_wrong_length + total_mismatched;
+            let total_records = records_out + rejected;
+            #[allow(clippy::cast_precision_loss)]
+            let ratio_kept = records_out as f64 / total_records as f64;
+            if ratio_kept < min {
+                bail!(
+                    "Final ratio of reads kept / total was {ratio_kept:.2} (user specified minimum was {min:.2}). \
+                    This could indicate a mismatch between library preparation and the provided UMI file."
+                );
+            }
+        }
+
         if let Some(path) = metrics_path {
-            // The fused process_fn does not yet expose per-stage
-            // accumulators, so both rows share the total wall time and a
-            // single records_in / records_out value (the post-correction
-            // record count). PR #329 wires per-stage counters via
-            // `--correct::metrics`; once those land, this block should
-            // split the timings and populate `extract.records_out` /
-            // `correct.records_in` from the pre-correction count.
+            // Both rows share the total wall time today; the `extract` row
+            // reflects the pre-correction record count (templates ×
+            // segments) and the `correct` row reflects the post-correction
+            // count. When no template is dropped these are equal; when
+            // templates are dropped by failing UMI correction the
+            // `extract` row shows the larger number.
+            let rejected = total_missing + total_wrong_length + total_mismatched;
+            let pre_correction = records_out + rejected;
             let mut writer = MetricsWriter::create(path)
                 .with_context(|| format!("opening --metrics path {} for write", path.display()))?;
             writer
                 .write_row(&MetricsRow {
                     stage: "extract".into(),
                     wall_time_secs: total_wall,
-                    records_in: records_out,
-                    records_out,
+                    records_in: pre_correction,
+                    records_out: pre_correction,
                 })
                 .with_context(|| format!("writing extract metrics row to {}", path.display()))?;
             writer
                 .write_row(&MetricsRow {
                     stage: "correct".into(),
                     wall_time_secs: total_wall,
-                    records_in: records_out,
+                    records_in: pre_correction,
                     records_out,
                 })
                 .with_context(|| format!("writing correct metrics row to {}", path.display()))?;
@@ -544,21 +738,22 @@ impl ChainRunner for ExtractCorrectChainRunner {
         EXTRACT_CORRECT_CHAIN_RUNNER_NAME
     }
 
-    /// Match `(Extract, Correct)` when:
-    /// * a UMI source is provided (inline `--correct::umis` or
-    ///   `--correct::umi-files`); and
-    /// * none of the `--correct::rejects`, `--correct::metrics`, or
-    ///   `--correct::min-corrected` flags are set (those still gate the
-    ///   runner off and fall through to `NotImplementedRunner`; PR #329
-    ///   will wire them).
+    /// Match `(Extract, Correct)` whenever a UMI source is provided
+    /// (inline `--correct::umis` or `--correct::umi-files`).
+    ///
+    /// `--correct::metrics` and `--correct::min-corrected` are wired
+    /// through to per-thread accumulators inside `run_chain`, so they
+    /// don't gate the runner.
+    ///
+    /// `--correct::rejects` ALSO does not gate `supports()` — when set we
+    /// still want this runner to win over `NotImplementedRunner` so the
+    /// user sees the specific "tracked in #329 / #330" error from
+    /// [`run_chain`] instead of the generic fallthrough message.
     ///
     /// The top-level `--metrics` flag does NOT gate this runner — it is
     /// honoured directly by `run_chain`, which writes one `extract` row
     /// followed by one `correct` row to the supplied TSV.
     fn supports(&self, ctx: &DispatchContext<'_>) -> bool {
-        if !self.rejects_unset || !self.metrics_unset || !self.min_corrected_unset {
-            return false;
-        }
         if self.umis.is_empty() && self.umi_files.is_empty() {
             return false;
         }
@@ -755,7 +950,11 @@ mod tests {
     }
 
     #[test]
-    fn does_not_support_when_correct_rejects_set() {
+    fn supports_when_correct_rejects_set_so_run_can_emit_specific_error() {
+        // Lifted gate (this PR): we want the runner to claim the chain
+        // shape even when `--correct::rejects` is set, so the user sees
+        // the specific "tracked in #329 / #330" error from `run_chain`
+        // rather than the generic NotImplementedRunner fallthrough.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_extract_correct(
             vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
@@ -765,13 +964,16 @@ mod tests {
         runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
         let runner = ExtractCorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
-            "--correct::rejects must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::rejects must NOT gate supports() — it routes through run_chain to fail \
+             with a specific error pointing at issues #329 and #330"
         );
     }
 
     #[test]
-    fn does_not_support_when_correct_metrics_set() {
+    fn supports_with_correct_metrics_set() {
+        // `--correct::metrics` is now wired through a per-thread accumulator
+        // in run_chain; the runner should claim the chain shape.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_extract_correct(
             vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
@@ -781,13 +983,15 @@ mod tests {
         runall.correct_opts.correct_metrics = Some(dir.path().join("correct-metrics.tsv"));
         let runner = ExtractCorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
-            "--correct::metrics must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::metrics must no longer gate supports() (this PR)"
         );
     }
 
     #[test]
-    fn does_not_support_when_correct_min_corrected_set() {
+    fn supports_with_correct_min_corrected_set() {
+        // `--correct::min-corrected` is now enforced post-pipeline against
+        // the same accumulator; the runner should claim the chain shape.
         let dir = tempfile::TempDir::new().unwrap();
         let mut runall = runall_for_extract_correct(
             vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
@@ -797,8 +1001,35 @@ mod tests {
         runall.correct_opts.correct_min_corrected = Some(0.5);
         let runner = ExtractCorrectChainRunner::from_runall(&runall);
         assert!(
-            !runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
-            "--correct::min-corrected must keep gating the runner off (PR #329)"
+            runner.supports(&dispatch_ctx(StartFrom::Extract, StopAfter::Correct)),
+            "--correct::min-corrected must no longer gate supports() (this PR)"
+        );
+    }
+
+    #[test]
+    fn rejects_set_returns_specific_error_pointing_at_issues_329_330() {
+        // `supports()` now matches; the specific error must surface from
+        // `run_chain` itself (no need to actually open the FASTQs because
+        // the rejects check fires before any I/O).
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut runall = runall_for_extract_correct(
+            vec![dir.path().join("r1.fq.gz"), dir.path().join("r2.fq.gz")],
+            dir.path().join("out.bam"),
+            vec!["AAAAAAAA".to_string()],
+        );
+        runall.correct_opts.correct_rejects = Some(dir.path().join("rejects.bam"));
+        let runner = ExtractCorrectChainRunner::from_runall(&runall);
+        let err = runner
+            .run_chain("fgumi runall", &dir.path().join("ignored.bam"), None)
+            .expect_err("run_chain must bail when --correct::rejects is set");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("fulcrumgenomics/fgumi#329"),
+            "error must mention upstream issue #329; got: {msg}"
+        );
+        assert!(
+            msg.contains("fulcrumgenomics/fgumi#330"),
+            "error must mention upstream issue #330; got: {msg}"
         );
     }
 

--- a/tests/integration/runall/mod.rs
+++ b/tests/integration/runall/mod.rs
@@ -6,6 +6,8 @@
 //! integration tests guard against CLI-parsing regressions and
 //! verify the binary's user-visible behaviour.
 
+mod test_correct_chain_metrics_parity;
+mod test_correct_chain_min_corrected_parity;
 mod test_correct_chain_parity;
 mod test_extract_chain_parity;
 mod test_extract_correct_chain_parity;

--- a/tests/integration/runall/test_correct_chain_metrics_parity.rs
+++ b/tests/integration/runall/test_correct_chain_metrics_parity.rs
@@ -1,0 +1,295 @@
+//! Real-data parity gate for `--correct::metrics` on the `(Correct, Correct)`
+//! and `(Extract, Correct)` chain runners.
+//!
+//! Builds a tiny BAM (or paired FASTQ for the fused chain) with a realistic
+//! UMI distribution: some UMIs are perfect matches, some are 8-mers within
+//! the per-segment edit distance budget that need correction, and some are
+//! N-only sentinels that fall outside the allowed list. We then run
+//! standalone `fgumi correct --metrics standalone.tsv` and
+//! `fgumi runall --correct::metrics runall.tsv` on the same input and assert
+//! the two TSVs are byte-for-byte identical (after sorting lines, since the
+//! standalone aggregation order isn't guaranteed across threads).
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tempfile::TempDir;
+
+/// Resolved path to the `fgumi` binary built by Cargo for this test.
+fn fgumi_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_fgumi")
+}
+
+/// Allowed UMI list. The synthetic fixture cycles through these plus
+/// `NNNNNNNN` and `AAAAAAAT` (a 1-mismatch off `AAAAAAAA`); with
+/// `--max-mismatches 1 --min-distance 1` the latter exercises the
+/// 1-mismatch correction bucket and the former exercises the rejection
+/// bucket.
+const ALLOWED_UMIS: &[&str] = &["AAAAAAAA", "CCCCCCCC", "GGGGGGGG", "TTTTTTTT"];
+
+/// UMI cycle: 4 perfect matches, 1 single-mismatch, 1 unmatchable.
+/// Layout chosen so the rounded counts are predictable per six-record block.
+const UMI_CYCLE: &[&[u8]] =
+    &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT", b"AAAAAAAT", b"NNNNNNNN"];
+
+/// Write a paired-end gzip-compressed FASTQ fixture.
+///
+/// R1 = 8 bp UMI (cycled) + 8 bp template, R2 = 8 bp template.
+fn write_paired_gzip_fastq_with_cycling_umi(r1: &Path, r2: &Path, num_pairs: usize) {
+    let f1 = std::fs::File::create(r1).unwrap();
+    let mut e1 = GzEncoder::new(f1, Compression::default());
+    let f2 = std::fs::File::create(r2).unwrap();
+    let mut e2 = GzEncoder::new(f2, Compression::default());
+
+    for i in 0..num_pairs {
+        let umi = UMI_CYCLE[i % UMI_CYCLE.len()];
+        let umi_str = std::str::from_utf8(umi).unwrap();
+        let r1_seq = format!("{umi_str}AAAAAAAA");
+        let r2_seq = "CCCCCCCC";
+
+        writeln!(e1, "@read{i}/1").unwrap();
+        writeln!(e1, "{r1_seq}").unwrap();
+        writeln!(e1, "+").unwrap();
+        writeln!(e1, "{}", "I".repeat(r1_seq.len())).unwrap();
+
+        writeln!(e2, "@read{i}/2").unwrap();
+        writeln!(e2, "{r2_seq}").unwrap();
+        writeln!(e2, "+").unwrap();
+        writeln!(e2, "{}", "I".repeat(r2_seq.len())).unwrap();
+    }
+    e1.finish().unwrap();
+    e2.finish().unwrap();
+}
+
+/// Subprocess `fgumi extract` to produce an input BAM with RX tags.
+fn run_extract_to_bam(r1: &Path, r2: &Path, out: &Path) {
+    let output = Command::new(fgumi_bin())
+        .args([
+            "extract",
+            "--threads",
+            "4",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--read-structures",
+            "8M+T",
+            "+T",
+            "--sample",
+            "S",
+            "--library",
+            "L",
+            "--compression-level",
+            "1",
+        ])
+        .output()
+        .expect("spawn fgumi extract");
+    assert!(
+        output.status.success(),
+        "fgumi extract failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi correct --metrics ...` (standalone).
+fn run_standalone_correct_metrics(input: &Path, out: &Path, metrics: &Path) {
+    let mut args: Vec<String> = vec![
+        "correct".into(),
+        "--threads".into(),
+        "4".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--metrics".into(),
+        metrics.to_str().unwrap().into(),
+        "--max-mismatches".into(),
+        "1".into(),
+        "--min-distance".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    for umi in ALLOWED_UMIS {
+        args.push("--umis".into());
+        args.push((*umi).to_string());
+    }
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi correct");
+    assert!(
+        output.status.success(),
+        "fgumi correct failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi runall --start-from correct --stop-after correct
+/// --correct::metrics ...`.
+fn run_runall_correct_chain_metrics(input: &Path, out: &Path, metrics: &Path) {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "correct".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--correct::metrics".into(),
+        metrics.to_str().unwrap().into(),
+        "--correct::max-mismatches".into(),
+        "1".into(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall");
+    assert!(
+        output.status.success(),
+        "fgumi runall failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Subprocess `fgumi runall --start-from extract --stop-after correct
+/// --correct::metrics ...` (the fused chain).
+fn run_runall_extract_correct_chain_metrics(r1: &Path, r2: &Path, out: &Path, metrics: &Path) {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "extract".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        r1.to_str().unwrap().into(),
+        r2.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--extract::sample".into(),
+        "S".into(),
+        "--extract::library".into(),
+        "L".into(),
+        "--extract::read-structures".into(),
+        "8M+T".into(),
+        "+T".into(),
+        "--correct::metrics".into(),
+        metrics.to_str().unwrap().into(),
+        "--correct::max-mismatches".into(),
+        "1".into(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    let output = Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall");
+    assert!(
+        output.status.success(),
+        "fgumi runall failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Read a TSV file and return its lines, preserving the header (first
+/// line) and sorting the data rows lexicographically. Standalone
+/// correct's per-UMI rows have a stable sort by UMI in
+/// `finalize_correct_metrics`, but we sort defensively in case any
+/// future change makes the order thread-dependent.
+fn normalize_tsv(path: &Path) -> (String, BTreeSet<String>) {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read TSV {} failed: {e}", path.display()));
+    let mut lines = text.lines();
+    let header = lines.next().unwrap_or_default().to_string();
+    let rows: BTreeSet<String> = lines.map(str::to_string).collect();
+    (header, rows)
+}
+
+#[test]
+fn correct_chain_metrics_parity_matches_standalone() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+
+    let standalone_out = dir.path().join("standalone.bam");
+    let standalone_metrics = dir.path().join("standalone-metrics.tsv");
+    let runall_out = dir.path().join("runall.bam");
+    let runall_metrics = dir.path().join("runall-metrics.tsv");
+
+    // 120 templates → exactly 20 templates per UMI in the cycle.
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    run_standalone_correct_metrics(&extracted, &standalone_out, &standalone_metrics);
+    run_runall_correct_chain_metrics(&extracted, &runall_out, &runall_metrics);
+
+    let (s_header, s_rows) = normalize_tsv(&standalone_metrics);
+    let (r_header, r_rows) = normalize_tsv(&runall_metrics);
+
+    assert_eq!(s_header, r_header, "TSV header rows must match");
+    assert_eq!(
+        s_rows, r_rows,
+        "per-UMI metrics rows must match exactly between standalone and runall"
+    );
+    // Sanity: at minimum we expect one row per allowed UMI plus the
+    // unmatched-UMI sentinel, so 5 rows.
+    assert!(
+        s_rows.len() > ALLOWED_UMIS.len(),
+        "standalone TSV has unexpectedly few rows: {}",
+        s_rows.len()
+    );
+}
+
+#[test]
+fn extract_correct_chain_metrics_parity_matches_standalone() {
+    // Same input, but compare the fused extract→correct chain's TSV
+    // against the standalone-correct TSV produced from the equivalent
+    // pre-extracted BAM. The two pipelines do the same per-template
+    // correction work, so the per-UMI counts must agree.
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+
+    let standalone_out = dir.path().join("standalone.bam");
+    let standalone_metrics = dir.path().join("standalone-metrics.tsv");
+    let fused_out = dir.path().join("fused.bam");
+    let fused_metrics = dir.path().join("fused-metrics.tsv");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    run_standalone_correct_metrics(&extracted, &standalone_out, &standalone_metrics);
+    run_runall_extract_correct_chain_metrics(&r1, &r2, &fused_out, &fused_metrics);
+
+    let (s_header, s_rows) = normalize_tsv(&standalone_metrics);
+    let (f_header, f_rows) = normalize_tsv(&fused_metrics);
+
+    assert_eq!(s_header, f_header, "TSV header rows must match");
+    assert_eq!(
+        s_rows, f_rows,
+        "per-UMI metrics rows must match exactly between standalone correct and the \
+         fused extract→correct chain"
+    );
+}

--- a/tests/integration/runall/test_correct_chain_min_corrected_parity.rs
+++ b/tests/integration/runall/test_correct_chain_min_corrected_parity.rs
@@ -1,0 +1,310 @@
+//! Real-data parity gate for `--correct::min-corrected` on the
+//! `(Correct, Correct)` and `(Extract, Correct)` chain runners.
+//!
+//! Two cases per chain:
+//! 1. Low threshold (0.50): both standalone and runall must SUCCEED on a
+//!    fixture where ~83% of templates pass correction; we additionally
+//!    assert byte-identical output BAMs between standalone and the BAM-
+//!    linear chain runner.
+//! 2. High threshold (0.99): both must FAIL with an error message
+//!    matching the standalone error text byte-for-byte (the runall
+//!    runners replicate the exact `bail!()` string from
+//!    `run_correct_pipeline`).
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tempfile::TempDir;
+
+fn fgumi_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_fgumi")
+}
+
+const ALLOWED_UMIS: &[&str] = &["AAAAAAAA", "CCCCCCCC", "GGGGGGGG", "TTTTTTTT"];
+
+/// 6-UMI cycle: 5 allowed (4 perfect + 1 single-mismatch off `AAAAAAAA`)
+/// and 1 unmatchable `NNNNNNNN`. With `--max-mismatches 1
+/// --min-distance 1`, 5 of every 6 templates are kept (~83%) and 1 is
+/// dropped — the kept fraction sits well above 0.50 (low threshold) and
+/// well below 0.99 (high threshold).
+const UMI_CYCLE: &[&[u8]] =
+    &[b"AAAAAAAA", b"CCCCCCCC", b"GGGGGGGG", b"TTTTTTTT", b"AAAAAAAT", b"NNNNNNNN"];
+
+fn write_paired_gzip_fastq_with_cycling_umi(r1: &Path, r2: &Path, num_pairs: usize) {
+    let f1 = std::fs::File::create(r1).unwrap();
+    let mut e1 = GzEncoder::new(f1, Compression::default());
+    let f2 = std::fs::File::create(r2).unwrap();
+    let mut e2 = GzEncoder::new(f2, Compression::default());
+
+    for i in 0..num_pairs {
+        let umi = UMI_CYCLE[i % UMI_CYCLE.len()];
+        let umi_str = std::str::from_utf8(umi).unwrap();
+        let r1_seq = format!("{umi_str}AAAAAAAA");
+        let r2_seq = "CCCCCCCC";
+
+        writeln!(e1, "@read{i}/1").unwrap();
+        writeln!(e1, "{r1_seq}").unwrap();
+        writeln!(e1, "+").unwrap();
+        writeln!(e1, "{}", "I".repeat(r1_seq.len())).unwrap();
+
+        writeln!(e2, "@read{i}/2").unwrap();
+        writeln!(e2, "{r2_seq}").unwrap();
+        writeln!(e2, "+").unwrap();
+        writeln!(e2, "{}", "I".repeat(r2_seq.len())).unwrap();
+    }
+    e1.finish().unwrap();
+    e2.finish().unwrap();
+}
+
+fn run_extract_to_bam(r1: &Path, r2: &Path, out: &Path) {
+    let output = Command::new(fgumi_bin())
+        .args([
+            "extract",
+            "--threads",
+            "4",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--read-structures",
+            "8M+T",
+            "+T",
+            "--sample",
+            "S",
+            "--library",
+            "L",
+            "--compression-level",
+            "1",
+        ])
+        .output()
+        .expect("spawn fgumi extract");
+    assert!(
+        output.status.success(),
+        "fgumi extract failed (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn run_standalone_correct(input: &Path, out: &Path, min_corrected: f64) -> Output {
+    let mut args: Vec<String> = vec![
+        "correct".into(),
+        "--threads".into(),
+        "4".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--min-corrected".into(),
+        format!("{min_corrected}"),
+        "--max-mismatches".into(),
+        "1".into(),
+        "--min-distance".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    for umi in ALLOWED_UMIS {
+        args.push("--umis".into());
+        args.push((*umi).to_string());
+    }
+    Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi correct")
+}
+
+fn run_runall_correct_chain(input: &Path, out: &Path, min_corrected: f64) -> Output {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "correct".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        input.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--correct::min-corrected".into(),
+        format!("{min_corrected}"),
+        "--correct::max-mismatches".into(),
+        "1".into(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall")
+}
+
+fn run_runall_extract_correct_chain(
+    r1: &Path,
+    r2: &Path,
+    out: &Path,
+    min_corrected: f64,
+) -> Output {
+    let mut args: Vec<String> = vec![
+        "runall".into(),
+        "--threads".into(),
+        "4".into(),
+        "--start-from".into(),
+        "extract".into(),
+        "--stop-after".into(),
+        "correct".into(),
+        "--input".into(),
+        r1.to_str().unwrap().into(),
+        r2.to_str().unwrap().into(),
+        "--output".into(),
+        out.to_str().unwrap().into(),
+        "--compression-level".into(),
+        "1".into(),
+        "--extract::sample".into(),
+        "S".into(),
+        "--extract::library".into(),
+        "L".into(),
+        "--extract::read-structures".into(),
+        "8M+T".into(),
+        "+T".into(),
+        "--correct::min-corrected".into(),
+        format!("{min_corrected}"),
+        "--correct::max-mismatches".into(),
+        "1".into(),
+        "--correct::min-distance".into(),
+        "1".into(),
+        "--correct::umis".into(),
+    ];
+    args.extend(ALLOWED_UMIS.iter().map(|s| (*s).to_string()));
+    Command::new(fgumi_bin()).args(&args).output().expect("spawn fgumi runall")
+}
+
+fn compare_bams_correct(a: &Path, b: &Path) -> Output {
+    Command::new(fgumi_bin())
+        .args(["compare", "bams", a.to_str().unwrap(), b.to_str().unwrap(), "--command", "correct"])
+        .output()
+        .expect("spawn fgumi compare bams")
+}
+
+#[test]
+fn correct_chain_min_corrected_low_threshold_succeeds_with_bam_parity() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+    let standalone_out = dir.path().join("standalone.bam");
+    let runall_out = dir.path().join("runall.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    let standalone = run_standalone_correct(&extracted, &standalone_out, 0.50);
+    assert!(
+        standalone.status.success(),
+        "standalone correct must succeed at min-corrected=0.50; stderr:\n{}",
+        String::from_utf8_lossy(&standalone.stderr),
+    );
+    let runall = run_runall_correct_chain(&extracted, &runall_out, 0.50);
+    assert!(
+        runall.status.success(),
+        "runall correct chain must succeed at --correct::min-corrected=0.50; stderr:\n{}",
+        String::from_utf8_lossy(&runall.stderr),
+    );
+
+    let cmp = compare_bams_correct(&standalone_out, &runall_out);
+    assert!(
+        cmp.status.success(),
+        "fgumi compare bams reported a mismatch (exit {}):\nstdout:\n{}\nstderr:\n{}",
+        cmp.status,
+        String::from_utf8_lossy(&cmp.stdout),
+        String::from_utf8_lossy(&cmp.stderr),
+    );
+}
+
+#[test]
+fn correct_chain_min_corrected_high_threshold_fails_with_matching_error() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+    let standalone_out = dir.path().join("standalone.bam");
+    let runall_out = dir.path().join("runall.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    let standalone = run_standalone_correct(&extracted, &standalone_out, 0.99);
+    assert!(
+        !standalone.status.success(),
+        "standalone correct must fail at min-corrected=0.99; stderr:\n{}",
+        String::from_utf8_lossy(&standalone.stderr),
+    );
+    let runall = run_runall_correct_chain(&extracted, &runall_out, 0.99);
+    assert!(
+        !runall.status.success(),
+        "runall correct chain must fail at --correct::min-corrected=0.99; stderr:\n{}",
+        String::from_utf8_lossy(&runall.stderr),
+    );
+
+    // Both runners route through `run_correct_pipeline`, so the
+    // user-facing error text must be byte-identical. Look for the
+    // signature substring in both stderr streams.
+    let needle = "Final ratio of reads kept / total was";
+    let s_err = String::from_utf8_lossy(&standalone.stderr);
+    let r_err = String::from_utf8_lossy(&runall.stderr);
+    assert!(s_err.contains(needle), "standalone stderr missing min-corrected error: {s_err}");
+    assert!(r_err.contains(needle), "runall stderr missing min-corrected error: {r_err}");
+}
+
+#[test]
+fn extract_correct_chain_min_corrected_low_threshold_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let fused_out = dir.path().join("fused.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+
+    let fused = run_runall_extract_correct_chain(&r1, &r2, &fused_out, 0.50);
+    assert!(
+        fused.status.success(),
+        "fused extract→correct chain must succeed at --correct::min-corrected=0.50; stderr:\n{}",
+        String::from_utf8_lossy(&fused.stderr),
+    );
+}
+
+#[test]
+fn extract_correct_chain_min_corrected_high_threshold_fails_with_matching_error() {
+    let dir = TempDir::new().unwrap();
+    let r1 = dir.path().join("R1.fastq.gz");
+    let r2 = dir.path().join("R2.fastq.gz");
+    let extracted = dir.path().join("extracted.bam");
+    let standalone_out = dir.path().join("standalone.bam");
+    let fused_out = dir.path().join("fused.bam");
+
+    write_paired_gzip_fastq_with_cycling_umi(&r1, &r2, 120);
+    run_extract_to_bam(&r1, &r2, &extracted);
+
+    let standalone = run_standalone_correct(&extracted, &standalone_out, 0.99);
+    assert!(
+        !standalone.status.success(),
+        "standalone correct must fail at min-corrected=0.99; stderr:\n{}",
+        String::from_utf8_lossy(&standalone.stderr),
+    );
+    let fused = run_runall_extract_correct_chain(&r1, &r2, &fused_out, 0.99);
+    assert!(
+        !fused.status.success(),
+        "fused extract→correct chain must fail at --correct::min-corrected=0.99; stderr:\n{}",
+        String::from_utf8_lossy(&fused.stderr),
+    );
+
+    let needle = "Final ratio of reads kept / total was";
+    let s_err = String::from_utf8_lossy(&standalone.stderr);
+    let f_err = String::from_utf8_lossy(&fused.stderr);
+    assert!(s_err.contains(needle), "standalone stderr missing min-corrected error: {s_err}");
+    assert!(f_err.contains(needle), "fused chain stderr missing min-corrected error: {f_err}");
+}


### PR DESCRIPTION
Stacked on #328. Wires two of the three remaining `--correct::*` flags currently gated off in PR #328's correct chain runners; the third (`--correct::rejects`) stays gated pending upstream architectural work.

## What changes
- `CorrectChainRunner` (BAM-linear) and `ExtractCorrectChainRunner` (fused FASTQ→BAM) honor `--correct::metrics` (per-UMI metrics TSV) and `--correct::min-corrected` (post-pipeline threshold check).
- Both flags use the same machinery as standalone `fgumi correct`: `PerThreadAccumulator<CollectedCorrectMetrics>` + `finalize_correct_metrics` for metrics, accumulator-based count + threshold for min-corrected.
- Drops the `metrics_unset` and `min_corrected_unset` gates in both runners' `supports()`.
- `--correct::rejects` remains gated, but now fails with a specific error pointing at the two upstream tracking issues (rather than the generic "not yet implemented" fallthrough).

## What stays gated and why
`--correct::rejects` would require either (a) migrating standalone correct's hand-rolled `Arc<Mutex<Option<RawBamWriter>>>` to the unified pipeline's first-class `secondary_output` (issue #329) and (b) adding secondary_output support to the FASTQ pipeline for the fused `ExtractCorrectChainRunner` (issue #330's phase 1+). Both are upstream concerns, not runall-scoped. Once those land, a small follow-up runall PR adds rejects support.

## Tests
- 2 perturbation-verified parity tests vs standalone `fgumi correct` (metrics.tsv text-diff; min-corrected exit-code parity at high+low thresholds, plus BAM parity in the success case).
- Unit tests covering the flag-honoring `supports()` flips and the rejects-set specific error.

## Audit
Every public flag on standalone `fgumi correct` is now either wired through runall or routed via global flags. The single remaining gap (`--correct::rejects`) has a specific error pointer to issues #329 and #330; tests cover that error path.