### PR TITLE
ci: add CodeRabbit config (assertive profile + path instructions)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,11 +15,12 @@
 language: en-US
 
 # Terse, technical, no praise or filler — match the codebase's review style.
+# NB: CodeRabbit caps tone_instructions at 250 characters — keep this terse.
 tone_instructions: >-
-  Be concise and technical. Skip praise and summaries of what the code does. Lead
-  with the concrete risk and a one-line fix. Favor correctness, output identity
-  (vs fgbio / samtools), concurrency soundness, and memory bounds over style. Do
-  not restate clippy/rustfmt findings — CI enforces those.
+  Concise and technical. Skip praise and restating the code. Lead with the risk
+  and a one-line fix. Favor correctness, output identity vs fgbio/samtools,
+  concurrency soundness, and memory bounds over style. Skip clippy/rustfmt nits;
+  CI enforces them.
 
 reviews:
   # Surface borderline correctness/soundness findings, not just high-confidence

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit review configuration for fgumi (high-performance UMI processing).
+#
+# fgumi is correctness-critical and throughput-critical: its outputs (grouping,
+# consensus, sort order, corrected UMIs) are validated for identity against
+# fgbio / samtools, it runs a hand-rolled concurrent pipeline whose liveness and
+# memory bounds are subtle, and it carries a small, documented set of `unsafe`
+# hot paths under an otherwise crate-wide `#![deny(unsafe_code)]`. The
+# `assertive` profile + the path instructions below aim the review at the failure
+# modes that actually bite here (output divergence vs fgbio, pipeline
+# deadlock/unbounded memory, FFI/`unsafe` unsoundness, doc/contract drift) rather
+# than generic style.
+
+language: en-US
+
+# Terse, technical, no praise or filler — match the codebase's review style.
+tone_instructions: >-
+  Be concise and technical. Skip praise and summaries of what the code does. Lead
+  with the concrete risk and a one-line fix. Favor correctness, output identity
+  (vs fgbio / samtools), concurrency soundness, and memory bounds over style. Do
+  not restate clippy/rustfmt findings — CI enforces those.
+
+reviews:
+  # Surface borderline correctness/soundness findings, not just high-confidence
+  # ones. For a tool whose output is checked byte-for-byte against fgbio, a false
+  # positive is cheaper than a missed output divergence.
+  profile: assertive
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  # Review automatically on push; don't review draft PRs.
+  auto_review:
+    enabled: true
+    drafts: false
+  # Never auto-block merges on a review verdict; findings are advisory.
+  request_changes_workflow: false
+
+  # Don't spend review budget on build output, fixtures, or vendored lockfiles.
+  path_filters:
+    - "!**/target/**"
+    - "!**/*.lock"
+
+  # MAINTENANCE: these instructions name specific modules, invariants, and code
+  # constructs. Re-read and update them whenever those modules are refactored or
+  # renamed — stale instructions silently misdirect the reviewer. (Both the
+  # `unified_pipeline` and `pipeline` paths are listed: issue #330 renames the
+  # former to the latter, so the same instructions apply to whichever is present.)
+  path_instructions:
+    - path: "src/lib/{unified_pipeline,pipeline}/**/*.rs"
+      instructions: >-
+        This is the hand-rolled concurrent step pipeline; its bugs are deadlocks,
+        lost output, and unbounded memory, not style. Treat any change to the
+        reorder stage, queue push/pop, backpressure, or producer gating as
+        liveness- and memory-critical. Require that the must-accept `next_serial`
+        exemption is preserved (the producer of `next_serial` can never be
+        backpressured — refusing it can deadlock), and that no path lets a
+        transport queue or reorder overflow stash grow without a byte bound
+        (memory must be a function of config, not input size). Flag: a byte/size
+        cap that is checked only on one sub-condition (e.g. only when transport is
+        full) so a consumer relocation can bypass it; capping a consumer drain
+        loop (must stay unbounded — bound producers instead); a Parallel step
+        whose drain-counter / output-close accounting can leave the shared output
+        unclosed; error/cancel paths that don't propagate via the shared signal so
+        `is_done()` is observed; and any new `unsafe` in the typed-step dispatch
+        hot path not matching the documented `#[allow(unsafe_code)]` sites.
+    - path: "crates/fgumi-sort/**/*.rs"
+      instructions: >-
+        This is the sort engine, including approved `unsafe` hot paths (LSD radix
+        sort with `Vec::set_len` + raw-pointer ping-pong in inline.rs, and the
+        natural-order queryname comparator). For every `unsafe` block require a
+        `// SAFETY:` comment whose invariant actually holds (buffer written exactly
+        once before read; pointers disjoint and properly aligned; read names
+        null-terminated by construction) AND a corresponding entry in the unsafe
+        allowlist in CLAUDE.md — flag new `unsafe` that lacks either. Treat the
+        sort-order comparators (coordinate, queryname, template-coordinate) as
+        output-identity-critical vs `samtools sort`: a change to key extraction or
+        comparison needs a test pinning identity. Flag off-by-one in radix passes,
+        `usize`/`u64` narrowing in key math, and external-merge / spill logic that
+        can drop or duplicate records under memory pressure.
+    - path: "crates/fgumi-raw-bam/**/*.rs"
+      instructions: >-
+        This is zero-copy raw-BAM byte handling and the samtools-compatible
+        natural-order comparator (`natural_compare` / `natural_compare_nul`), which
+        use `get_unchecked` / raw `*const u8` walks under `#[allow(unsafe_code)]`.
+        Require each unchecked access to be bounded by a loop invariant
+        (`debug_assert!`-ed) or a caller-guaranteed null terminator, with a SAFETY
+        comment and an allowlist entry. Flag record field-offset / endianness
+        errors, and any parser that trusts a length or offset from the BAM bytes
+        without validating it against the record/block bounds (fail closed on
+        malformed input, never read past the buffer).
+    - path: "crates/{fgumi-consensus,fgumi-umi,fgumi-metrics}/**/*.rs"
+      instructions: >-
+        These are the consensus callers, UMI assignment (identity / edit-distance /
+        adjacency / paired), and QC metrics — the output that is validated against
+        fgbio. Treat any change to consensus base/quality math, UMI grouping /
+        edit-distance / adjacency assignment, or a metric formula as
+        output-changing: require a test asserting identity (or documented,
+        intentional divergence) against the fgbio baseline, generated
+        programmatically. Flag silent behavior changes on the edge cases that
+        differ between tools: ties in adjacency/edit-distance, single-read or empty
+        families, min/max family-size thresholds, and quality-score capping /
+        rounding.
+    - path: "src/lib/umi/parallel_assigner.rs"
+      instructions: >-
+        Parallel UMI-assignment strategies (identity / edit-distance / adjacency /
+        paired) that must produce output identical to the sequential assigners in
+        `crates/fgumi-umi`. Treat any change to grouping/assignment as
+        output-changing: require parity coverage (or documented, intentional
+        divergence) against both the sequential code path and the fgbio baseline,
+        generated programmatically. Flag tie-breaking, empty/single-read family,
+        and threshold-boundary behavior changes, plus correctness of the lock-free
+        union-find and partition-merge concurrency.
+    - path: "**/tests/**/*.rs"
+      instructions: >-
+        Generate test data programmatically (SamBuilder / fgpyo-style builders); do
+        not add committed BAM/fixture files. New correctness-critical behavior
+        needs an INDEPENDENT oracle (e.g. parity against the fgbio baseline or a
+        second code path), not just a self-consistency check. Flag assertions
+        weaker than the stated contract, and end-to-end tests that assert a record
+        count but not record identity.


### PR DESCRIPTION
Adds a repo-root `.coderabbit.yaml` so the **GitHub CodeRabbit app** reviews this repo under an `assertive` profile with fgumi-specific instructions, instead of the org-UI default. Modeled on the same change in `fg-labs/prmi#38`.

## Why

fgumi is correctness-critical (grouping, consensus, sort order, and corrected UMIs are validated for identity against fgbio / samtools) and the failure modes that matter here — output divergence vs fgbio, pipeline deadlock / unbounded memory, `unsafe`/FFI unsoundness, doc-vs-contract drift — are exactly the borderline tier a lenient profile under-reports. Pinning `assertive` in-repo surfaces it. The bot **auto-reads** `.coderabbit.yaml`, so this takes effect on every PR review (the bot prints its active profile in the review body, so the switch is observable).

## What it sets

- **`reviews.profile: assertive`** — surface borderline correctness/soundness findings, not just high-confidence ones. For a tool whose output is checked byte-for-byte against fgbio, a false positive is cheaper than a missed output divergence.
- **Path-targeted instructions** aimed at the failure modes that actually bite here:
  - `src/lib/{unified_pipeline,pipeline}/**` — the hand-rolled concurrent step pipeline: the must-accept `next_serial` liveness exemption, byte-bounded transport queues + reorder overflow stashes (memory a function of config, not input size), Parallel drain-counter/output-close accounting, signal-based error/cancel propagation, and the documented typed-step `unsafe` hot path. (Both module names are listed because issue #330 renames `unified_pipeline` → `pipeline`.)
  - `crates/fgumi-sort/**` — the approved `unsafe` radix-sort / comparator hot paths (SAFETY-comment + allowlist parity) and sort-order identity vs `samtools sort`.
  - `crates/fgumi-raw-bam/**` — zero-copy raw-BAM byte handling and the samtools-compatible natural-order comparator (`get_unchecked` / raw-pointer walks; fail-closed on malformed input).
  - `crates/{fgumi-consensus,fgumi-umi,fgumi-metrics}/**` and `src/lib/{consensus,umi}/**` — consensus/UMI/metrics output validated against the fgbio baseline (tie-breaking, empty/single-read families, threshold boundaries).
  - `**/tests/**` — programmatic test data (no committed fixtures), independent oracles, identity-not-just-count assertions.
- **`tone_instructions`** terse/technical, **`poem: false`** — keep reviews signal-dense.
- **`request_changes_workflow: false`** — findings stay advisory; reviews never block merges.
- **`path_filters`** excluding `target/` and lockfiles.

## Scope: this tunes the bot, not the local CLI

Per the A/B test documented in `fg-labs/prmi#38`, the local `coderabbit` CLI does **not** reliably inherit this config via `-c .coderabbit.yaml` (it returned 0 findings on a diff with a known finding the GitHub bot caught). So:

- This file changes the **GitHub bot** (auto-read). That is its purpose.
- The local CLI remains a **lighter pre-push smoke check**, not a bot substitute.

## Heads-up

This **changes the bot's behavior repo-wide** (→ `assertive`) — expect more findings, including nitpicks, on future PRs. Worth an eyeball on the profile choice and the path instructions before merge. No code change; config only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->