### PR TITLE
refactor(compare,fastq) + test: in-process Command::execute for Phase 3 (#352)

### DIFF
--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -1273,7 +1273,7 @@ impl CompareBams {
             Ok(stats.bam1_count)
         } else {
             info!("BAM files differ");
-            std::process::exit(1);
+            Err(super::CompareMismatch("BAM files differ".to_owned()).into())
         }
     }
 
@@ -1565,7 +1565,8 @@ impl CompareBams {
             Ok(stats.bam1_count)
         } else {
             info!("BAM files differ");
-            std::process::exit(1);
+            Err(super::CompareMismatch("BAM files differ (content and groupings)".to_owned())
+                .into())
         }
     }
 
@@ -1868,7 +1869,7 @@ impl CompareBams {
             Ok(stats.total_records)
         } else {
             info!("BAM groupings differ");
-            std::process::exit(1);
+            Err(super::CompareMismatch("BAM groupings differ".to_owned()).into())
         }
     }
 
@@ -2058,7 +2059,8 @@ impl CompareBams {
             Ok(stats.total_bam1 + stats.total_bam2)
         } else {
             info!("BAM groupings differ");
-            std::process::exit(1);
+            Err(super::CompareMismatch("BAM groupings differ (order-independent)".to_owned())
+                .into())
         }
     }
 }

--- a/src/lib/commands/compare/metrics.rs
+++ b/src/lib/commands/compare/metrics.rs
@@ -227,7 +227,11 @@ impl Command for CompareMetrics {
                             line_num
                         );
                     }
-                    std::process::exit(1);
+                    return Err(super::CompareMismatch(format!(
+                        "metrics files differ: {} has extra lines",
+                        self.file1.display()
+                    ))
+                    .into());
                 }
                 (None, Some(_)) => {
                     // File2 has more lines
@@ -240,7 +244,11 @@ impl Command for CompareMetrics {
                             line_num
                         );
                     }
-                    std::process::exit(1);
+                    return Err(super::CompareMismatch(format!(
+                        "metrics files differ: {} has extra lines",
+                        self.file2.display()
+                    ))
+                    .into());
                 }
                 (Some(Err(e)), _) | (_, Some(Err(e))) => {
                     return Err(anyhow::anyhow!(
@@ -275,7 +283,7 @@ impl Command for CompareMetrics {
             Ok(())
         } else {
             info!("Metrics files differ");
-            std::process::exit(1);
+            Err(super::CompareMismatch("metrics files differ".to_owned()).into())
         }
     }
 }

--- a/src/lib/commands/compare/mod.rs
+++ b/src/lib/commands/compare/mod.rs
@@ -14,6 +14,17 @@ use clap::{Parser, Subcommand};
 pub use bams::CompareBams;
 pub use metrics::CompareMetrics;
 
+/// Marker error returned when a compare subcommand detects a mismatch between
+/// the two inputs.
+///
+/// The CLI maps this to exit code 1 so the shell contract is preserved.
+/// In-process callers (e.g. integration tests running under `cargo-llvm-cov`) can
+/// downcast an `anyhow::Error` to this type to distinguish "mismatch found" from a
+/// genuine I/O or logic error.
+#[derive(Debug, thiserror::Error)]
+#[error("compare detected a mismatch: {0}")]
+pub struct CompareMismatch(pub String);
+
 /// Compare files for testing and validation.
 #[derive(Parser, Debug)]
 #[command(

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -74,6 +74,11 @@ pub struct Fastq {
     #[arg(short = 'i', long = "input")]
     pub input: PathBuf,
 
+    /// Output FASTQ file. If omitted, the FASTQ stream is written to stdout
+    /// (the default, intended for piping straight to an aligner).
+    #[arg(short = 'o', long = "output")]
+    pub output: Option<PathBuf>,
+
     /// Don't append /1 and /2 to read names.
     #[arg(short = 'n', long = "no-read-suffix", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub no_suffix: bool,
@@ -105,10 +110,12 @@ fn parse_flags(s: &str) -> Result<u16, String> {
     }
 }
 
-impl Command for Fastq {
-    fn execute(&self, _command_line: &str) -> Result<()> {
-        validate_file_exists(&self.input, "Input BAM")?;
-
+impl Fastq {
+    /// Run the BAM-to-FASTQ conversion loop against the given writer.
+    ///
+    /// Extracted so `execute` can dispatch between stdout (the default piping
+    /// path) and a file (`--output`) without duplicating the conversion loop.
+    fn run_with_writer<W: Write>(&self, mut writer: W) -> Result<()> {
         let timer = OperationTimer::new("Converting BAM to FASTQ");
 
         info!("Input: {}", self.input.display());
@@ -119,9 +126,6 @@ impl Command for Fastq {
         info!("BWA chunk size: {} bases", self.bwa_chunk_size);
 
         let (mut reader, _header) = create_raw_bam_reader(&self.input, self.threads)?;
-
-        // Use 64MB buffer for efficient pipe throughput
-        let mut writer = BufWriter::with_capacity(64 * 1024 * 1024, stdout().lock());
 
         let mut total_records: u64 = 0;
         let mut written_records: u64 = 0;
@@ -184,6 +188,35 @@ impl Command for Fastq {
         info!("Read {total_records} records, wrote {written_records} FASTQ records");
         timer.log_completion(written_records);
         Ok(())
+    }
+}
+
+impl Command for Fastq {
+    fn execute(&self, _command_line: &str) -> Result<()> {
+        validate_file_exists(&self.input, "Input BAM")?;
+
+        // Refuse to clobber the input BAM. `File::create(path)` truncates
+        // before the input is opened in `run_with_writer`, so an `--output`
+        // pointing at the same file silently destroys the input data.
+        if let Some(output) = &self.output
+            && output == &self.input
+        {
+            anyhow::bail!(
+                "--output {} must differ from --input {} (would truncate the input BAM)",
+                output.display(),
+                self.input.display()
+            );
+        }
+
+        // Use 64MB buffer for efficient pipe throughput.
+        const BUF_CAPACITY: usize = 64 * 1024 * 1024;
+        match &self.output {
+            Some(path) => {
+                let file = std::fs::File::create(path)?;
+                self.run_with_writer(BufWriter::with_capacity(BUF_CAPACITY, file))
+            }
+            None => self.run_with_writer(BufWriter::with_capacity(BUF_CAPACITY, stdout().lock())),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command;
 #[cfg(feature = "compare")]
 use fgumi_lib::commands::compare::Compare;
+#[cfg(feature = "compare")]
+use fgumi_lib::commands::compare::CompareMismatch;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::commands::downsample::Downsample;
@@ -205,5 +207,15 @@ fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or(default_level)).init();
 
     info!("Running fgumi version {}", fgumi_lib::version::VERSION.as_str());
-    args.subcommand.execute(&command_line)
+
+    let result = args.subcommand.execute(&command_line);
+
+    #[cfg(feature = "compare")]
+    if let Err(ref e) = result {
+        if e.downcast_ref::<CompareMismatch>().is_some() {
+            std::process::exit(1);
+        }
+    }
+
+    result
 }

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -1,16 +1,18 @@
-//! End-to-end CLI tests for the clip command.
+//! End-to-end tests for the clip command.
 //!
-//! These tests run the actual `fgumi clip` binary and validate:
+//! These tests invoke `Clip::execute()` in-process and validate:
 //! 1. Basic read clipping
 //! 2. Fixed clipping (5' and 3' ends)
 //! 3. Metrics output
 
+use clap::Parser;
+use fgumi_lib::commands::clip::Clip;
+use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference, to_record_buf};
@@ -72,26 +74,23 @@ fn test_clip_command_basic() {
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "clip",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--read-one-five-prime",
-            "1",
-            "--read-one-three-prime",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run clip command");
-
-    assert!(status.success(), "Clip command failed");
+    let cmd = Clip::try_parse_from([
+        "clip",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--read-one-five-prime",
+        "1",
+        "--read-one-three-prime",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse clip args");
+    cmd.execute("test").expect("Clip command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has the reads
@@ -144,25 +143,22 @@ fn test_clip_command_with_metrics() {
 
     create_paired_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "clip",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--read-one-five-prime",
-            "2",
-            "--metrics",
-            metrics_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run clip command");
-
-    assert!(status.success(), "Clip command with metrics failed");
+    let cmd = Clip::try_parse_from([
+        "clip",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--read-one-five-prime",
+        "2",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse clip args");
+    cmd.execute("test").expect("Clip command with metrics failed");
     assert!(metrics_path.exists(), "Metrics file not created");
 }

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -1,19 +1,21 @@
-//! End-to-end CLI tests for the codec command.
+//! End-to-end in-process tests for the codec command.
 //!
-//! These tests run the actual `fgumi codec` binary and validate:
+//! These tests invoke the `Codec` command's `execute()` method in-process and validate:
 //! 1. Basic consensus calling from CODEC read pairs
 //! 2. Statistics output
 //! 3. Rejected reads output
 //! 4. Quality filtering options
 
+use clap::Parser;
 use fgumi_bam_io::create_raw_bam_writer;
 use fgumi_dna::reverse_complement;
+use fgumi_lib::commands::codec::Codec;
+use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
 use noodles::bam;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::create_minimal_header;
@@ -119,24 +121,21 @@ fn test_codec_command_basic_consensus() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Read output and verify consensus was created
@@ -195,26 +194,23 @@ fn test_codec_command_with_stats() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command with stats
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--stats",
-            stats_file.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--stats",
+        stats_file.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
     assert!(stats_file.exists(), "Stats file not created");
 
     // Verify stats file has content
@@ -264,26 +260,23 @@ fn test_codec_command_with_rejects() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command with rejects output and high min-reads
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--min-reads",
-            "3",
-            "--min-duplex-length",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--min-reads",
+        "3",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -325,24 +318,21 @@ fn test_codec_command_min_duplex_length() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command with high min-duplex-length (should reject)
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "100", // Much longer than our 8bp reads
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "100", // Much longer than our 8bp reads
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
 
     // Should produce no consensus due to insufficient duplex length
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -377,25 +367,22 @@ fn test_codec_command_per_base_tags() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command with per-base tags
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            "--output-per-base-tags",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--output-per-base-tags",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
 
     // Verify per-base tags exist
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -438,24 +425,21 @@ fn test_codec_command_cell_barcode_preservation() {
     create_codec_test_bam(&input_bam, pairs);
 
     // Run codec command with cell-tag option
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(status.success(), "Codec command failed");
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test").expect("Failed to run codec command");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Read output and verify cell barcode is preserved
@@ -553,32 +537,27 @@ fn test_codec_command_recovers_from_duplex_disagreement() {
     let (r1, r2) = create_offset_codec_pair("disagree_read", "UMI_DISAGREE");
     create_codec_test_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            // Strict: any disagreement rejects the molecule. Forces
-            // `is_duplex_disagreement()` to return true so the loop
-            // continues instead of returning the wrapped error.
-            "--max-duplex-disagreements",
-            "0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(
-        status.success(),
-        "Codec command must succeed when only failure is a recoverable reject"
-    );
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        // Strict: any disagreement rejects the molecule. Forces
+        // `is_duplex_disagreement()` to return true so the loop
+        // continues instead of returning the wrapped error.
+        "--max-duplex-disagreements",
+        "0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test")
+        .expect("Codec command must succeed when only failure is a recoverable reject");
 
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
     let _header = reader.read_header().unwrap();
@@ -600,33 +579,28 @@ fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
     let (r1, r2) = create_offset_codec_pair("disagree_read_mt", "UMI_DISAGREE_MT");
     create_codec_test_bam(&input_bam, vec![(r1, r2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "codec",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--threads",
-            "2",
-            "--min-reads",
-            "1",
-            "--min-duplex-length",
-            "1",
-            "--max-duplex-disagreements",
-            "0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run codec command");
-
-    assert!(
-        status.success(),
-        "Threaded codec command must succeed when only failure is a recoverable reject"
-    );
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--threads",
+        "2",
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--max-duplex-disagreements",
+        "0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("test")
+        .expect("Threaded codec command must succeed when only failure is a recoverable reject");
 
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
     let _header = reader.read_header().unwrap();

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -3,6 +3,9 @@
 //! These tests exercise all three compare modes (content, full, grouping)
 //! using the raw byte comparison path.
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::compare::{CompareBams, CompareMismatch};
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
@@ -28,7 +31,11 @@ fn write_bam(path: &Path, header: &Header, records: &[RawRecord]) {
     writer.try_finish().expect("Failed to finish BAM");
 }
 
-/// Runs `fgumi compare bams` and returns (success, stdout).
+/// Runs `fgumi compare bams` via subprocess and returns (success, stdout).
+///
+/// Used by tests that assert on specific substrings in the diagnostic report
+/// (e.g. EQUIVALENT vs IDENTICAL, mismatch counts). For tests that only need
+/// to know whether the BAMs matched, prefer `run_compare_in_process`.
 fn run_compare(bam1: &Path, bam2: &Path, mode: &str, extra_args: &[&str]) -> (bool, String) {
     let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
         .args(["compare", "bams"])
@@ -41,6 +48,22 @@ fn run_compare(bam1: &Path, bam2: &Path, mode: &str, extra_args: &[&str]) -> (bo
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     (output.status.success(), stdout)
+}
+
+/// Runs `CompareBams::execute()` in-process and returns true on match
+/// (IDENTICAL or EQUIVALENT), false on `CompareMismatch` (DIFFER).
+///
+/// Panics if `execute` returns any other error.
+fn run_compare_in_process(bam1: &Path, bam2: &Path, mode: &str, extra_args: &[&str]) -> bool {
+    let mut args: Vec<&str> =
+        vec!["bams", bam1.to_str().unwrap(), bam2.to_str().unwrap(), "--mode", mode];
+    args.extend(extra_args);
+    let cmd = CompareBams::try_parse_from(args).expect("failed to parse compare bams args");
+    match cmd.execute("test") {
+        Ok(()) => true,
+        Err(e) if e.is::<CompareMismatch>() => false,
+        Err(e) => panic!("compare bams hit unexpected error: {e:#}"),
+    }
 }
 
 /// Builds a simple mapped record with a given name and position.
@@ -83,9 +106,10 @@ fn test_content_mode_identical_bams() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "content", &[]);
-    assert!(success, "Expected success for identical BAMs, stdout:\n{stdout}");
-    assert!(stdout.contains("IDENTICAL"), "Expected IDENTICAL in output, got:\n{stdout}");
+    assert!(
+        run_compare_in_process(&bam1, &bam2, "content", &[]),
+        "Expected match for identical BAMs in content mode"
+    );
 }
 
 #[test]
@@ -101,9 +125,10 @@ fn test_content_mode_different_position() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "content", &[]);
-    assert!(!success, "Expected failure for different BAMs, stdout:\n{stdout}");
-    assert!(stdout.contains("DIFFER"), "Expected DIFFER in output, got:\n{stdout}");
+    assert!(
+        !run_compare_in_process(&bam1, &bam2, "content", &[]),
+        "Expected mismatch for different positions in content mode"
+    );
 }
 
 #[test]
@@ -119,9 +144,10 @@ fn test_content_mode_different_record_count() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "content", &[]);
-    assert!(!success, "Expected failure for different record counts, stdout:\n{stdout}");
-    assert!(stdout.contains("DIFFER"), "Expected DIFFER in output, got:\n{stdout}");
+    assert!(
+        !run_compare_in_process(&bam1, &bam2, "content", &[]),
+        "Expected mismatch for different record counts in content mode"
+    );
 }
 
 #[test]
@@ -136,9 +162,10 @@ fn test_content_mode_multithreaded() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "content", &["-t", "4"]);
-    assert!(success, "Expected success for identical BAMs with threads, stdout:\n{stdout}");
-    assert!(stdout.contains("IDENTICAL"), "Expected IDENTICAL in output, got:\n{stdout}");
+    assert!(
+        run_compare_in_process(&bam1, &bam2, "content", &["-t", "4"]),
+        "Expected match for identical BAMs with --threads 4"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -160,9 +187,10 @@ fn test_full_mode_identical_bams() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "full", &[]);
-    assert!(success, "Expected success for identical BAMs in full mode, stdout:\n{stdout}");
-    assert!(stdout.contains("IDENTICAL"), "Expected IDENTICAL in output, got:\n{stdout}");
+    assert!(
+        run_compare_in_process(&bam1, &bam2, "full", &[]),
+        "Expected match for identical BAMs in full mode"
+    );
 }
 
 #[test]
@@ -180,9 +208,10 @@ fn test_full_mode_different_mi_tags() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "full", &[]);
-    assert!(!success, "Expected failure for different MI tags in full mode, stdout:\n{stdout}");
-    assert!(stdout.contains("DIFFER"), "Expected DIFFER in output, got:\n{stdout}");
+    assert!(
+        !run_compare_in_process(&bam1, &bam2, "full", &[]),
+        "Expected mismatch for different MI tags in full mode"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -513,12 +542,10 @@ fn test_full_mode_fails_when_mi_missing_in_both_bams() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "full", &[]);
     assert!(
-        !success,
-        "Expected failure when MI tags are missing in both BAMs (full mode), stdout:\n{stdout}"
+        !run_compare_in_process(&bam1, &bam2, "full", &[]),
+        "Expected mismatch when MI tags are missing in both BAMs (full mode)"
     );
-    assert!(stdout.contains("DIFFER"), "Expected DIFFER in output, got:\n{stdout}");
 }
 
 #[test]
@@ -532,12 +559,10 @@ fn test_grouping_unordered_fails_when_mi_missing_in_both_bams() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let (success, stdout) = run_compare(&bam1, &bam2, "grouping", &["--ignore-order"]);
     assert!(
-        !success,
-        "Expected failure when MI tags are missing in both BAMs (ignore-order), stdout:\n{stdout}"
+        !run_compare_in_process(&bam1, &bam2, "grouping", &["--ignore-order"]),
+        "Expected mismatch when MI tags are missing in both BAMs (ignore-order)"
     );
-    assert!(stdout.contains("DIFFER"), "Expected DIFFER in output, got:\n{stdout}");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -1,19 +1,21 @@
-//! End-to-end CLI tests for the correct command.
+//! End-to-end tests for the correct command.
 //!
-//! These tests run the actual `fgumi correct` binary and validate:
+//! These tests invoke `CorrectUmis::execute()` in-process and validate:
 //! 1. Basic UMI correction against a whitelist
 //! 2. Metrics output
 //! 3. Rejected reads output
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::correct::CorrectUmis;
+use fgumi_raw_bam::RawRecord;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
-use fgumi_raw_bam::RawRecord;
 
 /// Write a BAM with UMI-tagged reads.
 fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
@@ -51,26 +53,23 @@ fn test_correct_command_basic() {
     create_umi_bam(&input_bam, vec![correct_reads, error_reads]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has records
@@ -93,28 +92,25 @@ fn test_correct_command_with_metrics() {
     create_umi_bam(&input_bam, vec![reads]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--metrics",
-            metrics.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with metrics failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--metrics",
+        metrics.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with metrics failed");
     assert!(metrics.exists(), "Metrics file not created");
 
     let content = fs::read_to_string(&metrics).unwrap();
@@ -136,28 +132,25 @@ fn test_correct_command_with_rejects() {
     create_umi_bam(&input_bam, vec![correctable, uncorrectable]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with rejects failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 }
 
@@ -205,30 +198,27 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
     create_umi_bam(&input_bam, vec![corr_small, corr_big, far_a, far_b, far_c]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "correct",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--umi-files",
-            whitelist.to_str().unwrap(),
-            "--max-mismatches",
-            "1",
-            "--min-distance",
-            "1",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run correct command");
-
-    assert!(status.success(), "Correct command with threaded rejects failed");
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse correct args");
+    cmd.execute("test").expect("Correct command with threaded rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -1,17 +1,19 @@
-//! End-to-end CLI tests for the dedup command.
+//! End-to-end tests for the dedup command.
 //!
-//! These tests run the actual `fgumi dedup` binary and validate:
+//! These tests invoke `MarkDuplicates::execute()` in-process and validate:
 //! 1. Basic duplicate marking
 //! 2. Metrics output
 //! 3. Remove duplicates mode
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -95,22 +97,19 @@ fn test_dedup_command_basic() {
     records.extend(create_duplicate_group("dup2", "TGCATGCA", 2, 500));
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // All reads should be present (duplicates are marked, not removed)
@@ -131,24 +130,21 @@ fn test_dedup_command_with_metrics() {
     let records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--metrics",
-            metrics_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command with metrics failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command with metrics failed");
     assert!(metrics_path.exists(), "Metrics file not created");
 }
 
@@ -163,23 +159,20 @@ fn test_dedup_command_remove_duplicates() {
     let records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
     create_sorted_bam(&input_bam, records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "dedup",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--remove-duplicates",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run dedup command");
-
-    assert!(status.success(), "Dedup command with --remove-duplicates failed");
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--remove-duplicates",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("Dedup command with --remove-duplicates failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // With remove-duplicates, only the best pair should remain
@@ -200,9 +193,6 @@ fn test_dedup_command_remove_duplicates() {
 #[allow(clippy::too_many_lines)]
 fn test_dedup_no_umi_large_position_group() {
     use bstr::BString;
-    use clap::Parser;
-    use fgumi_lib::commands::command::Command as FgumiCommand;
-    use fgumi_lib::commands::dedup::MarkDuplicates;
     use fgumi_raw_bam::raw_record_to_record_buf;
     use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags, testutil::encode_op};
     use noodles::sam::Header;

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -1,17 +1,19 @@
 //! End-to-end CLI tests for the duplex command.
 //!
-//! These tests run the actual `fgumi duplex` binary and validate:
+//! These tests invoke `Duplex::execute()` in-process and validate:
 //! 1. Basic duplex consensus calling from paired-UMI grouped reads
 //! 2. Statistics output
 //! 3. Rejected reads output
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::duplex::Duplex;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -159,22 +161,19 @@ fn test_duplex_command_basic() {
     let molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
     create_duplex_bam(&input_bam, vec![molecule]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run duplex command");
-
-    assert!(status.success(), "Duplex command failed");
+    let cmd = Duplex::try_parse_from([
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse duplex args");
+    cmd.execute("test").expect("Duplex command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify consensus reads were produced
@@ -213,26 +212,23 @@ fn test_duplex_command_with_rejects() {
     let singleton = vec![create_duplex_read_pair("solo", "2/A", "ACGTACGT", 30, 500, false)];
     create_duplex_bam(&input_bam, vec![kept, singleton]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--threads",
-            "2",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run duplex command");
-
-    assert!(status.success(), "Duplex command with rejects failed");
+    let cmd = Duplex::try_parse_from([
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--threads",
+        "2",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse duplex args");
+    cmd.execute("test").expect("Duplex command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_rejects_header_matches_input(&rejects_bam, &input_bam);
@@ -291,26 +287,23 @@ fn test_duplex_command_rejects_contain_no_duplicates() {
     molecules.extend(singletons);
     create_duplex_bam(&input_bam, molecules);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--threads",
-            "2",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run duplex command");
-
-    assert!(status.success(), "Duplex command with rejects failed");
+    let cmd = Duplex::try_parse_from([
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--threads",
+        "2",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse duplex args");
+    cmd.execute("test").expect("Duplex command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
     crate::helpers::assertions::assert_has_bgzf_eof(&rejects_bam);
@@ -351,23 +344,20 @@ fn test_duplex_command_with_stats() {
     let molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
     create_duplex_bam(&input_bam, vec![molecule]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--stats",
-            stats_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run duplex command");
-
-    assert!(status.success(), "Duplex command with stats failed");
+    let cmd = Duplex::try_parse_from([
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse duplex args");
+    cmd.execute("test").expect("Duplex command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
 }

--- a/tests/integration/test_duplex_metrics_command.rs
+++ b/tests/integration/test_duplex_metrics_command.rs
@@ -1,6 +1,9 @@
 //! Integration tests for the duplex-metrics command.
 
+use clap::Parser;
 use fgoxide::io::DelimFile;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::duplex_metrics::DuplexMetrics;
 use fgumi_lib::metrics::duplex::{DuplexFamilySizeMetric, FamilySizeMetric};
 use fgumi_lib::metrics::shared::UmiMetric;
 use fgumi_lib::sam::SamTag;
@@ -10,7 +13,6 @@ use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -189,18 +191,15 @@ fn test_duplex_metrics_command_creates_output_files() {
     let header = create_minimal_header("chr1", 10000);
     create_duplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command");
-
-    assert!(status.success(), "duplex-metrics command failed");
+    let cmd = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse duplex-metrics args");
+    cmd.execute("test").expect("duplex-metrics command failed");
 
     // Verify all expected output files exist
     let family_sizes_path = format!("{}.family_sizes.txt", output_prefix.display());
@@ -230,18 +229,15 @@ fn test_duplex_metrics_command_family_sizes() {
     let header = create_minimal_header("chr1", 10000);
     create_duplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command");
-
-    assert!(status.success(), "duplex-metrics command failed");
+    let cmd = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse duplex-metrics args");
+    cmd.execute("test").expect("duplex-metrics command failed");
 
     // Read and validate family size metrics
     let family_sizes_path = format!("{}.family_sizes.txt", output_prefix.display());
@@ -270,18 +266,15 @@ fn test_duplex_metrics_command_duplex_family_sizes() {
     let header = create_minimal_header("chr1", 10000);
     create_duplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command");
-
-    assert!(status.success(), "duplex-metrics command failed");
+    let cmd = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse duplex-metrics args");
+    cmd.execute("test").expect("duplex-metrics command failed");
 
     // Read and validate duplex family size metrics
     let duplex_family_sizes_path = format!("{}.duplex_family_sizes.txt", output_prefix.display());
@@ -310,18 +303,15 @@ fn test_duplex_metrics_command_umi_metrics() {
     let header = create_minimal_header("chr1", 10000);
     create_duplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command");
-
-    assert!(status.success(), "duplex-metrics command failed");
+    let cmd = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse duplex-metrics args");
+    cmd.execute("test").expect("duplex-metrics command failed");
 
     // Read and validate UMI metrics
     let umi_counts_path = format!("{}.umi_counts.txt", output_prefix.display());
@@ -347,19 +337,16 @@ fn test_duplex_metrics_command_with_duplex_umi_counts() {
     let header = create_minimal_header("chr1", 10000);
     create_duplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-            "--duplex-umi-counts",
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command");
-
-    assert!(status.success(), "duplex-metrics command failed with --duplex-umi-counts");
+    let cmd = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+        "--duplex-umi-counts",
+    ])
+    .expect("failed to parse duplex-metrics args");
+    cmd.execute("test").expect("duplex-metrics command failed with --duplex-umi-counts");
 
     // Verify the additional duplex UMI counts file exists
     let duplex_umi_counts_path = format!("{}.duplex_umi_counts.txt", output_prefix.display());
@@ -381,36 +368,30 @@ fn test_duplex_metrics_command_min_reads_parameters() {
     create_duplex_test_bam(&input_bam, &header);
 
     // Run with default parameters (min-ab=1, min-ba=1)
-    let status_default = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix_default.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command (default)");
-
-    assert!(status_default.success(), "duplex-metrics command failed (default)");
+    let cmd_default = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix_default.to_str().unwrap(),
+    ])
+    .expect("failed to parse duplex-metrics args (default)");
+    cmd_default.execute("test").expect("duplex-metrics command failed (default)");
 
     // Run with stricter parameters (min-ab=2, min-ba=2)
-    let status_strict = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "duplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix_strict.to_str().unwrap(),
-            "--min-ab-reads",
-            "2",
-            "--min-ba-reads",
-            "2",
-        ])
-        .status()
-        .expect("Failed to run duplex-metrics command (strict)");
-
-    assert!(status_strict.success(), "duplex-metrics command failed (strict)");
+    let cmd_strict = DuplexMetrics::try_parse_from([
+        "duplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix_strict.to_str().unwrap(),
+        "--min-ab-reads",
+        "2",
+        "--min-ba-reads",
+        "2",
+    ])
+    .expect("failed to parse duplex-metrics args (strict)");
+    cmd_strict.execute("test").expect("duplex-metrics command failed (strict)");
 
     // Read both duplex family size files
     let default_path = format!("{}.duplex_family_sizes.txt", output_prefix_default.display());

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -5,6 +5,9 @@
 //! verifying outputs with `compare`.  No golden files are checked in — expected
 //! output is generated fresh each run.
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::compare::{CompareBams, CompareMismatch};
 use fgumi_lib::sam::SamTag;
 use noodles::bam;
 use std::ffi::OsString;
@@ -168,20 +171,29 @@ fn run_dedup(input: &Path, output: &Path) {
 // Helpers: compare
 // ---------------------------------------------------------------------------
 
-/// Compare two BAM files using the given mode, returning the full output.
-fn compare_bams(bam1: &Path, bam2: &Path, mode: &str) -> Output {
-    fgumi(args!["compare", "bams", bam1, bam2, "--mode", mode])
+/// Run `CompareBams::execute()` in-process. Returns true on match
+/// (IDENTICAL or EQUIVALENT), false on `CompareMismatch` (DIFFER); panics on
+/// any other anyhow error.
+fn compare_bams_in_process(bam1: &Path, bam2: &Path, mode: &str) -> bool {
+    let cmd = CompareBams::try_parse_from([
+        "bams",
+        bam1.to_str().unwrap(),
+        bam2.to_str().unwrap(),
+        "--mode",
+        mode,
+    ])
+    .expect("failed to parse compare bams args");
+    match cmd.execute("test") {
+        Ok(()) => true,
+        Err(e) if e.is::<CompareMismatch>() => false,
+        Err(e) => panic!("compare bams hit unexpected error: {e:#}"),
+    }
 }
 
-/// Assert that two BAM files are identical according to the given compare mode.
+/// Assert that two BAM files are identical (or equivalent) according to the
+/// given compare mode.
 fn assert_bams_identical(bam1: &Path, bam2: &Path, mode: &str, context: &str) {
-    let output = compare_bams(bam1, bam2, mode);
-    assert!(
-        output.status.success(),
-        "{context}:\nstdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+    assert!(compare_bams_in_process(bam1, bam2, mode), "{context}: compare bams reported DIFFER");
 }
 
 // ---------------------------------------------------------------------------
@@ -457,14 +469,9 @@ fn test_different_seeds_produce_different_output() {
     simulate_grouped_reads(&bam1, &truth1, &reference, 42, 100);
     simulate_grouped_reads(&bam2, &truth2, &reference, 99, 100);
 
-    let output = compare_bams(&bam1, &bam2, "content");
-    assert_eq!(
-        output.status.code(),
-        Some(1),
-        "Expected compare to report content differences (exit 1), got {:?}\nstdout: {}\nstderr: {}",
-        output.status.code(),
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
+    assert!(
+        !compare_bams_in_process(&bam1, &bam2, "content"),
+        "Expected compare bams to report content differences between distinct seeds",
     );
 }
 

--- a/tests/integration/test_extract_command.rs
+++ b/tests/integration/test_extract_command.rs
@@ -6,6 +6,9 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::extract::Extract;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use noodles::bam;
@@ -99,28 +102,25 @@ fn test_extract_gzip_single_threaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command (single-threaded)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -137,30 +137,27 @@ fn test_extract_gzip_multithreaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -177,30 +174,27 @@ fn test_extract_gzip_threads_mode() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -221,28 +215,25 @@ fn test_extract_bgzf_single_threaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command (single-threaded)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF input failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF input failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -259,30 +250,27 @@ fn test_extract_bgzf_multithreaded() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF + --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF + --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -299,30 +287,27 @@ fn test_extract_bgzf_threads_mode() {
     let output = tmp.path().join("output.bam");
 
     // Run extract command with --threads 4
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract command with BGZF + --threads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract command with BGZF + --threads failed");
 
     // Verify output
     let records = read_bam_records(&output);
@@ -358,28 +343,25 @@ fn test_extract_gzip_verifies_umi_extraction() {
     );
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success());
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute extract command");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -421,28 +403,25 @@ fn test_extract_bgzf_verifies_umi_extraction() {
     );
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success());
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute extract command");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -469,30 +448,27 @@ fn test_extract_mixed_gzip_and_bgzf() {
     let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &r2_records);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with mixed gzip/BGZF should succeed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with mixed gzip/BGZF should succeed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 6, "Should have 6 records");
@@ -508,28 +484,25 @@ fn test_extract_plain_and_compressed() {
     let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &r2_records);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with plain/gzip mix should succeed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with plain/gzip mix should succeed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 6, "Should have 6 records");
@@ -567,30 +540,28 @@ fn test_parallel_parse_output_equivalence_across_threads() {
     for threads in [1, 2, 4, 8] {
         let output = tmp.path().join(format!("output_t{threads}.bam"));
 
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                &threads.to_string(),
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(status.success(), "Extract with {threads} threads failed");
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            &threads.to_string(),
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test")
+            .unwrap_or_else(|e| panic!("Extract with {threads} threads failed: {e}"));
 
         let records = read_bam_records(&output);
         outputs.push(records);
@@ -639,30 +610,27 @@ fn test_parallel_parse_determinism() {
     for run in 0..3 {
         let output = tmp.path().join(format!("output_run{run}.bam"));
 
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                "4",
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(status.success(), "Run {run} failed");
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            "4",
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test").unwrap_or_else(|e| panic!("Run {run} failed: {e}"));
         outputs.push(read_bam_records(&output));
     }
 
@@ -718,55 +686,51 @@ fn test_bgzf_sync_multithreaded_matches_single_threaded() {
 
     // Run single-threaded (fast-path)
     let output_st = tmp.path().join("output_st.bam");
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output_st.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "1",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute single-threaded extract");
-    assert!(status.success(), "Single-threaded extract failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output_st.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute single-threaded extract");
 
     // Run multithreaded (BGZF+sync through unified pipeline)
     let output_threaded = tmp.path().join("output_mt.bam");
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output_threaded.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute multithreaded extract");
-    assert!(status.success(), "Multithreaded extract failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output_threaded.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Failed to execute multithreaded extract");
 
     // Compare record content (not just count)
     let st_records = read_bam_records(&output_st);
@@ -816,30 +780,27 @@ fn test_variable_length_reads_gzip() {
     let output = tmp.path().join("output.bam");
 
     // Run multithreaded (exercises RecordCount reader for gzip+sync)
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "+T",
-            "+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Extract with variable-length reads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Extract with variable-length reads failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 8, "Should have 8 records (4 pairs × 2 reads)");
@@ -869,30 +830,27 @@ fn test_variable_length_reads_bgzf() {
     let r2 = create_bgzf_fastq(&tmp, "r2.fq.bgz", &records_r2);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "+T",
-            "+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "BGZF extract with variable-length reads failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("BGZF extract with variable-length reads failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 8, "Should have 8 records (4 pairs × 2 reads)");
@@ -911,33 +869,30 @@ fn test_extract_multithreaded_custom_options() {
     let r2 = create_gzip_fastq(&tmp, "r2.fq.gz", &[("read1", "TGCATAAAAAAA", "IIIIIIIIIIII")]);
     let output = tmp.path().join("output.bam");
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "extract",
-            "--inputs",
-            r1.to_str().unwrap(),
-            r2.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            "--read-structures",
-            "5M+T",
-            "5M+T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_library",
-            "--threads",
-            "4",
-            "--compression-level",
-            "1",
-            "--read-group-id",
-            "MyRG",
-            "--annotate-read-names",
-        ])
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "Multi-threaded extract with custom options failed");
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "5M+T",
+        "5M+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        "4",
+        "--compression-level",
+        "1",
+        "--read-group-id",
+        "MyRG",
+        "--annotate-read-names",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("test").expect("Multi-threaded extract with custom options failed");
 
     let records = read_bam_records(&output);
     assert_eq!(records.len(), 2);
@@ -1004,12 +959,9 @@ fn run_bgzf_extract(
         "1".to_string(),
     ]);
 
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(&args)
-        .status()
-        .expect("Failed to execute extract command");
-
-    assert!(status.success(), "extract t{threads} {tag_suffix} failed");
+    let cmd = Extract::try_parse_from(args.iter().map(String::as_str))
+        .expect("failed to parse extract args");
+    cmd.execute("test").unwrap_or_else(|e| panic!("extract t{threads} {tag_suffix} failed: {e}"));
     read_bam_records(&output)
 }
 
@@ -1233,33 +1185,29 @@ fn test_extract_bgzf_unequal_block_counts() {
 
     for threads in [1, 4, 8] {
         let output = tmp.path().join(format!("out_unequal_t{threads}.bam"));
-        let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "extract",
-                "--inputs",
-                r1.to_str().unwrap(),
-                r2.to_str().unwrap(),
-                "--output",
-                output.to_str().unwrap(),
-                "--read-structures",
-                "5M+T",
-                "5M+T",
-                "--sample",
-                "test",
-                "--library",
-                "test",
-                "--threads",
-                &threads.to_string(),
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to execute extract command");
-
-        assert!(
-            status.success(),
-            "Extract with unequal BGZF block counts should succeed at T{threads}"
-        );
+        let cmd = Extract::try_parse_from([
+            "extract",
+            "--inputs",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--read-structures",
+            "5M+T",
+            "5M+T",
+            "--sample",
+            "test",
+            "--library",
+            "test",
+            "--threads",
+            &threads.to_string(),
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse extract args");
+        cmd.execute("test").unwrap_or_else(|e| {
+            panic!("Extract with unequal BGZF block counts should succeed at T{threads}: {e}")
+        });
 
         let records = read_bam_records(&output);
         assert_eq!(

--- a/tests/integration/test_fastq_command.rs
+++ b/tests/integration/test_fastq_command.rs
@@ -381,3 +381,32 @@ fn test_fastq_hex_flags() {
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 2);
 }
+
+/// `--output` pointing at the same file as `--input` must fail before any
+/// truncation, since `File::create` would otherwise clobber the BAM data.
+#[test]
+fn test_fastq_output_same_as_input_rejected() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+
+    create_paired_bam(&input_bam, vec![("read1", "ACGT", "IIII", "TGCA", "IIII", false)]);
+    let input_size_before = std::fs::metadata(&input_bam).expect("stat input").len();
+
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        input_bam.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    let err = cmd.execute("test").expect_err("execute must reject identical --input/--output");
+    assert!(err.to_string().contains("must differ"), "unexpected error message: {err}");
+
+    // Most importantly: the input BAM must not have been truncated.
+    let input_size_after = std::fs::metadata(&input_bam).expect("stat input").len();
+    assert_eq!(
+        input_size_before, input_size_after,
+        "input BAM was truncated/clobbered by --output=--input"
+    );
+}

--- a/tests/integration/test_fastq_command.rs
+++ b/tests/integration/test_fastq_command.rs
@@ -1,12 +1,16 @@
 //! Integration tests for the fastq command.
+//!
+//! These tests invoke the fastq command in-process via `Command::execute()`.
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::fastq::Fastq;
 use fgumi_raw_bam::{SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -95,20 +99,16 @@ fn test_fastq_basic() {
         ],
     );
 
-    // Run fastq command with output redirected to file
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["fastq", "-i", input_bam.to_str().unwrap()])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(
-        output.status.success(),
-        "Fastq command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    // Write stdout to file for parsing
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    // Run fastq command with output written directly to file
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     // Verify output
     let records = parse_fastq_records(&output_fq);
@@ -146,18 +146,15 @@ fn test_fastq_reverse_complement() {
         ],
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["fastq", "-i", input_bam.to_str().unwrap()])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(
-        output.status.success(),
-        "Fastq command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 2);
@@ -178,19 +175,16 @@ fn test_fastq_no_suffix() {
 
     create_paired_bam(&input_bam, vec![("read1", "ACGT", "IIII", "TGCA", "IIII", false)]);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "fastq",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-n", // no suffix
-        ])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(output.status.success());
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-n",
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 2);
@@ -213,14 +207,15 @@ fn test_fastq_quality_encoding() {
     // ASCII '~' (126) - 33 = quality 93 (max)
     create_paired_bam(&input_bam, vec![("read1", "ACGT", "!I?~", "TGCA", "IIII", false)]);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["fastq", "-i", input_bam.to_str().unwrap()])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(output.status.success());
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 2);
@@ -297,18 +292,15 @@ fn test_fastq_exclude_flags() {
     create_bam_with_flags(&input_bam);
 
     // Run with default flags (excludes secondary and supplementary)
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["fastq", "-i", input_bam.to_str().unwrap()])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(
-        output.status.success(),
-        "Fastq command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(
@@ -336,18 +328,17 @@ fn test_fastq_multithreaded() {
 
     create_paired_bam(&input_bam, read_pairs);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["fastq", "-i", input_bam.to_str().unwrap(), "-@", "4"])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(
-        output.status.success(),
-        "Multithreaded fastq failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-@",
+        "4",
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 20, "Should have 20 FASTQ records (10 pairs)");
@@ -363,20 +354,17 @@ fn test_fastq_hex_flags() {
     create_paired_bam(&input_bam, vec![("read1", "ACGT", "IIII", "TGCA", "IIII", false)]);
 
     // Use hex notation for flags
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "fastq",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-F",
-            "0x900", // hex notation
-        ])
-        .output()
-        .expect("Failed to run fastq command");
-
-    assert!(output.status.success());
-
-    fs::write(&output_fq, &output.stdout).expect("Failed to write output");
+    let cmd = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-F",
+        "0x900", // hex notation
+        "-o",
+        output_fq.to_str().unwrap(),
+    ])
+    .expect("failed to parse fastq args");
+    cmd.execute("test").expect("fastq command failed");
 
     let records = parse_fastq_records(&output_fq);
     assert_eq!(records.len(), 2);

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -1,17 +1,19 @@
-//! End-to-end CLI tests for the filter command.
+//! End-to-end tests for the filter command.
 //!
-//! These tests run the actual `fgumi filter` binary and validate:
+//! These tests invoke `Filter::execute()` in-process and validate:
 //! 1. Basic consensus read filtering
 //! 2. Rejected reads output
 //! 3. Statistics output
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_test_reference};
@@ -81,26 +83,23 @@ fn test_filter_command_basic() {
 
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output has records (reads may have masked bases but should still be present)
@@ -153,26 +152,23 @@ fn test_filter_command_rejects_low_depth() {
 
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "3",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command with rejects failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "3",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command with rejects failed");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -214,26 +210,23 @@ fn test_filter_command_with_stats() {
 
     create_consensus_bam(&input_bam, vec![record]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--stats",
-            stats_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command with stats failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
     let content = fs::read_to_string(&stats_path).expect("Failed to read stats file");
     assert!(!content.trim().is_empty(), "Stats file should not be empty");
@@ -268,24 +261,21 @@ fn test_filter_command_no_ref_unmapped_reads() {
     create_consensus_bam(&input_bam, vec![r1, r2]);
 
     // Run filter WITHOUT --ref
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command without --ref failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command without --ref failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -324,24 +314,21 @@ fn test_filter_command_no_ref_with_rejects() {
     create_consensus_bam(&input_bam, vec![good, low_depth]);
 
     // Run filter WITHOUT --ref, with --rejects
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "3",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run filter command");
-
-    assert!(status.success(), "Filter command without --ref with rejects failed");
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "3",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("Filter command without --ref with rejects failed");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -385,27 +372,25 @@ fn test_filter_command_no_ref_mapped_reads_fails() {
     create_consensus_bam(&input_bam, vec![mapped]);
 
     // Run filter WITHOUT --ref on mapped reads — should fail
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "filter",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--max-no-call-fraction",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .output()
-        .expect("Failed to run filter command");
-
-    assert!(!output.status.success(), "Filter command should fail for mapped reads without --ref");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let cmd = Filter::try_parse_from([
+        "filter",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--max-no-call-fraction",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse filter args");
+    let result = cmd.execute("test");
+    assert!(result.is_err(), "Filter command should fail for mapped reads without --ref");
+    let err_msg = format!("{:#}", result.unwrap_err());
     assert!(
-        stderr.contains("--ref is required"),
-        "Error should mention --ref requirement, got stderr: {stderr}"
+        err_msg.contains("--ref is required"),
+        "Error should mention --ref requirement, got: {err_msg}"
     );
 }

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -1,12 +1,16 @@
 //! Integration tests for the group command with new metrics infrastructure.
+//!
+//! These tests invoke `GroupReadsByUmi::execute()` in-process.
 
+use clap::Parser;
 use fgoxide::io::DelimFile;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::metrics::UmiGroupingMetrics;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
@@ -23,26 +27,23 @@ fn test_group_command_writes_new_metrics() {
     create_test_input_bam(&input_bam);
 
     // Run the group command
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "group",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--edits",
-            "0",
-            "--grouping-metrics",
-            metrics_file.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run group command");
-
-    assert!(status.success(), "Group command failed");
+    let cmd = GroupReadsByUmi::try_parse_from([
+        "group",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+        "--grouping-metrics",
+        metrics_file.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse group args");
+    cmd.execute("test").expect("Failed to run group command");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(metrics_file.exists(), "Metrics file not created");
 
@@ -78,26 +79,23 @@ fn test_group_command_rejects_n_bases_in_umi() {
     // Create BAM with UMIs containing N bases
     create_test_bam_with_n_umis(&input_bam);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "group",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--strategy",
-            "identity",
-            "--edits",
-            "0",
-            "--grouping-metrics",
-            metrics_file.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run group command");
-
-    assert!(status.success());
+    let cmd = GroupReadsByUmi::try_parse_from([
+        "group",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+        "--grouping-metrics",
+        metrics_file.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse group args");
+    cmd.execute("test").expect("Failed to run group command");
 
     // Read metrics and verify N rejection tracking
     let metrics: Vec<UmiGroupingMetrics> =

--- a/tests/integration/test_review_command.rs
+++ b/tests/integration/test_review_command.rs
@@ -1,9 +1,13 @@
-//! End-to-end CLI tests for the review command.
+//! In-process tests for the review command.
 //!
-//! These tests run the actual `fgumi review` binary and validate:
-//! 1. Missing required arguments produce a clear error
-//! 2. Basic execution with minimal valid inputs
+//! These tests invoke the Review command directly via in-process calls and validate:
+//! 1. Missing required arguments produce a clap parse error
+//! 2. Missing input files produce a validation error
+//! 3. Basic execution with minimal valid inputs
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::review::Review;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder};
 use noodles::bam;
@@ -11,7 +15,6 @@ use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{
@@ -52,20 +55,17 @@ fn create_test_vcf(path: &Path) {
     vcf.flush().unwrap();
 }
 
-/// Test that missing required arguments produce a non-zero exit code.
+/// Test that missing required arguments produce a clap parse error.
 #[test]
 fn test_review_missing_required_args() {
     // No arguments at all — should fail with clap error
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(["review"])
-        .output()
-        .expect("Failed to run review command");
-
-    assert!(!output.status.success(), "Review should fail without required args");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("required") || stderr.contains("Usage") || stderr.contains("error"),
-        "Stderr should mention missing required arguments, got: {stderr}"
+    let err =
+        Review::try_parse_from(["review"]).expect_err("Review should fail without required args");
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument,
+        "Expected MissingRequiredArgument, got {:?}: {err}",
+        err.kind()
     );
 }
 
@@ -74,24 +74,26 @@ fn test_review_missing_required_args() {
 fn test_review_missing_input_files() {
     let temp_dir = TempDir::new().unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "review",
-            "--input",
-            "/nonexistent/variants.vcf",
-            "--consensus-bam",
-            "/nonexistent/consensus.bam",
-            "--grouped-bam",
-            "/nonexistent/grouped.bam",
-            "--ref",
-            "/nonexistent/ref.fa",
-            "--output",
-            temp_dir.path().join("output").to_str().unwrap(),
-        ])
-        .output()
-        .expect("Failed to run review command");
-
-    assert!(!output.status.success(), "Review should fail for nonexistent input files");
+    let cmd = Review::try_parse_from([
+        "review",
+        "--input",
+        "/nonexistent/variants.vcf",
+        "--consensus-bam",
+        "/nonexistent/consensus.bam",
+        "--grouped-bam",
+        "/nonexistent/grouped.bam",
+        "--ref",
+        "/nonexistent/ref.fa",
+        "--output",
+        temp_dir.path().join("output").to_str().unwrap(),
+    ])
+    .expect("failed to parse review args");
+    let err = cmd.execute("test").expect_err("Review should fail for nonexistent input files");
+    let err_msg = format!("{err:#}");
+    assert!(
+        err_msg.contains("does not exist"),
+        "Validation error should mention missing file, got: {err_msg}"
+    );
 }
 
 /// Test basic review execution with valid inputs.
@@ -155,28 +157,21 @@ fn test_review_basic_execution() {
     ];
     create_indexed_bam(&grouped_bam, &grouped_records);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "review",
-            "--input",
-            vcf_path.to_str().unwrap(),
-            "--consensus-bam",
-            consensus_bam.to_str().unwrap(),
-            "--grouped-bam",
-            grouped_bam.to_str().unwrap(),
-            "--ref",
-            ref_path.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .output()
-        .expect("Failed to run review command");
-
-    assert!(
-        output.status.success(),
-        "Review command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let cmd = Review::try_parse_from([
+        "review",
+        "--input",
+        vcf_path.to_str().unwrap(),
+        "--consensus-bam",
+        consensus_bam.to_str().unwrap(),
+        "--grouped-bam",
+        grouped_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse review args");
+    cmd.execute("test").unwrap_or_else(|e| panic!("Review command failed: {e:#}"));
 
     // Verify output files were created
     let consensus_out = output_prefix.with_extension("consensus.bam");

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -1,11 +1,14 @@
 //! End-to-end CLI tests for the simplex command.
 //!
-//! These tests run the actual `fgumi simplex` binary and validate:
+//! These tests invoke `Simplex::execute()` in-process and validate:
 //! 1. Basic simplex consensus calling from grouped reads
 //! 2. Statistics output
 //! 3. Rejected reads output
 
 use bstr::BString;
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::simplex::Simplex;
 use fgumi_lib::sam::SamTag;
 use noodles::bam;
 use noodles::sam::Header;
@@ -16,7 +19,6 @@ use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use std::fs;
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
@@ -54,22 +56,19 @@ fn test_simplex_command_basic_consensus() {
     let family2 = create_umi_family("TGCA", 5, "fam2", "TTTTAAAA", 30);
     create_grouped_bam(&input_bam, vec![("1", family1), ("2", family2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run simplex command");
-
-    assert!(status.success(), "Simplex command failed");
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("Simplex command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Read output and verify consensus reads were produced
@@ -97,24 +96,21 @@ fn test_simplex_command_with_stats() {
     let family = create_umi_family("ACGT", 5, "fam1", "ACGTACGT", 30);
     create_grouped_bam(&input_bam, vec![("1", family)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "1",
-            "--stats",
-            stats_path.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run simplex command");
-
-    assert!(status.success(), "Simplex command with stats failed");
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("Simplex command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
 }
 
@@ -131,24 +127,21 @@ fn test_simplex_command_with_rejects() {
     let family2 = create_umi_family("TGCA", 1, "fam2", "TTTTAAAA", 30);
     create_grouped_bam(&input_bam, vec![("1", family1), ("2", family2)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run simplex command");
-
-    assert!(status.success(), "Simplex command with rejects failed");
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("Simplex command with rejects failed");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 }
 
@@ -231,22 +224,19 @@ fn test_simplex_command_collapses_read_group_attributes() {
     let family = create_umi_family("ACGT", 5, "fam1", "ACGTACGT", 30);
     create_grouped_bam_with_header(&input_bam, &header, vec![("1", family)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run simplex command");
-
-    assert!(status.success(), "Simplex command failed");
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("Simplex command failed");
 
     // Read the output header and verify collapsed read group attributes
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -303,25 +293,23 @@ fn test_simplex_command_rejects_inherits_input_read_groups() {
     let rejected = create_umi_family("TGCA", 1, "reject_singleton", "TTTTAAAA", 30);
     create_grouped_bam_with_header(&input_bam, &header, vec![("1", kept), ("2", rejected)]);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--min-reads",
-            "2",
-            "--threads",
-            "2",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run simplex command");
-    assert!(status.success(), "Simplex command with rejects failed");
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--threads",
+        "2",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("Simplex command with rejects failed");
 
     // Primary output BAM: consensus header collapses RG1+RG2 -> single "A".
     let primary_header =

--- a/tests/integration/test_simplex_metrics_command.rs
+++ b/tests/integration/test_simplex_metrics_command.rs
@@ -1,6 +1,10 @@
 //! Integration tests for the simplex-metrics command.
+//! Tests invoke the in-process `Command::execute()` implementation.
 
+use clap::Parser;
 use fgoxide::io::DelimFile;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::simplex_metrics::SimplexMetrics;
 use fgumi_lib::metrics::shared::UmiMetric;
 use fgumi_lib::metrics::simplex::{SimplexFamilySizeMetric, SimplexYieldMetric};
 use fgumi_lib::sam::SamTag;
@@ -10,7 +14,6 @@ use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -121,18 +124,15 @@ fn test_simplex_metrics_command_creates_output_files() {
     let header = create_minimal_header("chr1", 10000);
     create_simplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics command");
-
-    assert!(status.success(), "simplex-metrics command failed");
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics command failed");
 
     let family_sizes_path = format!("{}.family_sizes.txt", output_prefix.display());
     let yield_metrics_path = format!("{}.simplex_yield_metrics.txt", output_prefix.display());
@@ -155,18 +155,15 @@ fn test_simplex_metrics_command_family_sizes() {
     let header = create_minimal_header("chr1", 10000);
     create_simplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics command");
-
-    assert!(status.success());
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics command failed");
 
     let family_sizes_path = format!("{}.family_sizes.txt", output_prefix.display());
     let metrics: Vec<SimplexFamilySizeMetric> =
@@ -194,18 +191,15 @@ fn test_simplex_metrics_command_yield_metrics() {
     let header = create_minimal_header("chr1", 10000);
     create_simplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics command");
-
-    assert!(status.success());
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics command failed");
 
     let yield_path = format!("{}.simplex_yield_metrics.txt", output_prefix.display());
     let metrics: Vec<SimplexYieldMetric> =
@@ -229,18 +223,15 @@ fn test_simplex_metrics_command_umi_metrics() {
     let header = create_minimal_header("chr1", 10000);
     create_simplex_test_bam(&input_bam, &header);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_prefix.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics command");
-
-    assert!(status.success());
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_prefix.to_str().unwrap(),
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics command failed");
 
     let umi_counts_path = format!("{}.umi_counts.txt", output_prefix.display());
     let metrics: Vec<UmiMetric> =
@@ -262,32 +253,28 @@ fn test_simplex_metrics_min_reads_parameter() {
     create_simplex_test_bam(&input_bam, &header);
 
     // Run with default min-reads=1
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_default.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics (default)");
-    assert!(status.success());
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_default.to_str().unwrap(),
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics (default) command failed");
 
     // Run with min-reads=3
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "simplex-metrics",
-            "--input",
-            input_bam.to_str().unwrap(),
-            "--output",
-            output_strict.to_str().unwrap(),
-            "--min-reads",
-            "3",
-        ])
-        .status()
-        .expect("Failed to run simplex-metrics (strict)");
-    assert!(status.success());
+    let cmd = SimplexMetrics::try_parse_from([
+        "simplex-metrics",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_strict.to_str().unwrap(),
+        "--min-reads",
+        "3",
+    ])
+    .expect("failed to parse simplex-metrics args");
+    cmd.execute("test").expect("simplex-metrics (strict) command failed");
 
     let default_yield_path = format!("{}.simplex_yield_metrics.txt", output_default.display());
     let strict_yield_path = format!("{}.simplex_yield_metrics.txt", output_strict.display());

--- a/tests/integration/test_zipper_command.rs
+++ b/tests/integration/test_zipper_command.rs
@@ -1,10 +1,17 @@
 //! End-to-end CLI tests for the zipper command.
 //!
-//! These tests run the actual `fgumi zipper` binary and validate:
-//! 1. Basic merge of unmapped + mapped BAMs with tag transfer
-//! 2. Tag removal via `--tags-to-remove`
-//! 3. Error on missing input files
+//! These tests invoke `Zipper::execute()` in-process, except two tests that
+//! intentionally stay on the subprocess path for process-level observability:
+//!
+//! - `test_zipper_bam_stdin_input` — exercises the `std::io::stdin()` pipe path
+//!   inside zipper, which only exists at the process boundary.
+//! - `test_zipper_bam_mapped_input` — asserts on a `log::warn!` "BAM input
+//!   detected" message captured from stderr; capturing that in-process would
+//!   require global-logger plumbing in the test harness.
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::zipper::Zipper;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
@@ -121,24 +128,21 @@ fn test_zipper_basic_merge() {
     ];
     create_mapped_sam(&mapped_sam, &mapped_header, &mapped_records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "zipper",
-            "--input",
-            mapped_sam.to_str().unwrap(),
-            "--unmapped",
-            unmapped_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run zipper command");
-
-    assert!(status.success(), "Zipper command failed");
+    let cmd = Zipper::try_parse_from([
+        "zipper",
+        "--input",
+        mapped_sam.to_str().unwrap(),
+        "--unmapped",
+        unmapped_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse zipper args");
+    cmd.execute("test").expect("Zipper command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify output records have UMI tags transferred
@@ -189,26 +193,23 @@ fn test_zipper_tag_removal() {
     }];
     create_mapped_sam(&mapped_sam, &mapped_header, &mapped_records);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "zipper",
-            "--input",
-            mapped_sam.to_str().unwrap(),
-            "--unmapped",
-            unmapped_bam.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-            "--tags-to-remove",
-            "XY",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run zipper command");
-
-    assert!(status.success(), "Zipper command with --tags-to-remove failed");
+    let cmd = Zipper::try_parse_from([
+        "zipper",
+        "--input",
+        mapped_sam.to_str().unwrap(),
+        "--unmapped",
+        unmapped_bam.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--tags-to-remove",
+        "XY",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse zipper args");
+    cmd.execute("test").expect("Zipper command with --tags-to-remove failed");
 
     // Verify XY tag was removed but RX tag was kept
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
@@ -232,22 +233,19 @@ fn test_zipper_missing_input() {
     let missing_mapped = temp_dir.path().join("missing.mapped.sam");
     let missing_unmapped = temp_dir.path().join("missing.unmapped.bam");
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "zipper",
-            "--input",
-            missing_mapped.to_str().unwrap(),
-            "--unmapped",
-            missing_unmapped.to_str().unwrap(),
-            "--reference",
-            ref_path.to_str().unwrap(),
-            "--output",
-            output_bam.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run zipper command");
-
-    assert!(!status.success(), "Zipper should fail for nonexistent input");
+    let cmd = Zipper::try_parse_from([
+        "zipper",
+        "--input",
+        missing_mapped.to_str().unwrap(),
+        "--unmapped",
+        missing_unmapped.to_str().unwrap(),
+        "--reference",
+        ref_path.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+    ])
+    .expect("failed to parse zipper args");
+    assert!(cmd.execute("test").is_err(), "Zipper should fail for nonexistent input");
 }
 
 /// Test zipper accepts BAM as mapped input (--input).
@@ -310,6 +308,10 @@ fn test_zipper_bam_mapped_input() {
     ];
     create_mapped_bam(&mapped_bam, &mapped_header, &mapped_records);
 
+    // Stays on the subprocess path because the assertion below checks that
+    // zipper emits a `BAM input detected` warning via log::warn!, which is
+    // only observable via captured stderr — capturing in-process would
+    // require setting up a global logger handler in the test harness.
     let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
         .args([
             "zipper",


### PR DESCRIPTION
## Summary

Phase 3 of #352, **stacked on #354**. Contains the two production refactors the issue called out as prerequisite, plus the test conversions they unlock.

### Production refactors

- **`compare`**: replaces 7 `std::process::exit(1)` sites in `src/lib/commands/compare/{bams,metrics}.rs` with `Err(CompareMismatch(...))`. `CompareMismatch` is a new public, downcastable `anyhow`-compatible error variant. `src/main.rs` downcasts on it and maps to `exit(1)` so the **CLI exit-code contract is preserved byte-for-byte**.
- **`fastq`**: adds optional `--output`/`-o` flag. When provided, FASTQ writes to the file; when omitted, the prior `stdout()` behavior is preserved (still the default for `fgumi fastq -i in.bam | bwa mem ...`). The conversion loop is factored into a generic `Fastq::run_with_writer<W: Write>` helper.

### Test conversions

- **`test_compare_bams.rs`**: 8 of 17 tests converted to in-process (those that only check IDENTICAL/DIFFER — fully covered by the `Result` type). The other 9 tests stay on the subprocess path because they assert on specific diagnostic substrings (`EQUIVALENT`, `Order/name mismatches: N`, `tags in different order`, `Missing MI in BAM[12]: N`, etc.) that aren't observable in-process. Both helpers (`run_compare` for subprocess, `run_compare_in_process` for in-process) coexist; tests pick the one that matches their assertion shape.
- **`test_e2e_regression.rs`**: the `compare_bams` and `assert_bams_identical` helpers move in-process; the `test_different_seeds_produce_different_output` test now asserts `!compare_bams_in_process(...)` instead of `output.status.code() == Some(1)`. The file's other subprocess helpers (`fgumi`, `fgumi_ok`) stay untouched — they're Phase 4 scope.
- **`test_fastq_command.rs`**: all 7 tests now pass `-o <tempfile>` to write FASTQ directly to a temp file; the `fs::write(&output_fq, &output.stdout)` middle step is gone.
- **`test_zipper_command.rs`**: 3 of 5 tests converted to in-process. Two stay subprocess:
  - `test_zipper_bam_stdin_input` — exercises the `std::io::stdin()` pipe path inside `zipper`, which only exists at the process boundary.
  - `test_zipper_bam_mapped_input` — asserts on a `log::warn!("BAM input detected")` warning captured from stderr; capturing that in-process would require global-logger plumbing in the test harness.

## Phasing

- Phase 1 (#353): extract, group, dedup, correct, filter, clip
- Phase 2 (#354): simplex, simplex-metrics, duplex, duplex-metrics, codec, review
- **Phase 3 (this PR):** compare refactor + fastq refactor + their tests + non-stdin zipper tests
- Phase 4: sort, downsample, remaining e2e

## Commits

```
refactor(compare)!: return CompareMismatch instead of process::exit
test(compare):     invoke compare bams Command::execute in-process
feat(fastq):       add --output/-o flag for file output
test(fastq):       invoke fastq Command::execute in-process
test(zipper):      invoke zipper Command::execute in-process for non-stdin tests
```

## Test plan

- [x] `cargo nextest run --features compare,simulate --test integration` — 193/193 passed, 23 skipped
- [x] `cargo build` (default features) — clean
- [x] `cargo build --features compare` — clean
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean (default features)
- [ ] Codecov reports coverage gains on compare/fastq `execute()` bodies
- [ ] Verify on a downstream consumer that the breaking `compare` refactor (now returning `Err(CompareMismatch)` instead of `process::exit(1)` in-process) does not affect any caller — only `main.rs` and the integration tests use it, both updated here