### PR TITLE
perf(sort): codec-aware streaming spill decompress; use main's zstd codec

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1393,16 +1393,18 @@ impl RawExternalSorter {
              queryname / template-coordinate streaming entry points are forthcoming",
             self.sort_order,
         );
+        self.ensure_spill_codec_compat()?;
 
-        // Force BGZF: the streaming merge's `SortSpillDecompress` reads spill
-        // chunks as raw BGZF blocks, so the spill codec must be BGZF regardless
-        // of `self.spill_codec` (which defaults to zstd). Enforced here so this
-        // public constructor can't hand the decoder slots it can't read.
+        // Spill codec from config (zstd by default, the same fast codec
+        // standalone sort uses). `SortSpillDecompress` is codec-aware — it
+        // detects each spill chunk's codec from its file magic (see
+        // `slots_for_chunk_files`) and dispatches accordingly — so the streaming
+        // path no longer has to pin BGZF.
         let pool = Arc::new(SortWorkerPool::new(
             self.threads.max(1),
             self.temp_compression,
             self.output_compression,
-            crate::codec::SpillCodec::Bgzf,
+            self.spill_codec,
         ));
         // Phase 1 is the steady-state ingest mode for incoming records.
         pool.set_phase(crate::worker_pool::phase::PHASE1);
@@ -1465,14 +1467,15 @@ impl RawExternalSorter {
             "into_template_coordinate_stream requires SortOrder::TemplateCoordinate (got {:?})",
             self.sort_order,
         );
+        self.ensure_spill_codec_compat()?;
 
-        // Force BGZF (see `into_coordinate_stream`): the streaming decoder only
-        // reads raw BGZF spill blocks, so override `self.spill_codec`.
+        // Spill codec from config (see `into_coordinate_stream`): the streaming
+        // decoder is codec-aware, so honor `self.spill_codec` (zstd default).
         let pool = Arc::new(SortWorkerPool::new(
             self.threads.max(1),
             self.temp_compression,
             self.output_compression,
-            crate::codec::SpillCodec::Bgzf,
+            self.spill_codec,
         ));
         pool.set_phase(crate::worker_pool::phase::PHASE1);
 
@@ -1853,16 +1856,17 @@ impl RawExternalSorter {
         Ok(())
     }
 
-    /// Sort a BAM file using raw-bytes approach.
+    /// Reject `temp_compression == 0` combined with `SpillCodec::Zstd`: zstd has
+    /// no level-0 "stored" mode, so silently remapping to 1 would surprise
+    /// callers who set `temp_compression(0)` expecting an uncompressed spill
+    /// (which works for BGZF). Called by `sort()` and by every streaming entry
+    /// point (`into_*_stream`) so neither the standalone nor the fused path can
+    /// reach a misconfigured pool.
     ///
     /// # Errors
     ///
-    /// Returns an error if reading, sorting, or writing the BAM file fails.
-    pub fn sort(&self, input: &Path, output: &Path) -> Result<RawSortStats> {
-        // zstd has no level-0 "stored" mode; silently remapping to 1 would
-        // surprise API callers who set temp_compression(0) expecting an
-        // uncompressed spill (which works for BGZF). Mirror the CLI guard so
-        // direct RawExternalSorter callers cannot reach a misconfigured pool.
+    /// Returns an error if `temp_compression == 0` and the spill codec is zstd.
+    fn ensure_spill_codec_compat(&self) -> Result<()> {
         anyhow::ensure!(
             !(self.temp_compression == 0
                 && matches!(self.spill_codec, crate::codec::SpillCodec::Zstd)),
@@ -1871,6 +1875,18 @@ impl RawExternalSorter {
              spill_codec(SpillCodec::Bgzf) to keep level-0 spill, or pick a \
              zstd level >= 1."
         );
+        Ok(())
+    }
+
+    /// Sort a BAM file using raw-bytes approach.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading, sorting, or writing the BAM file fails.
+    pub fn sort(&self, input: &Path, output: &Path) -> Result<RawSortStats> {
+        // Mirror the CLI guard so direct RawExternalSorter callers cannot reach
+        // a misconfigured pool.
+        self.ensure_spill_codec_compat()?;
 
         debug!("Starting raw-bytes sort with order: {:?}", self.sort_order);
         debug!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
@@ -3497,12 +3513,31 @@ fn slots_for_chunk_files(chunk_files: &[std::path::PathBuf]) -> Result<Vec<Arc<S
         .iter()
         .enumerate()
         .map(|(idx, path)| {
-            let file = std::fs::File::open(path)
+            let mut file = std::fs::File::open(path)
                 .with_context(|| format!("failed to open spill chunk {}", path.display()))?;
+            // Detect the spill codec from the file magic. For zstd ("ZSP1") the
+            // 4-byte magic is consumed here, leaving the reader at the first
+            // `[len][frame]` record; for BGZF the `1f 8b` is part of the first
+            // block, so rewind to byte 0. `SortSpillDecompress` reads
+            // `slot.codec` to decompress accordingly.
+            let mut magic = [0u8; 4];
+            let filled = read_exact_or_eof(&mut file, &mut magic)
+                .with_context(|| format!("failed to read spill chunk magic {}", path.display()))?;
+            let codec = if filled {
+                crate::codec::SpillCodec::from_magic(&magic)
+                    .unwrap_or(crate::codec::SpillCodec::Bgzf)
+            } else {
+                crate::codec::SpillCodec::Bgzf
+            };
+            if matches!(codec, crate::codec::SpillCodec::Bgzf) {
+                use std::io::Seek;
+                file.seek(std::io::SeekFrom::Start(0))
+                    .with_context(|| format!("failed to rewind spill chunk {}", path.display()))?;
+            }
             let reader = std::io::BufReader::new(file);
             let file_id = u32::try_from(idx)
                 .with_context(|| format!("spill file_id {idx} exceeds u32::MAX"))?;
-            Ok(Arc::new(SortMergeSlot::new(file_id, reader)))
+            Ok(Arc::new(SortMergeSlot::new(file_id, reader, codec)))
         })
         .collect()
 }
@@ -3904,13 +3939,15 @@ impl<K: RawSortKey + Default + 'static> QuerynameSortStreamGeneric<K> {
     fn new_from_sorter(sorter: RawExternalSorter, header: &Header) -> Result<Self> {
         use crate::keys::SortContext;
 
-        // Force BGZF (see `into_coordinate_stream`): the streaming decoder only
-        // reads raw BGZF spill blocks, so override `sorter.spill_codec`.
+        sorter.ensure_spill_codec_compat()?;
+
+        // Spill codec from config (see `into_coordinate_stream`): the streaming
+        // decoder is codec-aware, so honor `sorter.spill_codec` (zstd default).
         let pool = Arc::new(SortWorkerPool::new(
             sorter.threads.max(1),
             sorter.temp_compression,
             sorter.output_compression,
-            crate::codec::SpillCodec::Bgzf,
+            sorter.spill_codec,
         ));
         pool.set_phase(crate::worker_pool::phase::PHASE1);
 
@@ -5168,6 +5205,43 @@ mod tests {
             "unexpected error: {msg}"
         );
         assert!(!output.exists(), "no output should be produced on validation failure");
+    }
+
+    /// The streaming entry points must reject `temp_compression=0` + zstd too,
+    /// not just `sort()` — otherwise the fused pipeline path (which builds the
+    /// sorter then calls `into_*_stream`) could reach a misconfigured pool that
+    /// `sort()` would have refused. Header is irrelevant: the guard fires before
+    /// any pool/temp-dir work.
+    #[test]
+    fn test_streaming_entry_points_reject_temp_compression_zero_with_zstd() {
+        use noodles::sam::Header;
+
+        let header = Header::default();
+
+        for sort_order in [
+            SortOrder::Coordinate,
+            SortOrder::TemplateCoordinate,
+            SortOrder::Queryname(crate::keys::QuerynameComparator::Lexicographic),
+        ] {
+            let sorter = RawExternalSorter::new(sort_order)
+                .spill_codec(crate::codec::SpillCodec::Zstd)
+                .temp_compression(0);
+            let err = match sort_order {
+                SortOrder::Coordinate => sorter.into_coordinate_stream(&header).err(),
+                SortOrder::TemplateCoordinate => {
+                    sorter.into_template_coordinate_stream(&header).err()
+                }
+                SortOrder::Queryname(_) => sorter.into_queryname_stream(&header).err(),
+            }
+            .unwrap_or_else(|| {
+                panic!("{sort_order:?} stream should reject temp_compression=0 + zstd")
+            });
+            assert!(
+                err.to_string()
+                    .contains("temp_compression=0 is only supported with SpillCodec::Bgzf"),
+                "unexpected error for {sort_order:?}: {err}"
+            );
+        }
     }
 
     #[test]
@@ -7215,6 +7289,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             file_id,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         {
             let mut dec = slot.decompressed.lock().unwrap();
@@ -7312,6 +7387,7 @@ mod from_slots_merge_tests {
         let empty_slot = StdArc::new(SortMergeSlot::new(
             0,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         // Mark drained without inserting any blocks.
         empty_slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
@@ -7332,6 +7408,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             0,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         // Empty queue, NOT eof — the producer is "still feeding".
         let mut driver =
@@ -7370,6 +7447,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             0,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         // One record present, NOT eof (more "coming").
         {
@@ -7420,6 +7498,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             0,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         slot.decompressed.lock().unwrap().push_back(vec![serialized[0]]);
 
@@ -7464,6 +7543,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             0,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         slot.decompressed.lock().unwrap().push_back(head.to_vec());
 
@@ -7589,6 +7669,7 @@ mod from_slots_merge_tests {
         let slot = StdArc::new(SortMergeSlot::new(
             file_id,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         {
             let mut dec = slot.decompressed.lock().unwrap();
@@ -7651,6 +7732,7 @@ mod from_slots_merge_tests {
         let empty_slot = StdArc::new(SortMergeSlot::new(
             99,
             BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
         ));
         empty_slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
         // Insert empty-slot first, then a populated slot. The driver should

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;
 pub(crate) mod segmented_buf;
+pub(crate) mod spill_block_reader;
 pub(crate) mod tmp_dir_alloc;
 pub(crate) mod verify;
 pub(crate) mod worker_pool;
@@ -177,6 +178,7 @@ pub use keys::{
 };
 pub use merge_slots::{PHASE2_DECOMP_CAP, SortMergeSlot};
 pub use reader::RawBamRecordReader;
+pub use spill_block_reader::SpillBlockDecompressor;
 pub use verify::{VerifySummary, verify_sort_order};
 
 #[cfg(test)]

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -68,6 +68,8 @@ use std::io::BufReader;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::codec::SpillCodec;
+
 /// Per-slot decompressed-block queue cap. Bounds in-flight
 /// decompressed memory: `num_slots × PHASE2_DECOMP_CAP × ~256 KB`.
 /// Matches `worker_pool::PHASE2_DECOMP_CAP` numerically.
@@ -99,6 +101,11 @@ pub struct SortMergeSlot {
     /// `file_id` so the `LoserTree` tie-break for equal sort keys
     /// is deterministic and matches the legacy chunk-files order.
     pub file_id: u32,
+    /// Spill codec of this chunk's file, detected from the file magic when the
+    /// slot is opened (`slots_for_chunk_files`). The `SortSpillDecompress` step
+    /// reads it to decompress BGZF blocks or zstd frames; `reader` is already
+    /// positioned past any codec file-magic.
+    pub codec: SpillCodec,
     /// Disk reader. Held only while reading raw bytes from disk.
     /// One worker at a time per slot via `try_lock`.
     pub reader: Mutex<SortMergeReader>,
@@ -129,11 +136,13 @@ pub struct SortMergeSlot {
 }
 
 impl SortMergeSlot {
-    /// Construct an empty slot for `file_id` backed by `reader`.
+    /// Construct an empty slot for `file_id` backed by `reader` (positioned
+    /// past any codec file-magic) with the detected `codec`.
     #[must_use]
-    pub fn new(file_id: u32, reader: BufReader<File>) -> Self {
+    pub fn new(file_id: u32, reader: BufReader<File>, codec: SpillCodec) -> Self {
         Self {
             file_id,
+            codec,
             reader: Mutex::new(SortMergeReader { inner: reader }),
             decompressed: Mutex::new(VecDeque::with_capacity(PHASE2_DECOMP_CAP)),
             queue_eof: AtomicBool::new(false),
@@ -227,7 +236,7 @@ mod tests {
 
     #[test]
     fn new_slot_starts_empty_and_not_drained() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
         assert_eq!(slot.file_id, 0);
         assert!(!slot.is_drained(), "fresh slot not drained until queue_eof");
         let (pending_blocks, pending_bytes, active) = slot.probe_stats();
@@ -238,7 +247,7 @@ mod tests {
 
     #[test]
     fn drained_when_queue_eof_and_empty() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
 
         // Push a decompressed block; not drained even if queue_eof.
         slot.decompressed.lock().unwrap().push_back(vec![0xAB, 0xCD]);
@@ -253,7 +262,7 @@ mod tests {
 
     #[test]
     fn probe_stats_counts_decompressed_only() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
         slot.decompressed.lock().unwrap().push_back(vec![0u8; 1024]);
         slot.decompressed.lock().unwrap().push_back(vec![0u8; 512]);
 
@@ -265,7 +274,7 @@ mod tests {
 
     #[test]
     fn fifo_order() {
-        let slot = SortMergeSlot::new(7, empty_reader());
+        let slot = SortMergeSlot::new(7, empty_reader(), SpillCodec::Bgzf);
         // Push in order; pop must yield in same order.
         slot.decompressed.lock().unwrap().push_back(vec![0]);
         slot.decompressed.lock().unwrap().push_back(vec![1]);
@@ -281,7 +290,7 @@ mod tests {
 
     #[test]
     fn decomp_error_flag_set_and_read() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
         assert!(!slot.decomp_error.load(Ordering::Acquire));
         slot.decomp_error.store(true, Ordering::Release);
         assert!(slot.decomp_error.load(Ordering::Acquire));
@@ -289,7 +298,7 @@ mod tests {
 
     #[test]
     fn errored_slot_is_not_drained() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
 
         // Mark EOF with an empty queue but a decompression error set: this
         // must NOT be reported as a clean drain, otherwise a caller using
@@ -303,7 +312,7 @@ mod tests {
 
     #[test]
     fn clean_eof_reports_no_error() {
-        let slot = SortMergeSlot::new(0, empty_reader());
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
         slot.queue_eof.store(true, Ordering::Release);
         assert!(slot.is_drained(), "clean empty + queue_eof is drained");
         assert!(!slot.has_error(), "clean drain has no error");

--- a/crates/fgumi-sort/src/spill_block_reader.rs
+++ b/crates/fgumi-sort/src/spill_block_reader.rs
@@ -1,0 +1,241 @@
+//! Codec-aware streaming block decompressor for the typed-step
+//! `SortSpillDecompress` pipeline step.
+//!
+//! A spill chunk is either a BGZF block-stream (self-framed `1f 8b` blocks) or
+//! a zstd "ZSP1" stream (`[u32 LE frame-len][zstd frame]` records after the
+//! 4-byte file magic). Both standalone `fgumi sort` (via the worker pool) and
+//! the fused streaming sort write spill chunks with whichever
+//! [`SpillCodec`](crate::codec::SpillCodec) the sorter is configured for; this
+//! decompressor lets the streaming `SortSpillDecompress` step read either.
+//!
+//! Each decompressed BGZF block (or zstd frame) is returned as one `Vec<u8>`.
+//! The block/frame boundaries are immaterial: the downstream `MergeDriver`
+//! parses `[len][record]` records out of a slot's decompressed-block queue and
+//! reassembles records that span block boundaries, so any chunking of the
+//! decompressed byte stream is correct.
+
+use std::io::{self, Read};
+
+use libdeflater::Decompressor as BgzfDecompressor;
+use zstd::bulk::Decompressor as ZstdDecompressor;
+
+use crate::codec::SpillCodec;
+use crate::worker_pool::read_length_prefix;
+
+/// Output staging-buffer capacity for a single decompressed block/frame. Mirrors
+/// the worker pool's `ZSTD_FRAME_DECOMP_CAP` / `BgzfDecompress` scratch sizing so
+/// the mimalloc size-class reuse pattern matches.
+const SCRATCH_CAP: usize = 256 * 1024;
+
+/// Per-worker codec-aware decompressor. Holds a libdeflate decompressor (BGZF)
+/// and a zstd decompressor plus reusable scratch buffers; one instance per
+/// `SortSpillDecompress` worker copy.
+pub struct SpillBlockDecompressor {
+    bgzf: BgzfDecompressor,
+    zstd: ZstdDecompressor<'static>,
+    /// Reused output buffer for the BGZF path (`mem::replace`d into the result).
+    bgzf_scratch: Vec<u8>,
+    /// Reused output buffer for the zstd path (decompressed-into, then copied).
+    zstd_buf: Vec<u8>,
+    /// Reused input buffer for the zstd path (one compressed frame at a time).
+    zstd_frame: Vec<u8>,
+}
+
+impl SpillBlockDecompressor {
+    /// Construct a fresh decompressor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the zstd decompressor cannot be created (allocation failure).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            bgzf: BgzfDecompressor::new(),
+            zstd: ZstdDecompressor::new().expect("zstd decompressor init"),
+            bgzf_scratch: Vec::with_capacity(SCRATCH_CAP),
+            zstd_buf: Vec::new(),
+            zstd_frame: Vec::new(),
+        }
+    }
+
+    /// Read and decompress up to `max` blocks from `reader` using `codec`,
+    /// returning the decompressed block bytes. A result with fewer than `max`
+    /// entries (including an empty `Vec`) signals that the reader reached a
+    /// clean EOF.
+    ///
+    /// The reader must be positioned at a block boundary — for zstd, at the
+    /// start of a `[len][frame]` record (i.e. the `ZSP1` file magic already
+    /// consumed); for BGZF, at the start of a block. `slots_for_chunk_files`
+    /// detects the codec from the file magic and positions the reader
+    /// accordingly when opening each slot.
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O errors, BGZF/zstd decompression failures, and truncation
+    /// (a partial length prefix or frame body at EOF).
+    pub fn read_blocks<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        codec: SpillCodec,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        match codec {
+            SpillCodec::Bgzf => self.read_bgzf_blocks(reader, max),
+            SpillCodec::Zstd => self.read_zstd_frames(reader, max),
+        }
+    }
+
+    fn read_bgzf_blocks<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(reader, max)?;
+        let mut out = Vec::with_capacity(raw_blocks.len());
+        for raw in raw_blocks {
+            fgumi_bgzf::reader::decompress_block_slice_into(
+                &raw.data,
+                &mut self.bgzf,
+                &mut self.bgzf_scratch,
+            )?;
+            // mem::replace the filled scratch out and re-allocate a fresh one,
+            // so the consumer owns the bytes and the next decompress reuses a
+            // same-size-class allocation (matches `BgzfDecompress`).
+            out.push(std::mem::replace(&mut self.bgzf_scratch, Vec::with_capacity(SCRATCH_CAP)));
+        }
+        Ok(out)
+    }
+
+    fn read_zstd_frames<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        if self.zstd_buf.len() < SCRATCH_CAP {
+            self.zstd_buf.resize(SCRATCH_CAP, 0);
+        }
+        let mut out = Vec::with_capacity(max);
+        for _ in 0..max {
+            // `read_length_prefix` returns `Ok(None)` only at a clean frame
+            // boundary EOF; a 1–3 byte partial prefix surfaces as an error.
+            let Some(frame_len) = read_length_prefix(reader)? else {
+                break;
+            };
+            self.zstd_frame.clear();
+            self.zstd_frame.resize(frame_len, 0);
+            reader.read_exact(&mut self.zstd_frame)?;
+            let n = self
+                .zstd
+                .decompress_to_buffer(&self.zstd_frame, &mut self.zstd_buf)
+                .map_err(|e| io::Error::other(format!("zstd spill frame decompress: {e}")))?;
+            out.push(self.zstd_buf[..n].to_vec());
+        }
+        Ok(out)
+    }
+}
+
+impl Default for SpillBlockDecompressor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pooled_chunk_writer::PooledChunkWriter;
+    use crate::worker_pool::SortWorkerPool;
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    /// A spill chunk written with codec X, read back through
+    /// `SpillBlockDecompressor`, must yield the exact `[len][record]` byte
+    /// stream that was written — for BOTH codecs. This is the round-trip the
+    /// streaming merge depends on.
+    fn roundtrip(codec: SpillCodec) {
+        use crate::keys::{RawCoordinateKey, RawSortKey};
+        // Build framed records whose total size (~440 KB) far exceeds the
+        // writer's ~64 KB block cap, so the chunk is written as MANY blocks /
+        // frames. That is what actually exercises the per-block decompress and
+        // the downstream record reassembly across block boundaries — the whole
+        // reason `read_blocks` returns per-block `Vec<u8>`s. Each record is
+        // stamped with its index at both ends so a misaligned reassembly is
+        // caught, not just a stream of zeros.
+        let records: Vec<Vec<u8>> = (0usize..80)
+            .map(|i| {
+                let size = 3000 + (i % 13) * 500; // 3000..9000 bytes
+                let mut r = vec![0u8; size];
+                let stamp = u8::try_from(i % 251).expect("i % 251 fits u8");
+                r[0] = stamp;
+                let last = r.len() - 1;
+                r[last] = stamp;
+                r
+            })
+            .collect();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chunk.spill");
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6, codec));
+        {
+            let mut w = PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &path, codec)
+                .expect("writer");
+            for rec in &records {
+                let key = RawCoordinateKey::extract_from_record(rec);
+                w.write_record(&key, rec).expect("write");
+            }
+            w.start_finish().expect("start_finish").wait().expect("finish");
+        }
+
+        // Re-open + position past the codec magic exactly like
+        // slots_for_chunk_files does.
+        let mut file = std::fs::File::open(&path).expect("open");
+        let mut magic = [0u8; 4];
+        let filled = crate::external::read_exact_or_eof(&mut file, &mut magic).expect("magic");
+        let detected = if filled {
+            SpillCodec::from_magic(&magic).unwrap_or(SpillCodec::Bgzf)
+        } else {
+            SpillCodec::Bgzf
+        };
+        assert_eq!(detected, codec, "codec must be detected from the file magic");
+        if matches!(detected, SpillCodec::Bgzf) {
+            use std::io::Seek;
+            file.seek(std::io::SeekFrom::Start(0)).expect("seek");
+        }
+
+        let mut reader = std::io::BufReader::new(file);
+        let mut dec = SpillBlockDecompressor::new();
+        let mut all = Vec::new();
+        loop {
+            let blocks = dec.read_blocks(&mut reader, detected, 4).expect("read_blocks");
+            let got = blocks.len();
+            for b in blocks {
+                all.extend_from_slice(&b);
+            }
+            if got < 4 {
+                break;
+            }
+        }
+
+        // The decompressed stream is `[u32 LE len][record]` per record, in order.
+        let mut cursor = Cursor::new(&all);
+        let mut read_back: Vec<Vec<u8>> = Vec::new();
+        let mut len_buf = [0u8; 4];
+        while Read::read(&mut cursor, &mut len_buf).map(|n| n == 4).unwrap_or(false) {
+            let len = u32::from_le_bytes(len_buf) as usize;
+            let mut rec = vec![0u8; len];
+            cursor.read_exact(&mut rec).expect("record body");
+            read_back.push(rec);
+        }
+        assert_eq!(read_back, records, "round-trip mismatch for {codec:?}");
+    }
+
+    #[test]
+    fn roundtrip_bgzf() {
+        roundtrip(SpillCodec::Bgzf);
+    }
+
+    #[test]
+    fn roundtrip_zstd() {
+        roundtrip(SpillCodec::Zstd);
+    }
+}

--- a/src/lib/pipeline/steps/sort/and_spill.rs
+++ b/src/lib/pipeline/steps/sort/and_spill.rs
@@ -140,17 +140,10 @@ fn finalize_queryname_natural(
 }
 
 fn build_stream(sorter: RawExternalSorter, header: &Header) -> Result<SortStream> {
-    // Pin the spill codec to BGZF for the entire streaming-sort path. The
-    // downstream `SortSpillDecompress` step reads spill chunks as raw BGZF
-    // blocks (`fgumi_bgzf::reader::read_raw_blocks` + per-block inflate); main's
-    // default zstd spill codec (#341) uses an incompatible length-prefixed frame
-    // format that the block-wise read loop would decode to garbage. Enforcing it
-    // here — the single chokepoint for every streaming sorter (chain builder and
-    // tests alike) — makes the invariant impossible to violate at a call site.
-    // Standalone `fgumi sort` keeps zstd via its own sorter in `build_sort_step`;
-    // teaching `SortSpillDecompress` to stream-decode zstd frames is a tracked
-    // perf follow-up.
-    let sorter = sorter.spill_codec(fgumi_sort::SpillCodec::Bgzf);
+    // The streaming-sort path uses whatever spill codec the sorter is configured
+    // for (main's default is zstd, #341). `SortSpillDecompress` detects each
+    // spill chunk's codec from its file magic (`slot.codec`) and decodes BGZF
+    // blocks or zstd frames accordingly, so no codec pinning is needed here.
     match sorter.sort_order() {
         SortOrder::Coordinate => Ok(SortStream::Coordinate(sorter.into_coordinate_stream(header)?)),
         SortOrder::Queryname(_) => Ok(SortStream::Queryname(sorter.into_queryname_stream(header)?)),

--- a/src/lib/pipeline/steps/sort/protocol.rs
+++ b/src/lib/pipeline/steps/sort/protocol.rs
@@ -222,8 +222,11 @@ mod tests {
     #[test]
     fn records_ingested_so_far_accessors() {
         let dummy_path = std::path::PathBuf::from("/tmp/x");
-        let slot =
-            Arc::new(SortMergeSlot::new(0, std::io::BufReader::new(tempfile::tempfile().unwrap())));
+        let slot = Arc::new(SortMergeSlot::new(
+            0,
+            std::io::BufReader::new(tempfile::tempfile().unwrap()),
+            fgumi_sort::SpillCodec::Bgzf,
+        ));
         let ev1 = SortPhase1Event::SpillReady {
             slot: Arc::clone(&slot),
             path: dummy_path.clone(),

--- a/src/lib/pipeline/steps/sort/spill_decompress.rs
+++ b/src/lib/pipeline/steps/sort/spill_decompress.rs
@@ -1,6 +1,7 @@
-//! `SortSpillDecompress` — Parallel typed step that reads raw BGZF
-//! blocks from spill files, decompresses them inline, and pushes the
-//! decompressed bytes into per-slot bounded queues on
+//! `SortSpillDecompress` — Parallel typed step that reads spill chunk
+//! files, decompresses them inline (codec-aware: BGZF blocks or zstd
+//! frames per `slot.codec`, detected from the file magic at slot-open),
+//! and pushes the decompressed bytes into per-slot bounded queues on
 //! `SortMergeSlot`. Replaces the legacy +N `SortWorkerPool::Phase2`
 //! OS threads with framework workers from the unified pipeline's
 //! work-stealing pool.
@@ -47,8 +48,7 @@
 use std::io;
 use std::sync::Arc;
 
-use fgumi_sort::{PHASE2_DECOMP_CAP, SortMergeSlot};
-use libdeflater::Decompressor;
+use fgumi_sort::{PHASE2_DECOMP_CAP, SortMergeSlot, SpillBlockDecompressor};
 use parking_lot::Mutex;
 
 use crate::pipeline::core::Unpushed;
@@ -58,10 +58,6 @@ use crate::pipeline::core::queues::QueueSpec;
 use crate::pipeline::core::reorder::BranchOrdering;
 use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
 use crate::pipeline::steps::sort::protocol::{SortPhase1Event, SortPhase2Event};
-
-/// Per-worker decompression scratch capacity. Matches `BgzfDecompress`'s
-/// constant for the same mimalloc-size-class reuse pattern.
-const DECOMPRESS_SCRATCH_CAPACITY: usize = 256 * 1024;
 
 /// Max raw blocks read+decompressed by a single `try_fill_some_slot`
 /// call. Bounds the per-call work so the framework's round-robin
@@ -89,20 +85,18 @@ struct RegisteredSpill {
 ///
 /// Per-worker:
 ///
-/// * `decompressor: libdeflater::Decompressor` — fresh per worker
-///   copy (constructed in `new_worker_copy`).
-/// * `decompress_scratch: Vec<u8>` — fixed-capacity output buffer
-///   that `decompress_block_slice_into` fills; we `mem::replace` the
-///   filled `Vec` into the per-slot queue then re-allocate fresh.
-///   Mimalloc size-class reuse trick (same as `BgzfDecompress`).
+/// * `block_dec: SpillBlockDecompressor` — fresh per worker copy; the
+///   codec-aware (BGZF block / zstd frame) decompressor that reads +
+///   inflates a batch of blocks and returns owned `Vec<u8>`s for the
+///   per-slot queue (mimalloc size-class buffer reuse inside).
 /// * `held: HeldSlot<Unpushed<SortPhase2Event>>` — backpressure retry
 ///   slot for the forwarded events (`SpillReady`/`MemoryChunk`/
 ///   `AllAnnounced`). The per-slot decompressed queue handles its
 ///   own backpressure separately (producer SKIPs when at cap).
 pub struct SortSpillDecompress {
     registry: Arc<Mutex<Vec<RegisteredSpill>>>,
-    decompressor: Decompressor,
-    decompress_scratch: Vec<u8>,
+    /// Per-worker codec-aware decompressor (BGZF blocks or zstd frames).
+    block_dec: SpillBlockDecompressor,
     held: HeldSlot<Unpushed<SortPhase2Event>>,
     /// Max in-flight forwarded events. `SortSpillDecompress` emits at
     /// most one event per `try_run` (forward from input pop). 64
@@ -116,8 +110,7 @@ impl SortSpillDecompress {
     pub fn new(output_capacity: usize) -> Self {
         Self {
             registry: Arc::new(Mutex::new(Vec::new())),
-            decompressor: Decompressor::new(),
-            decompress_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            block_dec: SpillBlockDecompressor::new(),
             held: HeldSlot::new(),
             output_capacity,
         }
@@ -195,75 +188,37 @@ impl SortSpillDecompress {
             }
             let m = m.min(MAX_BATCH_PER_CALL);
 
-            // Read up to m raw BGZF blocks from disk. `read_raw_blocks`
-            // returns fewer than requested at EOF.
+            // Read + decompress up to m blocks from disk, codec-aware: BGZF
+            // self-framed blocks or zstd `[len][frame]` records, per `slot.codec`
+            // (detected from the file magic at slot-open). `read_blocks` returns
+            // fewer than `m` (incl. 0) at EOF.
             //
-            // **We hold `reader_guard` through decompression + push**
+            // **We hold `reader_guard` through the whole read+decompress + push**
             // for this batch — NOT just through the read. This is the
-            // "I'm the producer for this slot" lock: while held, no
-            // sibling worker can claim this slot, read another batch,
-            // and prematurely set `queue_eof` while our batch is
-            // still in flight. Releasing the reader before
-            // decompression would let a sibling worker see an empty
-            // read on a slot we'd already exhausted and set
-            // `queue_eof` before our batch lands — silently dropping
-            // our decompressed records.
+            // "I'm the producer for this slot" lock: while held, no sibling
+            // worker can claim this slot, read another batch, and prematurely set
+            // `queue_eof` while our batch is still in flight. Releasing the reader
+            // before decompression would let a sibling worker see an empty read on
+            // a slot we'd already exhausted and set `queue_eof` before our batch
+            // lands — silently dropping our decompressed records.
             //
-            // Cost: less per-slot parallelism (one worker
-            // decompresses per slot at a time). Cross-slot
-            // parallelism preserved — different workers handle
-            // different slots.
-            let raw_blocks = match fgumi_bgzf::reader::read_raw_blocks(&mut reader_guard.inner, m) {
-                Ok(v) => v,
-                Err(e) => {
-                    // Mark the slot as errored + EOF so the consumer
-                    // exits cleanly with Err. Release the reader
-                    // first to avoid lock-order issues.
-                    drop(reader_guard);
-                    {
-                        let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
-                        slot.decomp_error.store(true, std::sync::atomic::Ordering::Release);
-                        slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
-                    }
-                    return Err(e);
-                }
-            };
-            let got = raw_blocks.len();
-            let hit_eof = got < m;
-
-            if got == 0 {
-                // Empty read at EOF. Set queue_eof under the
-                // decompressed lock (still holding reader so no
-                // sibling can race).
-                {
-                    let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
-                    slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
-                }
-                drop(reader_guard);
-                return Ok(true);
-            }
-
-            // Decompress all `got` blocks on this worker.
-            let mut decompressed_batch: Vec<Vec<u8>> = Vec::with_capacity(got);
-            for raw in raw_blocks {
-                let decompress_result = fgumi_bgzf::reader::decompress_block_slice_into(
-                    &raw.data,
-                    &mut self.decompressor,
-                    &mut self.decompress_scratch,
-                );
-                match decompress_result {
-                    Ok(()) => {
-                        let bytes = std::mem::replace(
-                            &mut self.decompress_scratch,
-                            Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
-                        );
-                        decompressed_batch.push(bytes);
-                    }
+            // Cost: less per-slot parallelism (one worker decompresses per slot
+            // at a time). Cross-slot parallelism preserved — different workers
+            // handle different slots.
+            let decompressed_batch =
+                match self.block_dec.read_blocks(&mut reader_guard.inner, slot.codec, m) {
+                    Ok(b) => b,
                     Err(e) => {
-                        // Atomic-ordering: hold decompressed lock while
-                        // setting both atomics so consumer sees a
-                        // consistent view via the lock release-acquire
-                        // chain.
+                        // Mark the slot as errored + EOF so the consumer exits
+                        // cleanly with Err. Hold `reader_guard` through the flag
+                        // block (lock order: reader → decompressed, same as the
+                        // success paths below) and drop it AFTER. Dropping the
+                        // reader first would let a sibling worker claim the slot,
+                        // read a clean EOF, and set `queue_eof` WITHOUT
+                        // `decomp_error` in the window — which the consumer (checks
+                        // `decomp_error` then `queue_eof`) would see as a clean
+                        // drain, silently dropping this error and the records after
+                        // it.
                         {
                             let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
                             slot.decomp_error.store(true, std::sync::atomic::Ordering::Release);
@@ -272,7 +227,19 @@ impl SortSpillDecompress {
                         drop(reader_guard);
                         return Err(e);
                     }
+                };
+            let got = decompressed_batch.len();
+            let hit_eof = got < m;
+
+            if got == 0 {
+                // Empty read at EOF. Set queue_eof under the decompressed lock
+                // (still holding reader so no sibling can race).
+                {
+                    let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
+                    slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
                 }
+                drop(reader_guard);
+                return Ok(true);
             }
 
             // Push all decompressed blocks under one decompressed-lock
@@ -302,8 +269,7 @@ impl Clone for SortSpillDecompress {
             // the registry so SpillReady popped by any worker is
             // immediately visible to all others.
             registry: Arc::clone(&self.registry),
-            decompressor: Decompressor::new(),
-            decompress_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            block_dec: SpillBlockDecompressor::new(),
             held: HeldSlot::new(),
             output_capacity: self.output_capacity,
         }


### PR DESCRIPTION
**Stacked PR (stack position 08) of the #330 unified-pipeline landing.** Targets the long-lived integration branch `feat-runall` (not `main`); #398 (consensus rejects fan-out) is its merged predecessor. One commit.

The fused streaming sort previously pinned its temp spill to BGZF because `SortSpillDecompress` could only inflate raw BGZF blocks, while main's standalone sort defaults to the ~3–6×-faster zstd spill codec (#341). Pinning BGZF left the fused path slower than standalone for no good reason.

Make the streaming decompress codec-aware so the fused path can use zstd too:
- Add `SpillBlockDecompressor` (fgumi-sort): a per-worker codec-aware block reader. BGZF chunks decode via libdeflate; zstd "ZSP1" chunks decode frame-by-frame (`[u32 LE len][zstd frame]`).
- Detect each spill chunk's codec from its file magic (`SpillCodec::from_magic`) in `slots_for_chunk_files`, store it on `SortMergeSlot.codec`.
- `SortSpillDecompress` reads `slot.codec` and dispatches via `SpillBlockDecompressor`.
- Remove the BGZF pin in `build_stream`; the streaming sorter now uses main's default (zstd). Standalone sort is unchanged.

**Reconciliation note (important):** stack-03 (#395) had hardened the three `*SortStream` constructors to force `SpillCodec::Bgzf` (a CodeRabbit-CLI hardening — correct while the decoder was BGZF-only). That premise is now gone (the decoder is codec-aware), and leaving the force in place would *silently defeat* this PR's whole purpose — `build_stream` would hand a zstd sorter to a constructor that overrode it back to BGZF, so the spill would still be BGZF and tests would stay green. This PR therefore also **reverts that constructor force** (restores `self.spill_codec`), which both enables zstd and removes the now-unnecessary foot-gun (the codec-aware decoder reads any codec from magic). This interaction was caught in a pre-PR local review, not by the textual rebase.

**Validation:** round-trip unit tests for both codecs; the three-step streaming chain matches legacy sort output with **zstd** spill across all orders (in-memory + forced multi-spill + large-spill 60k records, t1–t8). Local: `fgumi-sort` 469/469, `three_step_chain` 14/14. clippy + fmt clean.
