### PR TITLE
perf(pipeline): inline OutputHandles push/view/retry accessors

### DIFF
--- a/src/lib/pipeline/core/handles.rs
+++ b/src/lib/pipeline/core/handles.rs
@@ -730,6 +730,7 @@ impl<T: Send + HeapSize + 'static> OutputHandles<Single<T>> {
     ///
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `SingleOutputsView<T>` (a framework invariant violation).
+    #[inline]
     pub fn push(&self, item: T) -> Result<(), Unpushed<T>> {
         let view = self
             .inner
@@ -749,6 +750,7 @@ impl<T: Send + HeapSize + 'static> OutputHandles<Single<T>> {
     ///
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `SingleOutputsView<T>`.
+    #[inline]
     pub fn retry(&self, unpushed: Unpushed<T>) -> Result<(), Unpushed<T>> {
         let view = self
             .inner
@@ -774,6 +776,7 @@ impl<T: Send + HeapSize + Ordered + 'static>
     ///
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `OrderedBytesSingleOutputsView<T>` (a framework invariant violation).
+    #[inline]
     pub fn push(&self, item: T) -> Result<(), Unpushed<T>> {
         let view = self
             .inner
@@ -793,6 +796,7 @@ impl<T: Send + HeapSize + Ordered + 'static>
     ///
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `OrderedBytesSingleOutputsView<T>`.
+    #[inline]
     pub fn retry(&self, unpushed: Unpushed<T>) -> Result<(), Unpushed<T>> {
         let view = self
             .inner
@@ -812,6 +816,7 @@ impl<T: Send + HeapSize + Ordered + 'static>
     /// forgot the put-back would silently drop a final batch). **Never spins** —
     /// the caller maps `StillHeld` to a yield (`NoProgress`/`Contention`) and
     /// retries on the next dispatch.
+    #[inline]
     pub fn retry_held(
         &self,
         held: &mut crate::pipeline::core::held::HeldSlot<Unpushed<T>>,
@@ -837,6 +842,7 @@ impl<A: Send + HeapSize + 'static, B: Send + HeapSize + 'static> OutputHandles<(
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `Tuple2OutputsView<A, B>` (a framework invariant violation).
     #[must_use]
+    #[inline]
     pub fn view(&self) -> Tuple2View<'_, A, B> {
         let v = self
             .inner
@@ -862,6 +868,7 @@ where
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `Tuple2OutputsView<A, B>` (a framework invariant violation).
     #[must_use]
+    #[inline]
     pub fn view(&self) -> Tuple2View<'_, A, B> {
         let v = self
             .inner
@@ -890,6 +897,7 @@ where
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `Tuple3OutputsView<A, B, C>` (a framework invariant violation).
     #[must_use]
+    #[inline]
     pub fn view(&self) -> Tuple3View<'_, A, B, C> {
         let v = self
             .inner
@@ -925,6 +933,7 @@ where
     /// Panics if the type-erased outputs view doesn't downcast to
     /// `Tuple4OutputsView<A, B, C, D>` (a framework invariant violation).
     #[must_use]
+    #[inline]
     pub fn view(&self) -> Tuple4View<'_, A, B, C, D> {
         let v = self
             .inner


### PR DESCRIPTION
Wave 1 perf cleanup (#4 of the feat-runall review series).

## What

The typed-step dispatch path already caches its input/output downcast (`TypedStep::resolve_input` / `resolve_outputs`), but the per-item `OutputHandles<O>` accessors that a step body calls — `push`, `retry`, `retry_held`, and the tuple `view()` methods — each perform an uncached `downcast_ref` on every call and were not `#[inline]`. Without inlining, the compiler can't hoist or fold that `downcast_ref` across a step's flush-then-push sequence.

This marks those nine accessors `#[inline]`. They are tiny forwarding methods on the per-record hot path, so this is a free codegen hint.

## Behavior

Unchanged — `#[inline]` is a hint only; no logic, signatures, or control flow changed. (The deeper downcast-caching follow-up needs `unsafe` and is tracked separately, out of scope here.)

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -E 'test(pipeline) or test(runall) or test(handles)'` — 573 tests pass, including the `pipeline_core_compile_fail` trybuild suite and the runall fused-pipeline parity tests.
- CodeRabbit CLI (`--agent`) and a CodeRabbit-style self-review: 0 findings.