### PR TITLE
perf(duplex): partition strand groups by move instead of cloning

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1881,15 +1881,14 @@ impl DuplexConsensusCaller {
 
         // Split filtered results back by firstOfPair flag (matching fgbio lines 347-350)
         // X = AB-R1 + BA-R2, Y = AB-R2 + BA-R1 (combined for alignment filtering)
-        // Now split them back into the four groups using sr.flags:
-        let filtered_ab_r1s: Vec<SourceRead> =
-            filtered_xs.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT != 0).cloned().collect();
-        let filtered_ba_r2s: Vec<SourceRead> =
-            filtered_xs.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT == 0).cloned().collect();
-        let filtered_ab_r2s: Vec<SourceRead> =
-            filtered_ys.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT == 0).cloned().collect();
-        let filtered_ba_r1s: Vec<SourceRead> =
-            filtered_ys.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT != 0).cloned().collect();
+        // Now split them back into the four groups using sr.flags. The two splits of
+        // each vec are disjoint partitions (`FIRST_SEGMENT` set vs clear), so move the
+        // reads into their groups with `partition` instead of cloning every surviving
+        // `SourceRead` (bases, quals, and two cigar vecs) out of a borrow.
+        let (filtered_ab_r1s, filtered_ba_r2s): (Vec<SourceRead>, Vec<SourceRead>) =
+            filtered_xs.into_iter().partition(|sr| sr.flags & flags::FIRST_SEGMENT != 0);
+        let (filtered_ba_r1s, filtered_ab_r2s): (Vec<SourceRead>, Vec<SourceRead>) =
+            filtered_ys.into_iter().partition(|sr| sr.flags & flags::FIRST_SEGMENT != 0);
 
         debug!(
             "MI {}: After split (filtered_AB-R1={}, filtered_AB-R2={}, filtered_BA-R1={}, filtered_BA-R2={})",


### PR DESCRIPTION
Wave 1 perf cleanup (#3 of the feat-runall review series).

## What

`process_group` split the alignment-filtered `filtered_xs` / `filtered_ys` back into the four strand groups (AB-R1, AB-R2, BA-R1, BA-R2) with four `iter().filter(...).cloned().collect()` passes — deep-cloning every surviving `SourceRead` (its bases, quals, and two cigar vecs) once per duplex template.

The two splits of each vec are disjoint partitions on a single flag bit (`FIRST_SEGMENT` set vs clear), so this moves each read into its group with `into_iter().partition(...)` in one pass, no clones.

## Behavior

Unchanged. The partition predicates map 1:1 to the original four filters, and `partition` preserves per-group iteration order, so consensus output is identical.

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -E 'test(duplex)'` — 91 tests pass, including `runall_duplex_record_stream_is_deterministic`, the fgbio-parity duplex tests, and `test_duplex_metrics_command::*`.
- CodeRabbit CLI (`--agent`) and a CodeRabbit-style self-review: 0 findings.