### PR TITLE
refactor(duplex-metrics): replace dead Binomial::new Err arm with expect

### DIFF
--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -512,10 +512,15 @@ impl DuplexMetrics {
             // and B = size - A. Equivalent to:
             //   P(min_ba <= A <= size - min_ab)
             //   = CDF(size - min_ab) - CDF(min_ba - 1)
-            let binomial = match Binomial::new(0.5, size as u64) {
-                Ok(b) => b,
-                Err(_) => continue, // Skip if binomial creation fails
-            };
+
+            // `Binomial::new(p, n)` only returns `Err` when `p` is NaN or
+            // outside `[0, 1]` (statrs 0.18 `BinomialError::ProbabilityInvalid`).
+            // With `p = 0.5` hardcoded the `Err` arm is statically unreachable;
+            // expect rather than silently skip so a future refactor that lets
+            // `p` become dynamic surfaces immediately instead of silently
+            // dropping families from the ideal-fraction calculation.
+            let binomial = Binomial::new(0.5, size as u64)
+                .expect("p = 0.5 is always a valid probability for Binomial::new");
 
             let upper_bound = size - min_ba;
             let lower_bound = min_ab;


### PR DESCRIPTION
## Summary

In `calculate_ideal_duplex_fraction`, the `match Binomial::new(0.5, size as u64) { Err(_) => continue, … }` arm is statically unreachable — `statrs::distribution::Binomial::new(p, n)` only returns `Err(BinomialError::ProbabilityInvalid)` when `p` is NaN or outside `[0, 1]` (see `statrs-0.18.0/src/distribution/binomial.rs:67-70`), and every call site here passes the literal `0.5`.

Replace the `match` with `.expect(\"…\")` so that any future refactor letting `p` become dynamic surfaces the panic immediately instead of silently dropping families from the ideal-fraction calculation.

## Diff

One file, 4 lines net:

```rust
- let binomial = match Binomial::new(0.5, size as u64) {
-     Ok(b) => b,
-     Err(_) => continue, // Skip if binomial creation fails
- };
+ // `Binomial::new(p, n)` only returns `Err` when `p` is NaN or
+ // outside `[0, 1]` (statrs 0.18 `BinomialError::ProbabilityInvalid`).
+ // With `p = 0.5` hardcoded the `Err` arm is statically unreachable;
+ // expect rather than silently skip so a future refactor that lets
+ // `p` become dynamic surfaces immediately instead of silently
+ // dropping families from the ideal-fraction calculation.
+ let binomial = Binomial::new(0.5, size as u64)
+     .expect(\"p = 0.5 is always a valid probability for Binomial::new\");
```

## Behaviour

None — the replaced arm could not have fired on any input. Spotted during review of #359; sized as a separate PR per reviewer guidance to keep that PR's diff focused on the OOM fix.

## Test plan

- [x] \`cargo test --release --lib duplex_metrics\` — 20 passed
- [x] \`cargo ci-fmt\`, \`cargo ci-lint\` clean