### PR TITLE
test(streaming): write MI as a string so simplex parity tests are non-vacuous

### DIFF
--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -185,6 +185,15 @@ fn test_simplex_command_with_piped_input() {
     assert!(status.success(), "Simplex command with piped input failed");
     assert!(output_from_pipe.exists(), "Output BAM from pipe not created");
 
+    // Guard against a vacuous pass: simplex must actually emit consensus records,
+    // otherwise the file-vs-pipe comparison below is trivially true (0 == 0) even
+    // if stdin were dropped entirely. (A non-string MI tag in the input silently
+    // produces zero consensus reads — see create_grouped_test_bam.)
+    assert!(
+        count_bam_records(&output_from_file) > 0,
+        "simplex produced no consensus records — parity check would be vacuous"
+    );
+
     // Compare outputs - records should be identical (headers may differ due to @PG command line)
     compare_bam_records(&output_from_file, &output_from_pipe);
 }
@@ -260,24 +269,28 @@ fn create_grouped_test_bam(path: &PathBuf) {
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
-    // Create grouped reads with MI tag
+    // Create grouped reads with MI tag.
+    //
+    // MI MUST be a STRING tag: `fgumi group` writes the MoleculeId as a string,
+    // and the consensus callers group reads by reading MI via
+    // `find_string_tag_in_record` (see `MiGrouper::get_mi_tag`). An integer MI is
+    // invisible to the grouper — every read is dropped, so simplex/duplex emit
+    // zero consensus records. Writing it as an integer here silently made the
+    // simplex stdin parity tests vacuous (comparing 0 records vs 0 records).
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
-    let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
 
-    // Add MI tag to each record (convert to RecordBuf first to enable tag mutation)
-    let mi_value = 1;
+    let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
     for raw in &records {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value));
+        rec.data_mut().insert(mi_tag, Value::String("1".into()));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
     // Second family with different MI
-    let mi_value2 = 2;
     let records2 = create_umi_family("CCCCCCCC", 3, "mol2", "TGCATGCA", 30);
     for raw in &records2 {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value2));
+        rec.data_mut().insert(mi_tag, Value::String("2".into()));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 


### PR DESCRIPTION
## Summary

`test_simplex_command_with_piped_input` was passing **vacuously**: it compared the file-input output against the piped-stdin output, but both were empty, so the comparison was trivially true (0 records == 0 records) even if stdin had been dropped entirely.

## Root cause

`create_grouped_test_bam` wrote the `MI` tag as an **integer** (`Value::from(1)`). The consensus callers group reads into molecules by reading `MI` as a **string** — `MiGrouper::get_mi_tag` (`src/lib/mi_group.rs`) uses `fgumi_raw_bam::find_string_tag_in_record`, and reads without a string `MI` are dropped. So every read in the test BAM was invisible to the grouper, simplex emitted **zero** consensus records, and the parity comparison had nothing to compare.

Real `fgumi group` writes the `MoleculeId` as a string tag, so the integer `MI` was simply unrepresentative test data.

## Fix

- Write `MI` as a string (`"1"` / `"2"`) in `create_grouped_test_bam`, matching what `fgumi group` emits, so the consensus callers actually group the reads and produce output.
- Add a non-vacuous guard (`count_bam_records(&output) > 0`) to `test_simplex_command_with_piped_input` so a future regression to empty output fails loudly instead of passing silently.

## Verification

With the string `MI`, simplex now emits consensus records and the test exercises a real file-vs-stdin record comparison. Full `test_streaming_input` suite passes; `cargo ci-fmt` / `cargo ci-lint` clean.

This was surfaced while reviewing the stdin-support PRs (#418 / #419): the stronger `assert_stdin_input_parity` harness includes the same non-vacuous guard, which is what exposed the zero-record output. Targeting `main` directly since the affected test and the builder are already merged; the simplex stdin tests added in #418 will inherit the fixed builder once they rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened integration tests for streaming stdin/pipe operations with added safeguards to ensure accurate result validation
  * Corrected test data generation format to align with expected consensus and grouping processing standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->