### PR TITLE
refactor(consensus): de-duplicate codec/simplex/duplex command wiring

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -11,9 +11,7 @@ use crate::commands::consensus_runner::{ConsensusStatsOps, create_unmapped_conse
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::{
-    create_bam_writer, create_optional_bam_writer, create_raw_bam_reader_with_opts,
-};
+use fgumi_bam_io::{create_bam_writer, create_optional_bam_writer};
 
 use super::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
@@ -339,12 +337,11 @@ impl Command for Codec {
         // loses the leading bytes (stdin can't be rewound or re-opened). SAM
         // input (not BGZF) fails the header read here; surface the --threads hint.
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
-                .with_context(|| {
-                    "Failed to open input as BAM. The single-threaded codec path is BAM-only; \
-                     if this is SAM input, pass --threads N to use the SAM-capable \
-                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
-                })?;
+            crate::commands::consensus_runner::open_single_threaded_consensus_input(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+                "codec",
+            )?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,

--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -18,6 +18,27 @@ use noodles::sam::header::record::value::map::header::tag as header_tag;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use noodles::sam::header::record::value::map::tag::Other;
 
+/// Open the single-threaded consensus fast path's input as a raw BAM reader,
+/// reading the input exactly once. That path is BAM-only; if the input is SAM
+/// (not BGZF) the header read fails, and the returned error carries a
+/// `--threads` hint pointing at the SAM-capable multi-threaded path. Shared by
+/// `codec`/`simplex`/`duplex`'s `execute` (their open logic and error message
+/// are identical bar the command name).
+pub(crate) fn open_single_threaded_consensus_input(
+    input: &std::path::Path,
+    reader_opts: fgumi_bam_io::PipelineReaderOpts,
+    command: &str,
+) -> Result<(fgumi_bam_io::RawBamReaderAuto, Header)> {
+    use anyhow::Context;
+    fgumi_bam_io::create_raw_bam_reader_with_opts(input, 1, reader_opts).with_context(|| {
+        format!(
+            "Failed to open input as BAM. The single-threaded {command} path is BAM-only; \
+             if this is SAM input, pass --threads N to use the SAM-capable multi-threaded \
+             path (ReadSamChunks + ParseSamChunk)."
+        )
+    })
+}
+
 /// Trait for converting command-specific statistics to metrics.
 pub trait ConsensusStatsOps: Clone + Default + Send {
     /// Merges another stats instance into this one.

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -8,9 +8,7 @@
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::{
-    create_bam_writer, create_optional_bam_writer, create_raw_bam_reader_with_opts,
-};
+use fgumi_bam_io::{create_bam_writer, create_optional_bam_writer};
 
 use super::common::{
     BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
@@ -437,16 +435,15 @@ impl Command for Duplex {
         }
 
         // Single-threaded fast path is BAM-only: open the raw reader once and
-        // derive the header from it. SAM input (not BGZF) fails the header read
-        // here; surface the --threads hint instead of a cryptic BGZF-magic error
-        // (mirrors the codec/simplex single-threaded paths).
+        // derive the header from it (shared with codec/simplex). SAM input (not
+        // BGZF) fails the header read with a --threads hint instead of a cryptic
+        // BGZF-magic error.
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
-                .with_context(|| {
-                    "Failed to open input as BAM. The single-threaded duplex path is BAM-only; \
-                     if this is SAM input, pass --threads N to use the SAM-capable \
-                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
-                })?;
+            crate::commands::consensus_runner::open_single_threaded_consensus_input(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+                "duplex",
+            )?;
         let header = crate::commands::common::add_pg_record(header, command_line)?;
         let read_name_prefix = self.read_group.prefix_or_from_header(&header);
         let methylation_ref: MethylationRef =

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -17,9 +17,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    create_bam_writer, create_optional_bam_writer, create_raw_bam_reader_with_opts,
-};
+use fgumi_bam_io::{create_bam_writer, create_optional_bam_writer};
 use fgumi_raw_bam::RawRecord;
 
 use log::info;
@@ -388,12 +386,11 @@ impl Command for Simplex {
         // loses the leading bytes (stdin can't be rewound or re-opened). SAM
         // input (not BGZF) fails the header read here; surface the --threads hint.
         let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())
-                .with_context(|| {
-                    "Failed to open input as BAM. The single-threaded simplex path is BAM-only; \
-                     if this is SAM input, pass --threads N to use the SAM-capable \
-                     multi-threaded path (ReadSamChunks + ParseSamChunk)."
-                })?;
+            crate::commands::consensus_runner::open_single_threaded_consensus_input(
+                &self.io.input,
+                self.io.pipeline_reader_opts(),
+                "simplex",
+            )?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -885,6 +885,41 @@ impl<'a> ChainBuilder<'a> {
         }
     }
 
+    /// Wire the rejects fan-out branch (branch 1) of a 2-output consensus step:
+    /// `BgzfCompress` → `WriteBgzfFile` with the **input** header, in input
+    /// order — the PR #332 fan-out contract (rejects flow through the ordered
+    /// serialize/compress stages, not a mutex side-channel).
+    ///
+    /// `consensus_pt` is the just-appended consensus step (branch 0 is its kept
+    /// output, consumed by the caller); `label` names the command for error
+    /// context. Shared by `add_simplex`/`add_duplex`/`add_codec`, whose
+    /// rejects wiring is otherwise identical — only the consensus step's type
+    /// (built inline by the caller) differs.
+    fn wire_consensus_rejects_branch(
+        &self,
+        consensus_pt: (StepIdx, BranchIdx),
+        rejects_path: Option<&std::path::Path>,
+        input_header: &Header,
+        label: &str,
+    ) -> Result<()> {
+        use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+        use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+        let rejects_path = rejects_path
+            .ok_or_else(|| anyhow!("rejects path unexpectedly None when track_rejects is set"))?;
+        let rejects_write =
+            WriteBgzfFile::new(rejects_path, input_header, self.tuning.compression_level)
+                .map_err(|e| anyhow!("WriteBgzfFile ({label} rejects): {e}"))?;
+
+        let rejects_branch = (consensus_pt.0, BranchIdx(1));
+        let rejects_compress_tail = self.pipeline.append_step(
+            BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit),
+            rejects_branch,
+        );
+        self.pipeline.append_step(rejects_write, rejects_compress_tail);
+        Ok(())
+    }
+
     /// Append the 4-step BAM decode preamble:
     /// `ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords`.
     fn build_bam_decode_preamble(
@@ -2594,27 +2629,14 @@ impl<'a> ChainBuilder<'a> {
         // public discard sink). Mirrors add_correct.
         let limit = self.tuning.per_step_byte_limit;
         let consensus_branch0 = if track_rejects {
-            use crate::pipeline::core::topology::BranchIdx;
-            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
-            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
-
-            let rejects_path = simplex.rejects_opts.rejects.as_ref().ok_or_else(|| {
-                anyhow!("rejects path unexpectedly None when track_rejects is set")
-            })?;
-            let rejects_write =
-                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
-                    .map_err(|e| anyhow!("WriteBgzfFile (simplex rejects): {e}"))?;
-
             let step = build_simplex_consensus_step_with_rejects(limit, consensus_cap);
             let pt = self.pipeline.append_step(step, tail);
-
-            let rejects_branch = (pt.0, BranchIdx(1));
-            let rejects_compress_tail = self.pipeline.append_step(
-                BgzfCompress::new(self.tuning.compression_level, limit),
-                rejects_branch,
-            );
-            self.pipeline.append_step(rejects_write, rejects_compress_tail);
-
+            self.wire_consensus_rejects_branch(
+                pt,
+                simplex.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "simplex",
+            )?;
             pt
         } else {
             let step = build_simplex_consensus_step_kept_only(limit, consensus_cap);
@@ -2943,27 +2965,14 @@ impl<'a> ChainBuilder<'a> {
         // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
         let limit = self.tuning.per_step_byte_limit;
         let consensus_branch0 = if track_rejects {
-            use crate::pipeline::core::topology::BranchIdx;
-            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
-            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
-
-            let rejects_path = duplex.rejects_opts.rejects.as_ref().ok_or_else(|| {
-                anyhow!("rejects path unexpectedly None when track_rejects is set")
-            })?;
-            let rejects_write =
-                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
-                    .map_err(|e| anyhow!("WriteBgzfFile (duplex rejects): {e}"))?;
-
             let step = build_duplex_consensus_step_with_rejects(limit, consensus_cap);
             let pt = self.pipeline.append_step(step, tail);
-
-            let rejects_branch = (pt.0, BranchIdx(1));
-            let rejects_compress_tail = self.pipeline.append_step(
-                BgzfCompress::new(self.tuning.compression_level, limit),
-                rejects_branch,
-            );
-            self.pipeline.append_step(rejects_write, rejects_compress_tail);
-
+            self.wire_consensus_rejects_branch(
+                pt,
+                duplex.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "duplex",
+            )?;
             pt
         } else {
             let step = build_duplex_consensus_step_kept_only(limit, consensus_cap);
@@ -3249,27 +3258,14 @@ impl<'a> ChainBuilder<'a> {
         // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
         let limit = self.tuning.per_step_byte_limit;
         let consensus_branch0 = if track_rejects {
-            use crate::pipeline::core::topology::BranchIdx;
-            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
-            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
-
-            let rejects_path = codec.rejects_opts.rejects.as_ref().ok_or_else(|| {
-                anyhow!("rejects path unexpectedly None when track_rejects is set")
-            })?;
-            let rejects_write =
-                WriteBgzfFile::new(rejects_path, &input_header, self.tuning.compression_level)
-                    .map_err(|e| anyhow!("WriteBgzfFile (codec rejects): {e}"))?;
-
             let step = build_codec_consensus_step_with_rejects(limit, consensus_cap);
             let pt = self.pipeline.append_step(step, tail);
-
-            let rejects_branch = (pt.0, BranchIdx(1));
-            let rejects_compress_tail = self.pipeline.append_step(
-                BgzfCompress::new(self.tuning.compression_level, limit),
-                rejects_branch,
-            );
-            self.pipeline.append_step(rejects_write, rejects_compress_tail);
-
+            self.wire_consensus_rejects_branch(
+                pt,
+                codec.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "codec",
+            )?;
             pt
         } else {
             let step = build_codec_consensus_step_kept_only(limit, consensus_cap);

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -156,15 +156,6 @@ pub(crate) struct CodecConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Append `[len:4 LE][record]` framing for a byte-slice record — the format
-/// `BgzfCompress` expects in a `DecompressedBlock`.
-fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
-    #[allow(clippy::cast_possible_truncation)]
-    let block_size = rec.len() as u32;
-    dst.extend_from_slice(&block_size.to_le_bytes());
-    dst.extend_from_slice(rec);
-}
-
 /// Per-worker init: build the `CodecConsensusCaller` once, reused across
 /// batches. Shared by both step variants.
 fn make_codec_consensus_init(
@@ -218,7 +209,7 @@ fn run_codec_consensus_batch(
                 batch_stats.merge(state.caller.statistics());
                 if track_rejects {
                     for raw in &state.caller.take_rejected_reads() {
-                        append_framed_bytes(&mut rejects_bytes, raw);
+                        super::append_framed_bytes(&mut rejects_bytes, raw);
                     }
                 }
             }
@@ -229,7 +220,7 @@ fn run_codec_consensus_batch(
                     batch_stats.merge(state.caller.statistics());
                     if track_rejects {
                         for raw in &state.caller.take_rejected_reads() {
-                            append_framed_bytes(&mut rejects_bytes, raw);
+                            super::append_framed_bytes(&mut rejects_bytes, raw);
                         }
                     }
                 } else {

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -184,15 +184,6 @@ pub(crate) struct DuplexConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Append `[len:4 LE][record]` framing for a byte-slice record — the format
-/// `BgzfCompress` expects in a `DecompressedBlock`.
-fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
-    #[allow(clippy::cast_possible_truncation)]
-    let block_size = rec.len() as u32;
-    dst.extend_from_slice(&block_size.to_le_bytes());
-    dst.extend_from_slice(rec);
-}
-
 /// Per-worker init: build the `DuplexConsensusCaller` (+ optional overlapping
 /// caller) once, reused across batches. Shared by both step variants.
 ///
@@ -295,7 +286,7 @@ fn run_duplex_consensus_batch(
         batch_stats.merge(&state.caller.statistics());
         if track_rejects {
             for raw in &state.caller.take_rejected_reads() {
-                append_framed_bytes(&mut rejects_bytes, raw);
+                super::append_framed_bytes(&mut rejects_bytes, raw);
             }
         }
     }

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -19,3 +19,17 @@ pub mod group;
 pub mod simplex;
 pub mod sort;
 pub mod zipper;
+
+/// Append `rec` to `dst` framed as a BAM record block: a 4-byte little-endian
+/// length prefix followed by the record bytes. Shared by the consensus
+/// command builders' rejects-serialization paths (codec/simplex/duplex), which
+/// emit raw record bytes into a `DecompressedBlock` buffer.
+///
+/// BAM record body size is u32-bounded per the spec; a single record's buffer
+/// cannot exceed `u32::MAX` in practice, so the length cast cannot truncate.
+pub(crate) fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
+    #[allow(clippy::cast_possible_truncation)]
+    let block_size = rec.len() as u32;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+}

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -178,18 +178,6 @@ pub(crate) struct SimplexConsensusCaptures {
     pub(crate) progress: Arc<AtomicU64>,
 }
 
-/// Append `[len:4 LE][record]` framing for each byte-slice record — the format
-/// `BgzfCompress` expects in a `DecompressedBlock`. Mirrors correct's
-/// `append_framed_raw_record`.
-fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
-    // BAM record body size is u32-bounded per the spec; a single record's
-    // buffer cannot exceed u32::MAX in practice.
-    #[allow(clippy::cast_possible_truncation)]
-    let block_size = rec.len() as u32;
-    dst.extend_from_slice(&block_size.to_le_bytes());
-    dst.extend_from_slice(rec);
-}
-
 /// Per-worker init: build the `VanillaUmiConsensusCaller` (+ optional
 /// overlapping caller) once, reused across batches. Shared by both step
 /// variants.
@@ -259,7 +247,7 @@ fn run_simplex_consensus_batch(
             batch_stats.record_rejection(RejectionReason::InsufficientReads, raw_records.len());
             if track_rejects {
                 for raw in &raw_records {
-                    append_framed_bytes(&mut rejects_bytes, raw.as_ref());
+                    super::append_framed_bytes(&mut rejects_bytes, raw.as_ref());
                 }
             }
             continue;
@@ -286,7 +274,7 @@ fn run_simplex_consensus_batch(
         batch_stats.merge(&state.caller.statistics());
         if track_rejects {
             for raw in &state.caller.take_rejected_reads() {
-                append_framed_bytes(&mut rejects_bytes, raw);
+                super::append_framed_bytes(&mut rejects_bytes, raw);
             }
         }
     }


### PR DESCRIPTION
## Summary

Pure, behavior-preserving refactor: three byte-identical patterns were copy-pasted across the consensus commands; each now has a single shared definition.

1. **Single-threaded BAM-open** — the fast-path `create_raw_bam_reader_with_opts` + `--threads`-hint `with_context` in `codec`/`simplex`/`duplex` `execute()` → `consensus_runner::open_single_threaded_consensus_input(input, opts, command)`. Reads the input exactly once (preserves the #412 stdin-once property) and parameterizes the error by command name. Incidentally unifies duplex's slightly-drifted error wording with codec/simplex.
2. **Rejects fan-out wiring** — the `BgzfCompress → WriteBgzfFile(input_header)` on `BranchIdx(1)` in `ChainBuilder::add_{simplex,duplex,codec}` → `ChainBuilder::wire_consensus_rejects_branch`. Only the consensus step's type differs, so it's still built inline by each `add_*`; only the type-independent rejects wiring moved (no macro/generics).
3. **`append_framed_bytes`** — the `[len:4 LE][record]` framing helper, defined 3× → one `pub(crate)` definition in `chains/commands/mod.rs`. `correct`'s `append_framed_raw_record` is intentionally left untouched (it lives in the lower `steps/` layer and takes `&RawRecord`; sharing across that boundary would invert the dependency direction).

## Behavior preservation

Output is unchanged. 347 consensus / rejects-fanout / streaming / runall-parity tests pass. Dual-reviewed before push (skill: 0 actionable; CLI: 1 nitpick declined + 1 "won't compile" flagged on `wire_consensus_rejects_branch`'s `&self` — a false positive, since `append_step` takes `&self` and mutates via interior `RefCell`; the lib compiles clean).

## Context

First of the post-#330 subsystem-simplification cleanups (discovery pass identified the consensus triplication as the highest-value, lowest-risk dedup). Tier-2 perf-sensitive fgumi-sort engine dedups are deferred pending a benchmark.