### PR TITLE
perf(consensus): compose consensus read names without a per-record String

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1291,21 +1291,31 @@ impl CodecConsensusCaller {
     ) -> Result<()> {
         // Generate read name - use ':' delimiter to match fgbio format
         self.consensus_counter += 1;
-        let read_name = if let Some(umi_str) = umi {
-            format!("{}:{}", self.read_name_prefix, umi_str)
-        } else {
-            format!("{}:{}", self.read_name_prefix, self.consensus_counter)
-        };
 
         // Codec always outputs unmapped fragments
         let flag = flags::UNMAPPED;
 
-        self.bam_builder.build_record(
-            read_name.as_bytes(),
-            flag,
-            &consensus.bases,
-            &consensus.quals,
-        );
+        // Read name is `<prefix>:<umi>` (or `<prefix>:<counter>` when there is
+        // no UMI). Compose the common UMI case straight into the record buffer
+        // rather than allocating a `String` per read; the counter fallback
+        // still formats the integer suffix.
+        if let Some(umi_str) = umi {
+            self.bam_builder.build_record_joined_name(
+                self.read_name_prefix.as_bytes(),
+                umi_str.as_bytes(),
+                flag,
+                &consensus.bases,
+                &consensus.quals,
+            );
+        } else {
+            let read_name = format!("{}:{}", self.read_name_prefix, self.consensus_counter);
+            self.bam_builder.build_record(
+                read_name.as_bytes(),
+                flag,
+                &consensus.bases,
+                &consensus.quals,
+            );
+        }
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1075,9 +1075,16 @@ impl DuplexConsensusCaller {
             }
         }
 
-        // Build the record (name, flags, bases, quals)
-        let read_name = format!("{read_name_prefix}:{umi}");
-        builder.build_record(read_name.as_bytes(), flag, &consensus.bases, &consensus.quals);
+        // Build the record (name, flags, bases, quals). The read name is
+        // `<prefix>:<umi>`; compose it straight into the record buffer rather
+        // than allocating a fresh `String` per output read.
+        builder.build_record_joined_name(
+            read_name_prefix.as_bytes(),
+            umi.as_bytes(),
+            flag,
+            &consensus.bases,
+            &consensus.quals,
+        );
 
         // 1. MI tag (string)
         builder.append_string_tag(SamTag::MI, umi.as_bytes());

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1374,8 +1374,6 @@ impl VanillaUmiConsensusCaller {
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
     ) {
-        let read_name = format!("{}:{}", self.read_name_prefix, umi);
-
         let mut flag = flags::UNMAPPED;
         match read_type {
             ReadType::R1 => {
@@ -1387,7 +1385,15 @@ impl VanillaUmiConsensusCaller {
             ReadType::Fragment => {}
         }
 
-        self.bam_builder.build_record(read_name.as_bytes(), flag, bases, quals);
+        // Read name is `<prefix>:<umi>`; compose it straight into the record
+        // buffer rather than allocating a fresh `String` per output read.
+        self.bam_builder.build_record_joined_name(
+            self.read_name_prefix.as_bytes(),
+            umi.as_bytes(),
+            flag,
+            bases,
+            quals,
+        );
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -86,8 +86,60 @@ impl UnmappedSamBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if `quals` is non-empty and `bases.len() != quals.len()`.
+    /// Panics if `name` is 255 bytes or longer, or if `quals` is non-empty and
+    /// `bases.len() != quals.len()`.
     pub fn build_record(&mut self, name: &[u8], flag: u16, bases: &[u8], quals: &[u8]) {
+        self.build_record_with_name(
+            name.len(),
+            |buf| buf.extend_from_slice(name),
+            flag,
+            bases,
+            quals,
+        );
+    }
+
+    /// Like [`Self::build_record`] but composes the read name as
+    /// `prefix:suffix` directly into the record buffer, avoiding a temporary
+    /// `String` allocation per record on the consensus hot path. Equivalent to
+    /// `build_record(format!("{prefix}:{suffix}").as_bytes(), flag, bases, quals)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the joined name (`prefix` + `:` + `suffix`) is 255 bytes or
+    /// longer, or if `quals` is non-empty and `bases.len() != quals.len()`.
+    pub fn build_record_joined_name(
+        &mut self,
+        prefix: &[u8],
+        suffix: &[u8],
+        flag: u16,
+        bases: &[u8],
+        quals: &[u8],
+    ) {
+        let name_len = prefix.len() + 1 + suffix.len(); // +1 for the ':' separator
+        self.build_record_with_name(
+            name_len,
+            |buf| {
+                buf.extend_from_slice(prefix);
+                buf.push(b':');
+                buf.extend_from_slice(suffix);
+            },
+            flag,
+            bases,
+            quals,
+        );
+    }
+
+    /// Shared record builder: writes the fixed header, the read name (via
+    /// `write_name`, which must append exactly `name_len` bytes), the packed
+    /// sequence, and the quality scores.
+    fn build_record_with_name(
+        &mut self,
+        name_len: usize,
+        write_name: impl FnOnce(&mut Vec<u8>),
+        flag: u16,
+        bases: &[u8],
+        quals: &[u8],
+    ) {
         assert!(
             bases.len() == quals.len() || quals.is_empty(),
             "bases.len() ({}) != quals.len() ({})",
@@ -98,12 +150,12 @@ impl UnmappedSamBuilder {
         self.buf.clear();
         self.sealed = false;
 
-        assert!(name.len() < 255, "read name too long ({} bytes, max 254)", name.len());
+        assert!(name_len < 255, "read name too long ({name_len} bytes, max 254)");
         #[expect(
             clippy::cast_possible_truncation,
-            reason = "assert above guarantees name.len() < 255"
+            reason = "assert above guarantees name_len < 255"
         )]
-        let l_read_name = (name.len() + 1) as u8; // +1 for NUL
+        let l_read_name = (name_len + 1) as u8; // +1 for NUL
         let l_seq = u32::try_from(bases.len()).expect("sequence length overflow");
         let packed_seq_len = bases.len().div_ceil(2);
 
@@ -124,7 +176,14 @@ impl UnmappedSamBuilder {
         self.buf.extend_from_slice(&0i32.to_le_bytes()); // tlen = 0
 
         // === Read name + NUL ===
-        self.buf.extend_from_slice(name);
+        let name_start = self.buf.len();
+        write_name(&mut self.buf);
+        debug_assert_eq!(
+            self.buf.len() - name_start,
+            name_len,
+            "write_name appended {} bytes, expected name_len = {name_len}",
+            self.buf.len() - name_start,
+        );
         self.buf.push(0);
 
         // === Packed sequence ===
@@ -594,6 +653,55 @@ mod tests {
     use crate::tags::*;
     use crate::testutil::*;
     use fgumi_tag::SamTag;
+
+    #[test]
+    fn test_build_record_joined_name_matches_format() {
+        // The joined-name fast path must produce byte-for-byte the same record
+        // as concatenating the name with `format!` and calling `build_record`.
+        let bases = b"ACGTACGT";
+        let quals: [u8; 8] = [30, 25, 35, 40, 20, 22, 33, 31];
+
+        let mut joined = UnmappedSamBuilder::new();
+        joined.build_record_joined_name(b"consensus", b"1/A", flags::UNMAPPED, bases, &quals);
+
+        let mut formatted = UnmappedSamBuilder::new();
+        let name = format!("{}:{}", "consensus", "1/A");
+        formatted.build_record(name.as_bytes(), flags::UNMAPPED, bases, &quals);
+
+        assert_eq!(joined.as_bytes(), formatted.as_bytes());
+        assert_eq!(read_name(joined.as_bytes()), b"consensus:1/A");
+        assert_eq!(l_read_name(joined.as_bytes()), 14); // "consensus:1/A" (13) + NUL
+    }
+
+    proptest::proptest! {
+        /// The joined-name fast path must be byte-for-byte identical to
+        /// concatenating `prefix:suffix` and calling `build_record`, across
+        /// varied prefix/suffix/bases/quals. `prefix` and `suffix` lengths are
+        /// bounded so the joined name brushes the 254-byte maximum
+        /// (`127 + 1 + 126 = 254`) without exceeding it.
+        #[test]
+        fn test_build_record_joined_name_matches_format_prop(
+            prefix in proptest::collection::vec(0x21..=0x7eu8, 0..=127),
+            suffix in proptest::collection::vec(0x21..=0x7eu8, 0..=126),
+            bases in proptest::collection::vec(proptest::sample::select(&b"ACGTN"[..]), 0..40),
+        ) {
+            // Raw Phred qualities (0..=93) matching the sequence length; the
+            // same values feed both builders, so the qual branch is identical.
+            let quals: Vec<u8> = bases.iter().map(|&b| b % 60).collect();
+
+            let mut joined = UnmappedSamBuilder::new();
+            joined.build_record_joined_name(&prefix, &suffix, flags::UNMAPPED, &bases, &quals);
+
+            // Reference path: build the joined name explicitly, then build_record.
+            let mut name = prefix.clone();
+            name.push(b':');
+            name.extend_from_slice(&suffix);
+            let mut formatted = UnmappedSamBuilder::new();
+            formatted.build_record(&name, flags::UNMAPPED, &bases, &quals);
+
+            proptest::prop_assert_eq!(joined.as_bytes(), formatted.as_bytes());
+        }
+    }
 
     #[test]
     fn test_builder_basic_unmapped_record() {


### PR DESCRIPTION
Wave 1 perf cleanup (#6 / final of the feat-runall review series).

## What

The simplex, duplex, and codec callers built each output read's name with `format!("{prefix}:{umi}")`, allocating a fresh `String` per consensus read purely to hand the bytes to `UnmappedSamBuilder::build_record` (which then copies them into the record buffer).

Adds `UnmappedSamBuilder::build_record_joined_name(prefix, suffix, …)`, which writes `prefix:suffix` straight into the record buffer the builder already owns and reuses, and routes the three callers through it. `build_record` and the new method now share a private `build_record_with_name` helper, so header/sequence/quality serialization is defined once. The codec no-UMI fallback still formats its integer counter suffix.

## Behavior

Unchanged. A new unit test asserts `build_record_joined_name` is byte-for-byte identical to `build_record(format!("{prefix}:{suffix}").as_bytes(), …)`, and the fgbio-parity simplex/duplex/codec tests confirm output is unchanged. Also completes `build_record`'s `# Panics` docs (the long-standing `name.len() >= 255` panic was undocumented).

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -E 'test(builder) or test(simplex) or test(duplex) or test(codec) or test(consensus)'` — 324 tests pass, including the new equivalence test and the command-level fgbio parity tests.
- CodeRabbit CLI (`--agent`) and a CodeRabbit-style self-review: 0 findings (one doc nit found and fixed during review).