### PR TITLE
ci: add codecov.yml with a project coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # Tolerate small, cosmetic dips in total coverage. Refactors that move
+        # code around can shift codecov's line attribution and nudge the project
+        # ratio down by a few hundredths of a percent even when the new code is
+        # fully tested. Without a threshold, codecov's default 0% gate fails the
+        # project status on these dips. 0.5% absorbs that noise while still
+        # catching meaningful regressions.
+        threshold: 0.5%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
## Summary

The repo has no `codecov.yml`, so Codecov applies its default `project` status gate of `target: auto, threshold: 0%`. That means **any** decrease in total coverage — even a few hundredths of a percent — fails the `codecov/project` check.

Refactors that move code around can shift Codecov's line attribution and nudge the project ratio down slightly even when all the new code is fully tested. For example, on a recent refactor PR `codecov/patch` reported 100% of the diff covered while `codecov/project` dropped -0.02% (90.96% → 90.95%) and failed — blocking an otherwise-green PR with no real coverage regression.

This adds a `codecov.yml` that:

- Sets a **0.5% project threshold** to absorb that cosmetic noise while still catching meaningful regressions.
- Pins the **patch target at 90%** so new code still has to be well covered.

## Notes

This is a CI-config-only change, independent of any in-flight PR. No source or test changes.