### PR TITLE
perf(deps): pin flate2 zlib-rs backend to restore fast FASTQ decompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,13 @@ approx = "0.5.1"
 ahash = "0.8"
 bytemuck = { workspace = true }
 rand_distr = "0.6"
-flate2 = "1.1"
+# `zlib-rs` selects flate2's fast Rust-zlib DEFLATE backend for gzipped FASTQ
+# decompression (used by `fgumi extract`). It must be requested explicitly: the
+# backend is otherwise chosen by Cargo feature unification, and a transitive
+# change can silently drop it back to the ~2x slower `miniz_oxide` default —
+# which regressed extract throughput ~1.6x at high thread counts. Keep this
+# feature pinned so the producer-thread decompressor stays on zlib-rs.
+flate2 = { version = "1.1", features = ["zlib-rs"] }
 dhat = { version = "0.3", optional = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-dna = { workspace = true }


### PR DESCRIPTION
## Summary

The #373 grouped dependency bump silently dropped flate2's `zlib-rs` backend from the unified feature set, so gzipped FASTQ decompression in `fgumi extract` fell back to flate2's default `miniz_oxide` backend — roughly 2× slower for DEFLATE inflate. Decompression runs on the single producer thread that feeds the parallel workers, so the slowdown is small single-threaded but **grows with thread count**: extract regressed ~1.1× at `--threads 0` and **~1.6× at `--threads 8`**.

`flate2 = "1.1"` was declared without features, relying on a transitive crate to enable `zlib-rs`; #373 removed that, reverting the backend. This PR requests the feature explicitly so the fast backend is guaranteed regardless of Cargo feature unification, with a comment so it isn't silently dropped again.

## Root cause

Found by bisecting extract throughput across the release range — the regression lands exactly on the #373 dependency bump (`da5c451`), not on any fgumi code change. CPU profiles then pinpointed the mechanism:

- **v0.2.0** decompresses via `zlib_rs::inflate` (fast).
- **post-bump** decompresses via `miniz_oxide::inflate` (slow).

Confirmed in `Cargo.lock`: flate2's resolved dependency set includes `zlib-rs` pre-bump and omits it post-bump (same flate2 1.1.9 in both — purely a feature-unification change). The `prefetch_reader`/nix code in #373 is `cfg(target_os = "linux")`-gated and reproduces on macOS too, ruling it out; mimalloc/wide/memchr were each tested and ruled out.

## Verification

5M-read-pair synthetic FASTQ, `fgumi extract --read-structures 10M1S+T 10M1S+T`, min of 5 interleaved runs:

| build | `--threads 8` |
|---|---|
| v0.2.0 (reference) | 3.25s |
| current `main` (regressed) | 5.35s |
| **this PR** | **3.33s** |

Full suite green: `cargo ci-test` (2192 passed), `ci-lint`, `ci-fmt`. zlib-rs and miniz_oxide produce identical inflate output, so this is a backend/perf change only.