### PR TITLE
feat: support reading BAM input from stdin for correct, codec, duplex, filter

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -46,7 +46,6 @@ use fgumi_bam_io::ProgressTracker;
 use fgumi_raw_bam::RawRecord;
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
 use crate::sam::SamTag;
-use crate::validation::validate_file_exists;
 use log::info;
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -264,7 +263,9 @@ impl Command for Codec {
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate inputs
         self.validate()?;
-        validate_file_exists(&self.io.input, "input BAM file")?;
+        // Validate the input exists (stdin paths are exempt — the reader
+        // streams them in a single pass).
+        self.io.validate()?;
 
         let timer = OperationTimer::new("Calling CODEC consensus");
 

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -59,17 +59,16 @@ use crate::unified_pipeline::{
     Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
     run_bam_pipeline_from_reader_with_secondary,
 };
-use crate::validation::validate_file_exists;
 use ahash::AHashMap;
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{
     BamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_with_opts,
+    create_optional_bam_writer,
 };
 use fgumi_raw_bam;
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
 use lru::LruCache;
 use noodles::sam::Header;
@@ -439,10 +438,10 @@ impl Command for CorrectUmis {
                 self.rejects_opts.rejects.is_some(),
             )?
         } else {
-            // Drop reader for single-threaded mode - uses its own iterator
-            drop(reader);
-            // Single-threaded: main thread only, template-level optimization
+            // Single-threaded: reuse the already-opened reader (required for stdin —
+            // re-opening would double-consume a pipe). Mirrors group::execute_single_threaded.
             self.execute_single_thread_mode(
+                reader,
                 header,
                 encoded_umi_set,
                 umi_length,
@@ -470,7 +469,9 @@ impl CorrectUmis {
         if self.umis.is_empty() && self.umi_files.is_empty() {
             bail!("At least one UMI or UMI file must be provided.");
         }
-        validate_file_exists(&self.io.input, "input BAM file")?;
+        // Validate the input exists (stdin paths are exempt — the reader
+        // streams them in a single pass).
+        self.io.validate()?;
         if let Some(min) = self.min_corrected {
             if !(0.0..=1.0).contains(&min) {
                 bail!("--min-corrected must be between 0 and 1.");
@@ -1134,6 +1135,7 @@ impl CorrectUmis {
     #[allow(clippy::too_many_lines)]
     fn execute_single_thread_mode(
         &self,
+        reader: Box<dyn std::io::Read + Send>,
         header: Header,
         encoded_umi_set: EncodedUmiSet,
         umi_length: usize,
@@ -1141,9 +1143,13 @@ impl CorrectUmis {
     ) -> Result<u64> {
         info!("Using single-threaded mode with template-level UMI correction");
 
-        // Open input BAM reader (raw-byte reader for zero-copy processing)
-        let (mut bam_reader, _) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        // Reuse the already-opened reader (required for stdin: re-opening a pipe
+        // double-consumes it). Skip past the BAM header to reach records, then
+        // wrap in RawBamReader for zero-copy processing.
+        let buf_reader = std::io::BufReader::new(reader);
+        let mut noodles_reader = noodles::bam::io::Reader::new(buf_reader);
+        let _ = noodles_reader.read_header().context("Failed to skip BAM header")?;
+        let mut bam_reader = RawBamReader::new(noodles_reader.into_inner());
 
         // Open output writer (single-threaded)
         let mut writer =

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -45,7 +45,6 @@ use crate::unified_pipeline::{
     GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
     run_bam_pipeline_from_reader_with_secondary,
 };
-use crate::validation::validate_file_exists;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_raw_bam;
 use fgumi_raw_bam::{RawRecord, RawRecordView};
@@ -288,8 +287,9 @@ impl Command for Duplex {
         // Start timing
         let timer = OperationTimer::new("Calling duplex consensus");
 
-        // Validate input file exists
-        validate_file_exists(&self.io.input, "Input BAM")?;
+        // Validate the input exists (stdin paths are exempt — the reader
+        // streams them in a single pass).
+        self.io.validate()?;
 
         // Get threading configuration (duplex is worker-heavy with consensus calling)
         let reader_threads = self.threading.num_threads();

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -287,8 +287,9 @@ struct FilterProcessCaptures {
 
 impl Command for Filter {
     fn execute(&self, command_line: &str) -> Result<()> {
-        // Validate inputs
-        validate_file_exists(&self.io.input, "Input BAM")?;
+        // Validate the input exists (stdin paths are exempt — the reader
+        // streams them in a single pass).
+        self.io.validate()?;
 
         if let Some(ref reference) = self.reference {
             validate_file_exists(reference, "Reference FASTA")?;

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -25,7 +25,7 @@ use crate::helpers::bam_generator::create_minimal_header;
 /// In CODEC sequencing, R1 and R2 come from opposite strands of the same molecule,
 /// so a single read pair can produce duplex consensus.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::too_many_arguments)]
-fn create_codec_read_pair(
+pub(crate) fn create_codec_read_pair(
     name: &str,
     r1_seq: &[u8],
     r2_seq: &[u8],
@@ -85,7 +85,7 @@ fn create_codec_read_pair(
 }
 
 /// Helper to create a test BAM file with CODEC read pairs.
-fn create_codec_test_bam(path: &PathBuf, pairs: Vec<(RawRecord, RawRecord)>) {
+pub(crate) fn create_codec_test_bam(path: &PathBuf, pairs: Vec<(RawRecord, RawRecord)>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         create_raw_bam_writer(path, &header, 1, 6).expect("Failed to create raw BAM writer");

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -98,7 +98,7 @@ fn create_duplex_read_pair(
 }
 
 /// Create a BAM with duplex-grouped reads (MI tags with /A and /B strand suffixes).
-fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RawRecord, RawRecord)>>) {
+pub(crate) fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RawRecord, RawRecord)>>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
@@ -118,7 +118,7 @@ fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RawRecord, RawRecord)>>) {
 }
 
 /// Create a single duplex molecule with `depth` read pairs on each strand.
-fn create_duplex_molecule(
+pub(crate) fn create_duplex_molecule(
     mi_id: &str,
     sequence: &str,
     quality: u8,

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -46,15 +46,9 @@ fn create_consensus_bam(path: &Path, records: Vec<RawRecord>) {
     writer.try_finish().expect("Failed to finish BAM");
 }
 
-/// Test basic filter command with passing reads.
-#[test]
-fn test_filter_command_basic() {
-    let temp_dir = TempDir::new().unwrap();
-    let input_bam = temp_dir.path().join("input.bam");
-    let output_bam = temp_dir.path().join("output.bam");
-    let ref_path = create_test_reference(temp_dir.path());
-
-    // Create consensus reads with good quality and per-base tags (cd/ce).
+/// Write a small mapped-consensus BAM (two reads with CD/CE per-base tags that
+/// pass `filter`). Shared by `test_filter_command` and the stdin parity test.
+pub(crate) fn write_filter_consensus_bam(path: &Path) {
     let r1 = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"cons1")
@@ -67,7 +61,6 @@ fn test_filter_command_basic() {
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
-
     let r2 = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"cons2")
@@ -80,8 +73,18 @@ fn test_filter_command_basic() {
         b.add_array_u16(SamTag::CD_BASES, &[5; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
+    create_consensus_bam(path, vec![r1, r2]);
+}
 
-    create_consensus_bam(&input_bam, vec![r1, r2]);
+/// Test basic filter command with passing reads.
+#[test]
+fn test_filter_command_basic() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+
+    write_filter_consensus_bam(&input_bam);
 
     let cmd = Filter::try_parse_from([
         "filter",

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -450,3 +450,229 @@ fn test_simplex_single_threaded_reads_stdin_once(#[case] async_reader: bool) {
         args
     });
 }
+
+fn push_threads(args: &mut Vec<String>, threads: Option<&str>) {
+    if let Some(t) = threads {
+        args.push(s("--threads"));
+        args.push(s(t));
+    }
+}
+
+#[rstest]
+#[case("1")]
+#[case("2")]
+fn test_group_reads_stdin_once(#[case] threads: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    assert_stdin_input_parity(&input, dir.path(), "group", |i, o| {
+        vec![
+            s("group"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--strategy"),
+            s("identity"),
+            s("--edits"),
+            s("0"),
+            s("--threads"),
+            s(threads),
+            s("--compression-level"),
+            s("1"),
+        ]
+    });
+}
+
+#[rstest]
+#[case("1")]
+#[case("2")]
+fn test_dedup_reads_stdin_once(#[case] threads: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    assert_stdin_input_parity(&input, dir.path(), "dedup", |i, o| {
+        vec![
+            s("dedup"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--strategy"),
+            s("identity"),
+            s("--edits"),
+            s("0"),
+            s("--threads"),
+            s(threads),
+            s("--compression-level"),
+            s("1"),
+        ]
+    });
+}
+
+/// correct has a single-threaded fast path (no `--threads`) plus the
+/// multi-threaded path; cover both (single-threaded exercises the reader reuse).
+#[rstest]
+#[case::single_threaded(None)]
+#[case::multi_threaded(Some("2"))]
+fn test_correct_reads_stdin_once(#[case] threads: Option<&str>) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.bam");
+    create_test_input_bam(&input);
+    // create_test_input_bam tags reads with RX = AAAAAAAA / CCCCCCCC.
+    assert_stdin_input_parity(&input, dir.path(), "correct", move |i, o| {
+        let mut args = vec![
+            s("correct"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--umis"),
+            s("AAAAAAAA"),
+            s("--umis"),
+            s("CCCCCCCC"),
+            s("--min-distance"),
+            s("1"),
+            s("--compression-level"),
+            s("1"),
+        ];
+        push_threads(&mut args, threads);
+        args
+    });
+}
+
+/// codec has a single-threaded fast path (no `--threads`) plus the
+/// multi-threaded path; cover both.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::multi_threaded(Some("2"))]
+fn test_codec_reads_stdin_once(#[case] threads: Option<&str>) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("codec.bam");
+    let pairs: Vec<_> = (0..3)
+        .map(|i| {
+            crate::test_codec_command::create_codec_read_pair(
+                &format!("read{i}"),
+                b"ACGTACGT",
+                b"ACGTACGT",
+                &[30; 8],
+                &[30; 8],
+                100,
+                "UMI001",
+                None,
+            )
+        })
+        .collect();
+    crate::test_codec_command::create_codec_test_bam(&input, pairs);
+    assert_stdin_input_parity(&input, dir.path(), "codec", move |i, o| {
+        let mut args = vec![
+            s("codec"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--min-reads"),
+            s("1"),
+            s("--min-duplex-length"),
+            s("1"),
+            s("--compression-level"),
+            s("1"),
+        ];
+        push_threads(&mut args, threads);
+        args
+    });
+}
+
+/// duplex has a single-threaded fast path (no `--threads`) plus the
+/// multi-threaded path; cover both.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::multi_threaded(Some("2"))]
+fn test_duplex_reads_stdin_once(#[case] threads: Option<&str>) {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("duplex.bam");
+    let molecule =
+        crate::test_duplex_command::create_duplex_molecule("MI001", "ACGTACGT", 30, 100, 3);
+    crate::test_duplex_command::create_duplex_bam(&input, vec![molecule]);
+    assert_stdin_input_parity(&input, dir.path(), "duplex", move |i, o| {
+        let mut args = vec![
+            s("duplex"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--min-reads"),
+            s("1"),
+            s("--compression-level"),
+            s("1"),
+        ];
+        push_threads(&mut args, threads);
+        args
+    });
+}
+
+#[rstest]
+#[case("1")]
+#[case("2")]
+fn test_filter_reads_stdin_once(#[case] threads: &str) {
+    use crate::helpers::bam_generator::create_test_reference;
+    let dir = TempDir::new().unwrap();
+    let reference = create_test_reference(dir.path()).to_str().unwrap().to_string();
+    let input = dir.path().join("consensus.bam");
+    crate::test_filter_command::write_filter_consensus_bam(&input);
+    assert_stdin_input_parity(&input, dir.path(), "filter", move |i, o| {
+        // --ref is required when filtering mapped reads (NM/UQ/MD).
+        vec![
+            s("filter"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--ref"),
+            reference.clone(),
+            s("--min-reads"),
+            s("1"),
+            s("--max-no-call-fraction"),
+            s("1.0"),
+            s("--threads"),
+            s(threads),
+            s("--compression-level"),
+            s("1"),
+        ]
+    });
+}
+
+/// clip has a single-threaded fast path (no `--threads`) plus the
+/// multi-threaded path; cover both.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::multi_threaded(Some("2"))]
+fn test_clip_reads_stdin_once(#[case] threads: Option<&str>) {
+    use crate::helpers::bam_generator::{create_paired_umi_family, create_test_reference};
+    let dir = TempDir::new().unwrap();
+    let reference = create_test_reference(dir.path()).to_str().unwrap().to_string();
+    let input = dir.path().join("paired.bam");
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer = bam::io::Writer::new(fs::File::create(&input).expect("create paired BAM"));
+    writer.write_header(&header).expect("write header");
+    for raw in &create_paired_umi_family("ACGTACGT", 3, "clip", "ACGTACGTAC", "TGCATGCATG", 30) {
+        writer.write_alignment_record(&header, &to_record_buf(raw)).expect("write paired record");
+    }
+    writer.try_finish().expect("finish BAM");
+    assert_stdin_input_parity(&input, dir.path(), "clip", move |i, o| {
+        let mut args = vec![
+            s("clip"),
+            s("--input"),
+            s(i),
+            s("--output"),
+            s(o),
+            s("--reference"),
+            reference.clone(),
+            s("--clip-overlapping-reads"),
+            s("--compression-level"),
+            s("1"),
+        ];
+        push_threads(&mut args, threads);
+        args
+    });
+}


### PR DESCRIPTION
## Summary

Extends stdin BAM input to the remaining BAM-input commands: `correct`, `codec`, `duplex`, and `filter`. (`group`, `dedup`, `clip`, `sort`, and the simplex single-threaded path already read stdin on `main`.) After this, every BAM-input command accepts `-i -` and `-i /dev/stdin`.

## What was blocking each command

These four called `validate_file_exists(&self.io.input, ...)` unconditionally, which rejected `-`/`/dev/stdin` before the reader ran. Their readers are already stdin-safe (multi-threaded via `create_bam_reader_for_pipeline*`; single-threaded via the `open_bgzf_reader` stdin branch in the parent PR). So the fix is a one-line gate exemption per command, matching the existing pattern in `group`/`dedup`/`clip`:

```rust
if !fgumi_bam_io::is_stdin_path(&self.io.input) {
    validate_file_exists(&self.io.input, "...")?;
}
```

## `correct` single-threaded double-open fix

`correct` additionally had a latent bug: `execute()` opened the input reader unconditionally, then the single-threaded path (`--threads` omitted) dropped it and re-opened the input — fatal for a pipe (the second open gets a drained stream). Fixed by reusing the already-opened reader in single-threaded mode, mirroring `group::execute_single_threaded` (skip the header on the existing reader, wrap in `RawBamReader`). `codec`/`duplex` already open inside their thread branches; `filter`/`dedup` open once — none of them had this issue.

## Tests

File-vs-`-`-vs-`/dev/stdin` byte-identical record parity (`assert_stdin_input_parity`) for `group`, `dedup`, `correct`, `codec`, `duplex`, `filter`, `clip`, each with a non-vacuous (`> 0` records) guard. Commands with a single-threaded fast path (`codec`, `duplex`, `clip`, and now `correct`) are parameterized over both single-threaded (no `--threads`) and multi-threaded — the single-threaded case is what surfaces reader-reuse bugs like the `correct` double-open. Cross-module test builders (`create_codec_*`, `create_duplex_*`) were made `pub(crate)`, and `write_filter_consensus_bam` was factored out of the existing filter test for reuse.

Full streaming-input integration suite passes; `cargo ci-fmt` / `cargo ci-lint` clean.

## Stack

Stacked on #418 (`open_bgzf_reader` stdin fix), which underpins the single-threaded `-` paths here. Base will retarget to `main` once #418 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stdin streaming consistency across multiple commands (correct, codec, duplex, filter).

* **Tests**
  * Added comprehensive integration tests verifying stdin streaming parity across group, dedup, correct, codec, duplex, filter, and clip commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->