### PR TITLE
perf(decode,group): cache UMI tag position during decode to skip a duplicate aux scan (#334/#343)

### DIFF
--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -180,16 +180,66 @@ pub struct DecodedRecord {
     pub key: GroupKey,
     /// Raw BAM record bytes.
     pub(crate) data: RawRecord,
+    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
+    /// first byte after the 2-byte tag header and the 1-byte type byte). The
+    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
+    /// the UMI bytes without the trailing NUL.
+    ///
+    /// Set to [`Self::UMI_OFFSET_UNCACHED`] when no UMI position was cached
+    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
+    pub(crate) umi_value_offset: u32,
+    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
+    pub(crate) umi_value_len: u16,
 }
 
 impl DecodedRecord {
+    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
+    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
+    /// offset (BAM records are bounded well under 4 GiB).
+    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+
     /// Create a decoded record from raw bytes, skipping noodles decode.
     ///
     /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
     /// an already-constructed `RawRecord`).
     #[must_use]
     pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
-        Self { key, data: raw.into() }
+        Self {
+            key,
+            data: raw.into(),
+            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
+            umi_value_len: 0,
+        }
+    }
+
+    /// Attach a cached UMI value position to this decoded record.
+    ///
+    /// `umi_value_offset` is the record-relative offset of the first UMI value
+    /// byte (after the tag header), and `umi_value_len` is the value length
+    /// (excluding any trailing NUL).
+    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
+        self.umi_value_offset = umi_value_offset;
+        self.umi_value_len = umi_value_len;
+    }
+
+    /// Returns the cached UMI bytes (without trailing NUL) if a position was
+    /// recorded during decode and still falls within the raw record bytes.
+    /// Returns `None` if no cache is set or the cached position is out of range.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            return None;
+        }
+        let start = self.umi_value_offset as usize;
+        let end = start.checked_add(self.umi_value_len as usize)?;
+        self.data.as_ref().get(start..end)
+    }
+
+    /// Returns the cached UMI offset ([`Self::UMI_OFFSET_UNCACHED`] when absent)
+    /// and length.
+    #[must_use]
+    pub fn cached_umi_position(&self) -> (u32, u16) {
+        (self.umi_value_offset, self.umi_value_len)
     }
 
     /// Returns a reference to the raw bytes.
@@ -246,6 +296,12 @@ pub struct GroupKeyConfig {
     /// [`GroupKey::name_hash`] — it skips the CIGAR 5′-position walk and the
     /// aux-tag (RG/CB/MC) extraction pass entirely. See [`name_hash_key`].
     pub name_hash_only: bool,
+    /// UMI tag (raw 2-byte form) whose value position should be cached on each
+    /// [`DecodedRecord`] during decode. `None` disables caching — downstream
+    /// code must fall back to scanning aux data. This is orthogonal to
+    /// `name_hash_only`: the UMI cache scan is gated solely on `umi_tag` being
+    /// set (in practice only the Group stage sets it).
+    pub umi_tag: Option<[u8; 2]>,
 }
 
 impl GroupKeyConfig {
@@ -256,13 +312,19 @@ impl GroupKeyConfig {
             library_index: Arc::new(library_index),
             cell_tag: Some(cell_tag),
             name_hash_only: false,
+            umi_tag: None,
         }
     }
 
     /// Create a `GroupKeyConfig` without cell barcode extraction.
     #[must_use]
     pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None, name_hash_only: false }
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: false,
+            umi_tag: None,
+        }
     }
 
     /// Create a `GroupKeyConfig` that computes only the read-name hash.
@@ -273,7 +335,23 @@ impl GroupKeyConfig {
     /// the config shape is uniform across the pipeline.
     #[must_use]
     pub fn name_hash_only(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None, name_hash_only: true }
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: true,
+            umi_tag: None,
+        }
+    }
+
+    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
+    ///
+    /// The Decode step will record the UMI value's record-relative position on
+    /// each [`DecodedRecord`] so downstream UMI lookups can slice it directly
+    /// via [`DecodedRecord::cached_umi`] without re-scanning aux data.
+    #[must_use]
+    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
+        self.umi_tag = Some(umi_tag);
+        self
     }
 }
 
@@ -283,6 +361,7 @@ impl Default for GroupKeyConfig {
             library_index: Arc::new(LibraryIndex::default()),
             cell_tag: Some(Tag::from([b'C', b'B'])), // Default cell barcode tag (CB)
             name_hash_only: false,
+            umi_tag: None,
         }
     }
 }

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -1448,6 +1448,7 @@ mod tests {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         assert!(!filter_template(&template, &config, &mut metrics));
@@ -1500,6 +1501,7 @@ mod tests {
             r1_secondaries: Some((2, 3)),
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         assert!(!filter_template(&template, &config, &mut metrics));

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -719,7 +719,12 @@ fn assign_umi_groups_for_indices_impl(
         } else {
             use fgumi_raw_bam;
 
-            let umi_bytes = if let Some(r1_raw) = template.r1() {
+            // Prefer the UMI position cached during the parallel Decode step
+            // (#334). The fallback exists for templates built outside the Decode
+            // path (e.g. tests, SAM input) and when the cache was not recorded.
+            let umi_bytes = if let Some(cached) = template.cached_umi() {
+                cached
+            } else if let Some(r1_raw) = template.r1() {
                 let aux = fgumi_raw_bam::aux_data_slice(r1_raw);
                 fgumi_raw_bam::find_string_tag(aux, raw_tag)
                     .ok_or_else(|| anyhow::anyhow!("Missing UMI tag"))?
@@ -5339,6 +5344,7 @@ mod tests {
             r1_secondaries: Some((2, 3)),
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         let config = GroupFilterConfig {
@@ -5388,6 +5394,7 @@ mod tests {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: crate::umi::MoleculeId::None,
+            cached_umi_position: None,
         };
 
         let config = GroupFilterConfig {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -649,7 +649,10 @@ fn group_by_name_and_build<T>(
 ///
 /// Returns an error if template construction from records fails.
 pub fn build_templates_from_records(records: Vec<DecodedRecord>) -> io::Result<Vec<Template>> {
-    group_by_name_and_build(records, |d| Ok(d.into_raw_bytes()), Template::from_records)
+    // Pass the `DecodedRecord`s through (not just their raw bytes) so the UMI
+    // value position cached during decode (#334) is propagated onto each
+    // `Template` via `from_decoded_records`.
+    group_by_name_and_build(records, Ok, Template::from_decoded_records)
 }
 
 use crate::fastq_parse::{FastqRecord, parse_fastq_records, strip_read_suffix};

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -797,7 +797,17 @@ impl<'a> ChainBuilder<'a> {
         use noodles::sam::alignment::record::data::field::Tag;
         let cell_tag = Tag::from(SamTag::CB);
         let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
-        fgumi_bam_io::GroupKeyConfig::new(library_index, cell_tag)
+        let config = fgumi_bam_io::GroupKeyConfig::new(library_index, cell_tag);
+        // When a Group stage is in the chain, cache the UMI (RX) value position
+        // during decode so `fgumi group`'s per-template UMI-assignment lookup can
+        // slice it without re-scanning aux data (#334). Group's UMI tag is fixed
+        // to RX (see `add_group`'s `raw_tag`). Chains without a Group stage skip
+        // the cache to avoid the extra per-record aux scan.
+        if self.spec.stages.contains(&Stage::Group) {
+            config.with_umi_tag(*SamTag::RX)
+        } else {
+            config
+        }
     }
 
     /// Group-key config for the **source preamble's** `DecodeRecords`.
@@ -1940,10 +1950,7 @@ impl<'a> ChainBuilder<'a> {
             use crate::pipeline::steps::serialize_record_batch::SerializeRecordBatch;
             use crate::pipeline::steps::sort::{SortAndSpill, SortMerge, SortSpillDecompress};
             use crate::sam::SamTag;
-            use fgumi_bam_io::GroupKeyConfig;
-            use fgumi_bam_io::LibraryIndex;
             use fgumi_sort::{RawExternalSorter, SortOrder};
-            use noodles::sam::alignment::record::data::field::Tag;
 
             // Auto isn't supported in a fused chain (sort shares the budget with
             // the other stages); require a fixed value.
@@ -2042,9 +2049,11 @@ impl<'a> ChainBuilder<'a> {
                 }
             } else {
                 // Intermediate: decode to DecodedRecordBatch for downstream stages.
-                let cell_tag = Tag::from(SamTag::CB);
-                let library_index = LibraryIndex::from_header(&self.header);
-                let group_key_config = GroupKeyConfig::new(library_index, cell_tag);
+                // Route through `bam_group_key_config` so a `[Sort, Group]` chain
+                // still caches the UMI (RX) value position during this decode —
+                // otherwise group would re-scan aux per template and lose the
+                // #334/#343 optimization on the sort→group path.
+                let group_key_config = self.bam_group_key_config();
                 let tail = self.pipeline.append_step(
                     DecodeFromRecords::new(group_key_config, self.tuning.per_step_byte_limit),
                     merge_tail,

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -40,6 +40,34 @@ use crate::pipeline::steps::parse::bam::parse_records;
 use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock, RecordBatch};
 use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
 
+/// Cache the UMI tag's value position on a `DecodedRecord` during decode.
+///
+/// Looks up `umi_tag` in the record's aux data and, when present and Z-typed,
+/// stores the record-relative offset of its value bytes (excluding the trailing
+/// NUL) via [`DecodedRecord::set_cached_umi`]. The UMI-assignment step can then
+/// slice the value through [`DecodedRecord::cached_umi`] instead of re-scanning
+/// aux data once per template. When the tag is absent or not Z-typed the cache
+/// is left in the `UMI_OFFSET_UNCACHED` state and downstream code falls back to
+/// scanning aux data. Issue #334.
+fn cache_umi_position(decoded: &mut DecodedRecord, umi_tag: [u8; 2]) {
+    let raw = decoded.raw_bytes();
+    let Some(aux_offset) = fgumi_raw_bam::aux_data_offset_from_record(raw) else {
+        return;
+    };
+    let aux = &raw[aux_offset..];
+    let Some((value_off_in_aux, value_len)) = fgumi_raw_bam::find_string_tag_position(aux, umi_tag)
+    else {
+        return;
+    };
+    let Ok(aux_offset_u32) = u32::try_from(aux_offset) else {
+        return;
+    };
+    let Some(value_offset) = aux_offset_u32.checked_add(value_off_in_aux) else {
+        return;
+    };
+    decoded.set_cached_umi(value_offset, value_len);
+}
+
 /// `Parallel + ByItemOrdinal` parse + decode. `DecompressedBlock →
 /// DecodedRecordBatch`.
 pub struct DecodeRecords {
@@ -113,6 +141,7 @@ impl Step for DecodeRecords {
         let library_index: &Arc<_> = &self.key_config.library_index;
         let cell_tag = self.key_config.cell_tag;
         let name_hash_only = self.key_config.name_hash_only;
+        let umi_tag = self.key_config.umi_tag;
         let decoded: Vec<DecodedRecord> = records
             .into_iter()
             .map(|raw| {
@@ -123,7 +152,13 @@ impl Step for DecodeRecords {
                 } else {
                     compute_group_key_from_raw(raw.as_ref(), library_index, cell_tag)
                 };
-                DecodedRecord::from_raw_bytes(raw, key)
+                let mut decoded = DecodedRecord::from_raw_bytes(raw, key);
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                decoded
             })
             .collect();
 
@@ -215,6 +250,7 @@ impl Step for DecodeFromRecords {
 
         let library_index: &Arc<_> = &self.key_config.library_index;
         let cell_tag = self.key_config.cell_tag;
+        let umi_tag = self.key_config.umi_tag;
         // `DecodedRecord` owns its bytes (via `RawRecord`), so we materialize
         // a heap-allocated copy here. The `RecordBatch`'s shared backing
         // buffer is dropped once this batch is consumed.
@@ -222,7 +258,16 @@ impl Step for DecodeFromRecords {
             .iter_record_bytes()
             .map(|bytes| {
                 let key = compute_group_key_from_raw(bytes, library_index, cell_tag);
-                DecodedRecord::from_raw_bytes(fgumi_raw_bam::RawRecord::from(bytes.to_vec()), key)
+                let mut decoded = DecodedRecord::from_raw_bytes(
+                    fgumi_raw_bam::RawRecord::from(bytes.to_vec()),
+                    key,
+                );
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                decoded
             })
             .collect();
 
@@ -307,5 +352,54 @@ mod tests {
                 "name_hash_only must leave all non-name fields at default"
             );
         }
+    }
+
+    // ========================================================================
+    // UMI position caching during Decode (issue #334)
+    // ========================================================================
+
+    #[test]
+    fn cache_umi_position_records_value_offset_matching_fallback() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        b.add_string_tag(SamTag::RX, b"ACGTACGT");
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        // The cached slice must equal the canonical find_string_tag answer.
+        let aux = fgumi_raw_bam::aux_data_slice(decoded.raw_bytes());
+        let expected = fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).expect("RX present");
+        assert_eq!(decoded.cached_umi(), Some(expected));
+        assert_eq!(decoded.cached_umi().unwrap(), b"ACGTACGT");
+    }
+
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_tag_missing() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        // Record with no RX tag — caching must be a no-op.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
     }
 }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -75,6 +75,12 @@ pub struct Template {
     pub r2_secondaries: Option<(usize, usize)>,
     /// Assigned molecule ID from UMI grouping (set during group command)
     pub mi: MoleculeId,
+    /// Cached UMI value position `(record_relative_offset, len)` for the primary
+    /// read returned by `r1().or(r2())`. Populated by
+    /// [`Template::from_decoded_records`] when the decode step recorded a UMI
+    /// position; left `None` by [`Template::from_records`] so callers fall back
+    /// to `find_string_tag`. See [`Template::cached_umi`] for the accessor.
+    pub cached_umi_position: Option<(u32, u16)>,
 }
 
 /// A batch of templates for parallel processing.
@@ -98,7 +104,46 @@ impl Template {
             r1_secondaries: None,
             r2_secondaries: None,
             mi: MoleculeId::None,
+            cached_umi_position: None,
         }
+    }
+
+    /// Build a [`Template`] from decoded records, preserving the UMI value
+    /// position cached on the primary read during the decode step.
+    ///
+    /// The primary read is chosen with the same priority used by
+    /// [`Template::r1`] / [`Template::r2`]: the first non-secondary,
+    /// non-supplementary R1 (or, failing that, R2). When that record carries a
+    /// cached UMI position, it is recorded on the returned template so
+    /// downstream UMI lookups can slice the value directly via
+    /// [`Template::cached_umi`] without re-scanning aux data.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Template::from_records`].
+    pub fn from_decoded_records(records: Vec<fgumi_bam_io::DecodedRecord>) -> Result<Self> {
+        let cached = primary_read_cached_umi(&records);
+
+        let raw_records: Vec<RawRecord> =
+            records.into_iter().map(fgumi_bam_io::DecodedRecord::into_raw_bytes).collect();
+        let mut template = Self::from_records(raw_records)?;
+        template.cached_umi_position = cached;
+        Ok(template)
+    }
+
+    /// Returns the cached UMI value bytes (without trailing NUL) for this
+    /// template's primary read, if a position was recorded during decode and
+    /// still falls within the primary record's bytes.
+    ///
+    /// Returns `None` when no UMI cache is set, when neither R1 nor R2 is
+    /// present, or when the cached position would slice outside the record.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        let (offset, len) = self.cached_umi_position?;
+        let raw = self.r1().or_else(|| self.r2())?;
+        let start = offset as usize;
+        let end = start.checked_add(len as usize)?;
+        raw.as_ref().get(start..end)
     }
 
     /// Approximate heap footprint in bytes — the sum of all member records'
@@ -231,6 +276,7 @@ impl Template {
                         r1_secondaries: None,
                         r2_secondaries: None,
                         mi: MoleculeId::None,
+                        cached_umi_position: None,
                     });
                 }
                 // Both R1 or both R2 — fall through to general path for error handling
@@ -352,6 +398,7 @@ impl Template {
             r1_secondaries: r1_sec_pair,
             r2_secondaries: r2_sec_pair,
             mi: MoleculeId::None,
+            cached_umi_position: None,
         })
     }
 
@@ -701,6 +748,51 @@ impl Template {
             fgumi_raw_bam::remove_tag(rr[unmapped_i].as_mut_vec(), SamTag::MC);
         }
         fgumi_raw_bam::set_template_length(&mut rr[unmapped_i], 0);
+    }
+}
+
+/// Pick the cached UMI position from the primary read that
+/// [`Template::cached_umi`] will resolve against.
+///
+/// Mirrors the priority used by [`Template::from_records`]: the first
+/// non-secondary, non-supplementary R1 (or, if no R1 is present, the first
+/// non-secondary, non-supplementary R2). Records without a cached UMI position
+/// return `None` even when found, so the downstream consumer falls back to
+/// scanning aux data.
+fn primary_read_cached_umi(records: &[fgumi_bam_io::DecodedRecord]) -> Option<(u32, u16)> {
+    use fgumi_raw_bam;
+
+    let mut primary_r2: Option<&fgumi_bam_io::DecodedRecord> = None;
+
+    for decoded in records {
+        let flg = RawRecordView::new(decoded.raw_bytes()).flags();
+        let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
+        let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
+        if is_secondary || is_supplementary {
+            continue;
+        }
+        let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
+        let is_first = (flg & fgumi_raw_bam::flags::FIRST_SEGMENT) != 0;
+        let is_r1 = !is_paired || is_first;
+
+        if is_r1 {
+            let (offset, len) = decoded.cached_umi_position();
+            if offset == fgumi_bam_io::DecodedRecord::UMI_OFFSET_UNCACHED {
+                return None;
+            }
+            return Some((offset, len));
+        }
+        if primary_r2.is_none() {
+            primary_r2 = Some(decoded);
+        }
+    }
+
+    let r2 = primary_r2?;
+    let (offset, len) = r2.cached_umi_position();
+    if offset == fgumi_bam_io::DecodedRecord::UMI_OFFSET_UNCACHED {
+        None
+    } else {
+        Some((offset, len))
     }
 }
 
@@ -2528,5 +2620,90 @@ mod tests {
             let result = mi.write_with_offset(100, &mut buf);
             assert_eq!(result, expected.as_bytes(), "Mismatch for {mi:?}");
         }
+    }
+
+    // ========================================================================
+    // Template::from_decoded_records / cached_umi (issue #334)
+    // ========================================================================
+
+    /// Build a raw record carrying an RX UMI tag with the given flags.
+    fn raw_with_umi(name: &[u8], flags: u16, umi: &[u8]) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flags);
+        b.add_string_tag(SamTag::RX, umi);
+        b.build()
+    }
+
+    /// Wrap a raw record in a `DecodedRecord` with its RX value position cached,
+    /// exactly as the Decode step's `cache_umi_position` would.
+    fn decoded_with_cached_umi(raw: RawRecord) -> fgumi_bam_io::DecodedRecord {
+        let bytes = raw.as_ref();
+        let aux_offset =
+            fgumi_raw_bam::aux_data_offset_from_record(bytes).expect("aux offset present");
+        let aux = &bytes[aux_offset..];
+        let (off_in_aux, len) =
+            fgumi_raw_bam::find_string_tag_position(aux, SamTag::RX).expect("RX tag present");
+        let offset = u32::try_from(aux_offset).expect("aux offset fits u32") + off_in_aux;
+        let mut d =
+            fgumi_bam_io::DecodedRecord::from_raw_bytes(raw, fgumi_bam_io::GroupKey::default());
+        d.set_cached_umi(offset, len);
+        d
+    }
+
+    #[test]
+    fn from_decoded_records_propagates_r1_umi_cache() {
+        // R1 carries RX:Z:ACGTACGT, R2 carries RX:Z:OTHERUMI; the assigner reads
+        // from R1 first, so the cached slice must match R1's UMI.
+        let r1 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"ACGTACGT");
+        let r2 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ2, b"OTHERUMI");
+        let decoded = vec![decoded_with_cached_umi(r1), decoded_with_cached_umi(r2)];
+        let template = Template::from_decoded_records(decoded).expect("template builds");
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()));
+    }
+
+    #[test]
+    fn from_decoded_records_falls_back_to_r2_when_no_r1() {
+        // Only an R2 primary is present; the cache must come from that record.
+        let r2 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ2, b"R2ONLY");
+        let template =
+            Template::from_decoded_records(vec![decoded_with_cached_umi(r2)]).expect("builds");
+        assert_eq!(template.cached_umi(), Some(b"R2ONLY".as_ref()));
+    }
+
+    #[test]
+    fn from_decoded_records_no_cache_when_primary_uncached() {
+        // R1 has the UMI tag but no cached position; the template must report no
+        // cached UMI so callers fall back to find_string_tag.
+        let r1 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"ACGT");
+        let decoded =
+            fgumi_bam_io::DecodedRecord::from_raw_bytes(r1, fgumi_bam_io::GroupKey::default());
+        let template = Template::from_decoded_records(vec![decoded]).expect("builds");
+        assert!(template.cached_umi().is_none());
+        assert!(template.cached_umi_position.is_none());
+    }
+
+    #[test]
+    fn from_decoded_records_ignores_supplementary() {
+        // The first record is a supplementary alignment whose cache must be
+        // ignored; the second is the primary R1 and its cache must be used.
+        let supp =
+            raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1 | FLAG_SUPPLEMENTARY, b"SUPPUMI");
+        let primary = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"PRIMARYY");
+        let decoded = vec![decoded_with_cached_umi(supp), decoded_with_cached_umi(primary)];
+        let template = Template::from_decoded_records(decoded).expect("builds");
+        assert_eq!(template.cached_umi(), Some(b"PRIMARYY".as_ref()));
+    }
+
+    #[test]
+    fn cached_umi_matches_find_string_tag_fallback() {
+        // The cached slice must equal the canonical find_string_tag answer — the
+        // optimization and the fallback must agree byte-for-byte.
+        let r1 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"GGTTCCAA");
+        let template =
+            Template::from_decoded_records(vec![decoded_with_cached_umi(r1)]).expect("builds");
+        let primary = template.r1().expect("r1 present");
+        let aux = fgumi_raw_bam::aux_data_slice(primary);
+        let expected = fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).expect("RX present");
+        assert_eq!(template.cached_umi(), Some(expected));
     }
 }


### PR DESCRIPTION
## Summary

The parallel Decode step already scans each record's aux data for the group key (RG/CB/MC). With this change, when a Group stage is in the chain it also records the UMI (RX) tag's value position on each `DecodedRecord` (`umi_value_offset: u32`, `umi_value_len: u16`). Template construction propagates the cached position to `Template::cached_umi_position`, and `fgumi group`'s UMI-assignment hot loop slices the value via `Template::cached_umi` instead of calling `find_string_tag` a second time per template (#334/#343).

This is a **re-application** onto the #330 pipeline (the decode path moved into `fgumi-bam-io` + `pipeline/steps/parse` since #334/#343 were authored), not a cherry-pick.

## Correctness (byte-identical output)

The cache is a pure optimization — output is byte-identical to the `find_string_tag` fallback:

- Records built outside the Decode path (tests, SAM input, the single-threaded group path) leave the cache at the `UMI_OFFSET_UNCACHED` sentinel and fall back to `find_string_tag`.
- `cache_umi_position` reuses `find_string_tag_position` and guards every `u32`/`u16` cast with `try_from`/`checked_add`, falling back to UNCACHED on overflow; `cached_umi` re-bounds-checks the slice.
- A fallback-agreement unit test asserts `cached_umi == find_string_tag`, and the group/dedup determinism + runall parity suites pass unchanged.

`dedup` keeps its own `find_string_tag` path and ignores the cache, so it is byte-identical by construction.

## Stack context

Part of the issue #330 unified-pipeline landing onto `feat-runall` (one commit per PR). Dual-reviewed before push; the CodeRabbit CLI caught (and this commit fixes) a `[Sort, Group]` path where the intermediate-sort `DecodeFromRecords` was rebuilding `GroupKeyConfig` without the UMI tag — dropping the cache (no correctness impact, but it silently lost the optimization on fused sort→group chains via runall). Now routed through `bam_group_key_config()` like the direct-group path; verified by the `Sort → Group/Simplex/Duplex/Codec` parity suite.