### PR TITLE
feat(sort): surface merged-record count from the streaming SortMerge step

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -7744,4 +7744,33 @@ mod from_slots_merge_tests {
         let emitted = drain_merge_driver_bytes(driver);
         assert_eq!(emitted, vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()]);
     }
+
+    #[test]
+    fn from_slots_records_merged_equals_emitted_total() {
+        // `records_merged()` (surfaced by `SortMerge` at completion) must equal
+        // the number of records actually emitted across all sources.
+        let f0: Vec<(TestKey, Vec<u8>)> =
+            (0u64..15).map(|i| (TestKey(i * 2), format!("a-{i:02}").into_bytes())).collect();
+        let f1: Vec<(TestKey, Vec<u8>)> =
+            (0u64..15).map(|i| (TestKey(i * 2 + 1), format!("b-{i:02}").into_bytes())).collect();
+        let total = (f0.len() + f1.len()) as u64;
+
+        let slots = vec![populated_slot(0, &f0, 3), populated_slot(1, &f1, 2)];
+        let mut driver = MergeDriver::<TestKey>::from_slots(slots, Vec::new(), total);
+
+        let mut emitted = 0u64;
+        loop {
+            match driver.try_step().expect("try_step") {
+                MergeStep::Produced(_) => emitted += 1,
+                MergeStep::Done => break,
+                MergeStep::Stalled => panic!("unexpected Stalled on pre-populated EOF slots"),
+            }
+        }
+        assert_eq!(emitted, total, "should emit every input record");
+        assert_eq!(
+            driver.records_merged(),
+            total,
+            "records_merged must equal the emitted record count"
+        );
+    }
 }

--- a/src/lib/pipeline/steps/sort/merge.rs
+++ b/src/lib/pipeline/steps/sort/merge.rs
@@ -165,8 +165,10 @@ enum NextBatch {
     /// The merge driver stalled on a not-yet-ready slot. Carries any
     /// partially-filled batch to flush before yielding.
     Stalled(Option<RecordBatch>),
-    /// The merge is exhausted. Carries any final partial batch to flush.
-    Done(Option<RecordBatch>),
+    /// The merge is exhausted. Carries any final partial batch to flush, plus
+    /// the driver's total `records_merged()` — read in `next_batch` while the
+    /// driver is still in scope — for the completion log.
+    Done(Option<RecordBatch>, u64),
 }
 
 /// Three-phase state machine for [`SortMerge`].
@@ -474,7 +476,10 @@ impl SortMerge {
                     return Ok(NextBatch::Stalled(flush_partial(builder, next_ordinal)));
                 }
                 MergeStep::Done => {
-                    return Ok(NextBatch::Done(flush_partial(builder, next_ordinal)));
+                    return Ok(NextBatch::Done(
+                        flush_partial(builder, next_ordinal),
+                        driver.records_merged(),
+                    ));
                 }
             }
         }
@@ -529,7 +534,7 @@ impl SortMerge {
                         StepOutcome::Contention
                     });
                 }
-                NextBatch::Done(partial) => {
+                NextBatch::Done(partial, merged) => {
                     if let Some(batch) = partial {
                         if let Err(unpushed) = ctx.outputs.push(batch) {
                             self.held.put(unpushed);
@@ -539,6 +544,10 @@ impl SortMerge {
                         }
                         delivered += 1;
                     }
+                    // Surface the merged-record count carried up from `next_batch`
+                    // (where the driver was in scope). The streaming sort's
+                    // analogue of standalone sort's Records-written summary.
+                    log::info!("Sort merge complete: {merged} records merged");
                     self.state = SortMergeState::Done;
                     return Ok(if delivered > 0 {
                         StepOutcome::Progress


### PR DESCRIPTION
**Stacked PR (stack position 09) of the #330 unified-pipeline landing.** Targets `feat-runall`; #399 (codec-aware spill decompress) is its merged predecessor. One commit.

`MergeDriverDyn::records_merged()` was write-only — incremented during the merge but never read. This logs it from `SortMerge` when the driver is exhausted (the streaming-sort analogue of standalone sort's Records-written summary), so the fused-sort path reports how many records the merge emitted. Adds a unit test asserting `records_merged()` equals the emitted record count across multi-slot/multi-block input.

+38 across `crates/fgumi-sort/src/external.rs` (test) and `src/lib/pipeline/steps/sort/merge.rs` (the completion log). Dual local review (coderabbit CLI + `/coderabbitai-review`): **0 findings**.
