### PR TITLE
ci: bump codecov-action to v6.0.2 to fix Codecov upload GPG failure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Generate coverage
         run: cargo llvm-cov nextest --features compare,simulate,profile-adjacency --no-tests=pass --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
## Problem

Every PR's `coverage` job currently fails at the **Upload to Codecov** step:

```
gpg: Signature made Tue Apr 21 19:28:03 2026 UTC
gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
##[error]Process completed with exit code 1.
```

The bundled Codecov CLI can't verify its own downloaded binary's GPG signature. With `fail_ci_if_error: true`, this fails the whole job and blocks merges.

This is **repo-wide and not coverage-related**: `main` last passed `coverage` on 2026-06-03, and every PR run since fails identically at this step (a Codecov uploader regression, not a threshold change).

## Fix

Bump `codecov/codecov-action` from v6.0.0 (2026-03-26) to v6.0.2. v6.0.2 and v7.0.0 were both published 2026-06-07 from the same commit (`fb8b3582`), updating the CLI download/verification path. v6.0.2 is the smallest jump that carries the fix and keeps us on the v6 major; pinned by hash per repo convention.

Keeps `fail_ci_if_error: true` so genuine upload failures still surface once the action works again.

## Validation

The `coverage` job on this PR exercises the bumped action end-to-end; it going green confirms the upload step is fixed. Unblocks all open PRs (e.g. #381).