### PR TITLE
ci(publish): fix crate publish order and guard topological drift

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,10 +92,10 @@ jobs:
             fgumi-tag
             fgumi-raw-bam
             fgumi-bam-io
-            fgumi-sort
             fgumi-umi
             fgumi-sam
             fgumi-metrics
+            fgumi-sort
             fgumi-consensus
             fgumi
           )
@@ -119,6 +119,43 @@ jobs:
             echo "ERROR: CRATES publish list contains entries not in workspace:"
             echo "$EXTRA"
             echo "Remove or rename stale entries before publishing."
+            exit 1
+          fi
+
+          # Verify the CRATES list is in valid topological order: every
+          # workspace dependency of a crate must appear EARLIER in the list.
+          # `cargo publish` resolves each crate's dependencies against the
+          # crates.io index, so a dependency published later does not yet
+          # exist when its dependent is published.  Catching this here -- as a
+          # pure list check, before any upload -- prevents a mid-publish
+          # failure that would leave a partially released version on crates.io
+          # (published versions cannot be deleted, only yanked).
+          META=$(cargo metadata --no-deps --format-version 1)
+          WS_JSON=$(echo "$META" | jq '[.packages[] | select(.publish != []) | .name]')
+          index_of() {
+            local target="$1" i
+            for i in "${!CRATES[@]}"; do
+              if [ "${CRATES[$i]}" = "$target" ]; then echo "$i"; return; fi
+            done
+            echo "-1"
+          }
+          ORDER_ERRORS=""
+          for i in "${!CRATES[@]}"; do
+            crate="${CRATES[$i]}"
+            DEPS=$(echo "$META" | jq -r --arg c "$crate" --argjson ws "$WS_JSON" '
+              .packages[] | select(.name == $c) | .dependencies[].name
+              | select(. as $d | $ws | index($d))' | sort -u)
+            for dep in $DEPS; do
+              j=$(index_of "$dep")
+              if [ "$j" -ge "$i" ]; then
+                ORDER_ERRORS="${ORDER_ERRORS}  ${crate} depends on ${dep}, which must be listed earlier\n"
+              fi
+            done
+          done
+          if [ -n "$ORDER_ERRORS" ]; then
+            echo "ERROR: CRATES publish list is not in valid dependency order:"
+            printf "%b" "$ORDER_ERRORS"
+            echo "Reorder the CRATES array so every dependency precedes its dependents."
             exit 1
           fi
 


### PR DESCRIPTION
## What

The `v0.3.0` release publish failed mid-run because the `CRATES` array in `.github/workflows/publish.yml` was not in valid topological order: `fgumi-sort` was listed before `fgumi-sam`, but `fgumi-sort` depends on `fgumi-sam`. `cargo publish -p fgumi-sort` could not resolve `fgumi-sam ^0.3.0` against the crates.io index (it had not been uploaded yet), so the run aborted with `failed to select a version for the requirement fgumi-sam = "^0.3.0"`.

## Changes

- Reorder `CRATES` into a valid topological order so every dependency precedes its dependents: `… fgumi-bam-io, fgumi-umi, fgumi-sam, fgumi-metrics, fgumi-sort, fgumi-consensus, fgumi`. The `fgumi-sort` / `fgumi-sam` inversion was the only violation, verified against `cargo metadata`.
- Add a pre-flight order guard that derives each crate's workspace dependencies from `cargo metadata` and fails if any dependency is listed after its dependent. The existing guards only checked set membership (missing/extra crates), not order, which is why the bad order reached a half-published release. The check runs as a pure list comparison before any `cargo publish`, so a future ordering mistake fails fast instead of aborting mid-publish — published crates.io versions cannot be deleted, only yanked.

## Completing the partial v0.3.0 release

The publish step is idempotent. `fgumi-dna`, `fgumi-bgzf`, `fgumi-simd-fastq`, `fgumi-tag`, `fgumi-raw-bam`, and `fgumi-bam-io` are already on crates.io at 0.3.0 and will be skipped; `fgumi-umi`, `fgumi-sam`, `fgumi-metrics`, `fgumi-sort`, `fgumi-consensus`, and `fgumi` are not yet published. Merging this PR triggers the `on: push` to `main`, which re-runs `publish` and uploads the remaining six crates to finish v0.3.0.

## Verification

A standalone reimplementation of the guard was run locally: it fails on the pre-fix order (reproducing the exact production error `fgumi-sort depends on fgumi-sam, which must be listed earlier`), passes on the new order, and catches other injected inversions. YAML validated.
