### PR TITLE
feat(sort,merge): add --cell-tag flag to override default CB

### DIFF
--- a/src/lib/commands/merge.rs
+++ b/src/lib/commands/merge.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::logging::OperationTimer;
+use crate::sam::SamTag;
 use crate::validation::validate_file_exists;
 use anyhow::{Result, bail};
 use clap::Parser;
@@ -89,6 +90,13 @@ pub struct Merge {
     /// Level 12 produces smallest files but is slowest.
     #[arg(long = "compression-level", default_value_t = 6)]
     pub compression_level: u32,
+
+    /// Two-character SAM tag carrying the cell barcode for `template-coordinate` merge.
+    ///
+    /// Defaults to `CB`. Only valid with `--order template-coordinate`. See the
+    /// corresponding `fgumi sort --cell-tag` flag for context.
+    #[arg(long = "cell-tag", value_parser = clap::value_parser!(SamTag))]
+    pub cell_tag: Option<SamTag>,
 }
 
 impl Command for Merge {
@@ -129,7 +137,7 @@ impl Command for Merge {
             }
         }
 
-        let cell_tag = crate::commands::sort::parse_cell_tag(self.order)?;
+        let cell_tag = crate::commands::sort::parse_cell_tag(self.order, self.cell_tag)?;
 
         let timer = OperationTimer::new("Merging BAMs");
 
@@ -420,6 +428,7 @@ mod tests {
             order: SortOrderArg::Coordinate,
             threads: 1,
             compression_level: 6,
+            cell_tag: None,
         };
 
         let result = merge.execute("test");
@@ -442,6 +451,7 @@ mod tests {
             order: SortOrderArg::Coordinate,
             threads: 1,
             compression_level: 6,
+            cell_tag: None,
         };
 
         let result = merge.execute("test");

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -279,6 +279,15 @@ pub struct Sort {
     /// on disk. Prototype flag; defaults to off.
     #[arg(long = "async-reader", default_value_t = false, hide = true)]
     pub async_reader: bool,
+
+    /// Two-character SAM tag carrying the cell barcode for `template-coordinate` sort.
+    ///
+    /// Templates with different values of this tag sort into disjoint cell groups,
+    /// matching the samtools `--template-coordinate` behavior with cell-aware data
+    /// (e.g. 10x single-cell). Defaults to `CB`. Only valid with
+    /// `--order template-coordinate`; passing it for any other order is an error.
+    #[arg(long = "cell-tag", value_parser = clap::value_parser!(SamTag))]
+    pub cell_tag: Option<SamTag>,
 }
 
 /// Represents the memory limit configuration for sorting.
@@ -360,10 +369,24 @@ pub(crate) fn parse_memory_reserve(s: &str) -> Result<MemoryReserve, String> {
     Ok(MemoryReserve::Fixed(bytes))
 }
 
-/// Parse the cell tag for template-coordinate sort/verify, returning `None`
-/// for other sort orders.
-pub(crate) fn parse_cell_tag(order: SortOrderArg) -> Result<Option<SamTag>> {
-    if matches!(order, SortOrderArg::TemplateCoordinate) { Ok(Some(SamTag::CB)) } else { Ok(None) }
+/// Parse the cell tag for template-coordinate sort/verify.
+///
+/// For `template-coordinate`, returns the user-supplied `override_tag` if any,
+/// otherwise the default `CB`. For any other sort order, returns `None` after
+/// erroring if the user explicitly passed `--cell-tag` (which only makes sense
+/// for template-coordinate sort).
+pub(crate) fn parse_cell_tag(
+    order: SortOrderArg,
+    override_tag: Option<SamTag>,
+) -> Result<Option<SamTag>> {
+    if matches!(order, SortOrderArg::TemplateCoordinate) {
+        Ok(Some(override_tag.unwrap_or(SamTag::CB)))
+    } else {
+        if override_tag.is_some() {
+            bail!("--cell-tag is only valid with --order template-coordinate");
+        }
+        Ok(None)
+    }
 }
 
 use fgumi_sort::verify_sort_order;
@@ -506,7 +529,7 @@ impl Sort {
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
     /// for other sort orders.
     fn parse_cell_tag(&self) -> Result<Option<SamTag>> {
-        parse_cell_tag(self.order)
+        parse_cell_tag(self.order, self.cell_tag)
     }
 
     /// Execute sort mode: read, sort, and write output.
@@ -799,6 +822,7 @@ mod tests {
             temp_compression: 1,
             write_index: false,
             async_reader: false,
+            cell_tag: None,
         }
     }
 
@@ -809,6 +833,30 @@ mod tests {
     fn test_parse_cell_tag(#[case] order: SortOrderArg, #[case] expected: Option<SamTag>) {
         let sort = make_sort(order);
         assert_eq!(sort.parse_cell_tag().expect("parse_cell_tag should succeed"), expected);
+    }
+
+    #[test]
+    fn test_parse_cell_tag_with_override() {
+        use std::str::FromStr;
+        let mut sort = make_sort(SortOrderArg::TemplateCoordinate);
+        let cr = SamTag::from_str("CR").expect("CR is a valid SAM tag");
+        sort.cell_tag = Some(cr);
+        assert_eq!(
+            sort.parse_cell_tag().expect("parse_cell_tag should succeed"),
+            Some(cr),
+            "user-supplied --cell-tag must override the CB default",
+        );
+    }
+
+    #[test]
+    fn test_parse_cell_tag_override_rejected_for_non_template_coordinate() {
+        let mut sort = make_sort(SortOrderArg::Coordinate);
+        sort.cell_tag = Some(SamTag::CB);
+        let err = sort.parse_cell_tag().expect_err("--cell-tag with non-tc sort should error");
+        assert!(
+            err.to_string().contains("--cell-tag is only valid with --order template-coordinate"),
+            "got error: {err}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When sorting or merging with `--order template-coordinate`, fgumi previously hard-coded `SamTag::CB` as the cell-barcode tag, with no way to use a different two-character SAM tag (e.g. `CR` for raw cell barcodes, or a vendor-specific tag).

Add an optional `--cell-tag <XX>` flag to both `fgumi sort` and `fgumi merge`:

- When omitted, behavior is unchanged (defaults to `CB`).
- When provided, the value must be a valid two-character SAM tag (`[A-Za-z][A-Za-z0-9]`), parsed via `SamTag::FromStr`.
- Passing `--cell-tag` with any non-`template-coordinate` sort order is a hard error (`--cell-tag is only valid with --order template-coordinate`).

Mirrors samtools' equivalent CLI shape for cell-aware template-coordinate sorting.

This was flagged by the Opus review of #356 (issue #352) as a known limitation; filing as a standalone enhancement since it's a real Sort/Merge feature, not test mechanics.

## Test plan

- [x] Two new unit tests in `sort.rs`: `test_parse_cell_tag_with_override`, `test_parse_cell_tag_override_rejected_for_non_template_coordinate`
- [x] Existing parameterized `test_parse_cell_tag` cases still pass (CB default preserved)
- [x] `cargo nextest run --features compare,simulate` — 2105/2105 passed, 23 skipped
- [x] `cargo ci-fmt` clean
- [x] `cargo ci-lint` clean

## Backward compatibility

No CLI surface removed; new flag is optional with the prior hard-coded default preserved.