### PR TITLE
feat(group): --parallel-group-min-templates with per-strategy auto thresholds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,10 @@ harness = false
 name = "raw_bam"
 harness = false
 
+[[bench]]
+name = "umi_assigner_threshold"
+harness = false
+
 [build-dependencies]
 built = { version = "0", features = ["git2"] }
 

--- a/benches/umi_assigner_threshold.rs
+++ b/benches/umi_assigner_threshold.rs
@@ -1,0 +1,262 @@
+//! Microbenchmark: parallel vs sequential UMI assigner at varying group sizes.
+//!
+//! Produces the per-strategy crossover points backing the `auto` mode of the
+//! `--parallel-group-min-templates` flag in `src/lib/commands/group.rs` (see
+//! `parallel_threshold`). For each strategy the gate decides, per position
+//! group, whether enough templates are present to justify the parallel
+//! assigner; the threshold differs per strategy because the per-template work
+//! differs. The hypothesis under test: building a per-group rayon `ThreadPool`
+//! (`ParallelXAssigner::new(threads)`) is expensive enough (~120 us) that for
+//! small groups the sequential assigner wins.
+//!
+//! Each bench iteration measures **construct + assign** as a single unit,
+//! because the threshold gate's job is to avoid pool construction. Measuring
+//! `assign()` alone would hide the cost we're trying to eliminate.
+//!
+//! Run with: `cargo bench --bench umi_assigner_threshold`
+//! Report:   `target/criterion/report/index.html`
+
+#![allow(clippy::cast_possible_truncation)]
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+use fgumi_lib::umi::assigner::{Strategy, Umi, UmiAssigner};
+use fgumi_lib::umi::parallel_assigner::{
+    ParallelAdjacencyAssigner, ParallelEditAssigner, ParallelIdentityAssigner,
+    ParallelPairedAssigner,
+};
+
+/// Group sizes with extra resolution around expected cross-over regions:
+///   - Paired: ~128-256 (per earlier coarse bench)
+///   - Edit / Adjacency: ~1024-4096
+const GROUP_SIZES: &[usize] = &[
+    64, 96, 128, 160, 192, 224, 256, 384, 512, 768, 1024, 1536, 2048, 2560, 3072, 4096, 8192, 16384,
+];
+
+/// UMI length per single read. Paired UMIs are `LEN-LEN` so the joined string
+/// is `2*LEN + 1` chars.
+const UMI_LEN: usize = 8;
+
+/// Number of duplicate copies per unique UMI sequence. Real UMI families have
+/// 1-20 reads; 8 puts us in the realistic middle for WGS/WES workloads.
+const COPIES_PER_UMI: usize = 8;
+
+/// Deterministic seed so all bench inputs are reproducible.
+const SEED: u64 = 0xFEED_BEEF;
+
+/// Number of threads the parallel assigner pool spawns. Mirrors what
+/// `Command::execute` passes (`num_threads`) on a typical workstation.
+fn bench_threads() -> usize {
+    num_cpus::get().clamp(2, 8)
+}
+
+/// Generate `n_templates` UMIs of length `UMI_LEN` with ~`COPIES_PER_UMI`
+/// reads per unique sequence and a small dose of single-base errors. This
+/// mimics the input the assigner sees inside one position group.
+fn make_umis(n_templates: usize) -> Vec<Umi> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let bases = [b'A', b'C', b'G', b'T'];
+    let n_unique = n_templates.div_ceil(COPIES_PER_UMI).max(1);
+
+    let unique: Vec<String> = (0..n_unique)
+        .map(|_| (0..UMI_LEN).map(|_| bases[rng.random_range(0..4)] as char).collect::<String>())
+        .collect();
+
+    let mut umis = Vec::with_capacity(n_templates);
+    while umis.len() < n_templates {
+        let pick = &unique[rng.random_range(0..unique.len())];
+        // 10% of the time inject a single-base substitution so the
+        // edit-distance / adjacency strategies have real clustering work.
+        if rng.random_range(0..10) == 0 {
+            let mut bytes = pick.clone().into_bytes();
+            let pos = rng.random_range(0..bytes.len());
+            let cur = bytes[pos];
+            let new = *[b'A', b'C', b'G', b'T'].iter().find(|&&b| b != cur).unwrap();
+            bytes[pos] = new;
+            umis.push(String::from_utf8(bytes).unwrap());
+        } else {
+            umis.push(pick.clone());
+        }
+    }
+    umis
+}
+
+/// Generate paired UMIs in the `AAAAAAAA-CCCCCCCC` format that the Paired
+/// strategy expects.
+fn make_paired_umis(n_templates: usize) -> Vec<Umi> {
+    let left = make_umis(n_templates);
+    // Use a different seed offset so the right halves are independent.
+    let mut rng = StdRng::seed_from_u64(SEED ^ 0xA5A5_A5A5);
+    let bases = [b'A', b'C', b'G', b'T'];
+    left.into_iter()
+        .map(|l| {
+            let r: String = (0..UMI_LEN).map(|_| bases[rng.random_range(0..4)] as char).collect();
+            format!("{l}-{r}")
+        })
+        .collect()
+}
+
+/// Index threshold passed to the sequential adjacency/paired assigners. The
+/// `group.rs` call sites pass `self.index_threshold` (default 100) so we
+/// match that here.
+const INDEX_THRESHOLD: usize = 100;
+
+fn bench_identity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("umi_assigner/identity");
+    let threads = bench_threads();
+    for &n in GROUP_SIZES {
+        let umis = make_umis(n);
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = Strategy::Identity.new_assigner_full(0, 1, INDEX_THRESHOLD);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("parallel", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = ParallelIdentityAssigner::new(threads);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_edit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("umi_assigner/edit_1");
+    let threads = bench_threads();
+    for &n in GROUP_SIZES {
+        let umis = make_umis(n);
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = Strategy::Edit.new_assigner_full(1, 1, INDEX_THRESHOLD);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("parallel", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = ParallelEditAssigner::new(1, threads);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_adjacency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("umi_assigner/adjacency_1");
+    let threads = bench_threads();
+    for &n in GROUP_SIZES {
+        let umis = make_umis(n);
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = Strategy::Adjacency.new_assigner_full(1, 1, INDEX_THRESHOLD);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("parallel", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = ParallelAdjacencyAssigner::new(1, threads);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_paired(c: &mut Criterion) {
+    let mut group = c.benchmark_group("umi_assigner/paired_1");
+    let threads = bench_threads();
+    for &n in GROUP_SIZES {
+        let umis = make_paired_umis(n);
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = Strategy::Paired.new_assigner_full(1, 1, INDEX_THRESHOLD);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("parallel", n), &umis, |b, umis| {
+            b.iter(|| {
+                let assigner = ParallelPairedAssigner::new(1, threads);
+                black_box(assigner.assign(black_box(umis)))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Isolate the cost of `ParallelXAssigner::new(threads)` — i.e. the rayon
+/// `ThreadPoolBuilder::build()` call — versus the trivial sequential
+/// constructor. This is the cost the threshold gate is designed to avoid.
+fn bench_constructor_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("umi_assigner/constructor_only");
+    let threads = bench_threads();
+
+    group.bench_function("sequential_identity", |b| {
+        b.iter(|| {
+            black_box(Strategy::Identity.new_assigner_full(0, 1, INDEX_THRESHOLD));
+        });
+    });
+    group.bench_function("parallel_identity", |b| {
+        b.iter(|| {
+            black_box(ParallelIdentityAssigner::new(threads));
+        });
+    });
+    group.bench_function("sequential_edit", |b| {
+        b.iter(|| {
+            black_box(Strategy::Edit.new_assigner_full(1, 1, INDEX_THRESHOLD));
+        });
+    });
+    group.bench_function("parallel_edit", |b| {
+        b.iter(|| {
+            black_box(ParallelEditAssigner::new(1, threads));
+        });
+    });
+    group.bench_function("sequential_adjacency", |b| {
+        b.iter(|| {
+            black_box(Strategy::Adjacency.new_assigner_full(1, 1, INDEX_THRESHOLD));
+        });
+    });
+    group.bench_function("parallel_adjacency", |b| {
+        b.iter(|| {
+            black_box(ParallelAdjacencyAssigner::new(1, threads));
+        });
+    });
+    group.bench_function("sequential_paired", |b| {
+        b.iter(|| {
+            black_box(Strategy::Paired.new_assigner_full(1, 1, INDEX_THRESHOLD));
+        });
+    });
+    group.bench_function("parallel_paired", |b| {
+        b.iter(|| {
+            black_box(ParallelPairedAssigner::new(1, threads));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_constructor_only,
+    bench_identity,
+    bench_edit,
+    bench_adjacency,
+    bench_paired,
+);
+criterion_main!(benches);

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -382,6 +382,85 @@ fn get_pair_orientation_impl(template: &Template) -> (bool, bool) {
     get_pair_orientation_raw(template)
 }
 
+/// Empirical minimum group size at which the parallel assigner is at least as
+/// fast as the sequential one. Below this threshold the per-group rayon
+/// `ThreadPool` construction cost (~120 us) dominates the per-template work
+/// and sequential wins.
+///
+/// Crossover points were measured on Apple M2 Max, 8 threads, via
+/// `benches/umi_assigner_threshold.rs`. See `ParallelMinTemplates`.
+fn parallel_threshold(strategy: Strategy, opt: &ParallelMinTemplates) -> usize {
+    match opt {
+        ParallelMinTemplates::Fixed(n) => *n,
+        ParallelMinTemplates::Auto => match strategy {
+            // Sequential wins at every measured size up to 16k templates. Per-
+            // template work is so small that pool startup cannot be amortized.
+            Strategy::Identity => usize::MAX,
+            // Crossover ~1536 templates (par 0.94x seq), 0.64x at 2k.
+            Strategy::Edit => 1536,
+            // Crossover ~3072 templates (par 0.94x seq), 0.75x at 4k.
+            Strategy::Adjacency => 3072,
+            // Crossover ~128 templates (par 0.93x seq). The win grows fast:
+            // 20x at 1k, 95x at 4k, 390x at 16k.
+            Strategy::Paired => 128,
+        },
+    }
+}
+
+/// Decide whether a position group should use the parallel UMI assigner.
+///
+/// Shared by the streaming pipeline path (`Command::execute`) and the
+/// single-threaded path (`process_and_write_position_group`) so the two stay
+/// in lockstep. Two independent triggers enable the parallel path:
+///
+/// 1. `allow_unmapped` is set (the `--allow-unmapped` flag). Such workflows
+///    (e.g. ribosome display) are essentially all-unmapped reads forming one
+///    large position group, where the parallel assigner always wins; the
+///    run-wide flag is a deliberate proxy for "this run is dominated by one
+///    huge group", so *every* group in the run takes the parallel path.
+/// 2. `parallel_group_min_templates` is set and this group has at least the
+///    per-strategy threshold number of templates (see `parallel_threshold`).
+fn should_use_parallel(
+    allow_unmapped: bool,
+    template_count: usize,
+    strategy: Strategy,
+    parallel_group_min_templates: Option<&ParallelMinTemplates>,
+) -> bool {
+    allow_unmapped
+        || parallel_group_min_templates
+            .is_some_and(|opt| template_count >= parallel_threshold(strategy, opt))
+}
+
+/// Construct a UMI assigner, choosing between the parallel and sequential
+/// variants based on `use_parallel`. Centralizes the four-arm strategy match
+/// shared by `Command::execute` (streaming pipeline path) and
+/// `process_and_write_position_group` (single-threaded path).
+///
+/// A parallel assigner is only built when `num_threads > 1`: a one-thread rayon
+/// pool delivers no parallelism while still paying pool-construction overhead,
+/// so `--threads 1` and `execute_single_threaded` (which passes `threads = 1`)
+/// always fall back to the sequential assigner regardless of `use_parallel`.
+fn create_umi_assigner(
+    strategy: Strategy,
+    effective_edits: u32,
+    index_threshold: usize,
+    num_threads: usize,
+    use_parallel: bool,
+) -> Box<dyn UmiAssigner> {
+    if use_parallel && num_threads > 1 {
+        match strategy {
+            Strategy::Identity => Box::new(ParallelIdentityAssigner::new(num_threads)),
+            Strategy::Edit => Box::new(ParallelEditAssigner::new(effective_edits, num_threads)),
+            Strategy::Adjacency => {
+                Box::new(ParallelAdjacencyAssigner::new(effective_edits, num_threads))
+            }
+            Strategy::Paired => Box::new(ParallelPairedAssigner::new(effective_edits, num_threads)),
+        }
+    } else {
+        strategy.new_assigner_full(effective_edits, 1, index_threshold)
+    }
+}
+
 /// Assign UMI groups to templates (static implementation).
 fn assign_umi_groups_impl(
     templates: &mut [Template],
@@ -510,6 +589,34 @@ fn assign_umi_groups_for_indices_impl(
     Ok(())
 }
 
+/// CLI value for `--parallel-group-min-templates`.
+///
+/// Either the literal `auto`, which selects per-strategy empirical thresholds
+/// (see `parallel_threshold` for the table), or an explicit non-negative
+/// integer applied uniformly to every strategy. A fixed `0` means "always
+/// parallel" (every group reaches the threshold).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParallelMinTemplates {
+    /// Use the per-strategy empirical thresholds (see `parallel_threshold`).
+    Auto,
+    /// Apply this threshold uniformly to every strategy.
+    Fixed(usize),
+}
+
+impl std::str::FromStr for ParallelMinTemplates {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("auto") {
+            Ok(Self::Auto)
+        } else {
+            s.parse::<usize>()
+                .map(Self::Fixed)
+                .map_err(|e| format!("expected 'auto' or a non-negative integer, got '{s}': {e}"))
+        }
+    }
+}
+
 /// Groups reads by UMI to identify reads from the same original molecule
 #[derive(Debug, Parser)]
 #[command(
@@ -581,10 +688,17 @@ different cells are never grouped together, even if they share a UMI sequence an
 The cell barcode is read from the standard `CB` tag. No correction or
 error-handling is performed on cell barcodes; they must be corrected upstream.
 
-Multi-threaded operation is supported via --threads N which spawns exactly N threads.
-Threads are allocated based on the command's workload profile to optimize performance.
+Multi-threaded operation is supported via --threads N, which spawns N pipeline threads
+allocated based on the command's workload profile to optimize performance.
 
-Example: --threads 8 spawns exactly 8 threads (2 reader, 4 workers, 2 writer)
+Example: --threads 8 spawns 8 pipeline threads (2 reader, 4 workers, 2 writer)
+
+Note: when --parallel-group-min-templates (or --allow-unmapped) engages the parallel UMI
+assigner, each parallel assigner constructs its own rayon thread pool of size --threads,
+independent of the pipeline threads above. As an example, one pipeline worker overlapping a
+single parallel assigner briefly runs ~2 * --threads OS threads; this is not an upper bound,
+because multiple pipeline workers can each spawn a --threads-sized pool concurrently and push
+the live thread count higher still. See --parallel-group-min-templates for details.
 "#
 )]
 pub struct GroupReadsByUmi {
@@ -636,6 +750,48 @@ pub struct GroupReadsByUmi {
     /// With --edits 1, only 1 mismatch is allowed across ALL bases.
     #[arg(long = "allow-unmapped", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub allow_unmapped: bool,
+
+    /// Enable the parallel UMI assigner for position groups with at least this
+    /// many templates. Useful for amplicon and other workflows where individual
+    /// mapped position groups are very large; the default for normal
+    /// whole-genome data is to stay sequential. Has an effect only when
+    /// `--threads` is greater than 1: with `--threads 1` the assigner always
+    /// falls back to the sequential implementation.
+    ///
+    /// Accepts either `auto` or an integer. `auto` selects per-strategy
+    /// empirical thresholds derived from `benches/umi_assigner_threshold.rs`:
+    ///
+    /// - Identity:  never go parallel (sequential always wins, including at
+    ///   16k templates)
+    /// - Edit:      1536 templates
+    /// - Adjacency: 3072 templates
+    /// - Paired:    128 templates (parallel is 95x faster at 4k, 390x at 16k)
+    ///
+    /// An integer applies that single threshold uniformly to *every* strategy,
+    /// including Identity (which `auto` keeps sequential): with a fixed `N`,
+    /// any group whose template count reaches `N` uses the parallel assigner
+    /// regardless of strategy.
+    ///
+    /// When `--allow-unmapped` is also set, *every* position group uses the
+    /// parallel assigner regardless of this flag. This is intentional:
+    /// allow-unmapped workflows (e.g. ribosome display) are essentially
+    /// all-unmapped reads forming one large position group, where parallel
+    /// always wins, so the run-wide flag is a good proxy. For mixed inputs that
+    /// also contain many small mapped groups, prefer
+    /// `--parallel-group-min-templates` over `--allow-unmapped`'s blanket
+    /// parallelization.
+    ///
+    /// WARNING: each parallel assigner constructs its own `rayon::ThreadPool`
+    /// of size `--threads`, which is independent of the pipeline's worker
+    /// threads. As an example, one pipeline worker overlapping a single parallel
+    /// assigner briefly runs ~2 * `--threads` OS threads; this is not an upper
+    /// bound, because multiple pipeline workers can each spawn a `--threads`-sized
+    /// pool concurrently, pushing the live thread count higher still. For amplicon
+    /// data (few large groups, pipeline threads mostly idle) the over-subscription
+    /// is harmless; for mixed workloads with many concurrent groups it can
+    /// contend. Tune `--threads` accordingly.
+    #[arg(long = "parallel-group-min-templates", value_name = "N|auto")]
+    pub parallel_group_min_templates: Option<ParallelMinTemplates>,
 
     /// The UMI assignment strategy
     #[arg(short = 's', long = "strategy", value_enum)]
@@ -885,6 +1041,7 @@ impl Command for GroupReadsByUmi {
         let index_threshold = self.index_threshold;
         let no_umi = self.no_umi;
         let allow_unmapped = self.allow_unmapped;
+        let parallel_group_min_templates = self.parallel_group_min_templates.clone();
         let accumulators_clone = Arc::clone(&accumulators);
 
         // Setup comprehensive memory monitoring first if debug mode is enabled
@@ -1091,27 +1248,24 @@ impl Command for GroupReadsByUmi {
                     });
                 }
 
-                // Create UMI assigner for this group
-                // Use parallel assigner when allow_unmapped is enabled (large single groups)
-                let assigner: Box<dyn UmiAssigner> = if allow_unmapped {
-                    match strategy {
-                        Strategy::Identity => {
-                            Box::new(ParallelIdentityAssigner::new(num_threads))
-                        }
-                        Strategy::Edit => {
-                            Box::new(ParallelEditAssigner::new(effective_edits, num_threads))
-                        }
-                        Strategy::Adjacency => {
-                            Box::new(ParallelAdjacencyAssigner::new(effective_edits, num_threads))
-                        }
-                        Strategy::Paired => {
-                            Box::new(ParallelPairedAssigner::new(effective_edits, num_threads))
-                        }
-                    }
-                } else {
-                    // Use existing sequential assigner for mapped data
-                    strategy.new_assigner_full(effective_edits, 1, index_threshold)
-                };
+                // Create UMI assigner for this group. See `should_use_parallel`
+                // for the two triggers: (a) `--allow-unmapped` parallelizes
+                // every group (these runs are dominated by one huge unmapped
+                // group); (b) the user-set `--parallel-group-min-templates`
+                // threshold is met for this group's strategy.
+                let use_parallel = should_use_parallel(
+                    allow_unmapped,
+                    filtered_templates.len(),
+                    strategy,
+                    parallel_group_min_templates.as_ref(),
+                );
+                let assigner = create_umi_assigner(
+                    strategy,
+                    effective_edits,
+                    index_threshold,
+                    num_threads,
+                    use_parallel,
+                );
 
                 // Assign UMI groups using the unified _impl function
                 let mut templates = filtered_templates;
@@ -1422,6 +1576,7 @@ impl GroupReadsByUmi {
                     effective_edits,
                     self.index_threshold,
                     1, // Single-threaded mode
+                    self.parallel_group_min_templates.as_ref(),
                     raw_tag,
                     assign_tag_bytes,
                     &mut total_filter_metrics,
@@ -1445,6 +1600,7 @@ impl GroupReadsByUmi {
                 effective_edits,
                 self.index_threshold,
                 1, // Single-threaded mode
+                self.parallel_group_min_templates.as_ref(),
                 raw_tag,
                 assign_tag_bytes,
                 &mut total_filter_metrics,
@@ -1488,6 +1644,7 @@ impl GroupReadsByUmi {
         effective_edits: u32,
         index_threshold: usize,
         threads: usize,
+        parallel_group_min_templates: Option<&ParallelMinTemplates>,
         raw_tag: [u8; 2],
         assign_tag_bytes: [u8; 2],
         total_filter_metrics: &mut FilterMetrics,
@@ -1515,21 +1672,17 @@ impl GroupReadsByUmi {
             return Ok(());
         }
 
-        // Create UMI assigner
-        // Use parallel assigner when allow_unmapped is enabled (large single groups)
-        let assigner: Box<dyn UmiAssigner> = if filter_config.allow_unmapped {
-            match strategy {
-                Strategy::Identity => Box::new(ParallelIdentityAssigner::new(threads)),
-                Strategy::Edit => Box::new(ParallelEditAssigner::new(effective_edits, threads)),
-                Strategy::Adjacency => {
-                    Box::new(ParallelAdjacencyAssigner::new(effective_edits, threads))
-                }
-                Strategy::Paired => Box::new(ParallelPairedAssigner::new(effective_edits, threads)),
-            }
-        } else {
-            // Use existing sequential assigner for mapped data
-            strategy.new_assigner_full(effective_edits, 1, index_threshold)
-        };
+        // Create UMI assigner. See `should_use_parallel` for the full
+        // rationale; this is the equivalent decision on the single-threaded
+        // path, kept in lockstep with the streaming path via the shared helper.
+        let use_parallel = should_use_parallel(
+            filter_config.allow_unmapped,
+            filtered_templates.len(),
+            strategy,
+            parallel_group_min_templates,
+        );
+        let assigner =
+            create_umi_assigner(strategy, effective_edits, index_threshold, threads, use_parallel);
 
         // Assign UMI groups
         let mut templates = filtered_templates;
@@ -1739,7 +1892,152 @@ mod tests {
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use rstest::rstest;
     use std::num::NonZeroUsize;
+    use std::str::FromStr;
     use tempfile::{NamedTempFile, TempDir};
+
+    #[rstest]
+    #[case("auto")]
+    #[case("AUTO")]
+    #[case("Auto")]
+    #[case("aUtO")]
+    fn parallel_min_templates_parses_auto_case_insensitively(#[case] s: &str) {
+        assert_eq!(
+            ParallelMinTemplates::from_str(s).unwrap(),
+            ParallelMinTemplates::Auto,
+            "expected Auto for '{s}'"
+        );
+    }
+
+    #[test]
+    fn parallel_min_templates_parses_non_negative_integer() {
+        assert_eq!(ParallelMinTemplates::from_str("0").unwrap(), ParallelMinTemplates::Fixed(0));
+        assert_eq!(
+            ParallelMinTemplates::from_str("1536").unwrap(),
+            ParallelMinTemplates::Fixed(1536)
+        );
+    }
+
+    #[test]
+    fn parallel_min_templates_rejects_garbage() {
+        let err = ParallelMinTemplates::from_str("not-a-number").unwrap_err();
+        assert!(err.contains("expected 'auto' or a non-negative integer"), "got: {err}");
+        // Negative is rejected (usize parse fails).
+        assert!(ParallelMinTemplates::from_str("-1").is_err());
+    }
+
+    #[test]
+    fn parallel_threshold_auto_matches_empirical_table() {
+        assert_eq!(parallel_threshold(Strategy::Identity, &ParallelMinTemplates::Auto), usize::MAX);
+        assert_eq!(parallel_threshold(Strategy::Edit, &ParallelMinTemplates::Auto), 1536);
+        assert_eq!(parallel_threshold(Strategy::Adjacency, &ParallelMinTemplates::Auto), 3072);
+        assert_eq!(parallel_threshold(Strategy::Paired, &ParallelMinTemplates::Auto), 128);
+    }
+
+    #[rstest]
+    #[case(Strategy::Identity)]
+    #[case(Strategy::Edit)]
+    #[case(Strategy::Adjacency)]
+    #[case(Strategy::Paired)]
+    fn parallel_threshold_fixed_applies_uniformly(#[case] strategy: Strategy) {
+        let opt = ParallelMinTemplates::Fixed(500);
+        assert_eq!(parallel_threshold(strategy, &opt), 500, "strategy {strategy:?}");
+    }
+
+    /// With `use_parallel = true`, `create_umi_assigner` must build the parallel
+    /// variant for every strategy (not just the ones exercised by end-to-end tests).
+    #[rstest]
+    #[case(Strategy::Identity)]
+    #[case(Strategy::Edit)]
+    #[case(Strategy::Adjacency)]
+    #[case(Strategy::Paired)]
+    fn create_umi_assigner_parallel_builds_parallel_variant(#[case] strategy: Strategy) {
+        let assigner = create_umi_assigner(strategy, 1, 0, 2, true);
+        let any = assigner.as_any();
+        let is_parallel = match strategy {
+            Strategy::Identity => any.is::<ParallelIdentityAssigner>(),
+            Strategy::Edit => any.is::<ParallelEditAssigner>(),
+            Strategy::Adjacency => any.is::<ParallelAdjacencyAssigner>(),
+            Strategy::Paired => any.is::<ParallelPairedAssigner>(),
+        };
+        assert!(is_parallel, "expected parallel assigner for {strategy:?}");
+    }
+
+    /// Even with `use_parallel = true`, a single worker thread must not build a
+    /// parallel assigner: a one-thread rayon pool is pure startup overhead with
+    /// zero parallelism. The `--threads 1` pipeline path and `execute_single_threaded`
+    /// (which passes `threads = 1`) both reach `create_umi_assigner` with
+    /// `num_threads == 1`, so this guards against spawning a useless pool there.
+    #[rstest]
+    #[case(Strategy::Identity)]
+    #[case(Strategy::Edit)]
+    #[case(Strategy::Adjacency)]
+    #[case(Strategy::Paired)]
+    fn create_umi_assigner_single_thread_builds_non_parallel_variant(#[case] strategy: Strategy) {
+        // num_threads = 1 with use_parallel = true must still fall back to sequential.
+        let assigner = create_umi_assigner(strategy, 0, 0, 1, true);
+        let any = assigner.as_any();
+        assert!(
+            !any.is::<ParallelIdentityAssigner>()
+                && !any.is::<ParallelEditAssigner>()
+                && !any.is::<ParallelAdjacencyAssigner>()
+                && !any.is::<ParallelPairedAssigner>(),
+            "expected sequential assigner for {strategy:?} when num_threads == 1"
+        );
+    }
+
+    /// With `use_parallel = false`, `create_umi_assigner` must build a sequential
+    /// (non-parallel) assigner.
+    #[rstest]
+    #[case(Strategy::Identity)]
+    #[case(Strategy::Edit)]
+    #[case(Strategy::Adjacency)]
+    #[case(Strategy::Paired)]
+    fn create_umi_assigner_sequential_builds_non_parallel_variant(#[case] strategy: Strategy) {
+        // Identity requires zero edits; the other strategies accept zero too.
+        let assigner = create_umi_assigner(strategy, 0, 0, 2, false);
+        let any = assigner.as_any();
+        assert!(
+            !any.is::<ParallelIdentityAssigner>()
+                && !any.is::<ParallelEditAssigner>()
+                && !any.is::<ParallelAdjacencyAssigner>()
+                && !any.is::<ParallelPairedAssigner>(),
+            "expected sequential assigner for {strategy:?}"
+        );
+    }
+
+    #[rstest]
+    // `--allow-unmapped` forces the parallel path for every group, regardless of
+    // template count, strategy, or whether a threshold opt is present.
+    #[case(true, 0, Strategy::Identity, None, true)]
+    #[case(true, 0, Strategy::Paired, Some(ParallelMinTemplates::Fixed(usize::MAX)), true)]
+    // No `--allow-unmapped` and no threshold opt: never parallel, even for a huge group.
+    #[case(false, 1_000_000, Strategy::Paired, None, false)]
+    // Fixed threshold applies uniformly, including to Identity: parallel iff count >= N.
+    // Fixed(0) means "always parallel": every count (including 0) clears the threshold.
+    #[case(false, 0, Strategy::Identity, Some(ParallelMinTemplates::Fixed(0)), true)]
+    #[case(false, 500, Strategy::Identity, Some(ParallelMinTemplates::Fixed(500)), true)]
+    #[case(false, 499, Strategy::Identity, Some(ParallelMinTemplates::Fixed(500)), false)]
+    // Auto thresholds, at the per-strategy crossover and just below it.
+    #[case(false, 128, Strategy::Paired, Some(ParallelMinTemplates::Auto), true)]
+    #[case(false, 127, Strategy::Paired, Some(ParallelMinTemplates::Auto), false)]
+    #[case(false, 1536, Strategy::Edit, Some(ParallelMinTemplates::Auto), true)]
+    #[case(false, 1535, Strategy::Edit, Some(ParallelMinTemplates::Auto), false)]
+    #[case(false, 3072, Strategy::Adjacency, Some(ParallelMinTemplates::Auto), true)]
+    #[case(false, 3071, Strategy::Adjacency, Some(ParallelMinTemplates::Auto), false)]
+    // Auto keeps Identity sequential even at very large group sizes.
+    #[case(false, 1_000_000, Strategy::Identity, Some(ParallelMinTemplates::Auto), false)]
+    fn should_use_parallel_covers_all_triggers(
+        #[case] allow_unmapped: bool,
+        #[case] template_count: usize,
+        #[case] strategy: Strategy,
+        #[case] opt: Option<ParallelMinTemplates>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(
+            should_use_parallel(allow_unmapped, template_count, strategy, opt.as_ref()),
+            expected,
+        );
+    }
 
     /// Helper struct for managing temporary test file paths.
     /// Keeps `TempDir` alive for the lifetime of the struct.
@@ -1793,6 +2091,7 @@ mod tests {
                 queue_memory_limit_mb: None,
             },
             allow_unmapped: false,
+            parallel_group_min_templates: None,
             #[cfg(feature = "memory-debug")]
             debug_memory: false,
             #[cfg(feature = "memory-debug")]


### PR DESCRIPTION
## Summary

- Add `--parallel-group-min-templates N|auto` to opt in to the parallel UMI assigner (Edit, Adjacency, Paired) on a per-position-group basis, sized by template count.
- Decouple the parallel path from `--allow-unmapped` so amplicon and other workflows with large *mapped* position groups can opt in.
- `auto` selects per-strategy empirical thresholds derived from a new `benches/umi_assigner_threshold.rs` microbench; a number applies a single threshold uniformly across all four strategies.
- Extract a `create_umi_assigner` helper to eliminate the duplicated parallel-vs-sequential strategy match between the streaming pipeline path (`Command::execute`) and the single-threaded path (`process_and_write_position_group`).

Supersedes #118 (different design — that PR used a single user-supplied integer threshold; this one adds an `auto` mode backed by empirically-justified per-strategy values, after benchmarking showed a flat threshold was the wrong shape for three of four strategies).

## Per-strategy thresholds (`--parallel-group-min-templates auto`)

Measured on Apple M2 Max, 8 threads, `--quick` mode (the new bench), with construct + assign timed as one unit because the rayon `ThreadPool` construction is exactly what the threshold gate exists to avoid:

| Strategy | Threshold | Bench evidence |
| --- | --- | --- |
| Identity | `usize::MAX` (never go parallel) | sequential wins at every measured size up to 16k templates |
| Edit | 1536 | par 0.94x seq at 1536; 0.64x at 2048; 0.04x at 16k |
| Adjacency | 3072 | par 0.94x seq at 3072; 0.75x at 4k; 0.40x at 16k |
| Paired | 128 | par 0.93x seq at 128; 0.07x at 1k; 0.01x at 4k; 0.0026x at 16k |

A flat threshold (e.g. the 1024 used in the original prototype on #118's branch) was wrong-shape for three of four strategies — it forced sequential where Paired parallel was already 20–95x faster, forced parallel where Edit/Adjacency sequential was still ~2x faster, and forced parallel where Identity sequential is always faster.

## Semantics

- Flag not set (default): preserves current behavior — parallel only via `--allow-unmapped`.
- `--parallel-group-min-templates auto`: per-strategy thresholds above.
- `--parallel-group-min-templates 500`: flat threshold of 500 across all strategies (including Identity).
- `--allow-unmapped` set: the unmapped position group always uses parallel, regardless of this flag.

## Thread over-subscription

Each parallel assigner constructs its own `rayon::ThreadPool` of size `--threads`, independent of the pipeline's worker threads. When parallel kicks in you have up to `2 * --threads` active OS threads briefly. For amplicon (few large groups, pipeline threads mostly idle) the over-subscription is harmless; for mixed workloads it can contend. The help text on the new flag documents this.

The principled fix (route everything through a single global rayon pool, push parallelism up to `assign_umi_groups_impl`) is deferred — local benches showed the per-pool cost is amortizable enough at the chosen thresholds.

## Test plan

- [x] New unit tests in `commands::group::tests`:
  - `parallel_min_templates_parses_auto_case_insensitively` (`auto`, `AUTO`, `Auto`, `aUtO`)
  - `parallel_min_templates_parses_non_negative_integer` (`0`, `1536`)
  - `parallel_min_templates_rejects_garbage` (`not-a-number`, `-1`)
  - `parallel_threshold_auto_matches_empirical_table`
  - `parallel_threshold_fixed_applies_uniformly`
- [x] `cargo nextest run --release` — 1662/1662 pass
- [x] `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` — clean (pre-commit hook)
- [x] Manual: `cargo bench --bench umi_assigner_threshold -- --quick` reproduces the threshold table above
- [ ] Real-data smoke (amplicon BAM with large mapped position groups) — recommend running before merge

## Closes

Supersedes #118 — close that PR with a comment pointing here.