### PR TITLE
refactor(consensus): delegate ConsensusOutput heap-size estimate to owning type

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -195,6 +195,20 @@ impl ConsensusOutput {
         self.data.append(&mut other.data);
         self.count += other.count;
     }
+
+    /// Estimated heap memory owned by this `ConsensusOutput`, in bytes.
+    ///
+    /// Returned value is the sum of every owned heap allocation this struct
+    /// holds (currently `data.capacity()`). Callers in batch
+    /// `MemoryEstimate` impls (`SimplexProcessedBatch`,
+    /// `DuplexProcessedBatch`, `CodecProcessedBatch`) call this method
+    /// rather than reaching into `data.capacity()` directly, so any future
+    /// owned heap field added here is accounted for in pipeline
+    /// backpressure without touching every consumer.
+    #[must_use]
+    pub fn estimate_heap_size(&self) -> usize {
+        self.data.capacity()
+    }
 }
 
 /// The main trait for consensus callers that generate consensus reads from groups of raw reads.
@@ -493,6 +507,21 @@ pub fn make_prefix_from_header(header: &Header) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_consensus_output_estimate_heap_size_empty() {
+        let out = ConsensusOutput::default();
+        assert_eq!(out.estimate_heap_size(), 0);
+    }
+
+    #[test]
+    fn test_consensus_output_estimate_heap_size_matches_data_capacity() {
+        let mut data = Vec::with_capacity(1024);
+        data.resize(100, 0u8);
+        let cap = data.capacity();
+        let out = ConsensusOutput { data, count: 1 };
+        assert_eq!(out.estimate_heap_size(), cap);
+    }
 
     #[test]
     fn test_rejection_reason_codes() {

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -75,7 +75,7 @@ impl MemoryEstimate for CodecProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
         let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
+        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
     }
 }
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -83,7 +83,7 @@ impl MemoryEstimate for DuplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
         let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
+        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
     }
 }
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -85,7 +85,7 @@ impl MemoryEstimate for SimplexProcessedBatch {
     fn estimate_heap_size(&self) -> usize {
         let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
         let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.data.capacity() + rej_size + rej_vec_overhead
+        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
     }
 }
 


### PR DESCRIPTION
## Summary

`DuplexProcessedBatch`, `SimplexProcessedBatch`, and `CodecProcessedBatch` all read `consensus_output.data.capacity()` directly from their `MemoryEstimate::estimate_heap_size` impls. `ConsensusOutput` is `{ data: Vec<u8>, count: usize }` today, so the estimate is accurate, but any future owned heap-allocating field added to `ConsensusOutput` would silently undercount in all three batch impls — and the unified pipeline's memory-bound queueing would mis-throttle as a result.

## Change

- Added inherent `ConsensusOutput::estimate_heap_size(&self) -> usize` in `crates/fgumi-consensus/src/caller.rs` that owns the accounting for its own fields. Current return value is unchanged (`data.capacity()`); future owned fields go here.
- Replaced `self.consensus_output.data.capacity()` with `self.consensus_output.estimate_heap_size()` in all three batch `MemoryEstimate` impls (`src/lib/commands/{duplex,simplex,codec}.rs`).
- Two new unit tests in `fgumi-consensus` lock the delegation contract: empty `ConsensusOutput` → 0, populated → `data.capacity()`.

### Why an inherent method, not `impl MemoryEstimate`

`MemoryEstimate` lives in `fgumi-bam-io`; `fgumi-consensus` doesn't depend on it. Adding the dep purely to host one trait impl wasn't worth the cross-crate coupling. The issue body lists `impl MemoryEstimate for ConsensusOutput` *or* `fn estimate_heap_size` as acceptable.

## Audit of the rest of the codebase

Per the issue's defense-in-depth note, looked for other `MemoryEstimate` impls that reach into a sibling type's private fields rather than delegating:

- `rejected_records: Vec<Vec<u8>>` accounting in all three batch impls inspects a field the batch itself owns, not a sibling type's internals — that's the batch doing its own job, out of scope.
- All other `MemoryEstimate` impls (`grouper`, `template`, `fastq_parse`, `mi_group`, `unified_pipeline::{base,fastq}`, `commands::{filter, dedup, extract, clip, correct}`, and the trait's built-ins in `fgumi-bam-io`) already delegate via `estimate_heap_size` rather than reading inner capacities directly.

## Test plan

- [x] `cargo nextest run -p fgumi-consensus -E 'test(/consensus_output|estimate/)'` — 8/8 pass (two new + six existing)
- [x] `cargo nextest run -E 'test(/processed_batch_memory_estimate|consensus_output_estimate/)'` — 9/9 pass (Duplex, Simplex, Codec, Correct, ConsensusOutput)
- [x] `cargo build --release`
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo ci-tag-literals`
- [ ] CI green

Flagged by CodeRabbit on PR #332 as out-of-scope.

Closes #339