### PR TITLE
test: in-process Command::execute for Phase 1 commands (#352)

### DIFF
--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -1,16 +1,18 @@
-//! End-to-end CLI tests for the clip command.
+//! End-to-end tests for the clip command.
 //!
-//! These tests run the actual `fgumi clip` binary and validate:
+//! These tests invoke `Clip::execute()` in-process and validate:
 //! 1. Basic read clipping
 //! 2. Fixed clipping (5' and 3' ends)
 //! 3. Metrics output
 
+use clap::Parser;
+use fgumi_lib::commands::clip::Clip;
+use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference, to_record_buf};
@@ -72,26 +74,23 @@ fn test_clip_command_basic() {
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "clip",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--read-one-five-prime",
-            "1",
-            "--read-one-three-prime",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run clip command");
-
-    assert!(status.success(), "Clip command failed");
+    let cmd = Clip::try_parse_from([
+        "clip",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--read-one-five-prime",
+        "1",
+        "--read-one-three-prime",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse clip args");
+    cmd.execute("test").expect("Clip command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has the reads
@@ -144,25 +143,22 @@ fn test_clip_command_with_metrics() {
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "clip",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--read-one-five-prime",
-            "2",
-            "--metrics",
-            metrics_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run clip command");
-
-    assert!(status.success(), "Clip command with metrics failed");
+    let cmd = Clip::try_parse_from([
+        "clip",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--read-one-five-prime",
+        "2",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse clip args");
+    cmd.execute("test").expect("Clip command with metrics failed");
     assert!(metrics_path.exists(), "Metrics file not created");
 }

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -1,19 +1,21 @@
-//! End-to-end CLI tests for the correct command.
+//! End-to-end tests for the correct command.
 //!
-//! These tests run the actual `fgumi correct` binary and validate:
+//! These tests invoke `CorrectUmis::execute()` in-process and validate:
 //! 1. Basic UMI correction against a whitelist
 //! 2. Metrics output
 //! 3. Rejected reads output
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::correct::CorrectUmis;
+use fgumi_raw_bam::RawRecord;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
-use fgumi_raw_bam::RawRecord;
 
 /// Write a BAM with UMI-tagged reads.
 fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
@@ -51,26 +53,23 @@ fn test_correct_command_basic() {
     create_umi_bam(&input_bam, vec![correct_reads, error_reads]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has records
@@ -93,28 +92,25 @@ fn test_correct_command_with_metrics() {
     create_umi_bam(&input_bam, vec![reads]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--metrics",
-            metrics.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with metrics failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--metrics",
+        metrics.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with metrics failed");
     assert!(metrics.exists(), "Metrics file not created");
 
     let content = fs::read_to_string(&metrics).unwrap();
@@ -136,28 +132,25 @@ fn test_correct_command_with_rejects() {
     create_umi_bam(&input_bam, vec![correctable, uncorrectable]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with rejects failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 }
 
@@ -205,30 +198,27 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
     create_umi_bam(&input_bam, vec![corr_small, corr_big, far_a, far_b, far_c]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with threaded rejects failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with threaded rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -1,17 +1,19 @@
-//! End-to-end CLI tests for the dedup command.
+//! End-to-end tests for the dedup command.
 //!
-//! These tests run the actual `fgumi dedup` binary and validate:
+//! These tests invoke `MarkDuplicates::execute()` in-process and validate:
 //! 1. Basic duplicate marking
 //! 2. Metrics output
 //! 3. Remove duplicates mode
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -95,22 +97,19 @@ fn test_dedup_command_basic() {
     records.extend(create_duplicate_group("dup2", "TGCATGCA", 2, 500));
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // All reads should be present (duplicates are marked, not removed)
@@ -131,24 +130,21 @@ fn test_dedup_command_with_metrics() {
     let records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--metrics",
-            metrics_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command with metrics failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command with metrics failed");
     assert!(metrics_path.exists(), "Metrics file not created");
 }
 
@@ -163,23 +159,20 @@ fn test_dedup_command_remove_duplicates() {
     let records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--remove-duplicates",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command with --remove-duplicates failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--remove-duplicates",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command with --remove-duplicates failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // With remove-duplicates, only the best pair should remain
@@ -200,9 +193,6 @@ fn test_dedup_command_remove_duplicates() {
 #[allow(clippy::too_many_lines)]
 fn test_dedup_no_umi_large_position_group() {
     use bstr::BString;
-    use clap::Parser;
-    use fgumi_lib::commands::command::Command as FgumiCommand;
-    use fgumi_lib::commands::dedup::MarkDuplicates;
     use fgumi_raw_bam::raw_record_to_record_buf;
     use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags, testutil::encode_op};
     use noodles::sam::Header;

--- a/tests/integration/test_extract_command.rs
+++ b/tests/integration/test_extract_command.rs
@@ -6,6 +6,9 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::extract::Extract;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use noodles::bam;
@@ -99,28 +102,25 @@ fn test_extract_gzip_single_threaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command (single-threaded)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -137,30 +137,27 @@ fn test_extract_gzip_multithreaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -177,30 +174,27 @@ fn test_extract_gzip_threads_mode() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -221,28 +215,25 @@ fn test_extract_bgzf_single_threaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command (single-threaded)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF input failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF input failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -259,30 +250,27 @@ fn test_extract_bgzf_multithreaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF + --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF + --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -299,30 +287,27 @@ fn test_extract_bgzf_threads_mode() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF + --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF + --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -358,28 +343,25 @@ fn test_extract_gzip_verifies_umi_extraction() {
     );
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success());
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute extract command");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -421,28 +403,25 @@ fn test_extract_bgzf_verifies_umi_extraction() {
     );
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success());
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute extract command");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -469,30 +448,27 @@ fn test_extract_mixed_gzip_and_bgzf() {
     let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &r2_records);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with mixed gzip/BGZF should succeed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with mixed gzip/BGZF should succeed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 6, "Should have 6 records");
@@ -508,28 +484,25 @@ fn test_extract_plain_and_compressed() {
     let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &r2_records);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with plain/gzip mix should succeed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with plain/gzip mix should succeed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 6, "Should have 6 records");
@@ -567,30 +540,28 @@ fn test_parallel_parse_output_equivalence_across_threads() {
     for threads in [1, 2, 4, 8] {
         let output = tmp.path().join(format!("output_t{threads}.bam"));
 
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                &threads.to_string(),
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(status.success(), "Extract with {threads} threads failed");
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            &threads.to_string(),
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test")
+            .unwrap_or_else(|e| panic!("Extract with {threads} threads failed: {e}"));
 
         let records = read_bam_records(&output);
         outputs.push(records);
@@ -639,30 +610,27 @@ fn test_parallel_parse_determinism() {
     for run in 0..3 {
         let output = tmp.path().join(format!("output_run{run}.bam"));
 
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                "4",
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(status.success(), "Run {run} failed");
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            "4",
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test").unwrap_or_else(|e| panic!("Run {run} failed: {e}"));
         outputs.push(read_bam_records(&output));
     }
 
@@ -718,55 +686,51 @@ fn test_bgzf_sync_multithreaded_matches_single_threaded() {
 
     // Run single-threaded (fast-path)
     let output_st = tmp.path().join("output_st.bam");
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output_st.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute single-threaded extract");
-    assert!(status.success(), "Single-threaded extract failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output_st.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute single-threaded extract");
 
     // Run multithreaded (BGZF+sync through unified pipeline)
     let output_threaded = tmp.path().join("output_mt.bam");
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output_threaded.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute multithreaded extract");
-    assert!(status.success(), "Multithreaded extract failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output_threaded.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute multithreaded extract");
 
     // Compare record content (not just count)
     let st_records = read_bam_records(&output_st);
@@ -816,30 +780,27 @@ fn test_variable_length_reads_gzip() {
     let output = tmp.path().join("output.bam");
 
     // Run multithreaded (exercises RecordCount reader for gzip+sync)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "+T",
-            "+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with variable-length reads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with variable-length reads failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 8, "Should have 8 records (4 pairs × 2 reads)");
@@ -869,30 +830,27 @@ fn test_variable_length_reads_bgzf() {
     let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &records_r2);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "+T",
-            "+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "BGZF extract with variable-length reads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("BGZF extract with variable-length reads failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 8, "Should have 8 records (4 pairs × 2 reads)");
@@ -911,33 +869,30 @@ fn test_extract_multithreaded_custom_options() {
     let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &[("read1", "TGCATAAAAAAA", "IIIIIIIIIIII")]);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-            "--read-group-id",
-            "MyRG",
-            "--annotate-read-names",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Multi-threaded extract with custom options failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+        "--read-group-id",
+        "MyRG",
+        "--annotate-read-names",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Multi-threaded extract with custom options failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -1004,12 +959,9 @@ fn run_bgzf_extract(
         "1".to_string(),
     ]);
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(&args)
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "extract t{threads} {tag_suffix} failed");
+    let cmd = Extract::try_parse_from(args.iter().map(String::as_str))
+        .expect("failed to parse extract args");
+    cmd.execute("test").unwrap_or_else(|e| panic!("extract t{threads} {tag_suffix} failed: {e}"));
     read_bam_records(&output)
 }
 
@@ -1233,33 +1185,29 @@ fn test_extract_bgzf_unequal_block_counts() {
 
     for threads in [1, 4, 8] {
         let output = tmp.path().join(format!("out_unequal_t{threads}.bam"));
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                &threads.to_string(),
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(
-            status.success(),
-            "Extract with unequal BGZF block counts should succeed at T{threads}"
-        );
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            &threads.to_string(),
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test").unwrap_or_else(|e| {
+            panic!("Extract with unequal BGZF block counts should succeed at T{threads}: {e}")
+        });
 
         let records = read_bam_records(&output);
         assert_eq!(

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -1,17 +1,19 @@
-//! End-to-end CLI tests for the filter command.
+//! End-to-end tests for the filter command.
 //!
-//! These tests run the actual `fgumi filter` binary and validate:
+//! These tests invoke `Filter::execute()` in-process and validate:
 //! 1. Basic consensus read filtering
 //! 2. Rejected reads output
 //! 3. Statistics output
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
@@ -81,26 +83,23 @@ fn test_filter_command_basic() {
 
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has records (reads may have masked bases but should still be present)
@@ -153,26 +152,23 @@ fn test_filter_command_rejects_low_depth() {
 
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "3",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command with rejects failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "3",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command with rejects failed");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -214,26 +210,23 @@ fn test_filter_command_with_stats() {
 
     create_consensus_bam(&input_bam, vec![record]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--stats",
-            stats_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command with stats failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
     let content = fs::read_to_string(&stats_path).expect("Failed to read stats file");
     assert!(!content.trim().is_empty(), "Stats file should not be empty");
@@ -268,24 +261,21 @@ fn test_filter_command_no_ref_unmapped_reads() {
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
     // Run filter WITHOUT --ref
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command without --ref failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command without --ref failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -324,24 +314,21 @@ fn test_filter_command_no_ref_with_rejects() {
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
     // Run filter WITHOUT --ref, with --rejects
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "3",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command without --ref with rejects failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "3",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command without --ref with rejects failed");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -385,27 +372,25 @@ fn test_filter_command_no_ref_mapped_reads_fails() {
     create_consensus_bam(&input_bam, vec![mapped]);
 
     // Run filter WITHOUT --ref on mapped reads — should fail
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .output()
-        .expect("Failed to run filter command");
-
-    assert!(!output.status.success(), "Filter command should fail for mapped reads without --ref");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    let result = cmd.execute("test");
+    assert!(result.is_err(), "Filter command should fail for mapped reads without --ref");
+    let err_msg = format!("{:#}", result.unwrap_err());
     assert!(
-        stderr.contains("--ref is required"),
-        "Error should mention --ref requirement, got stderr: {stderr}"
+        err_msg.contains("--ref is required"),
+        "Error should mention --ref requirement, got: {err_msg}"
     );
 }

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -1,12 +1,16 @@
 //! Integration tests for the group command with new metrics infrastructure.
+//!
+//! These tests invoke `GroupReadsByUmi::execute()` in-process.
 
+use clap::Parser;
 use fgoxide::io::DelimFile;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::metrics::UmiGroupingMetrics;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
@@ -23,26 +27,23 @@ fn test_group_command_writes_new_metrics() {
     create_test_input_bam(&input_bam);
 
     // Run the group command
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "group",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--edits",
-            "0",
-            "--grouping-metrics",
-            metrics_file.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run group command");
-
-    assert!(status.success(), "Group command failed");
+    let cmd = GroupReadsByUmi::try_parse_from([
+        "group",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+        "--grouping-metrics",
+        metrics_file.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse group args");
+    cmd.execute("test").expect("Failed to run group command");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(metrics_file.exists(), "Metrics file not created");
 
@@ -78,26 +79,23 @@ fn test_group_command_rejects_n_bases_in_umi() {
     // Create BAM with UMIs containing N bases
     create_test_bam_with_n_umis(&input_bam);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "group",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--edits",
-            "0",
-            "--grouping-metrics",
-            metrics_file.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run group command");
-
-    assert!(status.success());
+    let cmd = GroupReadsByUmi::try_parse_from([
+        "group",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+        "--grouping-metrics",
+        metrics_file.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse group args");
+    cmd.execute("test").expect("Failed to run group command");
 
     // Read metrics and verify N rejection tracking
     let metrics: Vec<UmiGroupingMetrics> =


### PR DESCRIPTION
## Summary

Phase 1 of #352: convert integration tests for the simplest commands to call `Command::execute()` in-process instead of spawning the `fgumi` binary via `std::process::Command`. This lets `cargo llvm-cov nextest` instrument `execute()` bodies, restoring coverage that was previously dropped on every PR that touched a command (e.g. the four patch-coverage misses inside `MarkDuplicates::execute` flagged on #351).

Converted commands: `extract`, `group`, `dedup`, `correct`, `filter`, `clip`. ~37 subprocess invocations across 7 test files. Test surface preserved verbatim — only the invocation mechanism changes. No production code is modified.

Notes on edge cases the conversion had to handle:

- **`test_filter_command.rs` error-path test (`--ref is required`).** Previously asserted on captured stderr; now asserts on `result.unwrap_err()` rendered with `format!("{:#}", err)`, which yields the same substring through the anyhow chain.
- **`test_extract_command.rs` loop tests use `format!`-style placeholders in their failure messages** (e.g. `"Run {run} failed"`). `.expect()` is `&str`, not `format!`, so those sites use `.unwrap_or_else(|e| panic!("..."))` to preserve interpolation and also surface the underlying anyhow error.
- **`test_group_determinism.rs` is intentionally left on the subprocess path.** The test relies on each run picking up a *different* per-process `AHashMap` hasher seed to exercise the orientation-subgroup iteration bug; running all `n_runs` iterations in one in-process loop would share a single seed and silently nullify the regression guard.

## Phasing

Per the issue, this is the first of four stacked PRs:

- **Phase 1 (this PR):** extract, group (excluding determinism), dedup, correct, filter, clip
- **Phase 2:** simplex, duplex, codec, `*-metrics`, review
- **Phase 3:** zipper + compare refactors and their tests — plus `fastq` (deferred from Phase 1 because `Fastq::execute` writes unconditionally to stdout with no `--output` flag, same pipe-shape refactor as zipper)
- **Phase 4:** sort, downsample, remaining e2e

## Commits

One commit per command file (group's two files share one commit):

```
test(clip):    invoke clip    Command::execute in-process
test(dedup):   invoke dedup   Command::execute in-process
test(correct): invoke correct Command::execute in-process
test(group):   invoke group   Command::execute in-process  (test_group_determinism.rs stays subprocess)
test(filter):  invoke filter  Command::execute in-process
test(extract): invoke extract Command::execute in-process
```

## Test plan

- [x] `cargo ci-test` — 2103 passed, 23 skipped
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [ ] Codecov reports increased coverage on `src/lib/commands/{extract,group,dedup,correct,filter,clip}.rs` `execute()` bodies