### PR TITLE
perf(bgzf): move compressed blocks out of the deflater scratch instead of cloning

### DIFF
--- a/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
+++ b/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
@@ -482,7 +482,13 @@ fn compress_block(
         buffer[buffer.len() - 5],
     ]);
 
-    Ok((buffer.clone(), crc32, input.len()))
+    // Move the compressed block out instead of cloning it (a full per-block
+    // memcpy). Reinstall a fresh buffer pre-sized to the same capacity so the
+    // next block compresses into it without regrowing from empty — `mem::take`
+    // would leave a zero-capacity buffer and force that regrowth.
+    let cap = buffer.capacity();
+    let frame = std::mem::replace(buffer, Vec::with_capacity(cap));
+    Ok((frame, crc32, input.len()))
 }
 
 fn spawn_writer<W>(


### PR DESCRIPTION
Wave 4 perf cleanup (item 12 of the feat-runall review series).

## What

Each multithreaded-writer deflater compresses a BGZF block into a reused `compress_buf` scratch, then returned `buffer.clone()` — a full per-block memcpy of the compressed bytes (up to ~64 KiB) on every output block, kept only so the scratch stays warm.

This moves the bytes out with `std::mem::replace`, reinstalling a fresh buffer pre-sized to the same capacity so the next block compresses into it without regrowing from empty. (A plain `mem::take` would leave a zero-capacity buffer and force that regrowth — which is why the naive version doesn't help.)

## Behavior

Same allocation count as the clone, minus the per-block memcpy. CRC32 is read from the buffer before the move, so it's unaffected; output bytes are unchanged.

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -p fgumi-bam-io` — 99 tests pass (incl. the prefetch byte-identity proptest); `-E 'test(sort) or test(group) or test(runall) or test(async) or test(streaming)'` — 583 integration tests pass (these write multithreaded BGZF end-to-end).
- CodeRabbit CLI (`--agent`) and a CodeRabbit-style self-review: 0 findings.