### PR TITLE
fix(consensus): migrate simplex/duplex/codec rejects to typed-step fan-out (#332)

### DIFF
--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2326,14 +2326,13 @@ impl<'a> ChainBuilder<'a> {
         use crate::per_thread_accumulator::PerThreadAccumulator;
         use crate::pipeline::chains::commands::simplex::{
             CollectedSimplexMetrics, SimplexConsensusCaptures, SimplexFinalizeHook,
-            build_simplex_consensus_step,
+            build_simplex_consensus_step_kept_only, build_simplex_consensus_step_with_rejects,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
-        use crate::sam::{SamTag, header_as_unsorted};
+        use crate::sam::SamTag;
         use crate::vanilla_consensus_caller::VanillaUmiConsensusOptions;
         use log::info;
         use noodles::sam::alignment::record::data::field::Tag;
-        use parking_lot::Mutex;
 
         let simplex = self
             .spec
@@ -2409,36 +2408,17 @@ impl<'a> ChainBuilder<'a> {
         // make_prefix_from_header returns "" which is the correct empty prefix.
         let read_name_prefix = simplex.read_group.prefix_or_from_header(&self.header);
 
+        // Capture the input header (raw-input RG/PG + @HD sort fields) BEFORE
+        // replacing self.header with the consensus output header. Per the PR
+        // #332 rejects contract, the rejects branch is written with this input
+        // header verbatim (rejects are raw-input records in input order).
+        let input_header = self.header.clone();
+
         // Replace self.header with the consensus output header so add_sink()
         // uses the correct header for WriteBgzfFile.
         self.replace_header(output_header);
 
         let track_rejects = simplex.rejects_opts.is_enabled();
-
-        // Open rejects writer up front. Rejected records are streamed straight
-        // to disk per-MI-group from the process closure, so no batch-level
-        // buffering. Workers flush under a mutex rather than through the
-        // ordered serialize stage, so reject records are emitted in
-        // mutex-acquisition order, not input order; the rejects header is
-        // marked `SO:unsorted`.
-        let rejects_writer: Option<Arc<Mutex<Option<fgumi_bam_io::RawBamWriter>>>> =
-            if track_rejects {
-                if let Some(path) = simplex.rejects_opts.rejects.as_ref() {
-                    let rejects_header = header_as_unsorted(&self.header);
-                    let w = fgumi_bam_io::create_raw_bam_writer(
-                        path,
-                        &rejects_header,
-                        num_threads,
-                        self.spec.compression.compression_level,
-                    )?;
-                    Some(Arc::new(Mutex::new(Some(w))))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-        let rejects_writer_for_step = rejects_writer.as_ref().map(Arc::clone);
 
         // Per-thread metrics accumulator.
         let accumulators = PerThreadAccumulator::<CollectedSimplexMetrics>::new(num_threads);
@@ -2467,21 +2447,17 @@ impl<'a> ChainBuilder<'a> {
 
         // ── Step factories (see chains::commands::simplex) ────────────────
 
-        let consensus_step = build_simplex_consensus_step(
-            self.tuning.per_step_byte_limit,
-            SimplexConsensusCaptures {
-                track_rejects,
-                rejects_writer: rejects_writer_for_step,
-                overlapping_enabled,
-                consensus_options,
-                read_name_prefix,
-                read_group_id,
-                methylation_ref,
-                accumulators: accumulators_for_step,
-                min_reads: simplex.min_reads,
-                progress: progress_records,
-            },
-        );
+        let consensus_cap = SimplexConsensusCaptures {
+            track_rejects,
+            overlapping_enabled,
+            consensus_options,
+            read_name_prefix,
+            read_group_id,
+            methylation_ref,
+            accumulators: accumulators_for_step,
+            min_reads: simplex.min_reads,
+            progress: progress_records,
+        };
 
         // ── Group-MI preamble: two paths depending on the incoming tail type ──
         //
@@ -2579,12 +2555,44 @@ impl<'a> ChainBuilder<'a> {
             self.pipeline.append_step(group_mi_step, tail)
         };
 
-        // Wire the simplex consensus step. For an Intermediate consensus stage
-        // (e.g. fused consensus → filter) this appends DecodeRecords so the
-        // downstream stage receives DecodedRecordBatch; Terminal leaves the
-        // DecompressedBlock for add_sink. See finish_consensus_tail.
-        let tail = self.pipeline.append_step(consensus_step, tail);
-        let tail = self.finish_consensus_tail(tail, position);
+        // Wire the simplex consensus step. With `--rejects` it is a 2-output
+        // step (branch 0 = consensus DecompressedBlock, branch 1 = rejects
+        // DecompressedBlock → BgzfCompress → WriteBgzfFile with the INPUT
+        // header, in input order — the PR #332 fan-out contract); without
+        // rejects it is the 1-output kept-only variant (the framework has no
+        // public discard sink). Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            use crate::pipeline::core::topology::BranchIdx;
+            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+            let rejects_path = simplex.rejects_opts.rejects.as_ref().ok_or_else(|| {
+                anyhow!("rejects path unexpectedly None when track_rejects is set")
+            })?;
+            let rejects_write =
+                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
+                    .map_err(|e| anyhow!("WriteBgzfFile (simplex rejects): {e}"))?;
+
+            let step = build_simplex_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+
+            let rejects_branch = (pt.0, BranchIdx(1));
+            let rejects_compress_tail = self.pipeline.append_step(
+                BgzfCompress::new(self.tuning.compression_level, limit),
+                rejects_branch,
+            );
+            self.pipeline.append_step(rejects_write, rejects_compress_tail);
+
+            pt
+        } else {
+            let step = build_simplex_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. For an Intermediate consensus
+        // stage finish_consensus_tail appends DecodeRecords; Terminal leaves the
+        // DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
         self.current_tail = Some(tail);
 
         // Register the simplex finalize hook.
@@ -2595,7 +2603,6 @@ impl<'a> ChainBuilder<'a> {
             accumulators,
             stats_path: simplex.stats_opts.stats.clone(),
             overlapping_enabled,
-            rejects_writer,
             timer,
         }));
 
@@ -2651,15 +2658,14 @@ impl<'a> ChainBuilder<'a> {
         use crate::per_thread_accumulator::PerThreadAccumulator;
         use crate::pipeline::chains::commands::duplex::{
             CollectedDuplexMetrics, DuplexConsensusCaptures, DuplexFinalizeHook,
-            build_duplex_consensus_step,
+            build_duplex_consensus_step_kept_only, build_duplex_consensus_step_with_rejects,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
-        use crate::sam::{SamTag, header_as_unsorted};
+        use crate::sam::SamTag;
         use crate::umi::extract_mi_base;
         use fgumi_raw_bam::RawRecordView;
         use log::info;
         use noodles::sam::alignment::record::data::field::Tag;
-        use parking_lot::Mutex;
 
         let duplex = self
             .spec
@@ -2737,36 +2743,16 @@ impl<'a> ChainBuilder<'a> {
         // make_prefix_from_header returns "" which is the correct empty prefix.
         let read_name_prefix = duplex.read_group.prefix_or_from_header(&self.header);
 
+        // Capture the input header BEFORE replacing self.header with the
+        // consensus output header — the rejects branch is written with the
+        // input header verbatim (PR #332 contract).
+        let input_header = self.header.clone();
+
         // Replace self.header with the consensus output header so add_sink()
         // uses the correct header for WriteBgzfFile.
         self.replace_header(output_header);
 
         let track_rejects = duplex.rejects_opts.is_enabled();
-
-        // Open rejects writer up front. Rejected records are streamed straight to
-        // disk per-MI-group from the process closure, so no batch-level buffering.
-        // Workers flush under a mutex rather than through the ordered serialize
-        // stage, so reject records are emitted in mutex-acquisition order, not
-        // input order; the rejects header is marked `SO:unsorted` so downstream
-        // tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<fgumi_bam_io::RawBamWriter>>>> =
-            if track_rejects {
-                if let Some(path) = duplex.rejects_opts.rejects.as_ref() {
-                    let rejects_header = header_as_unsorted(&self.header);
-                    let w = fgumi_bam_io::create_raw_bam_writer(
-                        path,
-                        &rejects_header,
-                        num_threads,
-                        self.spec.compression.compression_level,
-                    )?;
-                    Some(Arc::new(Mutex::new(Some(w))))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-        let rejects_writer_for_step = rejects_writer.as_ref().map(Arc::clone);
 
         // Per-thread metrics accumulator.
         let accumulators = PerThreadAccumulator::<CollectedDuplexMetrics>::new(num_threads);
@@ -2788,28 +2774,24 @@ impl<'a> ChainBuilder<'a> {
 
         // ── Step factories (see chains::commands::duplex) ────────────────────
 
-        let consensus_step = build_duplex_consensus_step(
-            self.tuning.per_step_byte_limit,
-            DuplexConsensusCaptures {
-                track_rejects,
-                rejects_writer: rejects_writer_for_step,
-                overlapping_enabled,
-                methylation_ref,
-                methylation_mode,
-                read_name_prefix,
-                read_group_id,
-                min_reads,
-                min_input_base_quality,
-                output_per_base_tags,
-                trim,
-                max_reads_per_strand,
-                error_rate_pre_umi,
-                error_rate_post_umi,
-                cell_tag,
-                accumulators: accumulators_for_step,
-                progress: progress_records,
-            },
-        );
+        let consensus_cap = DuplexConsensusCaptures {
+            track_rejects,
+            overlapping_enabled,
+            methylation_ref,
+            methylation_mode,
+            read_name_prefix,
+            read_group_id,
+            min_reads,
+            min_input_base_quality,
+            output_per_base_tags,
+            trim,
+            max_reads_per_strand,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+            cell_tag,
+            accumulators: accumulators_for_step,
+            progress: progress_records,
+        };
 
         // ── Group-MI preamble: two paths depending on the incoming tail type ──
         //
@@ -2924,12 +2906,41 @@ impl<'a> ChainBuilder<'a> {
             self.pipeline.append_step(group_mi_step, tail)
         };
 
-        // Wire the duplex consensus step. For an Intermediate consensus stage
-        // (e.g. fused consensus → filter) this appends DecodeRecords so the
-        // downstream stage receives DecodedRecordBatch; Terminal leaves the
-        // DecompressedBlock for add_sink. See finish_consensus_tail.
-        let tail = self.pipeline.append_step(consensus_step, tail);
-        let tail = self.finish_consensus_tail(tail, position);
+        // Wire the duplex consensus step. With `--rejects` it is a 2-output step
+        // (branch 0 = consensus, branch 1 = rejects → BgzfCompress → WriteBgzfFile
+        // with the INPUT header, in input order — the PR #332 fan-out contract);
+        // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            use crate::pipeline::core::topology::BranchIdx;
+            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+            let rejects_path = duplex.rejects_opts.rejects.as_ref().ok_or_else(|| {
+                anyhow!("rejects path unexpectedly None when track_rejects is set")
+            })?;
+            let rejects_write =
+                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
+                    .map_err(|e| anyhow!("WriteBgzfFile (duplex rejects): {e}"))?;
+
+            let step = build_duplex_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+
+            let rejects_branch = (pt.0, BranchIdx(1));
+            let rejects_compress_tail = self.pipeline.append_step(
+                BgzfCompress::new(self.tuning.compression_level, limit),
+                rejects_branch,
+            );
+            self.pipeline.append_step(rejects_write, rejects_compress_tail);
+
+            pt
+        } else {
+            let step = build_duplex_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. Intermediate appends
+        // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
         self.current_tail = Some(tail);
 
         // Register the duplex finalize hook.
@@ -2940,7 +2951,6 @@ impl<'a> ChainBuilder<'a> {
             accumulators,
             stats_path: duplex.stats_opts.stats.clone(),
             overlapping_enabled,
-            rejects_writer,
             timer,
         }));
 
@@ -2989,13 +2999,12 @@ impl<'a> ChainBuilder<'a> {
         use crate::per_thread_accumulator::PerThreadAccumulator;
         use crate::pipeline::chains::commands::codec::{
             CodecConsensusCaptures, CodecFinalizeHook, CollectedCodecMetrics,
-            build_codec_consensus_step,
+            build_codec_consensus_step_kept_only, build_codec_consensus_step_with_rejects,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
-        use crate::sam::{SamTag, header_as_unsorted};
+        use crate::sam::SamTag;
         use log::info;
         use noodles::sam::alignment::record::data::field::Tag;
-        use parking_lot::Mutex;
 
         let codec = self
             .spec
@@ -3059,37 +3068,16 @@ impl<'a> ChainBuilder<'a> {
         // make_prefix_from_header returns "" which is the correct empty prefix.
         let read_name_prefix = codec.read_group.prefix_or_from_header(&self.header);
 
+        // Capture the input header BEFORE replacing self.header with the
+        // consensus output header — the rejects branch is written with the
+        // input header verbatim (PR #332 contract).
+        let input_header = self.header.clone();
+
         // Replace self.header with the consensus output header so add_sink()
         // uses the correct header for WriteBgzfFile.
         self.replace_header(output_header);
 
         let track_rejects = codec.rejects_opts.is_enabled();
-
-        // Open rejects writer up front. Rejected records are streamed straight to
-        // disk per-MI-group from the process closure, so no batch-level buffering.
-        // Workers flush under a mutex rather than through the ordered serialize
-        // stage, so reject records are emitted in mutex-acquisition order, not
-        // input order; the rejects header is marked `SO:unsorted` so downstream
-        // tools don't assume the input's sort order carried over.
-        let rejects_writer: Option<Arc<Mutex<Option<fgumi_bam_io::RawBamWriter>>>> =
-            if track_rejects {
-                if let Some(path) = codec.rejects_opts.rejects.as_ref() {
-                    let writer_threads = self.spec.threading.num_threads();
-                    let rejects_header = header_as_unsorted(&self.header);
-                    let w = fgumi_bam_io::create_raw_bam_writer(
-                        path,
-                        &rejects_header,
-                        writer_threads,
-                        self.spec.compression.compression_level,
-                    )?;
-                    Some(Arc::new(Mutex::new(Some(w))))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-        let rejects_writer_for_step = rejects_writer.as_ref().map(Arc::clone);
 
         // Per-thread metrics accumulator.
         let accumulators = PerThreadAccumulator::<CollectedCodecMetrics>::new(num_threads);
@@ -3121,18 +3109,14 @@ impl<'a> ChainBuilder<'a> {
 
         // ── Step factories (see chains::commands::codec) ─────────────────────
 
-        let consensus_step = build_codec_consensus_step(
-            self.tuning.per_step_byte_limit,
-            CodecConsensusCaptures {
-                track_rejects,
-                rejects_writer: rejects_writer_for_step,
-                read_name_prefix,
-                read_group_id,
-                consensus_options,
-                accumulators: accumulators_for_step,
-                progress: progress_records,
-            },
-        );
+        let consensus_cap = CodecConsensusCaptures {
+            track_rejects,
+            read_name_prefix,
+            read_group_id,
+            consensus_options,
+            accumulators: accumulators_for_step,
+            progress: progress_records,
+        };
 
         // ── Group-MI preamble: two paths depending on the incoming tail type ──
         //
@@ -3228,12 +3212,41 @@ impl<'a> ChainBuilder<'a> {
             self.pipeline.append_step(group_mi_step, tail)
         };
 
-        // Wire the codec consensus step. For an Intermediate consensus stage
-        // (e.g. fused consensus → filter) this appends DecodeRecords so the
-        // downstream stage receives DecodedRecordBatch; Terminal leaves the
-        // DecompressedBlock for add_sink. See finish_consensus_tail.
-        let tail = self.pipeline.append_step(consensus_step, tail);
-        let tail = self.finish_consensus_tail(tail, position);
+        // Wire the codec consensus step. With `--rejects` it is a 2-output step
+        // (branch 0 = consensus, branch 1 = rejects → BgzfCompress → WriteBgzfFile
+        // with the INPUT header, in input order — the PR #332 fan-out contract);
+        // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            use crate::pipeline::core::topology::BranchIdx;
+            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+            let rejects_path = codec.rejects_opts.rejects.as_ref().ok_or_else(|| {
+                anyhow!("rejects path unexpectedly None when track_rejects is set")
+            })?;
+            let rejects_write =
+                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
+                    .map_err(|e| anyhow!("WriteBgzfFile (codec rejects): {e}"))?;
+
+            let step = build_codec_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+
+            let rejects_branch = (pt.0, BranchIdx(1));
+            let rejects_compress_tail = self.pipeline.append_step(
+                BgzfCompress::new(self.tuning.compression_level, limit),
+                rejects_branch,
+            );
+            self.pipeline.append_step(rejects_write, rejects_compress_tail);
+
+            pt
+        } else {
+            let step = build_codec_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. Intermediate appends
+        // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
         self.current_tail = Some(tail);
 
         // Register the codec finalize hook.
@@ -3243,7 +3256,6 @@ impl<'a> ChainBuilder<'a> {
         self.finalize.push(Box::new(CodecFinalizeHook {
             accumulators,
             stats_path: codec.stats_opts.stats.clone(),
-            rejects_writer,
             timer,
         }));
 

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -4,7 +4,7 @@
 //! Phase 3 (T3a.10) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the codec-specific types and step factory that the builder
-//! imports: [`CodecFinalizeHook`] and [`build_codec_consensus_step`] used
+//! imports: [`CodecFinalizeHook`] and the `build_codec_consensus_step_with_rejects` / `build_codec_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_codec`.
 //!
 //! [`build_codec_chain`] shrinks to a ~10-line delegate.
@@ -22,7 +22,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Result;
 use log::info;
-use parking_lot::Mutex;
 
 use crate::commands::consensus_runner::ConsensusStatsOps;
 use crate::consensus::codec_caller::{
@@ -34,10 +33,13 @@ use crate::mi_group::MiGroup;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::pipeline::chains::builder::ChainBuilder;
 use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
-use crate::pipeline::steps::process::{ProcessWithWorkerState, process_with_worker_state};
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
 use crate::pipeline::steps::types::DecompressedBlock;
-use fgumi_bam_io::RawBamWriter;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CollectedCodecMetrics
@@ -86,13 +88,12 @@ impl crate::pipeline::core::item::HeapSize for CodecState {}
 pub(crate) struct CodecFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
     pub(crate) stats_path: Option<std::path::PathBuf>,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) timer: OperationTimer,
 }
 
 impl FinalizeHook for CodecFinalizeHook {
     fn finalize(self: Box<Self>) -> Result<()> {
-        let CodecFinalizeHook { accumulators, stats_path, rejects_writer, timer } = *self;
+        let CodecFinalizeHook { accumulators, stats_path, timer } = *self;
 
         // Reduce per-thread accumulators.
         let mut total_groups = 0u64;
@@ -121,16 +122,8 @@ impl FinalizeHook for CodecFinalizeHook {
 
         info!("Wrote {consensus_count} CODEC consensus reads");
 
-        // Finalize the rejects writer (always finalize even on success to flush BGZF EOF).
-        if let Some(rw_arc) = rejects_writer {
-            let maybe_writer = rw_arc.lock().take();
-            if let Some(writer) = maybe_writer {
-                writer
-                    .finish()
-                    .map_err(|e| anyhow::anyhow!("Failed to finish rejects file: {e}"))?;
-                info!("Rejected reads streamed to rejects file during processing");
-            }
-        }
+        // Rejects are emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's WriteBgzfFile sink.
 
         timer.log_completion(consensus_count);
 
@@ -147,16 +140,15 @@ impl FinalizeHook for CodecFinalizeHook {
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Captures passed into [`build_codec_consensus_step`] from `add_codec`.
+/// Captures passed into [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`] from `add_codec`.
 ///
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_codec`
 /// can prepare them once and hand them off cleanly.
 ///
 /// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`] and
-/// [`build_codec_consensus_step`].
+/// [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`].
 pub(crate) struct CodecConsensusCaptures {
     pub(crate) track_rejects: bool,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) read_name_prefix: String,
     pub(crate) read_group_id: String,
     pub(crate) consensus_options: CodecConsensusOptions,
@@ -164,26 +156,164 @@ pub(crate) struct CodecConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Build the `CodecConsensus` step: parallel, `ByItemOrdinal`. Builds a
-/// per-worker [`CodecConsensusCaller`] once, reuses across batches. Streams
-/// rejects inline through `cap.rejects_writer`.
+/// Append `[len:4 LE][record]` framing for a byte-slice record — the format
+/// `BgzfCompress` expects in a `DecompressedBlock`.
+fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
+    #[allow(clippy::cast_possible_truncation)]
+    let block_size = rec.len() as u32;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+}
+
+/// Per-worker init: build the `CodecConsensusCaller` once, reused across
+/// batches. Shared by both step variants.
+fn make_codec_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    consensus_options: CodecConsensusOptions,
+    track_rejects: bool,
+) -> impl Fn() -> CodecState + Send + Sync + 'static {
+    move || {
+        let caller = CodecConsensusCaller::new_with_rejects_tracking(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            consensus_options.clone(),
+            track_rejects,
+        );
+        CodecState { caller }
+    }
+}
+
+/// Per-batch CODEC consensus body, shared by both step variants.
 ///
-/// Output: [`DecompressedBlock`] containing concatenated pre-serialized
-/// consensus records, ready for `BgzfCompress`.
-///
-/// Unlike duplex, codec does not apply a record filter, MI-tag transform,
-/// overlapping consensus, or methylation mode — matching fgbio's
-/// `CallCodecConsensusReads` behaviour.
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and any record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order — the PR #332 fan-out contract (rejects flow through the
+/// ordered serialize/compress stages, not a mutex side-channel; the rejects
+/// writer is configured with the input header by `add_codec`).
+fn run_codec_consensus_batch(
+    state: &mut CodecState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    accumulators: &Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = CodecConsensusStats::default();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records } in groups {
+        state.caller.clear();
+        total_input_records += records.len() as u64;
+
+        let result: anyhow::Result<ConsensusOutput> = state.caller.consensus_reads(records);
+        match result {
+            Ok(group_output) => {
+                all_output.merge(group_output);
+                batch_stats.merge(state.caller.statistics());
+                if track_rejects {
+                    for raw in &state.caller.take_rejected_reads() {
+                        append_framed_bytes(&mut rejects_bytes, raw);
+                    }
+                }
+            }
+            Err(e) => {
+                // Mirrors legacy: a "duplex disagreement" error isn't fatal —
+                // preserve stats + rejects and move on. Anything else is hard.
+                if e.to_string().contains("duplex disagreement") {
+                    batch_stats.merge(state.caller.statistics());
+                    if track_rejects {
+                        for raw in &state.caller.take_rejected_reads() {
+                            append_framed_bytes(&mut rejects_bytes, raw);
+                        }
+                    }
+                } else {
+                    return Err(io::Error::other(format!(
+                        "CODEC consensus error for MI {mi}: {e}"
+                    )));
+                }
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries.
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `CodecConsensus` step (used when `--rejects` is set):
+/// branch 0 = consensus, branch 1 = rejects.
 ///
 /// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+pub(crate) fn build_codec_consensus_step_with_rejects(
+    limit_bytes: u64,
+    cap: CodecConsensusCaptures,
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
+    let CodecConsensusCaptures {
+        track_rejects,
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_codec_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        track_rejects,
+    );
+    let body = move |state: &mut CodecState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) =
+            run_codec_consensus_batch(state, item, track_rejects, &accumulators, &progress)?;
+        match rejects {
+            Some(r) => Ok(Process2Output::both(consensus, r)),
+            None => Ok(Process2Output::only_a(consensus)),
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        CodecState,
+        _,
+        _,
+    >("CodecConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output kept-only `CodecConsensus` step (used when `--rejects`
+/// is unset). The framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant.
 ///
-/// # Panics
-///
-/// Does not panic during construction. Per-worker init failures are
-/// surfaced immediately because `CodecConsensusCaller::new_with_rejects_tracking`
-/// is infallible.
-#[allow(clippy::type_complexity, clippy::too_many_lines)]
-pub(crate) fn build_codec_consensus_step(
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_codec_consensus_step_kept_only(
     limit_bytes: u64,
     cap: CodecConsensusCaptures,
 ) -> ProcessWithWorkerState<
@@ -195,7 +325,6 @@ pub(crate) fn build_codec_consensus_step(
 > {
     let CodecConsensusCaptures {
         track_rejects,
-        rejects_writer,
         read_name_prefix,
         read_group_id,
         consensus_options,
@@ -203,86 +332,24 @@ pub(crate) fn build_codec_consensus_step(
         progress,
     } = cap;
 
+    let init = make_codec_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        track_rejects,
+    );
+    let body =
+        move |state: &mut CodecState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) =
+                run_codec_consensus_batch(state, item, track_rejects, &accumulators, &progress)?;
+            Ok(consensus)
+        };
+
     process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, CodecState, _>(
         "CodecConsensus",
         limit_bytes,
-        move || {
-            let caller = CodecConsensusCaller::new_with_rejects_tracking(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                consensus_options.clone(),
-                track_rejects,
-            );
-            CodecState { caller }
-        },
-        move |state: &mut CodecState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
-            let BatchedMiGroups { batch_serial, groups } = item;
-            let groups_count = groups.len() as u64;
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = CodecConsensusStats::default();
-
-            let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                if let Some(ref rw_arc) = rejects_writer {
-                    if !recs.is_empty() {
-                        let mut guard = rw_arc.lock();
-                        if let Some(w) = guard.as_mut() {
-                            for raw in recs {
-                                w.write_raw_record(raw)?;
-                            }
-                        }
-                    }
-                }
-                Ok(())
-            };
-
-            let mut total_input_records: u64 = 0;
-            for MiGroup { mi, records } in groups {
-                state.caller.clear();
-                total_input_records += records.len() as u64;
-
-                let result: anyhow::Result<ConsensusOutput> = state.caller.consensus_reads(records);
-                match result {
-                    Ok(group_output) => {
-                        all_output.merge(group_output);
-                        batch_stats.merge(state.caller.statistics());
-                        if track_rejects {
-                            flush_byte_records(&state.caller.take_rejected_reads())?;
-                        }
-                    }
-                    Err(e) => {
-                        // Mirrors legacy: a "duplex disagreement" error
-                        // isn't fatal — preserve stats + rejects and move
-                        // on. Anything else is a hard error.
-                        if e.to_string().contains("duplex disagreement") {
-                            batch_stats.merge(state.caller.statistics());
-                            if track_rejects {
-                                flush_byte_records(&state.caller.take_rejected_reads())?;
-                            }
-                        } else {
-                            return Err(io::Error::other(format!(
-                                "CODEC consensus error for MI {mi}: {e}"
-                            )));
-                        }
-                    }
-                }
-            }
-
-            // Merge per-batch metrics into this worker's slot.
-            accumulators.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                m.groups_processed += groups_count;
-            });
-
-            // Progress logging at million-record boundaries (mirrors
-            // legacy's `ProgressTracker::log_if_needed`).
-            let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
-            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + total_input_records);
-            }
-
-            Ok(DecompressedBlock { batch_serial, bytes: all_output.data })
-        },
+        init,
+        body,
     )
 }
 

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -4,7 +4,7 @@
 //! Phase 3 (T3a.9) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the duplex-specific types and step factory that the builder
-//! imports: [`DuplexFinalizeHook`] and [`build_duplex_consensus_step`] used
+//! imports: [`DuplexFinalizeHook`] and the `build_duplex_consensus_step_with_rejects` / `build_duplex_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_duplex`.
 //!
 //! [`build_duplex_chain`] shrinks to a ~10-line delegate.
@@ -22,7 +22,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Result;
 use log::info;
-use parking_lot::Mutex;
 
 use crate::commands::common::MethylationRef;
 use crate::commands::consensus_runner::{ConsensusStatsOps, log_overlapping_stats};
@@ -37,10 +36,13 @@ use crate::overlapping_consensus::{
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::pipeline::chains::builder::ChainBuilder;
 use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
-use crate::pipeline::steps::process::{ProcessWithWorkerState, process_with_worker_state};
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
 use crate::pipeline::steps::types::DecompressedBlock;
-use fgumi_bam_io::RawBamWriter;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CollectedDuplexMetrics
@@ -94,19 +96,12 @@ pub(crate) struct DuplexFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
     pub(crate) stats_path: Option<std::path::PathBuf>,
     pub(crate) overlapping_enabled: bool,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) timer: OperationTimer,
 }
 
 impl FinalizeHook for DuplexFinalizeHook {
     fn finalize(self: Box<Self>) -> Result<()> {
-        let DuplexFinalizeHook {
-            accumulators,
-            stats_path,
-            overlapping_enabled,
-            rejects_writer,
-            timer,
-        } = *self;
+        let DuplexFinalizeHook { accumulators, stats_path, overlapping_enabled, timer } = *self;
 
         // Reduce per-thread accumulators.
         let mut total_groups = 0u64;
@@ -144,16 +139,8 @@ impl FinalizeHook for DuplexFinalizeHook {
 
         info!("Wrote {consensus_count} duplex consensus reads");
 
-        // Finalize the rejects writer (always finalize even on success to flush BGZF EOF).
-        if let Some(rw_arc) = rejects_writer {
-            let maybe_writer = rw_arc.lock().take();
-            if let Some(writer) = maybe_writer {
-                writer
-                    .finish()
-                    .map_err(|e| anyhow::anyhow!("Failed to finish rejects file: {e}"))?;
-                info!("Rejected reads streamed to rejects file during processing");
-            }
-        }
+        // Rejects are emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's WriteBgzfFile sink.
 
         timer.log_completion(consensus_count);
 
@@ -170,17 +157,16 @@ impl FinalizeHook for DuplexFinalizeHook {
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Captures passed into [`build_duplex_consensus_step`] from `add_duplex`.
+/// Captures passed into [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`] from `add_duplex`.
 ///
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_duplex`
 /// can prepare them once and hand them off cleanly.
 ///
 /// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`] and
-/// [`build_duplex_consensus_step`].
+/// [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`].
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct DuplexConsensusCaptures {
     pub(crate) track_rejects: bool,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) overlapping_enabled: bool,
     pub(crate) methylation_ref: MethylationRef,
     pub(crate) methylation_mode: fgumi_consensus::MethylationMode,
@@ -198,37 +184,157 @@ pub(crate) struct DuplexConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Build the `DuplexConsensus` step: parallel, `ByItemOrdinal`. Builds a
-/// per-worker [`DuplexConsensusCaller`] and optional
-/// [`OverlappingBasesConsensusCaller`] once, reuses across batches. Streams
-/// rejects inline through `cap.rejects_writer`.
-///
-/// Output: [`DecompressedBlock`] containing concatenated pre-serialized
-/// consensus records, ready for `BgzfCompress`.
-///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+/// Append `[len:4 LE][record]` framing for a byte-slice record — the format
+/// `BgzfCompress` expects in a `DecompressedBlock`.
+fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
+    #[allow(clippy::cast_possible_truncation)]
+    let block_size = rec.len() as u32;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+}
+
+/// Per-worker init: build the `DuplexConsensusCaller` (+ optional overlapping
+/// caller) once, reused across batches. Shared by both step variants.
 ///
 /// # Panics
 ///
-/// Panics if `DuplexConsensusCaller::new` fails during per-worker
-/// initialization. This cannot be surfaced as an error because the worker
-/// init closure has type `Fn() -> DuplexState` — it cannot propagate
-/// `Result`. Construction only fails on invalid `min_reads` arguments, which
-/// are validated before the pipeline is built.
-#[allow(clippy::type_complexity, clippy::too_many_lines)]
-pub(crate) fn build_duplex_consensus_step(
+/// Panics if `DuplexConsensusCaller::new` fails (only on invalid `min_reads`,
+/// validated before the pipeline is built) — the init closure type
+/// `Fn() -> DuplexState` cannot propagate a `Result`.
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+fn make_duplex_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    min_reads: Vec<usize>,
+    min_input_base_quality: u8,
+    output_per_base_tags: bool,
+    trim: bool,
+    max_reads_per_strand: Option<usize>,
+    cell_tag: noodles::sam::alignment::record::data::field::Tag,
+    track_rejects: bool,
+    error_rate_pre_umi: u8,
+    error_rate_post_umi: u8,
+    methylation_ref: MethylationRef,
+    methylation_mode: fgumi_consensus::MethylationMode,
+    overlapping_enabled: bool,
+) -> impl Fn() -> DuplexState + Send + Sync + 'static {
+    move || {
+        let mut caller = DuplexConsensusCaller::new(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            min_reads.clone(),
+            min_input_base_quality,
+            output_per_base_tags,
+            trim,
+            max_reads_per_strand,
+            Some(cell_tag),
+            track_rejects,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+        )
+        .expect("DuplexConsensusCaller::new failed during worker init");
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
+            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names), methylation_mode);
+        }
+        let overlapping = if overlapping_enabled {
+            Some(OverlappingBasesConsensusCaller::new(
+                AgreementStrategy::Consensus,
+                DisagreementStrategy::Consensus,
+            ))
+        } else {
+            None
+        };
+        DuplexState { caller, overlapping }
+    }
+}
+
+/// Per-batch duplex consensus body, shared by both step variants.
+///
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and any record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order — the PR #332 fan-out contract (rejects flow through the
+/// ordered serialize/compress stages, not a mutex side-channel; the rejects
+/// writer is configured with the input header by `add_duplex`).
+fn run_duplex_consensus_batch(
+    state: &mut DuplexState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+    accumulators: &Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = ConsensusCallingStats::new();
+    let mut batch_overlapping = CorrectionStats::new();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records: mut group_reads } in groups {
+        state.caller.clear();
+        total_input_records += group_reads.len() as u64;
+
+        if let Some(ref mut oc) = state.overlapping {
+            if crate::commands::duplex::has_both_strands_raw(&group_reads) {
+                oc.reset_stats();
+                apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
+                    io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+                })?;
+                batch_overlapping.merge(oc.stats());
+            }
+        }
+
+        let group_output = state
+            .caller
+            .consensus_reads(group_reads)
+            .map_err(|e| io::Error::other(format!("Duplex consensus error for MI {mi}: {e}")))?;
+        all_output.merge(group_output);
+        batch_stats.merge(&state.caller.statistics());
+        if track_rejects {
+            for raw in &state.caller.take_rejected_reads() {
+                append_framed_bytes(&mut rejects_bytes, raw);
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        if overlapping_enabled {
+            m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&batch_overlapping);
+        }
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries.
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `DuplexConsensus` step (used when `--rejects` is set):
+/// branch 0 = consensus, branch 1 = rejects.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+pub(crate) fn build_duplex_consensus_step_with_rejects(
     limit_bytes: u64,
     cap: DuplexConsensusCaptures,
-) -> ProcessWithWorkerState<
-    BatchedMiGroups,
-    DecompressedBlock,
-    impl Fn(&mut DuplexState, BatchedMiGroups) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
-    DuplexState,
-    impl Fn() -> DuplexState + Send + Sync + 'static,
-> {
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
     let DuplexConsensusCaptures {
         track_rejects,
-        rejects_writer,
         overlapping_enabled,
         methylation_ref,
         methylation_mode,
@@ -246,110 +352,118 @@ pub(crate) fn build_duplex_consensus_step(
         progress,
     } = cap;
 
+    let init = make_duplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        cell_tag,
+        track_rejects,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        methylation_ref,
+        methylation_mode,
+        overlapping_enabled,
+    );
+    let body = move |state: &mut DuplexState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) = run_duplex_consensus_batch(
+            state,
+            item,
+            track_rejects,
+            overlapping_enabled,
+            &accumulators,
+            &progress,
+        )?;
+        match rejects {
+            Some(r) => Ok(Process2Output::both(consensus, r)),
+            None => Ok(Process2Output::only_a(consensus)),
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        DuplexState,
+        _,
+        _,
+    >("DuplexConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output kept-only `DuplexConsensus` step (used when `--rejects`
+/// is unset). The framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_duplex_consensus_step_kept_only(
+    limit_bytes: u64,
+    cap: DuplexConsensusCaptures,
+) -> ProcessWithWorkerState<
+    BatchedMiGroups,
+    DecompressedBlock,
+    impl Fn(&mut DuplexState, BatchedMiGroups) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+    DuplexState,
+    impl Fn() -> DuplexState + Send + Sync + 'static,
+> {
+    let DuplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        methylation_ref,
+        methylation_mode,
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        cell_tag,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_duplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        cell_tag,
+        track_rejects,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        methylation_ref,
+        methylation_mode,
+        overlapping_enabled,
+    );
+    let body =
+        move |state: &mut DuplexState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) = run_duplex_consensus_batch(
+                state,
+                item,
+                track_rejects,
+                overlapping_enabled,
+                &accumulators,
+                &progress,
+            )?;
+            Ok(consensus)
+        };
+
     process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, DuplexState, _>(
         "DuplexConsensus",
         limit_bytes,
-        move || {
-            let mut caller = DuplexConsensusCaller::new(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                min_reads.clone(),
-                min_input_base_quality,
-                output_per_base_tags,
-                trim,
-                max_reads_per_strand,
-                Some(cell_tag),
-                track_rejects,
-                error_rate_pre_umi,
-                error_rate_post_umi,
-            )
-            .expect("DuplexConsensusCaller::new failed during worker init");
-            if let Some((ref reference, ref ref_names)) = methylation_ref {
-                caller.set_reference(
-                    Arc::clone(reference),
-                    Arc::clone(ref_names),
-                    methylation_mode,
-                );
-            }
-            let overlapping = if overlapping_enabled {
-                Some(OverlappingBasesConsensusCaller::new(
-                    AgreementStrategy::Consensus,
-                    DisagreementStrategy::Consensus,
-                ))
-            } else {
-                None
-            };
-            DuplexState { caller, overlapping }
-        },
-        move |state: &mut DuplexState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
-            let BatchedMiGroups { batch_serial, groups } = item;
-            let groups_count = groups.len() as u64;
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = ConsensusCallingStats::new();
-            let mut batch_overlapping = CorrectionStats::new();
-
-            let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                if let Some(ref rw_arc) = rejects_writer {
-                    if !recs.is_empty() {
-                        let mut guard = rw_arc.lock();
-                        if let Some(w) = guard.as_mut() {
-                            for raw in recs {
-                                w.write_raw_record(raw)?;
-                            }
-                        }
-                    }
-                }
-                Ok(())
-            };
-
-            let mut total_input_records: u64 = 0;
-            for MiGroup { mi, records: mut group_reads } in groups {
-                state.caller.clear();
-                total_input_records += group_reads.len() as u64;
-
-                if let Some(ref mut oc) = state.overlapping {
-                    if crate::commands::duplex::has_both_strands_raw(&group_reads) {
-                        oc.reset_stats();
-                        apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
-                            io::Error::other(format!(
-                                "Overlapping consensus error for MI {mi}: {e}"
-                            ))
-                        })?;
-                        batch_overlapping.merge(oc.stats());
-                    }
-                }
-
-                let group_output = state.caller.consensus_reads(group_reads).map_err(|e| {
-                    io::Error::other(format!("Duplex consensus error for MI {mi}: {e}"))
-                })?;
-                all_output.merge(group_output);
-                batch_stats.merge(&state.caller.statistics());
-                if track_rejects {
-                    flush_byte_records(&state.caller.take_rejected_reads())?;
-                }
-            }
-
-            // Merge per-batch metrics into this worker's slot.
-            accumulators.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                if overlapping_enabled {
-                    m.overlapping_stats
-                        .get_or_insert_with(CorrectionStats::new)
-                        .merge(&batch_overlapping);
-                }
-                m.groups_processed += groups_count;
-            });
-
-            // Progress logging at million-record boundaries (mirrors
-            // legacy's `ProgressTracker::log_if_needed`).
-            let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
-            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + total_input_records);
-            }
-
-            Ok(DecompressedBlock { batch_serial, bytes: all_output.data })
-        },
+        init,
+        body,
     )
 }
 

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -4,7 +4,7 @@
 //! Phase 3 (T3a.8) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the simplex-specific types and step factory that the builder
-//! imports: [`SimplexFinalizeHook`] and [`build_simplex_consensus_step`] used
+//! imports: [`SimplexFinalizeHook`] and the `build_simplex_consensus_step_with_rejects` / `build_simplex_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_simplex`.
 //!
 //! [`build_simplex_chain`] shrinks to a ~10-line delegate.
@@ -21,7 +21,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Result;
 use log::info;
-use parking_lot::Mutex;
 
 use crate::commands::common::MethylationRef;
 use crate::commands::consensus_runner::{ConsensusStatsOps, log_overlapping_stats};
@@ -37,12 +36,14 @@ use crate::overlapping_consensus::{
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::pipeline::chains::builder::ChainBuilder;
 use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
-use crate::pipeline::steps::process::{ProcessWithWorkerState, process_with_worker_state};
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
 use crate::pipeline::steps::types::DecompressedBlock;
 use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
-use fgumi_bam_io::RawBamWriter;
-use fgumi_raw_bam::RawRecord;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CollectedSimplexMetrics
@@ -96,19 +97,12 @@ pub(crate) struct SimplexFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
     pub(crate) stats_path: Option<std::path::PathBuf>,
     pub(crate) overlapping_enabled: bool,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) timer: OperationTimer,
 }
 
 impl FinalizeHook for SimplexFinalizeHook {
     fn finalize(self: Box<Self>) -> Result<()> {
-        let SimplexFinalizeHook {
-            accumulators,
-            stats_path,
-            overlapping_enabled,
-            rejects_writer,
-            timer,
-        } = *self;
+        let SimplexFinalizeHook { accumulators, stats_path, overlapping_enabled, timer } = *self;
 
         // Reduce per-thread accumulators.
         let mut total_groups = 0u64;
@@ -146,16 +140,9 @@ impl FinalizeHook for SimplexFinalizeHook {
 
         info!("Wrote {consensus_count} consensus reads");
 
-        // Finalize the rejects writer (always finalize even on success to flush BGZF EOF).
-        if let Some(rw_arc) = rejects_writer {
-            let maybe_writer = rw_arc.lock().take();
-            if let Some(writer) = maybe_writer {
-                writer
-                    .finish()
-                    .map_err(|e| anyhow::anyhow!("Failed to finish rejects file: {e}"))?;
-                info!("Rejected reads streamed to rejects file during processing");
-            }
-        }
+        // Rejects are now emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's own WriteBgzfFile sink,
+        // so there is no rejects writer to finish here.
 
         timer.log_completion(consensus_count);
 
@@ -172,16 +159,15 @@ impl FinalizeHook for SimplexFinalizeHook {
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Captures passed into [`build_simplex_consensus_step`] from `add_simplex`.
+/// Captures passed into [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`] from `add_simplex`.
 ///
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_simplex`
 /// can prepare them once and hand them off cleanly.
 ///
 /// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`] and
-/// [`build_simplex_consensus_step`].
+/// [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`].
 pub(crate) struct SimplexConsensusCaptures {
     pub(crate) track_rejects: bool,
-    pub(crate) rejects_writer: Option<Arc<Mutex<Option<RawBamWriter>>>>,
     pub(crate) overlapping_enabled: bool,
     pub(crate) consensus_options: VanillaUmiConsensusOptions,
     pub(crate) read_name_prefix: String,
@@ -192,17 +178,210 @@ pub(crate) struct SimplexConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Build the `SimplexConsensus` step: parallel, `ByItemOrdinal`. Builds a
-/// per-worker [`VanillaUmiConsensusCaller`] and optional
-/// [`OverlappingBasesConsensusCaller`] once, reuses across batches. Streams
-/// rejects inline through `cap.rejects_writer`.
+/// Append `[len:4 LE][record]` framing for each byte-slice record — the format
+/// `BgzfCompress` expects in a `DecompressedBlock`. Mirrors correct's
+/// `append_framed_raw_record`.
+fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
+    // BAM record body size is u32-bounded per the spec; a single record's
+    // buffer cannot exceed u32::MAX in practice.
+    #[allow(clippy::cast_possible_truncation)]
+    let block_size = rec.len() as u32;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+}
+
+/// Per-worker init: build the `VanillaUmiConsensusCaller` (+ optional
+/// overlapping caller) once, reused across batches. Shared by both step
+/// variants.
+fn make_simplex_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    consensus_options: VanillaUmiConsensusOptions,
+    methylation_ref: MethylationRef,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+) -> impl Fn() -> ConsensusState + Send + Sync + 'static {
+    move || {
+        let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            consensus_options.clone(),
+            track_rejects,
+        );
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
+            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        }
+        let overlapping = if overlapping_enabled {
+            Some(OverlappingBasesConsensusCaller::new(
+                AgreementStrategy::Consensus,
+                DisagreementStrategy::Consensus,
+            ))
+        } else {
+            None
+        };
+        ConsensusState { caller, overlapping }
+    }
+}
+
+/// Per-batch simplex consensus body, shared by both step variants.
 ///
-/// Output: [`DecompressedBlock`] containing concatenated pre-serialized
-/// consensus records, ready for `BgzfCompress`.
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and at least one record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order. Per the PR #332 contract the rejects flow out through the
+/// ordered serialize/compress stages (input order) rather than a mutex
+/// side-channel (mutex-acquisition order); the rejects writer is configured
+/// with the input header by `add_simplex`.
+fn run_simplex_consensus_batch(
+    state: &mut ConsensusState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+    min_reads: usize,
+    accumulators: &Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = ConsensusCallingStats::new();
+    let mut batch_overlapping = CorrectionStats::new();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records: mut raw_records } in groups {
+        state.caller.clear();
+        total_input_records += raw_records.len() as u64;
+
+        if raw_records.len() < min_reads {
+            batch_stats.record_input(raw_records.len());
+            batch_stats.record_rejection(RejectionReason::InsufficientReads, raw_records.len());
+            if track_rejects {
+                for raw in &raw_records {
+                    append_framed_bytes(&mut rejects_bytes, raw.as_ref());
+                }
+            }
+            continue;
+        }
+
+        if let Some(ref mut oc) = state.overlapping {
+            oc.reset_stats();
+            // A failure here must be fatal to match the single-thread fast path
+            // in `src/lib/commands/simplex.rs`, which propagates
+            // `apply_overlapping_consensus` errors with `?`. Downgrading to a
+            // `RejectionReason::Other` reject would make the same input fail
+            // without `--threads` but succeed with it.
+            apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
+                io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+            })?;
+            batch_overlapping.merge(oc.stats());
+        }
+
+        let group_output = state
+            .caller
+            .consensus_reads(raw_records)
+            .map_err(|e| io::Error::other(format!("Consensus error for MI {mi}: {e}")))?;
+        all_output.merge(group_output);
+        batch_stats.merge(&state.caller.statistics());
+        if track_rejects {
+            for raw in &state.caller.take_rejected_reads() {
+                append_framed_bytes(&mut rejects_bytes, raw);
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        if overlapping_enabled {
+            m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&batch_overlapping);
+        }
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries (mirrors legacy's
+    // `ProgressTracker::log_if_needed`).
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `SimplexConsensus` step (used when `--rejects` is set):
+/// branch 0 carries the consensus `DecompressedBlock`, branch 1 carries the
+/// rejects `DecompressedBlock`. Parallel, `ByItemOrdinal`.
 ///
 /// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
-#[allow(clippy::type_complexity, clippy::too_many_lines)]
-pub(crate) fn build_simplex_consensus_step(
+pub(crate) fn build_simplex_consensus_step_with_rejects(
+    limit_bytes: u64,
+    cap: SimplexConsensusCaptures,
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
+    let SimplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        consensus_options,
+        read_name_prefix,
+        read_group_id,
+        methylation_ref,
+        accumulators,
+        min_reads,
+        progress,
+    } = cap;
+
+    let init = make_simplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        methylation_ref,
+        track_rejects,
+        overlapping_enabled,
+    );
+    let body = move |state: &mut ConsensusState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) = run_simplex_consensus_batch(
+            state,
+            item,
+            track_rejects,
+            overlapping_enabled,
+            min_reads,
+            &accumulators,
+            &progress,
+        )?;
+        match rejects {
+            Some(r) => Ok(Process2Output::both(consensus, r)),
+            None => Ok(Process2Output::only_a(consensus)),
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        ConsensusState,
+        _,
+        _,
+    >("SimplexConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output (kept-only) `SimplexConsensus` step (used when
+/// `--rejects` is unset). `track_rejects` is `false`, so no rejects are
+/// produced; the framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant (mirrors `correct_step_kept_only`).
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_simplex_consensus_step_kept_only(
     limit_bytes: u64,
     cap: SimplexConsensusCaptures,
 ) -> ProcessWithWorkerState<
@@ -217,7 +396,6 @@ pub(crate) fn build_simplex_consensus_step(
 > {
     let SimplexConsensusCaptures {
         track_rejects,
-        rejects_writer,
         overlapping_enabled,
         consensus_options,
         read_name_prefix,
@@ -228,127 +406,33 @@ pub(crate) fn build_simplex_consensus_step(
         progress,
     } = cap;
 
+    let init = make_simplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        methylation_ref,
+        track_rejects,
+        overlapping_enabled,
+    );
+    let body =
+        move |state: &mut ConsensusState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) = run_simplex_consensus_batch(
+                state,
+                item,
+                track_rejects,
+                overlapping_enabled,
+                min_reads,
+                &accumulators,
+                &progress,
+            )?;
+            Ok(consensus)
+        };
+
     process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, ConsensusState, _>(
         "SimplexConsensus",
         limit_bytes,
-        move || {
-            let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                consensus_options.clone(),
-                track_rejects,
-            );
-            if let Some((ref reference, ref ref_names)) = methylation_ref {
-                caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
-            }
-            let overlapping = if overlapping_enabled {
-                Some(OverlappingBasesConsensusCaller::new(
-                    AgreementStrategy::Consensus,
-                    DisagreementStrategy::Consensus,
-                ))
-            } else {
-                None
-            };
-            ConsensusState { caller, overlapping }
-        },
-        move |state: &mut ConsensusState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
-            let BatchedMiGroups { batch_serial, groups } = item;
-            let groups_count = groups.len() as u64;
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = ConsensusCallingStats::new();
-            let mut batch_overlapping = CorrectionStats::new();
-
-            // Stream per-MI-group rejects straight to disk so they
-            // don't accumulate in a batch-level Vec. The mutex only
-            // serializes the raw-byte append; BGZF compression runs
-            // on the writer's own thread pool.
-            let flush_raw_records = |recs: &[RawRecord]| -> io::Result<()> {
-                if let Some(ref rw_arc) = rejects_writer {
-                    if !recs.is_empty() {
-                        let mut guard = rw_arc.lock();
-                        if let Some(w) = guard.as_mut() {
-                            for raw in recs {
-                                w.write_raw_record(raw.as_ref())?;
-                            }
-                        }
-                    }
-                }
-                Ok(())
-            };
-            let flush_byte_records = |recs: &[Vec<u8>]| -> io::Result<()> {
-                if let Some(ref rw_arc) = rejects_writer {
-                    if !recs.is_empty() {
-                        let mut guard = rw_arc.lock();
-                        if let Some(w) = guard.as_mut() {
-                            for raw in recs {
-                                w.write_raw_record(raw)?;
-                            }
-                        }
-                    }
-                }
-                Ok(())
-            };
-
-            let mut total_input_records: u64 = 0;
-            for MiGroup { mi, records: mut raw_records } in groups {
-                state.caller.clear();
-                total_input_records += raw_records.len() as u64;
-
-                if raw_records.len() < min_reads {
-                    batch_stats.record_input(raw_records.len());
-                    batch_stats
-                        .record_rejection(RejectionReason::InsufficientReads, raw_records.len());
-                    if track_rejects {
-                        flush_raw_records(&raw_records)?;
-                    }
-                    continue;
-                }
-
-                if let Some(ref mut oc) = state.overlapping {
-                    oc.reset_stats();
-                    // A failure here must be fatal to match the single-thread
-                    // fast path in `src/lib/commands/simplex.rs`, which
-                    // propagates `apply_overlapping_consensus` errors with `?`.
-                    // Downgrading to a `RejectionReason::Other` reject would make
-                    // the same input fail without `--threads` but succeed with it.
-                    apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
-                        io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
-                    })?;
-                    batch_overlapping.merge(oc.stats());
-                }
-
-                let group_output = state
-                    .caller
-                    .consensus_reads(raw_records)
-                    .map_err(|e| io::Error::other(format!("Consensus error for MI {mi}: {e}")))?;
-                all_output.merge(group_output);
-                batch_stats.merge(&state.caller.statistics());
-                if track_rejects {
-                    flush_byte_records(&state.caller.take_rejected_reads())?;
-                }
-            }
-
-            // Merge per-batch metrics into this worker's slot.
-            accumulators.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                if overlapping_enabled {
-                    m.overlapping_stats
-                        .get_or_insert_with(CorrectionStats::new)
-                        .merge(&batch_overlapping);
-                }
-                m.groups_processed += groups_count;
-            });
-
-            // Progress logging at million-record boundaries (mirrors
-            // legacy's `ProgressTracker::log_if_needed`).
-            let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
-            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + total_input_records);
-            }
-
-            Ok(DecompressedBlock { batch_serial, bytes: all_output.data })
-        },
+        init,
+        body,
     )
 }
 


### PR DESCRIPTION
**Stacked PR (stack position 07) of the #330 unified-pipeline landing.** Targets the long-lived integration branch `feat-runall` (not `main`); #397 (`fix(correct)` rejects header) is its merged predecessor. One commit.

**This is the first fully-green PR in the stack** — it clears the last of the rejects-header test family. Verified locally: full suite **1813/1813 pass**, rejects family **90/90** (3/3 deterministic runs).

The simplex, duplex, and codec consensus steps streamed rejected reads to a side-channel `Arc<Mutex<Option<RawBamWriter>>>`: workers flushed under a mutex (so rejects landed in mutex-acquisition order, not input order) and the rejects BAM was stamped `SO:unsorted` via `header_as_unsorted(output_header)` (dropping the input's `@HD` `GO`/`SS` + raw-input RG/PG). That violates the PR #332 rejects contract (rejects are raw-input records → input header verbatim + input order; only the primary BAM carries the consensus header) and is what `correct`/`filter` already do.

Migrate all three to the same `Process2WithWorkerState` fan-out as `correct_step_with_rejects`:
- **branch 0** carries the consensus `DecompressedBlock`;
- **branch 1** carries `[len][record]`-framed rejected raw-input records that flow through the ordered serialize / `BgzfCompress` / `WriteBgzfFile` stages — giving input order, and a rejects writer configured with the captured **input header**.

Each consensus step factory splits into a 2-output `*_with_rejects` variant (used with `--rejects`) and a 1-output `*_kept_only` variant (the framework has no public discard sink). The 3 mutex writers + their finalize-hook flush + the `SO:unsorted` restamp are deleted.

**Fixes** `test_bgzf_eof::{test_simplex,test_duplex,test_codec}_rejects_has_bgzf_eof` plus `test_duplex_command::{test_duplex_command_with_rejects,test_duplex_command_rejects_contain_no_duplicates}` (all assert `assert_rejects_header_matches_input`).

**Reading order:** `builder.rs` (the wiring — `add_simplex`/`add_duplex`/`add_codec` each capture `input_header` before `replace_header`, then branch on `track_rejects`) is the entry point; the three `commands/{simplex,duplex,codec}.rs` files are parallel implementations of the same `make_*_init` / `run_*_batch` / `build_*_{with_rejects,kept_only}` shape.

*Folded in from a local dual review (`/coderabbitai-review` skill + `coderabbit` CLI):* updated 9 stale intra-doc links that pointed at the pre-rename `build_*_consensus_step` factory names. (A CLI nitpick suggesting `_kept_only` hardcode `track_rejects=false` was validated as a false positive — that variant is only ever built where `track_rejects` is already `false`, as its own doc states — so it was skipped.)
