### PR TITLE
fix(codec,simplex): read stdin once on the single-threaded path (was double-opened)

### DIFF
--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -163,6 +163,21 @@ fn open_bgzf_reader(
     threads: usize,
     label: &str,
 ) -> Result<BgzfReaderEnum> {
+    // stdin can't be re-opened: `File::open("-")` fails outright, and
+    // `File::open("/dev/stdin")` re-reads fd 0 — losing any bytes a caller
+    // already consumed. Read the process stdin directly so this BGZF reader is
+    // the sole consumer (fixes the codec single-threaded double-open data loss).
+    if is_stdin_path(path) {
+        // Honor --async-reader for stdin too (parity with the file path below):
+        // a pipe benefits from prefetch overlapping upstream production with us.
+        let reader: Box<dyn Read + Send> = if opts.async_reader {
+            log::info!("async {label} enabled: spawning fgumi-prefetch thread for stdin");
+            Box::new(crate::prefetch_reader::PrefetchReader::new(io::stdin()))
+        } else {
+            Box::new(io::stdin())
+        };
+        return Ok(make_bgzf_reader(reader, threads));
+    }
     let file = File::open(path)
         .with_context(|| format!("Failed to open input BAM: {}", path.display()))?;
     crate::os_hints::advise_sequential(&file);

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -333,24 +333,18 @@ impl Command for Codec {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        // Single-threaded fast path is BAM-only: it goes straight through
-        // create_raw_bam_reader_with_opts (BgzfReader-backed). Reject SAM
-        // up front with a clear error.
-        if let crate::pipeline::steps::source::InputSource::Sam { .. } =
-            crate::pipeline::steps::source::InputSource::open_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?
-        {
-            bail!(
-                "SAM input requires --threads N (single-threaded codec path is BAM-only; \
-                 the multi-threaded path handles SAM via ReadSamChunks + ParseSamChunk)"
-            );
-        }
-
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        // Single-threaded fast path is BAM-only. Open the raw reader ONCE and
+        // derive the header from it — this is the sole open of the input. Do NOT
+        // pre-open to sniff SAM-vs-BAM: a second open double-consumes stdin and
+        // loses the leading bytes (stdin can't be rewound or re-opened). SAM
+        // input (not BGZF) fails the header read here; surface the --threads hint.
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
+                .with_context(|| {
+                    "Failed to open input as BAM. The single-threaded codec path is BAM-only; \
+                     if this is SAM input, pass --threads N to use the SAM-capable \
+                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
+                })?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -436,9 +436,17 @@ impl Command for Duplex {
             return crate::pipeline::chains::build_for(spec)?.run();
         }
 
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        // Single-threaded fast path is BAM-only: open the raw reader once and
+        // derive the header from it. SAM input (not BGZF) fails the header read
+        // here; surface the --threads hint instead of a cryptic BGZF-magic error
+        // (mirrors the codec/simplex single-threaded paths).
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
+                .with_context(|| {
+                    "Failed to open input as BAM. The single-threaded duplex path is BAM-only; \
+                     if this is SAM input, pass --threads N to use the SAM-capable \
+                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
+                })?;
         let header = crate::commands::common::add_pg_record(header, command_line)?;
         let read_name_prefix = self.read_group.prefix_or_from_header(&header);
         let methylation_ref: MethylationRef =

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -382,25 +382,18 @@ impl Command for Simplex {
             return crate::pipeline::chains::build_for(spec)?.run();
         }
 
-        // Single-threaded fast path is BAM-only: it goes straight through
-        // create_raw_bam_reader_with_opts (BgzfReader-backed). Reject SAM
-        // up front with a clear error rather than the cryptic
-        // "invalid BGZF magic" that would come out of BgzfReader.
-        if let crate::pipeline::steps::source::InputSource::Sam { .. } =
-            crate::pipeline::steps::source::InputSource::open_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?
-        {
-            bail!(
-                "SAM input requires --threads N (single-threaded simplex path is BAM-only; \
-                 the multi-threaded path handles SAM via ReadSamChunks + ParseSamChunk)"
-            );
-        }
-
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
+        // Single-threaded fast path is BAM-only. Open the raw reader ONCE and
+        // derive the header from it — this is the sole open of the input. Do NOT
+        // pre-open to sniff SAM-vs-BAM: a second open double-consumes stdin and
+        // loses the leading bytes (stdin can't be rewound or re-opened). SAM
+        // input (not BGZF) fails the header read here; surface the --threads hint.
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
+                .with_context(|| {
+                    "Failed to open input as BAM. The single-threaded simplex path is BAM-only; \
+                     if this is SAM input, pass --threads N to use the SAM-capable \
+                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
+                })?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -188,6 +188,180 @@ fn test_simplex_command_with_piped_input() {
     compare_bam_records(&output_from_file, &output_from_pipe);
 }
 
+/// Single-threaded `simplex` (no `--threads`) must read stdin exactly once.
+/// The single-threaded path previously pre-sniffed SAM-vs-BAM via `InputSource`
+/// (consuming stdin) and then re-opened the input, so `-i -` failed outright and
+/// `-i /dev/stdin` silently dropped the leading bytes. The multi-threaded test
+/// above does not exercise this path — which is why the double-open shipped.
+/// Reading the same grouped BAM from a file vs piped stdin must yield
+/// byte-identical consensus records.
+#[test]
+fn test_simplex_single_threaded_reads_stdin_once() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_from_file = temp_dir.path().join("output_file.bam");
+    let output_from_pipe = temp_dir.path().join("output_pipe.bam");
+
+    create_grouped_test_bam(&input_bam);
+
+    // Baseline: single-threaded (no `--threads`) from a file.
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_from_file.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--min-consensus-base-quality",
+            "0",
+            "--compression-level",
+            "1",
+        ])
+        .status()
+        .expect("Failed to run single-threaded simplex with file input");
+    assert!(status.success(), "single-threaded simplex with file input failed");
+
+    // Piped: `cat grouped.bam | fgumi simplex -i -` (single-threaded).
+    let cat_child = Command::new("cat")
+        .arg(input_bam.to_str().unwrap())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn cat");
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            "-",
+            "--output",
+            output_from_pipe.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--min-consensus-base-quality",
+            "0",
+            "--compression-level",
+            "1",
+        ])
+        .stdin(cat_child.stdout.unwrap())
+        .status()
+        .expect("Failed to run single-threaded simplex with piped input");
+    assert!(
+        status.success(),
+        "single-threaded simplex with piped input failed (stdin double-open regression?)"
+    );
+
+    compare_bam_records(&output_from_file, &output_from_pipe);
+}
+
+/// SAM (non-BGZF) input to the single-threaded codec/simplex/duplex paths must
+/// fail at the header read with a `--threads` hint — those paths are BAM-only,
+/// and the multi-threaded path is the SAM-capable one. Guards the `with_context`
+/// message that replaced the removed SAM pre-sniff (codec/simplex) and the
+/// matching hint added to duplex.
+#[test]
+fn test_single_threaded_consensus_rejects_sam_with_threads_hint() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let bam = temp_dir.path().join("grouped.bam");
+    let sam = temp_dir.path().join("grouped.sam");
+    create_grouped_test_bam(&bam);
+    convert_bam_to_sam(&bam, &sam);
+    let input = sam.to_str().unwrap();
+
+    // Per-command minimal args; each runs single-threaded (no `--threads`).
+    let extra_args: [(&str, &[&str]); 3] = [
+        ("codec", &["--min-reads", "1", "--min-duplex-length", "1"]),
+        ("simplex", &["--min-reads", "1"]),
+        ("duplex", &["--min-reads", "1"]),
+    ];
+    for (cmd, extra) in extra_args {
+        let out = temp_dir.path().join(format!("{cmd}_out.bam"));
+        let mut args: Vec<&str> = vec![
+            cmd,
+            "--input",
+            input,
+            "--output",
+            out.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+            .args(&args)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn {cmd}: {e}"));
+        assert!(!output.status.success(), "single-threaded {cmd} must reject SAM input");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("--threads"),
+            "single-threaded {cmd} SAM error should hint at --threads; stderr: {stderr}"
+        );
+    }
+}
+
+/// `--async-reader` over stdin must spawn the prefetch thread (the stdin branch
+/// of `open_bgzf_reader` honors async like the file path) and still read the
+/// input correctly — file vs piped output must match.
+#[test]
+fn test_simplex_single_threaded_async_reader_over_stdin() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_from_file = temp_dir.path().join("output_file.bam");
+    let output_from_pipe = temp_dir.path().join("output_pipe.bam");
+    create_grouped_test_bam(&input_bam);
+
+    // Baseline: single-threaded + --async-reader from a file.
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_from_file.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--min-consensus-base-quality",
+            "0",
+            "--compression-level",
+            "1",
+            "--async-reader",
+        ])
+        .status()
+        .expect("Failed to run async-reader simplex with file input");
+    assert!(status.success(), "async-reader simplex from file failed");
+
+    // Piped: `cat grouped.bam | fgumi simplex -i - --async-reader` (single-threaded).
+    let cat_child = Command::new("cat")
+        .arg(input_bam.to_str().unwrap())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn cat");
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "simplex",
+            "--input",
+            "-",
+            "--output",
+            output_from_pipe.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--min-consensus-base-quality",
+            "0",
+            "--compression-level",
+            "1",
+            "--async-reader",
+        ])
+        .stdin(cat_child.stdout.unwrap())
+        .status()
+        .expect("Failed to run async-reader simplex with piped input");
+    assert!(
+        status.success(),
+        "async-reader simplex from stdin failed (prefetch-on-stdin regression?)"
+    );
+
+    compare_bam_records(&output_from_file, &output_from_pipe);
+}
+
 /// Convert a BAM file to a parallel SAM text file containing the same
 /// records. Lets `fgumi group --input foo.sam` reuse the same record
 /// set as the BAM-input baseline for parity tests.
@@ -594,29 +768,31 @@ fn read_file_contents(path: &PathBuf) -> Vec<u8> {
 }
 
 /// Helper to compare BAM records (ignoring header differences like @PG command line).
+///
+/// Decodes to eager `RecordBuf`s and compares them for full equality — every
+/// field including bases, qualities, flags, CIGAR, positions, and aux tags — so
+/// a record-level corruption from mishandled input (dropped or garbled bytes)
+/// fails here, not just a count/name mismatch.
 fn compare_bam_records(path1: &PathBuf, path2: &PathBuf) {
+    use noodles::sam::alignment::RecordBuf;
+
     let mut reader1 =
         bam::io::reader::Builder.build_from_path(path1).expect("Failed to open BAM 1");
-    let _header1 = reader1.read_header().expect("Failed to read header 1");
+    let header1 = reader1.read_header().expect("Failed to read header 1");
 
     let mut reader2 =
         bam::io::reader::Builder.build_from_path(path2).expect("Failed to open BAM 2");
-    let _header2 = reader2.read_header().expect("Failed to read header 2");
+    let header2 = reader2.read_header().expect("Failed to read header 2");
 
-    // Compare record counts and content
-    let records1: Vec<_> = reader1.records().map(|r| r.expect("Failed to read record")).collect();
-    let records2: Vec<_> = reader2.records().map(|r| r.expect("Failed to read record")).collect();
+    let records1: Vec<RecordBuf> =
+        reader1.record_bufs(&header1).map(|r| r.expect("Failed to read record 1")).collect();
+    let records2: Vec<RecordBuf> =
+        reader2.record_bufs(&header2).map(|r| r.expect("Failed to read record 2")).collect();
 
     assert_eq!(records1.len(), records2.len(), "BAM files have different record counts");
 
     for (i, (r1, r2)) in records1.iter().zip(records2.iter()).enumerate() {
-        // Compare key fields
-        assert_eq!(r1.name(), r2.name(), "Record {i} has different name");
-        assert_eq!(
-            r1.sequence().len(),
-            r2.sequence().len(),
-            "Record {i} has different sequence length"
-        );
+        assert_eq!(r1, r2, "Record {i} differs (full record identity)");
     }
 }
 


### PR DESCRIPTION
## Summary

The single-threaded `codec` and `simplex` paths opened the input **twice**: once via `InputSource` to sniff SAM-vs-BAM (consuming stdin), then again via `create_raw_bam_reader`. stdin can't be rewound or re-opened, so the second open lost the bytes the first consumed:
- `-i -` failed outright (`File::open("-")`),
- `-i /dev/stdin` silently dropped the leading ~2 MiB (header + records).

## Fix

Open the input exactly once on both paths:
- Drop the SAM pre-sniff. SAM input now fails the header read with a clear `--threads` hint (via `with_context`) instead of being pre-rejected.
- `open_bgzf_reader` reads `io::stdin()` directly for stdin paths instead of `File::open`, so it is the sole consumer. It also now honors `--async-reader` for stdin (parity with the file path — a pipe benefits from prefetch overlapping upstream production).

`duplex` already opened once (no data-loss bug), but its single-threaded SAM input hit the same cryptic "invalid BGZF magic" error — it gets the matching `--threads` hint so codec/simplex/duplex are consistent. `clip` also opens once, so the `open_bgzf_reader` change covers its stdin handling.

## Tests

Added `test_simplex_single_threaded_reads_stdin_once` (file vs `cat | … -i -`, single-threaded) — the existing piped test only exercised the multi-threaded path, which is why this shipped. Also strengthened the shared `compare_bam_records` helper to assert full `RecordBuf` identity (bases, qualities, flags, CIGAR, positions, aux tags), not just count + name + sequence length; all streaming + SAM-parity tests still pass.

## Stack context

Final follow-up fix for the issue #330 unified-pipeline landing onto `feat-runall` (found by an assertive CodeRabbit pass on the reconciliation). Dual-reviewed before push; the simplex/duplex siblings, the `--async-reader` stdin parity, and the strengthened test assertion were all surfaced by the pre-push dual review on this PR.