### PR TITLE
refactor(sort): demote algorithm-internal info! logs to debug

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1546,7 +1546,7 @@ impl RawExternalSorter {
         let n_to_merge = (self.max_temp_files / 2).max(2).min(chunk_files.len());
         let files_to_merge: Vec<PathBuf> = chunk_files.drain(..n_to_merge).collect();
 
-        info!(
+        debug!(
             "Consolidating {} temp files into 1 (total was {})...",
             n_to_merge,
             n_to_merge + chunk_files.len()
@@ -1618,7 +1618,7 @@ impl RawExternalSorter {
             let _ = std::fs::remove_file(path);
         }
 
-        info!("Consolidation complete, {} temp files remain", chunk_files.len());
+        debug!("Consolidation complete, {} temp files remain", chunk_files.len());
 
         Ok(())
     }
@@ -1642,9 +1642,9 @@ impl RawExternalSorter {
              zstd level >= 1."
         );
 
-        info!("Starting raw-bytes sort with order: {:?}", self.sort_order);
-        info!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
-        info!("Threads: {}", self.threads);
+        debug!("Starting raw-bytes sort with order: {:?}", self.sort_order);
+        debug!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
+        debug!("Threads: {}", self.threads);
 
         // Shared worker pool for parallel BGZF compress/decompress across all phases
         let pool = Arc::new(SortWorkerPool::new(
@@ -1657,7 +1657,10 @@ impl RawExternalSorter {
         // Open input BAM and create record source
         // N+2 model: workers do ReadInputBlocks + DecompressInput,
         // main thread reads records directly from PooledInputStream.
-        info!("Phase 1: Pool-integrated input reading ({} workers, N+2 model)", pool.num_workers());
+        debug!(
+            "Phase 1: Pool-integrated input reading ({} workers, N+2 model)",
+            pool.num_workers()
+        );
         let (record_source, header) = {
             let (reader, header) =
                 create_raw_bam_reader_pool_integrated(input, &pool, self.async_reader)?;
@@ -1703,7 +1706,7 @@ impl RawExternalSorter {
             SortContext,
         };
 
-        info!("Starting k-way merge of {} BAM files", inputs.len());
+        debug!("Starting k-way merge of {} BAM files", inputs.len());
 
         let mut readers = Self::open_bam_prefetch_readers(inputs)?;
         let output_header = self.create_output_header(header);
@@ -1780,7 +1783,7 @@ impl RawExternalSorter {
         }
 
         if initial_keys.is_empty() {
-            info!("Merge complete: 0 records merged");
+            debug!("Merge complete: 0 records merged");
             let writer = fgumi_bam_io::create_raw_bam_writer(
                 output,
                 output_header,
@@ -1880,7 +1883,7 @@ impl RawExternalSorter {
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
-        info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
+        debug!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
         let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
@@ -1963,7 +1966,7 @@ impl RawExternalSorter {
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
-            info!("All records fit in memory, performing in-memory sort");
+            debug!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
                 rayon_pool.install(|| buffer.par_sort());
@@ -1997,7 +2000,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            info!(
+            debug!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
                 chunk_files.len() + n_memory
             );
@@ -2020,7 +2023,7 @@ impl RawExternalSorter {
             pool.shutdown();
         }
         timer.log_summary(self.threads);
-        info!("Sort complete: {} records processed", stats.total_records);
+        debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
     }
@@ -2042,7 +2045,7 @@ impl RawExternalSorter {
         use crate::keys::RawCoordinateKey;
         use fgumi_bam_io::{create_indexing_bam_writer, write_bai_index};
 
-        info!("Indexing enabled: will write BAM index alongside output");
+        debug!("Indexing enabled: will write BAM index alongside output");
 
         let mut stats = RawSortStats::default();
         let mut timer = SortPhaseTimer::new();
@@ -2059,7 +2062,7 @@ impl RawExternalSorter {
         let mut pending_spill: Option<PendingSpill> = None;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
-        info!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
+        debug!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
         let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
@@ -2117,7 +2120,7 @@ impl RawExternalSorter {
         }
 
         timer.end_read_span();
-        info!("Read {} records total", stats.total_records);
+        debug!("Read {} records total", stats.total_records);
         if let Some(err) = record_source.take_error() {
             return Err(anyhow::Error::from(err));
         }
@@ -2137,7 +2140,7 @@ impl RawExternalSorter {
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
-            info!("All records fit in memory, performing in-memory sort");
+            debug!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
                 rayon_pool.install(|| buffer.par_sort());
@@ -2177,7 +2180,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            info!(
+            debug!(
                 "Phase 2: Merging {} chunks with index generation...",
                 chunk_files.len() + n_memory
             );
@@ -2204,7 +2207,7 @@ impl RawExternalSorter {
             pool.shutdown();
         }
         timer.log_summary(self.threads);
-        info!("Sort complete: {} records processed", stats.total_records);
+        debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
     }
@@ -2224,7 +2227,7 @@ impl RawExternalSorter {
         comparator: QuerynameComparator,
     ) -> Result<RawSortStats> {
         use crate::keys::{RawQuerynameKey, RawQuerynameLexKey};
-        info!("Using queryname sort with {comparator} comparator");
+        debug!("Using queryname sort with {comparator} comparator");
         match comparator {
             QuerynameComparator::Lexicographic => self.sort_queryname_keyed::<RawQuerynameLexKey>(
                 record_source,
@@ -2272,7 +2275,7 @@ impl RawExternalSorter {
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
-        info!("Phase 1: Reading and sorting chunks (keyed output)...");
+        debug!("Phase 1: Reading and sorting chunks (keyed output)...");
         let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
@@ -2359,7 +2362,7 @@ impl RawExternalSorter {
 
         if chunk_files.is_empty() {
             // All records fit in memory
-            info!("All records fit in memory, performing in-memory sort");
+            debug!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
                 use rayon::prelude::*;
@@ -2426,7 +2429,7 @@ impl RawExternalSorter {
             let memory_chunks = MemorySources::Owned(keyed_chunks);
 
             let n_memory = memory_chunks.num_non_empty();
-            info!(
+            debug!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
                 chunk_files.len() + n_memory
             );
@@ -2449,7 +2452,7 @@ impl RawExternalSorter {
             pool.shutdown();
         }
         timer.log_summary(self.threads);
-        info!("Sort complete: {} records processed", stats.total_records);
+        debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
     }
@@ -2496,7 +2499,7 @@ impl RawExternalSorter {
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
-        info!("Phase 1: Reading and sorting chunks (inline buffer)...");
+        debug!("Phase 1: Reading and sorting chunks (inline buffer)...");
         let mut probe = SpillProbe::new("phase1");
 
         for record in record_source.by_ref() {
@@ -2578,7 +2581,7 @@ impl RawExternalSorter {
 
         if chunk_files.is_empty() {
             // All records fit in memory
-            info!("All records fit in memory, performing in-memory sort");
+            debug!("All records fit in memory, performing in-memory sort");
 
             timer.time_sort(|| {
                 rayon_pool.install(|| buffer.par_sort());
@@ -2611,7 +2614,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            info!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
+            debug!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
             timer.time_merge(|| {
@@ -2631,7 +2634,7 @@ impl RawExternalSorter {
             pool.shutdown();
         }
         timer.log_summary(self.threads);
-        info!("Sort complete: {} records processed", stats.total_records);
+        debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
     }
@@ -2727,7 +2730,7 @@ impl RawExternalSorter {
         let num_disk = chunk_files.len();
 
         if num_disk > 0 {
-            info!(
+            debug!(
                 "Pool-integrated merge: {} disk sources, {} pool workers (N+2 model)",
                 num_disk,
                 pool.num_workers()
@@ -2743,7 +2746,7 @@ impl RawExternalSorter {
         )?;
 
         let num_sources = sources.len();
-        info!("Merging from {num_sources} sources...");
+        debug!("Merging from {num_sources} sources...");
 
         // Create pool consumer for PoolDisk sources and activate Phase 2.
         // The consumer holds an Arc snapshot of the pool's per-file Phase 2
@@ -2780,7 +2783,7 @@ impl RawExternalSorter {
         }
 
         if initial_keys.is_empty() {
-            info!("Merge complete: 0 records merged");
+            debug!("Merge complete: 0 records merged");
             guard.deactivate();
             let writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
             writer.finish()?;
@@ -2789,7 +2792,7 @@ impl RawExternalSorter {
 
         let mut tree = LoserTree::new(initial_keys);
 
-        info!("Merge thread budget: {} pool workers + 1 I/O + 1 main (N+2)", pool.num_workers());
+        debug!("Merge thread budget: {} pool workers + 1 I/O + 1 main (N+2)", pool.num_workers());
         let mut writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
 
         let mut records_merged = 0u64;
@@ -2916,11 +2919,11 @@ impl RawExternalSorter {
         )?;
 
         let num_sources = sources.len();
-        info!(
+        debug!(
             "Merge thread budget (indexing): {writer_threads} writer + {reader_concurrency} reader + 1 main = {} total",
             writer_threads + reader_concurrency + 1
         );
-        info!("Merging from {num_sources} sources (indexing)...");
+        debug!("Merging from {num_sources} sources (indexing)...");
 
         let output_header = self.create_output_header(header);
 
@@ -2946,7 +2949,7 @@ impl RawExternalSorter {
                 writer_threads,
             )?;
             let index = writer.finish()?;
-            info!("Merge complete: 0 records merged");
+            debug!("Merge complete: 0 records merged");
             return Ok(index);
         }
 
@@ -3196,7 +3199,7 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
 
         let reader: Box<dyn io::Read + Send> = if async_reader {
             fgumi_bam_io::os_hints::advise_sequential(&file);
-            log::info!(
+            log::debug!(
                 "async sort reader enabled: spawning fgumi-prefetch thread for {}",
                 path_ref.display()
             );

--- a/crates/fgumi-sort/src/memory_probe.rs
+++ b/crates/fgumi-sort/src/memory_probe.rs
@@ -14,9 +14,9 @@
 //! # Overhead
 //!
 //! All sampling and formatting is gated on
-//! `log::log_enabled!(target: "fgumi_lib::sort::memory_probe", Info)`, so when
+//! `log::log_enabled!(target: "fgumi_lib::sort::memory_probe", Debug)`, so when
 //! probe logging is off the hooks are a single atomic load. Enable with
-//! `RUST_LOG=fgumi_lib::sort::memory_probe=info` (or at the crate level).
+//! `RUST_LOG=fgumi_lib::sort::memory_probe=debug` (or at the crate level).
 //!
 //! # Usage
 //!
@@ -39,7 +39,7 @@
 //! ```
 
 use bytesize::ByteSize;
-use log::{Level, info, log_enabled};
+use log::{Level, debug, log_enabled};
 
 #[cfg(feature = "memory-debug")]
 #[allow(unused_imports)]
@@ -51,7 +51,7 @@ pub use platform_ffi::{force_mi_collect, process_rss_bytes};
 ///
 /// Intentionally retained as `fgumi_lib::sort::memory_probe` (the pre-extraction
 /// path) so existing operator runbooks continue to work. Enable with
-/// `RUST_LOG=fgumi_lib::sort::memory_probe=info`. Do not "fix" this string to
+/// `RUST_LOG=fgumi_lib::sort::memory_probe=debug`. Do not "fix" this string to
 /// match the new module path — that would silently break in-flight log filters.
 const TARGET: &str = "fgumi_lib::sort::memory_probe";
 
@@ -157,7 +157,7 @@ mod platform_ffi {
 #[must_use]
 #[inline]
 pub fn enabled() -> bool {
-    log_enabled!(target: TARGET, Level::Info)
+    log_enabled!(target: TARGET, Level::Debug)
 }
 
 /// Format a byte count as a human-readable value using the `bytesize` crate.
@@ -218,14 +218,14 @@ pub fn log_snapshot(label: &str, tracked_bytes: u64) {
             let residual = r.saturating_sub(tracked_bytes);
             let residual_str = fmt_bytes(residual);
             let pct = if r == 0 { 0 } else { (residual * 100) / r };
-            info!(
+            debug!(
                 target: TARGET,
                 "MEM[{label}] rss={} post_collect={} collected={} tracked={tracked_str} residual={residual_str} residual_pct={pct}%",
                 snap.rss_str, snap.post_collect_str, snap.collected_str,
             );
         }
         None => {
-            info!(
+            debug!(
                 target: TARGET,
                 "MEM[{label}] rss=? tracked={tracked_str} residual=? residual_pct=?"
             );
@@ -292,7 +292,7 @@ fn log_phase1_snapshot(
         }
         None => " residual=? residual_pct=?".to_string(),
     };
-    info!(
+    debug!(
         target: TARGET,
         "MEM[{label}] rss={} post_collect={} collected={}{buf_str}{pool_str}{residual_str}",
         snap.rss_str, snap.post_collect_str, snap.collected_str,
@@ -508,7 +508,7 @@ impl MergeProbe {
                 ),
                 None => String::new(),
             };
-            info!(
+            debug!(
                 target: TARGET,
                 "MEM[phase2.mid_{}] rss={} post_collect={} collected={} raw_q={raw_q} decomp_q={decomp_q} buf_q={buf_q}{consumer_str}",
                 self.sample_idx, snap.rss_str, snap.post_collect_str, snap.collected_str,

--- a/crates/fgumi-sort/src/pipeline.rs
+++ b/crates/fgumi-sort/src/pipeline.rs
@@ -204,7 +204,7 @@ where
     K: Clone + Send + Sync + Ord,
     F: Fn(&RawRecord) -> K + Send + Sync,
 {
-    log::info!(
+    log::debug!(
         "Starting parallel merge of {} chunks with {} reader threads",
         chunk_files.len(),
         config.reader_threads.min(chunk_files.len())
@@ -252,7 +252,7 @@ where
         }
     }
 
-    log::info!("Parallel merge complete: {records_merged} records merged");
+    log::debug!("Parallel merge complete: {records_merged} records merged");
 
     Ok(records_merged)
 }
@@ -280,7 +280,7 @@ where
 {
     const OUTPUT_BUFFER_SIZE: usize = 1024;
 
-    log::info!(
+    log::debug!(
         "Starting buffered parallel merge of {} chunks with {} reader threads",
         chunk_files.len(),
         config.reader_threads.min(chunk_files.len())
@@ -340,7 +340,7 @@ where
         writer.write_raw_record(&record)?;
     }
 
-    log::info!("Buffered parallel merge complete: {records_merged} records merged");
+    log::debug!("Buffered parallel merge complete: {records_merged} records merged");
 
     Ok(records_merged)
 }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -39,7 +39,7 @@ use crossbeam_queue::ArrayQueue;
 use fgumi_bgzf::reader::read_raw_blocks;
 use fgumi_bgzf::writer::InlineBgzfCompressor;
 use fgumi_bgzf::{RawBgzfBlock, decompress_block};
-use log::info;
+use log::debug;
 use std::collections::VecDeque;
 use std::fmt::Write as FmtWrite;
 use std::io::{BufReader, Read};
@@ -172,7 +172,7 @@ pub(crate) struct PoolStats {
 impl PoolStats {
     pub fn log_summary(&self) {
         let compress = self.compress_jobs_submitted.load(Ordering::Relaxed);
-        info!("  Pool stats: {compress} compress jobs");
+        debug!("  Pool stats: {compress} compress jobs");
     }
 }
 
@@ -349,7 +349,7 @@ impl SortPipelineStats {
 
         // Log as a single multiline message
         for line in s.trim_end().lines() {
-            info!("{line}");
+            debug!("{line}");
         }
     }
 }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -29,7 +29,7 @@ use clap::Parser;
 use fgumi_bam_io::create_raw_bam_reader;
 use fgumi_sort::{QuerynameComparator, RawExternalSorter, SortOrder};
 
-use log::info;
+use log::{debug, info};
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
@@ -483,7 +483,7 @@ fn resolve_memory_limit(
                         ByteSize(margin as u64),
                     );
                 }
-                info!(
+                debug!(
                     "Auto memory: using {} of {} ({}/thread x {} threads, reserve {})",
                     ByteSize(budget as u64),
                     ByteSize(total as u64),
@@ -494,7 +494,7 @@ fn resolve_memory_limit(
                 budget
             } else {
                 let budget = available.max(MIN_MEMORY_PER_THREAD);
-                info!(
+                debug!(
                     "Auto memory: using {} of {} (fixed total, reserve {})",
                     ByteSize(budget as u64),
                     ByteSize(total as u64),
@@ -557,7 +557,7 @@ impl Sort {
 
         let cell_tag = self.parse_cell_tag()?;
 
-        info!("Starting Sort");
+        debug!("Starting Sort");
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
         info!("Sort order: {:?}", self.order);
@@ -654,7 +654,7 @@ impl Sort {
 
         let timer = OperationTimer::new("Verifying BAM sort order");
 
-        info!("Starting Sort Verification");
+        debug!("Starting Sort Verification");
         info!("Input: {}", self.input.display());
         info!("Expected order: {:?}", self.order);
         if let Some(ct) = cell_tag {


### PR DESCRIPTION
## Summary

`fgumi_lib::commands::sort` emitted ~80 `info!` lines at the default log level, mixing user-relevant "what ran" output (config snapshot, summary, phase-timing report) with algorithm-internal chatter (per-phase markers, in-memory fast-path decisions, k-way merge thread budgets, memory-probe samples, worker-pool stats). Downstream library consumers worked around the volume by raising their own default filter (see [fg-labs/mako#5](https://github.com/fg-labs/mako/pull/5)); this fixes the cause instead.

## Kept at `info` (user-visible "what ran")

- `commands/sort.rs` `Sort::execute` config snapshot (Input, Output, Sort order, Cell tag, Max memory, Threads, Temp compression level, Write index, Temp directories) and the trailing `=== Summary ===` block.
- `commands/sort.rs` `Sort::verify` config snapshot (Input, Expected order, Cell tag) and the trailing `=== Verification Summary ===` block.
- `fgumi-sort/src/external.rs` final `=== Sort Phase Timing ===` report and the two `Wrote BAM index: …` outcome events.

## Demoted to `debug` (algorithm-internal)

- `Starting Sort` / `Starting Sort Verification` banners (the config snapshot already announces the operation).
- `Auto memory: using …` lines adjacent to the memory-fallback `warn!`s (they read as debug context for the warning, not standalone events).
- Per-phase markers (`Phase 1: …`, `Phase 2: Merging N chunks …`, `Consolidating N temp files …`, `Consolidation complete …`).
- Algorithm-layer startup duplicates (`Starting raw-bytes sort`, `Memory limit`, `Threads`) that duplicate the header config block at a different layer.
- Algorithm-choice noise (`All records fit in memory …`, `Using queryname sort with X comparator`).
- Intermediate progress already covered by the summary (`Read N records total`, `Sort complete: N records processed`).
- K-way merge internals (`Starting k-way merge …`, `Merge complete: 0 records merged`, `Merging from N sources …`, `Merge thread budget …`, `Pool-integrated merge: …`, `Starting parallel/buffered parallel merge of N chunks`).
- `Indexing enabled: …` pre-stage announcement (the final `Wrote BAM index: …` stays at info).
- `async sort reader enabled: …` (the user passed `--async-reader`; the algorithm-layer confirmation is debug detail).
- All four `memory_probe.rs` `info!` samples and the matching `log_enabled!(target, Level::Info)` gate, which is now `Level::Debug` so the cheap-path short-circuit still works at the new level.
- Both `worker_pool.rs` `info!` sites (`Pool stats: …`, per-line `{line}` forwarder).
- Pre-existing comment in `memory_probe.rs` that documented the gate as `Info`/`RUST_LOG=…=info` was updated to `Debug`/`…=debug`.

## Compatibility

The fgumi CLI's `-v` flag already jumps `info → debug`, so anyone who used it for "extra detail" keeps the same observable behavior; only the default level becomes quieter. Log lines are not a documented API surface, but anyone scraping stdout/stderr for the demoted phrases will see fewer of them at the default level.

## Out of scope

- No changes to `warn!`/`error!`/`debug!` calls.
- No new CLI flags (existing `-v` debug toggle is the escape hatch).
- No format changes (`env_logger` default keeps emitting `[<ts> <LEVEL> <module>] <msg>`).

## Test plan

- [x] `cargo build --release` (workspace)
- [x] `cargo nextest run -p fgumi-sort` — 396/396 pass
- [x] `cargo nextest run -E 'test(/sort/)'` — 56/56 pass
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo ci-tag-literals`
- [ ] CI green

Closes #364