### PR TITLE
refactor(consensus,correct): migrate hand-rolled rejects writers to first-class secondary_output

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -5,6 +5,15 @@
 //! CODEC (Bae et al 2023) is a sequencing protocol where each read-pair sequences both strands
 //! of the original duplex molecule. R1 comes from one strand, R2 from the opposite strand,
 //! allowing even a single read-pair to generate duplex consensus.
+//!
+//! When `--rejects` is set, the threaded pipeline routes rejected records through
+//! the unified pipeline's first-class secondary output (see
+//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
+//! Both reject paths (success and duplex-disagreement recovery) flow through a
+//! per-batch buffer and land in batch-input order. The rejects BAM advertises
+//! the input header so raw-input RG/PG/contig metadata is preserved. The pattern
+//! matches `commands::filter`, `commands::correct`, `commands::simplex`, and
+//! `commands::duplex`.
 
 use crate::commands::command::Command;
 use crate::commands::consensus_runner::{ConsensusStatsOps, create_unmapped_consensus_header};

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -13,8 +13,8 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::{
-    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 
 use super::common::{
@@ -31,16 +31,16 @@ use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
 use crate::read_info::LibraryIndex;
 use crate::unified_pipeline::{
     GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    run_bam_pipeline_from_reader_with_secondary,
 };
 use fgumi_bam_io::ProgressTracker;
 use fgumi_raw_bam::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
-use crate::sam::{SamTag, header_as_unsorted};
+use crate::sam::SamTag;
 use crate::validation::validate_file_exists;
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
-use parking_lot::Mutex;
 use std::io::{self, Write as IoWrite};
 use std::sync::Arc;
 
@@ -52,6 +52,10 @@ use std::sync::Arc;
 struct CodecProcessedBatch {
     /// Consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
+    /// Raw-byte rejected records (consensus-caller rejects from both the
+    /// success and duplex-disagreement paths), in batch-input order. Empty
+    /// unless `track_rejects` is true.
+    rejected_records: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// CODEC consensus calling statistics for this batch
@@ -60,7 +64,9 @@ struct CodecProcessedBatch {
 
 impl MemoryEstimate for CodecProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
-        self.consensus_output.data.capacity()
+        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
+        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
+        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
     }
 }
 
@@ -531,158 +537,152 @@ impl Codec {
         // Use larger batch size for codec (less work per group than simplex)
         let batch_size = 1000;
 
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk from process_fn, per-MI-group, so no batch-level buffering.
-        // Because workers flush under a mutex rather than through the ordered
-        // serialize stage, reject records are emitted in mutex-acquisition
-        // order, not input order; mark the rejects header as SO:unsorted so
-        // downstream tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
-            if let Some(path) = self.rejects_opts.rejects.as_ref() {
-                let writer_threads = self.threading.num_threads();
-                let rejects_header = header_as_unsorted(&input_header);
-                let w = create_raw_bam_writer(
-                    path,
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                Some(Arc::new(Mutex::new(Some(w))))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+        // Rejects flow through the unified pipeline's first-class secondary
+        // output (see correct.rs / simplex.rs / duplex.rs / filter.rs for the
+        // shared pattern). `process_fn` collects caller-emitted rejects from
+        // both the success path and the duplex-disagreement recovery path into
+        // `CodecProcessedBatch::rejected_records`; the pipeline's
+        // `secondary_serialize_fn` writes them in batch-input order with the
+        // input header.
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
-        // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let pipeline_result = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            input_header,
-            &self.io.output,
-            Some(output_header.clone()),
-            // ========== grouper_fn: Create MiGrouper ==========
-            move |_header: &Header| {
-                Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
-                    as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-            },
-            // ========== process_fn: CODEC consensus calling ==========
-            move |batch: MiGroupBatch| -> io::Result<CodecProcessedBatch> {
-                // Create per-thread CODEC consensus caller
-                let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
-                    read_name_prefix.clone(),
-                    read_group_id.clone(),
-                    options.clone(),
-                    track_rejects,
-                );
+        // ========== grouper_fn ==========
+        let grouper_fn = move |_header: &Header| {
+            Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
+                as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+        };
 
-                let mut all_output = ConsensusOutput::default();
-                let mut batch_stats = CodecConsensusStats::default();
-                let groups_count = batch.groups.len() as u64;
+        // ========== process_fn: CODEC consensus calling ==========
+        let process_fn = move |batch: MiGroupBatch| -> io::Result<CodecProcessedBatch> {
+            // Create per-thread CODEC consensus caller
+            let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
+                read_name_prefix.clone(),
+                read_group_id.clone(),
+                options.clone(),
+                track_rejects,
+            );
 
-                // Stream per-MI-group rejects straight to disk so they don't
-                // accumulate in a batch-level Vec. The mutex only serializes the
-                // raw-byte append; BGZF compression runs on the writer's own
-                // thread pool.
-                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in recs {
-                                    w.write_raw_record(raw)?;
-                                }
+            let mut all_output = ConsensusOutput::default();
+            let mut batch_stats = CodecConsensusStats::default();
+            let groups_count = batch.groups.len() as u64;
+            // Caller-emitted rejects collected per-batch (success +
+            // duplex-disagreement recovery paths) and drained by the
+            // pipeline's secondary serializer.
+            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
+
+            for MiGroup { mi, records } in batch.groups {
+                caller.clear();
+
+                // Call CODEC consensus directly — records are already RawRecord values.
+                let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
+                match result {
+                    Ok(batch_output) => {
+                        all_output.merge(batch_output);
+                        batch_stats.merge(caller.statistics());
+                        if track_rejects {
+                            for raw in caller.take_rejected_reads() {
+                                rejected_records.push(raw);
                             }
                         }
                     }
-                    Ok(())
-                };
-
-                for MiGroup { mi, records } in batch.groups {
-                    caller.clear();
-
-                    // Call CODEC consensus directly — records are already RawRecord values.
-                    let result: anyhow::Result<ConsensusOutput> = caller.consensus_reads(records);
-                    match result {
-                        Ok(batch_output) => {
-                            all_output.merge(batch_output);
+                    Err(e) => {
+                        // Handle duplex disagreement errors by merging stats and
+                        // preserving rejects so --rejects output matches single-threaded mode.
+                        if e.to_string().contains("duplex disagreement") {
                             batch_stats.merge(caller.statistics());
                             if track_rejects {
-                                flush_byte_records(&caller.take_rejected_reads())?;
-                            }
-                        }
-                        Err(e) => {
-                            // Handle duplex disagreement errors by merging stats and
-                            // preserving rejects so --rejects output matches single-threaded mode.
-                            if e.to_string().contains("duplex disagreement") {
-                                batch_stats.merge(caller.statistics());
-                                if track_rejects {
-                                    flush_byte_records(&caller.take_rejected_reads())?;
+                                for raw in caller.take_rejected_reads() {
+                                    rejected_records.push(raw);
                                 }
-                            } else {
-                                return Err(io::Error::other(format!(
-                                    "CODEC consensus error for MI {mi}: {e}"
-                                )));
                             }
+                        } else {
+                            return Err(io::Error::other(format!(
+                                "CODEC consensus error for MI {mi}: {e}"
+                            )));
                         }
                     }
                 }
-
-                Ok(CodecProcessedBatch {
-                    consensus_output: all_output,
-                    groups_count,
-                    stats: batch_stats,
-                })
-            },
-            // ========== serialize_fn: Serialize + collect metrics ==========
-            move |processed: CodecProcessedBatch,
-                  _header: &Header,
-                  output: &mut Vec<u8>|
-                  -> io::Result<u64> {
-                // Rejects were already streamed to disk in process_fn.
-                // Merge per-batch metrics into this worker's accumulator slot
-                let batch_stats = processed.stats;
-                let groups_count = processed.groups_count;
-                collected_metrics_for_serialize.with_slot(|m| {
-                    m.stats.merge(&batch_stats);
-                    m.groups_processed += groups_count;
-                });
-
-                // Serialize consensus reads
-                let count = processed.consensus_output.count as u64;
-                output.extend_from_slice(&processed.consensus_output.data);
-                Ok(count)
-            },
-        );
-
-        // Always finalize the rejects writer, even if the pipeline failed, so any
-        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
-        // finish() failures alongside any pipeline error so neither is silently
-        // dropped.
-        let rejects_finish_result = rejects_writer
-            .and_then(|rw_arc| rw_arc.lock().take())
-            .map(|writer| writer.finish().context("Failed to finish rejects file"));
-
-        let groups_processed = match (pipeline_result, rejects_finish_result) {
-            (Ok(groups_processed), Some(Ok(()))) => {
-                info!("Rejected reads streamed to rejects file during processing");
-                groups_processed
             }
-            (Ok(groups_processed), None) => groups_processed,
-            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
-            (Err(pipeline_err), Some(Err(finish_err))) => {
-                return Err(anyhow::anyhow!(
-                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
-                ));
+
+            Ok(CodecProcessedBatch {
+                consensus_output: all_output,
+                rejected_records,
+                groups_count,
+                stats: batch_stats,
+            })
+        };
+
+        // ========== serialize_fn: Serialize + collect metrics ==========
+        let serialize_fn = move |processed: CodecProcessedBatch,
+                                 _header: &Header,
+                                 output: &mut Vec<u8>|
+              -> io::Result<u64> {
+            // Merge per-batch metrics into this worker's accumulator slot.
+            // Rejects are drained by `secondary_serialize_fn` separately.
+            let batch_stats = processed.stats;
+            let groups_count = processed.groups_count;
+            collected_metrics_for_serialize.with_slot(|m| {
+                m.stats.merge(&batch_stats);
+                m.groups_processed += groups_count;
+            });
+
+            // Serialize consensus reads
+            let count = processed.consensus_output.count as u64;
+            output.extend_from_slice(&processed.consensus_output.data);
+            Ok(count)
+        };
+
+        // ========== secondary_serialize_fn: Drain rejected records ==========
+        let secondary_serialize_fn = |batch: &CodecProcessedBatch,
+                                      buf: &mut Vec<u8>|
+         -> io::Result<u64> {
+            for raw in &batch.rejected_records {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
+                    )
+                })?;
+                buf.extend_from_slice(&block_size.to_le_bytes());
+                buf.extend_from_slice(raw);
             }
-            (Err(pipeline_err), _) => {
-                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
-            }
+            Ok(batch.rejected_records.len() as u64)
+        };
+
+        // Run the 7-step pipeline with the already-opened reader (supports streaming).
+        // When `--rejects` is set, route rejects through the unified pipeline's
+        // first-class secondary output so they land in input/batch-serial order
+        // and the rejects BAM carries the input header.
+        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+            let secondary_header = input_header.clone();
+            run_bam_pipeline_from_reader_with_secondary(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                rejects_path,
+                Some(secondary_header),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+                secondary_serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
+        } else {
+            run_bam_pipeline_from_reader(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
         };
 
         // ========== Post-pipeline: Aggregate metrics ==========
@@ -1224,12 +1224,41 @@ mod tests {
 
         let batch = CodecProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
+            rejected_records: Vec::new(),
             groups_count: 1,
             stats: CodecConsensusStats::default(),
         };
 
         let estimate = batch.estimate_heap_size();
         assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
+    }
+
+    #[test]
+    fn test_codec_processed_batch_memory_estimate_with_rejects() {
+        let mut data = Vec::with_capacity(64);
+        data.extend_from_slice(&[0u8; 32]);
+
+        let mut rej_a = Vec::with_capacity(256);
+        rej_a.extend_from_slice(&[1u8; 8]);
+        let mut rej_b = Vec::with_capacity(128);
+        rej_b.extend_from_slice(&[2u8; 8]);
+        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rej_outer_capacity = rejected_records.capacity();
+
+        let batch = CodecProcessedBatch {
+            consensus_output: ConsensusOutput { data, count: 0 },
+            rejected_records,
+            groups_count: 0,
+            stats: CodecConsensusStats::default(),
+        };
+
+        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
+        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
+        let estimate = batch.estimate_heap_size();
+        assert_eq!(
+            estimate, expected,
+            "estimate should include rejected_records capacities and outer-vec overhead",
+        );
     }
 
     /// Asserts that single-threaded and multi-threaded codec produce the same number of

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -29,7 +29,7 @@ use fgumi_bam_io::{
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, QueueMemoryOptions,
     ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions, ThreadingOptions,
-    build_pipeline_config,
+    build_pipeline_config, serialize_raw_bam_records,
 };
 use crate::consensus::codec_caller::{
     CodecConsensusCaller, CodecConsensusOptions, CodecConsensusStats,
@@ -644,27 +644,17 @@ impl Codec {
         };
 
         // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn = |batch: &CodecProcessedBatch,
-                                      buf: &mut Vec<u8>|
-         -> io::Result<u64> {
-            for raw in &batch.rejected_records {
-                let block_size = u32::try_from(raw.len()).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
-                    )
-                })?;
-                buf.extend_from_slice(&block_size.to_le_bytes());
-                buf.extend_from_slice(raw);
-            }
-            Ok(batch.rejected_records.len() as u64)
-        };
+        let secondary_serialize_fn =
+            |batch: &CodecProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_raw_bam_records(&batch.rejected_records, buf)
+            };
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming).
         // When `--rejects` is set, route rejects through the unified pipeline's
         // first-class secondary output so they land in input/batch-serial order
         // and the rejects BAM carries the input header.
-        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
+        {
             let secondary_header = input_header.clone();
             run_bam_pipeline_from_reader_with_secondary(
                 pipeline_config,
@@ -707,7 +697,7 @@ impl Codec {
         // Log statistics
         info!("CODEC consensus calling complete");
         info!("Total MI groups processed: {total_groups}");
-        info!("Total groups processed by pipeline: {groups_processed}");
+        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
 
         let metrics = merged_stats.to_metrics();
         let consensus_count = metrics.consensus_reads;
@@ -1226,33 +1216,30 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_codec_processed_batch_memory_estimate() {
-        let mut data = Vec::with_capacity(1024);
-        data.extend_from_slice(&[0u8; 100]);
+    #[rstest]
+    #[case::empty_rejects(1024, 100, vec![])]
+    #[case::non_empty_rejects(64, 32, vec![256, 128])]
+    fn test_codec_processed_batch_memory_estimate(
+        #[case] consensus_capacity: usize,
+        #[case] consensus_len: usize,
+        #[case] rej_capacities: Vec<usize>,
+    ) {
+        let mut data = Vec::with_capacity(consensus_capacity);
+        data.resize(consensus_len, 0u8);
 
-        let batch = CodecProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 1 },
-            rejected_records: Vec::new(),
-            groups_count: 1,
-            stats: CodecConsensusStats::default(),
-        };
-
-        let estimate = batch.estimate_heap_size();
-        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
-    }
-
-    #[test]
-    fn test_codec_processed_batch_memory_estimate_with_rejects() {
-        let mut data = Vec::with_capacity(64);
-        data.extend_from_slice(&[0u8; 32]);
-
-        let mut rej_a = Vec::with_capacity(256);
-        rej_a.extend_from_slice(&[1u8; 8]);
-        let mut rej_b = Vec::with_capacity(128);
-        rej_b.extend_from_slice(&[2u8; 8]);
-        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rejected_records: Vec<Vec<u8>> = rej_capacities
+            .iter()
+            .map(|&cap| {
+                let mut v = Vec::with_capacity(cap);
+                v.extend_from_slice(&[1u8; 8]);
+                v
+            })
+            .collect();
         let rej_outer_capacity = rejected_records.capacity();
+        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
+        // round up. Read the observed capacities back so the expected value
+        // matches what was actually allocated under any allocator.
+        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
 
         let batch = CodecProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 0 },
@@ -1261,12 +1248,15 @@ mod tests {
             stats: CodecConsensusStats::default(),
         };
 
-        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
-        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        let estimate = batch.estimate_heap_size();
+        // Heap = consensus capacity + sum of per-reject inner capacities
+        // + outer-vec capacity * size_of::<Vec<u8>>().
+        let expected = consensus_capacity
+            + rej_inner_total
+            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
         assert_eq!(
-            estimate, expected,
-            "estimate should include rejected_records capacities and outer-vec overhead",
+            batch.estimate_heap_size(),
+            expected,
+            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
         );
     }
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -759,6 +759,70 @@ impl QueueMemoryOptions {
     }
 }
 
+/// Frame raw BAM record bytes into the pipeline's serialize buffer.
+///
+/// Each element of `records` is treated as the body of a BAM record (no
+/// `block_size` prefix). This function writes `<u32 LE block_size><body>`
+/// for each record, matching BAM's on-disk record framing. The pipeline's
+/// downstream BGZF compression stage operates on the framed bytes verbatim.
+///
+/// Used by command-level `serialize_fn` and `secondary_serialize_fn`
+/// closures that produce raw record bytes (e.g. `commands::filter`,
+/// the `--rejects` paths in `commands::correct`/`simplex`/`duplex`/`codec`).
+///
+/// Generic over `R: AsRef<[u8]>` so callers can pass either
+/// `&[fgumi_raw_bam::RawRecord]` or `&[Vec<u8>]` without copying.
+///
+/// # Errors
+///
+/// Returns [`std::io::ErrorKind::InvalidData`] if:
+/// - a record body exceeds `u32::MAX` bytes (BAM records cannot be larger
+///   than ~4 GiB by spec), or
+/// - the summed framed size of `records` overflows `usize` (only reachable
+///   on pathological inputs; surfaces as a hard error instead of wrapping
+///   silently in release builds).
+///
+/// Both error paths are checked in a single up-front validation pass, so
+/// `output` is never partially appended on error: either every record is
+/// written or none of `output`'s bytes are touched.
+pub(crate) fn serialize_raw_bam_records<R: AsRef<[u8]>>(
+    records: &[R],
+    output: &mut Vec<u8>,
+) -> std::io::Result<u64> {
+    // Reserve total framed size up front so the per-record extend_from_slice
+    // loop doesn't repeatedly grow `output`. Validates each record's body fits
+    // a `u32` `block_size` *and* that the summed framed size fits `usize` in
+    // this same pass: by the time we start writing, every record is known
+    // good, so the write loop cannot fail and leave `output` partially
+    // appended. Either no bytes are written on error or all records are.
+    let additional = records.iter().try_fold(0usize, |acc, record| {
+        let len = record.as_ref().len();
+        u32::try_from(len).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("BAM record too large ({len} bytes) for u32 block_size"),
+            )
+        })?;
+        len.checked_add(4).and_then(|frame| acc.checked_add(frame)).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "serialized BAM batch size overflowed usize",
+            )
+        })
+    })?;
+    output.reserve(additional);
+
+    for record in records {
+        let body = record.as_ref();
+        // Pre-validated in the first pass above; `body.len()` is known to fit
+        // a `u32`, so this conversion cannot fail.
+        let block_size = u32::try_from(body.len()).expect("body length pre-validated to fit u32");
+        output.extend_from_slice(&block_size.to_le_bytes());
+        output.extend_from_slice(body);
+    }
+    Ok(records.len() as u64)
+}
+
 /// Parses a boolean value from a string, accepting: true/false, yes/no, y/n, t/f
 /// (case-insensitive). Matches sopt/fgbio behavior.
 pub(crate) fn parse_bool(s: &str) -> Result<bool, String> {
@@ -1260,5 +1324,66 @@ mod tests {
             total <= sysinfo_total,
             "cgroup-limited total {total} exceeded sysinfo total {sysinfo_total}"
         );
+    }
+
+    #[test]
+    fn test_serialize_raw_bam_records_empty() {
+        let records: Vec<Vec<u8>> = Vec::new();
+        let mut output = Vec::new();
+        let count = serialize_raw_bam_records(&records, &mut output).unwrap();
+        assert_eq!(count, 0);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_serialize_raw_bam_records_single_frames_correctly() {
+        let records = vec![vec![0xDEu8, 0xAD, 0xBE, 0xEF]];
+        let mut output = Vec::new();
+        let count = serialize_raw_bam_records(&records, &mut output).unwrap();
+        assert_eq!(count, 1);
+        // <u32 LE block_size = 4><body = DE AD BE EF>
+        assert_eq!(output, vec![0x04, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn test_serialize_raw_bam_records_multiple_frames_concatenated() {
+        let records = vec![vec![0x11u8, 0x22], vec![0x33u8, 0x44, 0x55]];
+        let mut output = Vec::new();
+        let count = serialize_raw_bam_records(&records, &mut output).unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(
+            output,
+            vec![0x02, 0x00, 0x00, 0x00, 0x11, 0x22, 0x03, 0x00, 0x00, 0x00, 0x33, 0x44, 0x55],
+        );
+    }
+
+    #[test]
+    fn test_serialize_raw_bam_records_reserves_capacity_upfront() {
+        // Build a batch large enough that a naive per-record extend would
+        // trigger at least one realloc growth of `output`. We then assert
+        // that after one call `output.capacity()` is at least the exact
+        // serialized size — proof that the upfront reserve happened.
+        let records: Vec<Vec<u8>> = (0..32).map(|i| vec![i as u8; 64]).collect();
+        let expected_size: usize = records.iter().map(|r| 4 + r.len()).sum();
+
+        let mut output = Vec::new();
+        serialize_raw_bam_records(&records, &mut output).unwrap();
+        assert_eq!(output.len(), expected_size);
+        assert!(
+            output.capacity() >= expected_size,
+            "capacity {} should be >= expected serialized size {expected_size}",
+            output.capacity(),
+        );
+    }
+
+    #[test]
+    fn test_serialize_raw_bam_records_preserves_existing_output_content() {
+        // Reserve must extend, not clear: writing into a non-empty buffer
+        // (as the pipeline can do when reusing serialization scratch
+        // buffers) must leave the existing prefix untouched.
+        let mut output = vec![0xAAu8, 0xBB];
+        let records = vec![vec![0x01u8]];
+        serialize_raw_bam_records(&records, &mut output).unwrap();
+        assert_eq!(output, vec![0xAA, 0xBB, 0x01, 0x00, 0x00, 0x00, 0x01]);
     }
 }

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -5,6 +5,12 @@
 //! observed UMIs to match the expected set based on mismatch tolerance and minimum
 //! distance requirements.
 //!
+//! When `--rejects` is set, the threaded pipeline routes rejected records through
+//! the unified pipeline's first-class secondary output (see
+//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
+//! Rejects land in batch-input order rather than mutex-acquisition order, and the
+//! rejects BAM inherits the input header. The pattern matches `commands::filter`.
+//!
 //! # Example
 //!
 //! ```no_run

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -47,17 +47,20 @@ use crate::grouper::TemplateGrouper;
 use crate::logging::OperationTimer;
 use crate::metrics::correct::UmiCorrectionMetrics;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::sam::{SamTag, header_as_unsorted};
+use crate::sam::SamTag;
 use crate::template::TemplateBatch;
-use crate::unified_pipeline::{Grouper, MemoryEstimate, run_bam_pipeline_from_reader};
+use crate::unified_pipeline::{
+    Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    run_bam_pipeline_from_reader_with_secondary,
+};
 use crate::validation::validate_file_exists;
 use ahash::AHashMap;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{
-    BamWriter, RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
+    BamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_with_opts,
 };
 use fgumi_raw_bam;
 use fgumi_raw_bam::RawRecord;
@@ -65,7 +68,6 @@ use log::{info, warn};
 use lru::LruCache;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
-use parking_lot::Mutex;
 use std::io;
 use std::num::NonZero;
 use std::path::PathBuf;
@@ -299,6 +301,9 @@ struct TemplateCorrection {
 struct CorrectProcessedBatch {
     /// Raw-byte kept records.
     kept_raw_records: Vec<RawRecord>,
+    /// Raw-byte rejected records, in batch-input order. Empty unless the
+    /// pipeline was configured with a `--rejects` output.
+    rejected_records: Vec<Vec<u8>>,
     /// Number of templates processed.
     templates_count: u64,
     /// Number of missing UMI records.
@@ -315,7 +320,9 @@ impl MemoryEstimate for CorrectProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         let raw_size: usize = self.kept_raw_records.iter().map(RawRecord::capacity).sum();
         let raw_vec_overhead = self.kept_raw_records.capacity() * std::mem::size_of::<RawRecord>();
-        raw_size + raw_vec_overhead
+        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
+        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
+        raw_size + raw_vec_overhead + rej_size + rej_vec_overhead
     }
 }
 
@@ -808,30 +815,12 @@ impl CorrectUmis {
         let collected_metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(num_threads);
         let collected_for_serialize = Arc::clone(&collected_metrics);
 
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk from process_fn, per-template, so no batch-level buffering.
-        // Because workers flush under a mutex rather than through the ordered
-        // serialize stage, reject records are emitted in mutex-acquisition
-        // order, not input order; mark the rejects header as SO:unsorted so
-        // downstream tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
-            if let Some(path) = self.rejects_opts.rejects.as_ref() {
-                let writer_threads = self.threading.num_threads();
-                let rejects_header = header_as_unsorted(&header);
-                let w = create_raw_bam_writer(
-                    path,
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                Some(Arc::new(Mutex::new(Some(w))))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+        // Rejects (`--rejects`) flow through the unified pipeline's first-class
+        // secondary output (see `run_bam_pipeline_from_reader_with_secondary` in
+        // `unified_pipeline/bam.rs`). `process_fn` collects rejected raw bytes
+        // into `CorrectProcessedBatch::rejected_records`; the pipeline's
+        // `secondary_serialize_fn` writes them in batch-input order. This
+        // matches the pattern used by `commands/filter.rs`.
 
         // Configuration for closures
         const BATCH_SIZE: usize = 1000; // Templates per batch
@@ -875,6 +864,10 @@ impl CorrectUmis {
                 }
 
                 let mut kept_raw_records: Vec<RawRecord> = Vec::new();
+                // Rejected records are collected per-batch and drained by the
+                // unified pipeline's secondary serializer; empty unless
+                // `track_rejects` is true.
+                let mut rejected_records: Vec<Vec<u8>> = Vec::new();
                 let mut missing_umis = 0u64;
                 let mut wrong_length = 0u64;
                 let mut mismatched = 0u64;
@@ -883,24 +876,6 @@ impl CorrectUmis {
                 // Count ALL input records for progress tracking (not just kept/rejected)
                 let mut total_input_records = 0u64;
                 let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
-
-                // Stream rejected records straight to disk so they don't
-                // accumulate in a batch-level Vec. The mutex only serializes
-                // the raw-byte append; BGZF compression runs on the writer's
-                // own thread pool.
-                let flush_raw_records = |recs: Vec<RawRecord>| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in &recs {
-                                    w.write_raw_record(raw.as_ref())?;
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                };
 
                 for template in batch {
                     // Count input records BEFORE processing
@@ -925,7 +900,9 @@ impl CorrectUmis {
                                     });
                                 entry.total_matches += num_records;
                                 if track_rejects {
-                                    flush_raw_records(raw_records)?;
+                                    for raw in &raw_records {
+                                        rejected_records.push(raw.as_ref().to_vec());
+                                    }
                                 }
                             }
                             Some(umi) => {
@@ -986,7 +963,9 @@ impl CorrectUmis {
                                         });
                                     entry.total_matches += num_records;
                                     if track_rejects {
-                                        flush_raw_records(raw_records)?;
+                                        for raw in &raw_records {
+                                            rejected_records.push(raw.as_ref().to_vec());
+                                        }
                                     }
                                 }
                             }
@@ -1002,6 +981,7 @@ impl CorrectUmis {
 
                 Ok(CorrectProcessedBatch {
                     kept_raw_records,
+                    rejected_records,
                     templates_count,
                     missing_umis,
                     wrong_length,
@@ -1042,39 +1022,55 @@ impl CorrectUmis {
             Ok(kept_count)
         };
 
-        // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let pipeline_result = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            header,
-            &self.io.output,
-            None, // Use input header for output
-            grouper_fn,
-            process_fn,
-            serialize_fn,
-        );
-
-        // Always finalize the rejects writer, even if the pipeline failed, so any
-        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
-        // finish() failures alongside any pipeline error so neither is silently
-        // dropped.
-        let rejects_finish_result = rejects_writer
-            .and_then(|rw_arc| rw_arc.lock().take())
-            .map(|writer| writer.finish().context("Failed to finish rejects file"));
-
-        let records_written = match (pipeline_result, rejects_finish_result) {
-            (Ok(records_written), Some(Ok(()))) => {
-                info!("Rejected records streamed to rejects file during processing");
-                records_written
+        // Secondary serialize: drains the per-batch rejected_records into the
+        // pipeline's secondary output buffer (BAM-framed: u32 little-endian
+        // block_size + record bytes). The pipeline reorders by batch serial,
+        // so rejects land in input order and the secondary writer is finalized
+        // automatically inside the pipeline.
+        let secondary_serialize_fn = |batch: &CorrectProcessedBatch,
+                                      buf: &mut Vec<u8>|
+         -> io::Result<u64> {
+            for raw in &batch.rejected_records {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
+                    )
+                })?;
+                buf.extend_from_slice(&block_size.to_le_bytes());
+                buf.extend_from_slice(raw);
             }
-            (Ok(records_written), None) => records_written,
-            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
-            (Err(pipeline_err), Some(Err(finish_err))) => {
-                return Err(anyhow::anyhow!(
-                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
-                ));
-            }
-            (Err(pipeline_err), _) => return Err(pipeline_err.into()),
+            Ok(batch.rejected_records.len() as u64)
+        };
+
+        // Run the 7-step pipeline with the already-opened reader (supports streaming).
+        // When `--rejects` is set, route rejects through the unified pipeline's
+        // first-class secondary output so they land in input/batch-serial order.
+        let records_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+            run_bam_pipeline_from_reader_with_secondary(
+                pipeline_config,
+                reader,
+                header,
+                &self.io.output,
+                None, // primary uses input header
+                rejects_path,
+                None, // secondary uses resolved primary header (== input header for correct)
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+                secondary_serialize_fn,
+            )?
+        } else {
+            run_bam_pipeline_from_reader(
+                pipeline_config,
+                reader,
+                header,
+                &self.io.output,
+                None, // Use input header for output
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+            )?
         };
 
         // ========== Post-pipeline: Aggregate metrics ==========

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -83,7 +83,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions, SchedulerOptions,
-    ThreadingOptions, build_pipeline_config, parse_bool,
+    ThreadingOptions, build_pipeline_config, parse_bool, serialize_raw_bam_records,
 };
 
 /// Result of matching an observed UMI to an expected UMI.
@@ -906,8 +906,11 @@ impl CorrectUmis {
                                     });
                                 entry.total_matches += num_records;
                                 if track_rejects {
-                                    for raw in &raw_records {
-                                        rejected_records.push(raw.as_ref().to_vec());
+                                    // Move out of `raw_records` (consumed here) to
+                                    // avoid a per-record clone+memcpy on the rejects
+                                    // hot path.
+                                    for raw in raw_records {
+                                        rejected_records.push(raw.into_inner());
                                     }
                                 }
                             }
@@ -969,8 +972,10 @@ impl CorrectUmis {
                                         });
                                     entry.total_matches += num_records;
                                     if track_rejects {
-                                        for raw in &raw_records {
-                                            rejected_records.push(raw.as_ref().to_vec());
+                                        // Move out of `raw_records` (consumed
+                                        // here) to avoid a per-record clone.
+                                        for raw in raw_records {
+                                            rejected_records.push(raw.into_inner());
                                         }
                                     }
                                 }
@@ -997,14 +1002,12 @@ impl CorrectUmis {
             })
         };
 
-        // Serialize function: convert records to bytes and collect metrics
+        // Serialize function: convert kept records to bytes and collect metrics.
+        // Rejects are drained by `secondary_serialize_fn` separately.
         let serialize_fn = move |mut processed: CorrectProcessedBatch,
                                  _header: &Header,
                                  output: &mut Vec<u8>|
               -> io::Result<u64> {
-            // Rejects were already streamed to disk in process_fn.
-            // Merge per-batch counts + UMI matches into this worker's
-            // accumulator slot.
             let umi_matches = std::mem::take(&mut processed.umi_matches);
             collected_for_serialize.with_slot(|m| {
                 m.templates_processed += processed.templates_count;
@@ -1016,38 +1019,18 @@ impl CorrectUmis {
                 }
             });
 
-            // Serialize kept records
-            let mut kept_count = 0u64;
-            for raw in &processed.kept_raw_records {
-                let block_size = raw.len() as u32;
-                output.extend_from_slice(&block_size.to_le_bytes());
-                output.extend_from_slice(raw);
-                kept_count += 1;
-            }
-            // Return KEPT record count (not input count, to avoid double-counting)
-            Ok(kept_count)
+            // Return KEPT record count (not input count, to avoid double-counting).
+            serialize_raw_bam_records(&processed.kept_raw_records, output)
         };
 
         // Secondary serialize: drains the per-batch rejected_records into the
-        // pipeline's secondary output buffer (BAM-framed: u32 little-endian
-        // block_size + record bytes). The pipeline reorders by batch serial,
-        // so rejects land in input order and the secondary writer is finalized
-        // automatically inside the pipeline.
-        let secondary_serialize_fn = |batch: &CorrectProcessedBatch,
-                                      buf: &mut Vec<u8>|
-         -> io::Result<u64> {
-            for raw in &batch.rejected_records {
-                let block_size = u32::try_from(raw.len()).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
-                    )
-                })?;
-                buf.extend_from_slice(&block_size.to_le_bytes());
-                buf.extend_from_slice(raw);
-            }
-            Ok(batch.rejected_records.len() as u64)
-        };
+        // pipeline's secondary output buffer. The pipeline reorders by batch
+        // serial, so rejects land in input order and the secondary writer is
+        // finalized automatically inside the pipeline.
+        let secondary_serialize_fn =
+            |batch: &CorrectProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_raw_bam_records(&batch.rejected_records, buf)
+            };
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming).
         // When `--rejects` is set, route rejects through the unified pipeline's
@@ -3635,5 +3618,60 @@ mod tests {
         // OX tag should NOT be present (dont_store_original_umis = true)
         let ox = fgumi_raw_bam::find_string_tag_in_record(&raw, SamTag::OX);
         assert!(ox.is_none());
+    }
+
+    /// Verifies `CorrectProcessedBatch::estimate_heap_size` accounts for both
+    /// `kept_raw_records` (consensus path) and `rejected_records` (secondary
+    /// rejects path), plus the outer-vec capacity overhead for each. The
+    /// non-empty-rejects case in particular guards against a regression where
+    /// the buffered rejects branch added by the secondary-output migration is
+    /// dropped from the estimate (which would mis-throttle the pipeline).
+    #[rstest]
+    #[case::empty_rejects(vec![1024], vec![])]
+    #[case::non_empty_rejects(vec![64, 128], vec![256, 512])]
+    fn test_correct_processed_batch_memory_estimate(
+        #[case] kept_capacities: Vec<usize>,
+        #[case] rej_capacities: Vec<usize>,
+    ) {
+        let kept_raw_records: Vec<RawRecord> =
+            kept_capacities.iter().map(|&cap| RawRecord::with_capacity(cap)).collect();
+        let kept_outer_capacity = kept_raw_records.capacity();
+        // RawRecord::with_capacity / Vec::with_capacity(n) only guarantee AT
+        // LEAST n; the allocator may round up. Read the observed capacities
+        // back so the expected value matches what was actually allocated
+        // under any allocator.
+        let kept_inner_total: usize = kept_raw_records.iter().map(RawRecord::capacity).sum();
+
+        let rejected_records: Vec<Vec<u8>> = rej_capacities
+            .iter()
+            .map(|&cap| {
+                let mut v = Vec::with_capacity(cap);
+                v.extend_from_slice(&[1u8; 8]);
+                v
+            })
+            .collect();
+        let rej_outer_capacity = rejected_records.capacity();
+        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
+
+        let batch = CorrectProcessedBatch {
+            kept_raw_records,
+            rejected_records,
+            templates_count: 0,
+            missing_umis: 0,
+            wrong_length: 0,
+            mismatched: 0,
+            umi_matches: AHashMap::new(),
+        };
+
+        let expected = kept_inner_total
+            + kept_outer_capacity * std::mem::size_of::<RawRecord>()
+            + rej_inner_total
+            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
+        assert_eq!(
+            batch.estimate_heap_size(),
+            expected,
+            "estimate should account for kept-record capacities, rejects inner capacities, \
+             and both outer-vec overheads",
+        );
     }
 }

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -24,7 +24,7 @@ use fgumi_bam_io::{
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
     QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config,
+    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -752,27 +752,17 @@ impl Duplex {
         };
 
         // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn = |batch: &DuplexProcessedBatch,
-                                      buf: &mut Vec<u8>|
-         -> io::Result<u64> {
-            for raw in &batch.rejected_records {
-                let block_size = u32::try_from(raw.len()).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
-                    )
-                })?;
-                buf.extend_from_slice(&block_size.to_le_bytes());
-                buf.extend_from_slice(raw);
-            }
-            Ok(batch.rejected_records.len() as u64)
-        };
+        let secondary_serialize_fn =
+            |batch: &DuplexProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_raw_bam_records(&batch.rejected_records, buf)
+            };
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming).
         // When `--rejects` is set, route rejects through the unified pipeline's
         // first-class secondary output so they land in input/batch-serial order
         // and the rejects BAM carries the input header.
-        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
+        {
             let secondary_header = input_header.clone();
             run_bam_pipeline_from_reader_with_secondary(
                 pipeline_config,
@@ -824,7 +814,7 @@ impl Duplex {
         // Log statistics
         info!("Duplex consensus calling complete");
         info!("Total MI groups processed: {total_groups}");
-        info!("Total groups processed by pipeline: {groups_processed}");
+        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
 
         let metrics = merged_stats.to_metrics();
         let consensus_count = metrics.consensus_reads;
@@ -1710,34 +1700,30 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_duplex_processed_batch_memory_estimate() {
-        let mut data = Vec::with_capacity(1024);
-        data.extend_from_slice(&[0u8; 100]);
+    #[rstest]
+    #[case::empty_rejects(1024, 100, vec![])]
+    #[case::non_empty_rejects(64, 32, vec![256, 128])]
+    fn test_duplex_processed_batch_memory_estimate(
+        #[case] consensus_capacity: usize,
+        #[case] consensus_len: usize,
+        #[case] rej_capacities: Vec<usize>,
+    ) {
+        let mut data = Vec::with_capacity(consensus_capacity);
+        data.resize(consensus_len, 0u8);
 
-        let batch = DuplexProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 1 },
-            rejected_records: Vec::new(),
-            groups_count: 1,
-            stats: ConsensusCallingStats::default(),
-            overlapping_stats: None,
-        };
-
-        let estimate = batch.estimate_heap_size();
-        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
-    }
-
-    #[test]
-    fn test_duplex_processed_batch_memory_estimate_with_rejects() {
-        let mut data = Vec::with_capacity(64);
-        data.extend_from_slice(&[0u8; 32]);
-
-        let mut rej_a = Vec::with_capacity(256);
-        rej_a.extend_from_slice(&[1u8; 8]);
-        let mut rej_b = Vec::with_capacity(128);
-        rej_b.extend_from_slice(&[2u8; 8]);
-        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rejected_records: Vec<Vec<u8>> = rej_capacities
+            .iter()
+            .map(|&cap| {
+                let mut v = Vec::with_capacity(cap);
+                v.extend_from_slice(&[1u8; 8]);
+                v
+            })
+            .collect();
         let rej_outer_capacity = rejected_records.capacity();
+        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
+        // round up. Read the observed capacities back so the expected value
+        // matches what was actually allocated under any allocator.
+        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
 
         let batch = DuplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 0 },
@@ -1747,12 +1733,15 @@ mod tests {
             overlapping_stats: None,
         };
 
-        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
-        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        let estimate = batch.estimate_heap_size();
+        // Heap = consensus capacity + sum of per-reject inner capacities
+        // + outer-vec capacity * size_of::<Vec<u8>>().
+        let expected = consensus_capacity
+            + rej_inner_total
+            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
         assert_eq!(
-            estimate, expected,
-            "estimate should include rejected_records capacities and outer-vec overhead",
+            batch.estimate_heap_size(),
+            expected,
+            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
         );
     }
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -9,8 +9,8 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::{
-    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 
 use super::common::{
@@ -31,10 +31,11 @@ use crate::overlapping_consensus::{
 };
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::read_info::LibraryIndex;
-use crate::sam::{SamTag, header_as_unsorted};
+use crate::sam::SamTag;
 use crate::umi::extract_mi_base;
 use crate::unified_pipeline::{
     GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    run_bam_pipeline_from_reader_with_secondary,
 };
 use crate::validation::validate_file_exists;
 use fgumi_bam_io::ProgressTracker;
@@ -43,7 +44,6 @@ use fgumi_raw_bam::{RawRecord, RawRecordView};
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
-use parking_lot::Mutex;
 use std::io;
 use std::io::Write as IoWrite;
 use std::sync::Arc;
@@ -60,6 +60,9 @@ use super::common::{MethylationRef, load_methylation_reference};
 struct DuplexProcessedBatch {
     /// Consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
+    /// Raw-byte rejected records (consensus-caller rejects), in batch-input
+    /// order. Empty unless `track_rejects` is true.
+    rejected_records: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// Consensus calling statistics for this batch
@@ -70,7 +73,9 @@ struct DuplexProcessedBatch {
 
 impl MemoryEstimate for DuplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
-        self.consensus_output.data.capacity()
+        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
+        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
+        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
     }
 }
 
@@ -606,206 +611,187 @@ impl Duplex {
             extract_mi_base(&mi_str).to_string()
         };
 
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk from process_fn, per-MI-group, so no batch-level buffering.
-        // Because workers flush under a mutex rather than through the ordered
-        // serialize stage, reject records are emitted in mutex-acquisition
-        // order, not input order; mark the rejects header as SO:unsorted so
-        // downstream tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
-            if let Some(path) = self.rejects_opts.rejects.as_ref() {
-                let writer_threads = self.threading.num_threads();
-                let rejects_header = header_as_unsorted(&input_header);
-                let w = create_raw_bam_writer(
-                    path,
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                Some(Arc::new(Mutex::new(Some(w))))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+        // Rejects flow through the unified pipeline's first-class secondary
+        // output (see correct.rs / simplex.rs / filter.rs for the shared
+        // pattern). `process_fn` collects caller-emitted rejects into
+        // `DuplexProcessedBatch::rejected_records`; the pipeline's
+        // `secondary_serialize_fn` writes them in batch-input order with the
+        // input header.
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
-        // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let pipeline_result = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            input_header,
-            &self.io.output,
-            Some(output_header.clone()),
-            // ========== grouper_fn: Create MiGrouper with filter, transform, and cell tag ==========
-            move |_header: &Header| {
-                Box::new(
-                    MiGrouper::with_filter_and_transform(
-                        "MI",
-                        batch_size,
-                        record_filter,
-                        mi_transform,
-                    )
+        // ========== grouper_fn ==========
+        let grouper_fn = move |_header: &Header| {
+            Box::new(
+                MiGrouper::with_filter_and_transform("MI", batch_size, record_filter, mi_transform)
                     .with_cell_tag(Some(*SamTag::CB)),
-                ) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-            },
-            // ========== process_fn: Duplex consensus calling ==========
-            move |batch: MiGroupBatch| -> io::Result<DuplexProcessedBatch> {
-                // Create per-thread duplex consensus caller
-                let mut caller = DuplexConsensusCaller::new(
-                    read_name_prefix.clone(),
-                    read_group_id.clone(),
-                    min_reads.clone(),
-                    min_input_base_quality,
-                    output_per_base_tags,
-                    trim,
-                    max_reads_per_strand,
-                    Some(cell_tag),
-                    track_rejects,
-                    error_rate_pre_umi,
-                    error_rate_post_umi,
-                )
-                .map_err(|e| {
-                    io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}"))
+            ) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+        };
+
+        // ========== process_fn: Duplex consensus calling ==========
+        let process_fn = move |batch: MiGroupBatch| -> io::Result<DuplexProcessedBatch> {
+            // Create per-thread duplex consensus caller
+            let mut caller = DuplexConsensusCaller::new(
+                read_name_prefix.clone(),
+                read_group_id.clone(),
+                min_reads.clone(),
+                min_input_base_quality,
+                output_per_base_tags,
+                trim,
+                max_reads_per_strand,
+                Some(cell_tag),
+                track_rejects,
+                error_rate_pre_umi,
+                error_rate_post_umi,
+            )
+            .map_err(|e| {
+                io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}"))
+            })?;
+
+            // Set reference for methylation-aware consensus if enabled
+            if let Some((ref reference, ref ref_names)) = methylation_ref {
+                caller.set_reference(
+                    Arc::clone(reference),
+                    Arc::clone(ref_names),
+                    methylation_mode,
+                );
+            }
+
+            // Create overlapping caller if enabled
+            let mut overlapping_caller = if overlapping_enabled {
+                Some(OverlappingBasesConsensusCaller::new(
+                    AgreementStrategy::Consensus,
+                    DisagreementStrategy::Consensus,
+                ))
+            } else {
+                None
+            };
+
+            let mut all_output = ConsensusOutput::default();
+            let mut batch_stats = ConsensusCallingStats::new();
+            let mut batch_overlapping = CorrectionStats::new();
+            let groups_count = batch.groups.len() as u64;
+            // Caller-emitted rejects collected per-batch and drained by the
+            // pipeline's secondary serializer.
+            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
+
+            for MiGroup { mi, records: mut group_reads } in batch.groups {
+                caller.clear();
+
+                // Apply overlapping consensus if enabled (modifies raw bytes in-place).
+                // Skip if group doesn't have both strands — no duplex possible anyway.
+                // Propagate errors to match single-threaded behavior; silent drops here
+                // would turn real failures into output gaps in --threads mode only.
+                if let Some(ref mut oc) = overlapping_caller {
+                    if has_both_strands_raw(&group_reads) {
+                        oc.reset_stats();
+                        apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
+                            io::Error::other(format!(
+                                "Overlapping consensus error for MI {mi}: {e}"
+                            ))
+                        })?;
+                        batch_overlapping.merge(oc.stats());
+                    }
+                }
+
+                // Call duplex consensus directly — records are already RawRecord values.
+                // Propagate errors to match single-threaded behavior; a warn-and-drop here
+                // would silently turn real failures (OOM, malformed records, etc.) into
+                // output gaps in --threads mode only.
+                let batch_output = caller.consensus_reads(group_reads).map_err(|e| {
+                    io::Error::other(format!("Duplex consensus error for MI {mi}: {e}"))
                 })?;
-
-                // Set reference for methylation-aware consensus if enabled
-                if let Some((ref reference, ref ref_names)) = methylation_ref {
-                    caller.set_reference(
-                        Arc::clone(reference),
-                        Arc::clone(ref_names),
-                        methylation_mode,
-                    );
-                }
-
-                // Create overlapping caller if enabled
-                let mut overlapping_caller = if overlapping_enabled {
-                    Some(OverlappingBasesConsensusCaller::new(
-                        AgreementStrategy::Consensus,
-                        DisagreementStrategy::Consensus,
-                    ))
-                } else {
-                    None
-                };
-
-                let mut all_output = ConsensusOutput::default();
-                let mut batch_stats = ConsensusCallingStats::new();
-                let mut batch_overlapping = CorrectionStats::new();
-                let groups_count = batch.groups.len() as u64;
-
-                // Stream per-MI-group rejects straight to disk so they don't
-                // accumulate in a batch-level Vec. The mutex only serializes the
-                // raw-byte append; BGZF compression runs on the writer's own
-                // thread pool.
-                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in recs {
-                                    w.write_raw_record(raw)?;
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                };
-
-                for MiGroup { mi, records: mut group_reads } in batch.groups {
-                    caller.clear();
-
-                    // Apply overlapping consensus if enabled (modifies raw bytes in-place).
-                    // Skip if group doesn't have both strands — no duplex possible anyway.
-                    // Propagate errors to match single-threaded behavior; silent drops here
-                    // would turn real failures into output gaps in --threads mode only.
-                    if let Some(ref mut oc) = overlapping_caller {
-                        if has_both_strands_raw(&group_reads) {
-                            oc.reset_stats();
-                            apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
-                                io::Error::other(format!(
-                                    "Overlapping consensus error for MI {mi}: {e}"
-                                ))
-                            })?;
-                            batch_overlapping.merge(oc.stats());
-                        }
-                    }
-
-                    // Call duplex consensus directly — records are already RawRecord values.
-                    // Propagate errors to match single-threaded behavior; a warn-and-drop here
-                    // would silently turn real failures (OOM, malformed records, etc.) into
-                    // output gaps in --threads mode only.
-                    let batch_output = caller.consensus_reads(group_reads).map_err(|e| {
-                        io::Error::other(format!("Duplex consensus error for MI {mi}: {e}"))
-                    })?;
-                    all_output.merge(batch_output);
-                    batch_stats.merge(&caller.statistics());
-                    if track_rejects {
-                        flush_byte_records(&caller.take_rejected_reads())?;
+                all_output.merge(batch_output);
+                batch_stats.merge(&caller.statistics());
+                if track_rejects {
+                    for raw in caller.take_rejected_reads() {
+                        rejected_records.push(raw);
                     }
                 }
-
-                Ok(DuplexProcessedBatch {
-                    consensus_output: all_output,
-                    groups_count,
-                    stats: batch_stats,
-                    overlapping_stats: if overlapping_enabled {
-                        Some(batch_overlapping)
-                    } else {
-                        None
-                    },
-                })
-            },
-            // ========== serialize_fn: Serialize + collect metrics ==========
-            move |processed: DuplexProcessedBatch,
-                  _header: &Header,
-                  output: &mut Vec<u8>|
-                  -> io::Result<u64> {
-                // Rejects were already streamed to disk in process_fn.
-                // Merge per-batch metrics into this worker's accumulator slot
-                let batch_stats = processed.stats;
-                let batch_overlapping = processed.overlapping_stats;
-                let groups_count = processed.groups_count;
-                collected_metrics_for_serialize.with_slot(|m| {
-                    m.stats.merge(&batch_stats);
-                    if let Some(o) = batch_overlapping {
-                        m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
-                    }
-                    m.groups_processed += groups_count;
-                });
-
-                let count = processed.consensus_output.count as u64;
-                output.extend_from_slice(&processed.consensus_output.data);
-                Ok(count)
-            },
-        );
-
-        // Always finalize the rejects writer, even if the pipeline failed, so any
-        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
-        // finish() failures alongside any pipeline error so neither is silently
-        // dropped.
-        let rejects_finish_result = rejects_writer
-            .and_then(|rw_arc| rw_arc.lock().take())
-            .map(|writer| writer.finish().context("Failed to finish rejects file"));
-
-        let groups_processed = match (pipeline_result, rejects_finish_result) {
-            (Ok(groups_processed), Some(Ok(()))) => {
-                info!("Rejected reads streamed to rejects file during processing");
-                groups_processed
             }
-            (Ok(groups_processed), None) => groups_processed,
-            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
-            (Err(pipeline_err), Some(Err(finish_err))) => {
-                return Err(anyhow::anyhow!(
-                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
-                ));
+
+            Ok(DuplexProcessedBatch {
+                consensus_output: all_output,
+                rejected_records,
+                groups_count,
+                stats: batch_stats,
+                overlapping_stats: if overlapping_enabled { Some(batch_overlapping) } else { None },
+            })
+        };
+
+        // ========== serialize_fn: Serialize + collect metrics ==========
+        let serialize_fn = move |processed: DuplexProcessedBatch,
+                                 _header: &Header,
+                                 output: &mut Vec<u8>|
+              -> io::Result<u64> {
+            // Merge per-batch metrics into this worker's accumulator slot.
+            // Rejects are drained by `secondary_serialize_fn` separately.
+            let batch_stats = processed.stats;
+            let batch_overlapping = processed.overlapping_stats;
+            let groups_count = processed.groups_count;
+            collected_metrics_for_serialize.with_slot(|m| {
+                m.stats.merge(&batch_stats);
+                if let Some(o) = batch_overlapping {
+                    m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
+                }
+                m.groups_processed += groups_count;
+            });
+
+            let count = processed.consensus_output.count as u64;
+            output.extend_from_slice(&processed.consensus_output.data);
+            Ok(count)
+        };
+
+        // ========== secondary_serialize_fn: Drain rejected records ==========
+        let secondary_serialize_fn = |batch: &DuplexProcessedBatch,
+                                      buf: &mut Vec<u8>|
+         -> io::Result<u64> {
+            for raw in &batch.rejected_records {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
+                    )
+                })?;
+                buf.extend_from_slice(&block_size.to_le_bytes());
+                buf.extend_from_slice(raw);
             }
-            (Err(pipeline_err), _) => {
-                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
-            }
+            Ok(batch.rejected_records.len() as u64)
+        };
+
+        // Run the 7-step pipeline with the already-opened reader (supports streaming).
+        // When `--rejects` is set, route rejects through the unified pipeline's
+        // first-class secondary output so they land in input/batch-serial order
+        // and the rejects BAM carries the input header.
+        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+            let secondary_header = input_header.clone();
+            run_bam_pipeline_from_reader_with_secondary(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                rejects_path,
+                Some(secondary_header),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+                secondary_serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
+        } else {
+            run_bam_pipeline_from_reader(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
         };
 
         // ========== Post-pipeline: Aggregate metrics ==========
@@ -1723,6 +1709,7 @@ mod tests {
 
         let batch = DuplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
+            rejected_records: Vec::new(),
             groups_count: 1,
             stats: ConsensusCallingStats::default(),
             overlapping_stats: None,
@@ -1730,6 +1717,35 @@ mod tests {
 
         let estimate = batch.estimate_heap_size();
         assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
+    }
+
+    #[test]
+    fn test_duplex_processed_batch_memory_estimate_with_rejects() {
+        let mut data = Vec::with_capacity(64);
+        data.extend_from_slice(&[0u8; 32]);
+
+        let mut rej_a = Vec::with_capacity(256);
+        rej_a.extend_from_slice(&[1u8; 8]);
+        let mut rej_b = Vec::with_capacity(128);
+        rej_b.extend_from_slice(&[2u8; 8]);
+        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rej_outer_capacity = rejected_records.capacity();
+
+        let batch = DuplexProcessedBatch {
+            consensus_output: ConsensusOutput { data, count: 0 },
+            rejected_records,
+            groups_count: 0,
+            stats: ConsensusCallingStats::default(),
+            overlapping_stats: None,
+        };
+
+        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
+        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
+        let estimate = batch.estimate_heap_size();
+        assert_eq!(
+            estimate, expected,
+            "estimate should include rejected_records capacities and outer-vec overhead",
+        );
     }
 
     #[rstest]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -4,6 +4,14 @@
 //! duplex consensus reads by performing two-stage consensus calling:
 //! 1. Single-strand consensus for /A and /B reads separately
 //! 2. Duplex consensus from paired single-strand consensuses
+//!
+//! When `--rejects` is set, the threaded pipeline routes rejected records through
+//! the unified pipeline's first-class secondary output (see
+//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
+//! Caller-emitted rejects flow through a per-batch buffer and land in batch-input
+//! order. The rejects BAM advertises the input header so raw-input RG/PG/contig
+//! metadata is preserved. The pattern matches `commands::filter`,
+//! `commands::correct`, and `commands::simplex`.
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -47,7 +47,7 @@ use std::time::Instant;
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool,
+    build_pipeline_config, parse_bool, serialize_raw_bam_records,
 };
 
 /// Filters and masks consensus reads based on various quality metrics.
@@ -243,21 +243,6 @@ impl MemoryEstimate for FilterProcessedBatchRaw {
         let rejected_inner: usize = self.rejected_records.iter().map(RawRecord::capacity).sum();
         kept_outer + kept_inner + rejected_outer + rejected_inner
     }
-}
-
-/// Serialize raw BAM records directly (bypasses `bam_codec` encoder).
-fn serialize_raw_records(records: &[RawRecord], output: &mut Vec<u8>) -> io::Result<u64> {
-    for record in records {
-        let len = u32::try_from(record.len()).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("BAM record too large ({} bytes) for u32 block_size", record.len()),
-            )
-        })?;
-        output.extend_from_slice(&len.to_le_bytes());
-        output.extend_from_slice(record);
-    }
-    Ok(records.len() as u64)
 }
 
 /// Per-thread accumulator merged into final counts after pipeline completion.
@@ -482,14 +467,14 @@ impl Filter {
                 m.total_bases_masked += processed.bases_masked;
             });
 
-            serialize_raw_records(&processed.kept_records, output)
+            serialize_raw_bam_records(&processed.kept_records, output)
         };
 
         if let Some(rejects_path) = &self.rejects {
             // Secondary serialize: write rejected records
             let secondary_serialize_fn =
                 |batch: &FilterProcessedBatchRaw, buf: &mut Vec<u8>| -> io::Result<u64> {
-                    serialize_raw_records(&batch.rejected_records, buf)
+                    serialize_raw_bam_records(&batch.rejected_records, buf)
                 };
 
             run_bam_pipeline_from_reader_with_secondary(

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -499,6 +499,7 @@ impl Filter {
                 &self.io.output,
                 None,
                 rejects_path,
+                None, // secondary uses resolved primary output header
                 grouper_fn,
                 process_fn,
                 serialize_fn,

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -51,7 +51,7 @@ use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
     QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config,
+    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -608,20 +608,14 @@ impl Simplex {
                     continue;
                 }
 
-                // Apply overlapping consensus if enabled (modifies raw bytes in-place)
+                // Apply overlapping consensus if enabled (modifies raw bytes in-place).
+                // Propagate errors to match the single-threaded path (line ~410),
+                // which treats overlapping-consensus failures as fatal via `?`.
                 if let Some(ref mut oc) = overlapping_caller {
                     oc.reset_stats();
-                    if apply_overlapping_consensus(&mut raw_records, oc).is_err() {
-                        batch_overlapping.merge(oc.stats());
-                        batch_stats.record_input(raw_records.len());
-                        batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
-                        if track_rejects {
-                            for raw in &raw_records {
-                                rejected_records.push(raw.as_ref().to_vec());
-                            }
-                        }
-                        continue;
-                    }
+                    apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
+                        io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+                    })?;
                     batch_overlapping.merge(oc.stats());
                 }
 
@@ -674,27 +668,17 @@ impl Simplex {
         };
 
         // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn = |batch: &SimplexProcessedBatch,
-                                      buf: &mut Vec<u8>|
-         -> io::Result<u64> {
-            for raw in &batch.rejected_records {
-                let block_size = u32::try_from(raw.len()).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
-                    )
-                })?;
-                buf.extend_from_slice(&block_size.to_le_bytes());
-                buf.extend_from_slice(raw);
-            }
-            Ok(batch.rejected_records.len() as u64)
-        };
+        let secondary_serialize_fn =
+            |batch: &SimplexProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_raw_bam_records(&batch.rejected_records, buf)
+            };
 
         // Run the 7-step pipeline with the already-opened reader (supports streaming).
         // When `--rejects` is set, route rejects through the unified pipeline's
         // first-class secondary output so they land in input/batch-serial order
         // and the rejects BAM carries the input header.
-        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
+        {
             let secondary_header = input_header.clone();
             run_bam_pipeline_from_reader_with_secondary(
                 pipeline_config,
@@ -746,7 +730,7 @@ impl Simplex {
         // Log statistics and write to file
         info!("Consensus calling complete");
         info!("Total MI groups processed: {total_groups}");
-        info!("Total groups processed by pipeline: {groups_processed}");
+        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
 
         let metrics = merged_stats.to_metrics();
         let consensus_count = metrics.consensus_reads;
@@ -1639,35 +1623,30 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_simplex_processed_batch_memory_estimate() {
-        let mut data = Vec::with_capacity(1024);
-        data.extend_from_slice(&[0u8; 100]);
+    #[rstest]
+    #[case::empty_rejects(1024, 100, vec![])]
+    #[case::non_empty_rejects(64, 32, vec![256, 128])]
+    fn test_simplex_processed_batch_memory_estimate(
+        #[case] consensus_capacity: usize,
+        #[case] consensus_len: usize,
+        #[case] rej_capacities: Vec<usize>,
+    ) {
+        let mut data = Vec::with_capacity(consensus_capacity);
+        data.resize(consensus_len, 0u8);
 
-        let batch = SimplexProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 1 },
-            rejected_records: Vec::new(),
-            groups_count: 1,
-            stats: ConsensusCallingStats::default(),
-            overlapping_stats: None,
-        };
-
-        let estimate = batch.estimate_heap_size();
-        // Should use capacity (1024) not len (100); rejected_records is empty.
-        assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
-    }
-
-    #[test]
-    fn test_simplex_processed_batch_memory_estimate_with_rejects() {
-        let mut data = Vec::with_capacity(64);
-        data.extend_from_slice(&[0u8; 32]);
-
-        let mut rej_a = Vec::with_capacity(256);
-        rej_a.extend_from_slice(&[1u8; 8]);
-        let mut rej_b = Vec::with_capacity(128);
-        rej_b.extend_from_slice(&[2u8; 8]);
-        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rejected_records: Vec<Vec<u8>> = rej_capacities
+            .iter()
+            .map(|&cap| {
+                let mut v = Vec::with_capacity(cap);
+                v.extend_from_slice(&[1u8; 8]);
+                v
+            })
+            .collect();
         let rej_outer_capacity = rejected_records.capacity();
+        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
+        // round up. Read the observed capacities back so the expected value
+        // matches what was actually allocated under any allocator.
+        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
 
         let batch = SimplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 0 },
@@ -1677,12 +1656,15 @@ mod tests {
             overlapping_stats: None,
         };
 
-        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
-        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        let estimate = batch.estimate_heap_size();
+        // Heap = consensus capacity + sum of per-reject inner capacities
+        // + outer-vec capacity * size_of::<Vec<u8>>().
+        let expected = consensus_capacity
+            + rej_inner_total
+            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
         assert_eq!(
-            estimate, expected,
-            "estimate should include rejected_records capacities and outer-vec overhead",
+            batch.estimate_heap_size(),
+            expected,
+            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
         );
     }
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -3,6 +3,14 @@
 //! This tool takes reads that have been grouped by UMI (via `group`) and generates
 //! consensus reads using a likelihood-based model that accounts for sequencing errors and
 //! errors introduced during sample preparation.
+//!
+//! When `--rejects` is set, the threaded pipeline routes rejected records through
+//! the unified pipeline's first-class secondary output (see
+//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
+//! Both reject sources (input-record skips below `--min-reads` and caller-emitted
+//! rejects) flow through the same per-batch buffer and land in batch-input order.
+//! The rejects BAM advertises the input header so raw-input RG/PG/contig metadata
+//! is preserved. The pattern matches `commands::filter` and `commands::correct`.
 
 use crate::consensus_caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -16,21 +16,21 @@ use crate::overlapping_consensus::{
 use crate::read_info::LibraryIndex;
 use crate::unified_pipeline::{
     GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
+    run_bam_pipeline_from_reader_with_secondary,
 };
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{
-    RawBamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts, create_raw_bam_writer,
+    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
+    create_raw_bam_reader_with_opts,
 };
 use fgumi_raw_bam::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::sam::{SamTag, header_as_unsorted};
+use crate::sam::SamTag;
 use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
-use parking_lot::Mutex;
 
 use log::info;
 use noodles::sam::Header;
@@ -62,6 +62,9 @@ use super::common::{MethylationRef, load_methylation_reference};
 struct SimplexProcessedBatch {
     /// Pre-serialized consensus reads to write to output BAM
     consensus_output: ConsensusOutput,
+    /// Raw-byte rejected records (input records on batch-skip + caller
+    /// rejects), in batch-input order. Empty unless `track_rejects` is true.
+    rejected_records: Vec<Vec<u8>>,
     /// Number of MI groups in this batch
     groups_count: u64,
     /// Consensus calling statistics for this batch
@@ -72,7 +75,9 @@ struct SimplexProcessedBatch {
 
 impl MemoryEstimate for SimplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
-        self.consensus_output.data.capacity()
+        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
+        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
+        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
     }
 }
 
@@ -528,210 +533,187 @@ impl Simplex {
             methylation_mode,
         };
 
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk from process_fn, per-MI-group, so no batch-level buffering.
-        // Because workers flush under a mutex rather than through the ordered
-        // serialize stage, reject records are emitted in mutex-acquisition
-        // order, not input order; mark the rejects header as SO:unsorted so
-        // downstream tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>> = if track_rejects {
-            if let Some(path) = self.rejects_opts.rejects.as_ref() {
-                let writer_threads = self.threading.num_threads();
-                let rejects_header = header_as_unsorted(&input_header);
-                let w = create_raw_bam_writer(
-                    path,
-                    &rejects_header,
-                    writer_threads,
-                    self.compression.compression_level,
-                )?;
-                Some(Arc::new(Mutex::new(Some(w))))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let rejects_writer_for_process = rejects_writer.as_ref().map(Arc::clone);
+        // Rejects (`--rejects`) flow through the unified pipeline's first-class
+        // secondary output (see `run_bam_pipeline_from_reader_with_secondary` in
+        // `unified_pipeline/bam.rs`). `process_fn` collects rejected raw bytes
+        // (input records when an MI group is skipped + caller-emitted rejects)
+        // into `SimplexProcessedBatch::rejected_records`; the pipeline's
+        // `secondary_serialize_fn` writes them in batch-input order. The rejects
+        // BAM advertises the input header (via `secondary_output_header =
+        // Some(input_header)`) so it carries raw-input RG/PG/contig metadata.
 
         let library_index = LibraryIndex::from_header(&input_header);
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
-        // Run the 7-step pipeline with the already-opened reader (supports streaming)
-        let pipeline_result = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            input_header,
-            &self.io.output,
-            Some(output_header.clone()),
-            // ========== grouper_fn: Create MiGrouper ==========
-            move |_header: &Header| {
-                Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
-                    as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-            },
-            // ========== process_fn: Consensus calling ==========
-            move |batch: MiGroupBatch| -> io::Result<SimplexProcessedBatch> {
-                // Create per-thread consensus caller
-                let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
-                    read_name_prefix.clone(),
-                    read_group_id.clone(),
-                    options.clone(),
-                    track_rejects,
-                );
+        // ========== grouper_fn ==========
+        let grouper_fn = move |_header: &Header| {
+            Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
+                as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+        };
 
-                // Set reference for methylation-aware consensus if enabled
-                if let Some((ref reference, ref ref_names)) = methylation_ref {
-                    caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        // ========== process_fn: Consensus calling ==========
+        let process_fn = move |batch: MiGroupBatch| -> io::Result<SimplexProcessedBatch> {
+            // Create per-thread consensus caller
+            let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
+                read_name_prefix.clone(),
+                read_group_id.clone(),
+                options.clone(),
+                track_rejects,
+            );
+
+            // Set reference for methylation-aware consensus if enabled
+            if let Some((ref reference, ref ref_names)) = methylation_ref {
+                caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+            }
+
+            // Create overlapping caller if enabled
+            let mut overlapping_caller = if overlapping_enabled {
+                Some(OverlappingBasesConsensusCaller::new(
+                    AgreementStrategy::Consensus,
+                    DisagreementStrategy::Consensus,
+                ))
+            } else {
+                None
+            };
+
+            let mut all_output = ConsensusOutput::default();
+            let mut batch_stats = ConsensusCallingStats::new();
+            let mut batch_overlapping = CorrectionStats::new();
+            let groups_count = batch.groups.len() as u64;
+            // Rejected records (input-record skips + caller rejects) collected
+            // per-batch and drained by the pipeline's secondary serializer.
+            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
+
+            for MiGroup { mi, records: mut raw_records } in batch.groups {
+                caller.clear();
+
+                // Skip if below min_reads threshold
+                if raw_records.len() < min_reads {
+                    batch_stats.record_input(raw_records.len());
+                    batch_stats
+                        .record_rejection(RejectionReason::InsufficientReads, raw_records.len());
+                    if track_rejects {
+                        for raw in &raw_records {
+                            rejected_records.push(raw.as_ref().to_vec());
+                        }
+                    }
+                    continue;
                 }
 
-                // Create overlapping caller if enabled
-                let mut overlapping_caller = if overlapping_enabled {
-                    Some(OverlappingBasesConsensusCaller::new(
-                        AgreementStrategy::Consensus,
-                        DisagreementStrategy::Consensus,
-                    ))
-                } else {
-                    None
-                };
-
-                let mut all_output = ConsensusOutput::default();
-                let mut batch_stats = ConsensusCallingStats::new();
-                let mut batch_overlapping = CorrectionStats::new();
-                let groups_count = batch.groups.len() as u64;
-
-                // Stream per-MI-group rejects straight to disk so they don't
-                // accumulate in a batch-level Vec. The mutex only serializes the
-                // raw-byte append; BGZF compression runs on the writer's own
-                // thread pool.
-                let flush_raw_records = |recs: &[RawRecord]| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in recs {
-                                    w.write_raw_record(raw.as_ref())?;
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                };
-                let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                    if let Some(ref rw_arc) = rejects_writer_for_process {
-                        if !recs.is_empty() {
-                            let mut guard = rw_arc.lock();
-                            if let Some(w) = guard.as_mut() {
-                                for raw in recs {
-                                    w.write_raw_record(raw)?;
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                };
-
-                for MiGroup { mi, records: mut raw_records } in batch.groups {
-                    caller.clear();
-
-                    // Skip if below min_reads threshold
-                    if raw_records.len() < min_reads {
+                // Apply overlapping consensus if enabled (modifies raw bytes in-place)
+                if let Some(ref mut oc) = overlapping_caller {
+                    oc.reset_stats();
+                    if apply_overlapping_consensus(&mut raw_records, oc).is_err() {
+                        batch_overlapping.merge(oc.stats());
                         batch_stats.record_input(raw_records.len());
-                        batch_stats.record_rejection(
-                            RejectionReason::InsufficientReads,
-                            raw_records.len(),
-                        );
+                        batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
                         if track_rejects {
-                            flush_raw_records(&raw_records)?;
+                            for raw in &raw_records {
+                                rejected_records.push(raw.as_ref().to_vec());
+                            }
                         }
                         continue;
                     }
-
-                    // Apply overlapping consensus if enabled (modifies raw bytes in-place)
-                    if let Some(ref mut oc) = overlapping_caller {
-                        oc.reset_stats();
-                        if apply_overlapping_consensus(&mut raw_records, oc).is_err() {
-                            batch_overlapping.merge(oc.stats());
-                            batch_stats.record_input(raw_records.len());
-                            batch_stats.record_rejection(RejectionReason::Other, raw_records.len());
-                            if track_rejects {
-                                flush_raw_records(&raw_records)?;
-                            }
-                            continue;
-                        }
-                        batch_overlapping.merge(oc.stats());
-                    }
-
-                    // Call consensus — mi_group yields Vec<RawRecord> directly.
-                    // Propagate errors to match the single-threaded path, which
-                    // treats consensus failures as fatal.
-                    let batch_output = caller.consensus_reads(raw_records).map_err(|e| {
-                        io::Error::other(format!("Consensus error for MI {mi}: {e}"))
-                    })?;
-                    all_output.merge(batch_output);
-                    batch_stats.merge(&caller.statistics());
-                    if track_rejects {
-                        flush_byte_records(&caller.take_rejected_reads())?;
-                    }
+                    batch_overlapping.merge(oc.stats());
                 }
 
-                Ok(SimplexProcessedBatch {
-                    consensus_output: all_output,
-                    groups_count,
-                    stats: batch_stats,
-                    overlapping_stats: if overlapping_enabled {
-                        Some(batch_overlapping)
-                    } else {
-                        None
-                    },
-                })
-            },
-            // ========== serialize_fn: Serialize + collect metrics ==========
-            move |processed: SimplexProcessedBatch,
-                  _header: &Header,
-                  output: &mut Vec<u8>|
-                  -> io::Result<u64> {
-                // Rejects were already streamed to disk in process_fn.
-                // Merge per-batch metrics into this worker's accumulator slot
-                let batch_stats = processed.stats;
-                let batch_overlapping = processed.overlapping_stats;
-                let groups_count = processed.groups_count;
-                collected_metrics_for_serialize.with_slot(|m| {
-                    m.stats.merge(&batch_stats);
-                    if let Some(o) = batch_overlapping {
-                        m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
+                // Call consensus — mi_group yields Vec<RawRecord> directly.
+                // Propagate errors to match the single-threaded path, which
+                // treats consensus failures as fatal.
+                let batch_output = caller
+                    .consensus_reads(raw_records)
+                    .map_err(|e| io::Error::other(format!("Consensus error for MI {mi}: {e}")))?;
+                all_output.merge(batch_output);
+                batch_stats.merge(&caller.statistics());
+                if track_rejects {
+                    for raw in caller.take_rejected_reads() {
+                        rejected_records.push(raw);
                     }
-                    m.groups_processed += groups_count;
-                });
-
-                // Serialize consensus reads
-                let count = processed.consensus_output.count as u64;
-                output.extend_from_slice(&processed.consensus_output.data);
-                Ok(count)
-            },
-        );
-
-        // Always finalize the rejects writer, even if the pipeline failed, so any
-        // partially written rejects BAM still gets a valid BGZF EOF block. Surface
-        // finish() failures alongside any pipeline error so neither is silently
-        // dropped.
-        let rejects_finish_result = rejects_writer
-            .and_then(|rw_arc| rw_arc.lock().take())
-            .map(|writer| writer.finish().context("Failed to finish rejects file"));
-
-        let groups_processed = match (pipeline_result, rejects_finish_result) {
-            (Ok(groups_processed), Some(Ok(()))) => {
-                info!("Rejected reads streamed to rejects file during processing");
-                groups_processed
+                }
             }
-            (Ok(groups_processed), None) => groups_processed,
-            (Ok(_), Some(Err(finish_err))) => return Err(finish_err),
-            (Err(pipeline_err), Some(Err(finish_err))) => {
-                return Err(anyhow::anyhow!(
-                    "Pipeline error: {pipeline_err}; additionally failed to finish rejects file: {finish_err}"
-                ));
+
+            Ok(SimplexProcessedBatch {
+                consensus_output: all_output,
+                rejected_records,
+                groups_count,
+                stats: batch_stats,
+                overlapping_stats: if overlapping_enabled { Some(batch_overlapping) } else { None },
+            })
+        };
+
+        // ========== serialize_fn: Serialize + collect metrics ==========
+        let serialize_fn = move |processed: SimplexProcessedBatch,
+                                 _header: &Header,
+                                 output: &mut Vec<u8>|
+              -> io::Result<u64> {
+            // Merge per-batch metrics into this worker's accumulator slot.
+            // Rejects are drained by `secondary_serialize_fn` separately.
+            let batch_stats = processed.stats;
+            let batch_overlapping = processed.overlapping_stats;
+            let groups_count = processed.groups_count;
+            collected_metrics_for_serialize.with_slot(|m| {
+                m.stats.merge(&batch_stats);
+                if let Some(o) = batch_overlapping {
+                    m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
+                }
+                m.groups_processed += groups_count;
+            });
+
+            // Serialize consensus reads
+            let count = processed.consensus_output.count as u64;
+            output.extend_from_slice(&processed.consensus_output.data);
+            Ok(count)
+        };
+
+        // ========== secondary_serialize_fn: Drain rejected records ==========
+        let secondary_serialize_fn = |batch: &SimplexProcessedBatch,
+                                      buf: &mut Vec<u8>|
+         -> io::Result<u64> {
+            for raw in &batch.rejected_records {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes) for u32 block_size", raw.len()),
+                    )
+                })?;
+                buf.extend_from_slice(&block_size.to_le_bytes());
+                buf.extend_from_slice(raw);
             }
-            (Err(pipeline_err), _) => {
-                return Err(anyhow::anyhow!("Pipeline error: {pipeline_err}"));
-            }
+            Ok(batch.rejected_records.len() as u64)
+        };
+
+        // Run the 7-step pipeline with the already-opened reader (supports streaming).
+        // When `--rejects` is set, route rejects through the unified pipeline's
+        // first-class secondary output so they land in input/batch-serial order
+        // and the rejects BAM carries the input header.
+        let groups_processed = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
+            let secondary_header = input_header.clone();
+            run_bam_pipeline_from_reader_with_secondary(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                rejects_path,
+                Some(secondary_header),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+                secondary_serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
+        } else {
+            run_bam_pipeline_from_reader(
+                pipeline_config,
+                reader,
+                input_header,
+                &self.io.output,
+                Some(output_header.clone()),
+                grouper_fn,
+                process_fn,
+                serialize_fn,
+            )
+            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
         };
 
         // ========== Post-pipeline: Aggregate metrics ==========
@@ -1656,14 +1638,44 @@ mod tests {
 
         let batch = SimplexProcessedBatch {
             consensus_output: ConsensusOutput { data, count: 1 },
+            rejected_records: Vec::new(),
             groups_count: 1,
             stats: ConsensusCallingStats::default(),
             overlapping_stats: None,
         };
 
         let estimate = batch.estimate_heap_size();
-        // Should use capacity (1024) not len (100)
+        // Should use capacity (1024) not len (100); rejected_records is empty.
         assert_eq!(estimate, 1024, "estimate should match consensus_output capacity");
+    }
+
+    #[test]
+    fn test_simplex_processed_batch_memory_estimate_with_rejects() {
+        let mut data = Vec::with_capacity(64);
+        data.extend_from_slice(&[0u8; 32]);
+
+        let mut rej_a = Vec::with_capacity(256);
+        rej_a.extend_from_slice(&[1u8; 8]);
+        let mut rej_b = Vec::with_capacity(128);
+        rej_b.extend_from_slice(&[2u8; 8]);
+        let rejected_records: Vec<Vec<u8>> = vec![rej_a, rej_b];
+        let rej_outer_capacity = rejected_records.capacity();
+
+        let batch = SimplexProcessedBatch {
+            consensus_output: ConsensusOutput { data, count: 0 },
+            rejected_records,
+            groups_count: 0,
+            stats: ConsensusCallingStats::default(),
+            overlapping_stats: None,
+        };
+
+        // 64 (consensus capacity) + 256 + 128 (per-rej capacities) + outer-vec capacity * size_of::<Vec<u8>>()
+        let expected = 64 + 256 + 128 + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
+        let estimate = batch.estimate_heap_size();
+        assert_eq!(
+            estimate, expected,
+            "estimate should include rejected_records capacities and outer-vec overhead",
+        );
     }
 
     #[rstest]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -4255,6 +4255,17 @@ fn resolve_secondary_header(
 /// The secondary serialize function is called with a borrow of the processed batch
 /// BEFORE the primary serialize function consumes it.
 ///
+/// # Parameters
+///
+/// - `output_header`: header for the primary output BAM. `None` reuses
+///   `input_header`.
+/// - `secondary_output_header`: header for the rejects (secondary) BAM. `None`
+///   reuses the resolved primary `output_header` — the filter-style case where
+///   primary and secondary share a header. Consensus commands pass
+///   `Some(input_header)` so the rejects BAM advertises the raw-input header
+///   (with the input's RG/PG/contig metadata and sort order) instead of the
+///   transformed primary output header.
+///
 /// # Errors
 ///
 /// Returns an I/O error if any pipeline step or file I/O fails.
@@ -4814,20 +4825,18 @@ mod tests {
         assert!(!state.q2b_boundaries.is_empty(), "Q2b should not have been popped");
     }
 
-    #[test]
-    fn test_resolve_secondary_header_defaults_to_primary() {
+    #[rstest]
+    #[case::none_falls_back_to_primary(None, "primary")]
+    #[case::some_overrides_primary(Some("rejects"), "rejects")]
+    fn test_resolve_secondary_header(
+        #[case] override_comment: Option<&str>,
+        #[case] expected_comment: &str,
+    ) {
         let primary = Header::builder().add_comment("primary").build();
-        let resolved = resolve_secondary_header(None, &primary);
-        assert_eq!(resolved, primary);
-    }
-
-    #[test]
-    fn test_resolve_secondary_header_uses_override_when_provided() {
-        let primary = Header::builder().add_comment("primary").build();
-        let override_header = Header::builder().add_comment("rejects").build();
-        let resolved = resolve_secondary_header(Some(&override_header), &primary);
-        assert_eq!(resolved, override_header);
-        assert_ne!(resolved, primary);
+        let override_header = override_comment.map(|c| Header::builder().add_comment(c).build());
+        let resolved = resolve_secondary_header(override_header.as_ref(), &primary);
+        let expected = Header::builder().add_comment(expected_comment).build();
+        assert_eq!(resolved, expected);
     }
 
     #[test]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -3311,22 +3311,24 @@ where
                 // Step 6: Process
                 let processed = (fns.process_fn)(group)?;
 
-                // Step 7a: Secondary serialize (borrows processed)
-                buffers.secondary.clear();
-                if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
-                    (secondary_fn)(&processed, &mut buffers.secondary)?;
-                }
-
-                // Step 7b: Primary serialize (consumes processed, reuse buffer).
-                // Run the optional MI Assign hook first so any per-template
-                // rewriting it does is reflected in the bytes serialize
-                // emits.
-                buffers.serialized.clear();
+                // Step 7a: Run the optional MI Assign hook so any per-template
+                // rewriting it does is reflected in BOTH outputs. The parallel
+                // path runs MI Assign before secondary_serialize, so doing it
+                // here keeps single-threaded byte-for-byte equivalent.
                 let processed = run_mi_assign_single_threaded(
                     fns.mi_assign_fn.as_deref(),
                     &mut next_serial,
                     processed,
                 )?;
+
+                // Step 7b: Secondary serialize (borrows processed)
+                buffers.secondary.clear();
+                if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
+                    (secondary_fn)(&processed, &mut buffers.secondary)?;
+                }
+
+                // Step 7c: Primary serialize (consumes processed, reuse buffer).
+                buffers.serialized.clear();
                 let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
 
                 // Step 8: Compress (only when buffer reaches 64KB)
@@ -3357,17 +3359,20 @@ where
             for group in groups {
                 let processed = (fns.process_fn)(group)?;
 
+                // Run MI Assign first so secondary_serialize sees the same
+                // post-assign state as the parallel path (matches Step 7 above).
+                let processed = run_mi_assign_single_threaded(
+                    fns.mi_assign_fn.as_deref(),
+                    &mut next_serial,
+                    processed,
+                )?;
+
                 buffers.secondary.clear();
                 if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
                     (secondary_fn)(&processed, &mut buffers.secondary)?;
                 }
 
                 buffers.serialized.clear();
-                let processed = run_mi_assign_single_threaded(
-                    fns.mi_assign_fn.as_deref(),
-                    &mut next_serial,
-                    processed,
-                )?;
                 let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
                 compressor.write_all(&buffers.serialized)?;
                 compressor.maybe_compress()?;
@@ -3389,21 +3394,22 @@ where
         // Step 6: Process
         let processed = (fns.process_fn)(final_group)?;
 
-        // Step 7a: Secondary serialize (borrows processed)
-        buffers.secondary.clear();
-        if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
-            (secondary_fn)(&processed, &mut buffers.secondary)?;
-        }
-
-        // Step 7b: Primary serialize (consumes processed, reuse buffer).
-        // Run the MI Assign hook first so the bytes reflect any per-template
-        // rewriting it performs.
-        buffers.serialized.clear();
+        // Step 7a: Run MI Assign first so per-template rewriting is reflected
+        // in BOTH outputs and matches the parallel path's ordering.
         let processed = run_mi_assign_single_threaded(
             fns.mi_assign_fn.as_deref(),
             &mut next_serial,
             processed,
         )?;
+
+        // Step 7b: Secondary serialize (borrows processed)
+        buffers.secondary.clear();
+        if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
+            (secondary_fn)(&processed, &mut buffers.secondary)?;
+        }
+
+        // Step 7c: Primary serialize (consumes processed, reuse buffer).
+        buffers.serialized.clear();
         let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
 
         // Step 8: Compress (only when buffer reaches 64KB)
@@ -4229,6 +4235,20 @@ where
 
 /// Run a BAM pipeline from an already-opened reader, with a secondary output file.
 ///
+/// Pick the header that the rejects (secondary) BAM should advertise.
+///
+/// `None` falls back to the resolved primary output header — that matches
+/// `filter.rs`'s prior behavior, where rejects share the primary's header.
+/// Consensus commands pass `Some(input_header)` so the rejects BAM carries
+/// the raw-input header rather than the consensus output header.
+#[inline]
+fn resolve_secondary_header(
+    secondary_output_header: Option<&Header>,
+    primary_output_header: &Header,
+) -> Header {
+    secondary_output_header.cloned().unwrap_or_else(|| primary_output_header.clone())
+}
+
 /// This variant routes rejected/secondary records through the pipeline's ordering
 /// infrastructure so both primary and secondary output files maintain input order.
 ///
@@ -4254,6 +4274,7 @@ pub fn run_bam_pipeline_from_reader_with_secondary<
     output_path: &Path,
     output_header: Option<Header>,
     secondary_output_path: &Path,
+    secondary_output_header: Option<Header>,
     grouper_fn: GrouperFn,
     process_fn: ProcessFn,
     serialize_fn: SerializeFn,
@@ -4270,6 +4291,14 @@ where
 {
     // Use output_header if provided, otherwise clone input_header
     let output_header = output_header.unwrap_or_else(|| input_header.clone());
+
+    // Resolve which header the rejects (secondary) BAM should advertise.
+    // Defaults to the primary output header to match prior behavior; consensus
+    // commands override this with the input header so rejects carry raw-input
+    // RG/PG/contig metadata and the input's claimed sort order (rejects are
+    // emitted in input order, so the input sort order remains valid).
+    let secondary_header =
+        resolve_secondary_header(secondary_output_header.as_ref(), &output_header);
 
     // Create primary output BAM and write the output header
     let output_writer = open_pipeline_output(output_path)?;
@@ -4290,7 +4319,7 @@ where
     // Create secondary output (reject BAM) with its own BGZF compression
     let secondary_writer = fgumi_bam_io::create_raw_bam_writer(
         secondary_output_path,
-        &output_header,
+        &secondary_header,
         1, // single-threaded BGZF for secondary
         config.compression_level,
     )
@@ -4783,6 +4812,22 @@ mod tests {
         assert!(!state.has_error(), "should NOT set error; got: {:?}", state.take_error());
         assert!(worker.held_decoded.is_some(), "held batch should be preserved");
         assert!(!state.q2b_boundaries.is_empty(), "Q2b should not have been popped");
+    }
+
+    #[test]
+    fn test_resolve_secondary_header_defaults_to_primary() {
+        let primary = Header::builder().add_comment("primary").build();
+        let resolved = resolve_secondary_header(None, &primary);
+        assert_eq!(resolved, primary);
+    }
+
+    #[test]
+    fn test_resolve_secondary_header_uses_override_when_provided() {
+        let primary = Header::builder().add_comment("primary").build();
+        let override_header = Header::builder().add_comment("rejects").build();
+        let resolved = resolve_secondary_header(Some(&override_header), &primary);
+        assert_eq!(resolved, override_header);
+        assert_ne!(resolved, primary);
     }
 
     #[test]

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -36,7 +36,7 @@ pub fn assert_has_bgzf_eof(path: &std::path::Path) {
 /// Asserts that a BAM file's `@HD` line has `SO:unsorted` and no `GO` or `SS`
 /// tags, matching the contract of `fgumi_lib::sam::header_as_unsorted`.
 ///
-/// Use this on rejects BAMs produced by the pipeline commands, whose records
+/// Use this on rejects BAMs produced by hand-rolled writer paths whose records
 /// are emitted in mutex-acquisition order rather than input order.
 ///
 /// # Panics
@@ -61,6 +61,58 @@ pub fn assert_header_unsorted(path: &std::path::Path) {
     );
     assert!(other_fields.get(b"GO").is_none(), "GO should be cleared in {}", path.display());
     assert!(other_fields.get(b"SS").is_none(), "SS should be cleared in {}", path.display());
+}
+
+/// Asserts that a rejects BAM's `@HD` sort-order fields (`SO`, `GO`, `SS`)
+/// match those of the input BAM.
+///
+/// Pipeline commands route rejects through the unified pipeline's first-class
+/// secondary output, which emits rejects in batch-input order (a subset of an
+/// SO-X stream is still SO-X). The rejects BAM therefore inherits the input
+/// header verbatim — including whatever sort-order claim the input made (or
+/// the absence of one).
+///
+/// # Panics
+///
+/// Panics if either file cannot be opened, the header cannot be read, or the
+/// sort-order fields differ.
+pub fn assert_rejects_header_matches_input(
+    rejects_path: &std::path::Path,
+    input_path: &std::path::Path,
+) {
+    #[derive(Debug, Eq, PartialEq)]
+    struct SortFields {
+        so: Option<Vec<u8>>,
+        go: Option<Vec<u8>>,
+        ss: Option<Vec<u8>>,
+    }
+
+    fn read_sort_fields(path: &std::path::Path) -> SortFields {
+        let mut reader = noodles::bam::io::Reader::new(
+            std::fs::File::open(path).expect("Failed to open BAM for header check"),
+        );
+        let header = reader.read_header().expect("Failed to read BAM header");
+        // `@HD` is optional in noodles' Header — treat its absence as "no fields".
+        let Some(hdr_map) = header.header() else {
+            return SortFields { so: None, go: None, ss: None };
+        };
+        let other = hdr_map.other_fields();
+        SortFields {
+            so: other.get(b"SO").map(|v| v.to_vec()),
+            go: other.get(b"GO").map(|v| v.to_vec()),
+            ss: other.get(b"SS").map(|v| v.to_vec()),
+        }
+    }
+
+    let actual = read_sort_fields(rejects_path);
+    let expected = read_sort_fields(input_path);
+    assert_eq!(
+        actual,
+        expected,
+        "rejects @HD sort fields should match input ({} vs {})",
+        rejects_path.display(),
+        input_path.display()
+    );
 }
 
 /// Asserts that a record has a specific MI (molecule ID) tag value.

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -58,6 +58,10 @@ pub fn assert_rejects_header_matches_input(
     }
 
     fn read_sort_fields(path: &std::path::Path) -> SortFields {
+        use noodles::sam::header::record::value::map::header::tag::{
+            GROUP_ORDER, SORT_ORDER, SUBSORT_ORDER,
+        };
+
         let mut reader = noodles::bam::io::Reader::new(
             std::fs::File::open(path).expect("Failed to open BAM for header check"),
         );
@@ -66,11 +70,14 @@ pub fn assert_rejects_header_matches_input(
         let Some(hdr_map) = header.header() else {
             return SortFields { so: None, go: None, ss: None };
         };
+        // Use typed `Other` tag constants rather than raw byte slices so this
+        // keeps working if noodles ever promotes these to first-class fields
+        // on `Map<Header>` (currently 0.82 keeps them in `other_fields`).
         let other = hdr_map.other_fields();
         SortFields {
-            so: other.get(b"SO").map(|v| v.to_vec()),
-            go: other.get(b"GO").map(|v| v.to_vec()),
-            ss: other.get(b"SS").map(|v| v.to_vec()),
+            so: other.get(&SORT_ORDER).map(|v| v.to_vec()),
+            go: other.get(&GROUP_ORDER).map(|v| v.to_vec()),
+            ss: other.get(&SUBSORT_ORDER).map(|v| v.to_vec()),
         }
     }
 
@@ -218,6 +225,30 @@ mod tests {
     use super::*;
     use crate::helpers::bam_generator::to_record_buf;
     use fgumi_raw_bam::{SamBuilder, flags};
+
+    /// Locks down the noodles behavior that `assert_rejects_header_matches_input`
+    /// relies on: SO/GO/SS are accessible via the typed `Other` tag constants on
+    /// `Map<Header>::other_fields()`. If noodles ever moves these to first-class
+    /// fields on `Map<Header>`, this test will fail and the helper above must be
+    /// updated to use the new accessors instead.
+    #[test]
+    fn sort_fields_are_readable_from_other_fields() {
+        use noodles::sam::header::record::value::map::header::tag::{
+            GROUP_ORDER, SORT_ORDER, SUBSORT_ORDER,
+        };
+
+        let header_text =
+            "@HD\tVN:1.6\tSO:queryname\tGO:none\tSS:queryname:natural\n@PG\tID:test\tPN:test\n";
+        let header: noodles::sam::Header = header_text.parse().unwrap();
+        let hdr_map = header.header().expect("@HD should be present");
+        let other = hdr_map.other_fields();
+        assert_eq!(other.get(&SORT_ORDER).map(|v| v.to_vec()), Some(b"queryname".to_vec()),);
+        assert_eq!(other.get(&GROUP_ORDER).map(|v| v.to_vec()), Some(b"none".to_vec()));
+        assert_eq!(
+            other.get(&SUBSORT_ORDER).map(|v| v.to_vec()),
+            Some(b"queryname:natural".to_vec()),
+        );
+    }
 
     #[test]
     fn test_assert_mi_tag() {

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -33,36 +33,6 @@ pub fn assert_has_bgzf_eof(path: &std::path::Path) {
     );
 }
 
-/// Asserts that a BAM file's `@HD` line has `SO:unsorted` and no `GO` or `SS`
-/// tags, matching the contract of `fgumi_lib::sam::header_as_unsorted`.
-///
-/// Use this on rejects BAMs produced by hand-rolled writer paths whose records
-/// are emitted in mutex-acquisition order rather than input order.
-///
-/// # Panics
-///
-/// Panics if the file cannot be opened, the header cannot be read, or the
-/// sort-order tags do not match the unsorted contract.
-pub fn assert_header_unsorted(path: &std::path::Path) {
-    let mut reader = noodles::bam::io::Reader::new(
-        std::fs::File::open(path).expect("Failed to open BAM for header check"),
-    );
-    let header = reader.read_header().expect("Failed to read BAM header");
-    let hdr_map = header.header().expect("BAM header is missing an @HD line");
-    let other_fields = hdr_map.other_fields();
-
-    let so =
-        other_fields.get(b"SO").unwrap_or_else(|| panic!("@HD missing SO in {}", path.display()));
-    assert_eq!(
-        <_ as AsRef<[u8]>>::as_ref(so),
-        b"unsorted",
-        "SO should be 'unsorted' in {}",
-        path.display()
-    );
-    assert!(other_fields.get(b"GO").is_none(), "GO should be cleared in {}", path.display());
-    assert!(other_fields.get(b"SS").is_none(), "SS should be cleared in {}", path.display());
-}
-
 /// Asserts that a rejects BAM's `@HD` sort-order fields (`SO`, `GO`, `SS`)
 /// match those of the input BAM.
 ///

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -15,9 +15,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-use crate::helpers::assertions::{
-    assert_has_bgzf_eof, assert_header_unsorted, assert_rejects_header_matches_input,
-};
+use crate::helpers::assertions::{assert_has_bgzf_eof, assert_rejects_header_matches_input};
 use crate::helpers::bam_generator::{
     create_minimal_header, create_test_reference, create_umi_family, to_record_buf,
 };
@@ -767,7 +765,7 @@ fn test_codec_rejects_has_bgzf_eof() {
     assert!(status.success(), "codec command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
-    assert_header_unsorted(&rejects_bam);
+    assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }
 
 #[test]

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -671,7 +671,7 @@ fn test_simplex_rejects_has_bgzf_eof() {
     assert!(status.success(), "simplex command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
-    assert_header_unsorted(&rejects_bam);
+    assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }
 
 #[test]

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -723,7 +723,7 @@ fn test_duplex_rejects_has_bgzf_eof() {
     assert!(status.success(), "duplex command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
-    assert_header_unsorted(&rejects_bam);
+    assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }
 
 #[test]

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -15,7 +15,9 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-use crate::helpers::assertions::{assert_has_bgzf_eof, assert_header_unsorted};
+use crate::helpers::assertions::{
+    assert_has_bgzf_eof, assert_header_unsorted, assert_rejects_header_matches_input,
+};
 use crate::helpers::bam_generator::{
     create_minimal_header, create_test_reference, create_umi_family, to_record_buf,
 };
@@ -808,7 +810,7 @@ fn test_correct_rejects_has_bgzf_eof() {
     assert!(status.success(), "correct command with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
-    assert_header_unsorted(&rejects_bam);
+    assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }
 
 #[test]
@@ -850,4 +852,5 @@ fn test_correct_single_threaded_rejects_has_bgzf_eof() {
     assert_has_bgzf_eof(&rejects_bam);
     // Single-threaded correct writes rejects in input order, so it keeps the
     // input header as-is rather than marking it SO:unsorted.
+    assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -848,7 +848,5 @@ fn test_correct_single_threaded_rejects_has_bgzf_eof() {
     assert!(status.success(), "correct single-threaded with rejects failed");
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
-    // Single-threaded correct writes rejects in input order, so it keeps the
-    // input header as-is rather than marking it SO:unsorted.
     assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 }

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -228,7 +228,7 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);
-    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+    crate::helpers::assertions::assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 
     let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
     let _header = reader.read_header().unwrap();

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -163,8 +163,9 @@ fn test_correct_command_with_rejects() {
 
 /// Exercises the multi-threaded rejects-streaming path end-to-end and asserts:
 /// 1. The rejects BAM is a valid BGZF stream with the terminating EOF block.
-/// 2. The `@HD` header reports `SO:unsorted` because rejects are emitted in
-///    mutex-acquisition order rather than input order.
+/// 2. The `@HD` sort fields (`SO`/`GO`/`SS`) match the input BAM, because
+///    rejects flow through the unified pipeline's secondary output in
+///    batch/input order (a subset of an SO-X stream is still SO-X).
 /// 3. Every uncorrectable input record appears exactly once in the rejects
 ///    BAM — the writer does not drop records under worker contention and does
 ///    not emit duplicates.
@@ -189,13 +190,16 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
     let far_c = create_umi_family("CCCCCCCC", far_family_size as usize, "far_c", "AAAAGGGG", 30);
 
     // Expected reject names mirror `create_umi_family`'s "{base_name}_{i}"
-    // convention for the three uncorrectable families.
-    let mut expected_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for base in ["far_a", "far_b", "far_c"] {
-        for i in 0..far_family_size {
-            expected_names.insert(format!("{base}_{i}"));
-        }
-    }
+    // convention for the three uncorrectable families. The vector encodes the
+    // batch-input order the pipeline now guarantees for rejects (far_a, then
+    // far_b, then far_c — each family's records emitted in their original
+    // 0..far_family_size order).
+    let expected_order: Vec<String> = ["far_a", "far_b", "far_c"]
+        .into_iter()
+        .flat_map(|base| (0..far_family_size).map(move |i| format!("{base}_{i}")))
+        .collect();
+    let expected_names: std::collections::HashSet<String> =
+        expected_order.iter().cloned().collect();
     let expected_rejects = expected_names.len();
 
     create_umi_bam(&input_bam, vec![corr_small, corr_big, far_a, far_b, far_c]);
@@ -232,26 +236,23 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
 
     let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
     let _header = reader.read_header().unwrap();
-    let mut seen: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
-    let mut total: usize = 0;
+    let mut observed_order: Vec<String> = Vec::with_capacity(expected_rejects);
     for result in reader.records() {
         let record = result.expect("Failed to read reject record");
         let name = record.name().expect("reject record missing read name").to_string();
-        *seen.entry(name).or_insert(0) += 1;
-        total += 1;
+        observed_order.push(name);
     }
 
     assert_eq!(
-        total, expected_rejects,
+        observed_order.len(),
+        expected_rejects,
         "rejects BAM should contain one record per uncorrectable input read",
     );
-    assert_eq!(seen.len(), expected_rejects, "unexpected reject-name set size");
-    for name in &expected_names {
-        assert_eq!(
-            seen.remove(name),
-            Some(1),
-            "expected uncorrectable record {name} exactly once in the rejects BAM",
-        );
-    }
-    assert!(seen.is_empty(), "rejects BAM contained unexpected records: {seen:?}");
+    // Strict equality on the full sequence catches both drops/dupes (covered
+    // by the count check) and a regression to mutex-acquisition (or any other
+    // non-input) ordering.
+    assert_eq!(observed_order, expected_order, "rejects should be emitted in batch-input order",);
+    let observed_names: std::collections::HashSet<String> =
+        observed_order.iter().cloned().collect();
+    assert_eq!(observed_names, expected_names, "unexpected reject-name set");
 }

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -195,9 +195,9 @@ fn test_duplex_command_basic() {
 /// Runs the multi-threaded pipeline with `--min-reads 2` and a singleton /A
 /// template that fails the single-strand `min-reads` check. Verifies that:
 ///
-/// 1. The rejects BAM is created and has its `@HD` header rewritten to
-///    `SO:unsorted` because reject writes are emitted in mutex-acquisition
-///    order rather than input order.
+/// 1. The rejects BAM is created and its `@HD` sort fields (`SO`/`GO`/`SS`)
+///    match the input BAM, because rejects flow through the unified
+///    pipeline's secondary output in batch/input order.
 /// 2. The singleton template's raw records are actually streamed to the
 ///    rejects BAM rather than being silently dropped.
 #[test]
@@ -235,7 +235,7 @@ fn test_duplex_command_with_rejects() {
     assert!(status.success(), "Duplex command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
-    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+    crate::helpers::assertions::assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 
     // The singleton /A template (R1 + R2) should be streamed to the rejects BAM.
     let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
@@ -314,7 +314,7 @@ fn test_duplex_command_rejects_contain_no_duplicates() {
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);
-    crate::helpers::assertions::assert_header_unsorted(&rejects_bam);
+    crate::helpers::assertions::assert_rejects_header_matches_input(&rejects_bam, &input_bam);
 
     let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
     let _header = reader.read_header().unwrap();

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -278,3 +278,95 @@ fn test_simplex_command_collapses_read_group_attributes() {
         "PL tag should be uppercased and deduplicated",
     );
 }
+
+/// Verifies that the rejects BAM advertises the **input** header (RGs included),
+/// while the primary output BAM advertises the **consensus** header (RGs collapsed).
+///
+/// This is the end-to-end check for the `secondary_output_header` parameter on
+/// [`run_bam_pipeline_from_reader_with_secondary`][rbprws]. A regression where a
+/// caller accidentally passes the primary `output_header` (consensus header) for
+/// the secondary would collapse rejects' RGs to "A" — this test catches that.
+///
+/// [rbprws]: fgumi_lib::unified_pipeline::run_bam_pipeline_from_reader_with_secondary
+#[test]
+fn test_simplex_command_rejects_inherits_input_read_groups() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // Build an input with two distinct read groups (RG1, RG2) that the
+    // consensus header would collapse to a single RG "A".
+    let header = create_header_with_read_groups("chr1", 10000);
+    // One family that passes consensus (kept), one singleton that doesn't (rejected).
+    let kept = create_umi_family("ACGT", 5, "kept", "ACGTACGT", 30);
+    let rejected = create_umi_family("TGCA", 1, "reject_singleton", "TTTTAAAA", 30);
+    create_grouped_bam_with_header(&input_bam, &header, vec![("1", kept), ("2", rejected)]);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--rejects",
+            rejects_bam.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--threads",
+            "2",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run simplex command");
+    assert!(status.success(), "Simplex command with rejects failed");
+
+    // Primary output BAM: consensus header collapses RG1+RG2 -> single "A".
+    let primary_header =
+        bam::io::Reader::new(fs::File::open(&output_bam).unwrap()).read_header().unwrap();
+    let primary_rgs: Vec<BString> = primary_header.read_groups().keys().cloned().collect();
+    assert_eq!(
+        primary_rgs,
+        vec![BString::from("A")],
+        "primary output should have the collapsed consensus RG 'A'",
+    );
+
+    // Rejects BAM: input header preserved verbatim — both RG1 and RG2 present.
+    let mut reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
+    let rejects_header = reader.read_header().unwrap();
+    let mut rejects_rgs: Vec<BString> = rejects_header.read_groups().keys().cloned().collect();
+    rejects_rgs.sort();
+    assert_eq!(
+        rejects_rgs,
+        vec![BString::from("RG1"), BString::from("RG2")],
+        "rejects BAM should inherit the input header's read groups verbatim",
+    );
+
+    // Sanity-check that the rejection path actually fired: the singleton
+    // input record (TGCA family, depth=1) must land in the rejects BAM.
+    // Assert the read *name* (not just the count) so a regression that
+    // rejects the wrong family (e.g. the kept "ACGT" family instead of the
+    // singleton "TGCA" family) is caught — a count-only check would still
+    // pass on a swap.
+    let reject_names: Vec<String> = reader
+        .records()
+        .map(|result| {
+            result
+                .expect("Failed to read rejects record")
+                .name()
+                .expect("reject record missing read name")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        reject_names.len(),
+        1,
+        "rejects BAM should contain the singleton record dropped by --min-reads",
+    );
+    assert!(
+        reject_names[0].starts_with("reject_singleton"),
+        "expected the singleton family in rejects, got {reject_names:?}",
+    );
+}


### PR DESCRIPTION
Closes #329.

## Summary

- Adds `secondary_output_header: Option<Header>` to `run_bam_pipeline_from_reader_with_secondary` so the rejects BAM can carry a different header than the primary output. Defaults (`None`) reuse the resolved primary header — `filter`'s prior behavior. Consensus commands pass `Some(input_header)` so the rejects BAM advertises the raw-input header rather than the consensus header.
- Migrates `correct`, `simplex`, `duplex`, `codec` (`execute_threads_mode`) from a hand-rolled `Arc<Mutex<Option<RawBamWriter>>>` to the unified pipeline's first-class `secondary_output` path. Each command's `ProcessedBatch` gains a `rejected_records: Vec<Vec<u8>>` field; rejects flow through a per-batch buffer and the pipeline drains them via `secondary_serialize_fn` in batch-input order.
- Drops `header_as_unsorted` from the four rejects sites: the input header's claimed sort order remains valid for the rejects subset because rejects are now in input/batch-serial order (a subset of an SO-X stream is still SO-X).
- Hoists the byte-identical `secondary_serialize_fn` framing into a single `pub(crate) fn serialize_raw_bam_records<R: AsRef<[u8]>>(records: &[R], output: &mut Vec<u8>) -> io::Result<u64>` in `commands/common.rs`. Filter's previously-private `serialize_raw_records` is removed in favor of the shared helper.

## Order change (user-visible)

Rejects records previously landed in **mutex-acquisition order** across worker threads (arbitrary, non-deterministic). After this change they land in **batch-serial order = input order**, matching the primary BAM. Rejects content is unchanged; only the order changes.

Existing integration tests use content (set/count) assertions, not specific orderings, so they pass unchanged. The one helper that asserted the old hand-rolled `SO:unsorted` contract (`assert_header_unsorted`) is replaced by `assert_rejects_header_matches_input(rejects, input)`, which verifies the rejects header inherits the input's sort fields verbatim.

## Memory profile note

The hand-rolled path streamed rejects to disk during `process_fn` under a mutex — per-batch reject memory was effectively zero. The new path collects rejects in `batch.rejected_records: Vec<Vec<u8>>` until the pipeline's serialize step consumes them. At high reject rates this adds in-flight memory bounded by the pipeline's `queue_memory_limit`. Each migrated command's `MemoryEstimate` impl was updated to account for `rejected_records.iter().map(Vec::capacity).sum() + rejected_records.capacity() * size_of::<Vec<u8>>()`, so the pipeline correctly throttles.

## Per-command perf bench: deferred

The issue's acceptance criteria include a per-command perf bench (≤5% wall + RSS regression). The local benchmark host wasn't quiet at the time of this PR (load average 32, BWA + indexer + media all running). The bench will land in a follow-up commit on this branch — either when the local host is quiet (\`hyperfine\` + \`gtime\` + \`sudo purge\` between trials) or on the documented \`m7g.4xlarge\` AWS instance (\`/usr/bin/time -v\`). The bench artifact will land at \`docs/perf/issue-329-rejects-secondary.md\`.

## Test plan

- [x] \`cargo ci-test\` (2070 tests pass, +1 new)
- [x] \`cargo ci-fmt && cargo ci-lint\` (clean)
- [x] \`cargo doc --no-deps\` (clean for changed items)
- [x] New unit tests on \`resolve_secondary_header\` (None-default + Some-override)
- [x] New integration test \`test_simplex_command_rejects_inherits_input_read_groups\` — exercises the secondary header override end-to-end (input has RG1+RG2; primary collapses to RG \"A\"; rejects must preserve both)
- [x] Existing integration tests on \`--rejects\` for all four commands pass
- [ ] Per-command perf bench on quiet host (deferred to follow-up commit on this branch)

## Out of scope (per issue)

- \`commands/dedup.rs\` and \`commands/downsample.rs\` (use \`Arc<Mutex>\` for unrelated purposes, not secondary BAM output).
- \`fgumi runall --correct::rejects\` wiring — separate follow-up.