### PR TITLE
perf(decode,dedup): single-pass aux scan captures UMI position (#334)

### DIFF
--- a/benches/raw_bam.rs
+++ b/benches/raw_bam.rs
@@ -209,7 +209,7 @@ fn bench_tags_read(c: &mut Criterion) {
     c.bench_function("tags::extract_string_batch", |b| {
         b.iter(|| {
             let v = RawRecordView::new(black_box(&bytes));
-            black_box(v.tags().extract_string_batch(b"CR"))
+            black_box(v.tags().extract_string_batch(b"CR", None))
         });
     });
 }

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -256,15 +256,28 @@ pub struct AuxStringTags<'a> {
     pub rg: Option<&'a [u8]>,
     pub cell: Option<&'a [u8]>,
     pub mc: Option<&'a str>,
+    /// Aux-relative `(value_offset, value_len)` of the UMI tag's value bytes
+    /// (excluding NUL terminator), when the caller supplied a `umi_tag` to look
+    /// for. `None` when no `umi_tag` was supplied, or when the tag is absent
+    /// or non-Z-typed. Aux-relative — to convert to record-relative for use
+    /// with `update_string_tag_at_position` etc., add the record's aux offset.
+    pub umi_position: Option<(u32, u16)>,
 }
 
-/// Extract RG, cell barcode, and MC tags in a single pass over the aux data.
+/// Extract RG, cell barcode, MC, and optionally UMI tag position in a single
+/// pass over the aux data.
 #[inline]
 #[must_use]
-pub fn extract_aux_string_tags(aux_data: &[u8], cell_tag: impl AsTagBytes) -> AuxStringTags<'_> {
+pub fn extract_aux_string_tags(
+    aux_data: &[u8],
+    cell_tag: impl AsTagBytes,
+    umi_tag: Option<[u8; 2]>,
+) -> AuxStringTags<'_> {
     let cell_tag = cell_tag.as_tag_bytes();
-    let mut result = AuxStringTags { rg: None, cell: None, mc: None };
-    let mut found = 0u8; // bit 0=RG, bit 1=cell, bit 2=MC
+    let mut result = AuxStringTags { rg: None, cell: None, mc: None, umi_position: None };
+    let mut found = 0u8; // bit 0=RG, bit 1=cell, bit 2=MC, bit 3=UMI
+    // Early-exit mask: only require UMI if the caller asked for it.
+    let target = 7u8 | if umi_tag.is_some() { 8 } else { 0 };
     let mut p = 0;
     while p + 3 <= aux_data.len() {
         let t = [aux_data[p], aux_data[p + 1]];
@@ -283,8 +296,15 @@ pub fn extract_aux_string_tags(aux_data: &[u8], cell_tag: impl AsTagBytes) -> Au
                 } else if t == SamTag::MC {
                     result.mc = std::str::from_utf8(value).ok();
                     found |= 4;
+                } else if matches!(umi_tag, Some(ut) if t == ut) {
+                    // Width checks are defensive only (BAM records < 4 GiB,
+                    // aux values < 64 KiB); silently skip if they fail.
+                    if let (Ok(off_u32), Ok(len_u16)) = (u32::try_from(start), u16::try_from(end)) {
+                        result.umi_position = Some((off_u32, len_u16));
+                        found |= 8;
+                    }
                 }
-                if found == 7 {
+                if found == target {
                     return result;
                 }
                 p = start + end + 1;
@@ -1253,11 +1273,16 @@ impl<'a> IntoIterator for &RawTagsView<'a> {
 }
 
 impl<'a> RawTagsView<'a> {
-    /// Single-pass extraction of (RG, cell, MC) string tags from this aux section.
+    /// Single-pass extraction of (RG, cell, MC) string tags from this aux
+    /// section, optionally also capturing the UMI tag's position.
     #[inline]
     #[must_use]
-    pub fn extract_string_batch(&self, cell_tag: impl AsTagBytes) -> AuxStringTags<'a> {
-        extract_aux_string_tags(self.0, cell_tag)
+    pub fn extract_string_batch(
+        &self,
+        cell_tag: impl AsTagBytes,
+        umi_tag: Option<[u8; 2]>,
+    ) -> AuxStringTags<'a> {
+        extract_aux_string_tags(self.0, cell_tag, umi_tag)
     }
 }
 
@@ -2607,7 +2632,7 @@ mod tests {
         aux.extend_from_slice(b"RGZsample1\x00");
         aux.extend_from_slice(b"CBZcell42\x00");
         aux.extend_from_slice(b"MCZ10M5S\x00");
-        let result = extract_aux_string_tags(&aux, SamTag::CB);
+        let result = extract_aux_string_tags(&aux, SamTag::CB, None);
         assert_eq!(result.rg, Some(b"sample1".as_ref()));
         assert_eq!(result.cell, Some(b"cell42".as_ref()));
         assert_eq!(result.mc, Some("10M5S"));
@@ -2622,7 +2647,7 @@ mod tests {
         aux.extend_from_slice(b"MCZ5M\x00");
         // Add extra tags that should never be reached
         aux.extend_from_slice(&[b'X', b'Y', b'C', 99]);
-        let result = extract_aux_string_tags(&aux, SamTag::CB);
+        let result = extract_aux_string_tags(&aux, SamTag::CB, None);
         assert_eq!(result.rg, Some(b"rg1".as_ref()));
         assert_eq!(result.cell, Some(b"bc1".as_ref()));
         assert_eq!(result.mc, Some("5M"));
@@ -2632,7 +2657,7 @@ mod tests {
     fn test_extract_aux_string_tags_partial() {
         // Only RG present, others missing
         let aux = b"RGZsample\x00";
-        let result = extract_aux_string_tags(aux, SamTag::CB);
+        let result = extract_aux_string_tags(aux, SamTag::CB, None);
         assert_eq!(result.rg, Some(b"sample".as_ref()));
         assert!(result.cell.is_none());
         assert!(result.mc.is_none());
@@ -2646,7 +2671,7 @@ mod tests {
         aux.extend_from_slice(b"RGZlib1\x00"); // RG:Z:lib1
         aux.extend_from_slice(&[b'A', b'S', b'C', 30]); // AS:C:30
         aux.extend_from_slice(b"MCZ20M\x00"); // MC:Z:20M
-        let result = extract_aux_string_tags(&aux, SamTag::CB);
+        let result = extract_aux_string_tags(&aux, SamTag::CB, None);
         assert_eq!(result.rg, Some(b"lib1".as_ref()));
         assert!(result.cell.is_none());
         assert_eq!(result.mc, Some("20M"));
@@ -2654,7 +2679,7 @@ mod tests {
 
     #[test]
     fn test_extract_aux_string_tags_empty() {
-        let result = extract_aux_string_tags(&[], SamTag::CB);
+        let result = extract_aux_string_tags(&[], SamTag::CB, None);
         assert!(result.rg.is_none());
         assert!(result.cell.is_none());
         assert!(result.mc.is_none());
@@ -2667,7 +2692,7 @@ mod tests {
         aux.extend_from_slice(b"MCZ");
         aux.extend_from_slice(&[0xFF, 0xFE, 0xFD]); // invalid UTF-8
         aux.push(0); // null terminator
-        let result = extract_aux_string_tags(&aux, SamTag::CB);
+        let result = extract_aux_string_tags(&aux, SamTag::CB, None);
         assert!(result.mc.is_none()); // from_utf8 fails
     }
 
@@ -2675,8 +2700,39 @@ mod tests {
     fn test_extract_aux_string_tags_truncated_z() {
         // RG:Z:lib1 with no null → should break out, no tags found
         let aux = b"RGZlib1";
-        let result = extract_aux_string_tags(aux, SamTag::CB);
+        let result = extract_aux_string_tags(aux, SamTag::CB, None);
         assert!(result.rg.is_none());
+    }
+
+    #[test]
+    fn test_extract_aux_string_tags_captures_umi_position() {
+        // Build aux: NM:i:5  RX:Z:ACGT  RG:Z:lib1
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"NMC");
+        aux.push(5);
+        aux.extend_from_slice(b"RXZACGT\x00");
+        aux.extend_from_slice(b"RGZlib1\x00");
+        let result = extract_aux_string_tags(&aux, SamTag::CB, Some(*SamTag::RX));
+        assert_eq!(result.rg, Some(b"lib1".as_ref()));
+        let (off, len) = result.umi_position.expect("UMI position should be captured");
+        assert_eq!(&aux[off as usize..off as usize + len as usize], b"ACGT");
+    }
+
+    #[test]
+    fn test_extract_aux_string_tags_umi_none_when_tag_absent() {
+        // Aux has RG but no RX.
+        let aux = b"RGZlib1\x00";
+        let result = extract_aux_string_tags(aux, SamTag::CB, Some(*SamTag::RX));
+        assert!(result.rg.is_some());
+        assert!(result.umi_position.is_none());
+    }
+
+    #[test]
+    fn test_extract_aux_string_tags_umi_skipped_when_caller_disinterested() {
+        // RX present but caller passed umi_tag=None — must not capture.
+        let aux = b"RXZACGT\x00";
+        let result = extract_aux_string_tags(aux, SamTag::CB, None);
+        assert!(result.umi_position.is_none());
     }
 
     // ========================================================================
@@ -3664,7 +3720,7 @@ mod tests {
         use crate::fields::RawRecordView;
         let aux = b"RGZmygrp\0BCZACGT\0MCZ50M\0";
         let rec = make_bam_bytes(0, 0, 0, b"r", &[], 0, -1, -1, aux);
-        let s = RawRecordView::new(&rec).tags().extract_string_batch(SamTag::BC);
+        let s = RawRecordView::new(&rec).tags().extract_string_batch(SamTag::BC, None);
         assert_eq!(s.rg, Some(b"mygrp".as_slice()));
         assert_eq!(s.cell, Some(b"ACGT".as_slice()));
         assert_eq!(s.mc, Some("50M"));

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -514,16 +514,23 @@ fn assign_umi_groups_for_indices(
         let processed_umi = if no_umi {
             String::new()
         } else {
-            let umi_bytes = if let Some(r1_raw) = template.r1() {
+            // Prefer the UMI position cached during the parallel Decode step
+            // (enabled via GroupKeyConfig::with_umi_tag). The fallback exists
+            // for templates built outside the Decode path and for cases where
+            // the cache was disabled.
+            let umi_bytes = if let Some(cached) = template.cached_umi() {
+                cached
+            } else if let Some(r1_raw) = template.r1() {
                 let aux = fgumi_raw_bam::aux_data_slice(r1_raw);
                 fgumi_raw_bam::find_string_tag(aux, raw_tag)
+                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
             } else if let Some(r2_raw) = template.r2() {
                 let aux = fgumi_raw_bam::aux_data_slice(r2_raw);
                 fgumi_raw_bam::find_string_tag(aux, raw_tag)
+                    .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
             } else {
-                None
+                bail!("Template has no reads");
             };
-            let umi_bytes = umi_bytes.ok_or_else(|| anyhow::anyhow!("No UMI tag found"))?;
             let umi_str = std::str::from_utf8(umi_bytes)
                 .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {e}"))?;
             let is_r1_earlier = if let (Some(r1), Some(r2)) = (template.r1(), template.r2()) {
@@ -1029,7 +1036,17 @@ impl Command for MarkDuplicates {
         info!("Using pipeline with {num_threads} threads");
 
         let library_index = LibraryIndex::from_header(&header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
+        // Cache the UMI tag's value position on each DecodedRecord so the
+        // Process step's UMI-assignment pass can slice the value without
+        // re-scanning aux data (issue #334). In `--no-umi` mode the
+        // assignment site emits `String::new()` and never reads the cache,
+        // so populating it during decode would be pure overhead.
+        let group_key_config = GroupKeyConfig::new(library_index, cell_tag);
+        pipeline_config.group_key_config = Some(if self.no_umi {
+            group_key_config
+        } else {
+            group_key_config.with_umi_tag(*raw_tag)
+        });
 
         // Cumulative MoleculeId counter, advanced **only** by the
         // serial-ordered MI Assign hook installed below. Mirrors the

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -938,9 +938,14 @@ impl Command for GroupReadsByUmi {
         let library_index = LibraryIndex::from_header(&header);
         // Cache the UMI tag's value position on each DecodedRecord so the Process
         // step's UMI-assignment pass can slice the value without re-scanning aux
-        // data (issue #334).
-        pipeline_config.group_key_config =
-            Some(GroupKeyConfig::new(library_index, cell_tag).with_umi_tag(raw_tag));
+        // data (issue #334). Skip the cache in --no-umi mode where the assignment
+        // site emits String::new() and never reads the cache.
+        let group_key_config = GroupKeyConfig::new(library_index, cell_tag);
+        pipeline_config.group_key_config = Some(if self.no_umi {
+            group_key_config
+        } else {
+            group_key_config.with_umi_tag(raw_tag)
+        });
 
         // Short-circuit support for memory bisection debugging.
         // Set FGUMI_SHORT_CIRCUIT=process|serialize|compress to skip downstream steps.
@@ -1401,8 +1406,11 @@ impl GroupReadsByUmi {
                 break; // EOF
             }
 
-            // Compute GroupKey directly from raw bytes — no noodles decode needed
-            let key = compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag));
+            // Compute GroupKey directly from raw bytes — no noodles decode needed.
+            // This caller does not need UMI position caching (the group command's
+            // hot path goes through `decode_records`, which threads the umi_tag).
+            let (key, _umi_position) =
+                compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag), None);
             let decoded = DecodedRecord::from_raw_bytes(raw_rec.clone(), key);
 
             // Feed to RecordPositionGrouper - may emit a completed group

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -128,6 +128,10 @@ impl Template {
 
     /// Returns mutable access to all records.
     pub fn records_mut(&mut self) -> &mut [RawRecord] {
+        // Mutating raw record bytes can rewrite aux data and shift the offsets
+        // captured by `cached_umi_position`. Clear the cache so `cached_umi()`
+        // does not return stale slices afterward.
+        self.cached_umi_position = None;
         &mut self.records
     }
 
@@ -454,6 +458,11 @@ impl Template {
     #[allow(clippy::too_many_lines)]
     pub fn fix_mate_info(&mut self) -> Result<()> {
         use fgumi_raw_bam;
+
+        // remove_tag / append_*_tag below rewrite MS/MC/MQ aux entries on
+        // primary records, which can shift RX bytes. Drop any cached UMI
+        // offset so `cached_umi()` does not return stale slices.
+        self.cached_umi_position = None;
 
         let rr = &mut self.records;
 
@@ -2697,5 +2706,42 @@ mod tests {
         let decoded = vec![decoded_with_cached_umi(supp), decoded_with_cached_umi(primary)];
         let template = Template::from_decoded_records(decoded).expect("template builds");
         assert_eq!(template.cached_umi(), Some(b"PRIMARYY".as_ref()));
+    }
+
+    #[test]
+    fn test_records_mut_invalidates_umi_cache() {
+        // Handing out mutable access to the primary record bytes can shift
+        // aux data, so the cached UMI offset must be cleared defensively.
+        let r1 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT, b"ACGTACGT");
+        let template = Template::from_decoded_records(vec![decoded_with_cached_umi(r1)])
+            .expect("template builds");
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()));
+
+        let mut template = template;
+        let _ = template.records_mut();
+        assert!(template.cached_umi_position.is_none());
+        assert!(template.cached_umi().is_none());
+    }
+
+    #[test]
+    fn test_fix_mate_info_invalidates_umi_cache() {
+        // fix_mate_info rewrites MS/MC/MQ aux tags on primary records via
+        // remove_tag / append_*_tag, which can shift RX bytes. The cached
+        // offset must be cleared so cached_umi() does not return stale slices.
+        let r1 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT, b"ACGTACGT");
+        let r2 =
+            build_raw_with_umi(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT, b"OTHERUMI");
+        let mut template = Template::from_decoded_records(vec![
+            decoded_with_cached_umi(r1),
+            decoded_with_cached_umi(r2),
+        ])
+        .expect("template builds");
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()));
+
+        template.fix_mate_info().expect("fix_mate_info succeeds");
+        assert!(template.cached_umi_position.is_none());
+        assert!(template.cached_umi().is_none());
     }
 }

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -391,14 +391,17 @@ pub fn decode_records(
                 ),
             ));
         }
-        let key = compute_group_key_from_raw(
+        let (key, umi_position) = compute_group_key_from_raw(
             &raw,
             &group_key_config.library_index,
             group_key_config.cell_tag,
+            group_key_config.umi_tag,
         );
         let mut decoded = DecodedRecord::from_raw_bytes(raw, key);
-        if let Some(umi_tag) = group_key_config.umi_tag {
-            cache_umi_position(&mut decoded, umi_tag);
+        // The UMI position returned above is record-relative (already converted
+        // from aux-relative inside `compute_group_key_from_raw`).
+        if let Some((value_offset, value_len)) = umi_position {
+            decoded.set_cached_umi(value_offset, value_len);
         }
         records.push(decoded);
     }
@@ -406,35 +409,17 @@ pub fn decode_records(
     Ok(records)
 }
 
-/// Cache the UMI tag's value position on a `DecodedRecord`.
-///
-/// Looks up the configured UMI tag in the record's aux data and, if present,
-/// stores the record-relative offset of its value bytes (excluding the trailing
-/// NUL terminator). When the UMI tag is absent or not Z-typed, the record's
-/// cache remains in the uninitialized `UMI_OFFSET_UNCACHED` state and
-/// downstream code must fall back to scanning aux data.
-fn cache_umi_position(decoded: &mut DecodedRecord, umi_tag: [u8; 2]) {
-    let raw = decoded.raw_bytes();
-    let Some(aux_offset) = fgumi_raw_bam::aux_data_offset_from_record(raw) else {
-        return;
-    };
-    let aux = &raw[aux_offset..];
-    let Some((value_off_in_aux, value_len)) = fgumi_raw_bam::find_string_tag_position(aux, umi_tag)
-    else {
-        return;
-    };
-    let Ok(aux_offset_u32) = u32::try_from(aux_offset) else {
-        return;
-    };
-    let Some(value_offset) = aux_offset_u32.checked_add(value_off_in_aux) else {
-        return;
-    };
-    decoded.set_cached_umi(value_offset, value_len);
-}
-
 /// Compute a `GroupKey` directly from raw BAM bytes, matching `compute_group_key()` exactly.
 ///
 /// Uses 1-based coordinate helpers to produce identical keys to the noodles path.
+///
+/// When `umi_tag` is `Some`, the same aux-data scan that locates RG, the cell
+/// barcode, and MC also locates the UMI tag's value. The returned tuple's
+/// second element is the **record-relative** `(value_offset, value_len)` of
+/// the UMI tag's value bytes (excluding NUL terminator), suitable for
+/// `DecodedRecord::set_cached_umi`. It is `None` when no `umi_tag` was
+/// supplied, when the tag is absent or non-Z-typed, or when the record's aux
+/// offset cannot be resolved.
 ///
 /// # Panics
 ///
@@ -446,7 +431,8 @@ pub fn compute_group_key_from_raw(
     raw: &[u8],
     library_index: &LibraryIndex,
     cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
-) -> super::base::GroupKey {
+    umi_tag: Option<[u8; 2]>,
+) -> (super::base::GroupKey, Option<(u32, u16)>) {
     use super::base::GroupKey;
 
     // Extract name hash (match noodles path: empty name → None → hash 0)
@@ -462,7 +448,7 @@ pub fn compute_group_key_from_raw(
     let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
     let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
     if is_secondary || is_supplementary {
-        return GroupKey { name_hash, ..GroupKey::default() };
+        return (GroupKey { name_hash, ..GroupKey::default() }, None);
     }
 
     // Own position (1-based, matching noodles) — zero-allocation CIGAR iteration
@@ -472,10 +458,20 @@ pub fn compute_group_key_from_raw(
     let own_ref_id = fgumi_raw_bam::ref_id(raw);
     let strand = u8::from(reverse);
 
-    // Single-pass aux tag extraction (RG, cell barcode, MC)
-    let aux_data = fgumi_raw_bam::aux_data_slice(raw);
+    // Single-pass aux tag extraction (RG, cell barcode, MC, optional UMI).
+    // Resolve aux_offset once so we can both slice aux data and convert the
+    // returned UMI position from aux-relative to record-relative.
+    let aux_offset = fgumi_raw_bam::aux_data_offset_from_record(raw).unwrap_or(raw.len());
+    let aux_data = &raw[aux_offset..];
     let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
-    let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes);
+    let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, umi_tag);
+
+    // Convert UMI position from aux-relative to record-relative.
+    let umi_position = aux_tags.umi_position.and_then(|(value_off_in_aux, value_len)| {
+        let aux_offset_u32 = u32::try_from(aux_offset).ok()?;
+        let value_offset = aux_offset_u32.checked_add(value_off_in_aux)?;
+        Some((value_offset, value_len))
+    });
 
     let library_idx = if let Some(rg) = aux_tags.rg {
         let rg_hash = LibraryIndex::hash_rg(rg);
@@ -490,7 +486,10 @@ pub fn compute_group_key_from_raw(
     // Check if paired
     let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
     if !is_paired {
-        return GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash);
+        return (
+            GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash),
+            umi_position,
+        );
     }
 
     // Mate info — guard against MATE_UNMAPPED (matching noodles path)
@@ -509,7 +508,7 @@ pub fn compute_group_key_from_raw(
             .map(|mc| fgumi_raw_bam::mate_unclipped_5prime_1based(raw_mate_pos, mate_reverse, mc))
     };
 
-    match mate_pos_result {
+    let key = match mate_pos_result {
         Some(mp) => GroupKey::paired(
             own_ref_id,
             own_pos,
@@ -525,7 +524,8 @@ pub fn compute_group_key_from_raw(
             // No MC tag — fall back to single-end behavior
             GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash)
         }
-    }
+    };
+    (key, umi_position)
 }
 
 // ============================================================================
@@ -4397,7 +4397,6 @@ where
 mod tests {
     use super::*;
     use crate::read_info::LibraryIndex;
-    use crate::unified_pipeline::GroupKey;
     use rstest::rstest;
 
     // ========================================================================
@@ -4889,42 +4888,6 @@ mod tests {
             .cigar_ops(&[4u32 << 4]);
         b.add_string_tag(SamTag::RX, umi);
         b.build()
-    }
-
-    #[test]
-    fn test_cache_umi_position_records_value_offset_and_len() {
-        let raw = raw_record_with_rx(b"ACGTACGT");
-        let mut decoded = DecodedRecord::from_raw_bytes(raw.as_ref().to_vec(), GroupKey::default());
-        cache_umi_position(&mut decoded, *SamTag::RX);
-
-        // The cached slice must equal the canonical find_string_tag answer.
-        let aux = fgumi_raw_bam::aux_data_slice(decoded.raw_bytes());
-        let expected = fgumi_raw_bam::find_string_tag(aux, SamTag::RX).unwrap();
-        assert_eq!(decoded.cached_umi(), Some(expected));
-        assert_eq!(decoded.cached_umi().unwrap(), b"ACGTACGT");
-    }
-
-    #[test]
-    fn test_cache_umi_position_leaves_cache_unset_when_tag_missing() {
-        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
-
-        // Record with no RX tag — caching should be a no-op.
-        let mut b = RawSamBuilder::new();
-        b.read_name(b"read1")
-            .sequence(b"ACGT")
-            .qualities(&[30u8; 4])
-            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
-            .ref_id(0)
-            .pos(0)
-            .mapq(30)
-            .cigar_ops(&[4u32 << 4]);
-        let raw = b.build();
-
-        let mut decoded = DecodedRecord::from_raw_bytes(raw.as_ref().to_vec(), GroupKey::default());
-        cache_umi_position(&mut decoded, *SamTag::RX);
-
-        assert!(decoded.cached_umi().is_none());
-        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves #334. Two improvements landed together because the smaller one revealed the larger one:

1. **`fgumi dedup` opts in to the per-record UMI position cache** (#343 infrastructure) and reads via `template.cached_umi()` in its UMI-assignment loop with a fallback to `find_string_tag`. Skipped in `--no-umi` mode (the assignment site emits `String::new()` and never reads the cache there).

2. **The cache populate is folded into `extract_aux_string_tags`**, so a single linear walk over each record's aux bytes captures RG + cell + MC + UMI position together. The previous separate `cache_umi_position` walk and helper function are deleted. `aux_data_offset_from_record` is now called exactly once per record on the decode hot path.

Both improvements affect every command that consumes the UMI cache via the parallel pipeline — `fgumi group` (already opted in via #343) and `fgumi dedup` (opted in here).

Output BAM is byte-identical pre/post on dedup: `diff <(samtools view) <(samtools view) | wc -l` = 0 across all 53.1M records on the test workload.

## Mechanics

- `AuxStringTags` gains `umi_position: Option<(u32, u16)>` (aux-relative value offset + length, NUL excluded).
- `extract_aux_string_tags` takes `umi_tag: Option<[u8; 2]>`; the inner loop captures the UMI position in the same branch ladder as RG/cell/MC; early-exit mask widens from 7 to 15 when `umi_tag` is requested.
- `compute_group_key_from_raw` returns `(GroupKey, Option<(u32, u16)>)`; `decode_records` converts aux-relative to record-relative and stores via `decoded.set_cached_umi(...)`.
- Single-threaded `group` fast path (`commands/group.rs:1408`) passes `None` for `umi_tag` — it doesn't populate the cache and didn't before.

## Measurements

Workload: 2.0 GB template-coordinate-sorted grouped BAM (53.1M records, 26.6M templates), `--threads 4`, `profiling` profile binary, warm-cache tricord runs.

### `fgumi dedup` (3-run median; runs within 0.02s wall)

| Metric | Parent (#343 tip) | This PR | Δ |
|---|---|---|---|
| wall | 17.82s | **17.67s** | **–0.8%** |
| cpu_time | 68.83s | **67.84s** | **–1.4%** |
| max_rss | 1435 MB | 1435 MB | flat |

### `fgumi group` (8-run statistics)

| Metric | Parent (#343 tip) | This PR | Δ |
|---|---|---|---|
| wall min | 17.67s | 17.66s | flat |
| wall median | 17.92s | 18.91s | (noise — bimodal due to system interference) |
| cpu_time median | 68.36s | 69.31s | (within run-to-run variance) |

`fgumi group`'s improvement is below the noise floor on this workload. Best-case runs match parent (~17.66s). The per-record CPU saving from eliminating the redundant aux walk remains architecturally real (one fewer `aux_data_offset_from_record` call + one fewer inline scan per record) and may be detectable on larger or less-noisy environments.

## Test plan

- [x] `cargo ci-fmt` / `cargo ci-lint` / `cargo ci-test` (2101/2101 pass, 23 skipped)
- [x] Output BAM byte-identical (above)
- [x] `aux_data_offset_from_record` called exactly once per record on the decode hot path (previously twice)