### PR TITLE
fix(group,dedup,downsample)!: require SS:template-coordinate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- [**breaking**] `fgumi group`, `fgumi dedup`, and `fgumi downsample` now strictly require template-coordinate sorted input — the header must advertise `SO:unsorted`, `GO:query`, **and** `SS:template-coordinate`. The previous implementation accepted any `SO:unsorted GO:query` header even without `SS:template-coordinate`, which caused `fgumi extract` output (FASTQ-order, no `SS`) and other queryname-grouped BAMs to be silently treated as template-coordinate sorted. Because the streaming `RecordPositionGrouper` requires records sharing a position key to be consecutive, this could split a single true molecule across multiple position groups and assign distinct `MI` tags to reads that should share one. The `--allow-unmapped` queryname-sort shortcut has also been removed for the same reason. To migrate: insert `fgumi sort --order template-coordinate` between extract (or any non-TC source) and `fgumi group`/`dedup`/`downsample`.
+
 ### Refactor
 
 - Extracted the sort engine into the new `fgumi-sort` crate and the BAM-pipeline I/O layer into the new `fgumi-bam-io` crate. The main `fgumi` binary now consumes both as workspace dependencies; behavior is unchanged.

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -148,9 +148,19 @@ pub fn is_sorted(header: &Header, sort_order: &[u8]) -> bool {
 /// This sort order is indicated in the SAM header by:
 /// - SO:unsorted (not coordinate sorted)
 /// - GO:query (grouped by query name)
-/// - SS:template-coordinate (optional, but must match if present)
+/// - SS:template-coordinate (required — without SS, GO:query alone only means
+///   reads with the same QNAME are grouped, not that templates are
+///   template-coordinate ordered)
 ///
-/// This matches the behavior of fgbio's `GroupReadsByUmi` output format.
+/// All three tags must be present. A header advertising only `SO:unsorted GO:query`
+/// is queryname-grouped but **not** template-coordinate sorted: that's what
+/// `fgumi extract` (and any tool that emits FASTQ-order BAMs) writes, and treating
+/// it as template-coordinate sorted leads to incorrect grouping in the streaming
+/// `RecordPositionGrouper` because templates that share a position key are not
+/// guaranteed to be consecutive.
+///
+/// This matches fgbio's `SamOrder.apply` (`bam/api/SamOrder.scala`), which
+/// requires the `SS` sub-sort tag for exact match.
 ///
 /// # Arguments
 ///
@@ -180,18 +190,22 @@ pub fn is_template_coordinate_sorted(header: &Header) -> bool {
         let is_query_grouped =
             other_fields.get(b"GO").is_some_and(|go| <_ as AsRef<[u8]>>::as_ref(go) == b"query");
 
-        // Check SS tag - if present, must be "template-coordinate" (or "SO:template-coordinate"), but it's optional
-        // The SS tag may be prefixed with the sort order (e.g., "unsorted:template-coordinate")
-        // per the SAM spec, so we need to extract the part after the colon
-        let ss_matches = other_fields.get(b"SS").is_none_or(|ss| {
+        // Check SS tag - must be present and equal to "template-coordinate" (or
+        // "<so>:template-coordinate", per the SAM spec, e.g. "unsorted:template-coordinate").
+        //
+        // The SAM spec defines SS as the single colon-delimited pair `<SO>:<sub>` (§1.3),
+        // so we split on the FIRST colon and exact-match the suffix. This matches fgbio's
+        // `SamOrder.apply` (`s.substring(s.indexOf(':') + 1)`), so values written by fgbio
+        // and accepted by it are accepted here. Plain `template-coordinate` (no prefix) is
+        // also accepted because some writers emit the bare sub-sort.
+        let ss_matches = other_fields.get(b"SS").is_some_and(|ss| {
             let ss_bytes = <_ as AsRef<[u8]>>::as_ref(ss);
-            // Find the last colon and take everything after it, or use the whole value if no colon
             if let Some(colon_pos) = ss_bytes.iter().position(|&b| b == b':') {
                 &ss_bytes[colon_pos + 1..] == b"template-coordinate"
             } else {
                 ss_bytes == b"template-coordinate"
             }
-        }); // If SS is missing, that's acceptable
+        });
 
         is_unsorted && is_query_grouped && ss_matches
     } else {
@@ -785,10 +799,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_template_coordinate_sorted_valid_minimal() {
-        // SO:unsorted + GO:query (no SS)
+    fn test_is_template_coordinate_sorted_missing_ss_is_rejected() {
+        // SO:unsorted + GO:query without SS is queryname-grouped, NOT template-coordinate
+        // sorted. This is what `fgumi extract` and other FASTQ-order writers emit, and
+        // treating it as template-coordinate sorted leads to silently wrong grouping
+        // because templates sharing a position key aren't guaranteed to be consecutive.
         let header = create_template_coord_header("unsorted", Some("query"), None);
-        assert!(is_template_coordinate_sorted(&header));
+        assert!(!is_template_coordinate_sorted(&header));
     }
 
     #[test]

--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -55,6 +55,14 @@ fgumi merge --order template-coordinate --output merged.bam \
   lane1.bam lane2.bam lane3.bam
 ```
 
+If you produce a queryname-sorted output from `fgumi merge` (or from any
+other source — `fgumi extract`, `samtools sort -n`, etc.), insert a
+`fgumi sort --order template-coordinate` step before `fgumi group`,
+`fgumi dedup`, or `fgumi downsample`. Unlike fgbio's `GroupReadsByUmi`,
+`fgumi group` does not sort internally — it requires its input to be
+template-coordinate sorted with the `SS:template-coordinate` header tag,
+and rejects any other sort order with an actionable error.
+
 ### Simplex QC Metrics
 
 fgbio has no equivalent to `fgumi simplex-metrics`. This command provides yield curves,

--- a/docs/src/guide/umi-grouping.md
+++ b/docs/src/guide/umi-grouping.md
@@ -141,12 +141,20 @@ large position groups may indicate high on-target duplication or UMI exhaustion.
 
 ## Template-Coordinate Sort Order
 
-If the input is not sorted in template-coordinate order, `fgumi group` will internally sort the
-reads. To avoid this overhead, pre-sort with:
+`fgumi group` requires its input to be template-coordinate sorted. The header must advertise
+`SO:unsorted`, `GO:query`, and `SS:template-coordinate`; without `SS:template-coordinate` the
+input is treated as queryname-grouped (e.g. FASTQ-order output from `fgumi extract`) and
+rejected with an actionable error pointing back here. `fgumi group` does **not** sort
+internally — pre-sort with:
 
 ```bash
 fgumi sort --order template-coordinate --input aligned.bam --output sorted.bam
 ```
+
+The streaming grouper relies on records that share a position key being consecutive in the
+input, which is what template-coordinate sort guarantees. Any other ordering (queryname,
+coordinate, FASTQ-order) would split each true molecule across many small groups and assign
+distinct `MI` values to reads that should share one.
 
 For single-cell data, the `CB` cell barcode tag is automatically incorporated in the sort key,
 keeping templates from different cells at the same locus separate:

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -980,10 +980,11 @@ impl Command for MarkDuplicates {
 
         if !is_template_coordinate_sorted(&header) {
             bail!(
-                "Input BAM must be template-coordinate sorted.\n\n\
-                To prepare your BAM file, run:\n  \
-                fgumi zipper -i mapped.bam -u unmapped.bam -r reference.fa -o merged.bam\n  \
-                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
+                "Input BAM must be template-coordinate sorted (header must advertise \
+                 SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+                 To prepare your BAM file, run:\n  \
+                 fgumi zipper -i mapped.bam -u unmapped.bam -r reference.fa -o merged.bam\n  \
+                 fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
             );
         }
         info!("Template-coordinate sorted");

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -14,7 +14,7 @@ use crate::logging::{OperationTimer, log_umi_grouping_summary};
 use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::read_info::LibraryIndex;
-use crate::sam::{is_sorted, is_template_coordinate_sorted};
+use crate::sam::is_template_coordinate_sorted;
 use crate::template::Template;
 use crate::umi::parallel_assigner::{
     ParallelAdjacencyAssigner, ParallelEditAssigner, ParallelIdentityAssigner,
@@ -41,7 +41,6 @@ use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -516,18 +515,18 @@ are grouped by template, and then templates are sorted by the 5' mapping positio
 the reads from the template, used from earliest mapping position to latest. Reads that
 have the same end positions are then sub-grouped by UMI sequence.
 
-Accepts reads in any order (including unsorted) and outputs reads sorted by:
+Requires input to be template-coordinate sorted (header must advertise
+SO:unsorted, GO:query, and SS:template-coordinate). Sort upstream sources
+(`fgumi extract`, `samtools sort -n`, `fgumi merge --order queryname`, etc.)
+with `fgumi sort -i input.bam -o sorted.bam --order template-coordinate`
+before piping into this tool. Output is always written in template-coordinate
+order, sorted by:
 
    1. The lower genome coordinate of the two outer ends of the templates (strand-aware)
    2. The sequencing library
    3. The cell barcode (CB tag, if present)
    4. The assigned UMI tag
    5. Read Name
-
-It is recommended to sort the reads into template-coordinate order prior to running
-this tool to avoid re-sorting the input. Use `fgumi sort --order template-coordinate`
-for the pre-sorting. The output will always be written
-in template-coordinate order.
 
 During grouping, reads and templates are filtered out as follows:
 
@@ -612,11 +611,15 @@ pub struct GroupReadsByUmi {
     #[arg(short = 'n', long = "include-non-pf-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub include_non_pf_reads: bool,
 
-    /// Allow fully unmapped templates (both reads unmapped).
+    /// Allow fully unmapped templates (both reads unmapped). Input must be
+    /// template-coordinate sorted (`fgumi sort --order template-coordinate`).
     ///
     /// Groups unmapped reads by UMI only within each library/cell barcode.
     /// Useful for ribosome display or other protocols with unmapped reads.
-    /// When enabled, queryname-sorted input is also accepted.
+    /// Template-coordinate sort clusters unmapped reads by library/cell-barcode,
+    /// which is what the streaming grouper needs to see consecutive same-cell
+    /// reads. Queryname-sorted or FASTQ-order input (e.g. `fgumi extract`
+    /// output) is rejected — pipe through `fgumi sort` first.
     ///
     /// IMPORTANT: All unmapped reads are placed in a single position group,
     /// meaning reads with identical/similar UMIs will be grouped together
@@ -808,32 +811,22 @@ impl Command for GroupReadsByUmi {
         info!("Reading input BAM");
         let (reader, header) = create_bam_reader_for_pipeline(&self.io.input)?;
 
-        // Check sort order - template-coordinate sorted is required,
-        // but queryname-sorted is also accepted when --allow-unmapped is set
-        let is_tc_sorted = is_template_coordinate_sorted(&header);
-        let is_qname_sorted = is_sorted(&header, QUERY_NAME);
-
-        if !(is_tc_sorted || self.allow_unmapped && is_qname_sorted) {
-            if self.allow_unmapped {
-                bail!(
-                    "Input BAM must be template-coordinate sorted or queryname sorted \
-                    when --allow-unmapped is enabled.\n\n\
-                    To queryname sort your BAM file, run:\n  \
-                    samtools sort -n input.bam -o sorted.bam"
-                );
-            } else {
-                bail!(
-                    "Input BAM must be template-coordinate sorted.\n\n\
-                    To sort your BAM file, run:\n  \
-                    fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
-                );
-            }
+        // Sort order: template-coordinate is the only accepted ordering. The streaming
+        // `RecordPositionGrouper` emits a group whenever the position key changes between
+        // consecutive records, so any input where records sharing a position key aren't
+        // already adjacent (queryname-sorted, coordinate-sorted, FASTQ-order, etc.) would
+        // be split into many small groups and assigned distinct MoleculeIds — silently
+        // wrong. Template-coordinate sort is what makes adjacency match the grouping key.
+        if !is_template_coordinate_sorted(&header) {
+            bail!(
+                "Input BAM must be template-coordinate sorted (header must advertise \
+                 SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+                 To sort your BAM file, run:\n  \
+                 fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
+            );
         }
-
-        if is_tc_sorted {
-            info!("Input is template-coordinate sorted");
-        } else {
-            info!("Input is queryname sorted (accepted with --allow-unmapped)");
+        info!("Input is template-coordinate sorted");
+        if self.allow_unmapped {
             info!("All unmapped reads will form a single position group per library/cell");
         }
 
@@ -5589,8 +5582,11 @@ mod tests {
     // Tests for --allow-unmapped feature
     // ========================================================================
 
-    /// Create a minimal SAM header for testing with queryname sort order
-    fn create_queryname_sorted_header() -> sam::Header {
+    /// Create a minimal SAM header advertising template-coordinate sort order
+    /// (SO:unsorted GO:query SS:template-coordinate). Used by `--allow-unmapped`
+    /// tests now that template-coordinate is the only accepted sort order for
+    /// `fgumi group`.
+    fn create_template_coordinate_sorted_header() -> sam::Header {
         use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
         use noodles::sam::header::record::value::{
             Map as HeaderRecordMap,
@@ -5599,11 +5595,14 @@ mod tests {
 
         let mut builder = sam::Header::builder();
 
-        // Add header with queryname sort order
         let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+        let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+        let HeaderTag::Other(ss_tag) = HeaderTag::from([b'S', b'S']) else { unreachable!() };
 
         let map = HeaderRecordMap::<HeaderRecord>::builder()
-            .insert(so_tag, "queryname")
+            .insert(so_tag, "unsorted")
+            .insert(go_tag, "query")
+            .insert(ss_tag, "template-coordinate")
             .build()
             .expect("valid header record");
         builder = builder.set_header(map);
@@ -5616,6 +5615,38 @@ mod tests {
             ),
         );
 
+        builder.build()
+    }
+
+    /// Create a minimal SAM header advertising the given SO/GO/SS triple. Used by
+    /// rejection tests to cover every non-template-coordinate ordering `fgumi group`
+    /// is expected to reject.
+    fn create_header_with_sort_tags(so: &str, go: Option<&str>, ss: Option<&str>) -> sam::Header {
+        use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+        use noodles::sam::header::record::value::{
+            Map as HeaderRecordMap,
+            map::{Header as HeaderRecord, Tag as HeaderTag},
+        };
+
+        let mut builder = sam::Header::builder();
+        let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+        let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+        let HeaderTag::Other(ss_tag) = HeaderTag::from([b'S', b'S']) else { unreachable!() };
+
+        let mut map_builder = HeaderRecordMap::<HeaderRecord>::builder().insert(so_tag, so);
+        if let Some(go_val) = go {
+            map_builder = map_builder.insert(go_tag, go_val);
+        }
+        if let Some(ss_val) = ss {
+            map_builder = map_builder.insert(ss_tag, ss_val);
+        }
+        builder = builder.set_header(map_builder.build().expect("valid header record"));
+        builder = builder.add_reference_sequence(
+            BString::from("chr1"),
+            Map::<ReferenceSequence>::new(
+                NonZeroUsize::new(248_956_422).expect("non-zero chr1 length"),
+            ),
+        );
         builder.build()
     }
 
@@ -5644,12 +5675,14 @@ mod tests {
         (r1, r2)
     }
 
-    /// Write records to a temporary BAM file with queryname sorted header
-    fn create_queryname_sorted_test_bam(
+    /// Write records to a temporary BAM file advertising template-coordinate sort order.
+    /// Used by `--allow-unmapped` tests — template-coordinate is the only accepted
+    /// input sort order for `fgumi group`.
+    fn create_template_coordinate_sorted_test_bam(
         records: Vec<fgumi_raw_bam::RawRecord>,
     ) -> Result<NamedTempFile> {
         let temp_file = NamedTempFile::new()?;
-        let header = create_queryname_sorted_header();
+        let header = create_template_coordinate_sorted_header();
 
         let mut writer = bam::io::writer::Builder.build_from_path(temp_file.path())?;
 
@@ -5663,6 +5696,29 @@ mod tests {
 
         drop(writer); // Ensure file is flushed
 
+        Ok(temp_file)
+    }
+
+    /// Write records to a temporary BAM file with the given SO/GO/SS sort tags.
+    /// Used by rejection tests to cover every non-template-coordinate ordering
+    /// `fgumi group` is expected to reject.
+    fn create_test_bam_with_sort_tags(
+        records: Vec<fgumi_raw_bam::RawRecord>,
+        so: &str,
+        go: Option<&str>,
+        ss: Option<&str>,
+    ) -> Result<NamedTempFile> {
+        let temp_file = NamedTempFile::new()?;
+        let header = create_header_with_sort_tags(so, go, ss);
+
+        let mut writer = bam::io::writer::Builder.build_from_path(temp_file.path())?;
+        writer.write_header(&header)?;
+        for record in &records {
+            let record_buf =
+                raw_record_to_record_buf(record, &header).map_err(std::io::Error::other)?;
+            writer.write_alignment_record(&header, &record_buf)?;
+        }
+        drop(writer);
         Ok(temp_file)
     }
 
@@ -5737,7 +5793,7 @@ mod tests {
         records.push(r1_d);
         records.push(r2_d);
 
-        let input = create_queryname_sorted_test_bam(records)?;
+        let input = create_template_coordinate_sorted_test_bam(records)?;
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
@@ -5774,7 +5830,7 @@ mod tests {
         records.push(r1_b);
         records.push(r2_b);
 
-        let input = create_queryname_sorted_test_bam(records)?;
+        let input = create_template_coordinate_sorted_test_bam(records)?;
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
@@ -5888,7 +5944,7 @@ mod tests {
             records.push(r2);
         }
 
-        let input = create_queryname_sorted_test_bam(records)?;
+        let input = create_template_coordinate_sorted_test_bam(records)?;
         let paths = TestPaths::new()?;
 
         let cmd = GroupReadsByUmi {
@@ -5910,6 +5966,61 @@ mod tests {
         // All records with same UMI should be in one group
         let unique_groups = count_unique_mi_tags(&output_records);
         assert_eq!(unique_groups, 1, "All records with same UMI should be in 1 group");
+
+        Ok(())
+    }
+
+    /// `fgumi group` only accepts template-coordinate-sorted input — even with
+    /// `--allow-unmapped`. Every non-template-coordinate header (queryname,
+    /// extract-style `SO:unsorted GO:query` without `SS`, or `SS` set to anything
+    /// other than `template-coordinate`) must be rejected with a clear error
+    /// pointing at `fgumi sort`. Both `--allow-unmapped` modes are exercised so
+    /// the rejection is not gated on that flag.
+    ///
+    /// The `extract_style_no_ss` case is the direct regression test for the
+    /// silent-acceptance bug: `fgumi extract` emits `SO:unsorted GO:query` with
+    /// no `SS`, and the previous lenient check treated that as template-coordinate.
+    #[rstest]
+    #[case::queryname("queryname", None, None)]
+    #[case::extract_style_no_ss("unsorted", Some("query"), None)]
+    #[case::wrong_ss_value("unsorted", Some("query"), Some("coordinate"))]
+    #[case::wrong_so_with_ss("coordinate", Some("query"), Some("template-coordinate"))]
+    #[case::missing_go_with_ss("unsorted", None, Some("template-coordinate"))]
+    fn test_group_rejects_non_template_coordinate_input(
+        #[case] so: &str,
+        #[case] go: Option<&str>,
+        #[case] ss: Option<&str>,
+        #[values(true, false)] allow_unmapped: bool,
+    ) -> Result<()> {
+        let (r1, r2) = build_unmapped_test_pair("read_a", "AAAAAA");
+        let input = create_test_bam_with_sort_tags(vec![r1, r2], so, go, ss)?;
+        let paths = TestPaths::new()?;
+
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
+            allow_unmapped,
+            ..test_group_cmd(Strategy::Identity, 0)
+        };
+
+        let err =
+            cmd.execute("test").expect_err("non-template-coordinate-sorted input must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("template-coordinate"),
+            "error should mention template-coordinate: {msg}",
+        );
+        assert!(
+            msg.contains("SS:template-coordinate"),
+            "error should mention the SS:template-coordinate tag specifically: {msg}",
+        );
+        assert!(
+            msg.contains("fgumi sort"),
+            "error should point at `fgumi sort` as the remediation: {msg}",
+        );
 
         Ok(())
     }

--- a/src/lib/sam/mod.rs
+++ b/src/lib/sam/mod.rs
@@ -15,9 +15,12 @@ pub use fgumi_sam::SamTag;
 // Re-export TC (template-coordinate) sort-key tag and parser
 pub use fgumi_sam::{TC_TAG, TemplateCoordinateInfo};
 
-// Re-export top-level functions from fgumi-sam
+// Re-export top-level functions from fgumi-sam.
+// `is_sorted` stays public in fgumi-sam (published crate) but is no longer
+// re-exported here — nothing in the `fgumi` binary uses it directly, and
+// `check_sort` calls it internally within fgumi-sam.
 pub use fgumi_sam::{
-    buf_value_to_smallest_signed_int, check_sort, header_as_unsorted, is_sorted,
+    buf_value_to_smallest_signed_int, check_sort, header_as_unsorted,
     is_template_coordinate_sorted, revcomp_buf_value, reverse_buf_value, to_smallest_signed_int,
 };
 

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -301,11 +301,24 @@ fn test_full_pipeline_extract_to_filter() {
             "test_lib",
         ]);
 
+        // Extract emits SO:unsorted GO:query (no SS); `fgumi group` requires
+        // template-coordinate sorted input, so put the sort step between them.
+        let sorted = tmp.path().join(format!("sorted_{suffix}.bam"));
+        fgumi_ok(args![
+            "sort",
+            "--input",
+            &extracted,
+            "--output",
+            &sorted,
+            "--order",
+            "template-coordinate",
+        ]);
+
         let grouped = tmp.path().join(format!("grouped_{suffix}.bam"));
         fgumi_ok(args![
             "group",
             "--input",
-            &extracted,
+            &sorted,
             "--output",
             &grouped,
             "--strategy",
@@ -327,6 +340,83 @@ fn test_full_pipeline_extract_to_filter() {
         &tmp.path().join("filtered_b.bam"),
         "content",
         "Two full pipeline runs should produce identical BAMs",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Strict template-coordinate input: extract → group must fail without sort
+// ---------------------------------------------------------------------------
+
+/// CLI-level regression test for the strict template-coordinate sort
+/// requirement. `fgumi extract` writes `SO:unsorted GO:query` with no `SS`
+/// tag; piping that directly into `fgumi group` must fail with an actionable
+/// error message naming `SS:template-coordinate` and pointing at `fgumi sort`.
+///
+/// This test runs the actual `fgumi` binary (via `CARGO_BIN_EXE_fgumi`)
+/// instead of calling `cmd.execute(...)` in-process so that it pins the
+/// user-visible behavior — exit status and stderr — that downstream tooling
+/// and CI pipelines depend on.
+#[test]
+fn test_group_rejects_extract_output_without_sort_step() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
+
+    let r1 = tmp.path().join("r1.fq.gz");
+    let r2 = tmp.path().join("r2.fq.gz");
+    let truth = tmp.path().join("truth.tsv");
+    simulate_fastq_reads(&r1, &r2, &truth, &reference, 42, 50);
+
+    let extracted = tmp.path().join("extracted.bam");
+    fgumi_ok(args![
+        "extract",
+        "--inputs",
+        &r1,
+        &r2,
+        "--output",
+        &extracted,
+        "--read-structures",
+        "6M94T",
+        "100T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_lib",
+    ]);
+
+    // Run `fgumi group` on the extract output directly — must fail.
+    let grouped = tmp.path().join("grouped.bam");
+    let output = fgumi(args![
+        "group",
+        "--input",
+        &extracted,
+        "--output",
+        &grouped,
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "fgumi group must reject extract output (non-template-coordinate sorted); \
+         got exit status {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("template-coordinate"),
+        "stderr should mention template-coordinate: {stderr}",
+    );
+    assert!(
+        stderr.contains("SS:template-coordinate"),
+        "stderr should name the SS:template-coordinate tag specifically: {stderr}",
+    );
+    assert!(
+        stderr.contains("fgumi sort"),
+        "stderr should point at `fgumi sort` as the remediation: {stderr}",
     );
 }
 


### PR DESCRIPTION
## Summary

`is_template_coordinate_sorted` (`crates/fgumi-sam/src/lib.rs`) previously treated the SAM `SS` sub-sort tag as optional, so any header advertising `SO:unsorted GO:query` — notably the queryname-grouped output of `fgumi extract`, which has no `SS` — was silently accepted as template-coordinate sorted. Three commands rely on this check: `group`, `dedup`, and `downsample`. They all feed input through a streaming position grouper (`RecordPositionGrouper`) that requires records sharing a position key to be consecutive — a guarantee that template-coordinate sort provides and that queryname-grouped / FASTQ-order / coordinate-sorted input does not.

Two consequences in the wild, reported by a user this week:

- **Performance.** `fgumi group --threads 4 --allow-unmapped` on a queryname-grouped BAM with diverse `CB` tags: the streaming grouper produces one position group per template (~10M tiny groups). Each group spins up its own `rayon::ThreadPool` inside the parallel UMI assigner. On a 3M-record subset, `--threads 4` took **135 s wall with 856 s of sys time**, vs **34 s** for the same input with `--threads 1` — i.e. multi-threaded was *slower* than single-threaded.
- **Correctness risk.** On mapped data, the same input shape would split a real molecule across multiple position groups and assign distinct `MI` integers to reads that should share one — silent wrong groupings, undetectable from logs and unsafe to feed into downstream consensus.

This PR tightens `is_template_coordinate_sorted` to **require** `SS:template-coordinate` (with or without the `<so>:` prefix), matching fgbio's `SamOrder.apply`. It also removes the `--allow-unmapped` queryname-sort shortcut from `fgumi group` (same underlying issue), updates error messages, the clap doc for `--allow-unmapped`, the UMI grouping user-guide, and the fgbio migration guide. `fgumi group` does **not** sort internally (unlike fgbio's `GroupReadsByUmi`); users must pipe through `fgumi sort --order template-coordinate` first. The CHANGELOG entry is flagged `[**breaking**]`.

This PR is correctness-only. The follow-up rayon-pool-per-group performance bug (which still bites legitimate single large-group workloads at `--threads N`) is a separate change.

### Migration

Insert `fgumi sort --order template-coordinate` between any non-template-coordinate source (`fgumi extract`, `samtools sort -n`, `fgumi merge --order queryname`, etc.) and `fgumi group`, `fgumi dedup`, or `fgumi downsample`. The new error message names this remediation directly.

### Other touch-ups bundled in

- Comment in `is_template_coordinate_sorted` claimed "find the last colon" but the code uses `.position()` (first colon); behavior matches fgbio's `indexOf` parsing, so the comment is corrected and a cross-reference added.
- `src/lib/sam/mod.rs` no longer re-exports `is_sorted` (it had no non-test caller after this PR). The function itself stays `pub` in the published `fgumi-sam` crate; `check_sort` still uses it internally.

## Test plan

- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [x] `cargo ci-test`: 2078 tests pass, 23 skipped — 11 net new test cases:
  - 10-case parametric `test_group_rejects_non_template_coordinate_input` (5 non-TC header shapes × 2 `--allow-unmapped` modes); the `extract_style_no_ss` case is the direct regression for the reported bug
  - `test_group_rejects_extract_output_without_sort_step` spawns the actual `fgumi` binary and asserts exit status + stderr (CLI-level pin, not just in-process)
- [x] Flipped `test_is_template_coordinate_sorted_valid_minimal` (which previously asserted the lenient behavior) to `test_..._missing_ss_is_rejected`
- [x] Updated `test_full_pipeline_extract_to_filter` to insert `fgumi sort --order template-coordinate` between extract and group (the old test was inadvertently exercising the buggy path)
- [x] Manual repro against the user's BAM: extract-style header now produces the expected error pointing at `fgumi sort`; happy path `sort → group --threads 4` succeeds end-to-end