### PR TITLE
fix(compare): use 128-bit composite hash for read-name keys

### DIFF
--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -462,17 +462,43 @@ struct GroupingCompareResult {
 // Types and MI map helpers (using ahash)
 // ============================================================================
 
-/// Compact read key using hash - saves ~70 bytes per entry vs (String, bool)
-type ReadKeyHash = u64;
+/// Compact read key using a 128-bit composite hash (saves ~50 bytes per entry
+/// vs `(Vec<u8>, bool)` while making the birthday-paradox collision
+/// probability negligible at any realistic BAM size).
+///
+/// A 64-bit key was previously used here; the birthday-paradox collision
+/// probability is `n² / 2^65`, which becomes non-trivial above ~10⁸ reads
+/// (~2.7×10⁻⁴ at 100M, ~2.7×10⁻² at 1B). On a real disagreement near a
+/// collision the comparator could report "equivalent" when the files
+/// actually differ. 128-bit makes that probability astronomical (`n² /
+/// 2^129`) for any realistic BAM.
+type ReadKeyHash = u128;
 
-/// Compute a hash for a read key from raw bytes (avoids String allocation).
+/// Compute a 128-bit composite hash for a read key from raw bytes.
+///
+/// Two passes of `ahash::AHasher` with distinct domain-separator prefixes
+/// produce independent 64-bit halves that we concatenate. `ahash::AHasher`'s
+/// avalanche property means the prefix byte change is sufficient to make
+/// the two halves uncorrelated; combining them gives 128 bits of effective
+/// entropy.
 #[inline]
 fn hash_read_key_raw(name: &[u8], is_read1: bool) -> ReadKeyHash {
     use std::hash::{Hash, Hasher};
-    let mut hasher = ahash::AHasher::default();
-    name.hash(&mut hasher);
-    is_read1.hash(&mut hasher);
-    hasher.finish()
+    let lo = {
+        let mut hasher = ahash::AHasher::default();
+        0u8.hash(&mut hasher);
+        name.hash(&mut hasher);
+        is_read1.hash(&mut hasher);
+        hasher.finish()
+    };
+    let hi = {
+        let mut hasher = ahash::AHasher::default();
+        1u8.hash(&mut hasher);
+        name.hash(&mut hasher);
+        is_read1.hash(&mut hasher);
+        hasher.finish()
+    };
+    (u128::from(hi) << 64) | u128::from(lo)
 }
 
 /// Key used to group records by molecular identifier during comparison.
@@ -2075,6 +2101,39 @@ mod tests {
         let mut argv = vec!["bams", "a.bam", "b.bam"];
         argv.extend_from_slice(args);
         CompareBams::try_parse_from(argv).expect("parse")
+    }
+
+    #[test]
+    fn hash_read_key_raw_is_deterministic() {
+        let h1 = hash_read_key_raw(b"read_one", true);
+        let h2 = hash_read_key_raw(b"read_one", true);
+        assert_eq!(h1, h2, "same input must yield same hash");
+    }
+
+    #[test]
+    fn hash_read_key_raw_distinguishes_read1_vs_read2() {
+        let h_r1 = hash_read_key_raw(b"read_one", true);
+        let h_r2 = hash_read_key_raw(b"read_one", false);
+        assert_ne!(h_r1, h_r2, "is_read1 flag must affect the hash");
+    }
+
+    #[test]
+    fn hash_read_key_raw_distinguishes_different_names() {
+        let h_a = hash_read_key_raw(b"read_a", true);
+        let h_b = hash_read_key_raw(b"read_b", true);
+        assert_ne!(h_a, h_b, "different names must yield different hashes");
+    }
+
+    #[test]
+    fn hash_read_key_raw_uses_full_128_bits() {
+        // High and low 64-bit halves come from independently-seeded ahash
+        // passes; they should not collapse to the same value (which would
+        // indicate the domain separator is being ignored and the hash is
+        // effectively 64-bit again).
+        let h = hash_read_key_raw(b"some_realistic_read_name_1234", true);
+        let lo = h as u64;
+        let hi = (h >> 64) as u64;
+        assert_ne!(lo, hi, "lo and hi halves must come from independent hashes");
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

`fgumi compare --mode grouping` (and the `--ignore-order` variant) used a 64-bit `ahash` of `(read_name, is_first_segment)` as the key for the MI lookup maps and grouping sets. Because the key stored only the hash — not the original bytes — two distinct reads that hashed to the same `u64` were indistinguishable, so a legitimate mismatch near a collision could be reported as "equivalent."

## Impact

Birthday-paradox collision probability for 64-bit hashes over `n` keys is roughly `n² / 2⁶⁵`:

| n           | P(any collision) |
|-------------|------------------|
| 10M reads   | ~2.7e-6 (negligible) |
| 100M reads  | ~2.7e-4 (small but real) |
| 1B  reads   | ~2.7e-2 (noticeable) |

For a diagnostic tool the probability was low but nonzero; on a real disagreement near a collision the tool could report a false "match."

## Change

Widen `ReadKeyHash` from `u64` to `u128` and compute the hash as two passes of `ahash::AHasher` with distinct 1-byte domain-separator prefixes (`0u8` / `1u8`). `ahash::AHasher::default()` uses fixed constants, so the prefix is what makes the two halves independent. The resulting 128-bit key has collision probability `n² / 2¹²⁹`, which is astronomically small for any realistic BAM.

This is option (2) from the issue — the recommended cost/benefit compromise. Option (1) — store the full `(Vec<u8>, bool)` key — would have cost ~10× more memory (~70 bytes/entry vs 16). Option (3) — `(u64 hash, full key bucket)` — adds collision-resolution machinery that the existing `AHashMap` already provides if we just widen the key.

## Memory cost

The per-entry hash key grows from 8 to 16 bytes (+8 bytes/entry in the `AHashMap<ReadKeyHash, MiKey>` and `AHashSet<ReadKeyHash>` collections). At 100M reads that's an extra ~800 MB peak — still ~6× cheaper than storing the full key.

## Tests

Four new unit tests in `compare::bams::tests`:
- determinism (same input → same hash)
- `is_read1` flag changes the hash
- different names change the hash
- lo/hi halves come from independently-seeded passes (guards against the domain separator being optimised away by future cleanup)

## Test plan

- [x] `cargo build --release --features compare,simulate`
- [x] `cargo nextest run --features compare,simulate -E 'test(/hash_read_key_raw|compare_bams|compare::bams/)'` — 45/45 pass (4 new + 41 existing)
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] `cargo ci-tag-literals`
- [ ] CI green

Pre-existing on `main`; not introduced by PR #296. Flagged by CodeRabbit on #296 as a Major issue.

Closes #303