### PR TITLE
fix(bam-io): read process stdin directly in open_bgzf_reader

### DIFF
--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -163,6 +163,22 @@ fn open_bgzf_reader(
     threads: usize,
     label: &str,
 ) -> Result<BgzfReaderEnum> {
+    // stdin can't be re-opened: `File::open("-")` fails outright, and
+    // `File::open("/dev/stdin")` re-reads fd 0 — losing any bytes a caller
+    // already consumed. Read the process stdin directly so this BGZF reader is
+    // the sole consumer (fixes the single-threaded double-open data loss).
+    if is_stdin_path(path) {
+        // Honor --async-reader for stdin too (parity with the file path below):
+        // a pipe benefits from prefetch overlapping upstream production with us.
+        let reader: Box<dyn Read + Send> = if opts.async_reader {
+            log::info!("async {label} enabled: spawning fgumi-prefetch thread for stdin");
+            Box::new(crate::prefetch_reader::PrefetchReader::new(io::stdin()))
+        } else {
+            Box::new(io::stdin())
+        };
+        return Ok(make_bgzf_reader(reader, threads));
+    }
+
     let file = File::open(path)
         .with_context(|| format!("Failed to open input BAM: {}", path.display()))?;
     crate::os_hints::advise_sequential(&file);

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -185,6 +185,14 @@ fn test_simplex_command_with_piped_input() {
     assert!(status.success(), "Simplex command with piped input failed");
     assert!(output_from_pipe.exists(), "Output BAM from pipe not created");
 
+    // Guard against a vacuous pass: simplex must actually emit consensus records,
+    // otherwise the file-vs-pipe comparison below is trivially true (0 == 0) even
+    // if stdin were dropped entirely.
+    assert!(
+        count_bam_records(&output_from_file) > 0,
+        "simplex produced no consensus records — parity check would be vacuous"
+    );
+
     // Compare outputs - records should be identical (headers may differ due to @PG command line)
     compare_bam_records(&output_from_file, &output_from_pipe);
 }
@@ -260,24 +268,27 @@ fn create_grouped_test_bam(path: &PathBuf) {
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
-    // Create grouped reads with MI tag
+    // Create grouped reads with MI tag.
+    //
+    // MI MUST be a STRING tag: `fgumi group` writes the MoleculeId as a string,
+    // and the consensus callers group reads by reading MI as a string (see
+    // `MiGrouper::get_mi_tag` via `find_string_tag_in_record`). An integer MI is
+    // invisible to the grouper — every read is dropped, so simplex/duplex emit
+    // zero consensus records (which would silently make the parity tests vacuous).
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
-    let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
 
-    // Add MI tag to each record (convert to RecordBuf first to enable tag mutation)
-    let mi_value = 1;
+    let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
     for raw in &records {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value));
+        rec.data_mut().insert(mi_tag, Value::String("1".into()));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
     // Second family with different MI
-    let mi_value2 = 2;
     let records2 = create_umi_family("CCCCCCCC", 3, "mol2", "TGCATGCA", 30);
     for raw in &records2 {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value2));
+        rec.data_mut().insert(mi_tag, Value::String("2".into()));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
@@ -403,4 +414,39 @@ fn test_sort_verify_rejects_stdin_with_clear_message(#[case] input_arg: &str) {
         stderr.contains("stdin"),
         "sort --verify stdin ({input_arg}) rejection should mention stdin; stderr: {stderr}"
     );
+}
+
+/// Single-threaded `simplex -i -` exercises the shared `open_bgzf_reader` stdin
+/// path (the multi-threaded path does not — which is how the single-threaded
+/// `File::open("-")` double-open regression shipped). With `--async-reader`, the
+/// stdin branch must also spawn the prefetch thread and still read correctly.
+/// `assert_stdin_input_parity` covers both `-` and `/dev/stdin` and guards
+/// against a vacuous pass (it requires the file baseline to emit records).
+#[rstest]
+#[case::sync(false)]
+#[case::async_reader(true)]
+fn test_simplex_single_threaded_reads_stdin_once(#[case] async_reader: bool) {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let input = dir.path().join("input.bam");
+    create_grouped_test_bam(&input);
+    // No `--threads` → single-threaded fast path.
+    assert_stdin_input_parity(&input, dir.path(), "simplex", move |i, o| {
+        let mut args = vec![
+            s("simplex"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--min-reads"),
+            s("1"),
+            s("--min-consensus-base-quality"),
+            s("0"),
+            s("--compression-level"),
+            s("1"),
+        ];
+        if async_reader {
+            args.push(s("--async-reader"));
+        }
+        args
+    });
 }


### PR DESCRIPTION
## Summary

`open_bgzf_reader` in `fgumi-bam-io` opened its input with `File::open(path)` unconditionally. For a stdin input that breaks the single-threaded reader path: `File::open("-")` fails outright, and `File::open("/dev/stdin")` re-opens fd 0 (losing any bytes a caller already consumed). This made single-threaded `fgumi <cmd> -i -` fail for the commands whose single-threaded fast path routes through `create_raw_bam_reader_with_opts` → `open_bgzf_reader` (simplex, clip, codec, duplex, correct).

## Fix

Add an `is_stdin_path` branch to `open_bgzf_reader` that reads `io::stdin()` directly, so this BGZF reader is the sole consumer of the pipe. The branch honors `--async-reader` for parity with the file path (wrapping stdin in `PrefetchReader`). This is the single, shared change that closes the single-threaded `-` gap for every command that uses this reader — no per-command code is needed for the reader itself.

## Tests (TDD)

Single-threaded `simplex -i -` is the ideal regression: simplex's input gate is already stdin-exempt, so its single-threaded `-` path was broken *only* by `open_bgzf_reader`. Added two tests (written first, red on the `File::open("-")` failure, green after the fix):

- `test_simplex_single_threaded_reads_stdin_once` — file-vs-piped byte-identical consensus records via the single-threaded path.
- `test_simplex_single_threaded_async_reader_over_stdin` — same, with `--async-reader`, exercising the prefetch-on-stdin sub-branch.

Full streaming-input integration suite (9 tests) and the `fgumi-bam-io` crate (106 tests) pass; `cargo ci-fmt` / `cargo ci-lint` clean.

## Stack

This is the foundational piece of porting stdin support across all BAM-input commands. #415 (sort stdin + the file-vs-stdin parity harness these tests use) has merged to `main`, so this targets `main` directly. A follow-up PR adds the per-command validation-gate exemptions (correct/codec/duplex/filter) and the full parity-test matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stdin handling to avoid reopening stdin and prevent data loss during single-threaded processing.
  * Improved behavior for piped input when using the async reader for consistent BGZF decompression.

* **Tests**
  * Strengthened integration coverage for stdin/piped streaming, including a non-vacuous baseline check and corrected grouping tag typing.
  * Added a parameterized test to confirm single-threaded runs read from stdin correctly in both standard and async-reader modes with byte-identical output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->