### PR TITLE
fix(duplex-metrics): drop dense (max_ab × max_ba) grid that OOMs on cfDNA hot spots

### DIFF
--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -718,6 +718,43 @@ mod tests {
         assert_eq!(metrics[2].ba_size, 3);
     }
 
+    /// Regression test for the sparse-vs-dense bug that OOM'd `fgumi
+    /// duplex-metrics` on cfDNA inputs. With a single duplex family at
+    /// `(50_000, 50_000)`, the previous dense-grid implementation would
+    /// allocate a `(50_001 × 50_001) × usize` scratch grid (~20 GiB) to
+    /// compute the cumulative fractions. The sparse implementation
+    /// iterates only the three observed `(ab, ba)` entries and computes
+    /// `fraction_gt_or_eq_size` correctly in microseconds.
+    ///
+    /// The assertions verify behaviour; the implicit assertion is that
+    /// the test completes without OOM, which guards against any future
+    /// refactor reintroducing an `O(max_ab × max_ba)` allocation.
+    #[test]
+    fn test_duplex_family_size_metrics_sparse_hot_spot() {
+        let mut collector = DuplexMetricsCollector::new(false);
+        collector.record_duplex_family(2, 1);
+        collector.record_duplex_family(5, 3);
+        collector.record_duplex_family(50_000, 50_000);
+
+        let metrics = collector.duplex_family_size_metrics();
+        assert_eq!(metrics.len(), 3, "exactly 3 sparse entries, not max_ab × max_ba");
+
+        // Sorted ascending by (ab, ba): (2,1) → (5,3) → (50000, 50000).
+        let total = 3.0_f64;
+        // (2, 1): all three entries have ab≥2 ∧ ba≥1.
+        assert_eq!(metrics[0].ab_size, 2);
+        assert_eq!(metrics[0].ba_size, 1);
+        assert!((metrics[0].fraction_gt_or_eq_size - 3.0 / total).abs() < 1e-9);
+        // (5, 3): only (5, 3) and (50000, 50000) satisfy.
+        assert_eq!(metrics[1].ab_size, 5);
+        assert_eq!(metrics[1].ba_size, 3);
+        assert!((metrics[1].fraction_gt_or_eq_size - 2.0 / total).abs() < 1e-9);
+        // (50000, 50000): only itself satisfies.
+        assert_eq!(metrics[2].ab_size, 50_000);
+        assert_eq!(metrics[2].ba_size, 50_000);
+        assert!((metrics[2].fraction_gt_or_eq_size - 1.0 / total).abs() < 1e-9);
+    }
+
     #[test]
     fn test_duplex_umi_expected_frequency() {
         let mut collector = DuplexMetricsCollector::new(true);

--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -386,32 +386,33 @@ impl DuplexMetricsCollector {
 
         metrics.sort();
 
-        // Calculate 2D cumulative fractions: fraction of families with AB >= ab AND BA >= ba
-        // This matches fgbio's definition in DuplexFamilySizeMetric
+        // Calculate 2D cumulative fractions: fraction of families with AB >= ab AND BA >= ba.
+        // This matches fgbio's definition in DuplexFamilySizeMetric.
         //
-        // Build a 2D suffix sum grid to avoid O(n²) per-metric iteration.
+        // The previous implementation built a dense `(max_ab+1) × (max_ba+1)` `usize`
+        // grid and ran 2D suffix sums over it. That `O(max_ab × max_ba)` allocation
+        // OOM'd `fgumi duplex-metrics` on real cfDNA inputs whose hottest duplex
+        // family lands in the tens-of-thousands of reads per strand — e.g.
+        // `max_ab = max_ba = 50_000` yields a 20 GiB scratch grid before any
+        // metric is computed.
+        //
+        // `duplex_family_sizes` is sparse: the HashMap typically holds well under
+        // a thousand distinct `(ab, ba)` pairs even on cfDNA-scale inputs, while
+        // `max_ab × max_ba` can run into the billions. Computing each entry's
+        // suffix sum by direct sparse iteration is `O(N²)` in the number of
+        // distinct pairs — for N≈1000 that's ≈10⁶ comparisons, dwarfed by the
+        // I/O cost of getting here, and the grid allocation is gone.
         if total > 0 {
-            let max_ab = self.duplex_family_sizes.keys().map(|(a, _)| *a).max().unwrap_or(0);
-            let max_ba = self.duplex_family_sizes.keys().map(|(_, b)| *b).max().unwrap_or(0);
-            let cols = max_ba + 1;
-            let mut grid = vec![0usize; (max_ab + 1) * cols];
-            for (&(a, b), &count) in &self.duplex_family_sizes {
-                grid[a * cols + b] = count;
-            }
-            // Accumulate suffix sums: first along ba (columns right-to-left),
-            // then along ab (rows bottom-to-top)
-            for a in 0..=max_ab {
-                for b in (0..max_ba).rev() {
-                    grid[a * cols + b] += grid[a * cols + b + 1];
-                }
-            }
-            for b in 0..=max_ba {
-                for a in (0..max_ab).rev() {
-                    grid[a * cols + b] += grid[(a + 1) * cols + b];
-                }
-            }
+            // Snapshot the sparse `(key, count)` pairs once so the inner loop
+            // doesn't re-borrow the HashMap on every iteration.
+            let entries: Vec<((usize, usize), usize)> =
+                self.duplex_family_sizes.iter().map(|(&k, &v)| (k, v)).collect();
             for metric in &mut metrics {
-                let cumulative_count = grid[metric.ab_size * cols + metric.ba_size];
+                let cumulative_count: usize = entries
+                    .iter()
+                    .filter(|((a, b), _)| *a >= metric.ab_size && *b >= metric.ba_size)
+                    .map(|(_, count)| *count)
+                    .sum();
                 metric.fraction_gt_or_eq_size = frac(cumulative_count, total);
             }
         }

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -305,12 +305,18 @@ impl DuplexMetrics {
         // Pre-compute metadata once for the entire group
         let metadata = compute_template_metadata(group);
 
-        // Hoist scratch buffers outside the 20-fraction loop so we reuse each
-        // HashMap/Vec's bucket allocation across iterations instead of
-        // allocating-and-dropping 20× per coordinate group. This matches what
-        // `simplex_metrics::process_coordinate_group` already does with its
-        // `ss_groups` map, and is the single biggest source of allocator
-        // churn observed on real cfDNA inputs (millions of coordinate groups).
+        // Hoist scratch buffers outside the 20-fraction loop. `HashMap::clear()`
+        // preserves the outer bucket array across iterations — that's the
+        // dominant allocator win on real cfDNA inputs with millions of
+        // coordinate groups, and is the same pattern
+        // `simplex_metrics::process_coordinate_group` already uses for its
+        // `ss_groups` map.
+        //
+        // The inner `Vec<(&str, &str)>` stored as `ds_groups` entry.2 is
+        // still freed per entry on `.clear()`. Combined with the
+        // `is_full_fraction` gate below, that inner Vec now allocates exactly
+        // once per coordinate group (at the 100% fraction) rather than once
+        // per fraction × per `or_default()` slot.
         let mut downsampled: Vec<&TemplateMetadata> = Vec::new();
         let mut ss_groups: HashMap<&str, usize> = HashMap::new();
         #[allow(clippy::type_complexity)]

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -305,11 +305,22 @@ impl DuplexMetrics {
         // Pre-compute metadata once for the entire group
         let metadata = compute_template_metadata(group);
 
+        // Hoist scratch buffers outside the 20-fraction loop so we reuse each
+        // HashMap/Vec's bucket allocation across iterations instead of
+        // allocating-and-dropping 20× per coordinate group. This matches what
+        // `simplex_metrics::process_coordinate_group` already does with its
+        // `ss_groups` map, and is the single biggest source of allocator
+        // churn observed on real cfDNA inputs (millions of coordinate groups).
+        let mut downsampled: Vec<&TemplateMetadata> = Vec::new();
+        let mut ss_groups: HashMap<&str, usize> = HashMap::new();
+        #[allow(clippy::type_complexity)]
+        let mut ds_groups: HashMap<&str, (usize, usize, Vec<(&str, &str)>)> = HashMap::new();
+
         // For each fraction: filter ONCE, then groupBy (like fgbio)
         for (idx, &fraction) in fractions.iter().enumerate() {
             // Filter once per fraction - equivalent to fgbio's downsampledGroup
-            let downsampled: Vec<&TemplateMetadata> =
-                metadata.iter().filter(|m| m.template.hash_fraction <= fraction).collect();
+            downsampled.clear();
+            downsampled.extend(metadata.iter().filter(|m| m.template.hash_fraction <= fraction));
 
             if downsampled.is_empty() {
                 continue;
@@ -319,8 +330,10 @@ impl DuplexMetrics {
             fraction_template_counts[idx] += downsampled.len();
             collectors[idx].record_cs_family(downsampled.len());
 
+            let is_full_fraction = (fraction - 1.0_f64).abs() < 0.01;
+
             // Group by MI tag for SS families (like fgbio's groupBy)
-            let mut ss_groups: HashMap<&str, usize> = HashMap::new();
+            ss_groups.clear();
             for m in &downsampled {
                 *ss_groups.entry(m.template.mi.as_str()).or_default() += 1;
             }
@@ -328,10 +341,12 @@ impl DuplexMetrics {
                 collectors[idx].record_ss_family(ss_size);
             }
 
-            // Group by base_umi for DS families with strand counts
-            // HashMap value: (a_count, b_count, mi_rx_pairs for UMI metrics)
-            #[allow(clippy::type_complexity)]
-            let mut ds_groups: HashMap<&str, (usize, usize, Vec<(&str, &str)>)> = HashMap::new();
+            // Group by base_umi for DS families with strand counts.
+            // HashMap value: (a_count, b_count, mi_rx_pairs for UMI metrics).
+            // The mi/rx pair vec is consumed only at the 100% fraction by
+            // `update_umi_metrics`; skip populating it on downsampled fractions
+            // to avoid O(group_size) wasted pushes per non-full fraction.
+            ds_groups.clear();
             for m in &downsampled {
                 let entry = ds_groups.entry(m.base_umi).or_default();
                 if m.is_a_strand {
@@ -339,11 +354,10 @@ impl DuplexMetrics {
                 } else if m.is_b_strand {
                     entry.1 += 1;
                 }
-                // Collect mi/rx pairs for UMI metrics (only used at 100% fraction)
-                entry.2.push((m.template.mi.as_str(), m.template.rx.as_str()));
+                if is_full_fraction {
+                    entry.2.push((m.template.mi.as_str(), m.template.rx.as_str()));
+                }
             }
-
-            let is_full_fraction = (fraction - 1.0_f64).abs() < 0.01;
 
             for (base_umi, (a_count, b_count, mi_rx_pairs)) in &ds_groups {
                 let ds_size = a_count + b_count;
@@ -354,17 +368,15 @@ impl DuplexMetrics {
 
                 collectors[idx].record_duplex_family(ab_count, ba_count);
 
-                // Only collect UMI metrics for the 100% fraction
+                // Only collect UMI metrics for the 100% fraction. Pass the
+                // (&str, &str) pairs directly — the underlying String storage
+                // lives in `group`, which outlives this call, so the previous
+                // `Vec<(String, String)>` clone was pure overhead.
                 if is_full_fraction {
-                    let owned_pairs: Vec<(String, String)> = mi_rx_pairs
-                        .iter()
-                        .map(|(mi, rx)| ((*mi).to_string(), (*rx).to_string()))
-                        .collect();
-
                     metrics.update_umi_metrics(
                         &mut collectors[idx],
                         umi_consensus_caller,
-                        &owned_pairs,
+                        mi_rx_pairs.as_slice(),
                         base_umi,
                         *a_count,
                         *b_count,
@@ -516,7 +528,7 @@ impl DuplexMetrics {
         &self,
         collector: &mut DuplexMetricsCollector,
         umi_consensus_caller: &mut SimpleUmiConsensusCaller,
-        group_pairs: &[(String, String)],
+        group_pairs: &[(&str, &str)],
         base_umi: &str,
         _a_count: usize,
         _b_count: usize,
@@ -527,7 +539,7 @@ impl DuplexMetrics {
         let mut umi1s = Vec::new();
         let mut umi2s = Vec::new();
 
-        for (mi, rx) in group_pairs {
+        for &(mi, rx) in group_pairs {
             // Check if this MI tag belongs to the current base_umi family
             let mi_base = extract_mi_base(mi);
 
@@ -548,7 +560,9 @@ impl DuplexMetrics {
                 continue;
             }
 
-            // Add UMI parts based on strand
+            // Add UMI parts based on strand. The String allocations here are
+            // bounded by the consensus caller's `&[String]` signature; only the
+            // post-filter (base-matching, non-empty parts) subset is cloned.
             if mi.ends_with("/A") {
                 // For /A strand: u1 goes to umi1s, u2 goes to umi2s
                 umi1s.push(parts[0].to_string());
@@ -591,9 +605,11 @@ impl DuplexMetrics {
             let expected_duplex2 = format!("{}-{}", consensus_umis[1], consensus_umis[0]);
             let error_count = group_pairs
                 .iter()
-                .filter(|(mi, rx)| {
+                .filter(|&&(mi, rx)| {
                     let mi_base = extract_mi_base(mi);
-                    mi_base == base_umi && *rx != expected_duplex1 && *rx != expected_duplex2
+                    mi_base == base_umi
+                        && rx != expected_duplex1.as_str()
+                        && rx != expected_duplex2.as_str()
                 })
                 .count();
 

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -8,7 +8,7 @@
 
 use crate::commands::common::parse_bool;
 use crate::logging::OperationTimer;
-use crate::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric};
+use crate::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric, FamilySizeMetric};
 use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
 use crate::umi::extract_mi_base;
 use crate::validation::validate_file_exists;
@@ -425,12 +425,17 @@ impl DuplexMetrics {
             .map(|m| m.count)
             .sum();
 
-        // Calculate ideal fraction
-        let ds_family_sizes: Vec<usize> =
-            family_size_metrics.iter().flat_map(|m| vec![m.family_size; m.ds_count]).collect();
-
-        let ideal_fraction = Self::calculate_ideal_duplex_fraction(
-            &ds_family_sizes,
+        // Calculate ideal fraction directly from the per-size DS counts. The
+        // previous implementation flat-mapped each `family_size_metric` into a
+        // `Vec<usize>` containing `m.family_size` repeated `m.ds_count` times,
+        // then iterated that flat Vec computing one `Binomial::cdf` per entry.
+        // For inputs with even one family that ran into the tens-of-thousands
+        // of reads the flat Vec adds tens of MB and the inner loop recomputes
+        // the *same* binomial probability `ds_count` times for every distinct
+        // family size. Iterating the per-size buckets is mathematically
+        // equivalent: each family size's contribution is `prob × ds_count`.
+        let ideal_fraction = Self::calculate_ideal_duplex_fraction_per_size(
+            &family_size_metrics,
             self.min_ab_reads,
             self.min_ba_reads,
         );
@@ -466,36 +471,47 @@ impl DuplexMetrics {
         }
     }
 
-    /// Calculates the ideal duplex fraction using binomial model.
+    /// Calculates the ideal duplex fraction directly from per-family-size
+    /// counts, weighting each family size's probability by its DS count
+    /// instead of materializing a flat `Vec<usize>` of repeated sizes.
     ///
-    /// For each family of size N, calculates the probability that both strands
-    /// have sufficient reads (A >= `min_ab` AND B >= `min_ba` where A + B = N).
-    /// Assumes each read has 0.5 probability of being on each strand.
-    fn calculate_ideal_duplex_fraction(
-        family_sizes: &[usize],
+    /// For each family size N with `ds_count` observations, calculates the
+    /// probability that both strands have sufficient reads
+    /// (A >= `min_ab` AND B >= `min_ba` where A + B = N), assuming each read
+    /// has 0.5 probability of being on each strand. The numerator
+    /// accumulates `prob × ds_count` per unique size; the denominator is the
+    /// total number of DS family observations.
+    ///
+    /// This is mathematically equivalent to the previous
+    /// `calculate_ideal_duplex_fraction(&[usize])` form but avoids both the
+    /// `vec![size; ds_count]` allocation and the redundant `Binomial::cdf`
+    /// recomputation for repeated family sizes.
+    fn calculate_ideal_duplex_fraction_per_size(
+        family_size_metrics: &[FamilySizeMetric],
         min_ab: usize,
         min_ba: usize,
     ) -> f64 {
-        if family_sizes.is_empty() {
+        let total_families: usize = family_size_metrics.iter().map(|m| m.ds_count).sum();
+        if total_families == 0 {
             return 0.0;
         }
 
         let mut ideal_duplexes = 0.0;
-        let total_families = family_sizes.len() as f64;
 
-        for &size in family_sizes {
+        for m in family_size_metrics {
+            if m.ds_count == 0 {
+                continue;
+            }
+            let size = m.family_size;
             if size < min_ab + min_ba {
                 // Impossible to form a duplex with this family size
                 continue;
             }
 
             // Calculate P(A >= min_ab AND B >= min_ba) where A ~ Binomial(n=size, p=0.5)
-            // and B = size - A
-            //
-            // This is equivalent to: P(min_ba <= A <= size - min_ab)
-            // = P(A <= size - min_ab) - P(A < min_ba)
-            // = CDF(size - min_ab) - CDF(min_ba - 1)
-
+            // and B = size - A. Equivalent to:
+            //   P(min_ba <= A <= size - min_ab)
+            //   = CDF(size - min_ab) - CDF(min_ba - 1)
             let binomial = match Binomial::new(0.5, size as u64) {
                 Ok(b) => b,
                 Err(_) => continue, // Skip if binomial creation fails
@@ -504,7 +520,6 @@ impl DuplexMetrics {
             let upper_bound = size - min_ba;
             let lower_bound = min_ab;
 
-            // P(A >= lower_bound AND A <= upper_bound)
             let prob = if upper_bound >= lower_bound {
                 let p_upper = binomial.cdf(upper_bound as u64);
                 let p_lower =
@@ -514,10 +529,10 @@ impl DuplexMetrics {
                 0.0
             };
 
-            ideal_duplexes += prob;
+            ideal_duplexes += prob * (m.ds_count as f64);
         }
 
-        ideal_duplexes / total_families
+        ideal_duplexes / (total_families as f64)
     }
 
     /// Updates UMI metrics for a duplex family


### PR DESCRIPTION
## What this fixes

`fgumi duplex-metrics` OOMs on real cfDNA-class inputs (`vendor`-profile samples — `idt-cfdna`, `kapa-umi`, `agilent-hs2`, `schmitt-abl1`, `twist-umi`) on a 30 GiB `c7g.4xlarge`. The same machine processes the simplex-metrics counterpart of the same files without issue.

The OOM happens **after** the streaming pass: every affected job logs `Processed N templates` and then gets OOM-killed during the per-collector yield-metric pass, at the exact same template count run after run.

### Real cause

`DuplexMetricsCollector::duplex_family_size_metrics()` computed the 2D cumulative `fraction_gt_or_eq_size` by materializing a dense `(max_ab + 1) × (max_ba + 1) × usize` grid and running 2D suffix sums over it. The underlying `duplex_family_sizes: HashMap<(usize, usize), usize>` is **sparse** — typically well under a thousand distinct `(ab, ba)` pairs even on cfDNA-scale inputs — but the grid is sized by the *maxima* of the two dimensions. On a cfDNA sample whose hottest duplex family lands in the tens of thousands of reads per strand, this allocates billions of cells (`max_ab = max_ba = 50_000` → ~20 GiB scratch) before any metric is computed. With 20 collectors and `generate_yield_metric` calling `duplex_family_size_metrics()` per collector, you OOM before producing any output.

## Changes

* **`crates/fgumi-metrics/src/duplex.rs::duplex_family_size_metrics`** — replace the dense-grid 2D suffix-sum with a sparse `O(N²)` iteration over the actual `(key, count)` HashMap entries, where `N` is the number of distinct `(ab, ba)` pairs (typically <1000, dwarfed by upstream I/O cost). No more `max_ab × max_ba` allocation.
* **`src/lib/commands/duplex_metrics.rs::generate_yield_metric` + new `calculate_ideal_duplex_fraction_per_size`** — stop expanding `family_size_metrics` into a flat `Vec<usize>` of `m.family_size` repeated `m.ds_count` times. Iterate per-size buckets and weight each size's binomial probability by its `ds_count`. Mathematically equivalent; eliminates the flat-Vec allocation *and* the `O(ds_count)` redundant `Binomial::cdf` calls per distinct family size.
* **`src/lib/commands/duplex_metrics.rs::process_coordinate_group`** — hoist `ss_groups` and `ds_groups` scratch HashMaps out of the 20-fraction loop and reuse via `.clear()`; skip `entry.2.push(...)` on non-full fractions; switch `update_umi_metrics` to `&[(&str, &str)]` to drop the owned-`String` clone at the call site. These are the original commits in this PR — they're real micro-perf improvements (mirroring the existing pattern in `simplex_metrics::process_coordinate_group`) but did NOT move the needle on the OOM, because the OOM is downstream of the streaming pass. They stay because they reduce allocator churn on the hot path.

## Behaviour

No behavioural change in any output column. Verified by:

- 20 existing `duplex_metrics::tests` pass on the post-fix tree.
- 107 existing `fgumi-metrics::tests` pass (was 106; the new regression test below adds one).
- 7 existing `simplex_metrics::tests` pass (unchanged file, sanity check on the shared metrics path).
- `cargo ci-fmt`, `cargo ci-lint` clean.

## Regression test

`test_duplex_family_size_metrics_sparse_hot_spot` in `crates/fgumi-metrics/src/duplex.rs` constructs a collector with one duplex family at `(50_000, 50_000)` alongside two small entries. Under the previous dense-grid implementation this would have allocated ~20 GiB before any assertion ran; under the sparse implementation it completes in microseconds. Pins the invariant against any future refactor that might silently reintroduce an `O(max_ab × max_ba)` allocation.

## Note on simplex-metrics

Reviewer asked whether simplex-metrics has the analogous bug. **No** — simplex-metrics has no equivalent 2D `(ab, ba)` cumulative structure (its `family_size_metrics` is 1D over `1..=max_size`, which is bounded by `max_size × ~80B` per call). The 1D densification pattern is shared between duplex and simplex `family_size_metrics`, but at realistic `max_size` it does not OOM. Left untouched in this PR.

## Test plan

- [x] `cargo test --release --lib duplex_metrics` — 20 passed
- [x] `cargo test --release --lib simplex_metrics` — 7 passed
- [x] `cargo test --release -p fgumi-metrics` — 107 passed (incl. new sparse-hot-spot regression)
- [x] `cargo ci-fmt`, `cargo ci-lint` clean
- [x] Real `vendor` benchmark on cfDNA-class inputs against the prior broken build reproduced the OOM at the same template count; re-running with this PR's bundled into `2fdcc7b` reproduced the OOM at the same point (confirming the original hoist-only fix was insufficient) — that's the empirical evidence behind this follow-up fix
- [ ] Re-run `vendor` profile against this PR head after a fresh submodule bump to confirm `duplex_metrics_fgumi` no longer OOMs on any of the 5 duplex-capable vendor samples

## Commit sequence

| Commit | What |
|---|---|
| `4649c11` | `perf(duplex-metrics): hoist scratch maps and drop unnecessary string clones` — micro-perf; not the OOM fix |
| `2fdcc7b` | `docs(duplex-metrics): clarify what HashMap::clear actually reuses` — comment-accuracy nit from initial review |
| `f6a1174` | `fix(duplex-metrics): drop dense (max_ab × max_ba) grid that OOMs on cfDNA hot spots` — **the actual OOM fix** |
| `7460059` | `test(duplex-metrics): pin the sparse-hot-spot regression` — guards against re-introducing dense allocation |