### PR TITLE
perf(sort): pool raw BGZF block buffers on input read

### DIFF
--- a/crates/fgumi-bgzf/src/lib.rs
+++ b/crates/fgumi-bgzf/src/lib.rs
@@ -12,6 +12,6 @@ pub mod writer;
 // Re-export commonly used types
 pub use reader::{
     BGZF_EOF, BGZF_FOOTER_SIZE, BGZF_HEADER_SIZE, RawBgzfBlock, decompress_block,
-    decompress_block_into, decompress_block_slice_into, read_raw_blocks,
+    decompress_block_into, decompress_block_slice_into, read_raw_blocks, read_raw_blocks_into,
 };
 pub use writer::{BGZF_MAX_BLOCK_SIZE, CompressedBlock, InlineBgzfCompressor};

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -132,22 +132,41 @@ impl RawBgzfBlock {
     pub fn crc32(&self) -> u32 {
         crc32_from_slice(&self.data)
     }
+
+    /// Take ownership of the block's raw byte buffer, leaving the
+    /// block with an empty `Vec<u8>`.
+    ///
+    /// Use this to return the underlying allocation to a recycling
+    /// buffer pool once the block has been decompressed.
+    #[must_use]
+    pub fn take_data(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.data)
+    }
 }
 
 // ============================================================================
 // Reading Functions
 // ============================================================================
 
-/// Read a single raw BGZF block from the input.
+/// Read a single raw BGZF block from the input, sourcing its byte
+/// storage from `get_buf` (only invoked once a block header is
+/// successfully read).
 ///
-/// Returns `Ok(Some(block))` if a block was read, `Ok(None)` at EOF,
-/// or an error if reading failed or the data is invalid.
+/// This is the buffer-recycling variant of [`read_raw_block`]: callers
+/// can pass a closure that pulls from a `Vec<u8>` recycling pool to
+/// avoid the per-block `mi_malloc` that the convenience entry point
+/// pays. On clean EOF (`Ok(None)`) the closure is *not* called, so the
+/// pool is never charged for a wasted checkout.
 ///
 /// # Errors
 ///
 /// Returns an error if the block header is invalid or reading fails.
-fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzfBlock>> {
-    // Read the 18-byte header
+fn read_raw_block_into<R, F>(reader: &mut R, get_buf: F) -> io::Result<Option<RawBgzfBlock>>
+where
+    R: Read + ?Sized,
+    F: FnOnce() -> Vec<u8>,
+{
+    // Read the 18-byte header (or detect clean EOF).
     let mut header = [0u8; BGZF_HEADER_SIZE];
     match reader.read_exact(&mut header) {
         Ok(()) => {}
@@ -155,7 +174,7 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
         Err(e) => return Err(e),
     }
 
-    // Validate gzip magic bytes
+    // Validate header (same checks as `read_raw_block`).
     if header[0] != 0x1f || header[1] != 0x8b {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -165,21 +184,15 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
             ),
         ));
     }
-
-    // Validate compression method (deflate)
     if header[2] != 0x08 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("Invalid compression method: expected 0x08, got 0x{:02x}", header[2]),
         ));
     }
-
-    // Validate FEXTRA flag
     if header[3] & 0x04 == 0 {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "BGZF block missing FEXTRA flag"));
     }
-
-    // Validate BC subfield identifier
     if header[12] != b'B' || header[13] != b'C' {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -190,12 +203,8 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
         ));
     }
 
-    // Get block size from BSIZE field (bytes 16-17, little-endian)
-    // BSIZE = total_block_size - 1
-    // BSIZE is u16, so block_size fits in usize on all platforms
     let bsize = usize::from(u16::from_le_bytes([header[16], header[17]]));
     let block_size = bsize + 1;
-
     if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -203,14 +212,32 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
         ));
     }
 
-    // Allocate buffer and copy header
-    let mut data = vec![0u8; block_size];
+    // Acquire a buffer from the caller-supplied source only now —
+    // after a valid header has been read, so a checkout never charges
+    // for a wasted-on-EOF cycle.
+    let mut data = get_buf();
+    data.clear();
+    data.resize(block_size, 0);
     data[..BGZF_HEADER_SIZE].copy_from_slice(&header);
-
-    // Read remaining block data
     reader.read_exact(&mut data[BGZF_HEADER_SIZE..])?;
 
     Ok(Some(RawBgzfBlock { data }))
+}
+
+/// Read a single raw BGZF block from the input, allocating a fresh
+/// `Vec<u8>` per block. Convenience wrapper around
+/// [`read_raw_block_into`] for callers that do not want to manage a
+/// recycling buffer pool.
+///
+/// Returns `Ok(Some(block))` if a block was read, `Ok(None)` at EOF,
+/// or an error if reading failed or the data is invalid.
+///
+/// # Errors
+///
+/// Returns an error if the block header is invalid or reading fails.
+#[cfg(test)]
+fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzfBlock>> {
+    read_raw_block_into(reader, Vec::new)
 }
 
 /// Read multiple raw BGZF blocks as a batch.
@@ -235,12 +262,55 @@ pub fn read_raw_blocks<R: Read + ?Sized>(
     reader: &mut R,
     max_blocks: usize,
 ) -> io::Result<Vec<RawBgzfBlock>> {
+    // No recycling pool to feed; discard the EOF marker's buffer.
+    read_raw_blocks_into(reader, max_blocks, Vec::new, |_| {})
+}
+
+/// Read multiple raw BGZF blocks as a batch, sourcing each block's
+/// byte storage from `get_buf` and routing any discarded blocks'
+/// buffers through `recycle`.
+///
+/// The buffer-recycling variant of [`read_raw_blocks`]: pass a
+/// closure that pulls `Vec<u8>` from a recycling pool to avoid the
+/// per-block `mi_malloc` that the convenience entry point pays.
+///
+/// `get_buf` is invoked only when a block header is successfully
+/// read, so clean EOF detection does not waste a checkout.
+/// `recycle` is invoked for the BGZF EOF marker block that closes
+/// every stream — its buffer is consumed via `get_buf` to read the
+/// trailer bytes but is not returned to the caller in the result
+/// `Vec`. Without the `recycle` callback the EOF marker would
+/// silently lose one pooled buffer per file (a 1-buffer-per-stream
+/// pool drain across Phase 2's K spill files).
+///
+/// # Errors
+///
+/// Returns an error if reading or validation fails. On a mid-block
+/// I/O error the freshly-checked-out buffer for the failing block
+/// is dropped (not routed through `recycle`); this is acceptable
+/// because the pool's `try_send`-based `checkin` already drops
+/// excess buffers, and a mid-block error aborts the whole sort.
+pub fn read_raw_blocks_into<R, F, G>(
+    reader: &mut R,
+    max_blocks: usize,
+    mut get_buf: F,
+    mut recycle: G,
+) -> io::Result<Vec<RawBgzfBlock>>
+where
+    R: Read + ?Sized,
+    F: FnMut() -> Vec<u8>,
+    G: FnMut(Vec<u8>),
+{
     let mut blocks = Vec::with_capacity(max_blocks);
     for _ in 0..max_blocks {
-        match read_raw_block(reader)? {
-            Some(block) => {
-                // Skip EOF marker blocks
-                if !block.is_eof() {
+        match read_raw_block_into(reader, &mut get_buf)? {
+            Some(mut block) => {
+                if block.is_eof() {
+                    // Skip the EOF marker block; return its buffer
+                    // through the recycle callback so the pool
+                    // does not lose one slot per stream.
+                    recycle(block.take_data());
+                } else {
                     blocks.push(block);
                 }
             }
@@ -513,6 +583,120 @@ mod tests {
         let mut reader = Cursor::new(Vec::<u8>::new());
         let result = read_raw_block(&mut reader).expect("reading raw BGZF block should succeed");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_raw_block_into_reuses_buffer() {
+        // Build a single-block BGZF stream by compressing a payload
+        // and concatenating its raw bytes.
+        use crate::writer::InlineBgzfCompressor;
+        let payload = b"hello, recycled buffer";
+        let mut compressor = InlineBgzfCompressor::new(6);
+        compressor.write_all(payload).expect("write");
+        compressor.flush().expect("flush");
+        let blocks = compressor.take_blocks();
+        assert_eq!(blocks.len(), 1, "small payload fits in one BGZF block");
+        let stream = blocks.into_iter().next().unwrap().data;
+
+        // Pre-warm a buffer with capacity well above the block size
+        // so we can prove the buffer is reused, not freshly allocated.
+        let recycled = Vec::with_capacity(64 * 1024);
+        let recycled_ptr = recycled.as_ptr();
+        let recycled_cap = recycled.capacity();
+
+        let mut reader = std::io::Cursor::new(stream);
+        let mut buf_holder = Some(recycled);
+        let block = read_raw_block_into(&mut reader, || buf_holder.take().expect("buf consumed"))
+            .expect("read should succeed")
+            .expect("one block before EOF");
+
+        // The returned block's data Vec is exactly the one we supplied:
+        // same allocation (ptr equal at offset 0) and capacity preserved.
+        assert!(block.data.capacity() >= recycled_cap);
+        assert!(std::ptr::eq(block.data.as_ptr(), recycled_ptr));
+
+        // Decompresses back to the original payload.
+        let mut decompressor = Decompressor::new();
+        let out = decompress_block(&block, &mut decompressor).expect("decompress");
+        assert_eq!(out.as_slice(), payload);
+    }
+
+    #[test]
+    fn test_read_raw_block_into_skips_callback_on_eof() {
+        // get_buf must not be invoked when the reader is already at
+        // clean EOF (no header bytes available).
+        let mut reader = std::io::Cursor::new(Vec::<u8>::new());
+        let called = std::cell::Cell::new(false);
+        let result = read_raw_block_into(&mut reader, || {
+            called.set(true);
+            Vec::new()
+        })
+        .expect("EOF should not be an error");
+        assert!(result.is_none(), "clean EOF returns None");
+        assert!(!called.get(), "get_buf should not be invoked on EOF");
+    }
+
+    #[test]
+    fn test_take_data_extracts_owned_buffer() {
+        let mut block = RawBgzfBlock { data: vec![1, 2, 3, 4, 5] };
+        let data = block.take_data();
+        assert_eq!(data, vec![1, 2, 3, 4, 5]);
+        assert!(block.data.is_empty(), "block's data should be drained");
+    }
+
+    #[test]
+    fn test_read_raw_blocks_into_recycles_eof_marker_and_iterates_get_buf() {
+        // Build a 3-block stream + EOF marker by compressing three
+        // payloads separately. Each `flush` emits the buffered bytes
+        // as its own BGZF block, so three flushes produce three blocks
+        // even though the payloads are small.
+        use crate::writer::InlineBgzfCompressor;
+        let payloads: [&[u8]; 3] = [b"alpha", b"beta!", b"gamma!!"];
+        let mut stream: Vec<u8> = Vec::new();
+        for p in payloads {
+            let mut compressor = InlineBgzfCompressor::new(6);
+            compressor.write_all(p).expect("write");
+            compressor.flush().expect("flush");
+            let blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1);
+            stream.extend_from_slice(&blocks[0].data);
+        }
+        // Append the BGZF EOF marker so the reader produces an
+        // EOF-marker block that `read_raw_blocks_into` must recycle.
+        stream.extend_from_slice(&BGZF_EOF);
+
+        let mut reader = std::io::Cursor::new(stream);
+        let get_calls = std::cell::Cell::new(0usize);
+        let recycled = std::cell::RefCell::new(Vec::<Vec<u8>>::new());
+
+        let blocks = read_raw_blocks_into(
+            &mut reader,
+            8, // max_blocks
+            || {
+                get_calls.set(get_calls.get() + 1);
+                Vec::with_capacity(64 * 1024)
+            },
+            |buf| recycled.borrow_mut().push(buf),
+        )
+        .expect("read");
+
+        // 3 payload blocks returned (EOF marker skipped).
+        assert_eq!(blocks.len(), 3, "3 payload blocks returned");
+        // `get_buf` was called once per block including the EOF marker = 4 times.
+        assert_eq!(get_calls.get(), 4, "get_buf called once per real block");
+        // The EOF marker's buffer was routed through `recycle`.
+        assert_eq!(recycled.borrow().len(), 1, "EOF marker buffer recycled once");
+        assert!(
+            recycled.borrow()[0].capacity() >= 64 * 1024,
+            "recycled buffer preserves original capacity"
+        );
+
+        // Payload bytes round-trip via decompress_block.
+        let mut decompressor = Decompressor::new();
+        for (block, expected) in blocks.iter().zip(payloads.iter()) {
+            let out = decompress_block(block, &mut decompressor).expect("decompress");
+            assert_eq!(out.as_slice(), *expected);
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -33,7 +33,7 @@
 use crossbeam_channel::{Receiver, Sender, bounded};
 use crossbeam_queue::ArrayQueue;
 use fgumi_bgzf::reader::decompress_block_into;
-use fgumi_bgzf::reader::read_raw_blocks;
+use fgumi_bgzf::reader::read_raw_blocks_into;
 use fgumi_bgzf::writer::InlineBgzfCompressor;
 use fgumi_bgzf::{BGZF_MAX_BLOCK_SIZE, RawBgzfBlock};
 use log::info;
@@ -658,6 +658,12 @@ pub(crate) struct SharedPipelineState {
     /// this pool inside `try_decompress_input` and `try_phase2_file_work`.
     pub(crate) decompress_buffer_pool: BufferPool,
 
+    /// Recycling pool for raw (compressed) BGZF block buffers (clone of
+    /// `SortWorkerPool::raw_block_buffer_pool`). Disk readers source
+    /// each block's byte buffer here; decompress workers return the
+    /// buffer after `decompress_block_into` completes.
+    pub(crate) raw_block_buffer_pool: BufferPool,
+
     /// Main thread handle for `park()`/`unpark()` notification.
     /// Workers call `unpark()` after inserting into `decompressed_input`
     /// (Phase 1) or into a per-file `Phase2FileState.decompressed` reorder
@@ -671,6 +677,7 @@ impl SharedPipelineState {
         num_workers: usize,
         main_thread_handle: std::thread::Thread,
         decompress_buffer_pool: BufferPool,
+        raw_block_buffer_pool: BufferPool,
     ) -> Self {
         let data_queue_cap = num_workers * 8;
         let compress_queue_cap = num_workers * 4;
@@ -699,6 +706,7 @@ impl SharedPipelineState {
 
             num_workers,
             decompress_buffer_pool,
+            raw_block_buffer_pool,
             main_thread_handle,
         }
     }
@@ -936,6 +944,17 @@ impl SortWorkerPool {
         // empty-Vec path — graceful degradation, not a correctness issue (the
         // original pre-PR behavior on every block).
         let decompress_buffer_pool = BufferPool::pre_warmed(num_workers * 32, BGZF_MAX_BLOCK_SIZE);
+        // The raw-block pool covers in-flight compressed block buffers:
+        //   Phase 1: N workers reading (1 each, via held_raw_input_blocks
+        //            staging) + N*8 raw_input_blocks ArrayQueue cap
+        //            + N workers mid-decompress (block still alive until
+        //            checkin) = ~N * 10
+        //   Phase 2: K files × PHASE2_RAW_CAP (= 8) + in-flight decompress
+        //            = ~K * 9 (overflow falls back to fresh alloc, same
+        //            graceful-degradation as the decompress pool).
+        // `N * 32` matches the decompress pool sizing for symmetry; the
+        // typical Phase 1 working set is well under this cap.
+        let raw_block_buffer_pool = BufferPool::pre_warmed(num_workers * 32, BGZF_MAX_BLOCK_SIZE);
         let stats = PoolStats::default();
         let pipeline_stats = Arc::new(SortPipelineStats::new(num_workers));
         let main_thread_handle = std::thread::current();
@@ -943,6 +962,7 @@ impl SortWorkerPool {
             num_workers,
             main_thread_handle,
             decompress_buffer_pool.clone(),
+            raw_block_buffer_pool.clone(),
         ));
 
         let workers: Vec<JoinHandle<()>> = (0..num_workers)
@@ -1289,8 +1309,17 @@ impl SortWorkerPool {
             return StepResult::InputEmpty; // No input file set
         };
 
-        // Read a batch of raw BGZF blocks
-        let blocks = match read_raw_blocks(reader.as_mut(), INPUT_READ_BATCH_SIZE) {
+        // Read a batch of raw BGZF blocks, sourcing each block's
+        // byte buffer from the recycling pool (so the decompress
+        // worker can return it after `decompress_block_into`). The
+        // EOF-marker block's buffer is recycled back via the
+        // `recycle` callback so we do not drain one slot per stream.
+        let blocks = match read_raw_blocks_into(
+            reader.as_mut(),
+            INPUT_READ_BATCH_SIZE,
+            || shared.raw_block_buffer_pool.checkout(),
+            |buf| shared.raw_block_buffer_pool.checkin(buf),
+        ) {
             Ok(b) => b,
             Err(e) => {
                 log::error!("I/O error reading input BAM: {e}");
@@ -1341,7 +1370,7 @@ impl SortWorkerPool {
             return StepResult::OutputFull;
         }
 
-        let Some((serial, block)) = shared.raw_input_blocks.pop() else {
+        let Some((serial, mut block)) = shared.raw_input_blocks.pop() else {
             // No blocks to decompress. Check if all blocks are done — the EOF
             // condition can only be detected here (not after a successful pop)
             // when the last block was already queued before input_eof was set.
@@ -1363,13 +1392,17 @@ impl SortWorkerPool {
         let mut data = shared.decompress_buffer_pool.checkout();
         if let Err(e) = decompress_block_into(&block, &mut worker.decompressor, &mut data) {
             log::error!("BGZF decompression error (input block serial {serial}): {e}");
-            // Return the buffer to the pool so we don't leak the pre-warmed
-            // allocation on the error path.
+            // Return both buffers to their pools so we don't leak
+            // pre-warmed allocations on the error path.
             shared.decompress_buffer_pool.checkin(data);
+            shared.raw_block_buffer_pool.checkin(block.take_data());
             shared.decompression_error.store(true, Ordering::Release);
             shared.main_thread_handle.unpark();
             return StepResult::InputEmpty;
         }
+        // Return the raw (compressed) buffer to the pool now that
+        // decompression has consumed its bytes.
+        shared.raw_block_buffer_pool.checkin(block.take_data());
 
         let input_eof = shared.input_eof.load(Ordering::Acquire);
         let raw_empty = shared.raw_input_blocks.is_empty();
@@ -1457,14 +1490,16 @@ impl SortWorkerPool {
             // decrement after inserting into the reorder buffer (or on the
             // error path) to keep the counter balanced.
             let popped = Self::try_pop_raw_for_decompress(file);
-            if let Some((serial, raw_block)) = popped {
+            if let Some((serial, mut raw_block)) = popped {
                 let mut data = shared.decompress_buffer_pool.checkout();
                 if let Err(e) =
                     decompress_block_into(&raw_block, &mut worker.decompressor, &mut data)
                 {
                     log::error!("BGZF decompression error (chunk source {i} serial {serial}): {e}");
-                    // Return the buffer to the pool to avoid leaking pre-warmed capacity.
+                    // Return both buffers to their pools to avoid
+                    // leaking pre-warmed capacity on the error path.
                     shared.decompress_buffer_pool.checkin(data);
+                    shared.raw_block_buffer_pool.checkin(raw_block.take_data());
                     shared.decompression_error.store(true, Ordering::Release);
                     // Balance the in-flight increment from try_pop_raw_for_decompress.
                     file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
@@ -1472,6 +1507,9 @@ impl SortWorkerPool {
                     worker.phase2_file_cursor = (i + 1) % n;
                     return StepResult::Success;
                 }
+                // Return the raw (compressed) buffer to the pool now
+                // that decompression has consumed its bytes.
+                shared.raw_block_buffer_pool.checkin(raw_block.take_data());
                 let now_poppable = {
                     let mut dec_guard =
                         file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
@@ -1513,7 +1551,12 @@ impl SortWorkerPool {
                 continue;
             }
 
-            let blocks = match read_raw_blocks(&mut reader_guard.inner, PHASE2_READ_BATCH) {
+            let blocks = match read_raw_blocks_into(
+                &mut reader_guard.inner,
+                PHASE2_READ_BATCH,
+                || shared.raw_block_buffer_pool.checkout(),
+                |buf| shared.raw_block_buffer_pool.checkin(buf),
+            ) {
                 Ok(b) => b,
                 Err(e) => {
                     log::error!("I/O error reading chunk file (source {i}): {e}");


### PR DESCRIPTION
## Summary

Adds a recycling pool for the *raw (compressed)* BGZF block buffers on input read, symmetric to PR #346's pool for decompressed-output buffers. Previously every `read_raw_blocks` call allocated one fresh `Vec<u8>` per block; for the twist-umi sort that's ~27 K `mi_malloc` + matching `mi_free` cycles on the input side, mirror-image of the decompress side PR #346 already addressed.

Stacked on `nh/perf-no-record-tovec-chunks` (PR #347). When #347 merges, this PR's base auto-retargets to `nh/perf-decompress-buffer-pool` (PR #346); when #346 merges, to `main`.

## Mechanism

### `fgumi-bgzf` additions

- `pub fn read_raw_block_into<R, F>(reader, get_buf: F)` — buffer-recycling variant. `get_buf` is invoked **only after** the 18-byte block header is successfully read; clean EOF returns `Ok(None)` without ever calling `get_buf`, so the pool is never charged for a wasted checkout.
- `pub fn read_raw_blocks_into<R, F, G>(reader, max_blocks, get_buf: F, recycle: G)` — batched variant. The extra `recycle` callback handles the BGZF EOF-marker block at end-of-stream: its buffer is consumed via `get_buf` (to read the trailer) but is **not** returned in the result `Vec`, so without `recycle` the pool would silently lose one slot per stream. Across Phase 2's K spill files that's a K-buffer drain per sort.
- `pub fn RawBgzfBlock::take_data(&mut self) -> Vec<u8>` — extracts the block's owned buffer for the consumer-side checkin.
- `read_raw_block` (no-pool single-block read) is now `#[cfg(test)]` — only test callers remain; production goes through `read_raw_block_into`.

### `fgumi-sort` changes

- New `SharedPipelineState::raw_block_buffer_pool` (pre-warmed at `BGZF_MAX_BLOCK_SIZE`, size `num_workers * 32` — same sizing as the decompress pool).
- Phase 1 `try_read_input_blocks` and Phase 2's chunk-file read step both call `read_raw_blocks_into` with `|| pool.checkout()` and `|buf| pool.checkin(buf)`.
- The decompression workers (`try_decompress_input` and `try_phase2_file_work`) check the raw buffer back in via `pool.checkin(block.take_data())` after `decompress_block_into` completes (and on the error path before propagating the error flag).
- The `raw_block_buffer_pool` field lives **only** on `SharedPipelineState` (not on `SortWorkerPool`), because no external consumer needs the pool — workers access via shared state. This is the only asymmetry with `decompress_buffer_pool`, which `PooledInputStream` and `MainThreadChunkConsumer` access via a public-crate getter.

## Benchmark

`twist-umi.mapped.bam` (1.7 GB / 16.1 M records), `--threads 8`, in-memory sort, 7 runs each via hyperfine:

| Variant | Wall time | σ |
| --- | --- | --- |
| PR #347 base | 4.480 s | ± 0.367 s |
| This PR | **4.390 s** | **± 0.070 s** |

→ 1.02× faster; **σ tightens 5×**.

The wall-time delta is small (input-side allocations are not on the critical path for an in-memory sort) but the variance reduction is the cleanest structural signal — removing input-side allocations eliminates a source of jitter independent of PR #346.

## Memory

Combined PR #346 + this PR pre-warm: `num_workers * 64 * BGZF_MAX_BLOCK_SIZE` ≈ 32 MiB at `--threads 8`, 128 MiB at `--threads 32`. Documented at the field definitions.

## Edge cases

- Mid-block I/O errors (truncated input) drop the checked-out buffer (not routed through `recycle`) — acceptable because such errors abort the entire sort. Documented in the `read_raw_blocks_into` docstring.
- The BGZF EOF marker is detected via `block.is_eof()` after construction (28-byte fixed marker). The buffer is recycled before the block is dropped.
- `block.take_data()` leaves the block with `Vec::new()` (capacity 0); no callsite reads `RawBgzfBlock::data` after `take_data`. Verified by trace.

## Tests

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` — 2067 / 2067 pass.
- Four new tests in `crates/fgumi-bgzf/src/reader.rs`:
  - `test_read_raw_block_into_reuses_buffer`: pointer-equality proof that the checked-out `Vec` becomes the block's `data` field.
  - `test_read_raw_block_into_skips_callback_on_eof`: `get_buf` is not invoked on clean EOF.
  - `test_take_data_extracts_owned_buffer`: `take_data` semantics.
  - `test_read_raw_blocks_into_recycles_eof_marker_and_iterates_get_buf`: end-to-end with 3 real blocks + EOF marker; asserts `get_buf` called once per block, `recycle` called once for the EOF marker, returned `Vec` has 3 payload blocks, recycled buffer preserves capacity, payloads decompress to original bytes.

## Test plan

- [x] `cargo build --release` clean across the workspace.
- [x] `cargo ci-fmt` passes.
- [x] `cargo ci-lint` passes (no `--no-verify`).
- [x] `cargo ci-test` — 2067 / 2067 pass.
- [x] Hyperfine bench on twist-umi (in-memory).
- [ ] CI green on this branch.

## Notes

- The signing key was unavailable at commit time; the commit is unsigned. Will re-sign / amend on rebase if needed.