### PR TITLE
style: clear clippy --all-features --all-targets warnings

### DIFF
--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -219,6 +219,13 @@ impl MemoryDebugStats {
     }
 }
 
+#[cfg(feature = "memory-debug")]
+impl Default for MemoryDebugStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ============================================================================
 // Thread-Local Memory Tracking
 // ============================================================================
@@ -229,7 +236,7 @@ const THREAD_ID_UNSET: usize = usize::MAX;
 
 #[cfg(feature = "memory-debug")]
 thread_local! {
-    static THREAD_ID: std::cell::Cell<usize> = std::cell::Cell::new(THREAD_ID_UNSET);
+    static THREAD_ID: std::cell::Cell<usize> = const { std::cell::Cell::new(THREAD_ID_UNSET) };
 }
 
 #[cfg(feature = "memory-debug")]

--- a/tests/integration/test_pipeline_concurrency.rs
+++ b/tests/integration/test_pipeline_concurrency.rs
@@ -979,7 +979,7 @@ mod stress_tests {
                     move |record: RecordBuf| {
                         let n = count_clone.fetch_add(1, Ordering::Relaxed);
                         if n == fail_at {
-                            return Err(io::Error::new(io::ErrorKind::Other, "random fail"));
+                            return Err(io::Error::other("random fail"));
                         }
                         Ok(record)
                     },
@@ -1030,8 +1030,8 @@ mod stress_tests {
                                 })
                             })
                             .unwrap_or(0);
-                        if hash % 10 == 0 {
-                            return Err(io::Error::new(io::ErrorKind::Other, "intermittent fail"));
+                        if hash.is_multiple_of(10) {
+                            return Err(io::Error::other("intermittent fail"));
                         }
                         Ok(record)
                     },


### PR DESCRIPTION
## Summary

Five clippy warnings only surfaced under `--all-features` (the `memory-debug` feature) and `--all-targets`, which the default CI lint feature-set doesn't exercise — so they accumulated silently. The Fulcrum Rust convention is to lint with `clippy --all-features --all-targets -- -D warnings`, so this clears them:

- `src/lib/unified_pipeline/base.rs`: add `Default` for `MemoryDebugStats` (`new_without_default`); make the `THREAD_ID` thread-local initializer `const` (`missing_const_for_thread_local`).
- `tests/integration/test_pipeline_concurrency.rs`: `io::Error::other(..)` (×2) and `hash.is_multiple_of(10)`.

Pure lint cleanup, no behavior change. `cargo clippy --all-features --all-targets -- -D warnings` is now clean.

Found while accounting for deferred items during the stdin-support work; unrelated to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory debug statistics initialization.
  * Optimized thread-local value construction.

* **Tests**
  * Refined stress test error injection patterns for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->