### PR TITLE
perf(bgzf): read block bodies into reserved capacity instead of zero-filling

### DIFF
--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -206,12 +206,22 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
         ));
     }
 
-    // Allocate buffer and copy header
-    let mut data = vec![0u8; block_size];
-    data[..BGZF_HEADER_SIZE].copy_from_slice(&header);
-
-    // Read remaining block data
-    reader.read_exact(&mut data[BGZF_HEADER_SIZE..])?;
+    // Reserve the exact block size and append the header, then read the
+    // remaining bytes via `read_to_end` into the uninitialized spare capacity.
+    // This avoids the `vec![0u8; block_size]` zero-fill that `read_exact` would
+    // immediately overwrite (std fills the spare capacity without a memset). The
+    // length check below restores `read_exact`'s "error on a short block"
+    // semantics, since `read_to_end` itself returns `Ok` on early EOF.
+    let mut data = Vec::with_capacity(block_size);
+    data.extend_from_slice(&header);
+    let remaining = block_size - BGZF_HEADER_SIZE;
+    let read = reader.take(remaining as u64).read_to_end(&mut data)?;
+    if read != remaining {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!("truncated BGZF block: expected {remaining} more bytes, got {read}"),
+        ));
+    }
 
     Ok(Some(RawBgzfBlock { data }))
 }


### PR DESCRIPTION
Sort-hotspot Task 2 (`2026-06-18-sort-hotspot-tasks.md`) — the safe, no-unsafe half of the zero-fill removal.

## What

`read_raw_block` allocated `vec![0u8; block_size]` then overwrote it (header copy + `read_exact` of the body) — a per-block `memset` of up to ~64 KiB that's immediately discarded. Now it reserves the exact block size, appends the 18-byte header, and reads the remainder with `take(remaining).read_to_end(...)`, which fills the uninitialized spare capacity **without a zero-fill** (std handles the uninit internally — no `unsafe` in this crate, which stays `#![deny(unsafe_code)]`).

A `read != remaining` length check restores `read_exact`'s "error on a short/truncated block" behavior, since `read_to_end` returns `Ok` on early EOF.

## Behavior

Byte-identical output (the read region is fully overwritten either way), same truncation-error semantics. Removes the `compressed/uncompressed`-fraction half of the sort memset bucket (~1.6% total). The bigger decompress-side memset (`reader.rs:484`) needs `unsafe` and is deliberately left out per the task plan.

## Verification

- `cargo ci-fmt` / `cargo ci-lint` (clippy pedantic) clean.
- `cargo nextest -p fgumi-bgzf` 26 pass; `-E 'test(sort) or test(runall) or test(streaming) or test(async) or test(bgzf)'` 343 pass (these read BGZF end-to-end).
- CodeRabbit CLI (`--agent`) + CodeRabbit-style self-review: 0 findings.