### PR TITLE
perf(pipeline): hash reorder buffer with ahash instead of SipHash

### DIFF
--- a/src/lib/pipeline/core/reorder.rs
+++ b/src/lib/pipeline/core/reorder.rs
@@ -26,7 +26,8 @@
 //!     transport (`CountBounded` / `Unbounded` — see PR 1 caveat below).
 //!   - "Stashed" items (must-accept overflow when transport rejected, or
 //!     items pulled but not yet at their turn) live in `state.buffer:
-//!     HashMap<u64, T>`.
+//!     AHashMap<u64, T>` (ahash — the ordinals are trivial monotonic `u64`
+//!     keys, so the default `SipHash` buys nothing on this per-item path).
 //!   - The transport's backpressure budget covers only in-flight items.
 //!     The overflow stash has its own byte cap (`max_overflow_bytes`). The
 //!     framework sizes that cap thread-awarely from the per-edge transport
@@ -41,8 +42,8 @@
 //! / `ByItemOrdinal` compose with `QueueSpec::ByteBounded` — the canonical BAM
 //! step output shape (`build_branch_ordered_bytes`).
 
+use ahash::AHashMap;
 use parking_lot::Mutex;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
@@ -213,7 +214,7 @@ struct ReorderState<T> {
     /// The size is consumed by `buffer_bytes` accounting; for items
     /// whose `heap_size()` is O(records) (e.g. position groups) this
     /// caching avoids 3× the `heap_size` cost per item flowing through.
-    buffer: HashMap<u64, (T, u64)>,
+    buffer: AHashMap<u64, (T, u64)>,
     /// Tracked heap bytes of items currently in `buffer`. Updated on
     /// insert + on `try_pop_in_order` drain. Used to enforce
     /// `max_overflow_bytes`. Mirrors legacy
@@ -229,7 +230,7 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
         Self {
             transport,
             state: Mutex::new(ReorderState {
-                buffer: HashMap::new(),
+                buffer: AHashMap::new(),
                 buffer_bytes: 0,
                 next_serial: 0,
             }),
@@ -269,7 +270,7 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
         Self {
             transport,
             state: Mutex::new(ReorderState {
-                buffer: HashMap::new(),
+                buffer: AHashMap::new(),
                 buffer_bytes: 0,
                 next_serial: 0,
             }),


### PR DESCRIPTION
Wave 2 perf cleanup (#7 of the feat-runall review series).

## What

`ReorderState::buffer` keys items by their framework-internal `u64` ordinal but used the std `HashMap` default hasher (SipHash-1-3) — DoS-resistant but slow, and pointless for monotonic, adversary-free integer keys. Every ordered (`ByOrdinal` / `ByItemOrdinal`) edge funnels through this buffer (insert + `contains_key` + remove per released item, under the state lock), so it sits on the per-item path of every consensus pipeline.

Switches the buffer to `ahash::AHashMap`, the fast hasher already used across the codebase (`umi`, `filter`, `grouper`).

## Behavior

Unchanged — same map API, same ordering and backpressure invariants. (A `VecDeque` ring keyed by `ordinal - base` is the maximal version since release is strictly monotonic; `AHashMap` is the zero-risk drop-in and was chosen for that reason.)

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -E 'test(reorder) or test(pipeline)'` — 450 tests pass, including the in-module reorder unit tests and the `pipeline_core_compile_fail` trybuild suite.
- CodeRabbit CLI (`--agent`) and a CodeRabbit-style self-review: 0 findings.