### PR TITLE
test: in-process Command::execute for Phase 4 commands (#352)

### DIFF
--- a/tests/integration/test_downsample_command.rs
+++ b/tests/integration/test_downsample_command.rs
@@ -1,5 +1,11 @@
 //! Integration tests for the downsample command.
+//!
+//! These tests invoke the downsample `Command::execute()` in-process rather than spawning
+//! the actual `fgumi downsample` binary.
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::downsample::Downsample;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::SamBuilder;
 use noodles::bam;
@@ -8,7 +14,6 @@ use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::data::field::Value;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::create_minimal_header;
@@ -92,24 +97,21 @@ fn test_downsample_basic() {
     create_grouped_bam(&input_bam, families);
 
     // Run downsample with fraction=0.5 and seed for reproducibility
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "0.5",
-            "--seed",
-            "42",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(status.success(), "Downsample command failed");
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "0.5",
+        "--seed",
+        "42",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("test").expect("Downsample command failed");
     assert!(output_bam.exists(), "Output BAM not created");
 
     // Verify that some families were kept (with seed 42 and fraction 0.5, should be around 5)
@@ -135,26 +137,23 @@ fn test_downsample_with_rejects() {
         (0..10).map(|i| (Box::leak(format!("{i}").into_boxed_str()) as &str, 5)).collect();
     create_grouped_bam(&input_bam, families);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "0.5",
-            "--seed",
-            "42",
-            "--rejects",
-            rejects_bam.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(status.success(), "Downsample command failed");
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "0.5",
+        "--seed",
+        "42",
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("test").expect("Downsample command failed");
     assert!(output_bam.exists(), "Output BAM not created");
     assert!(rejects_bam.exists(), "Rejects BAM not created");
 
@@ -180,24 +179,21 @@ fn test_downsample_deterministic() {
 
     // Run twice with same seed
     for output in [&output1_bam, &output2_bam] {
-        let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-            .args([
-                "downsample",
-                "-i",
-                input_bam.to_str().unwrap(),
-                "-o",
-                output.to_str().unwrap(),
-                "-f",
-                "0.3",
-                "--seed",
-                "12345",
-                "--compression-level",
-                "1",
-            ])
-            .status()
-            .expect("Failed to run downsample command");
-
-        assert!(status.success(), "Downsample command failed");
+        let cmd = Downsample::try_parse_from([
+            "downsample",
+            "-i",
+            input_bam.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "-f",
+            "0.3",
+            "--seed",
+            "12345",
+            "--compression-level",
+            "1",
+        ])
+        .expect("failed to parse downsample args");
+        cmd.execute("test").expect("Downsample command failed");
     }
 
     // Both outputs should be identical
@@ -249,28 +245,25 @@ fn test_downsample_histograms() {
     let families = vec![("0", 1), ("1", 2), ("2", 3), ("3", 4), ("4", 5)];
     create_grouped_bam(&input_bam, families);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "0.5",
-            "--seed",
-            "42",
-            "--histogram-kept",
-            hist_kept.to_str().unwrap(),
-            "--histogram-rejected",
-            hist_rejected.to_str().unwrap(),
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(status.success(), "Downsample command failed");
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "0.5",
+        "--seed",
+        "42",
+        "--histogram-kept",
+        hist_kept.to_str().unwrap(),
+        "--histogram-rejected",
+        hist_rejected.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("test").expect("Downsample command failed");
     assert!(hist_kept.exists(), "Kept histogram not created");
     assert!(hist_rejected.exists(), "Rejected histogram not created");
 
@@ -292,70 +285,49 @@ fn test_downsample_keep_all() {
     let families = vec![("0", 5), ("1", 3), ("2", 7)];
     create_grouped_bam(&input_bam, families);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "1.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(status.success(), "Downsample command failed");
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("test").expect("Downsample command failed");
 
     // All records should be kept
     let output_records = read_bam_records(&output_bam);
     assert_eq!(output_records.len(), 15, "All 15 records should be kept with fraction=1.0");
 }
 
-/// Test error handling for invalid fraction.
-#[test]
-fn test_downsample_invalid_fraction() {
+/// Test error handling for invalid fractions. Each case writes to a
+/// distinct output path so an artifact left by one case can never make a
+/// later assertion pass by accident.
+#[rstest::rstest]
+#[case::zero("0.0", "output_zero.bam")]
+#[case::greater_than_one("1.5", "output_gt1.bam")]
+fn test_downsample_invalid_fraction(#[case] fraction: &str, #[case] output_name: &str) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
-    let output_bam = temp_dir.path().join("output.bam");
+    let output_bam = temp_dir.path().join(output_name);
 
     create_grouped_bam(&input_bam, vec![("0", 5)]);
 
-    // Test fraction = 0.0
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "0.0",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(!status.success(), "Fraction=0.0 should fail");
-
-    // Test fraction > 1.0
-    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "downsample",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            output_bam.to_str().unwrap(),
-            "-f",
-            "1.5",
-            "--compression-level",
-            "1",
-        ])
-        .status()
-        .expect("Failed to run downsample command");
-
-    assert!(!status.success(), "Fraction>1.0 should fail");
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        fraction,
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    assert!(cmd.execute("test").is_err(), "Fraction={fraction} should fail");
 }

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -8,9 +8,17 @@
 use clap::Parser;
 use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_lib::commands::compare::{CompareBams, CompareMismatch};
+use fgumi_lib::commands::dedup::MarkDuplicates;
+use fgumi_lib::commands::extract::Extract;
+use fgumi_lib::commands::filter::Filter;
+use fgumi_lib::commands::group::GroupReadsByUmi;
+use fgumi_lib::commands::simplex::Simplex;
+use fgumi_lib::commands::simulate::fastq_reads::FastqReads;
+use fgumi_lib::commands::simulate::grouped_reads::GroupedReads;
+use fgumi_lib::commands::sort::Sort;
 use fgumi_lib::sam::SamTag;
 use noodles::bam;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -24,18 +32,6 @@ use tempfile::TempDir;
 /// Run a fgumi subcommand and return the full output.
 fn fgumi(args: &[OsString]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_fgumi")).args(args).output().expect("failed to execute fgumi")
-}
-
-/// Run a fgumi subcommand, assert it succeeded, and return stdout.
-fn fgumi_ok(args: &[OsString]) -> String {
-    let output = fgumi(args);
-    assert!(
-        output.status.success(),
-        "fgumi {args:?} failed:\nstdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    String::from_utf8_lossy(&output.stdout).to_string()
 }
 
 /// Build a command argument list from mixed string and path arguments.
@@ -69,26 +65,29 @@ fn simulate_grouped_reads(
     seed: u32,
     num_molecules: u32,
 ) {
-    fgumi_ok(args![
-        "simulate",
-        "grouped-reads",
-        "-o",
-        output,
-        "--truth",
-        truth,
-        "--reference",
-        reference,
-        "--num-molecules",
-        &num_molecules.to_string(),
-        "--seed",
-        &seed.to_string(),
-        "--read-length",
-        "100",
-        "--umi-length",
-        "6",
-        "--min-family-size",
-        "2",
-    ]);
+    let num_molecules_str = num_molecules.to_string();
+    let seed_str = seed.to_string();
+    let cmd = GroupedReads::try_parse_from([
+        OsStr::new("grouped-reads"),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--truth"),
+        truth.as_os_str(),
+        OsStr::new("--reference"),
+        reference.as_os_str(),
+        OsStr::new("--num-molecules"),
+        OsStr::new(&num_molecules_str),
+        OsStr::new("--seed"),
+        OsStr::new(&seed_str),
+        OsStr::new("--read-length"),
+        OsStr::new("100"),
+        OsStr::new("--umi-length"),
+        OsStr::new("6"),
+        OsStr::new("--min-family-size"),
+        OsStr::new("2"),
+    ])
+    .expect("failed to parse grouped-reads args");
+    cmd.execute("test").expect("simulate grouped-reads failed");
 }
 
 /// Generate FASTQ reads using simulate with deterministic seed.
@@ -100,32 +99,35 @@ fn simulate_fastq_reads(
     seed: u32,
     num_molecules: u32,
 ) {
-    fgumi_ok(args![
-        "simulate",
-        "fastq-reads",
-        "-1",
-        r1,
-        "-2",
-        r2,
-        "--truth",
-        truth,
-        "--reference",
-        reference,
-        "--num-molecules",
-        &num_molecules.to_string(),
-        "--seed",
-        &seed.to_string(),
-        "--read-length",
-        "100",
-        "--umi-length",
-        "6",
-        "--read-structure-r1",
-        "6M94T",
-        "--read-structure-r2",
-        "100T",
-        "--min-family-size",
-        "2",
-    ]);
+    let num_molecules_str = num_molecules.to_string();
+    let seed_str = seed.to_string();
+    let cmd = FastqReads::try_parse_from([
+        OsStr::new("fastq-reads"),
+        OsStr::new("-1"),
+        r1.as_os_str(),
+        OsStr::new("-2"),
+        r2.as_os_str(),
+        OsStr::new("--truth"),
+        truth.as_os_str(),
+        OsStr::new("--reference"),
+        reference.as_os_str(),
+        OsStr::new("--num-molecules"),
+        OsStr::new(&num_molecules_str),
+        OsStr::new("--seed"),
+        OsStr::new(&seed_str),
+        OsStr::new("--read-length"),
+        OsStr::new("100"),
+        OsStr::new("--umi-length"),
+        OsStr::new("6"),
+        OsStr::new("--read-structure-r1"),
+        OsStr::new("6M94T"),
+        OsStr::new("--read-structure-r2"),
+        OsStr::new("100T"),
+        OsStr::new("--min-family-size"),
+        OsStr::new("2"),
+    ])
+    .expect("failed to parse fastq-reads args");
+    cmd.execute("test").expect("simulate fastq-reads failed");
 }
 
 // ---------------------------------------------------------------------------
@@ -134,37 +136,52 @@ fn simulate_fastq_reads(
 
 /// Run simplex consensus calling with single-threaded deterministic execution.
 fn run_simplex(input: &Path, output: &Path, min_reads: u32) {
-    fgumi_ok(args![
-        "simplex",
-        "-i",
-        input,
-        "-o",
-        output,
-        "--threads",
-        "1",
-        "--min-reads",
-        &min_reads.to_string(),
-    ]);
+    let min_reads_str = min_reads.to_string();
+    let cmd = Simplex::try_parse_from([
+        OsStr::new("simplex"),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--threads"),
+        OsStr::new("1"),
+        OsStr::new("--min-reads"),
+        OsStr::new(&min_reads_str),
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("test").expect("simplex failed");
 }
 
 /// Run filter on a consensus BAM.
 fn run_filter(input: &Path, output: &Path, min_reads: u32, min_base_quality: u32) {
-    fgumi_ok(args![
-        "filter",
-        "-i",
-        input,
-        "-o",
-        output,
-        "--min-reads",
-        &min_reads.to_string(),
-        "--min-base-quality",
-        &min_base_quality.to_string(),
-    ]);
+    let min_reads_str = min_reads.to_string();
+    let min_base_quality_str = min_base_quality.to_string();
+    let cmd = Filter::try_parse_from([
+        OsStr::new("filter"),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--min-reads"),
+        OsStr::new(&min_reads_str),
+        OsStr::new("--min-base-quality"),
+        OsStr::new(&min_base_quality_str),
+    ])
+    .expect("failed to parse filter args");
+    cmd.execute("test").expect("filter failed");
 }
 
 /// Run dedup on a grouped BAM.
 fn run_dedup(input: &Path, output: &Path) {
-    fgumi_ok(args!["dedup", "--input", input, "--output", output]);
+    let cmd = MarkDuplicates::try_parse_from([
+        OsStr::new("dedup"),
+        OsStr::new("--input"),
+        input.as_os_str(),
+        OsStr::new("--output"),
+        output.as_os_str(),
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("test").expect("dedup failed");
 }
 
 // ---------------------------------------------------------------------------
@@ -176,11 +193,11 @@ fn run_dedup(input: &Path, output: &Path) {
 /// any other anyhow error.
 fn compare_bams_in_process(bam1: &Path, bam2: &Path, mode: &str) -> bool {
     let cmd = CompareBams::try_parse_from([
-        "bams",
-        bam1.to_str().unwrap(),
-        bam2.to_str().unwrap(),
-        "--mode",
-        mode,
+        OsStr::new("bams"),
+        bam1.as_os_str(),
+        bam2.as_os_str(),
+        OsStr::new("--mode"),
+        OsStr::new(mode),
     ])
     .expect("failed to parse compare bams args");
     match cmd.execute("test") {
@@ -297,47 +314,56 @@ fn test_full_pipeline_extract_to_filter() {
     // Run the full pipeline twice to verify determinism
     for suffix in ["a", "b"] {
         let extracted = tmp.path().join(format!("extracted_{suffix}.bam"));
-        fgumi_ok(args![
-            "extract",
-            "--inputs",
-            &r1,
-            &r2,
-            "--output",
-            &extracted,
-            "--read-structures",
-            "6M94T",
-            "100T",
-            "--sample",
-            "test_sample",
-            "--library",
-            "test_lib",
-        ]);
+        Extract::try_parse_from([
+            OsStr::new("extract"),
+            OsStr::new("--inputs"),
+            r1.as_os_str(),
+            r2.as_os_str(),
+            OsStr::new("--output"),
+            extracted.as_os_str(),
+            OsStr::new("--read-structures"),
+            OsStr::new("6M94T"),
+            OsStr::new("100T"),
+            OsStr::new("--sample"),
+            OsStr::new("test_sample"),
+            OsStr::new("--library"),
+            OsStr::new("test_lib"),
+        ])
+        .expect("failed to parse extract args")
+        .execute("test")
+        .expect("extract failed");
 
         // Extract emits SO:unsorted GO:query (no SS); `fgumi group` requires
         // template-coordinate sorted input, so put the sort step between them.
         let sorted = tmp.path().join(format!("sorted_{suffix}.bam"));
-        fgumi_ok(args![
-            "sort",
-            "--input",
-            &extracted,
-            "--output",
-            &sorted,
-            "--order",
-            "template-coordinate",
-        ]);
+        Sort::try_parse_from([
+            OsStr::new("sort"),
+            OsStr::new("--input"),
+            extracted.as_os_str(),
+            OsStr::new("--output"),
+            sorted.as_os_str(),
+            OsStr::new("--order"),
+            OsStr::new("template-coordinate"),
+        ])
+        .expect("failed to parse sort args")
+        .execute("test")
+        .expect("sort failed");
 
         let grouped = tmp.path().join(format!("grouped_{suffix}.bam"));
-        fgumi_ok(args![
-            "group",
-            "--input",
-            &sorted,
-            "--output",
-            &grouped,
-            "--strategy",
-            "identity",
-            "--edits",
-            "0",
-        ]);
+        GroupReadsByUmi::try_parse_from([
+            OsStr::new("group"),
+            OsStr::new("--input"),
+            sorted.as_os_str(),
+            OsStr::new("--output"),
+            grouped.as_os_str(),
+            OsStr::new("--strategy"),
+            OsStr::new("identity"),
+            OsStr::new("--edits"),
+            OsStr::new("0"),
+        ])
+        .expect("failed to parse group args")
+        .execute("test")
+        .expect("group failed");
 
         let simplex = tmp.path().join(format!("simplex_{suffix}.bam"));
         run_simplex(&grouped, &simplex, 1);
@@ -379,21 +405,24 @@ fn test_group_rejects_extract_output_without_sort_step() {
     simulate_fastq_reads(&r1, &r2, &truth, &reference, 42, 50);
 
     let extracted = tmp.path().join("extracted.bam");
-    fgumi_ok(args![
-        "extract",
-        "--inputs",
-        &r1,
-        &r2,
-        "--output",
-        &extracted,
-        "--read-structures",
-        "6M94T",
-        "100T",
-        "--sample",
-        "test_sample",
-        "--library",
-        "test_lib",
-    ]);
+    Extract::try_parse_from([
+        OsStr::new("extract"),
+        OsStr::new("--inputs"),
+        r1.as_os_str(),
+        r2.as_os_str(),
+        OsStr::new("--output"),
+        extracted.as_os_str(),
+        OsStr::new("--read-structures"),
+        OsStr::new("6M94T"),
+        OsStr::new("100T"),
+        OsStr::new("--sample"),
+        OsStr::new("test_sample"),
+        OsStr::new("--library"),
+        OsStr::new("test_lib"),
+    ])
+    .expect("failed to parse extract args")
+    .execute("test")
+    .expect("extract failed");
 
     // Run `fgumi group` on the extract output directly — must fail.
     let grouped = tmp.path().join("grouped.bam");
@@ -495,46 +524,51 @@ fn test_e2e_methylation_pipeline() {
     // Generate grouped reads with EM-Seq methylation
     let grouped = tmp.path().join("grouped.bam");
     let truth = tmp.path().join("truth.tsv");
-    fgumi_ok(args![
-        "simulate",
-        "grouped-reads",
-        "-o",
-        &grouped,
-        "--truth",
-        &truth,
-        "--reference",
-        &ref_path,
-        "--num-molecules",
-        "50",
-        "--seed",
-        "42",
-        "--read-length",
-        "100",
-        "--umi-length",
-        "6",
-        "--min-family-size",
-        "3",
-        "--methylation-mode",
-        "em-seq"
-    ]);
+    GroupedReads::try_parse_from([
+        OsStr::new("grouped-reads"),
+        OsStr::new("-o"),
+        grouped.as_os_str(),
+        OsStr::new("--truth"),
+        truth.as_os_str(),
+        OsStr::new("--reference"),
+        ref_path.as_os_str(),
+        OsStr::new("--num-molecules"),
+        OsStr::new("50"),
+        OsStr::new("--seed"),
+        OsStr::new("42"),
+        OsStr::new("--read-length"),
+        OsStr::new("100"),
+        OsStr::new("--umi-length"),
+        OsStr::new("6"),
+        OsStr::new("--min-family-size"),
+        OsStr::new("3"),
+        OsStr::new("--methylation-mode"),
+        OsStr::new("em-seq"),
+    ])
+    .expect("failed to parse grouped-reads args")
+    .execute("test")
+    .expect("simulate grouped-reads failed");
 
     // Run simplex consensus with methylation mode
     let simplex = tmp.path().join("simplex.bam");
-    fgumi_ok(args![
-        "simplex",
-        "-i",
-        &grouped,
-        "-o",
-        &simplex,
-        "--threads",
-        "1",
-        "--min-reads",
-        "1",
-        "--methylation-mode",
-        "em-seq",
-        "--ref",
-        &ref_path
-    ]);
+    Simplex::try_parse_from([
+        OsStr::new("simplex"),
+        OsStr::new("-i"),
+        grouped.as_os_str(),
+        OsStr::new("-o"),
+        simplex.as_os_str(),
+        OsStr::new("--threads"),
+        OsStr::new("1"),
+        OsStr::new("--min-reads"),
+        OsStr::new("1"),
+        OsStr::new("--methylation-mode"),
+        OsStr::new("em-seq"),
+        OsStr::new("--ref"),
+        ref_path.as_os_str(),
+    ])
+    .expect("failed to parse simplex args")
+    .execute("test")
+    .expect("simplex failed");
 
     // Verify the simplex output actually carries methylation emission.
     // The simplex BAM should contain at least one consensus record with the

--- a/tests/integration/test_sort_correctness.rs
+++ b/tests/integration/test_sort_correctness.rs
@@ -9,19 +9,23 @@
 use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Command;
 use tempfile::TempDir;
+
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::sort::Sort;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn fgumi_binary() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_fgumi"))
-}
-
-fn fgumi(args: &[OsString]) -> Output {
-    Command::new(fgumi_binary()).args(args).output().expect("failed to execute fgumi")
+fn fgumi_sort_in_process(args: &[OsString]) -> anyhow::Result<()> {
+    // `clap::Parser::try_parse_from` accepts any iterator of `Into<OsString>`
+    // values, so feeding `OsString` through avoids a UTF-8 round-trip that
+    // would panic on a non-UTF-8 temp-dir path.
+    let cmd = Sort::try_parse_from(args.iter().cloned()).expect("failed to parse sort args");
+    cmd.execute("test")
 }
 
 fn samtools_available() -> bool {
@@ -100,7 +104,7 @@ fn create_test_bam(dir: &Path, num_reads: usize) -> std::path::PathBuf {
 
 /// Run `fgumi sort --verify` and return whether the file is correctly sorted.
 fn verify_sorted(bam_path: &Path, order: &str) -> bool {
-    let mut cmd_args: Vec<OsString> = vec![
+    let cmd_args: Vec<OsString> = vec![
         "sort".into(),
         "--verify".into(),
         "-i".into(),
@@ -108,12 +112,7 @@ fn verify_sorted(bam_path: &Path, order: &str) -> bool {
         "--order".into(),
         order.into(),
     ];
-    if order == "template-coordinate" {
-        cmd_args.push("--cell-tag".into());
-        cmd_args.push("CB".into());
-    }
-    let output = fgumi(&cmd_args);
-    output.status.success()
+    fgumi_sort_in_process(&cmd_args).is_ok()
 }
 
 /// Count records in a BAM using samtools.
@@ -157,19 +156,12 @@ fn sort_bam_with_args(
         "--temp-compression".into(),
         "1".into(),
     ];
-    if order == "template-coordinate" {
-        cmd_args.push("--cell-tag".into());
-        cmd_args.push("CB".into());
-    }
     for arg in extra_args {
         cmd_args.push((*arg).into());
     }
-    let output_result = fgumi(&cmd_args);
-    assert!(
-        output_result.status.success(),
-        "fgumi sort failed for order={order} threads={threads} memory={max_memory}:\nstderr: {}",
-        String::from_utf8_lossy(&output_result.stderr),
-    );
+    fgumi_sort_in_process(&cmd_args).unwrap_or_else(|e| {
+        panic!("fgumi sort failed for order={order} threads={threads} memory={max_memory}: {e:#}")
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/test_sort_write_index.rs
+++ b/tests/integration/test_sort_write_index.rs
@@ -1,8 +1,15 @@
 //! Integration tests for sort --write-index functionality.
 //!
-//! These tests verify that the BAM index generation works correctly
-//! for both fast (raw-bytes) and standard (record buffer) sorting modes.
+//! Verifies that BAM index generation produces a valid `.bai` that
+//! samtools can query, across the coordinate sort code path.
+//!
+//! fgumi sort is invoked in-process via `Sort::execute()`; samtools
+//! is invoked as a subprocess (external tool).
 
+use clap::Parser;
+use fgumi_lib::commands::command::Command as FgumiCommand;
+use fgumi_lib::commands::sort::Sort;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -10,11 +17,6 @@ use tempfile::TempDir;
 /// Check if samtools is available in PATH.
 fn samtools_available() -> bool {
     Command::new("samtools").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
-}
-
-/// Check if the fgumi binary exists.
-fn fgumi_binary_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_fgumi"))
 }
 
 /// Create a small test BAM file using samtools.
@@ -64,10 +66,10 @@ fn verify_index_works(bam_path: &Path) -> bool {
     count > 0
 }
 
-/// Test sort --fast --write-index creates a valid index.
+/// Test sort --write-index creates a valid index.
 #[test]
 #[ignore = "requires samtools"]
-fn test_sort_fast_write_index() {
+fn test_sort_write_index() {
     if !samtools_available() {
         eprintln!("Skipping: samtools not available");
         return;
@@ -78,64 +80,24 @@ fn test_sort_fast_write_index() {
     let sorted_bam_path = temp_dir.path().join("sorted.bam");
     let index_path = temp_dir.path().join("sorted.bam.bai");
 
-    // Run fgumi sort --fast --write-index
-    let status = Command::new(fgumi_binary_path())
-        .args([
-            "sort",
-            "--fast",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            sorted_bam_path.to_str().unwrap(),
-            "--order",
-            "coordinate",
-            "--write-index",
-            "-m",
-            "10M",
-        ])
-        .status()
-        .expect("Failed to run fgumi sort");
+    // Run fgumi sort (non-fast) --write-index. Pass `&OsStr` directly so
+    // `try_parse_from` doesn't UTF-8 round-trip the temp paths (would panic
+    // on a non-UTF-8 temp dir).
+    let cmd = Sort::try_parse_from([
+        OsStr::new("sort"),
+        OsStr::new("-i"),
+        input_bam.as_os_str(),
+        OsStr::new("-o"),
+        sorted_bam_path.as_os_str(),
+        OsStr::new("--order"),
+        OsStr::new("coordinate"),
+        OsStr::new("--write-index"),
+        OsStr::new("-m"),
+        OsStr::new("10M"),
+    ])
+    .expect("failed to parse sort args");
 
-    assert!(status.success(), "fgumi sort --fast --write-index failed");
-    assert!(sorted_bam_path.exists(), "Output BAM not created");
-    assert!(index_path.exists(), "Output BAI not created");
-
-    // Verify index works
-    assert!(verify_index_works(&sorted_bam_path), "Index does not work for region queries");
-}
-
-/// Test sort (non-fast) --write-index creates a valid index.
-#[test]
-#[ignore = "requires samtools"]
-fn test_sort_standard_write_index() {
-    if !samtools_available() {
-        eprintln!("Skipping: samtools not available");
-        return;
-    }
-
-    let temp_dir = TempDir::new().unwrap();
-    let input_bam = create_test_bam(temp_dir.path());
-    let sorted_bam_path = temp_dir.path().join("sorted.bam");
-    let index_path = temp_dir.path().join("sorted.bam.bai");
-
-    // Run fgumi sort (non-fast) --write-index
-    let status = Command::new(fgumi_binary_path())
-        .args([
-            "sort",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            sorted_bam_path.to_str().unwrap(),
-            "--order",
-            "coordinate",
-            "--write-index",
-            "-m",
-            "10M",
-        ])
-        .status()
-        .expect("Failed to run fgumi sort");
-
-    assert!(status.success(), "fgumi sort --write-index failed");
+    cmd.execute("test").expect("fgumi sort --write-index failed");
     assert!(sorted_bam_path.exists(), "Output BAM not created");
     assert!(index_path.exists(), "Output BAI not created");
 
@@ -157,27 +119,24 @@ fn test_sort_write_index_multithreaded() {
     let sorted_bam_path = temp_dir.path().join("sorted.bam");
     let index_path = temp_dir.path().join("sorted.bam.bai");
 
-    // Run fgumi sort --fast --write-index with multiple threads
-    let status = Command::new(fgumi_binary_path())
-        .args([
-            "sort",
-            "--fast",
-            "-i",
-            input_bam.to_str().unwrap(),
-            "-o",
-            sorted_bam_path.to_str().unwrap(),
-            "--order",
-            "coordinate",
-            "--write-index",
-            "-m",
-            "10M",
-            "-@",
-            "4",
-        ])
-        .status()
-        .expect("Failed to run fgumi sort");
+    // Run fgumi sort --write-index with multiple threads
+    let cmd = Sort::try_parse_from([
+        OsStr::new("sort"),
+        OsStr::new("-i"),
+        input_bam.as_os_str(),
+        OsStr::new("-o"),
+        sorted_bam_path.as_os_str(),
+        OsStr::new("--order"),
+        OsStr::new("coordinate"),
+        OsStr::new("--write-index"),
+        OsStr::new("-m"),
+        OsStr::new("10M"),
+        OsStr::new("-@"),
+        OsStr::new("4"),
+    ])
+    .expect("failed to parse sort args");
 
-    assert!(status.success(), "fgumi sort --fast --write-index -@ 4 failed");
+    cmd.execute("test").expect("fgumi sort --write-index -@ 4 failed");
     assert!(sorted_bam_path.exists(), "Output BAM not created");
     assert!(index_path.exists(), "Output BAI not created");
 
@@ -192,25 +151,24 @@ fn test_write_index_requires_coordinate_sort() {
     let sorted_bam_path = temp_dir.path().join("sorted.bam");
 
     // Run fgumi sort with queryname order and --write-index (should fail)
-    let output = Command::new(fgumi_binary_path())
-        .args([
-            "sort",
-            "-i",
-            "/dev/null", // Won't get to reading input
-            "-o",
-            sorted_bam_path.to_str().unwrap(),
-            "--order",
-            "queryname",
-            "--write-index",
-        ])
-        .output()
-        .expect("Failed to run fgumi sort");
+    let cmd = Sort::try_parse_from([
+        OsStr::new("sort"),
+        OsStr::new("-i"),
+        OsStr::new("/dev/null"), // Won't get to reading input
+        OsStr::new("-o"),
+        sorted_bam_path.as_os_str(),
+        OsStr::new("--order"),
+        OsStr::new("queryname"),
+        OsStr::new("--write-index"),
+    ])
+    .expect("failed to parse sort args");
 
-    assert!(!output.status.success(), "fgumi sort --order queryname --write-index should fail");
+    let result = cmd.execute("test");
+    assert!(result.is_err(), "fgumi sort --order queryname --write-index should fail");
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let err_msg = format!("{:#}", result.unwrap_err());
     assert!(
-        stderr.contains("--write-index is only valid for coordinate sort"),
-        "Expected error about coordinate sort, got: {stderr}"
+        err_msg.contains("--write-index is only valid for coordinate sort"),
+        "Expected error about coordinate sort, got: {err_msg}"
     );
 }


### PR DESCRIPTION
## Summary

Phase 4 of #352, **stacked on #355**. Wraps up the migration by converting the remaining single-command files (sort, downsample) and the end-to-end pipeline file.

Converted commands: `downsample`, `sort`, plus the in-process e2e pipeline (extract → sort → group → simplex → filter, plus the simulate subcommands `grouped-reads` and `fastq-reads`, plus dedup).

## Highlights worth flagging

- **`test_sort_correctness.rs` and `test_sort_write_index.rs` drop dead `--cell-tag CB` and `--fast` args** that prior subprocess tests passed but `Sort` no longer exposes. `Sort::parse_cell_tag` hard-codes `SamTag::CB` for `template-coordinate`; raw-bytes mode selection is internal. The flags were dead under subprocess too — both files are `#[ignore = "requires samtools"]` so the silent parse error never surfaced in default CI.
- **`test_sort_fast_write_index` and `test_sort_standard_write_index` are merged into a single `test_sort_write_index`** because `--fast` no longer exists, so the two tests exercised identical code paths.
- **`test_group_rejects_extract_output_without_sort_step` intentionally stays on the subprocess path.** It asserts on specific stderr substrings (`template-coordinate`, `SS:template-coordinate`, `fgumi sort`) that are CLI-shaped user-facing diagnostics — keeping it subprocess is correct per the issue's acceptance criteria.
- **`test_simulate_sort.rs` is unchanged.** Its tests use `cargo run --features simulate --release -- simulate ...` (not direct fgumi binary invocations) and are `#[ignore]`-gated; converting them is low value and out of scope.
- **`test_streaming_input.rs`, `test_bam_pipeline.rs`, `test_codec_pipeline.rs`, `test_simplex_pipeline.rs`, `test_pipeline_concurrency.rs`, `test_async_reader.rs`, `test_bgzf_eof.rs`, `test_error_paths.rs`** stay subprocess — they're genuine pipeline / pipe-shape tests, exactly the kind of "remaining subprocess invocations" the issue's acceptance criteria allows.

## Phasing — complete after this PR

- Phase 1 (#353): extract, group (excl. determinism), dedup, correct, filter, clip
- Phase 2 (#354): simplex, simplex-metrics, duplex, duplex-metrics, codec, review
- Phase 3 (#355): compare refactor + fastq refactor + non-stdin zipper tests
- **Phase 4 (this PR):** sort, downsample, e2e pipeline

## Commits

```
test(downsample): invoke downsample Command::execute in-process
test(sort):       invoke sort       Command::execute in-process
test(e2e):        invoke pipeline commands in-process via Command::execute
```

## Test plan

- [x] `cargo nextest run --features compare,simulate --test integration` — 193/193 passed, 22 skipped
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean
- [ ] Codecov reports coverage gains on the converted command bodies