### PR TITLE
perf(group): cache UMI position to drop redundant aux scan (#334)

### DIFF
--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -112,9 +112,10 @@ pub use tags::{
     TagValue, TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
     array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
     find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
-    find_string_tag_in_record, find_tag_type, find_uint8_tag, normalize_int_tag_to_smallest_signed,
-    remove_tag, reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
-    reverse_string_tag_in_place, update_int_tag, update_string_tag,
+    find_string_tag_in_record, find_string_tag_position, find_tag_type, find_uint8_tag,
+    normalize_int_tag_to_smallest_signed, remove_tag, reverse_array_tag_in_place,
+    reverse_complement_string_tag_in_place, reverse_string_tag_in_place, update_int_tag,
+    update_string_tag,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -47,6 +47,31 @@ pub fn find_string_tag(aux_data: &[u8], tag: impl AsTagBytes) -> Option<&[u8]> {
     Some(&aux_data[start..start + end])
 }
 
+/// Find a string (Z-type) tag and return its value position as `(offset, len)` —
+/// where `offset` is the offset into `aux_data` of the first value byte (after the
+/// 2-byte tag identifier and 1-byte type byte) and `len` is the value length in
+/// bytes, excluding the NUL terminator.
+///
+/// Used to cache a Z-tag's position so a later caller can slice the value without
+/// re-scanning aux data.
+///
+/// Returns `None` if the tag is absent, is not Z-type, has no NUL terminator, or
+/// would not fit in the returned types (`u32` offset, `u16` length). BAM records
+/// are bounded well under 4 GiB and aux tag values well under 64 KiB, so the
+/// width-fit checks are defensive only.
+#[inline]
+#[must_use]
+pub fn find_string_tag_position(aux_data: &[u8], tag: impl AsTagBytes) -> Option<(u32, u16)> {
+    let tag = tag.as_tag_bytes();
+    let (p, val_type) = find_tag_position(aux_data, *tag)?;
+    if val_type != b'Z' {
+        return None;
+    }
+    let start = p + 3;
+    let len = aux_data[start..].iter().position(|&b| b == 0)?;
+    Some((u32::try_from(start).ok()?, u16::try_from(len).ok()?))
+}
+
 /// Check whether a tag exists in auxiliary data, returning its type byte if found.
 ///
 /// Returns `Some(type_byte)` (e.g. `b'Z'`, `b'C'`, `b'i'`) if the tag is present,
@@ -2052,6 +2077,64 @@ mod tests {
         // RX:Z:hello but no null terminator — should return None
         let aux = b"RXZhello";
         assert_eq!(find_string_tag(aux, SamTag::RX), None);
+    }
+
+    // ========================================================================
+    // find_string_tag_position tests
+    // ========================================================================
+
+    #[test]
+    fn test_find_string_tag_position_first_tag() {
+        // "RXZACGT\0" — tag header occupies bytes 0..3; value occupies 3..7; NUL at 7
+        let aux = b"RXZACGT\x00";
+        let (offset, len) =
+            find_string_tag_position(aux, SamTag::RX).expect("UMI tag should be present");
+        assert_eq!(offset, 3);
+        assert_eq!(len, 4);
+        let bytes = &aux[offset as usize..offset as usize + len as usize];
+        assert_eq!(bytes, b"ACGT");
+        assert_eq!(bytes, find_string_tag(aux, SamTag::RX).unwrap());
+    }
+
+    #[test]
+    fn test_find_string_tag_position_after_other_tags() {
+        // NM:C:5 then RX:Z:ACGT — the UMI value should be located after the NM entry.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"NMC");
+        aux.push(5);
+        aux.extend_from_slice(b"RXZACGT\x00");
+        let (offset, len) = find_string_tag_position(&aux, SamTag::RX).unwrap();
+        assert_eq!(&aux[offset as usize..offset as usize + len as usize], b"ACGT");
+        assert_eq!(len, 4);
+    }
+
+    #[test]
+    fn test_find_string_tag_position_empty_value() {
+        // RX:Z: (empty UMI) — len should be 0 with a valid offset.
+        let aux = b"RXZ\x00";
+        let (offset, len) = find_string_tag_position(aux, SamTag::RX).unwrap();
+        assert_eq!(offset, 3);
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn test_find_string_tag_position_absent_returns_none() {
+        let aux = b"RGZsample1\x00";
+        assert_eq!(find_string_tag_position(aux, SamTag::RX), None);
+    }
+
+    #[test]
+    fn test_find_string_tag_position_non_z_returns_none() {
+        // Tag matches but type is 'C' (uint8), not 'Z'.
+        let aux = [b'R', b'X', b'C', 42];
+        assert_eq!(find_string_tag_position(&aux, SamTag::RX), None);
+    }
+
+    #[test]
+    fn test_find_string_tag_position_truncated_no_nul() {
+        // RX:Z:hello but no NUL terminator — should return None.
+        let aux = b"RXZhello";
+        assert_eq!(find_string_tag_position(aux, SamTag::RX), None);
     }
 
     // --- Per-type find_string_tag tests ---

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -1659,6 +1659,7 @@ mod tests {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -1711,6 +1712,7 @@ mod tests {
             r1_secondaries: Some((2, 3)),
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         assert!(!filter_template(&template, &config, &mut metrics));

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -462,7 +462,12 @@ fn assign_umi_groups_for_indices_impl(
         } else {
             use fgumi_raw_bam;
 
-            let umi_bytes = if let Some(r1_raw) = template.r1() {
+            // Prefer the UMI position cached during the parallel Decode step.
+            // The fallback exists for templates built outside the Decode path
+            // (e.g. tests) and for cases where the cache was disabled.
+            let umi_bytes = if let Some(cached) = template.cached_umi() {
+                cached
+            } else if let Some(r1_raw) = template.r1() {
                 let aux = fgumi_raw_bam::aux_data_slice(r1_raw);
                 fgumi_raw_bam::find_string_tag(aux, raw_tag)
                     .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
@@ -931,7 +936,11 @@ impl Command for GroupReadsByUmi {
         // This provides consistent batch sizes across datasets with varying templates-per-group ratios.
 
         let library_index = LibraryIndex::from_header(&header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
+        // Cache the UMI tag's value position on each DecodedRecord so the Process
+        // step's UMI-assignment pass can slice the value without re-scanning aux
+        // data (issue #334).
+        pipeline_config.group_key_config =
+            Some(GroupKeyConfig::new(library_index, cell_tag).with_umi_tag(raw_tag));
 
         // Short-circuit support for memory bisection debugging.
         // Set FGUMI_SHORT_CIRCUIT=process|serialize|compress to skip downstream steps.
@@ -5412,6 +5421,7 @@ mod tests {
             r1_secondaries: Some((2, 3)),
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         let config = GroupFilterConfig {
@@ -5461,6 +5471,7 @@ mod tests {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         let config = GroupFilterConfig {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -643,7 +643,7 @@ fn group_by_name_and_build<T>(
 ///
 /// Returns an error if template construction from records fails.
 pub fn build_templates_from_records(records: Vec<DecodedRecord>) -> io::Result<Vec<Template>> {
-    group_by_name_and_build(records, |d| Ok(d.data), Template::from_records)
+    group_by_name_and_build(records, Ok, Template::from_decoded_records)
 }
 
 use crate::fastq_parse::{FastqRecord, parse_fastq_records, strip_read_suffix};

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::sam::SamTag;
-use crate::unified_pipeline::MemoryEstimate;
+use crate::unified_pipeline::{DecodedRecord, MemoryEstimate};
 use anyhow::{Result, bail};
 use fgumi_raw_bam::{RawRecord, RawRecordView};
 
@@ -75,6 +75,12 @@ pub struct Template {
     pub r2_secondaries: Option<(usize, usize)>,
     /// Assigned molecule ID from UMI grouping (set during group command)
     pub mi: MoleculeId,
+    /// Cached UMI value position `(record_relative_offset, len)` for the primary
+    /// read returned by `r1().or(r2())`. Populated by
+    /// [`Template::from_decoded_records`] when the decode step recorded a UMI
+    /// position; left `None` by [`Template::from_records`] so callers fall back
+    /// to `find_string_tag`. See [`Template::cached_umi`] for the accessor.
+    pub cached_umi_position: Option<(u32, u16)>,
 }
 
 /// A batch of templates for parallel processing.
@@ -98,6 +104,7 @@ impl Template {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: MoleculeId::None,
+            cached_umi_position: None,
         }
     }
 
@@ -221,6 +228,7 @@ impl Template {
                         r1_secondaries: None,
                         r2_secondaries: None,
                         mi: MoleculeId::None,
+                        cached_umi_position: None,
                     });
                 }
                 // Both R1 or both R2 — fall through to general path for error handling
@@ -342,7 +350,46 @@ impl Template {
             r1_secondaries: r1_sec_pair,
             r2_secondaries: r2_sec_pair,
             mi: MoleculeId::None,
+            cached_umi_position: None,
         })
+    }
+
+    /// Build a [`Template`] from decoded records, preserving the UMI value
+    /// position cached on the primary read during the decode step.
+    ///
+    /// The primary read is chosen with the same priority used by
+    /// [`Template::r1`] / [`Template::r2`]: the first non-secondary,
+    /// non-supplementary R1 (or, failing that, R2). When that record carries a
+    /// cached UMI position, it is recorded on the returned template so
+    /// downstream UMI lookups can slice the value directly via
+    /// [`Template::cached_umi`] without re-scanning aux data.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Template::from_records`].
+    pub fn from_decoded_records(records: Vec<DecodedRecord>) -> Result<Self> {
+        let cached = primary_read_cached_umi(&records);
+
+        let raw_records: Vec<RawRecord> =
+            records.into_iter().map(DecodedRecord::into_raw_bytes).collect();
+        let mut template = Self::from_records(raw_records)?;
+        template.cached_umi_position = cached;
+        Ok(template)
+    }
+
+    /// Returns the cached UMI value bytes (without trailing NUL) for this
+    /// template's primary read, if a position was recorded during decode and
+    /// still falls within the primary record's bytes.
+    ///
+    /// Returns `None` when no UMI cache is set, when neither R1 nor R2 is
+    /// present, or when the cached position would slice outside the record.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        let (offset, len) = self.cached_umi_position?;
+        let raw = self.r1().or_else(|| self.r2())?;
+        let start = offset as usize;
+        let end = start.checked_add(len as usize)?;
+        raw.as_ref().get(start..end)
     }
 
     /// Returns the pair orientation if both R1 and R2 are present and mapped to the same chromosome.
@@ -692,6 +739,47 @@ impl Template {
         }
         fgumi_raw_bam::set_template_length(&mut rr[unmapped_i], 0);
     }
+}
+
+/// Pick the cached UMI position from the primary read that
+/// [`Template::cached_umi`] will resolve against.
+///
+/// Mirrors the priority used by [`Template::from_records`]: the first
+/// non-secondary, non-supplementary R1 (or, if no R1 is present, the first
+/// non-secondary, non-supplementary R2). Records without a cached UMI position
+/// return `None` even when found, so the downstream consumer falls back to
+/// scanning aux data.
+fn primary_read_cached_umi(records: &[DecodedRecord]) -> Option<(u32, u16)> {
+    use fgumi_raw_bam;
+
+    let mut primary_r2: Option<&DecodedRecord> = None;
+
+    for decoded in records {
+        let flg = RawRecordView::new(decoded.raw_bytes()).flags();
+        let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
+        let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
+        if is_secondary || is_supplementary {
+            continue;
+        }
+        let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
+        let is_first = (flg & fgumi_raw_bam::flags::FIRST_SEGMENT) != 0;
+        let is_r1 = !is_paired || is_first;
+
+        if is_r1 {
+            let (offset, len) = decoded.cached_umi_position();
+            if offset == DecodedRecord::UMI_OFFSET_UNCACHED {
+                return None;
+            }
+            return Some((offset, len));
+        }
+        if primary_r2.is_none() {
+            primary_r2 = Some(decoded);
+        }
+    }
+
+    let r2 = primary_r2?;
+    let (offset, len) = r2.cached_umi_position();
+    if offset == DecodedRecord::UMI_OFFSET_UNCACHED { None } else { Some((offset, len)) }
 }
 
 /// Sets mate flags (`MATE_REVERSE`, `MATE_UNMAPPED`) on a raw BAM record.
@@ -2518,5 +2606,96 @@ mod tests {
             let result = mi.write_with_offset(100, &mut buf);
             assert_eq!(result, expected.as_bytes(), "Mismatch for {mi:?}");
         }
+    }
+
+    // ========================================================================
+    // Template::from_decoded_records / cached_umi tests (issue #334)
+    // ========================================================================
+
+    use crate::unified_pipeline::{DecodedRecord, GroupKey};
+
+    fn build_raw_with_umi(name: &[u8], flags: u16, umi: &[u8]) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name)
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(flags)
+            .ref_id(0)
+            .pos(0)
+            .mapq(30)
+            .cigar_ops(&[4u32 << 4]);
+        b.add_string_tag(SamTag::RX, umi);
+        b.build()
+    }
+
+    fn decoded_with_cached_umi(raw: RawRecord) -> DecodedRecord {
+        let raw_bytes = raw.as_ref();
+        let aux_offset =
+            fgumi_raw_bam::aux_data_offset_from_record(raw_bytes).expect("aux offset present");
+        let aux = &raw_bytes[aux_offset..];
+        let (value_off_in_aux, len) = fgumi_raw_bam::find_string_tag_position(aux, SamTag::RX)
+            .expect("RX tag must be present for this test helper");
+        let offset = u32::try_from(aux_offset).unwrap() + value_off_in_aux;
+        let mut d = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        d.set_cached_umi(offset, len);
+        d
+    }
+
+    #[test]
+    fn test_template_from_decoded_records_propagates_r1_umi_cache() {
+        // R1 carries RX:Z:ACGTACGT, R2 carries RX:Z:OTHER; assigner reads from
+        // R1 first, so the cached slice must match R1's UMI.
+        let r1 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT, b"ACGTACGT");
+        let r2 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT, b"OTHERUMI");
+
+        let decoded = vec![decoded_with_cached_umi(r1), decoded_with_cached_umi(r2)];
+        let template = Template::from_decoded_records(decoded).expect("template builds");
+
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_template_from_decoded_records_falls_back_to_r2_when_no_r1() {
+        // Only an R2 primary is present; cache must come from that record.
+        let r2 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT, b"R2ONLY");
+        let decoded = vec![decoded_with_cached_umi(r2)];
+        let template = Template::from_decoded_records(decoded).expect("template builds");
+
+        assert_eq!(template.cached_umi(), Some(b"R2ONLY".as_ref()));
+    }
+
+    #[test]
+    fn test_template_from_decoded_records_no_cache_when_primary_uncached() {
+        // R1 has the UMI tag but no cached position; the resulting template
+        // must report no cached UMI so callers fall back to find_string_tag.
+        let r1 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT, b"ACGT");
+        let mut decoded = DecodedRecord::from_raw_bytes(r1, GroupKey::default());
+        // Explicitly leave the cache uninitialised.
+        decoded.set_cached_umi(DecodedRecord::UMI_OFFSET_UNCACHED, 0);
+
+        let template = Template::from_decoded_records(vec![decoded]).expect("template builds");
+        assert!(template.cached_umi().is_none());
+        assert!(template.cached_umi_position.is_none());
+    }
+
+    #[test]
+    fn test_template_from_decoded_records_ignores_supplementary() {
+        // The first record is a supplementary alignment whose cache must be
+        // ignored; the second is the primary R1 and its cache must be used.
+        let supp = build_raw_with_umi(
+            b"read1",
+            raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::SUPPLEMENTARY,
+            b"SUPPUMI",
+        );
+        let primary =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT, b"PRIMARYY");
+
+        let decoded = vec![decoded_with_cached_umi(supp), decoded_with_cached_umi(primary)];
+        let template = Template::from_decoded_records(decoded).expect("template builds");
+        assert_eq!(template.cached_umi(), Some(b"PRIMARYY".as_ref()));
     }
 }

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -396,10 +396,40 @@ pub fn decode_records(
             &group_key_config.library_index,
             group_key_config.cell_tag,
         );
-        records.push(DecodedRecord::from_raw_bytes(raw, key));
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, key);
+        if let Some(umi_tag) = group_key_config.umi_tag {
+            cache_umi_position(&mut decoded, umi_tag);
+        }
+        records.push(decoded);
     }
 
     Ok(records)
+}
+
+/// Cache the UMI tag's value position on a `DecodedRecord`.
+///
+/// Looks up the configured UMI tag in the record's aux data and, if present,
+/// stores the record-relative offset of its value bytes (excluding the trailing
+/// NUL terminator). When the UMI tag is absent or not Z-typed, the record's
+/// cache remains in the uninitialized `UMI_OFFSET_UNCACHED` state and
+/// downstream code must fall back to scanning aux data.
+fn cache_umi_position(decoded: &mut DecodedRecord, umi_tag: [u8; 2]) {
+    let raw = decoded.raw_bytes();
+    let Some(aux_offset) = fgumi_raw_bam::aux_data_offset_from_record(raw) else {
+        return;
+    };
+    let aux = &raw[aux_offset..];
+    let Some((value_off_in_aux, value_len)) = fgumi_raw_bam::find_string_tag_position(aux, umi_tag)
+    else {
+        return;
+    };
+    let Ok(aux_offset_u32) = u32::try_from(aux_offset) else {
+        return;
+    };
+    let Some(value_offset) = aux_offset_u32.checked_add(value_off_in_aux) else {
+        return;
+    };
+    decoded.set_cached_umi(value_offset, value_len);
 }
 
 /// Compute a `GroupKey` directly from raw BAM bytes, matching `compute_group_key()` exactly.
@@ -4367,6 +4397,7 @@ where
 mod tests {
     use super::*;
     use crate::read_info::LibraryIndex;
+    use crate::unified_pipeline::GroupKey;
     use rstest::rstest;
 
     // ========================================================================
@@ -4837,6 +4868,105 @@ mod tests {
         let resolved = resolve_secondary_header(override_header.as_ref(), &primary);
         let expected = Header::builder().add_comment(expected_comment).build();
         assert_eq!(resolved, expected);
+    }
+
+    // ========================================================================
+    // UMI position caching during Decode (issue #334)
+    // ========================================================================
+
+    /// Build a raw BAM record carrying an RX UMI tag for cache tests.
+    fn raw_record_with_rx(umi: &[u8]) -> fgumi_raw_bam::RawRecord {
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(0)
+            .mapq(30)
+            .cigar_ops(&[4u32 << 4]);
+        b.add_string_tag(SamTag::RX, umi);
+        b.build()
+    }
+
+    #[test]
+    fn test_cache_umi_position_records_value_offset_and_len() {
+        let raw = raw_record_with_rx(b"ACGTACGT");
+        let mut decoded = DecodedRecord::from_raw_bytes(raw.as_ref().to_vec(), GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        // The cached slice must equal the canonical find_string_tag answer.
+        let aux = fgumi_raw_bam::aux_data_slice(decoded.raw_bytes());
+        let expected = fgumi_raw_bam::find_string_tag(aux, SamTag::RX).unwrap();
+        assert_eq!(decoded.cached_umi(), Some(expected));
+        assert_eq!(decoded.cached_umi().unwrap(), b"ACGTACGT");
+    }
+
+    #[test]
+    fn test_cache_umi_position_leaves_cache_unset_when_tag_missing() {
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
+        // Record with no RX tag — caching should be a no-op.
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(0)
+            .mapq(30)
+            .cigar_ops(&[4u32 << 4]);
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw.as_ref().to_vec(), GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+
+    #[test]
+    fn test_decode_records_populates_umi_cache_when_configured() {
+        // Build a BoundaryBatch holding one record (with the 4-byte block_size
+        // prefix BAM records carry on disk) and decode it with a GroupKeyConfig
+        // that asks for RX caching.
+        let raw = raw_record_with_rx(b"CACHEDUMI");
+        let mut buffer = Vec::with_capacity(raw.as_ref().len() + 4);
+        let block_size = u32::try_from(raw.as_ref().len()).unwrap();
+        buffer.extend_from_slice(&block_size.to_le_bytes());
+        buffer.extend_from_slice(raw.as_ref());
+        let offsets = vec![0usize, buffer.len()];
+        let batch = BoundaryBatch { buffer, offsets };
+
+        let header = Header::default();
+        let library_index = LibraryIndex::from_header(&header);
+        let cfg = GroupKeyConfig::new(library_index, SamTag::CB.into()).with_umi_tag(*SamTag::RX);
+
+        let decoded = decode_records(&batch, &cfg).expect("decode succeeds");
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].cached_umi(), Some(b"CACHEDUMI".as_ref()));
+    }
+
+    #[test]
+    fn test_decode_records_leaves_umi_cache_unset_when_disabled() {
+        let raw = raw_record_with_rx(b"CACHEDUMI");
+        let mut buffer = Vec::with_capacity(raw.as_ref().len() + 4);
+        let block_size = u32::try_from(raw.as_ref().len()).unwrap();
+        buffer.extend_from_slice(&block_size.to_le_bytes());
+        buffer.extend_from_slice(raw.as_ref());
+        let offsets = vec![0usize, buffer.len()];
+        let batch = BoundaryBatch { buffer, offsets };
+
+        let header = Header::default();
+        let library_index = LibraryIndex::from_header(&header);
+        // No `with_umi_tag` → caching is disabled.
+        let cfg = GroupKeyConfig::new(library_index, SamTag::CB.into());
+
+        let decoded = decode_records(&batch, &cfg).expect("decode succeeds");
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].cached_umi().is_none());
     }
 
     #[test]

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1458,16 +1458,65 @@ pub struct DecodedRecord {
     pub key: GroupKey,
     /// Raw BAM record bytes.
     pub(crate) data: RawRecord,
+    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
+    /// first byte after the 2-byte tag header and the 1-byte type byte). The
+    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
+    /// the UMI bytes without the trailing NUL.
+    ///
+    /// Set to `Self::UMI_OFFSET_UNCACHED` when no UMI position was cached
+    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
+    pub(crate) umi_value_offset: u32,
+    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
+    pub(crate) umi_value_len: u16,
 }
 
 impl DecodedRecord {
+    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
+    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
+    /// offset (BAM records are bounded well under 4 GiB).
+    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+
     /// Create a decoded record from raw bytes, skipping noodles decode.
     ///
     /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
     /// an already-constructed `RawRecord`).
     #[must_use]
     pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
-        Self { key, data: raw.into() }
+        Self {
+            key,
+            data: raw.into(),
+            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
+            umi_value_len: 0,
+        }
+    }
+
+    /// Attach a cached UMI value position to this decoded record.
+    ///
+    /// `umi_value_offset` is the record-relative offset of the first UMI value
+    /// byte (after the tag header), and `umi_value_len` is the value length
+    /// (excluding any trailing NUL).
+    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
+        self.umi_value_offset = umi_value_offset;
+        self.umi_value_len = umi_value_len;
+    }
+
+    /// Returns the cached UMI bytes (without trailing NUL) if a position was
+    /// recorded during decode and still falls within the raw record bytes.
+    /// Returns `None` if no cache is set or the cached position is out of range.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            return None;
+        }
+        let start = self.umi_value_offset as usize;
+        let end = start.checked_add(self.umi_value_len as usize)?;
+        self.data.as_ref().get(start..end)
+    }
+
+    /// Returns the cached UMI offset (`UMI_OFFSET_UNCACHED` when absent) and length.
+    #[must_use]
+    pub fn cached_umi_position(&self) -> (u32, u16) {
+        (self.umi_value_offset, self.umi_value_len)
     }
 
     /// Returns a reference to the raw bytes.
@@ -1508,19 +1557,30 @@ pub struct GroupKeyConfig {
     pub library_index: Arc<LibraryIndex>,
     /// Tag used for cell barcode extraction. None skips cell extraction.
     pub cell_tag: Option<Tag>,
+    /// UMI tag (raw 2-byte form) whose value position should be cached on each
+    /// `DecodedRecord` during decode. None disables caching — downstream code
+    /// must fall back to scanning aux data.
+    pub umi_tag: Option<[u8; 2]>,
 }
 
 impl GroupKeyConfig {
     /// Create a new `GroupKeyConfig`.
     #[must_use]
     pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: Some(cell_tag) }
+        Self { library_index: Arc::new(library_index), cell_tag: Some(cell_tag), umi_tag: None }
     }
 
     /// Create a `GroupKeyConfig` without cell barcode extraction.
     #[must_use]
     pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None }
+        Self { library_index: Arc::new(library_index), cell_tag: None, umi_tag: None }
+    }
+
+    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
+    #[must_use]
+    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
+        self.umi_tag = Some(umi_tag);
+        self
     }
 }
 
@@ -1529,6 +1589,7 @@ impl Default for GroupKeyConfig {
         Self {
             library_index: Arc::new(LibraryIndex::default()),
             cell_tag: Some(Tag::from(SamTag::CB)), // Default cell barcode tag
+            umi_tag: None,
         }
     }
 }
@@ -5914,6 +5975,37 @@ mod tests {
     fn test_decoded_record_raw_accessor() {
         let raw = DecodedRecord::from_raw_bytes(vec![0u8; 32], GroupKey::default());
         assert!(!raw.raw_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_decoded_record_cached_umi_default_absent() {
+        let raw = DecodedRecord::from_raw_bytes(vec![0u8; 32], GroupKey::default());
+        assert!(raw.cached_umi().is_none());
+        let (offset, len) = raw.cached_umi_position();
+        assert_eq!(offset, DecodedRecord::UMI_OFFSET_UNCACHED);
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn test_decoded_record_cached_umi_round_trip() {
+        // Build a payload where bytes [3..7] hold "ACGT" so we can verify the
+        // cached offset/len slice yields exactly those bytes.
+        let mut buf = vec![0u8; 16];
+        buf[3..7].copy_from_slice(b"ACGT");
+        let mut decoded = DecodedRecord::from_raw_bytes(buf, GroupKey::default());
+        decoded.set_cached_umi(3, 4);
+
+        assert_eq!(decoded.cached_umi(), Some(b"ACGT".as_ref()));
+        assert_eq!(decoded.cached_umi_position(), (3, 4));
+    }
+
+    #[test]
+    fn test_decoded_record_cached_umi_out_of_range_returns_none() {
+        // Offset+len falls outside the record bytes — the accessor must reject
+        // rather than panic.
+        let mut decoded = DecodedRecord::from_raw_bytes(vec![0u8; 4], GroupKey::default());
+        decoded.set_cached_umi(2, 10);
+        assert!(decoded.cached_umi().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves #334. `fgumi_raw_bam::find_tag_position` accounts for ~5% of CPU time on `fgumi group` because the same record's aux data is scanned independently by the Decode step (RG/CB/MC), the filter step (MQ/UMI), and the UMI-assignment step (UMI again). This change caches the UMI tag's value position on each `DecodedRecord` during the existing parallel Decode pass and slices the value out of that cache in the assignment step, eliminating the second `find_tag_position` walk per template.

- New `fgumi_raw_bam::find_string_tag_position(aux, tag) -> Option<(u32, u16)>` returns the offset (within aux data) of a Z-tag's value bytes and its length, without the trailing NUL — useful to anything that wants to cache a Z-tag position rather than borrow its slice.
- `GroupKeyConfig` gains an opt-in `umi_tag: Option<[u8; 2]>` and a `with_umi_tag` builder.
- `DecodedRecord` carries `umi_value_offset: u32` (sentinel `UMI_OFFSET_UNCACHED = u32::MAX`) and `umi_value_len: u16`, populated by `decode_records` when `umi_tag` is set.
- `Template::from_decoded_records` picks the cached UMI from the primary read (R1, falling back to R2; secondary / supplementary records ignored) and stores it in `cached_umi_position`. `Template::cached_umi()` slices the primary record bytes to recover the UMI without rescanning. `Template::from_records` (used by tests and non-group callers) leaves the cache `None`, so `assign_umi_groups_for_indices_impl` falls back to `find_string_tag` exactly as before.
- `fgumi group` opts in via `GroupKeyConfig::new(..).with_umi_tag(raw_tag)`.

## Test plan

- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo ci-test` — 2078 tests pass, including the existing `test_paired_mi_deterministic` matrix that exercises `fgumi group` end-to-end with multiple thread configurations
- [x] New unit tests:
  - `tags::tests::test_find_string_tag_position_*` (6 cases: first/subsequent tag, empty value, absent, non-Z, missing NUL)
  - `unified_pipeline::base::tests::test_decoded_record_cached_umi_{default_absent,round_trip,out_of_range_returns_none}`
  - `unified_pipeline::bam::tests::test_cache_umi_position_{records_value_offset_and_len,leaves_cache_unset_when_tag_missing}` and `test_decode_records_{populates,leaves}_umi_cache_*`
  - `template::tests::test_template_from_decoded_records_{propagates_r1_umi_cache,falls_back_to_r2_when_no_r1,no_cache_when_primary_uncached,ignores_supplementary}`
- [ ] Profile-diff `target/profiling/fgumi group` with samply at 999 Hz before/after on `agilent-hs2.mapped.bam` per the issue's verification plan; expect `find_tag_position` contribution in `assign_umi_groups_for_indices_impl` to drop to near zero (Decode-stage scan unchanged).