### PR TITLE
feat(memory): add host-aware --max-memory to pipeline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,17 +217,18 @@ fgumi filter \
 fgumi supports multi-threading and memory management for optimal performance:
 
 - **Threading**: `--threads N` for parallel processing
-- **Memory**: `--queue-memory 768` (plain numbers are MB; supports human-readable formats like `2GB`)
+- **Memory**: `--max-memory 768` (plain numbers are MiB; supports human-readable formats like `2GB`; pass `auto` to size to the host)
 - **Compression**: `--compression-level 1-12` for speed vs size trade-offs
 
 > **Memory Model — Important for fgbio users:**
 > Unlike fgbio's JVM `-Xmx` which sets a hard ceiling on total process memory,
-> fgumi's `--queue-memory` controls pipeline queue backpressure only. Two things
+> fgumi's `--max-memory` controls pipeline queue backpressure only. Two things
 > to be aware of:
 >
-> 1. **Per-thread scaling (default):** `--queue-memory 768 --threads 8` allocates
->    768 MB **per thread** = ~6 GB total queue memory. Use `--queue-memory-per-thread false`
->    for a fixed total budget.
+> 1. **Per-thread scaling (default):** `--max-memory 768 --threads 8` allocates
+>    768 MiB **per thread** = ~6 GB total queue memory. Use `--memory-per-thread false`
+>    for a fixed total budget, or `--max-memory auto` to size the budget to the host
+>    (cgroup-aware, minus `--memory-reserve`) so the command self-throttles instead of OOM-ing.
 > 2. **Queue memory < total process memory:** Actual RSS will be higher due to
 >    UMI data structures, decompressors, thread stacks, and working buffers.
 >

--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -41,7 +41,7 @@ Thread allocation is automatically optimized per-command based on workload profi
 
 ### Memory
 
-fgumi's memory model differs significantly from fgbio's JVM `-Xmx`. In particular, `--queue-memory` is per-thread by default and controls only pipeline queue backpressure — actual process memory will be higher. See the [Performance Tuning Guide](performance-tuning.md) for detailed guidance, including a comparison table for fgbio users.
+fgumi's memory model differs significantly from fgbio's JVM `-Xmx`. In particular, `--max-memory` is per-thread by default and controls only pipeline queue backpressure — actual process memory will be higher. On a fixed-RAM host, pass `--max-memory auto` to size the budget to the host. See the [Performance Tuning Guide](performance-tuning.md) for detailed guidance, including a comparison table for fgbio users.
 
 ### Boolean Flags
 

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -8,19 +8,19 @@ If you're used to fgbio's JVM-based memory model (`java -Xmx4g`), there are impo
 
 | | fgbio (JVM) | fgumi |
 |---|---|---|
-| **Memory control** | `-Xmx` sets a hard ceiling on the entire process | `--queue-memory` controls pipeline queue backpressure |
+| **Memory control** | `-Xmx` sets a hard ceiling on the entire process | `--max-memory` controls pipeline queue backpressure |
 | **Enforcement** | Hard limit — JVM throws `OutOfMemoryError` at the ceiling | Soft limit — triggers backpressure to slow producers |
 | **Scope** | Total process memory (heap + off-heap) | Queue memory only; does not cover UMI data structures, decompressors, thread stacks, or working buffers |
-| **Scaling** | Fixed regardless of threads | Per-thread by default (`--queue-memory 768 --threads 8` = ~6 GB) |
-| **Recommendation** | Set once and forget | Monitor RSS and adjust; use `--queue-memory-per-thread false` for a fixed total budget |
+| **Scaling** | Fixed regardless of threads | Per-thread by default (`--max-memory 768 --threads 8` = ~6 GB) |
+| **Recommendation** | Set once and forget | Monitor RSS and adjust; use `--max-memory auto` (or `--memory-per-thread false`) for a host-aware/fixed total budget |
 
-**Key takeaway:** fgumi's actual process memory (RSS) will be higher than the `--queue-memory` value. When estimating memory needs, account for:
-- Queue memory (controlled by `--queue-memory`)
+**Key takeaway:** fgumi's actual process memory (RSS) will be higher than the `--max-memory` value. When estimating memory needs, account for:
+- Queue memory (controlled by `--max-memory`)
 - UMI grouping data structures (scales with UMI diversity and position depth)
 - Per-thread decompressor and compressor instances
 - Thread stacks and I/O buffers
 
-For memory-constrained environments, start with `--queue-memory-per-thread false` and a conservative total budget, then increase if throughput is too low.
+For memory-constrained environments, pass `--max-memory auto` to detect (cgroup-aware) host memory and subtract `--memory-reserve`, so the budget shrinks to fit the host. Alternatively, start with `--memory-per-thread false` and a conservative total budget, then increase if throughput is too low.
 
 ## Threading Options
 
@@ -43,34 +43,46 @@ For memory-constrained environments, start with `--queue-memory-per-thread false
 
 fgumi's unified memory management controls pipeline queue memory to prevent out-of-memory conditions while maintaining throughput.
 
-### Queue Memory Options
+### Memory Options
 
 ```bash
-# Basic usage (768MB per thread - default)
-fgumi filter --queue-memory 768 --queue-memory-per-thread true
+# Basic usage (768 MiB per thread - default; plain numbers are MiB)
+fgumi filter --max-memory 768 --memory-per-thread true
 
 # Human-readable formats
-fgumi filter --queue-memory 2GB
-fgumi filter --queue-memory 1024MiB
+fgumi filter --max-memory 2GB
+fgumi filter --max-memory 1024MiB
 
 # Fixed total memory (no per-thread scaling)
-fgumi filter --queue-memory 4096 --queue-memory-per-thread false
+fgumi filter --max-memory 4096 --memory-per-thread false
+
+# Host-aware: detect (cgroup-aware) RAM and subtract --memory-reserve
+fgumi filter --max-memory auto
+fgumi filter --max-memory auto --memory-reserve 12GiB
 ```
+
+This is the same `--max-memory` surface as `fgumi sort`. The default is opt-in:
+the budget stays 768 MiB/thread unless you pass `auto`, so on a fixed-RAM host
+(e.g. a 30 GiB container at `--threads 16`) prefer `--max-memory auto` or a fixed
+total budget to avoid OOM.
 
 ### Memory Scaling Behavior
 
 | Threads | Per-thread Mode | Fixed Mode |
 |---------|----------------|------------|
-| 1       | 768MB          | 768MB      |
-| 4       | 3GB            | 768MB      |
-| 8       | 6GB            | 768MB      |
-| 16      | 12GB           | 768MB      |
+| 1       | 768 MiB        | 768 MiB    |
+| 4       | 3 GiB          | 768 MiB    |
+| 8       | 6 GiB          | 768 MiB    |
+| 16      | 12 GiB         | 768 MiB    |
 
-### Memory Validation
+With `--max-memory auto`, the total budget is instead `host RAM − reserve`
+(divided across threads when per-thread), so it never scales past the host.
 
-- **System check**: Warns if requesting >90% of available system memory
-- **Overflow protection**: Prevents integer overflow with checked arithmetic
-- **Decimal support**: Accepts formats like `1.5GB` in addition to integers
+### Deprecated flags
+
+`--queue-memory`, `--queue-memory-per-thread`, and `--queue-memory-limit-mb`
+remain accepted as hidden aliases of `--max-memory` / `--memory-per-thread` for
+backward compatibility, but new scripts should use the `--max-memory` flags.
 
 ## Compression Options
 
@@ -157,7 +169,7 @@ before spending on higher provisioned throughput.
 ```bash
 fgumi filter \
   --threads 16 \
-  --queue-memory 1GB \
+  --max-memory 1GB \
   --compression-level 3 \
   --input large_dataset.bam \
   --output filtered.bam
@@ -174,8 +186,8 @@ fgumi filter \
 ```bash
 fgumi filter \
   --threads 8 \
-  --queue-memory 512 \
-  --queue-memory-per-thread false \
+  --max-memory 512 \
+  --memory-per-thread false \
   --compression-level 6 \
   --input dataset.bam \
   --output filtered.bam
@@ -192,7 +204,7 @@ fgumi filter \
 ```bash
 fgumi filter \
   --threads 8 \
-  --queue-memory 2GB \
+  --max-memory 2GB \
   --compression-level 1 \
   --input dataset.bam \
   --output filtered.bam
@@ -209,7 +221,7 @@ fgumi filter \
 fgumi filter \
   --async-reader \
   --threads 4 \
-  --queue-memory 512 \
+  --max-memory 512 \
   --compression-level 9 \
   --input dataset.bam \
   --output filtered.bam
@@ -226,7 +238,7 @@ fgumi filter \
 
 ```bash
 fgumi filter \
-  --queue-memory 256 \
+  --max-memory 256 \
   --compression-level 1 \
   --input small_test.bam \
   --output test_output.bam
@@ -294,7 +306,7 @@ With `--deadlock-recover`, the pipeline progressively doubles queue memory limit
 ### Memory Usage
 - Monitor system memory usage during execution
 - Watch for "exceeds available memory" warnings
-- Adjust `--queue-memory` if seeing swap activity
+- Adjust `--max-memory` if seeing swap activity (or pass `--max-memory auto`)
 
 ### Thread Utilization
 - Use `htop` or similar to monitor CPU usage
@@ -310,13 +322,13 @@ With `--deadlock-recover`, the pipeline progressively doubles queue memory limit
 ## Troubleshooting
 
 ### Out of Memory Errors
-1. Reduce `--queue-memory`
-2. Set `--queue-memory-per-thread false` for fixed limits
+1. Pass `--max-memory auto` to size the budget to the host, or reduce `--max-memory`
+2. Set `--memory-per-thread false` for a fixed total budget
 3. Reduce `--threads`
 
 ### Poor Performance
 1. Increase `--threads` if CPU usage is low
-2. Increase `--queue-memory` if I/O bound
+2. Increase `--max-memory` if I/O bound
 3. Reduce `--compression-level` if CPU bound
 4. Check OS readahead and EBS throughput if disk I/O is the bottleneck (see [I/O and Storage Tuning](#io-and-storage-tuning))
 
@@ -333,7 +345,7 @@ If a command hangs without producing output:
 Requested memory 16GB exceeds 90% of system memory (14.4GB)
 ```
 - Reduce memory allocation or add more RAM
-- Consider using `--queue-memory-per-thread false`
+- Consider using `--memory-per-thread false` (or `--max-memory auto`)
 
 ## Command-Specific Considerations
 
@@ -384,14 +396,20 @@ Requested memory 16GB exceeds 90% of system memory (14.4GB)
 
 ## Migration from Legacy Parameters
 
-If using deprecated `--queue-memory-limit-mb`:
+The `--queue-memory`, `--queue-memory-per-thread`, and `--queue-memory-limit-mb`
+flags are deprecated (but still accepted as hidden aliases). Migrate to the
+`--max-memory` family, which matches `fgumi sort`:
 
 ```bash
 # Old (deprecated)
 fgumi group --queue-memory-limit-mb 4096
+fgumi group --queue-memory 4096 --queue-memory-per-thread false
 
 # New (recommended)
-fgumi group --queue-memory 4096 --queue-memory-per-thread false
+fgumi group --max-memory 4096 --memory-per-thread false
+
+# Or let fgumi size the budget to the host:
+fgumi group --max-memory auto
 ```
 
-The new parameters provide better control and human-readable formats while maintaining backward compatibility.
+The new parameters provide host-aware (`auto`) sizing and human-readable formats while maintaining backward compatibility.

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -564,31 +564,228 @@ impl ThreadingOptions {
     }
 }
 
+//////////////////////////////////////////////////////////////////////////////
+// Shared memory-budget types
+//
+// `--max-memory` / `--memory-reserve` are used both by `fgumi sort` (to bound
+// the in-memory sort buffer before spilling to disk) and by every pipeline
+// command via [`QueueMemoryOptions`] (to bound the inter-stage pipeline queue).
+// The types, parsers, and resolution logic live here so the two surfaces stay
+// in lockstep.
+//////////////////////////////////////////////////////////////////////////////
+
+/// A memory limit, either auto-detected from the host or a fixed byte count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLimit {
+    /// Detect the (cgroup-aware) host memory and subtract the reserve.
+    Auto,
+    /// Use a fixed memory limit in bytes.
+    Fixed(usize),
+}
+
+/// How much memory to reserve for other processes (OS, aligners, etc.) when a
+/// memory limit is set to [`MemoryLimit::Auto`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryReserve {
+    /// Automatic: `min(10 GiB, 50% of host memory)`.
+    Auto,
+    /// Reserve a fixed number of bytes.
+    Fixed(usize),
+}
+
+/// The minimum per-thread memory budget (256 MiB).
+pub(crate) const MIN_MEMORY_PER_THREAD: usize = 256 * 1024 * 1024;
+
+/// Default auto-reserve cap: 10 GiB.
+pub(crate) const AUTO_RESERVE_CAP: usize = 10 * 1024 * 1024 * 1024;
+
+/// Parse a memory size string into `usize` bytes, suitable for use in clap
+/// value parsers.
+///
+/// Delegates to [`parse_memory_size`] for numeric parsing. Plain numbers are
+/// interpreted as MiB (e.g. "768" = 768 MiB). Supports human-readable formats
+/// like "2GB", "1GiB", "512MiB". See [`parse_memory_size`] for full details.
+fn parse_memory_bytes(s: &str, label: &str) -> Result<usize, String> {
+    let bytes = parse_memory_size(s).map_err(|e| e.to_string())?;
+    usize::try_from(bytes).map_err(|_| format!("{label} too large: {bytes}"))
+}
+
+/// Parse a memory-limit string (e.g. "512M", "1G", "768", "auto").
+pub(crate) fn parse_memory(s: &str) -> Result<MemoryLimit, String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(MemoryLimit::Auto);
+    }
+    Ok(MemoryLimit::Fixed(parse_memory_bytes(s, "Memory size")?))
+}
+
+/// Parse a memory-reserve string (e.g. "10G", "auto").
+pub(crate) fn parse_memory_reserve(s: &str) -> Result<MemoryReserve, String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(MemoryReserve::Auto);
+    }
+    Ok(MemoryReserve::Fixed(parse_memory_bytes(s, "Memory reserve")?))
+}
+
+/// Resolve a [`MemoryReserve`] to a concrete byte count given total host memory.
+pub(crate) fn resolve_reserve(reserve: MemoryReserve, total_memory: usize) -> usize {
+    match reserve {
+        MemoryReserve::Fixed(bytes) => bytes,
+        // min(10 GiB, 50% of host memory)
+        MemoryReserve::Auto => AUTO_RESERVE_CAP.min(total_memory / 2),
+    }
+}
+
+/// Resolve a memory budget to a concrete byte count.
+///
+/// For [`MemoryLimit::Auto`]: detects total host memory (cgroup-aware via
+/// [`detect_total_memory`]), subtracts the reserve, and—when `per_thread` is
+/// set—targets each thread's share with a 256 MiB floor. The result is then
+/// **capped to the available (post-reserve) memory**, so the floor can never
+/// push the total past what the host has. The reserve makes the budget shrink
+/// to fit the host, which is what lets pipeline commands self-throttle instead
+/// of OOM-ing.
+///
+/// For [`MemoryLimit::Fixed`]: multiplies by `threads` when `per_thread` is set;
+/// the reserve and host size are ignored.
+///
+/// Calls [`detect_total_memory`] exactly once (it invokes `sysinfo`, which is
+/// not free).
+pub(crate) fn resolve_memory_budget(
+    limit: MemoryLimit,
+    reserve: MemoryReserve,
+    threads: usize,
+    per_thread: bool,
+) -> anyhow::Result<usize> {
+    // Call once — detect_total_memory() invokes sysinfo, which is not free.
+    resolve_memory_budget_with_total(limit, reserve, threads, per_thread, detect_total_memory())
+}
+
+/// Pure resolver behind [`resolve_memory_budget`], with `total` (host memory)
+/// injected so the `Auto` math is unit-testable on simulated small hosts.
+fn resolve_memory_budget_with_total(
+    limit: MemoryLimit,
+    reserve: MemoryReserve,
+    threads: usize,
+    per_thread: bool,
+    total: usize,
+) -> anyhow::Result<usize> {
+    if threads == 0 {
+        anyhow::bail!("--threads must be at least 1");
+    }
+
+    let budget = match limit {
+        MemoryLimit::Fixed(bytes) => {
+            if per_thread {
+                bytes
+                    .checked_mul(threads)
+                    .ok_or_else(|| anyhow::anyhow!("memory limit × {threads} threads overflowed"))?
+            } else {
+                bytes
+            }
+        }
+        MemoryLimit::Auto => {
+            let margin = resolve_reserve(reserve, total);
+            let available = total.saturating_sub(margin);
+            // The per-thread floor is a *target*, not a guarantee. On a small
+            // host (or high thread count) the floor-based budget can exceed what
+            // is actually available; cap it to `available` so `auto` truly
+            // self-throttles instead of multiplying the floor past physical
+            // memory — the exact OOM this feature exists to prevent (#380).
+            let target = if per_thread {
+                (available / threads)
+                    .max(MIN_MEMORY_PER_THREAD)
+                    .checked_mul(threads)
+                    .ok_or_else(|| anyhow::anyhow!("auto memory budget overflowed"))?
+            } else {
+                available.max(MIN_MEMORY_PER_THREAD)
+            };
+            let budget = target.min(available);
+            if budget < target {
+                log::warn!(
+                    "Auto memory: capping budget to host-available {} ({}/thread target × {} threads \
+                     exceeds it after reserve {}); throughput may drop but the run stays within memory",
+                    ByteSize(budget as u64),
+                    ByteSize(MIN_MEMORY_PER_THREAD as u64),
+                    threads,
+                    ByteSize(margin as u64),
+                );
+            }
+            log::debug!(
+                "Auto memory: {} of {} ({}/thread × {} threads, reserve {})",
+                ByteSize(budget as u64),
+                ByteSize(total as u64),
+                ByteSize((budget / threads) as u64),
+                threads,
+                ByteSize(margin as u64),
+            );
+            budget
+        }
+    };
+
+    if budget > total {
+        log::warn!(
+            "Memory budget {} exceeds total host memory {}; this may cause OOM (or, for sort, earlier spill-to-disk)",
+            ByteSize(budget as u64),
+            ByteSize(total as u64),
+        );
+    }
+
+    Ok(budget)
+}
+
 /// Options for pipeline queue memory limits.
 ///
-/// Controls memory usage in pipeline queues to prevent out-of-memory conditions.
-/// Supports human-readable formats for better UX.
+/// Bounds the memory held in the pipeline's inter-stage queues so a command
+/// self-throttles instead of OOM-ing. Shared (via `#[command(flatten)]`) by
+/// every multi-threaded command, so the `--max-memory` surface matches
+/// `fgumi sort`.
+///
+/// `--max-memory` is the dominant *controllable* consumer; it is a budget, not
+/// a hard RSS cap — a single pathological position group is still processed
+/// whole, and each worker has transient working-set memory on top of the queue.
 #[derive(Debug, Clone, Args)]
 pub struct QueueMemoryOptions {
-    /// Pipeline queue memory limit per thread (default) or total.
+    /// Maximum memory for the pipeline queues.
     ///
-    /// Plain numbers are interpreted as MB. Also supports human-readable
-    /// formats like "2GB", "1.5GB", or "1024MiB".
-    /// By default this value is per-thread, so with --threads 8 the total
-    /// memory will be 8x this value. Use --queue-memory-per-thread false
-    /// for a fixed total limit.
-    #[arg(long = "queue-memory", default_value = "768")]
-    pub queue_memory: String,
+    /// Default is "768" (768 MiB) per thread. Pass "auto" to detect host memory
+    /// (cgroup-aware) and subtract --memory-reserve, so the budget shrinks to
+    /// fit the host and the command self-throttles instead of OOM-ing. Explicit
+    /// values like "512M", "1G", "4GiB" are per-thread when --memory-per-thread
+    /// is enabled (default); plain numbers are MiB. Mirrors `fgumi sort`'s
+    /// --max-memory.
+    #[arg(long = "max-memory", default_value = "768", value_parser = parse_memory)]
+    pub max_memory: MemoryLimit,
 
-    /// Interpret --queue-memory as per-thread (true, default) or total (false).
+    /// Memory to reserve for other processes when --max-memory=auto.
     ///
-    /// When true, total memory = queue-memory * threads. For example,
-    /// --queue-memory 768 with --threads 16 allocates 12 GB total.
-    /// Set to false for a fixed total memory budget regardless of thread count.
-    #[arg(long = "queue-memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
-    pub queue_memory_per_thread: bool,
+    /// "auto" (default) reserves min(10 GiB, 50% of host memory). Explicit
+    /// values like "10G", "8GiB" set a fixed reservation. Ignored when
+    /// --max-memory is an explicit value.
+    #[arg(long = "memory-reserve", default_value = "auto", value_parser = parse_memory_reserve)]
+    pub memory_reserve: MemoryReserve,
 
-    /// DEPRECATED: Use --queue-memory instead. Memory limit for pipeline queues in megabytes.
+    /// Scale the memory limit by thread count.
+    ///
+    /// When enabled (default), --max-memory is per thread, so total memory =
+    /// `max_memory` × threads. Disable for a fixed total budget regardless of
+    /// thread count (recommended on fixed-RAM hosts).
+    #[arg(long = "memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub memory_per_thread: bool,
+
+    /// DEPRECATED: use --max-memory instead. Kept as a hidden alias; when set it
+    /// overrides --max-memory.
+    #[arg(long = "queue-memory", hide = true)]
+    pub queue_memory: Option<String>,
+
+    /// DEPRECATED: use --memory-per-thread instead. Hidden alias that overrides
+    /// --memory-per-thread when --queue-memory is set.
+    #[arg(long = "queue-memory-per-thread", hide = true, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub queue_memory_per_thread: Option<bool>,
+
+    /// DEPRECATED: use --max-memory instead. Hidden alias for a fixed total
+    /// limit in megabytes.
     #[arg(long = "queue-memory-limit-mb", hide = true)]
     pub queue_memory_limit_mb: Option<u64>,
 }
@@ -596,167 +793,96 @@ pub struct QueueMemoryOptions {
 impl Default for QueueMemoryOptions {
     fn default() -> Self {
         Self {
-            queue_memory: "768".to_string(),
-            queue_memory_per_thread: true,
+            // 768 MiB per thread — byte-identical to the historical
+            // --queue-memory 768 default.
+            max_memory: MemoryLimit::Fixed(768 * 1024 * 1024),
+            memory_reserve: MemoryReserve::Auto,
+            memory_per_thread: true,
+            queue_memory: None,
+            queue_memory_per_thread: None,
             queue_memory_limit_mb: None,
         }
     }
 }
 
 impl QueueMemoryOptions {
-    /// Maximum reasonable memory per thread (1TB)
-    const MAX_MEMORY_PER_THREAD: u64 = 1024 * 1024 * 1024 * 1024;
-
-    /// Minimum reasonable memory (1MB)
-    const MIN_MEMORY_TOTAL: u64 = 1024 * 1024;
-
-    /// Calculates the total queue memory limit in bytes with comprehensive validation.
-    ///
-    /// This includes system memory checks via `sysinfo` (warns if >90% of system memory).
-    /// Use [`compute_memory_limit`](Self::compute_memory_limit) for the pure arithmetic
-    /// without system queries (e.g. in tests).
+    /// Resolve the effective `(limit, reserve, per_thread)` triple, honoring the
+    /// deprecated `--queue-memory*` aliases over the modern `--max-memory*`
+    /// flags. Pure: no warnings, no system queries.
     ///
     /// # Errors
-    /// Returns an error if the memory size string cannot be parsed, `num_threads` is 0,
-    /// or the memory calculation would overflow.
+    /// Returns an error if a deprecated `--queue-memory` string fails to parse.
+    fn resolve_spec(&self) -> anyhow::Result<(MemoryLimit, MemoryReserve, bool)> {
+        // The deprecated `--queue-memory-per-thread` alias overrides
+        // `--memory-per-thread` when set, even on its own (i.e. without
+        // `--queue-memory`); otherwise passing it alone would be a silent no-op.
+        let per_thread = self.queue_memory_per_thread.unwrap_or(self.memory_per_thread);
+
+        // Legacy fixed-total flag wins if present (matches prior behavior).
+        if let Some(legacy_mb) = self.queue_memory_limit_mb {
+            let bytes = usize::try_from(legacy_mb)
+                .ok()
+                .and_then(|mb| mb.checked_mul(1024 * 1024))
+                .ok_or_else(|| anyhow::anyhow!("--queue-memory-limit-mb too large: {legacy_mb}"))?;
+            return Ok((MemoryLimit::Fixed(bytes), MemoryReserve::Auto, false));
+        }
+
+        // Deprecated --queue-memory overrides --max-memory when set.
+        if let Some(queue_memory) = &self.queue_memory {
+            let limit = parse_memory(queue_memory).map_err(|e| {
+                anyhow::anyhow!("Failed to parse --queue-memory {queue_memory}: {e}")
+            })?;
+            return Ok((limit, self.memory_reserve, per_thread));
+        }
+
+        Ok((self.max_memory, self.memory_reserve, per_thread))
+    }
+
+    /// Emit a one-time deprecation warning for any legacy flag in use.
+    fn warn_deprecations(&self) {
+        if self.queue_memory_limit_mb.is_some() {
+            log::warn!("DEPRECATED: --queue-memory-limit-mb; use --max-memory <N> instead.");
+        } else if self.queue_memory.is_some() {
+            log::warn!(
+                "DEPRECATED: --queue-memory / --queue-memory-per-thread; use --max-memory / --memory-per-thread instead."
+            );
+        } else if self.queue_memory_per_thread.is_some() {
+            log::warn!("DEPRECATED: --queue-memory-per-thread; use --memory-per-thread instead.");
+        }
+    }
+
+    /// Resolve the total queue memory budget in bytes for `num_threads`.
+    ///
+    /// Under `--max-memory auto` the budget is detected from (cgroup-aware) host
+    /// memory minus `--memory-reserve`, so it shrinks to fit the host. Under an
+    /// explicit value it is `max_memory` (× threads when per-thread).
+    ///
+    /// # Errors
+    /// Returns an error if `num_threads` is 0, a deprecated `--queue-memory`
+    /// string fails to parse, or the multiplication overflows.
     pub fn calculate_memory_limit(&self, num_threads: usize) -> anyhow::Result<u64> {
-        let total_memory = self.compute_memory_limit(num_threads)?;
-        Self::validate_against_system_memory(total_memory);
-        Ok(total_memory)
+        self.warn_deprecations();
+        let (limit, reserve, per_thread) = self.resolve_spec()?;
+        let bytes = resolve_memory_budget(limit, reserve, num_threads, per_thread)?;
+        Ok(bytes as u64)
     }
 
-    /// Computes the total queue memory limit in bytes (pure arithmetic, no system queries).
-    ///
-    /// # Errors
-    /// Returns an error if:
-    /// - The memory size string cannot be parsed
-    /// - `num_threads` is 0
-    /// - Memory calculation would overflow
-    /// - Memory values are unreasonable
-    pub fn compute_memory_limit(&self, num_threads: usize) -> anyhow::Result<u64> {
-        // Validate thread count
-        if num_threads == 0 {
-            anyhow::bail!("Number of threads must be greater than 0, got: {num_threads}");
-        }
-
-        // Handle migration from old parameter
-        let (base_memory_bytes, is_legacy) = if let Some(legacy_mb) = self.queue_memory_limit_mb {
-            log::warn!(
-                "DEPRECATED: --queue-memory-limit-mb is deprecated. Use --queue-memory instead."
-            );
-            log::warn!(
-                "Migration: --queue-memory-limit-mb {legacy_mb} → --queue-memory {legacy_mb} --queue-memory-per-thread false"
-            );
-            (
-                legacy_mb.checked_mul(1024 * 1024).ok_or_else(|| {
-                    anyhow::anyhow!("Legacy memory size overflow: {legacy_mb} MB")
-                })?,
-                true,
-            )
-        } else {
-            (
-                parse_memory_size(&self.queue_memory).map_err(|e| {
-                    anyhow::anyhow!("Failed to parse queue memory size: {}: {e}", self.queue_memory)
-                })?,
-                false,
-            )
-        };
-
-        // Validate base memory range
-        if base_memory_bytes < Self::MIN_MEMORY_TOTAL {
-            anyhow::bail!(
-                "Memory limit too small: {} (minimum: {})",
-                ByteSize(base_memory_bytes),
-                ByteSize(Self::MIN_MEMORY_TOTAL)
-            );
-        }
-
-        // Calculate total memory with overflow checking
-        let total_memory = if self.queue_memory_per_thread && !is_legacy {
-            // Validate per-thread memory limit
-            if base_memory_bytes > Self::MAX_MEMORY_PER_THREAD {
-                anyhow::bail!(
-                    "Memory per thread too large: {} (maximum: {})",
-                    ByteSize(base_memory_bytes),
-                    ByteSize(Self::MAX_MEMORY_PER_THREAD)
-                );
-            }
-
-            // Check for overflow before multiplication
-            base_memory_bytes
-                .checked_mul(num_threads as u64)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Memory calculation overflow: {} × {} threads exceeds maximum addressable memory",
-                        ByteSize(base_memory_bytes),
-                        num_threads
-                    )
-                })?
-        } else {
-            // Fixed total memory (legacy mode or explicit setting)
-            base_memory_bytes
-        };
-
-        Ok(total_memory)
-    }
-
-    /// Warns if the requested memory exceeds reasonable system limits.
-    fn validate_against_system_memory(requested_bytes: u64) {
-        let mut system = sysinfo::System::new();
-        system.refresh_memory();
-
-        // Use cgroup-aware total clamped to physical RAM, matching detect_total_memory().
-        // A misconfigured container may report a cgroup limit exceeding physical RAM;
-        // clamping keeps warnings consistent with the value used by resolve_memory_limit.
-        let physical = system.total_memory();
-        let total_memory_bytes =
-            system.cgroup_limits().map_or(physical, |c| c.total_memory.min(physical));
-
-        // available_memory reflects free physical pages; no cgroup equivalent.
-        let available_memory_bytes = system.available_memory();
-
-        // Calculate 90% limit using integer arithmetic to avoid precision loss
-        let memory_limit = total_memory_bytes - (total_memory_bytes / 10); // 90% = total - 10%
-        if requested_bytes > memory_limit {
-            log::warn!(
-                "Requested memory {} exceeds 90% of system memory ({}). System has {} total, {} available. This may cause OOM conditions.",
-                ByteSize(requested_bytes),
-                ByteSize(memory_limit),
-                ByteSize(total_memory_bytes),
-                ByteSize(available_memory_bytes)
-            );
-        }
-
-        // Warn if requesting more than currently available memory
-        if requested_bytes > available_memory_bytes {
-            log::warn!(
-                "Requested memory {} exceeds currently available memory {}. This may cause swapping.",
-                ByteSize(requested_bytes),
-                ByteSize(available_memory_bytes)
-            );
-        }
-    }
-
-    /// Logs the memory configuration.
+    /// Logs the resolved memory configuration.
     ///
     /// # Arguments
-    /// * `num_threads` - Number of threads for the calculation
-    /// * `total_memory` - Pre-computed total memory limit in bytes from `calculate_memory_limit`
+    /// * `num_threads` - Number of threads used for the calculation.
+    /// * `total_memory` - The resolved total budget from `calculate_memory_limit`.
     pub fn log_memory_config(&self, num_threads: usize, total_memory: u64) {
-        if let Some(legacy_mb) = self.queue_memory_limit_mb {
+        let per_thread = self.resolve_spec().map(|(_, _, pt)| pt).unwrap_or(true);
+        if per_thread && num_threads > 1 {
             log::info!(
-                "Queue memory limit: {} (LEGACY: {legacy_mb} MB total, per-thread scaling disabled)",
-                ByteSize(total_memory)
-            );
-        } else if self.queue_memory_per_thread && num_threads > 1 {
-            log::info!(
-                "Queue memory limit: {} total ({} MB/thread × {} threads)",
+                "Queue memory budget: {} total ({}/thread × {} threads)",
                 ByteSize(total_memory),
-                self.queue_memory,
+                ByteSize(total_memory / num_threads as u64),
                 num_threads
             );
         } else {
-            log::info!("Queue memory limit: {} total (fixed)", ByteSize(total_memory));
+            log::info!("Queue memory budget: {} total", ByteSize(total_memory));
         }
     }
 }
@@ -870,6 +996,16 @@ pub fn build_pipeline_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Enable an at-Trace logger so `log::warn!`/`debug!` macros evaluate their
+    /// arguments — without an enabled logger the `log` crate skips argument
+    /// evaluation, leaving the formatting expressions inside the memory-budget
+    /// warn/debug branches unexecuted under test. nextest runs each test in its
+    /// own process, so `try_init` is local and idempotent.
+    fn enable_logging() {
+        let _ =
+            env_logger::builder().is_test(true).filter_level(log::LevelFilter::Trace).try_init();
+    }
 
     #[test]
     fn test_none_is_single_threaded() {
@@ -1039,112 +1175,246 @@ mod tests {
     // ========== Tests for QueueMemoryOptions ==========
 
     #[test]
-    fn test_queue_memory_options_compute_basic() {
-        let opts = QueueMemoryOptions {
-            queue_memory: "100".to_string(),
-            queue_memory_per_thread: true,
-            queue_memory_limit_mb: None,
-        };
-
-        // 100MB × 4 threads = 400MB
-        let result = opts
-            .compute_memory_limit(4)
-            .expect("compute_memory_limit should succeed for 100MB x 4 threads");
-        assert_eq!(result, 100 * 1024 * 1024 * 4);
-
-        // Fixed memory (no scaling)
-        let opts_fixed = QueueMemoryOptions {
-            queue_memory: "200".to_string(),
-            queue_memory_per_thread: false,
-            queue_memory_limit_mb: None,
-        };
-        let result_fixed = opts_fixed
-            .compute_memory_limit(8)
-            .expect("compute_memory_limit should succeed for fixed 200MB");
-        assert_eq!(result_fixed, 200 * 1024 * 1024); // Should not scale
-    }
-
-    #[test]
-    fn test_queue_memory_options_validation_errors() {
+    fn test_queue_memory_default_is_768_mib_per_thread() {
+        // The default must stay byte-identical to the historical
+        // `--queue-memory 768` (768 MiB per thread).
         let opts = QueueMemoryOptions::default();
-
-        // Zero threads should fail
-        assert!(opts.compute_memory_limit(0).is_err());
-
-        // Very large memory per thread should fail
-        let large_opts = QueueMemoryOptions {
-            queue_memory: "2TB".to_string(),
-            queue_memory_per_thread: true,
-            queue_memory_limit_mb: None,
-        };
-        assert!(large_opts.compute_memory_limit(1).is_err());
-
-        // Very small memory should fail
-        let tiny_opts = QueueMemoryOptions {
-            queue_memory: "1KB".to_string(),
-            queue_memory_per_thread: false,
-            queue_memory_limit_mb: None,
-        };
-        assert!(tiny_opts.compute_memory_limit(1).is_err());
-    }
-
-    #[test]
-    fn test_queue_memory_options_overflow() {
-        let opts = QueueMemoryOptions {
-            queue_memory: "2TB".to_string(), // 2TB > 1TB limit
-            queue_memory_per_thread: true,
-            queue_memory_limit_mb: None,
-        };
-
-        // Should fail due to per-thread limit
-        assert!(opts.compute_memory_limit(1).is_err());
-
-        // Large total (100TB) succeeds at the math level (system check is separate)
-        let opts2 = QueueMemoryOptions {
-            queue_memory: "100GB".to_string(),
-            queue_memory_per_thread: true,
-            queue_memory_limit_mb: None,
-        };
-        assert!(opts2.compute_memory_limit(1000).is_ok());
-    }
-
-    #[test]
-    fn test_queue_memory_options_legacy_migration() {
-        let legacy_opts = QueueMemoryOptions {
-            queue_memory: "768".to_string(), // Should be ignored
-            queue_memory_per_thread: true,   // Should be ignored
-            queue_memory_limit_mb: Some(2048),
-        };
-
-        let result = legacy_opts
-            .compute_memory_limit(4)
-            .expect("compute_memory_limit should succeed for legacy migration");
-        assert_eq!(result, 2048 * 1024 * 1024); // Should use legacy value, no scaling
-    }
-
-    #[test]
-    fn test_queue_memory_options_human_readable() {
-        let opts = QueueMemoryOptions {
-            queue_memory: "2GB".to_string(),
-            queue_memory_per_thread: false,
-            queue_memory_limit_mb: None,
-        };
-
         let result = opts
-            .compute_memory_limit(4)
-            .expect("compute_memory_limit should succeed for 2GB fixed");
-        assert_eq!(result, 2 * 1000 * 1000 * 1000); // 2GB in bytes
+            .calculate_memory_limit(4)
+            .expect("calculate_memory_limit should succeed for the default");
+        assert_eq!(result, 768 * 1024 * 1024 * 4);
     }
 
     #[test]
-    fn test_queue_memory_options_small_value() {
+    fn test_queue_memory_max_memory_per_thread_scaling() {
+        // 100 MiB × 4 threads = 400 MiB
         let opts = QueueMemoryOptions {
-            queue_memory: "1".to_string(), // 1MB
-            queue_memory_per_thread: false,
-            queue_memory_limit_mb: None,
+            max_memory: MemoryLimit::Fixed(100 * 1024 * 1024),
+            ..QueueMemoryOptions::default()
         };
+        let result = opts.calculate_memory_limit(4).expect("should succeed");
+        assert_eq!(result, 100 * 1024 * 1024 * 4);
+    }
 
-        assert!(opts.compute_memory_limit(1).is_ok());
+    #[test]
+    fn test_queue_memory_fixed_total_does_not_scale() {
+        let opts = QueueMemoryOptions {
+            max_memory: MemoryLimit::Fixed(200 * 1024 * 1024),
+            memory_per_thread: false,
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(8).expect("should succeed");
+        assert_eq!(result, 200 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_queue_memory_zero_threads_is_error() {
+        assert!(QueueMemoryOptions::default().calculate_memory_limit(0).is_err());
+    }
+
+    #[test]
+    fn test_queue_memory_human_readable_via_parse() {
+        // "2GB" parses as decimal gigabytes (matching `fgumi sort` / ByteSize).
+        let opts = QueueMemoryOptions {
+            max_memory: parse_memory("2GB").expect("parse 2GB"),
+            memory_per_thread: false,
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(4).expect("should succeed");
+        assert_eq!(result, 2 * 1000 * 1000 * 1000);
+    }
+
+    #[test]
+    fn test_queue_memory_auto_is_bounded_by_host() {
+        // `auto` self-throttles: the budget must never exceed (cgroup-aware)
+        // host memory, regardless of thread count.
+        let total = detect_total_memory() as u64;
+        let opts =
+            QueueMemoryOptions { max_memory: MemoryLimit::Auto, ..QueueMemoryOptions::default() };
+        let result = opts.calculate_memory_limit(4).expect("auto should resolve");
+        assert!(result > 0, "auto resolved to a zero budget");
+        assert!(result <= total, "auto budget {result} exceeded host total {total}");
+    }
+
+    #[test]
+    fn test_auto_never_oversubscribes_small_host() {
+        enable_logging(); // exercise the cap-warning and auto-debug log branches
+        // Simulated 4 GiB host, 16 threads: the 256 MiB/thread floor would want
+        // 4 GiB before reserve, which cannot fit after the auto reserve. The
+        // budget must be capped to `available`, never `floor × threads`.
+        let total = 4 * 1024 * 1024 * 1024; // 4 GiB
+        let margin = resolve_reserve(MemoryReserve::Auto, total); // min(10 GiB, 2 GiB) = 2 GiB
+        let available = total - margin;
+        let budget = resolve_memory_budget_with_total(
+            MemoryLimit::Auto,
+            MemoryReserve::Auto,
+            16,
+            true,
+            total,
+        )
+        .expect("should resolve");
+        assert!(budget <= available, "budget {budget} oversubscribed available {available}");
+        assert!(budget <= total, "budget {budget} oversubscribed host {total}");
+    }
+
+    #[test]
+    fn test_auto_uses_floor_when_host_is_ample() {
+        // Simulated 256 GiB host, 4 threads: plenty of room, so the budget is
+        // the per-thread share and stays under available.
+        let total = 256 * 1024 * 1024 * 1024;
+        let margin = resolve_reserve(MemoryReserve::Auto, total); // 10 GiB cap
+        let available = total - margin;
+        let budget = resolve_memory_budget_with_total(
+            MemoryLimit::Auto,
+            MemoryReserve::Auto,
+            4,
+            true,
+            total,
+        )
+        .expect("should resolve");
+        assert!(budget >= MIN_MEMORY_PER_THREAD * 4, "budget {budget} fell below the floor");
+        assert!(budget <= available, "budget {budget} exceeded available {available}");
+    }
+
+    #[test]
+    fn test_fixed_budget_independent_of_host() {
+        enable_logging(); // exercise the "budget exceeds host total" warn branch
+        // Fixed limits ignore host size entirely (reserve is irrelevant).
+        let tiny_host = 512 * 1024 * 1024;
+        let budget = resolve_memory_budget_with_total(
+            MemoryLimit::Fixed(2 * 1024 * 1024 * 1024),
+            MemoryReserve::Auto,
+            4,
+            false,
+            tiny_host,
+        )
+        .expect("should resolve");
+        assert_eq!(budget, 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_queue_memory_auto_reserve_shrinks_budget() {
+        let large_reserve = QueueMemoryOptions {
+            max_memory: MemoryLimit::Auto,
+            memory_reserve: MemoryReserve::Fixed(512 * 1024 * 1024),
+            ..QueueMemoryOptions::default()
+        }
+        .calculate_memory_limit(4)
+        .expect("should succeed");
+        let small_reserve = QueueMemoryOptions {
+            max_memory: MemoryLimit::Auto,
+            memory_reserve: MemoryReserve::Fixed(128 * 1024 * 1024),
+            ..QueueMemoryOptions::default()
+        }
+        .calculate_memory_limit(4)
+        .expect("should succeed");
+        assert!(large_reserve <= small_reserve);
+    }
+
+    #[test]
+    fn test_queue_memory_deprecated_queue_memory_alias() {
+        // The hidden `--queue-memory` alias overrides `--max-memory`, honoring
+        // its companion `--queue-memory-per-thread`.
+        let opts = QueueMemoryOptions {
+            queue_memory: Some("200".to_string()),
+            queue_memory_per_thread: Some(false),
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(8).expect("should succeed");
+        assert_eq!(result, 200 * 1024 * 1024); // fixed total, no scaling
+    }
+
+    #[test]
+    fn test_queue_memory_per_thread_alias_alone_takes_effect() {
+        // `--queue-memory-per-thread false` on its own must override
+        // `--memory-per-thread` (default true), not be a silent no-op.
+        let opts = QueueMemoryOptions {
+            max_memory: MemoryLimit::Fixed(200 * 1024 * 1024),
+            queue_memory_per_thread: Some(false),
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(8).expect("should succeed");
+        assert_eq!(result, 200 * 1024 * 1024); // fixed total, no per-thread scaling
+    }
+
+    #[test]
+    fn test_queue_memory_deprecated_alias_defaults_to_per_thread() {
+        // When `--queue-memory-per-thread` is unset, the alias falls back to
+        // `--memory-per-thread` (default true).
+        let opts = QueueMemoryOptions {
+            queue_memory: Some("100".to_string()),
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(4).expect("should succeed");
+        assert_eq!(result, 100 * 1024 * 1024 * 4);
+    }
+
+    #[test]
+    fn test_queue_memory_legacy_limit_mb_fixed_total() {
+        let opts = QueueMemoryOptions {
+            queue_memory_limit_mb: Some(2048),
+            // These must be ignored in favor of the legacy fixed total.
+            max_memory: MemoryLimit::Fixed(1),
+            memory_per_thread: true,
+            ..QueueMemoryOptions::default()
+        };
+        let result = opts.calculate_memory_limit(4).expect("should succeed");
+        assert_eq!(result, 2048 * 1024 * 1024); // fixed total, no scaling
+    }
+
+    #[test]
+    fn test_legacy_limit_mb_overflow_is_error() {
+        // u64::MAX MiB overflows when multiplied by 1 MiB.
+        let opts = QueueMemoryOptions {
+            queue_memory_limit_mb: Some(u64::MAX),
+            ..QueueMemoryOptions::default()
+        };
+        assert!(opts.calculate_memory_limit(1).is_err());
+    }
+
+    #[test]
+    fn test_deprecated_queue_memory_parse_error_is_error() {
+        let opts = QueueMemoryOptions {
+            queue_memory: Some("not-a-size".to_string()),
+            ..QueueMemoryOptions::default()
+        };
+        assert!(opts.calculate_memory_limit(4).is_err());
+    }
+
+    #[test]
+    fn test_fixed_per_thread_overflow_is_error() {
+        let opts = QueueMemoryOptions {
+            max_memory: MemoryLimit::Fixed(usize::MAX),
+            ..QueueMemoryOptions::default()
+        };
+        assert!(opts.calculate_memory_limit(4).is_err());
+    }
+
+    #[test]
+    fn test_auto_per_thread_overflow_is_error() {
+        // A pathological thread count makes the per-thread floor × threads
+        // overflow; this must surface as an error, not wrap.
+        let result = resolve_memory_budget_with_total(
+            MemoryLimit::Auto,
+            MemoryReserve::Auto,
+            usize::MAX,
+            true,
+            1024 * 1024 * 1024,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_log_memory_config_exercises_both_branches() {
+        // Logging only (no return value); call both paths to keep them covered
+        // and to guard against a panic in the formatting/division.
+        let per_thread = QueueMemoryOptions::default();
+        per_thread.log_memory_config(8, 8 * 768 * 1024 * 1024); // per-thread, threads > 1
+        per_thread.log_memory_config(1, 768 * 1024 * 1024); // threads == 1 → total branch
+
+        let fixed_total =
+            QueueMemoryOptions { memory_per_thread: false, ..QueueMemoryOptions::default() };
+        fixed_total.log_memory_config(8, 1024 * 1024 * 1024); // fixed total branch
     }
 
     #[test]
@@ -1218,16 +1488,42 @@ mod tests {
     }
 
     #[rstest]
-    // --queue-memory-per-thread (default true)
+    // --memory-per-thread (default true)
     #[case(&["test"], true)]
-    #[case(&["test", "--queue-memory-per-thread"], true)]
-    #[case(&["test", "--queue-memory-per-thread", "true"], true)]
-    #[case(&["test", "--queue-memory-per-thread", "false"], false)]
-    #[case(&["test", "--queue-memory-per-thread=true"], true)]
-    #[case(&["test", "--queue-memory-per-thread=false"], false)]
-    fn test_queue_memory_per_thread_parsing(#[case] args: &[&str], #[case] expected: bool) {
+    #[case(&["test", "--memory-per-thread"], true)]
+    #[case(&["test", "--memory-per-thread", "true"], true)]
+    #[case(&["test", "--memory-per-thread", "false"], false)]
+    #[case(&["test", "--memory-per-thread=true"], true)]
+    #[case(&["test", "--memory-per-thread=false"], false)]
+    fn test_memory_per_thread_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = TestBoolFlags::try_parse_from(args).expect("valid CLI args should parse");
-        assert_eq!(cmd.queue_memory.queue_memory_per_thread, expected);
+        assert_eq!(cmd.queue_memory.memory_per_thread, expected);
+    }
+
+    #[rstest]
+    // --max-memory parses to a MemoryLimit; "auto" and explicit values both work.
+    #[case(&["test"], MemoryLimit::Fixed(768 * 1024 * 1024))]
+    #[case(&["test", "--max-memory", "auto"], MemoryLimit::Auto)]
+    #[case(&["test", "--max-memory", "2GiB"], MemoryLimit::Fixed(2 * 1024 * 1024 * 1024))]
+    #[case(&["test", "--max-memory=512M"], MemoryLimit::Fixed(512 * 1000 * 1000))]
+    fn test_max_memory_parsing(#[case] args: &[&str], #[case] expected: MemoryLimit) {
+        let cmd = TestBoolFlags::try_parse_from(args).expect("valid CLI args should parse");
+        assert_eq!(cmd.queue_memory.max_memory, expected);
+    }
+
+    #[test]
+    fn test_deprecated_queue_memory_flag_still_parses() {
+        // The hidden alias remains accepted for backward compatibility.
+        let cmd = TestBoolFlags::try_parse_from([
+            "test",
+            "--queue-memory",
+            "512",
+            "--queue-memory-per-thread",
+            "false",
+        ])
+        .expect("deprecated flags should still parse");
+        assert_eq!(cmd.queue_memory.queue_memory.as_deref(), Some("512"));
+        assert_eq!(cmd.queue_memory.queue_memory_per_thread, Some(false));
     }
 
     #[rstest]

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -860,6 +860,27 @@ genomic position are partitioned by cell barcode before deduplication. This ensu
 different cells are never marked as duplicates of each other, even if they share a UMI sequence and
 mapping position. The cell barcode is read from the standard `CB` tag. No
 correction or error-handling is performed on cell barcodes; they must be corrected upstream.
+
+# Memory
+
+dedup streams the input and processes one genomic position group at a time, so memory scales with
+parallelism, not input size. The two contributors are:
+
+  - Pipeline queue: bounded by --max-memory, which is per thread by default. With the default
+    (768 MiB/thread), --threads 16 budgets ~12 GiB of queue alone and --threads 8 budgets ~6 GiB.
+  - Per-worker working set: each worker transiently holds the templates of the group it is
+    processing (building, scoring, sorting). This is on top of the queue budget, so peak RSS is
+    higher than --max-memory; empirically ~1-2 GiB/thread on WGS-scale input.
+
+A practical rule of thumb for WGS-scale input is to budget ~2 GiB per thread of total RSS. On a
+fixed-RAM host, prefer one of:
+
+  fgumi dedup ... --threads 16 --max-memory auto              # detect host RAM, self-throttle
+  fgumi dedup ... --threads 16 --max-memory 16G --memory-per-thread false   # fixed total budget
+
+--max-memory is a budget for the controllable consumer (the queue), not a hard RSS cap: a single
+pathological high-coverage position group is still processed whole. The legacy --queue-memory /
+--queue-memory-per-thread flags remain accepted as hidden aliases.
 "#
 )]
 pub struct MarkDuplicates {

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -2085,11 +2085,7 @@ mod tests {
             index_threshold: 100,
             no_umi: false,
             scheduler_opts: SchedulerOptions::default(),
-            queue_memory: QueueMemoryOptions {
-                queue_memory: "768".to_string(),
-                queue_memory_per_thread: true,
-                queue_memory_limit_mb: None,
-            },
+            queue_memory: QueueMemoryOptions::default(),
             allow_unmapped: false,
             parallel_group_min_templates: None,
             #[cfg(feature = "memory-debug")]

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -35,8 +35,10 @@ use log::{debug, info};
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
-use crate::commands::common::{CompressionOptions, detect_total_memory, parse_bool};
-use crate::validation::parse_memory_size;
+use crate::commands::common::{
+    CompressionOptions, MemoryLimit, MemoryReserve, parse_bool, parse_memory, parse_memory_reserve,
+    resolve_memory_budget,
+};
 
 /// Sort order for BAM files.
 ///
@@ -313,47 +315,6 @@ pub struct Sort {
     pub async_reader: bool,
 }
 
-/// Represents the memory limit configuration for sorting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MemoryLimit {
-    /// Automatically detect system memory and compute an optimal limit.
-    Auto,
-    /// Use a fixed memory limit in bytes.
-    Fixed(usize),
-}
-
-/// Represents how much memory to reserve for other processes (OS, aligners, etc.)
-/// when `--max-memory=auto`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MemoryReserve {
-    /// Automatic: `min(10 GiB, 50% of system memory)`.
-    Auto,
-    /// Reserve a fixed number of bytes.
-    Fixed(usize),
-}
-
-/// Parse a memory size string into `usize` bytes, suitable for use in clap
-/// value parsers.
-///
-/// Delegates to [`parse_memory_size`] for numeric parsing. Plain numbers are
-/// interpreted as MiB (e.g. "768" = 768 MiB). Supports human-readable formats
-/// like "2GB", "1GiB", "512MiB". See [`parse_memory_size`] for full details.
-fn parse_memory_bytes(s: &str, label: &str) -> Result<usize, String> {
-    let bytes = parse_memory_size(s).map_err(|e| e.to_string())?;
-    usize::try_from(bytes).map_err(|_| format!("{label} too large: {bytes}"))
-}
-
-/// Parse memory size string (e.g., "512M", "1G", "2G", "auto").
-pub(crate) fn parse_memory(s: &str) -> Result<MemoryLimit, String> {
-    let s = s.trim();
-
-    if s.eq_ignore_ascii_case("auto") {
-        return Ok(MemoryLimit::Auto);
-    }
-
-    Ok(MemoryLimit::Fixed(parse_memory_bytes(s, "Memory size")?))
-}
-
 /// Environment variable name for the fallback temp-dir list, parsed as a
 /// `PATH`-style list when no `-T/--tmp-dir` flags are passed.
 const TMP_DIRS_ENV: &str = "FGUMI_TMP_DIRS";
@@ -378,18 +339,6 @@ pub(crate) fn resolve_tmp_dirs(cli: &[PathBuf], env_value: Option<&str>) -> Vec<
         .filter(|p| !p.as_os_str().is_empty())
         .filter(|p| !p.to_string_lossy().trim().is_empty())
         .collect()
-}
-
-/// Parse memory reserve string (e.g., "10G", "auto").
-pub(crate) fn parse_memory_reserve(s: &str) -> Result<MemoryReserve, String> {
-    let s = s.trim();
-
-    if s.eq_ignore_ascii_case("auto") {
-        return Ok(MemoryReserve::Auto);
-    }
-
-    let bytes = parse_memory_bytes(s, "Memory reserve")?;
-    Ok(MemoryReserve::Fixed(bytes))
 }
 
 /// Parse the cell tag for template-coordinate sort/verify, returning `None`
@@ -453,115 +402,6 @@ impl Command for Sort {
     }
 }
 
-/// The minimum per-thread memory budget (256 MiB).
-const MIN_MEMORY_PER_THREAD: usize = 256 * 1024 * 1024;
-
-/// Default auto-reserve cap: 10 GiB.
-const AUTO_RESERVE_CAP: usize = 10 * 1024 * 1024 * 1024;
-
-/// Resolve a [`MemoryReserve`] to a concrete byte count given total system memory.
-fn resolve_reserve(reserve: MemoryReserve, total_memory: usize) -> usize {
-    match reserve {
-        MemoryReserve::Fixed(bytes) => bytes,
-        MemoryReserve::Auto => {
-            // min(10 GiB, 50% of system memory)
-            AUTO_RESERVE_CAP.min(total_memory / 2)
-        }
-    }
-}
-
-/// Resolves a [`MemoryLimit`] to a concrete byte count.
-///
-/// For [`MemoryLimit::Auto`]: detects total system memory (cgroup-aware via
-/// [`detect_total_memory`]), subtracts the reserve (via [`MemoryReserve`]),
-/// and divides by thread count (when `memory_per_thread` is true). The result
-/// is clamped to a minimum of 256 MiB per thread.
-///
-/// For [`MemoryLimit::Fixed`]: applies the same `memory_per_thread`
-/// multiplication as before. The reserve is ignored.
-///
-/// # Note
-///
-/// Calls [`detect_total_memory`] exactly once regardless of `limit` variant.
-/// That function invokes `sysinfo` (creates a `System` instance and refreshes
-/// memory counters), so repeated calls add unnecessary overhead.
-fn resolve_memory_limit(
-    limit: MemoryLimit,
-    reserve: MemoryReserve,
-    threads: usize,
-    memory_per_thread: bool,
-) -> Result<usize> {
-    if threads == 0 {
-        bail!("--threads must be at least 1");
-    }
-
-    // Call once — detect_total_memory() invokes sysinfo, which is not free.
-    let total = detect_total_memory();
-
-    let total_budget = match limit {
-        MemoryLimit::Fixed(bytes) => {
-            if memory_per_thread {
-                bytes
-                    .checked_mul(threads)
-                    .ok_or_else(|| anyhow::anyhow!("--max-memory × --threads overflowed"))?
-            } else {
-                bytes
-            }
-        }
-        MemoryLimit::Auto => {
-            let margin = resolve_reserve(reserve, total);
-            let available = total.saturating_sub(margin);
-
-            if memory_per_thread {
-                let per_thread = (available / threads).max(MIN_MEMORY_PER_THREAD);
-                let budget = per_thread
-                    .checked_mul(threads)
-                    .ok_or_else(|| anyhow::anyhow!("auto memory budget overflowed"))?;
-                if budget > available {
-                    log::warn!(
-                        "Auto memory: total budget {} exceeds available {} \
-                         ({}/thread x {} threads, reserve {}); may spill to disk earlier than expected",
-                        ByteSize(budget as u64),
-                        ByteSize(available as u64),
-                        ByteSize(per_thread as u64),
-                        threads,
-                        ByteSize(margin as u64),
-                    );
-                }
-                debug!(
-                    "Auto memory: using {} of {} ({}/thread x {} threads, reserve {})",
-                    ByteSize(budget as u64),
-                    ByteSize(total as u64),
-                    ByteSize(per_thread as u64),
-                    threads,
-                    ByteSize(margin as u64),
-                );
-                budget
-            } else {
-                let budget = available.max(MIN_MEMORY_PER_THREAD);
-                debug!(
-                    "Auto memory: using {} of {} (fixed total, reserve {})",
-                    ByteSize(budget as u64),
-                    ByteSize(total as u64),
-                    ByteSize(margin as u64),
-                );
-                budget
-            }
-        }
-    };
-
-    // Post-resolution sanity check: warn if budget exceeds the effective memory limit.
-    if total_budget > total {
-        log::warn!(
-            "Memory budget {} exceeds total system memory {}; spill-to-disk is likely",
-            ByteSize(total_budget as u64),
-            ByteSize(total as u64),
-        );
-    }
-
-    Ok(total_budget)
-}
-
 impl Sort {
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
     /// for other sort orders.
@@ -593,7 +433,7 @@ impl Sort {
         let timer = OperationTimer::new("Sorting BAM");
 
         // Resolve memory limit (auto-detect or fixed)
-        let effective_memory = resolve_memory_limit(
+        let effective_memory = resolve_memory_budget(
             self.max_memory,
             self.memory_reserve,
             self.threads,
@@ -783,6 +623,9 @@ impl Sort {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Memory-budget helpers moved to `commands::common`; import the `pub(crate)`
+    // items these tests exercise that are not re-exported through `super::*`.
+    use crate::commands::common::{MIN_MEMORY_PER_THREAD, detect_total_memory, resolve_reserve};
     use clap::Parser;
     use rstest::rstest;
 
@@ -995,7 +838,7 @@ mod tests {
         let fixed = MemoryLimit::Fixed(1024 * 1024 * 1024); // 1 GiB
         // Reserve is ignored for fixed limits
         let resolved =
-            resolve_memory_limit(fixed, MemoryReserve::Auto, 4, true).expect("should succeed");
+            resolve_memory_budget(fixed, MemoryReserve::Auto, 4, true).expect("should succeed");
         // Fixed + memory_per_thread: total = 1 GiB * 4 = 4 GiB
         assert_eq!(resolved, 4 * 1024 * 1024 * 1024);
     }
@@ -1004,7 +847,7 @@ mod tests {
     fn test_resolve_memory_limit_fixed_no_per_thread() {
         let fixed = MemoryLimit::Fixed(4 * 1024 * 1024 * 1024); // 4 GiB
         let resolved =
-            resolve_memory_limit(fixed, MemoryReserve::Auto, 4, false).expect("should succeed");
+            resolve_memory_budget(fixed, MemoryReserve::Auto, 4, false).expect("should succeed");
         // Fixed + no per-thread: total = 4 GiB
         assert_eq!(resolved, 4 * 1024 * 1024 * 1024);
     }
@@ -1013,7 +856,7 @@ mod tests {
     fn test_resolve_memory_limit_auto() {
         let total = detect_total_memory();
 
-        let resolved = resolve_memory_limit(MemoryLimit::Auto, MemoryReserve::Auto, 4, true)
+        let resolved = resolve_memory_budget(MemoryLimit::Auto, MemoryReserve::Auto, 4, true)
             .expect("should succeed");
         // Must be at least the per-thread minimum floor (256 MiB * 4 threads)
         let min_expected = MIN_MEMORY_PER_THREAD.saturating_mul(4).min(total);
@@ -1030,7 +873,7 @@ mod tests {
 
     #[test]
     fn test_resolve_memory_limit_auto_no_per_thread() {
-        let resolved = resolve_memory_limit(MemoryLimit::Auto, MemoryReserve::Auto, 8, false)
+        let resolved = resolve_memory_budget(MemoryLimit::Auto, MemoryReserve::Auto, 8, false)
             .expect("should succeed");
         // Auto + no per-thread: should be total budget, not divided by threads
         // Must be at least the minimum floor (256 MB)
@@ -1074,14 +917,14 @@ mod tests {
         // With a larger fixed reserve, auto should return less memory.
         // Use modest reserve sizes (128 MiB vs 512 MiB) to stay well within
         // CI runner RAM and avoid the per-thread floor clamping both results.
-        let large_reserve = resolve_memory_limit(
+        let large_reserve = resolve_memory_budget(
             MemoryLimit::Auto,
             MemoryReserve::Fixed(512 * 1024 * 1024),
             4,
             true,
         )
         .expect("should succeed");
-        let small_reserve = resolve_memory_limit(
+        let small_reserve = resolve_memory_budget(
             MemoryLimit::Auto,
             MemoryReserve::Fixed(128 * 1024 * 1024),
             4,


### PR DESCRIPTION
## Summary

Closes #380. `fgumi dedup --no-umi --threads 16` gets OOM-killed on a 30 GiB host while `--threads 8` completes. Root cause: the shared `QueueMemoryOptions` bounded pipeline-queue memory only via `--queue-memory`, which defaulted to **768 MiB per thread** with no host-aware mode. On a fixed-RAM host the queue budget therefore grows linearly with `--threads` (≈12 GiB at 16, ≈6 GiB at 8), and combined with per-worker working set (~1–2 GiB/thread on WGS-scale input) the 16-thread run exceeds 30 GiB. The benchmark's production rule passes neither a cap nor `--queue-memory`, so it hit the default.

This gives every pipeline command (`dedup`, `group`, `correct`, `simplex`, `duplex`, `codec`, `filter`, `clip`, `extract`) the same memory surface as `fgumi sort` and lets them self-throttle instead of OOM-ing.

## What changed

- **New flags on the shared `QueueMemoryOptions`** (so all pipeline commands get them via `#[command(flatten)]`):
  - `--max-memory` (accepts `auto` or a size; plain numbers are MiB) — long-only to avoid clashing with `dedup`'s `-m/--metrics`.
  - `--memory-reserve` (default `auto` = `min(10 GiB, 50% host)`), used only with `--max-memory auto`.
  - `--memory-per-thread` (default `true`).
- **`--max-memory auto`** detects cgroup-aware host memory minus the reserve, so the budget shrinks to fit the host. This is the self-throttle (issue ask #2).
- **Default is opt-in `auto`, matching sort**: the default stays 768 MiB/thread and is byte-identical to the old `--queue-memory 768` default — no change to existing runs.
- **Shared types**: `MemoryLimit`/`MemoryReserve`, their parsers, `resolve_reserve`, and the budget resolver move from `commands::sort` into `commands::common` so the sort and pipeline surfaces stay in lockstep.
- **Backward compatible**: `--queue-memory`, `--queue-memory-per-thread`, and `--queue-memory-limit-mb` remain accepted as hidden deprecated aliases that map onto the new flags.
- **Docs (issue ask #1)**: a Memory section in `dedup --help` describing the budget as a function of `--threads` and input size; README and the tuning/best-practices guides updated to `--max-memory`.

On a fixed-RAM host the fix is opt-in, so the benchmark should add `--max-memory auto` (or a fixed total budget) to the production dedup rule — a one-line change in `fgumi-benchmarks`.

## Not in scope

Issue ask #3 (reduce the ~1.9 GiB/worker working set) is the lower-priority investigation item and is left for a follow-up; this PR bounds the controllable consumer (the queue) rather than the per-group working set, so `--max-memory` is a budget, not a hard RSS cap.

## Testing

- `cargo ci-fmt`, `cargo ci-lint`, and `cargo ci-test` all pass (2183 tests).
- New/updated unit tests cover: default = 768 MiB/thread, per-thread scaling, fixed total, `auto` bounded by host, reserve shrinks the budget, deprecated-alias mapping, legacy `--queue-memory-limit-mb`, and clap parsing of `--max-memory`/`--memory-per-thread` plus the deprecated aliases.

## Note

Commit is currently unsigned (1Password biometric unavailable at author time); will re-sign before merge.