### PR TITLE
feat(sort): support reading BAM input from stdin

### DIFF
--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -369,8 +369,23 @@ impl Command for Sort {
             bail!("--write-index cannot be used with --verify");
         }
 
-        // Validate inputs
-        validate_file_exists(&self.input, "Input BAM")?;
+        // Validate inputs. Exempt stdin paths (`-` / `/dev/stdin`): the
+        // streaming sort path reads stdin once (the sort engine's reader
+        // handles stdin directly), so a file-existence check would spuriously
+        // reject it — matching the stdin exemption in group/dedup/correct.
+        // `--verify` is the exception: it re-scans the input (header probe +
+        // a fresh record pass), which a non-seekable stdin can't satisfy, so
+        // reject stdin there up front with a clear message.
+        if fgumi_bam_io::is_stdin_path(&self.input) {
+            if self.verify {
+                bail!(
+                    "fgumi sort --verify cannot read from stdin (it re-scans the input); \
+                     provide a file path instead"
+                );
+            }
+        } else {
+            validate_file_exists(&self.input, "Input BAM")?;
+        }
 
         // Either --output or --verify must be specified
         if !self.verify && self.output.is_none() {

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -328,8 +328,23 @@ impl<'a> ChainBuilder<'a> {
         let tuning = BamPipelineTuning::auto_tuned(num_threads)
             .with_compression_level(spec.compression.compression_level);
 
-        let (raw_header, pending_source) = Self::open_source(spec)?;
-        let header = crate::commands::common::add_pg_record(raw_header, &spec.command_line)?;
+        // Standalone sort (`[Stage::Sort]`) is special: `build_for` skips
+        // `add_source`/`add_sink`, and the terminal `SortBamFile` step opens
+        // and reads the input (header included) itself via the sort engine.
+        // Opening the source here would be wasted work — and for a stdin input
+        // it would drain the pipe before `SortBamFile` reads it, leaving the
+        // engine to fail on an empty stdin. The header resolved here is unused
+        // by the sort-terminal branch, so skip the open entirely.
+        let sort_terminal = matches!(spec.stages.as_slice(), [Stage::Sort]);
+        let (header, pending_source) = if sort_terminal {
+            (Header::default(), None)
+        } else {
+            let (raw_header, pending_source) = Self::open_source(spec)?;
+            (
+                crate::commands::common::add_pg_record(raw_header, &spec.command_line)?,
+                pending_source,
+            )
+        };
 
         Ok(Self {
             spec,

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -929,13 +929,56 @@ fn s(v: &str) -> String {
     v.to_string()
 }
 
-// NOTE: `sort` is intentionally NOT covered here — it does not currently
-// support stdin input. Its terminal-sort path uses a file-to-file
-// `RawExternalSorter` (`SortBamFile`) that reads the input path directly and
-// double-reads the header, so a stdin stream is drained/empty by the second
-// read; input validation also rejects `-`/`/dev/stdin` outright. Supporting
-// stdin requires refactoring the external sorter to consume the stream once
-// (tracked separately).
+#[rstest]
+#[case("1")]
+#[case("2")]
+fn test_sort_reads_stdin_once(#[case] threads: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    assert_stdin_input_parity(&input, dir.path(), "sort", |i, o| {
+        vec![
+            s("sort"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--order"),
+            s("coordinate"),
+            s("--threads"),
+            s(threads),
+            s("--compression-level"),
+            s("1"),
+        ]
+    });
+}
+
+/// `sort --verify` reads its input twice (header probe + a fresh record
+/// re-scan), which a non-seekable stdin stream can't satisfy, so it must be
+/// rejected up front with a clear message rather than failing deep in a
+/// re-open. (Plain `sort` streams stdin once and IS supported — above.)
+#[test]
+fn test_sort_verify_rejects_stdin_with_clear_message() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    let cat = Command::new("cat")
+        .arg(input.to_str().unwrap())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn cat");
+    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(["sort", "--verify", "--input", "-", "--order", "coordinate"])
+        .stdin(cat.stdout.unwrap())
+        .output()
+        .expect("run sort --verify -i -");
+    assert!(!output.status.success(), "sort --verify from stdin must be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stdin"),
+        "sort --verify stdin rejection should mention stdin; stderr: {stderr}"
+    );
+}
 
 /// Push `--threads <n>` only when `threads` is `Some`; `None` exercises a
 /// command's single-threaded fast path (where it has one).


### PR DESCRIPTION
## Summary

`fgumi sort -i -` (and `-i /dev/stdin`) failed with `Invalid Input BAM file '-': File does not exist`. The sort engine's reader already handles stdin (a `TeeReader` reads the header, then a `ChainedReader` replays it and streams the rest — a single pass), but two things blocked it:

1. `Sort::execute` ran `validate_file_exists` on the input with **no stdin exemption** (unlike group/dedup/correct), rejecting `-` up front.
2. `ChainBuilder::new` **unconditionally opened the input to read the header** for `@PG` injection — but for the standalone-sort chain (`[Stage::Sort]`), `build_for` skips `add_source`, so that opened source was dropped unused. For stdin, that wasted read drained the pipe, so the terminal `SortBamFile` step then re-opened an empty stdin and failed (`failed to fill whole buffer`).

## Fix

- **Exempt stdin** from the file-existence check on the sort path. `--verify` still rejects stdin with a clear message (it re-scans the input — header probe + a fresh record pass — which a non-seekable stream can't satisfy).
- **Skip `open_source`** in `ChainBuilder::new` for the `[Stage::Sort]` terminal case. The header it resolves is unused there (the `SortBamFile` step reads and writes the header itself via the sort engine), so skipping it avoids both wasted work on files and the stdin drain.

No sort-engine changes, and **no change to the file-input path's reader** (it keeps its seek-rewind + async-prefetch open). Verified safe: every `self.header` use in the chain builder is in `add_source`/`add_sink`/consensus/clip/filter/align or the streaming-sort branch (which requires upstream stages, so `stages != [Stage::Sort]` and `open_source` runs normally) — none run for the standalone `[Stage::Sort]` path that gets `Header::default()`.

## Tests (TDD)

Added to the stdin parity matrix from #411: `sort` (`-` and `/dev/stdin`, single- and multi-threaded, file-vs-stdin byte-identical), plus a test that `sort --verify` from stdin is rejected with a clear message. Wrote the tests first (red on the validation rejection), then made them green. Full sort + chain + runall-parity + write-index suites (222 tests) pass — no regression to the file path.

## Stack

Stacked on **#411** (`feat-runall-18-stdin-coverage`); this completes the stdin matrix that #411 deliberately left sort out of. Rebase onto `feat-runall` + retarget base to `feat-runall` once #411 merges. Dual-reviewed before push (CLI: no findings; skill: clean with the `self.header` safety trace).