### PR TITLE
refactor: route group/dedup/clip stdin gate through BamIoOptions::validate

### DIFF
--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -21,9 +21,7 @@ use crate::validation::validate_file_exists;
 use anyhow::Result;
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    create_bam_reader_for_pipeline, create_raw_bam_reader, create_raw_bam_writer, is_stdin_path,
-};
+use fgumi_bam_io::{create_bam_reader_for_pipeline, create_raw_bam_reader, create_raw_bam_writer};
 use fgumi_raw_bam::RawRecord;
 use log::info;
 use noodles::sam::Header;
@@ -195,10 +193,8 @@ struct CollectedClipMetrics {
 impl Command for Clip {
     #[allow(clippy::too_many_lines)]
     fn execute(&self, command_line: &str) -> Result<()> {
-        // Validate input files exist (skip for stdin)
-        if !is_stdin_path(&self.io.input) {
-            validate_file_exists(&self.io.input, "Input BAM")?;
-        }
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
         validate_file_exists(&self.reference, "Reference FASTA")?;
 
         info!("Clip");

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -37,12 +37,11 @@ use crate::unified_pipeline::{
     BatchWeight, GroupKeyConfig, Grouper, MemoryEstimate,
     run_bam_pipeline_from_reader_with_mi_assign,
 };
-use crate::validation::validate_file_exists;
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::{create_bam_reader_for_pipeline_with_opts, is_stdin_path};
+use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
 
 use log::info;
 use noodles::sam::Header;
@@ -968,10 +967,8 @@ impl Command for MarkDuplicates {
             (self.strategy, false)
         };
 
-        // Validate input file exists
-        if !is_stdin_path(&self.io.input) {
-            validate_file_exists(&self.io.input, "input BAM file")?;
-        }
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
 
         let min_mapq: u8 = self.min_map_q.unwrap_or(0);
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -31,12 +31,11 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{create_bam_reader_for_pipeline, create_bam_writer, is_stdin_path};
+use fgumi_bam_io::{create_bam_reader_for_pipeline, create_bam_writer};
 // MemoryEstimate is gated because it's only used in memory-debug blocks below
 use crate::sam::SamTag;
 #[cfg(feature = "memory-debug")]
 use crate::unified_pipeline::MemoryEstimate;
-use crate::validation::validate_file_exists;
 use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
 use noodles::sam::Header;
@@ -917,10 +916,8 @@ impl Command for GroupReadsByUmi {
             (self.strategy, false)
         };
 
-        // Validate input file exists (skip for stdin)
-        if !is_stdin_path(&self.io.input) {
-            validate_file_exists(&self.io.input, "input BAM file")?;
-        }
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
 
         // Set minimum mapping quality
         let min_mapq: u8 = self.min_map_q.unwrap_or(1);


### PR DESCRIPTION
## Summary

`group`, `dedup`, and `clip` each inlined the stdin-exempt input check:

```rust
if !is_stdin_path(&self.io.input) { validate_file_exists(&self.io.input, "...")?; }
```

That logic already exists as `BamIoOptions::validate()`, which `simplex` (and, since the stdin work, `correct`/`codec`/`duplex`/`filter`) use. This routes the remaining three through `self.io.validate()?` so **all** BAM-input commands share one helper, and removes the now-unused `is_stdin_path` / `validate_file_exists` imports (`clip` keeps `validate_file_exists` for its `--reference` check).

Behavior-preserving — the helper performs the identical `!is_stdin_path` gate. It standardizes the error message on `"Input BAM"` (group/dedup previously said "input BAM file"); no test asserts the prior wording. `ci-fmt`/`ci-lint` clean; stdin parity tests pass.

Follow-up cleanup from the deferred-items list during the stdin-support work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated input validation logic across multiple commands for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->