### PR TITLE
perf+ux: follow-ups from the agilent sort profile

### DIFF
--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -320,7 +320,13 @@ pub fn decompress_block(
     block: &RawBgzfBlock,
     decompressor: &mut Decompressor,
 ) -> io::Result<Vec<u8>> {
-    let mut output = Vec::new();
+    // Pre-size to one BGZF block. Avoids the multi-step `RawVec::finish_grow`
+    // we see in profiles (~1.9% of decompress CPU on the merge hot path):
+    // starting from capacity 0, the resize inside `decompress_and_verify` has
+    // to grow through several capacity classes before reaching the final
+    // ~64 KiB. A single `with_capacity` lands at the right size on the first
+    // allocation.
+    let mut output = Vec::with_capacity(crate::BGZF_MAX_BLOCK_SIZE);
     decompress_block_into(block, decompressor, &mut output)?;
     Ok(output)
 }

--- a/crates/fgumi-sort/src/tmp_dir_alloc.rs
+++ b/crates/fgumi-sort/src/tmp_dir_alloc.rs
@@ -10,7 +10,32 @@
 //!   below a minimum threshold are dropped from rotation automatically.
 
 use anyhow::{Result, anyhow, bail};
+use log::warn;
 use std::path::{Path, PathBuf};
+
+/// Best-effort check: is the path on a tmpfs (RAM-backed) filesystem?
+///
+/// Spilling to tmpfs defeats the entire memory-management purpose of external
+/// sort — every byte spilled comes back out of RAM, so peak RSS climbs as
+/// if `--max-memory` were ignored and the process eventually OOMs on small
+/// hosts. Most users learn this the hard way when the default `/tmp` on
+/// Amazon Linux 2023 turns out to be tmpfs sized at 50 % of RAM.
+///
+/// Returns `Ok(true)` only when we positively identify the filesystem as
+/// tmpfs. Returns `Ok(false)` for any other filesystem, and `Ok(false)` on
+/// non-Linux targets where we don't probe the filesystem type. Returns
+/// `Err` if the `statfs(2)` call itself fails.
+#[cfg(target_os = "linux")]
+fn is_tmpfs(path: &Path) -> std::io::Result<bool> {
+    use nix::sys::statfs::{TMPFS_MAGIC, statfs};
+    statfs(path).map(|s| s.filesystem_type() == TMPFS_MAGIC).map_err(std::io::Error::from)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
+fn is_tmpfs(_path: &Path) -> std::io::Result<bool> {
+    Ok(false)
+}
 
 /// Minimum free bytes a directory must have to remain in rotation.
 pub const DEFAULT_MIN_FREE_BYTES: u64 = 1 << 30; // 1 GiB
@@ -73,7 +98,17 @@ impl TmpDirAllocator {
         let mut active = Vec::with_capacity(dirs.len());
         for dir in dirs {
             match probe(&dir) {
-                Ok(free) if free >= min_free_bytes => active.push(dir),
+                Ok(free) if free >= min_free_bytes => {
+                    if let Ok(true) = is_tmpfs(&dir) {
+                        warn!(
+                            "Temp dir {} is on tmpfs (RAM-backed): spill files will consume \
+                             RAM not disk, defeating --max-memory. Pass -T <path-on-disk> \
+                             to use a real filesystem.",
+                            dir.display()
+                        );
+                    }
+                    active.push(dir);
+                }
                 Ok(free) => log::warn!(
                     "Temp dir {} dropped: only {} free (need {})",
                     dir.display(),


### PR DESCRIPTION
## Summary

Two small, independent improvements surfaced by the perf investigation that motivated #341 (zstd spill codec). Each is its own commit so it can be reverted in isolation if needed.

Items deferred to a later PR (require bench validation):
- **B**: `ProgressTracker::log_if_needed` showed up at 1.18 % of total CPU. The function design is fine (cheap atomic + interval check), but at ~32M calls/s aggregate the per-call cost adds up. Needs an EC2-backed bench to confirm the diagnosis before fixing — likely a per-thread accumulator that touches the global atomic less frequently.
- **C**: per-worker BGZF decompress scratch buffer (mirror of the zstd scratch buffer in #341). Largely subsumed by commit 1 once `decompress_block` pre-sizes — the remaining win is the buffer-pool reuse, which is structural enough to deserve its own PR.

## Commits

### 1. `perf(bgzf): pre-size decompress_block output buffer`

`decompress_block` returned a fresh `Vec::new()` and let `decompress_and_verify` resize it to the block's uncompressed size. Profiles on a 30-second BAM sort showed **~1.9 % of total CPU in `RawVec::finish_grow` / `mi_theap_malloc_zero_aligned_at_overalloc`**, attributed to that resize growing through several capacity classes before reaching ~64 KiB on every block.

`Vec::with_capacity(BGZF_MAX_BLOCK_SIZE)` lands the first allocation at the final size, eliminating the grow steps. Callers that already use `decompress_block_into` / `decompress_block_slice_into` are unaffected.

### 2. `feat(sort): warn when a -T temp dir is on tmpfs`

Many container images and cloud AMIs (notably Amazon Linux 2023) ship `/tmp` as a tmpfs sized at 50 % of RAM. Spilling to tmpfs makes every byte spilled come back out of RAM, so peak RSS climbs as if `--max-memory` were ignored and the process OOMs on small hosts. The misbehavior is invisible from the inside: free space looks fine, writes succeed, only the working-set numbers reveal the trap.

`TmpDirAllocator::with_probe` now calls `statfs(2)` on each configured temp directory (via the already-vendored `nix` crate on Linux) and emits a `log::warn!` when it detects tmpfs. The sort continues normally; this is informational only.

Non-Linux targets fall through to a stub that always returns false, since `f_type == TMPFS_MAGIC` is a Linux concept.

## Test plan

- [x] `cargo build --release` clean across the workspace.
- [x] `cargo ci-lint` passes (no `--no-verify` needed).
- [x] `cargo ci-fmt` passes.
- [x] `cargo test --release -p fgumi-sort` — 342 unit + 11 integration tests pass.
- [x] `cargo test --release -p fgumi-bgzf` — 18 tests pass.
- [ ] CI green on this branch.

## Notes

- Independent of #340 and #341; the three can land in any order.
- The pre-size change is one line of substantive code; the tmpfs check is ~30 lines plus a helper.