### PR TITLE
docs(zipper): recommend uncompressed BAM input for streaming pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- Recommend uncompressed BAM (`bwa-mem3 mem --bam=0`) as the preferred `fgumi zipper` input format for streaming pipelines, with SAM kept as a fallback for aligners that can't emit BAM. Replaced the misleading "BAM input is discouraged" `warn!` on the stdin-BAM path with a neutral `info!`, and dropped the equivalent warning on the file-BAM path. Updated `zipper` CLI help/long_about and the getting-started, best-practices, performance-tuning, and migration-from-fgbio guides accordingly.
+
 ### Bug Fixes
 
 - [**breaking**] `fgumi group`, `fgumi dedup`, and `fgumi downsample` now strictly require template-coordinate sorted input — the header must advertise `SO:unsorted`, `GO:query`, **and** `SS:template-coordinate`. The previous implementation accepted any `SO:unsorted GO:query` header even without `SS:template-coordinate`, which caused `fgumi extract` output (FASTQ-order, no `SS`) and other queryname-grouped BAMs to be silently treated as template-coordinate sorted. Because the streaming `RecordPositionGrouper` requires records sharing a position key to be consecutive, this could split a single true molecule across multiple position groups and assign distinct `MI` tags to reads that should share one. The `--allow-unmapped` queryname-sort shortcut has also been removed for the same reason. To migrate: insert `fgumi sort --order template-coordinate` between extract (or any non-TC source) and `fgumi group`/`dedup`/`downsample`.

--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -153,8 +153,9 @@ Key points:
 - `-K 150000000` sets batch size (improves reproducibility)
 - **`-Y` is critical**: Use soft-clipping for supplementary alignments to preserve bases
 - `fgumi zipper` transfers tags from unmapped BAM to aligned reads
-- `fgumi zipper` accepts SAM piped from the aligner (preferred) or a BAM file via `--input`;
-  piping SAM avoids an extra encode/decode step
+- `fgumi zipper` accepts SAM or BAM on stdin or `--input`. For best performance, pipe
+  uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`); SAM is fine for aligners
+  that can't emit BAM
 
 For large files, add threading:
 

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -52,9 +52,11 @@ This pipes reads through:
 3. `zipper` — merges aligned reads with original unmapped BAM to restore UMI tags
 4. `sort` — sorts into template-coordinate order for grouping
 
-> **Note:** `fgumi zipper` accepts SAM input (piped from the aligner) or a BAM file via `--input`.
-> Piping SAM directly from the aligner is preferred for best performance; BAM input is
-> functional but involves an extra decode step.
+> **Note:** `fgumi zipper` accepts SAM or BAM input, on stdin or via `--input`. For best
+> performance, pipe uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`) — this
+> skips both the SAM text formatting on the aligner side and the SAM parsing on the zipper
+> side. SAM is fine for aligners that can't emit BAM; compressed BAM on a pipe is not
+> recommended (wasted CPU on both ends).
 
 For single-cell data, the `CB` cell barcode tag is automatically included in the
 template-coordinate sort key, keeping templates from different cells at the same locus separate:

--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -38,7 +38,7 @@ fgumi fastq --input unaligned.bam \
   | fgumi sort --output sorted.bam --order template-coordinate
 ```
 
-This replaces multiple separate fgbio/picard steps (SortBam, ZipperBams/MergeBamAlignment) with a single streaming pass. `fgumi zipper` accepts SAM piped from the aligner (preferred) or a BAM file via `--input`.
+This replaces multiple separate fgbio/picard steps (SortBam, ZipperBams/MergeBamAlignment) with a single streaming pass. `fgumi zipper` accepts SAM or BAM on stdin or via `--input`; for best performance, pipe uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`).
 
 ### Merging Multiple BAMs
 

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -342,8 +342,11 @@ Requested memory 16GB exceeds 90% of system memory (14.4GB)
 - Compression level affects output size significantly
 
 ### Zipper
-- For best throughput, pipe SAM directly from the aligner rather than writing and re-reading a BAM
-- BAM file input is supported via `--input` but adds an extra decode step
+- For best throughput, pipe uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`).
+  Uncompressed BAM skips SAM text formatting on the aligner side and SAM parsing on the zipper
+  side, and adds only ~26 bytes of BGZF framing per ~64 KiB block
+- SAM input is fine for aligners that can't emit BAM; compressed BAM on a pipe wastes CPU on
+  both ends for data the sort step will re-compress anyway
 - The zipper pipeline uses raw-byte merging internally: aligned records are not fully decoded and
   re-encoded unless the record actually needs modification, which eliminates a significant CPU
   bottleneck on high-throughput runs

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -62,7 +62,7 @@ use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{RawBamReaderAuto, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path};
 use fgumi_raw_bam;
 use fgumi_raw_bam::{BAM_BASE_TO_ASCII, RawRecord, RawRecordView, RecordBufEncoder};
-use log::{debug, info, warn};
+use log::{debug, info};
 use noodles::core::Position;
 use noodles::sam::Header;
 use std::collections::HashSet;
@@ -105,13 +105,25 @@ Named tag sets like "Consensus" are automatically expanded to their constituent 
 By default, input is read from stdin and output is written to stdout, allowing for streaming
 workflows like:
 
-  bwa mem -t 8 -p -K 150000000 -Y ref.fa reads.fq | fgumi zipper -u unmapped.bam -r ref.fa | fgumi sort -i /dev/stdin -o output.bam --order template-coordinate
+  # Recommended when the aligner can emit uncompressed BAM:
+  bwa-mem3 mem --bam=0 -t 16 -p -K 150000000 -Y ref.fa reads.fq | fgumi zipper -u unmapped.bam -r ref.fa | fgumi sort -i /dev/stdin -o output.bam --order template-coordinate
+
+  # SAM-only aligners (e.g. classic bwa mem, bwa-mem2):
+  bwa mem -t 16 -p -K 150000000 -Y ref.fa reads.fq | fgumi zipper -u unmapped.bam -r ref.fa | fgumi sort -i /dev/stdin -o output.bam --order template-coordinate
+
+Uncompressed BAM avoids the SAM text formatting/parsing round-trip in both processes
+and adds only ~26 bytes of BGZF framing per ~64 KiB block. Compressed BAM on a pipe
+is not recommended — it burns CPU on the writer and reader for data the sort step
+will re-compress anyway.
 "#
 )]
 #[command(verbatim_doc_comment)]
 pub struct Zipper {
     /// Input mapped SAM or BAM file (or `-` for stdin; SAM or BAM is auto-detected).
-    /// BAM input is discouraged; prefer piping SAM directly from the aligner for best performance.
+    /// For streaming pipelines, uncompressed BAM (e.g. `bwa-mem3 mem --bam=0`) is the
+    /// fastest option — it skips both SAM text formatting on the aligner side and SAM
+    /// parsing on this side. SAM is fine if your aligner can't emit BAM. Compressed
+    /// BAM on a pipe wastes CPU on both ends.
     #[arg(short = 'i', long, default_value = "-")]
     pub input: PathBuf,
 
@@ -1055,10 +1067,7 @@ impl Command for Zipper {
             let (is_bgzf, stdin) = peek_stdin_bgzf(stdin)?;
             let buffered = BufReader::with_capacity(64 * 1024, stdin);
             if is_bgzf {
-                warn!(
-                    "BAM input detected on stdin. For best performance, pipe SAM directly \
-                     from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
-                );
+                info!("Reading BAM from stdin");
                 let bgzf = noodles::bgzf::io::Reader::new(buffered);
                 let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
                 let header = bam_reader.read_header()?;
@@ -1076,11 +1085,6 @@ impl Command for Zipper {
                 (MappedReader::Sam(sam_reader), header)
             }
         } else if self.input.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("bam")) {
-            // BAM file input — functional but discouraged
-            warn!(
-                "BAM input detected for --input. For best performance, pipe SAM directly \
-                 from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
-            );
             let (raw_reader, header) = create_raw_bam_reader(&self.input, self.threads)?;
             (MappedReader::Bam(raw_reader), header)
         } else {

--- a/tests/integration/test_zipper_command.rs
+++ b/tests/integration/test_zipper_command.rs
@@ -344,10 +344,6 @@ fn test_zipper_bam_mapped_input() {
     for record in &records {
         assert!(record.data().get(&rx_tag).is_some(), "Output record should have RX tag");
     }
-
-    // Verify warning about BAM input was emitted
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("BAM input detected"), "Should warn about BAM input. stderr: {stderr}");
 }
 
 /// Test zipper accepts BAM piped to stdin (auto-detected via BGZF magic bytes).


### PR DESCRIPTION
## Summary

`fgumi zipper` accepts uncompressed BAM on stdin via the existing raw-byte path, which is faster end-to-end than piping SAM text — it skips ASCII formatting in the aligner and SAM parsing in zipper. The prior recommendation in the CLI help, `long_about`, two `warn!` calls, and four guide pages predates aligners that can emit uncompressed BAM directly. [`bwa-mem3`](https://github.com/fg-labs/bwa-mem3) supports `--bam[=N]` with `N=0` (uncompressed BGZF, no DEFLATE) and builds `bam1_t` records directly from `mem_aln_t` without going through a SAM-text intermediate, so the recommended pipeline shape now is uncompressed BAM end-to-end.

This PR flips the recommendation:

- Updates `--input` CLI help and the `long_about` example block to recommend `bwa-mem3 mem --bam=0` for streaming pipelines, keeping a SAM example for aligners that can't emit BAM.
- Replaces the stdin-BAM `warn!` with a neutral `info!("Reading BAM from stdin")` mirroring the existing stdin-SAM info log; drops the file-BAM `warn!` entirely (the SAM-file path doesn't log either, so this restores symmetry).
- Applies the same recommendation flip to `docs/src/guide/{getting-started,best-practices,performance-tuning,migration-from-fgbio}.md`.
- Removes a stale integration-test assertion that expected the dropped warn text.
- Adds a `## [Unreleased]` `### Documentation` CHANGELOG entry.

No behavior change.

## Why uncompressed BAM beats SAM text on a pipe

Both formats end up at roughly the same on-pipe byte count (BGZF level 0 adds ~26 bytes of framing per ~64 KiB block — header 18 + trailer 8). The win is on the CPU side at both ends:

- **Aligner side:** writing BAM skips formatting integers, flags, and CIGAR ops to ASCII. `bwa-mem3` builds `bam1_t` directly (`mem_aln_to_bam`, no SAM-text intermediate).
- **zipper side:** the BAM-stdin path feeds raw bytes straight into `TemplateIterator` (`MappedReader::StdinBam` → `RawBamReader`). The SAM path goes through noodles `RecordBuf` decode + `RecordBufEncoder` re-encode (`record_bufs_to_templates` in `src/lib/commands/zipper.rs`), which is meaningful CPU per record.

Compressed BAM on a pipe (`--bam=1+`) is still discouraged in the new copy — it burns DEFLATE CPU on the writer and inflate on the reader for data the downstream sort step recompresses anyway.

## Test plan

- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo nextest run -E 'test(zipper)'` — 75/75 zipper tests pass, including `test_zipper_bam_mapped_input` (file BAM input) and `test_zipper_bam_stdin_input` (stdin BAM auto-detect)
- [x] mdBook docs render — only prose changed; no syntax disturbed
- [x] CLI help renders cleanly: `cargo run -- zipper --help`

## Notes for reviewers

- I left the README.md Quick Start example and `fgumi fastq`'s `long_about` examples on plain `bwa mem` — those are aligner-agnostic illustrations and inverting them feels out of scope for a zipper-docs PR. Happy to do a follow-up if the team wants consistency.
- The new `long_about` block is slightly longer than sibling commands' help text (e.g. `fastq`, `sort`) — included a three-sentence rationale paragraph because zipper is the most pipeline-shape-sensitive command. Will trim if reviewers prefer a terser feel.