### PR TITLE
perf(sort): recycle BGZF decompress output buffers via a pre-warmed pool

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -31,7 +31,7 @@ use crate::memory_probe::{
 use crate::pooled_chunk_writer::PooledChunkWriter;
 use crate::read_ahead::{PooledInputStream, RawReadAheadReader, RecordSource};
 use crate::tmp_dir_alloc::TmpDirAllocator;
-use crate::worker_pool::SortWorkerPool;
+use crate::worker_pool::{BufferPool, SortWorkerPool};
 use anyhow::{Context as _, Result};
 use crossbeam_channel::{Receiver, Sender, bounded};
 use fgumi_bam_io::ProgressTracker;
@@ -841,6 +841,10 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Set by `do_shutdown` when a worker thread panicked unexpectedly.
     worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Recycling pool for decompressed BGZF block buffers. The previous
+    /// `current_buf` of each parser-state slot is returned here when a new
+    /// block is pulled from the reorder buffer.
+    decompress_buffer_pool: BufferPool,
     _phantom: std::marker::PhantomData<K>,
 }
 
@@ -852,6 +856,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         decompression_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        decompress_buffer_pool: BufferPool,
     ) -> Self {
         let parser_state = (0..files.len()).map(|_| SourceParserState::new()).collect();
         Self {
@@ -860,6 +865,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             decompression_error,
             chunk_read_error,
             worker_panicked,
+            decompress_buffer_pool,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -902,7 +908,15 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 if let Some(data) = guard.try_pop_next() {
                     drop(guard);
                     let st = &mut self.parser_state[source_id];
-                    st.current_buf = data;
+                    // Return the previous block's buffer to the pool so a
+                    // worker can reuse it on the next decompression. Skip
+                    // the checkin if the prior buffer was the placeholder
+                    // `Vec::new()` from `SourceParserState::new` — recycling
+                    // a zero-capacity slot would dilute the pre-warmed pool.
+                    let old = std::mem::replace(&mut st.current_buf, data);
+                    if old.capacity() > 0 {
+                        self.decompress_buffer_pool.checkin(old);
+                    }
                     st.current_pos = 0;
                     return Ok(true);
                 }
@@ -2629,6 +2643,7 @@ impl RawExternalSorter {
                 pool.decompress_error_flag(),
                 pool.chunk_read_error_flag(),
                 pool.worker_panicked_flag(),
+                pool.decompress_buffer_pool(),
             );
             pool.set_phase(phase::PHASE2);
             Phase2Guard { pool, consumer: Some(consumer), active: true }
@@ -3108,6 +3123,7 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
         pool.decompressed_input_done_flag(),
         pool.input_read_error_flag(),
         pool.decompress_error_flag(),
+        pool.decompress_buffer_pool(),
     );
 
     skip_bam_header(&mut pooled_input)

--- a/crates/fgumi-sort/src/read_ahead.rs
+++ b/crates/fgumi-sort/src/read_ahead.rs
@@ -26,6 +26,7 @@
 use crossbeam_channel::{Receiver, Sender, bounded};
 use std::thread::{self, JoinHandle};
 
+use crate::worker_pool::BufferPool;
 use fgumi_bam_io::RawBamReaderAuto;
 use fgumi_raw_bam::{RawBamReader, RawRecord};
 use std::io::Read as IoRead;
@@ -248,6 +249,11 @@ pub struct PooledInputStream {
     current_buf: Vec<u8>,
     /// Read position within `current_buf`.
     current_pos: usize,
+    /// Recycling pool for decompressed BGZF block buffers. The previous
+    /// `current_buf` is returned here when a new block is loaded, so workers
+    /// can reuse the allocation on subsequent decompressions instead of
+    /// faulting in fresh anonymous pages (`clear_page_erms` in profiles).
+    decompress_buffer_pool: BufferPool,
 }
 
 impl PooledInputStream {
@@ -258,6 +264,7 @@ impl PooledInputStream {
         decompressed_input_done: std::sync::Arc<std::sync::atomic::AtomicBool>,
         input_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         decompression_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        decompress_buffer_pool: BufferPool,
     ) -> Self {
         Self {
             decompressed_input,
@@ -267,6 +274,7 @@ impl PooledInputStream {
             reorder: fgumi_bam_io::ReorderBuffer::new(),
             current_buf: Vec::new(),
             current_pos: 0,
+            decompress_buffer_pool,
         }
     }
 
@@ -377,9 +385,22 @@ impl IoRead for PooledInputStream {
             let n = data.len().min(buf.len());
             buf[..n].copy_from_slice(&data[..n]);
             if n < data.len() {
-                self.current_buf = data;
+                // Replace current_buf with the new block; return the prior
+                // buffer to the pool so a worker can reuse it. Skip the
+                // checkin if the prior buffer was the placeholder
+                // `Vec::new()` from initial construction — recycling a
+                // zero-capacity slot would dilute the pre-warmed pool.
+                let old = std::mem::replace(&mut self.current_buf, data);
+                if old.capacity() > 0 {
+                    self.decompress_buffer_pool.checkin(old);
+                }
                 self.current_pos = n;
             } else {
+                // The block was fully consumed in one read; return it to
+                // the pool directly. Keep current_buf empty (its capacity
+                // is preserved by `clear` so a subsequent partial-block
+                // read will still recycle into the pool).
+                self.decompress_buffer_pool.checkin(data);
                 self.current_buf.clear();
                 self.current_pos = 0;
             }

--- a/crates/fgumi-sort/src/tmp_dir_alloc.rs
+++ b/crates/fgumi-sort/src/tmp_dir_alloc.rs
@@ -10,7 +10,34 @@
 //!   below a minimum threshold are dropped from rotation automatically.
 
 use anyhow::{Result, anyhow, bail};
+use log::warn;
 use std::path::{Path, PathBuf};
+
+/// Best-effort check: is the path on a tmpfs (RAM-backed) filesystem?
+///
+/// Spilling to tmpfs defeats the entire memory-management purpose of external
+/// sort — every byte spilled comes back out of RAM, so peak RSS climbs as
+/// if `--max-memory` were ignored and the process eventually OOMs on small
+/// hosts. Most users learn this the hard way when the default `/tmp` on
+/// Amazon Linux 2023 turns out to be tmpfs sized at 50 % of RAM.
+///
+/// Returns `Ok(true)` only when we positively identify the filesystem as
+/// tmpfs. Returns `Ok(false)` for any other filesystem, and `Ok(false)` on
+/// non-Linux targets where we don't probe the filesystem type. Returns
+/// `Err` if the `statfs(2)` call itself fails.
+#[cfg(target_os = "linux")]
+fn is_tmpfs(path: &Path) -> std::io::Result<bool> {
+    use nix::sys::statfs::{TMPFS_MAGIC, statfs};
+    statfs(path)
+        .map(|s| s.filesystem_type() == TMPFS_MAGIC)
+        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
+fn is_tmpfs(_path: &Path) -> std::io::Result<bool> {
+    Ok(false)
+}
 
 /// Minimum free bytes a directory must have to remain in rotation.
 pub const DEFAULT_MIN_FREE_BYTES: u64 = 1 << 30; // 1 GiB
@@ -73,7 +100,15 @@ impl TmpDirAllocator {
         let mut active = Vec::with_capacity(dirs.len());
         for dir in dirs {
             match probe(&dir) {
-                Ok(free) if free >= min_free_bytes => active.push(dir),
+                Ok(free) if free >= min_free_bytes => {
+                    if let Ok(true) = is_tmpfs(&dir) {
+                        warn!(
+                            "Temp dir {} is on tmpfs (RAM-backed): spill files will consume                              RAM not disk, defeating --max-memory. Pass -T <path-on-disk>                              to use a real filesystem.",
+                            dir.display()
+                        );
+                    }
+                    active.push(dir);
+                }
                 Ok(free) => log::warn!(
                     "Temp dir {} dropped: only {} free (need {})",
                     dir.display(),

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -32,9 +32,10 @@
 
 use crossbeam_channel::{Receiver, Sender, bounded};
 use crossbeam_queue::ArrayQueue;
+use fgumi_bgzf::reader::decompress_block_into;
 use fgumi_bgzf::reader::read_raw_blocks;
 use fgumi_bgzf::writer::InlineBgzfCompressor;
-use fgumi_bgzf::{RawBgzfBlock, decompress_block};
+use fgumi_bgzf::{BGZF_MAX_BLOCK_SIZE, RawBgzfBlock};
 use log::info;
 use std::collections::VecDeque;
 use std::fmt::Write as FmtWrite;
@@ -301,6 +302,22 @@ impl BufferPool {
         Self { tx, rx }
     }
 
+    /// Create a buffer pool pre-filled with `capacity` buffers, each
+    /// `Vec::with_capacity(buf_capacity)`.
+    ///
+    /// Useful when callers will overwrite buffer contents on every use, so the
+    /// first checkout returns a buffer that's already sized to avoid the
+    /// initial grow-through-capacity-classes seen by `Vec::new()` callers.
+    #[must_use]
+    pub fn pre_warmed(capacity: usize, buf_capacity: usize) -> Self {
+        let (tx, rx) = bounded(capacity);
+        for _ in 0..capacity {
+            tx.try_send(Vec::with_capacity(buf_capacity))
+                .expect("fresh bounded channel has room for initial pre-warm");
+        }
+        Self { tx, rx }
+    }
+
     /// Get a buffer from the pool, or allocate a new one if the pool is empty.
     #[must_use]
     pub fn checkout(&self) -> Vec<u8> {
@@ -547,6 +564,18 @@ pub struct SortWorkerPool {
     pub(crate) stats: PoolStats,
     pub(crate) pipeline_stats: Arc<SortPipelineStats>,
     pub buffer_pool: BufferPool,
+    /// Recycling pool for decompressed BGZF block buffers.
+    ///
+    /// Workers check a buffer out before each call to `decompress_block_into`;
+    /// the consumer (`PooledInputStream` or `MainThreadChunkConsumer`) returns
+    /// the previous block's buffer when it advances. Pre-warmed at
+    /// `BGZF_MAX_BLOCK_SIZE` (~65 KiB) so the very first checkout lands at the
+    /// final size and avoids the grow-through-capacity-classes that previously
+    /// charged ~1.9 % of total CPU to `RawVec::finish_grow` /
+    /// `mi_theap_malloc_zero_aligned_at_overalloc`. Pool memory budget is
+    /// `pool_capacity * BGZF_MAX_BLOCK_SIZE` (≈ 2 MiB / worker — 16 MiB at
+    /// `--threads 8`, 64 MiB at `--threads 32`).
+    pub(crate) decompress_buffer_pool: BufferPool,
     num_workers: usize,
 }
 
@@ -624,6 +653,11 @@ pub(crate) struct SharedPipelineState {
     /// Number of workers (for `low_water` threshold in backpressure).
     num_workers: usize,
 
+    /// Recycling pool for decompressed BGZF block buffers (clone of
+    /// `SortWorkerPool::decompress_buffer_pool`). Workers borrow buffers from
+    /// this pool inside `try_decompress_input` and `try_phase2_file_work`.
+    pub(crate) decompress_buffer_pool: BufferPool,
+
     /// Main thread handle for `park()`/`unpark()` notification.
     /// Workers call `unpark()` after inserting into `decompressed_input`
     /// (Phase 1) or into a per-file `Phase2FileState.decompressed` reorder
@@ -633,7 +667,11 @@ pub(crate) struct SharedPipelineState {
 }
 
 impl SharedPipelineState {
-    fn new(num_workers: usize, main_thread_handle: std::thread::Thread) -> Self {
+    fn new(
+        num_workers: usize,
+        main_thread_handle: std::thread::Thread,
+        decompress_buffer_pool: BufferPool,
+    ) -> Self {
         let data_queue_cap = num_workers * 8;
         let compress_queue_cap = num_workers * 4;
 
@@ -660,6 +698,7 @@ impl SharedPipelineState {
             compress_queue: Arc::new(ArrayQueue::new(compress_queue_cap)),
 
             num_workers,
+            decompress_buffer_pool,
             main_thread_handle,
         }
     }
@@ -877,10 +916,34 @@ impl SortWorkerPool {
     #[must_use]
     pub fn new(num_workers: usize, temp_compression: u32, output_compression: u32) -> Self {
         let buffer_pool = BufferPool::new(num_workers * 4);
+        // Pre-warm a decompress pool sized to cover the Phase 1 working set
+        // with margin. Counts of buffers the pool must hold to avoid
+        // fallback `Vec::new()` allocations:
+        //
+        //   Phase 1 (writing N workers, queue, reorder, consumer):
+        //     N         workers mid-decompression (1 each)
+        //   + N * 8     decompressed_input ArrayQueue cap (= data_queue_cap)
+        //   + N * 16    PooledInputStream reorder buffer soft cap (= 2× queue
+        //               cap; see `read_ahead::PooledInputStream::drain_queue`)
+        //   + 1         PooledInputStream::current_buf
+        //   = N * 25 + 1
+        //
+        //   Phase 2 (per-file caps × K spill files):
+        //     K * PHASE2_DECOMP_CAP (= 8) + K current_bufs = K * 9
+        //
+        // `N * 32` covers Phase 1 with ~25 % margin. When Phase 2 K exceeds
+        // ~`N * 3`, excess decompressions fall back to `BufferPool::checkout`'s
+        // empty-Vec path — graceful degradation, not a correctness issue (the
+        // original pre-PR behavior on every block).
+        let decompress_buffer_pool = BufferPool::pre_warmed(num_workers * 32, BGZF_MAX_BLOCK_SIZE);
         let stats = PoolStats::default();
         let pipeline_stats = Arc::new(SortPipelineStats::new(num_workers));
         let main_thread_handle = std::thread::current();
-        let shared = Arc::new(SharedPipelineState::new(num_workers, main_thread_handle));
+        let shared = Arc::new(SharedPipelineState::new(
+            num_workers,
+            main_thread_handle,
+            decompress_buffer_pool.clone(),
+        ));
 
         let workers: Vec<JoinHandle<()>> = (0..num_workers)
             .map(|worker_id| {
@@ -905,7 +968,15 @@ impl SortWorkerPool {
             })
             .collect();
 
-        Self { shared, workers: Some(workers), stats, pipeline_stats, buffer_pool, num_workers }
+        Self {
+            shared,
+            workers: Some(workers),
+            stats,
+            pipeline_stats,
+            buffer_pool,
+            decompress_buffer_pool,
+            num_workers,
+        }
     }
 
     // ========================================================================
@@ -1289,15 +1360,16 @@ impl SortWorkerPool {
             return StepResult::InputEmpty;
         };
 
-        let data = match decompress_block(&block, &mut worker.decompressor) {
-            Ok(d) => d,
-            Err(e) => {
-                log::error!("BGZF decompression error (input block serial {serial}): {e}");
-                shared.decompression_error.store(true, Ordering::Release);
-                shared.main_thread_handle.unpark();
-                return StepResult::InputEmpty;
-            }
-        };
+        let mut data = shared.decompress_buffer_pool.checkout();
+        if let Err(e) = decompress_block_into(&block, &mut worker.decompressor, &mut data) {
+            log::error!("BGZF decompression error (input block serial {serial}): {e}");
+            // Return the buffer to the pool so we don't leak the pre-warmed
+            // allocation on the error path.
+            shared.decompress_buffer_pool.checkin(data);
+            shared.decompression_error.store(true, Ordering::Release);
+            shared.main_thread_handle.unpark();
+            return StepResult::InputEmpty;
+        }
 
         let input_eof = shared.input_eof.load(Ordering::Acquire);
         let raw_empty = shared.raw_input_blocks.is_empty();
@@ -1386,20 +1458,20 @@ impl SortWorkerPool {
             // error path) to keep the counter balanced.
             let popped = Self::try_pop_raw_for_decompress(file);
             if let Some((serial, raw_block)) = popped {
-                let data = match decompress_block(&raw_block, &mut worker.decompressor) {
-                    Ok(d) => d,
-                    Err(e) => {
-                        log::error!(
-                            "BGZF decompression error (chunk source {i} serial {serial}): {e}"
-                        );
-                        shared.decompression_error.store(true, Ordering::Release);
-                        // Balance the in-flight increment from try_pop_raw_for_decompress.
-                        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                        shared.main_thread_handle.unpark();
-                        worker.phase2_file_cursor = (i + 1) % n;
-                        return StepResult::Success;
-                    }
-                };
+                let mut data = shared.decompress_buffer_pool.checkout();
+                if let Err(e) =
+                    decompress_block_into(&raw_block, &mut worker.decompressor, &mut data)
+                {
+                    log::error!("BGZF decompression error (chunk source {i} serial {serial}): {e}");
+                    // Return the buffer to the pool to avoid leaking pre-warmed capacity.
+                    shared.decompress_buffer_pool.checkin(data);
+                    shared.decompression_error.store(true, Ordering::Release);
+                    // Balance the in-flight increment from try_pop_raw_for_decompress.
+                    file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+                    shared.main_thread_handle.unpark();
+                    worker.phase2_file_cursor = (i + 1) % n;
+                    return StepResult::Success;
+                }
                 let now_poppable = {
                     let mut dec_guard =
                         file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
@@ -1585,6 +1657,13 @@ impl SortWorkerPool {
         &self,
     ) -> Arc<crossbeam_queue::ArrayQueue<(u64, Vec<u8>)>> {
         Arc::clone(&self.shared.decompressed_input)
+    }
+
+    /// Get a clone of the decompress buffer pool so consumers can return
+    /// buffers when they advance past a block.
+    #[must_use]
+    pub(crate) fn decompress_buffer_pool(&self) -> BufferPool {
+        self.decompress_buffer_pool.clone()
     }
 
     /// Get a clone of the decompressed input done flag for `PooledInputStream`.
@@ -1836,6 +1915,113 @@ mod tests {
         // Buffer should be cleared but retain capacity
         assert!(recycled.is_empty());
         assert!(recycled.capacity() >= 1024);
+    }
+
+    #[test]
+    fn test_buffer_pool_pre_warmed_yields_sized_buffers() {
+        let pool = BufferPool::pre_warmed(3, 8 * 1024);
+        assert_eq!(pool.len(), 3, "pool should be filled to `capacity`");
+
+        for _ in 0..3 {
+            let buf = pool.checkout();
+            assert!(buf.is_empty(), "pre-warmed buffer has length 0");
+            assert!(
+                buf.capacity() >= 8 * 1024,
+                "pre-warmed buffer should land at the requested capacity, got {}",
+                buf.capacity()
+            );
+        }
+
+        // Exhausted pool falls back to a fresh empty Vec (capacity 0).
+        let fallback = pool.checkout();
+        assert!(fallback.is_empty());
+        assert_eq!(fallback.capacity(), 0);
+    }
+
+    #[test]
+    fn test_buffer_pool_concurrent_recycle_no_leak() {
+        // Mirror the worker → consumer pattern used in the decompress
+        // pipeline: P "worker" threads checkout and (fake) fill a buffer,
+        // hand it across a channel to a "consumer" thread that checks it
+        // back in. Verify that the pool's free count stays bounded
+        // (no growth beyond capacity) and recovers to its pre-warmed size
+        // once all in-flight buffers are returned.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const POOL_CAP: usize = 16;
+        const BUF_CAP: usize = 8 * 1024;
+        const PRODUCERS: usize = 4;
+        const ITEMS_PER_PRODUCER: usize = 64;
+
+        let pool = BufferPool::pre_warmed(POOL_CAP, BUF_CAP);
+        assert_eq!(pool.len(), POOL_CAP);
+
+        let (tx, rx) = crossbeam_channel::bounded::<Vec<u8>>(POOL_CAP);
+        let returned = Arc::new(AtomicUsize::new(0));
+
+        let consumer_pool = pool.clone();
+        let consumer_returned = Arc::clone(&returned);
+        let consumer = std::thread::spawn(move || {
+            while let Ok(buf) = rx.recv() {
+                consumer_pool.checkin(buf);
+                consumer_returned.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|_| {
+                let p = pool.clone();
+                let t = tx.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..ITEMS_PER_PRODUCER {
+                        let mut buf = p.checkout();
+                        // Simulate decompress filling the buffer.
+                        buf.resize(BUF_CAP, 0xAB);
+                        t.send(buf).expect("consumer receiver alive");
+                    }
+                })
+            })
+            .collect();
+        drop(tx);
+
+        for p in producers {
+            p.join().expect("producer should not panic");
+        }
+        consumer.join().expect("consumer should not panic");
+
+        assert_eq!(returned.load(Ordering::Relaxed), PRODUCERS * ITEMS_PER_PRODUCER);
+        assert!(
+            pool.len() <= POOL_CAP,
+            "pool should never exceed its capacity; got {}",
+            pool.len()
+        );
+        // After all producers finish and all consumers drain, the pool
+        // should be at its full capacity again (every buffer either fell
+        // through a checkout/checkin cycle or was retained by `try_send`
+        // succeeding into a free slot).
+        assert_eq!(pool.len(), POOL_CAP);
+    }
+
+    #[test]
+    fn test_buffer_pool_pre_warmed_round_trip_preserves_capacity() {
+        let pool = BufferPool::pre_warmed(2, 4 * 1024);
+        let mut buf = pool.checkout();
+        let initial_cap = buf.capacity();
+        assert!(initial_cap >= 4 * 1024);
+
+        // Simulate decompress filling the buffer.
+        buf.extend_from_slice(&[0u8; 4 * 1024]);
+        pool.checkin(buf);
+
+        let recycled = pool.checkout();
+        assert!(recycled.is_empty(), "checkin clears length");
+        assert!(
+            recycled.capacity() >= initial_cap,
+            "round-trip should not shrink capacity: got {}, expected >= {}",
+            recycled.capacity(),
+            initial_cap
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Picks up item **C** that PR #344 explicitly deferred: a per-worker BGZF decompress scratch pool. PR #344 commit 1 pre-sizes `decompress_block`'s output `Vec`; this PR makes that buffer pooled and reused across blocks instead of freshly allocated per call.

Stacked on `nh/perf-followups` (PR #344). When #344 merges, this PR's base auto-retargets to `main`.

## Motivation

The fgumi sort pool's Phase 1 (`worker_pool::try_decompress_input`) and Phase 2 (`worker_pool::try_phase2_file_work`) both call `decompress_block(&block, &mut decompressor)`, which returns a fresh `Vec<u8>` per BGZF block. PR #344 commit 1 sized the first allocation correctly via `Vec::with_capacity(BGZF_MAX_BLOCK_SIZE)`, but every block still pays:

- one `malloc` per block (~25 K blocks for a 1.7 GB BAM),
- one `clear_page_erms` first-touch fault when the OS hands us a fresh anonymous page (~2 % of total CPU in the past agilent-hs2 sort profile),
- a matching `mi_free` when the consumer drops the Vec on a different thread (the cross-thread page-ownership-transfer case mimalloc handles via `mi_abandoned_page_try_reclaim`).

## Change

A second `BufferPool` (`SortWorkerPool::decompress_buffer_pool`) alongside the existing compress staging pool, pre-warmed at `BGZF_MAX_BLOCK_SIZE`. Workers checkout before `decompress_block_into(&mut buf)`; consumers (`PooledInputStream` and `MainThreadChunkConsumer`) check the previous block's buffer back in when they advance.

- Pool size: `num_workers * 32` slots. Sized for the Phase 1 working set (`N (workers) + N*8 (decompressed_input cap) + N*16 (reorder buf soft cap) + 1 (current_buf) = N*25 + 1`) with ~25 % margin.
- Phase 2 with K > ~`N*3` spill files: excess decompressions fall back to the empty-Vec path — same behavior as before this PR, graceful degradation.
- Memory budget: `pool_capacity × BGZF_MAX_BLOCK_SIZE` ≈ 2 MiB / worker. 16 MiB at `--threads 8`, 64 MiB at `--threads 32`.
- Error paths return the buffer to the pool before propagating.
- The first-iteration placeholder `Vec::new()` (capacity 0) in `current_buf` is detected and not checked in, so zero-cap slots never dilute the pre-warmed pool.

## Benchmarks

`twist-umi.mapped.bam` (1.7 GB / 16.1 M records), `--threads 8`, 5 runs each via hyperfine:

**Spilling workload** (`--max-memory 256M`, exercises Phase 2):

| Variant | Wall time | σ | User | System |
| --- | --- | --- | --- | --- |
| Parent (#344 base) | 8.936 s | ± 2.170 s | 46.75 s | 2.72 s |
| This PR | **8.223 s** | **± 0.146 s** | 47.83 s | 2.91 s |

→ 1.09 ± 0.26× faster; **σ is 15× tighter** (allocation jitter is the dominant source of run-to-run variance on the spilling workload, and the pool eliminates it).

**In-memory workload** (`--max-memory 768M`, no spill, Phase 2 inactive):

| Variant | Wall time | σ |
| --- | --- | --- |
| Parent (#344 base) | 4.413 s | ± 0.159 s |
| This PR | 4.575 s | ± 0.026 s |

→ Wall-time delta within noise; σ ratio still 6× tighter.

## Tests

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` — 2067 / 2067 pass.
- Three new unit tests in `crates/fgumi-sort/src/worker_pool.rs`:
  - `test_buffer_pool_pre_warmed_yields_sized_buffers`: pre-warm yields N buffers of the requested capacity; falls back to `Vec::default()` when exhausted.
  - `test_buffer_pool_pre_warmed_round_trip_preserves_capacity`: round-trip checkout → fill → checkin → checkout preserves the underlying allocation.
  - `test_buffer_pool_concurrent_recycle_no_leak`: 4 producers × 64 items × 1 consumer through a channel; asserts pool length never exceeds capacity and recovers fully after drain.

## Test plan

- [x] `cargo build --release` clean across the workspace.
- [x] `cargo ci-fmt` passes.
- [x] `cargo ci-lint` passes (no `--no-verify`).
- [x] `cargo ci-test` — 2067 / 2067 pass.
- [x] Hyperfine bench on `twist-umi.mapped.bam` (spilling + in-memory).
- [ ] CI green on this branch.

## Notes

- Stack: based on `nh/perf-followups` (#344). Retarget to `main` when #344 lands.
- The `decompress_buffer_pool` field and its accessor are `pub(crate)` — no cross-crate exposure.
- On panic-unwind inside `decompress_block_into` the checked-out buffer leaks; acceptable because a worker panic terminates the sort. A drop-guard wrapper is a possible future cleanup but is not required.