### PR TITLE
perf(sort): share SegmentedBuf across in-memory sort chunks via Arc

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -23,7 +23,9 @@
 //! 3. Sort by keys while keeping raw records
 //! 4. Write raw record bytes to output
 
-use crate::inline::{ProbeableBuffer, RecordBuffer, TemplateKey, TemplateRecordBuffer};
+use crate::inline::{
+    InMemoryChunk, ProbeableBuffer, RecordBuffer, TemplateKey, TemplateRecordBuffer,
+};
 use crate::keys::{QuerynameComparator, RawSortKey, SortOrder};
 use crate::memory_probe::{
     BufferProbeStats, ConsumerProbeStats, MergeProbe, SpillProbe, force_mi_collect, log_snapshot,
@@ -733,12 +735,63 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
     }
 }
 
+/// Container for the in-memory chunks passed into the merge.
+///
+/// Inline-buffer sorts (coordinate, template) produce
+/// `Shared` chunks that share an `Arc<SegmentedBuf>` backing store —
+/// zero per-record allocation, one memcpy per record at merge time.
+///
+/// The queryname streaming path accumulates records upstream as
+/// individual `RawRecord`s and produces `Owned` chunks — the
+/// per-record allocation is sunk cost, so we preserve the original
+/// zero-copy `mem::swap` merge bridge.
+pub(crate) enum MemorySources<K: RawSortKey + Default + 'static> {
+    Shared(Vec<InMemoryChunk<K>>),
+    Owned(Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>),
+}
+
+impl<K: RawSortKey + Default + 'static> MemorySources<K> {
+    fn num_non_empty(&self) -> usize {
+        match self {
+            Self::Shared(chunks) => chunks.iter().filter(|c| !c.is_empty()).count(),
+            Self::Owned(chunks) => chunks.iter().filter(|c| !c.is_empty()).count(),
+        }
+    }
+
+    fn push_into(self, sources: &mut Vec<ChunkSource<K>>) {
+        match self {
+            Self::Shared(chunks) => {
+                for chunk in chunks {
+                    if !chunk.is_empty() {
+                        sources.push(ChunkSource::Memory { chunk, idx: 0 });
+                    }
+                }
+            }
+            Self::Owned(chunks) => {
+                for records in chunks {
+                    if !records.is_empty() {
+                        sources.push(ChunkSource::MemoryOwned { records, idx: 0 });
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Source for keyed chunks during merge (disk or in-memory).
 enum ChunkSource<K: RawSortKey + Default + 'static> {
     /// Disk-based chunk with prefetching reader (legacy path with per-source threads).
     Disk(GenericKeyedChunkReader<K>),
-    /// In-memory sorted records from the inline buffer.
-    Memory { records: Vec<(K, fgumi_raw_bam::RawRecord)>, idx: usize },
+    /// In-memory chunk from an inline-buffer sort (coordinate /
+    /// template). All records borrow their bytes from a shared
+    /// `Arc<SegmentedBuf>`; merge bridges via `extend_from_slice`.
+    Memory { chunk: InMemoryChunk<K>, idx: usize },
+    /// In-memory chunk from a queryname-style sort, where each record
+    /// was already accumulated upstream as its own `RawRecord` (owned
+    /// `Vec<u8>`). Merge bridges via `mem::swap` to preserve the
+    /// zero-copy bridge that the streaming path already pays an
+    /// allocation for upstream.
+    MemoryOwned { records: Vec<(K, fgumi_raw_bam::RawRecord)>, idx: usize },
     /// Pool-integrated disk source — workers read and decompress, main thread parses.
     /// The `source_id` maps to the `MainThreadChunkConsumer`'s per-source buffer.
     PoolDisk { source_id: usize },
@@ -756,12 +809,32 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     ) -> Result<Option<K>> {
         match self {
             ChunkSource::Disk(reader) => reader.next_record(buf),
-            ChunkSource::Memory { records, idx } => {
+            ChunkSource::Memory { chunk, idx } => {
+                if *idx < chunk.len() {
+                    // Copy record bytes out of the shared backing
+                    // `SegmentedBuf` into the merge scratch. The
+                    // previous owned-`RawRecord`-per-record design
+                    // could `mem::swap` here, but paid one heap
+                    // allocation per record at materialization time;
+                    // sharing the backing store eliminates the
+                    // per-record allocation in exchange for one
+                    // memcpy at merge time.
+                    let bytes = chunk.record_bytes(*idx);
+                    buf.clear();
+                    buf.extend_from_slice(bytes);
+                    let key = chunk.take_key(*idx);
+                    *idx += 1;
+                    Ok(Some(key))
+                } else {
+                    Ok(None)
+                }
+            }
+            ChunkSource::MemoryOwned { records, idx } => {
                 if *idx < records.len() {
                     let (ref mut key, ref mut data) = records[*idx];
-                    // Bridge: RawRecord wraps Vec<u8>; swap via the inner vec to avoid
-                    // re-allocating. The caller's buf is a plain Vec<u8> (merge scratch).
-                    // TODO: change merge scratch to RawRecord to eliminate this bridge.
+                    // Zero-copy bridge: swap the owned `RawRecord`'s
+                    // inner Vec into the merge scratch. The caller's
+                    // scratch becomes the now-stale previous record.
                     std::mem::swap(buf, data.as_mut_vec());
                     let key = std::mem::take(key);
                     *idx += 1;
@@ -1847,9 +1920,7 @@ impl RawExternalSorter {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer); each
             // chunk becomes its own in-memory merge source.
-            let memory_chunks: Vec<Vec<(RawCoordinateKey, fgumi_raw_bam::RawRecord)>> = if buffer
-                .is_empty()
-            {
+            let memory_chunks: Vec<InMemoryChunk<RawCoordinateKey>> = if buffer.is_empty() {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -1857,18 +1928,11 @@ impl RawExternalSorter {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
-                let chunk = buffer
-                    .refs()
-                    .iter()
-                    .map(|r| {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        (key, fgumi_raw_bam::RawRecord::from(buffer.get_record(r).to_vec()))
-                    })
-                    .collect();
-                vec![chunk]
+                vec![buffer.drain_into_single_chunk()]
             };
 
-            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+            let memory_chunks = MemorySources::Shared(memory_chunks);
+            let n_memory = memory_chunks.num_non_empty();
             info!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
                 chunk_files.len() + n_memory
@@ -2033,9 +2097,7 @@ impl RawExternalSorter {
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks
-            let memory_chunks: Vec<Vec<(RawCoordinateKey, fgumi_raw_bam::RawRecord)>> = if buffer
-                .is_empty()
-            {
+            let memory_chunks: Vec<InMemoryChunk<RawCoordinateKey>> = if buffer.is_empty() {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -2043,18 +2105,11 @@ impl RawExternalSorter {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
-                let chunk = buffer
-                    .refs()
-                    .iter()
-                    .map(|r| {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        (key, fgumi_raw_bam::RawRecord::from(buffer.get_record(r).to_vec()))
-                    })
-                    .collect();
-                vec![chunk]
+                vec![buffer.drain_into_single_chunk()]
             };
 
-            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+            let memory_chunks = MemorySources::Shared(memory_chunks);
+            let n_memory = memory_chunks.num_non_empty();
             info!(
                 "Phase 2: Merging {} chunks with index generation...",
                 chunk_files.len() + n_memory
@@ -2253,8 +2308,14 @@ impl RawExternalSorter {
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
-            // intermediate merge back into a single sorted buffer)
-            let memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if entries.is_empty() {
+            // intermediate merge back into a single sorted buffer). The
+            // queryname path accumulates records as individual `RawRecord`
+            // allocations upstream (per-record alloc already paid), so we
+            // sort the keyed `Vec`s in place and pack the owned `RawRecord`s
+            // into `MemorySources::Owned` for the merge interface — unlike
+            // the inline-buffer paths (coordinate, template), which produce
+            // `InMemoryChunk`s sharing an `Arc<SegmentedBuf>`.
+            let keyed_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if entries.is_empty() {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| {
@@ -2291,8 +2352,9 @@ impl RawExternalSorter {
                 });
                 vec![entries]
             };
+            let memory_chunks = MemorySources::Owned(keyed_chunks);
 
-            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+            let n_memory = memory_chunks.num_non_empty();
             info!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
                 chunk_files.len() + n_memory
@@ -2462,9 +2524,7 @@ impl RawExternalSorter {
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer)
-            let memory_chunks: Vec<Vec<(TemplateKey, fgumi_raw_bam::RawRecord)>> = if buffer
-                .is_empty()
-            {
+            let memory_chunks: Vec<InMemoryChunk<TemplateKey>> = if buffer.is_empty() {
                 Vec::new()
             } else if self.threads > 1 {
                 timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
@@ -2472,14 +2532,11 @@ impl RawExternalSorter {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
-                let chunk = buffer
-                    .iter_sorted_keyed()
-                    .map(|(k, r)| (k, fgumi_raw_bam::RawRecord::from(r.to_vec())))
-                    .collect();
-                vec![chunk]
+                vec![buffer.drain_into_single_chunk()]
             };
 
-            let n_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+            let memory_chunks = MemorySources::Shared(memory_chunks);
+            let n_memory = memory_chunks.num_non_empty();
             info!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
@@ -2516,13 +2573,13 @@ impl RawExternalSorter {
     /// does not yet support pool-integrated decompression.
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
+        memory_chunks: MemorySources<K>,
         reader_concurrency: usize,
         pool_decompress: bool,
         pool: &Arc<SortWorkerPool>,
     ) -> Result<Vec<ChunkSource<K>>> {
         let num_disk = chunk_files.len();
-        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        let num_memory = memory_chunks.num_non_empty();
         let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
 
         if pool_decompress && !chunk_files.is_empty() {
@@ -2545,11 +2602,7 @@ impl RawExternalSorter {
             }
         }
 
-        for chunk in memory_chunks {
-            if !chunk.is_empty() {
-                sources.push(ChunkSource::Memory { records: chunk, idx: 0 });
-            }
-        }
+        memory_chunks.push_into(&mut sources);
 
         Ok(sources)
     }
@@ -2561,7 +2614,7 @@ impl RawExternalSorter {
     fn merge_chunks_keyed(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(TemplateKey, fgumi_raw_bam::RawRecord)>>,
+        memory_chunks: MemorySources<TemplateKey>,
         header: &Header,
         output: &Path,
         total_records: u64,
@@ -2586,7 +2639,7 @@ impl RawExternalSorter {
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
+        memory_chunks: MemorySources<K>,
         header: &Header,
         output: &Path,
         total_records: u64,
@@ -2754,26 +2807,6 @@ impl RawExternalSorter {
         Ok(records_merged)
     }
 
-    /// Test helper: merge keyed chunk files into a BAM.
-    ///
-    /// Exposes `merge_chunks_generic` for use in tests where the spill pipeline
-    /// produces chunk files that need merging.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if merging fails.
-    #[cfg(test)]
-    pub fn merge_chunks_for_test<K: RawSortKey + Default + 'static>(
-        &self,
-        chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
-        header: &Header,
-        output: &Path,
-        pool: &Arc<SortWorkerPool>,
-    ) -> Result<u64> {
-        self.merge_chunks_generic::<K>(chunk_files, memory_chunks, header, output, 0, pool)
-    }
-
     /// Merge keyed chunks with BAM index generation.
     ///
     /// Similar to `merge_chunks_generic` but uses `IndexingBamWriter` to build
@@ -2781,7 +2814,7 @@ impl RawExternalSorter {
     fn merge_chunks_with_index<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
-        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
+        memory_chunks: MemorySources<K>,
         header: &Header,
         output: &Path,
         total_records: u64,

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -17,9 +17,108 @@
 use crate::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::radix::bytes_needed_u64;
 use crate::segmented_buf::SegmentedBuf;
-use fgumi_raw_bam::{RawRecord, RawRecordView};
+use fgumi_raw_bam::RawRecordView;
 use std::cmp::Ordering;
 use std::io::{Read, Write};
+use std::sync::Arc;
+
+// ============================================================================
+// In-memory sorted chunk (shared-buffer)
+// ============================================================================
+
+/// A sorted in-memory chunk produced by `par_sort_into_chunks`.
+///
+/// All chunks produced by a single sort share the original
+/// `RecordBuffer`'s `SegmentedBuf` via `Arc`, instead of each record
+/// owning its own `Vec<u8>`. The previous design called
+/// `RawRecord::from(buffer.get_record(r).to_vec())` once per record,
+/// paying one `mi_malloc` + memcpy per record (~16 M of each for the
+/// twist-umi sort). The shared-buffer design pays zero per-record
+/// allocations and reads record bytes directly out of the shared
+/// segments at merge time.
+///
+/// The merge consumer still copies record bytes into its own scratch
+/// `Vec<u8>` via `extend_from_slice` — the original `mem::swap`
+/// zero-copy bridge no longer applies because the bytes are now
+/// borrowed from the shared `SegmentedBuf`, not owned per record.
+/// In exchange, materialization is allocation-free and the peak
+/// memory of the sort drops by ~1× (the materialization no longer
+/// transiently doubles the buffer).
+pub(crate) struct InMemoryChunk<K> {
+    /// Shared backing store for record bytes (the original sort
+    /// buffer's `SegmentedBuf`). All sibling chunks from one
+    /// `par_sort_into_chunks` call share this Arc, so the segments
+    /// are freed only when the last chunk drops. The buffer stays
+    /// resident for the entire merge phase, unlike the pre-PR
+    /// behavior where per-record `Vec<u8>`s could free incrementally
+    /// as the merge consumed them — steady-state RSS during the
+    /// merge is slightly higher, but the materialization-peak
+    /// memory drops by ~1× (pre-PR transiently held both the buffer
+    /// and a full copy in per-record `Vec<u8>`s).
+    data: Arc<SegmentedBuf>,
+    /// `(sort_key, byte_offset_in_data, len)` per record, in sorted
+    /// order. `offset` is `u64` because a single `SegmentedBuf` can
+    /// exceed 4 GiB at high `--max-memory` × `--threads`; `len` is
+    /// `u32` because individual BAM records are < 4 GiB.
+    records: Vec<(K, u64, u32)>,
+}
+
+impl<K> InMemoryChunk<K> {
+    /// Construct an empty chunk backed by an empty shared buffer.
+    #[must_use]
+    pub(crate) fn empty() -> Self {
+        Self { data: Arc::new(SegmentedBuf::default()), records: Vec::new() }
+    }
+
+    /// Construct a chunk holding the given records, all referencing
+    /// the same shared data buffer.
+    #[must_use]
+    pub(crate) fn from_parts(data: Arc<SegmentedBuf>, records: Vec<(K, u64, u32)>) -> Self {
+        Self { data, records }
+    }
+
+    /// Number of records in the chunk.
+    #[must_use]
+    pub(crate) fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the chunk is empty.
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Borrow the `i`th record's bytes from the shared data buffer.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)] // offset/len fit in usize on all supported targets
+    pub(crate) fn record_bytes(&self, i: usize) -> &[u8] {
+        let (_, offset, len) = &self.records[i];
+        self.data.slice(*offset as usize, *len as usize)
+    }
+
+    /// Borrow the `i`th record's sort key.
+    #[must_use]
+    pub(crate) fn key_at(&self, i: usize) -> &K {
+        &self.records[i].0
+    }
+
+    /// Move out the `i`th record's key (replaces it with
+    /// `K::default()`). Used by the merge loop after the
+    /// loser-tree consumes the key.
+    pub(crate) fn take_key(&mut self, i: usize) -> K
+    where
+        K: Default,
+    {
+        std::mem::take(&mut self.records[i].0)
+    }
+}
+
+impl<K> Default for InMemoryChunk<K> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
 
 // ============================================================================
 // Buffer Probe Trait
@@ -184,22 +283,36 @@ const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
 /// Shared implementation for `par_sort_into_chunks` on both buffer types.
 ///
-/// Factors out the threshold check, chunk sizing, parallel radix sort, and
-/// materialization into a single macro so tuning and fixes stay in one place.
+/// Sorts refs in place (parallel radix sort, partitioned by `chunk_size`),
+/// then drains `self.data` into a single `Arc<SegmentedBuf>` shared
+/// across all produced chunks. Each chunk's `records` Vec is built from
+/// its refs' `(key, offset + header_size, len)` triples — no per-record
+/// allocation or memcpy.
+///
+/// `$header_size` is the byte distance from each ref's `offset` field
+/// to the start of its actual record bytes inside `data`
+/// (`HEADER_SIZE` for `RecordBuffer`, `TEMPLATE_HEADER_SIZE` for
+/// `TemplateRecordBuffer`).
 macro_rules! par_sort_into_chunks_impl {
-    ($self:expr, $threads:expr, $sort_fn:ident, $key_fn:expr) => {{
+    ($self:expr, $threads:expr, $sort_fn:ident, $header_size:expr, $key_fn:expr) => {{
         use rayon::prelude::*;
+        use std::sync::Arc;
 
         let n = $self.refs.len();
+        let header_size: u64 = $header_size as u64;
 
         if $threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
             $sort_fn(&mut $self.refs);
-            let chunk = $self
-                .refs
-                .iter()
-                .map(|r| ($key_fn(r), RawRecord::from($self.get_record(r).to_vec())))
-                .collect();
-            return vec![chunk];
+            let data = Arc::new(std::mem::take(&mut $self.data));
+            let records: Vec<_> =
+                $self.refs.iter().map(|r| ($key_fn(r), r.offset + header_size, r.len)).collect();
+            // Clear refs to leave the buffer in a consistent drained
+            // state (both `data` and `refs` empty). Callers must drop
+            // the buffer after this — `iter_sorted()` would yield zero
+            // records and `get_record()` with a stale `RecordRef` would
+            // index-panic against the empty `SegmentedBuf`.
+            $self.refs.clear();
+            return vec![InMemoryChunk::from_parts(data, records)];
         }
 
         let chunk_size = n.div_ceil($threads);
@@ -208,16 +321,21 @@ macro_rules! par_sort_into_chunks_impl {
             $sort_fn(chunk);
         });
 
-        $self
+        let data = Arc::new(std::mem::take(&mut $self.data));
+
+        let chunks: Vec<_> = $self
             .refs
             .chunks(chunk_size)
-            .map(|chunk| {
-                chunk
+            .map(|chunk_refs| {
+                let records: Vec<_> = chunk_refs
                     .iter()
-                    .map(|r| ($key_fn(r), RawRecord::from($self.get_record(r).to_vec())))
-                    .collect()
+                    .map(|r| ($key_fn(r), r.offset + header_size, r.len))
+                    .collect();
+                InMemoryChunk::from_parts(Arc::clone(&data), records)
             })
-            .collect()
+            .collect();
+        $self.refs.clear();
+        chunks
     }};
 }
 
@@ -314,17 +432,52 @@ impl RecordBuffer {
     ///
     /// Instead of merging the parallel sort sub-arrays back into one sorted
     /// buffer (as `par_sort` does), this returns each sub-array as its own
-    /// `Vec<(RawCoordinateKey, RawRecord)>` so they can be passed as separate
+    /// `InMemoryChunk<RawCoordinateKey>` so they can be passed as separate
     /// merge sources to the k-way merge, avoiding the intermediate merge step.
     ///
     /// When `threads <= 1`, returns a single chunk.
-    pub fn par_sort_into_chunks(
+    ///
+    /// After this returns, `self.data` and `self.refs` are both empty —
+    /// the produced chunks share the original data via `Arc<SegmentedBuf>`.
+    /// The caller must drop the buffer. `iter_sorted()` would yield zero
+    /// records and `get_record()` called with a stale `RecordRef` would
+    /// index-panic against the empty `SegmentedBuf`.
+    pub(crate) fn par_sort_into_chunks(
         &mut self,
         threads: usize,
-    ) -> Vec<Vec<(RawCoordinateKey, RawRecord)>> {
-        par_sort_into_chunks_impl!(self, threads, radix_sort_record_refs, |r: &RecordRef| {
-            RawCoordinateKey { sort_key: r.sort_key }
-        })
+    ) -> Vec<InMemoryChunk<RawCoordinateKey>> {
+        par_sort_into_chunks_impl!(
+            self,
+            threads,
+            radix_sort_record_refs,
+            HEADER_SIZE,
+            |r: &RecordRef| RawCoordinateKey { sort_key: r.sort_key }
+        )
+    }
+
+    /// Drain the (already-sorted) buffer into a single in-memory chunk
+    /// whose records share an `Arc<SegmentedBuf>` backing store.
+    ///
+    /// Used by sort entry points that call `par_sort` directly (e.g.
+    /// the single-thread non-rayon path) and then need to hand the
+    /// sorted records to the merge as one chunk. After this returns,
+    /// both `self.data` and `self.refs` are empty; the caller must
+    /// drop the buffer. `iter_sorted()` would yield zero records and
+    /// `get_record()` called with a stale `RecordRef` would
+    /// index-panic against the empty `SegmentedBuf`.
+    #[must_use]
+    pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<RawCoordinateKey> {
+        let data = Arc::new(std::mem::take(&mut self.data));
+        let records: Vec<_> = self
+            .refs
+            .iter()
+            .map(|r| {
+                let key = RawCoordinateKey { sort_key: r.sort_key };
+                (key, r.offset + HEADER_SIZE as u64, r.len)
+            })
+            .collect();
+        self.refs.clear();
+        InMemoryChunk::from_parts(data, records)
     }
 
     /// Get record bytes by reference.
@@ -924,17 +1077,48 @@ impl TemplateRecordBuffer {
     ///
     /// Instead of merging the parallel sort sub-arrays back into one sorted
     /// buffer (as `par_sort` does), this returns each sub-array as its own
-    /// `Vec<(TemplateKey, RawRecord)>` so they can be passed as separate merge
+    /// `InMemoryChunk<TemplateKey>` so they can be passed as separate merge
     /// sources to the k-way merge, avoiding the intermediate merge step.
     ///
     /// When `threads <= 1`, returns a single chunk.
-    pub fn par_sort_into_chunks(&mut self, threads: usize) -> Vec<Vec<(TemplateKey, RawRecord)>> {
+    ///
+    /// After this returns, `self.data` and `self.refs` are both empty —
+    /// the produced chunks share the original data via `Arc<SegmentedBuf>`.
+    /// The caller must drop the buffer. `iter_sorted_keyed()` would yield
+    /// zero records and `get_record()` called with a stale
+    /// `TemplateRecordRef` would index-panic against the empty
+    /// `SegmentedBuf`.
+    pub(crate) fn par_sort_into_chunks(
+        &mut self,
+        threads: usize,
+    ) -> Vec<InMemoryChunk<TemplateKey>> {
         par_sort_into_chunks_impl!(
             self,
             threads,
             radix_sort_template_refs,
+            TEMPLATE_HEADER_SIZE,
             |r: &TemplateRecordRef| r.key
         )
+    }
+
+    /// Drain the (already-sorted) buffer into a single in-memory chunk
+    /// whose records share an `Arc<SegmentedBuf>` backing store.
+    ///
+    /// See [`RecordBuffer::drain_into_single_chunk`] for usage and
+    /// lifetime notes — both `data` and `refs` are cleared after this
+    /// call. `iter_sorted_keyed()` would yield zero records and
+    /// `get_record()` called with a stale `TemplateRecordRef` would
+    /// index-panic against the empty `SegmentedBuf`.
+    #[must_use]
+    pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<TemplateKey> {
+        let data = Arc::new(std::mem::take(&mut self.data));
+        let records: Vec<_> = self
+            .refs
+            .iter()
+            .map(|r| (r.key, r.offset + TEMPLATE_HEADER_SIZE as u64, r.len))
+            .collect();
+        self.refs.clear();
+        InMemoryChunk::from_parts(data, records)
     }
 }
 
@@ -1876,97 +2060,6 @@ mod tests {
         record
     }
 
-    #[test]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn test_par_sort_into_chunks_single_threaded_fallback() {
-        // With 1 thread, par_sort_into_chunks should return exactly 1 chunk.
-        let n = 100;
-        let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
-
-        for i in 0..n {
-            let key = TemplateKey::new(
-                0,
-                (n - i) as i32,
-                false,
-                0,
-                200,
-                false,
-                0,
-                0,
-                (1, true),
-                0,
-                false,
-            );
-            buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
-        }
-
-        let chunks = buffer.par_sort_into_chunks(1);
-        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
-        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
-
-        // Verify the chunk is sorted
-        for i in 1..chunks[0].len() {
-            assert!(
-                chunks[0][i - 1].0 <= chunks[0][i].0,
-                "single chunk should be sorted at index {i}"
-            );
-        }
-    }
-
-    #[test]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn test_par_sort_into_chunks_parallel_path() {
-        // Use a dedicated rayon thread pool with multiple threads so that
-        // rayon::current_num_threads() > 1 inside par_sort_into_chunks.
-        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2 (512)
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(4)
-            .build()
-            .expect("failed to build rayon thread pool");
-
-        let chunks = pool.install(|| {
-            let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
-
-            for i in 0..n {
-                // Vary the primary sort field so records are not all equal
-                let key = TemplateKey::new(
-                    0,
-                    (n - i) as i32,
-                    false,
-                    0,
-                    200,
-                    false,
-                    0,
-                    0,
-                    (1, true),
-                    0,
-                    false,
-                );
-                buffer.push(&make_bam_record(i as u16), key).expect("push should succeed in tests");
-            }
-
-            buffer.par_sort_into_chunks(4)
-        });
-
-        // With 4 threads and > 10_000 records we should get multiple chunks
-        assert!(
-            chunks.len() > 1,
-            "expected multiple chunks from parallel path, got {}",
-            chunks.len()
-        );
-
-        // Verify each chunk is individually sorted
-        for (ci, chunk) in chunks.iter().enumerate() {
-            for i in 1..chunk.len() {
-                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
-            }
-        }
-
-        // Verify total record count across all chunks matches input
-        let total: usize = chunks.iter().map(Vec::len).sum();
-        assert_eq!(total, n, "total records across chunks should equal input count");
-    }
-
     /// Helper: build a minimal raw BAM record for coordinate sort with a specific position.
     fn make_coordinate_bam_record(tid: i32, pos: i32) -> Vec<u8> {
         let mut record = Vec::with_capacity(40);
@@ -1990,74 +2083,273 @@ mod tests {
         record
     }
 
-    #[test]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn test_par_sort_into_chunks_coordinate_single_threaded() {
-        let nref = 10u32;
-        let n = 100;
-        let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
-
-        for i in 0..n {
-            // Reverse order so sorting is non-trivial
-            let pos = (n - i) as i32;
-            buffer
-                .push_coordinate(&make_coordinate_bam_record(0, pos))
-                .expect("push_coordinate should succeed in tests");
+    /// Assert that `chunks` are each individually sorted and that the total
+    /// record count across all chunks equals `expected_total`.
+    fn assert_chunks_sorted_and_complete<K: RawSortKey + Default + Ord + 'static>(
+        chunks: &[InMemoryChunk<K>],
+        expected_total: usize,
+    ) {
+        for (ci, chunk) in chunks.iter().enumerate() {
+            for i in 1..chunk.len() {
+                assert!(
+                    chunk.key_at(i - 1) <= chunk.key_at(i),
+                    "chunk {ci} not sorted at index {i}"
+                );
+            }
         }
-
-        let chunks = buffer.par_sort_into_chunks(1);
-        assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
-        assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
-
-        // Verify the chunk is sorted by key
-        for i in 1..chunks[0].len() {
-            assert!(
-                chunks[0][i - 1].0 <= chunks[0][i].0,
-                "single chunk should be sorted at index {i}"
-            );
-        }
+        let total: usize = chunks.iter().map(InMemoryChunk::len).sum();
+        assert_eq!(total, expected_total, "total records across chunks should equal input count");
     }
 
-    #[test]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn test_par_sort_into_chunks_coordinate_parallel() {
-        let nref = 10u32;
-        let n: usize = 10_500; // > 10_000 and > RADIX_THRESHOLD * 2
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(4)
-            .build()
-            .expect("failed to build rayon thread pool");
+    // `par_sort_into_chunks` returns exactly 1 chunk on the single-threaded
+    // fallback (`threads == 1` or `n` below `RADIX_THRESHOLD * 2` / 10_000),
+    // and > 1 chunks on the parallel path. We cover both ends across both
+    // buffer types via `rstest`. The parallel cases must run inside a rayon
+    // pool so `rayon::current_num_threads() > 1` inside the sort.
+    //
+    // (n, threads): n=100 stays under the parallel-path floor so we exercise
+    // the fallback; n=10_500 clears both the > 10_000 and > RADIX_THRESHOLD*2
+    // (512) gates.
 
-        let chunks = pool.install(|| {
-            let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
-
+    #[rstest::rstest]
+    #[case::template_single_threaded(100, 1)]
+    #[case::template_parallel(10_500, 4)]
+    fn test_par_sort_into_chunks_template(#[case] n: usize, #[case] threads: usize) {
+        let run = || {
+            let mut buffer = TemplateRecordBuffer::with_capacity(n, n * 50);
             for i in 0..n {
-                let pos = (n - i) as i32;
+                // Reverse-vary the primary sort field so sorting is non-trivial.
+                let pos = i32::try_from(n - i).expect("test n fits in i32");
+                let idx = u16::try_from(i).expect("test n fits in u16");
+                let key = TemplateKey::new(0, pos, false, 0, 200, false, 0, 0, (1, true), 0, false);
+                buffer.push(&make_bam_record(idx), key).expect("push should succeed in tests");
+            }
+            buffer.par_sort_into_chunks(threads)
+        };
+
+        let chunks = if threads > 1 {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("failed to build rayon thread pool");
+            pool.install(run)
+        } else {
+            run()
+        };
+
+        if threads == 1 {
+            assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+            assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+        } else {
+            assert!(
+                chunks.len() > 1,
+                "expected multiple chunks from parallel path, got {}",
+                chunks.len()
+            );
+        }
+        assert_chunks_sorted_and_complete(&chunks, n);
+    }
+
+    #[rstest::rstest]
+    #[case::coordinate_single_threaded(100, 1)]
+    #[case::coordinate_parallel(10_500, 4)]
+    fn test_par_sort_into_chunks_coordinate(#[case] n: usize, #[case] threads: usize) {
+        let nref = 10u32;
+        let run = || {
+            let mut buffer = RecordBuffer::with_capacity(n, n * 50, nref);
+            for i in 0..n {
+                // Reverse-vary the position so sorting is non-trivial.
+                let pos = i32::try_from(n - i).expect("test n fits in i32");
                 buffer
                     .push_coordinate(&make_coordinate_bam_record(0, pos))
                     .expect("push_coordinate should succeed in tests");
             }
+            buffer.par_sort_into_chunks(threads)
+        };
 
+        let chunks = if threads > 1 {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("failed to build rayon thread pool");
+            pool.install(run)
+        } else {
+            run()
+        };
+
+        if threads == 1 {
+            assert_eq!(chunks.len(), 1, "single-threaded should produce exactly 1 chunk");
+            assert_eq!(chunks[0].len(), n, "the single chunk should contain all records");
+        } else {
+            assert!(
+                chunks.len() > 1,
+                "expected multiple chunks from parallel path, got {}",
+                chunks.len()
+            );
+        }
+        assert_chunks_sorted_and_complete(&chunks, n);
+    }
+
+    /// Helper: build a `SegmentedBuf` containing the given byte chunks
+    /// concatenated, plus a vec of `(offset, len)` for each chunk.
+    fn build_segmented_buf_with_records(records: &[&[u8]]) -> (SegmentedBuf, Vec<(u64, u32)>) {
+        let total_bytes: usize = records.iter().map(|r| r.len()).sum();
+        let mut buf = SegmentedBuf::with_capacity(total_bytes.max(1), total_bytes.max(1));
+        let mut offsets = Vec::with_capacity(records.len());
+        let mut cursor: u64 = 0;
+        for r in records {
+            buf.extend_in_place(r);
+            offsets.push((cursor, u32::try_from(r.len()).unwrap()));
+            cursor += r.len() as u64;
+        }
+        (buf, offsets)
+    }
+
+    #[test]
+    fn test_in_memory_chunk_from_parts_reads_records() {
+        let (buf, offsets) =
+            build_segmented_buf_with_records(&[b"first", b"second-record", b"third"]);
+        let data = Arc::new(buf);
+        let records = vec![
+            (10u32, offsets[0].0, offsets[0].1),
+            (20u32, offsets[1].0, offsets[1].1),
+            (30u32, offsets[2].0, offsets[2].1),
+        ];
+        let chunk = InMemoryChunk::<u32>::from_parts(data, records);
+
+        assert_eq!(chunk.len(), 3);
+        assert!(!chunk.is_empty());
+        assert_eq!(chunk.record_bytes(0), b"first");
+        assert_eq!(chunk.record_bytes(1), b"second-record");
+        assert_eq!(chunk.record_bytes(2), b"third");
+        assert_eq!(chunk.key_at(0), &10);
+        assert_eq!(chunk.key_at(1), &20);
+        assert_eq!(chunk.key_at(2), &30);
+    }
+
+    #[test]
+    fn test_in_memory_chunk_take_key_replaces_with_default() {
+        let (buf, offsets) = build_segmented_buf_with_records(&[b"payload"]);
+        let chunk = InMemoryChunk::<u32>::from_parts(
+            Arc::new(buf),
+            vec![(42u32, offsets[0].0, offsets[0].1)],
+        );
+        let mut chunk = chunk;
+        let k = chunk.take_key(0);
+        assert_eq!(k, 42);
+        // Subsequent take returns the default, which is what the merge
+        // loop relies on once a record has been consumed.
+        assert_eq!(chunk.take_key(0), 0);
+    }
+
+    #[test]
+    fn test_in_memory_chunk_shared_arc_across_sibling_chunks() {
+        // The whole point of the shared-buffer design: sibling chunks
+        // from a single par_sort_into_chunks call share one
+        // Arc<SegmentedBuf>, so the data isn't duplicated and is freed
+        // only when the last chunk drops.
+        let (buf, offsets) = build_segmented_buf_with_records(&[b"alpha", b"beta", b"gamma"]);
+        let data = Arc::new(buf);
+        let chunk_a = InMemoryChunk::<u32>::from_parts(
+            Arc::clone(&data),
+            vec![(1, offsets[0].0, offsets[0].1)],
+        );
+        let chunk_b = InMemoryChunk::<u32>::from_parts(
+            Arc::clone(&data),
+            vec![(2, offsets[1].0, offsets[1].1), (3, offsets[2].0, offsets[2].1)],
+        );
+        assert_eq!(Arc::strong_count(&data), 3, "data + 2 chunks share the Arc");
+        assert_eq!(chunk_a.record_bytes(0), b"alpha");
+        assert_eq!(chunk_b.record_bytes(0), b"beta");
+        assert_eq!(chunk_b.record_bytes(1), b"gamma");
+
+        drop(chunk_a);
+        assert_eq!(Arc::strong_count(&data), 2);
+        drop(chunk_b);
+        assert_eq!(Arc::strong_count(&data), 1);
+    }
+
+    #[test]
+    fn test_in_memory_chunk_empty_default() {
+        let chunk = InMemoryChunk::<u32>::empty();
+        assert_eq!(chunk.len(), 0);
+        assert!(chunk.is_empty());
+        // Default produces an empty chunk too.
+        let chunk_default: InMemoryChunk<u32> = InMemoryChunk::default();
+        assert!(chunk_default.is_empty());
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_drain_into_single_chunk_round_trips_record_bytes() {
+        // End-to-end: insert records into a real RecordBuffer, sort,
+        // drain into a single chunk, and verify that record_bytes(i)
+        // returns the same bytes the original input held (offset +
+        // HEADER_SIZE arithmetic must be correct).
+        let nref = 4u32;
+        let n: usize = 32;
+        let mut buffer = RecordBuffer::with_capacity(n, n * 64, nref);
+
+        let mut originals: Vec<Vec<u8>> = Vec::with_capacity(n);
+        for i in 0..n {
+            // Reverse position so the sort is non-trivial.
+            let rec = make_coordinate_bam_record(0, (n - i) as i32);
+            originals.push(rec.clone());
+            buffer.push_coordinate(&rec).expect("push_coordinate should succeed");
+        }
+
+        buffer.par_sort();
+        let chunk = buffer.drain_into_single_chunk();
+
+        // Buffer's refs and data must both be empty after the drain.
+        assert!(buffer.refs().is_empty(), "refs cleared after drain");
+        assert!(buffer.is_empty());
+
+        assert_eq!(chunk.len(), n);
+
+        // The chunk contains the same byte multisets as the input. Use
+        // a sorted compare since the input order was reversed.
+        let mut chunk_bytes: Vec<Vec<u8>> =
+            (0..chunk.len()).map(|i| chunk.record_bytes(i).to_vec()).collect();
+        chunk_bytes.sort();
+        originals.sort();
+        assert_eq!(chunk_bytes, originals, "chunk records round-trip input bytes");
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn test_par_sort_into_chunks_shares_arc_across_siblings() {
+        // Multi-thread path: verify all returned chunks share the same
+        // Arc<SegmentedBuf>, i.e. the macro really does avoid duplicating
+        // the source data into per-chunk owned buffers.
+        let nref = 4u32;
+        let n: usize = 10_500;
+        let pool =
+            rayon::ThreadPoolBuilder::new().num_threads(4).build().expect("rayon pool build");
+
+        let chunks = pool.install(|| {
+            let mut buffer = RecordBuffer::with_capacity(n, n * 64, nref);
+            for i in 0..n {
+                let rec = make_coordinate_bam_record(0, (n - i) as i32);
+                buffer.push_coordinate(&rec).expect("push_coordinate");
+            }
             buffer.par_sort_into_chunks(4)
         });
 
-        // With 4 threads and > 10_000 records we should get multiple chunks
-        assert!(
-            chunks.len() > 1,
-            "expected multiple chunks from parallel path, got {}",
-            chunks.len()
-        );
+        assert!(chunks.len() > 1, "expected multiple chunks");
 
-        // Verify each chunk is individually sorted
-        for (ci, chunk) in chunks.iter().enumerate() {
-            for i in 1..chunk.len() {
-                assert!(chunk[i - 1].0 <= chunk[i].0, "chunk {ci} not sorted at index {i}");
-            }
+        // All chunks must point at the same Arc. ptr_eq compares the
+        // Arc allocation address.
+        let first_data = Arc::as_ptr(&chunks[0].data);
+        for (i, c) in chunks.iter().enumerate().skip(1) {
+            assert!(
+                std::ptr::eq(Arc::as_ptr(&c.data), first_data),
+                "chunk {i} should share the same Arc as chunk 0"
+            );
         }
-
-        // Verify total record count across all chunks matches input
-        let total: usize = chunks.iter().map(Vec::len).sum();
-        assert_eq!(total, n, "total records across chunks should equal input count");
+        // Strong count = number of chunks (after the macro's local `data`
+        // binding has been dropped).
+        assert_eq!(Arc::strong_count(&chunks[0].data), chunks.len());
     }
 
     mod proptest_msd {


### PR DESCRIPTION
## Summary

Eliminates the per-record `RawRecord::from(buffer.get_record(r).to_vec())` allocation when materializing in-memory sort chunks. For an agilent-hs2 sort (~46 M records) that was ~46 M `mi_malloc` + memcpy + matching `mi_free` cycles plus a transient ~2× memory peak during materialization.

Independent of the rest of the perf stack (#341 / #344 / #346 / #347 / #348) — this PR is branched directly off `main` so it can land standalone. (The same change is also commit-2 of #347 stacked on #346; if the stack lands, this PR becomes redundant and can be closed.)

## Mechanism

A new `InMemoryChunk<K>` whose records borrow their bytes from a single `Arc<SegmentedBuf>` shared across all sibling chunks produced by one `par_sort_into_chunks` call. Each chunk stores `(sort_key, byte_offset_in_data, len)` triples; the merge consumer copies bytes via `extend_from_slice` (one memcpy per record, same as before, but without the matching `malloc`/`free`).

- The source `RecordBuffer`'s `SegmentedBuf` is moved into an `Arc` via `mem::take(&mut self.data)`; `self.refs` is also cleared so any stale `get_record` / `iter_sorted` call fails-fast at the index bound rather than silently slicing an empty buffer.
- Sibling chunks share one `Arc` (verified by a test asserting `Arc::strong_count` and `Arc::as_ptr` equality).
- The queryname streaming path is **unchanged**: it accumulates records upstream as individual `RawRecord`s (per-record alloc is sunk cost), so a second `ChunkSource::MemoryOwned` variant preserves the original zero-copy `mem::swap` merge bridge. An earlier prototype converted queryname to bulk-pack and showed a regression — hence the separate variant.
- A `MemorySources<K>` enum wraps both shapes at the merge-call boundary; `build_chunk_sources` dispatches.

## Benchmark

Bench host: EC2 `c7i.4xlarge` (Intel Xeon Platinum 8488C / Sapphire Rapids, AVX-512), Amazon Linux 2023, us-east-1b. Workload: `agilent-hs2.aligned.bam` (3.85 GiB / ~46 M records). `--order coordinate --threads 16`. Hyperfine 3 warmup + 7 runs.

| Variant | Mean | σ | Min | Max |
| --- | ---:| ---:| ---:| ---:|
| `main` | 23.655 s | ± 0.251 s | 23.313 s | 24.093 s |
| **this PR** | **22.908 s** | **± 0.187 s** | 22.675 s | 23.205 s |

→ **1.03 ± 0.01× faster (3.2 %).**

**The ranges do not overlap** — PR's max (23.205 s) is below main's min (23.313 s) across 7 runs. This is reproducible, not noise.

Variance also tightens (σ 0.187 vs 0.251), consistent with the removal of per-record allocator jitter.

## Memory

Materialization-peak memory drops by ~1× — the pre-PR design transiently held both the source `SegmentedBuf` AND per-record `Vec<u8>` copies. The shared `Arc<SegmentedBuf>` keeps the buffer resident for the entire merge phase (steady-state in-merge RSS is slightly higher than pre-PR end-of-merge RSS), but the materialization saving dominates.

## Tests

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` — 2092 / 2092 pass.
- Six new unit tests in `crates/fgumi-sort/src/inline.rs`:
  - `test_in_memory_chunk_from_parts_reads_records` — basic round-trip.
  - `test_in_memory_chunk_take_key_replaces_with_default` — merge consumer semantics.
  - `test_in_memory_chunk_shared_arc_across_sibling_chunks` — `Arc::strong_count` decrements as chunks drop.
  - `test_in_memory_chunk_empty_default` — empty/default behavior.
  - `test_drain_into_single_chunk_round_trips_record_bytes` — end-to-end: insert records into a real `RecordBuffer`, sort, drain, assert `record_bytes(i)` round-trips the input multiset (catches `HEADER_SIZE` off-by-one).
  - `test_par_sort_into_chunks_shares_arc_across_siblings` — 4-thread path returns chunks that all share one `Arc<SegmentedBuf>`.

## Test plan

- [x] `cargo build --release` clean across the workspace.
- [x] `cargo ci-fmt` passes.
- [x] `cargo ci-lint` passes (no `--no-verify`).
- [x] `cargo ci-test` — 2092 / 2092 pass.
- [x] Hyperfine bench on EC2 c7i.4xlarge against `main`.
- [ ] CI green on this branch.

## Notes

- `InMemoryChunk` is `pub(crate)` (only used inside `fgumi-sort`).
- Offsets are `u64` (a single `SegmentedBuf` can exceed 4 GiB at high `--max-memory` × `--threads`); lengths remain `u32`.
- After `par_sort_into_chunks` / `drain_into_single_chunk` returns, both `self.data` and `self.refs` are empty; the buffer is intended to be dropped immediately by the caller — `get_record` and `iter_sorted` will index-panic if called.
- The dead `merge_chunks_for_test` helper (no callers) is removed in the same commit.