### PR TITLE
feat(sort): support reading BAM input from stdin

### DIFF
--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -386,8 +386,24 @@ impl Command for Sort {
             bail!("--write-index cannot be used with --verify");
         }
 
-        // Validate inputs
-        validate_file_exists(&self.input, "Input BAM")?;
+        // Validate inputs. Exempt stdin paths (`-` / `/dev/stdin`): the sort
+        // engine reads stdin in a single pass (a `TeeReader` reads the header,
+        // then a `ChainedReader` replays it and streams the rest), so a
+        // file-existence check would spuriously reject it — matching the stdin
+        // exemption in group/dedup/clip. `--verify` is the exception: it
+        // re-scans the input (header probe + a fresh `File::open` record pass),
+        // which a non-seekable stdin can't satisfy, so reject stdin there up
+        // front with a clear message.
+        if fgumi_bam_io::is_stdin_path(&self.input) {
+            if self.verify {
+                bail!(
+                    "fgumi sort --verify cannot read from stdin (it re-scans the input); \
+                     provide a file path instead"
+                );
+            }
+        } else {
+            validate_file_exists(&self.input, "Input BAM")?;
+        }
 
         // Either --output or --verify must be specified
         if !self.verify && self.output.is_none() {

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -11,6 +11,10 @@ use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+// `rstest` is imported here for the file-vs-stdin parity tests added in a later
+// task; no test in this file references it yet.
+#[allow(unused_imports)]
+use rstest::rstest;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
@@ -199,29 +203,31 @@ fn read_file_contents(path: &PathBuf) -> Vec<u8> {
 }
 
 /// Helper to compare BAM records (ignoring header differences like @PG command line).
+///
+/// Decodes to eager `RecordBuf`s and compares them for full equality — every
+/// field including bases, qualities, flags, CIGAR, positions, and aux tags — so
+/// a record-level corruption from mishandled input (dropped or garbled bytes)
+/// fails here, not just a count/name mismatch.
 fn compare_bam_records(path1: &PathBuf, path2: &PathBuf) {
+    use noodles::sam::alignment::RecordBuf;
+
     let mut reader1 =
         bam::io::reader::Builder.build_from_path(path1).expect("Failed to open BAM 1");
-    let _header1 = reader1.read_header().expect("Failed to read header 1");
+    let header1 = reader1.read_header().expect("Failed to read header 1");
 
     let mut reader2 =
         bam::io::reader::Builder.build_from_path(path2).expect("Failed to open BAM 2");
-    let _header2 = reader2.read_header().expect("Failed to read header 2");
+    let header2 = reader2.read_header().expect("Failed to read header 2");
 
-    // Compare record counts and content
-    let records1: Vec<_> = reader1.records().map(|r| r.expect("Failed to read record")).collect();
-    let records2: Vec<_> = reader2.records().map(|r| r.expect("Failed to read record")).collect();
+    let records1: Vec<RecordBuf> =
+        reader1.record_bufs(&header1).map(|r| r.expect("Failed to read record 1")).collect();
+    let records2: Vec<RecordBuf> =
+        reader2.record_bufs(&header2).map(|r| r.expect("Failed to read record 2")).collect();
 
     assert_eq!(records1.len(), records2.len(), "BAM files have different record counts");
 
     for (i, (r1, r2)) in records1.iter().zip(records2.iter()).enumerate() {
-        // Compare key fields
-        assert_eq!(r1.name(), r2.name(), "Record {i} has different name");
-        assert_eq!(
-            r1.sequence().len(),
-            r2.sequence().len(),
-            "Record {i} has different sequence length"
-        );
+        assert_eq!(r1, r2, "Record {i} differs (full record identity)");
     }
 }
 
@@ -279,4 +285,72 @@ fn create_grouped_test_bam(path: &PathBuf) {
     }
 
     writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Run `fgumi` with `args`; if `stdin_bam` is `Some`, pipe that BAM to its
+/// stdin via `cat`. Asserts the process exits successfully.
+#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
+fn run_fgumi_checked(args: &[String], stdin_bam: Option<&std::path::Path>) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_fgumi"));
+    command.args(args);
+    let status = if let Some(bam) = stdin_bam {
+        let cat = Command::new("cat")
+            .arg(bam.to_str().unwrap())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn cat");
+        command.stdin(cat.stdout.unwrap()).status()
+    } else {
+        command.status()
+    };
+    let status = status.unwrap_or_else(|e| panic!("Failed to run fgumi {args:?}: {e}"));
+    assert!(status.success(), "fgumi {args:?} failed (stdin_piped={})", stdin_bam.is_some());
+}
+
+/// Assert a command emits byte-identical records reading `input_bam` from a
+/// file vs piped stdin (`-`) vs `/dev/stdin`. `build_args(input, output)`
+/// returns the full argv for one invocation; `label` namespaces temp outputs.
+#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
+fn assert_stdin_input_parity(
+    input_bam: &std::path::Path,
+    temp: &std::path::Path,
+    label: &str,
+    build_args: impl Fn(&str, &str) -> Vec<String>,
+) {
+    let out_file = temp.join(format!("{label}_file.bam"));
+    let out_dash = temp.join(format!("{label}_dash.bam"));
+    let out_dev = temp.join(format!("{label}_dev.bam"));
+
+    run_fgumi_checked(&build_args(input_bam.to_str().unwrap(), out_file.to_str().unwrap()), None);
+    run_fgumi_checked(&build_args("-", out_dash.to_str().unwrap()), Some(input_bam));
+    run_fgumi_checked(&build_args("/dev/stdin", out_dev.to_str().unwrap()), Some(input_bam));
+
+    // Guard against a vacuous pass: if the command emitted no records, a
+    // file-vs-stdin parity check would be trivially true even if stdin were
+    // dropped entirely. Require the file baseline to produce real output.
+    assert!(
+        count_bam_records(&out_file) > 0,
+        "{label}: file baseline produced no records — parity check would be vacuous"
+    );
+
+    compare_bam_records(&out_file, &out_dash);
+    compare_bam_records(&out_file, &out_dev);
+}
+
+/// Count records in a BAM (eager decode). Used to reject vacuous parity tests.
+#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
+fn count_bam_records(path: &std::path::Path) -> usize {
+    let mut reader = bam::io::reader::Builder.build_from_path(path).expect("open BAM for count");
+    let header = reader.read_header().expect("read header for count");
+    let mut count = 0;
+    for record in reader.record_bufs(&header) {
+        record.expect("read record for count");
+        count += 1;
+    }
+    count
+}
+
+#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
+fn s(v: &str) -> String {
+    v.to_string()
 }

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -11,9 +11,6 @@ use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-// `rstest` is imported here for the file-vs-stdin parity tests added in a later
-// task; no test in this file references it yet.
-#[allow(unused_imports)]
 use rstest::rstest;
 use tempfile::TempDir;
 
@@ -289,7 +286,6 @@ fn create_grouped_test_bam(path: &PathBuf) {
 
 /// Run `fgumi` with `args`; if `stdin_bam` is `Some`, pipe that BAM to its
 /// stdin via `cat`. Asserts the process exits successfully.
-#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
 fn run_fgumi_checked(args: &[String], stdin_bam: Option<&std::path::Path>) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_fgumi"));
     command.args(args);
@@ -310,7 +306,6 @@ fn run_fgumi_checked(args: &[String], stdin_bam: Option<&std::path::Path>) {
 /// Assert a command emits byte-identical records reading `input_bam` from a
 /// file vs piped stdin (`-`) vs `/dev/stdin`. `build_args(input, output)`
 /// returns the full argv for one invocation; `label` namespaces temp outputs.
-#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
 fn assert_stdin_input_parity(
     input_bam: &std::path::Path,
     temp: &std::path::Path,
@@ -338,7 +333,6 @@ fn assert_stdin_input_parity(
 }
 
 /// Count records in a BAM (eager decode). Used to reject vacuous parity tests.
-#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
 fn count_bam_records(path: &std::path::Path) -> usize {
     let mut reader = bam::io::reader::Builder.build_from_path(path).expect("open BAM for count");
     let header = reader.read_header().expect("read header for count");
@@ -350,7 +344,63 @@ fn count_bam_records(path: &std::path::Path) -> usize {
     count
 }
 
-#[allow(dead_code)] // used by the sort stdin parity tests added in a later task
 fn s(v: &str) -> String {
     v.to_string()
+}
+
+#[rstest]
+#[case("1")]
+#[case("2")]
+fn test_sort_reads_stdin_once(#[case] threads: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    assert_stdin_input_parity(&input, dir.path(), "sort", |i, o| {
+        vec![
+            s("sort"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--order"),
+            s("coordinate"),
+            s("--threads"),
+            s(threads),
+            s("--compression-level"),
+            s("1"),
+        ]
+    });
+}
+
+/// `sort --verify` reads its input twice (header probe + a fresh record
+/// re-scan via `File::open`), which a non-seekable stdin stream can't satisfy,
+/// so it must be rejected up front with a clear message rather than failing
+/// deep in a re-open. (Plain `sort` streams stdin once and IS supported.)
+///
+/// The rejection keys off `is_stdin_path`, so both `-` and `/dev/stdin` must be
+/// rejected — `/dev/stdin` is a real path (`Path::exists` is `true`), so a gate
+/// keyed on the literal `-` would let it slip into the double-read path.
+#[rstest]
+#[case("-")]
+#[case("/dev/stdin")]
+fn test_sort_verify_rejects_stdin_with_clear_message(#[case] input_arg: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    let cat = Command::new("cat")
+        .arg(input.to_str().unwrap())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn cat");
+    let output = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(["sort", "--verify", "--input", input_arg, "--order", "coordinate"])
+        .stdin(cat.stdout.unwrap())
+        .output()
+        .unwrap_or_else(|e| panic!("run sort --verify -i {input_arg}: {e}"));
+    assert!(!output.status.success(), "sort --verify from stdin ({input_arg}) must be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stdin"),
+        "sort --verify stdin ({input_arg}) rejection should mention stdin; stderr: {stderr}"
+    );
 }


### PR DESCRIPTION
## Summary

`fgumi sort -i -` failed on `main` with `Invalid Input BAM file '-': File does not exist`. Every other input-accepting command (`group`, `dedup`, `clip`, …) reads BAM from stdin; `sort` was the gap. This blocks streaming pipelines that pipe a BAM straight into a sort without an intermediate file.

The good news: the sort **engine** on `main` already streams stdin in a single pass. `create_raw_bam_reader_pool_integrated` branches on `is_stdin_path` — a `TeeReader` reads the header, then a `ChainedReader` replays it and streams the rest. The only thing blocking `fgumi sort -i -` was the input-validation gate in `Sort::execute`, which ran `validate_file_exists` with no stdin exemption.

(Note: the gate uses `Path::exists()`, which is `false` for `-` but `true` for `/dev/stdin` — so only `-` actually failed on the sort path today. The fix handles both uniformly via `is_stdin_path`.)

## Fix

- **Exempt stdin** (`-` / `/dev/stdin`) from the file-existence check on the sort path, matching the stdin exemption in `group`/`dedup`/`clip`. No engine changes, no change to the file-input reader path.
- **Reject `sort --verify` from stdin** with a clear message. `execute_verify` opens the input twice (header probe via `create_raw_bam_reader`, then a fresh `File::open` record re-scan), which a non-seekable pipe can't satisfy — so it's rejected up front rather than failing deep in a re-open. The reject keys off `is_stdin_path`, covering both `-` and `/dev/stdin`.

## Tests (TDD)

Backported the file-vs-stdin parity harness and strengthened `compare_bam_records` to full `RecordBuf` identity (bases, qualities, flags, CIGAR, positions, and all aux tags) so a record-level corruption from mishandled input fails the assertion, not just a count/name mismatch. Verified the existing `group`/`simplex` parity tests still pass under the stronger comparator.

Added:
- `test_sort_reads_stdin_once` — file-vs-`-`-vs-`/dev/stdin` byte-for-byte record parity, single- and multi-threaded, with a guard against a vacuous (zero-record) pass.
- `test_sort_verify_rejects_stdin_with_clear_message` — parameterized over `-` and `/dev/stdin`, asserting a non-zero exit and a stderr message mentioning stdin.

Full streaming-input integration suite and the `fgumi-sort` crate pass; `cargo ci-fmt` and `cargo ci-lint` are clean.

## Relationship to #412

This is the `main`-targeting, standalone version of the sort-stdin fix in #412, so it can land independently of the runall stack. #412 is stacked on #411 and targets `feat-runall`, and it additionally patches `src/lib/pipeline/chains/builder.rs` — that file is part of the runall pipeline-chains architecture and does not exist on `main`, so the builder half does not apply here. This PR is the minimal change `main` needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sort command now properly validates stdin input. When using the `--verify` flag with non-seekable stdin (`-` or `/dev/stdin`), the command fails early with a clear error message.

* **Tests**
  * Expanded streaming input test coverage to verify sorting consistency between stdin and file input.
  * Enhanced output validation for improved record integrity checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->