### PR TITLE
refactor(bam-io): collapse cached-UMI sentinel handling at the owning layer

### DIFF
--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -242,6 +242,19 @@ impl DecodedRecord {
         (self.umi_value_offset, self.umi_value_len)
     }
 
+    /// Returns the cached UMI `(offset, len)` position, or `None` when no
+    /// position was recorded during decode (the [`Self::UMI_OFFSET_UNCACHED`]
+    /// sentinel). Keeps the sentinel check at the owning layer so callers can
+    /// branch on a plain `Option` instead of comparing against the sentinel.
+    #[must_use]
+    pub fn cached_umi_position_opt(&self) -> Option<(u32, u16)> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            None
+        } else {
+            Some((self.umi_value_offset, self.umi_value_len))
+        }
+    }
+
     /// Returns a reference to the raw bytes.
     #[must_use]
     pub fn raw_bytes(&self) -> &[u8] {

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -760,8 +760,6 @@ impl Template {
 /// return `None` even when found, so the downstream consumer falls back to
 /// scanning aux data.
 fn primary_read_cached_umi(records: &[fgumi_bam_io::DecodedRecord]) -> Option<(u32, u16)> {
-    use fgumi_raw_bam;
-
     let mut primary_r2: Option<&fgumi_bam_io::DecodedRecord> = None;
 
     for decoded in records {
@@ -776,24 +774,15 @@ fn primary_read_cached_umi(records: &[fgumi_bam_io::DecodedRecord]) -> Option<(u
         let is_r1 = !is_paired || is_first;
 
         if is_r1 {
-            let (offset, len) = decoded.cached_umi_position();
-            if offset == fgumi_bam_io::DecodedRecord::UMI_OFFSET_UNCACHED {
-                return None;
-            }
-            return Some((offset, len));
+            // First non-secondary/supplementary R1 wins, cached or not.
+            return decoded.cached_umi_position_opt();
         }
         if primary_r2.is_none() {
             primary_r2 = Some(decoded);
         }
     }
 
-    let r2 = primary_r2?;
-    let (offset, len) = r2.cached_umi_position();
-    if offset == fgumi_bam_io::DecodedRecord::UMI_OFFSET_UNCACHED {
-        None
-    } else {
-        Some((offset, len))
-    }
+    primary_r2?.cached_umi_position_opt()
 }
 
 /// Sets mate flags (`MATE_REVERSE`, `MATE_UNMAPPED`) on a raw BAM record.


### PR DESCRIPTION
## Summary

`primary_read_cached_umi` (template.rs) duplicated the same `cached_umi_position()` → `UMI_OFFSET_UNCACHED`-sentinel → `Option` conversion in both its R1 and R2 arms, leaking the sentinel detail to the caller. Add `DecodedRecord::cached_umi_position_opt() -> Option<(u32, u16)>` — which does the sentinel check once at the type that owns it — and have both arms return it directly. Also drops a redundant function-body `use fgumi_raw_bam;` (the crate is already nameable; the fully-qualified `fgumi_raw_bam::flags::*` paths resolve without it).

## Behavior preservation

Identical: an R1 (cached or not) still wins over R2, and an uncached primary still yields `None` (caller falls back to `find_string_tag`). Cached-UMI, decode, and group-determinism tests pass unchanged.

`DecodedRecord::cached_umi()` is intentionally **kept** — though production reads the cache via `Template::cached_umi`, the `DecodedRecord` accessor is the clean expression of the load-bearing "cached slice == `find_string_tag`" invariant test in `decode.rs`; removing it would force that test to re-implement the slice it verifies.

## Context

Second of the post-#330 subsystem-simplification cleanups (discovery bundle "bam-io/template"). Dual-reviewed before push (CLI: no findings; skill: 0 actionable). The discovery's "delete dead `DecodedRecord::cached_umi()`" item was assessed and declined for the reason above.