### PR TITLE
fix(group): name SS:template-coordinate in reject message; widen compile-fail test timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,10 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+# The trybuild compile-fail suite (`tests/compile_fail.rs`) invokes `rustc` once
+# per fail-case; on a cold build cache the whole run can exceed the default 120s
+# terminate cap (2 × 60s), causing intermittent CI timeouts that have nothing to
+# do with the code under test. Give just that binary headroom.
+[[profile.default.overrides]]
+filter = 'binary(compile_fail)'
+slow-timeout = { period = "120s", terminate-after = 5 }

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -887,7 +887,8 @@ impl Command for GroupReadsByUmi {
                     );
                 } else {
                     bail!(
-                        "Input BAM must be template-coordinate sorted.\n\n\
+                        "Input BAM must be template-coordinate sorted (header must advertise \
+                        SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
                         To sort your BAM file, run:\n  \
                         fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
                     );

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2181,7 +2181,8 @@ impl<'a> ChainBuilder<'a> {
                 );
             }
             bail!(
-                "Input BAM must be template-coordinate sorted.\n\n\
+                "Input BAM must be template-coordinate sorted (header must advertise \
+                SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
                 To sort your BAM file, run:\n  \
                 fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
             );


### PR DESCRIPTION
**Hotfix against `feat-runall`** (not a stack-position PR) — un-reddens the integration branch's CI, which has two independent problems:

**1. `group` sort-order rejection message.** On both the single-threaded `commands::group` path and the multi-threaded chain-builder path, the template-coordinate-sort rejection emitted a terse *"Input BAM must be template-coordinate sorted."*. The test `test_e2e_regression::test_group_rejects_extract_output_without_sort_step` (already on `feat-runall`) asserts the message names the required **`SS:template-coordinate`** tag — the actionable form. The satisfying edit otherwise lands only in **#381** (host-aware `--max-memory`), far later in the #330 stack, so `feat-runall`, the already-merged **#398**, and **#399** have all been red on this test. Pulled the two-site message edit forward here; #381's identical change becomes a no-op on rebase.

**2. `compile_fail` nextest timeout.** The trybuild compile-fail suite (`tests/compile_fail.rs`) invokes `rustc` per fail-case; on a cold build cache the run exceeds the default 120 s terminate cap (2 × 60 s), intermittently timing out in CI for reasons unrelated to the code. Adds a `binary(compile_fail)` override raising its cap (5 × 120 s).

Verified: the group test passes; full `cargo ci-test` otherwise green. +12/−2 across `group.rs`, `builder.rs`, `.config/nextest.toml`.
