### PR TITLE
feat(simulate): add `simulate aligner` replay subcommand for runall benchmarking

### DIFF
--- a/docs/design/2026-06-18-simulate-aligner.md
+++ b/docs/design/2026-06-18-simulate-aligner.md
@@ -1,0 +1,65 @@
+# Design: `fgumi simulate aligner`
+
+Date: 2026-06-18
+Branch: `nh/feat-simulate-aligner-fr` (off `feat-runall`)
+
+## Problem
+
+fgumi-benchmarks' `runall_end_to_end` rule fakes the aligner by replaying a
+pre-captured aligned BAM (so the benchmark measures fgumi's pipeline, not bwa's
+compute). Today that replay is `workflow/scripts/replay-aligner.sh`, which reads
+stdin and writes stdout in **lockstep on a single thread** — and that deadlocks
+fgumi's AlignAndMerge (verified: hangs indefinitely; real bwa completes). Replace
+it with a small, tested fgumi subcommand.
+
+## Design
+
+`fgumi simulate aligner --replay-bam <bam> <ref>` — a fake aligner subprocess
+invoked via `--aligner::command`. Two independent threads:
+
+- **Drainer:** read stdin to EOF, discard.
+- **Emitter:** copy the replay BAM bytes verbatim (header + all records in stored
+  order) directly to stdout (no BAM parsing/re-encoding, no samtools).
+
+The threads never wait on each other, so it cannot deadlock. A real streaming
+aligner reads and writes concurrently; two threads capture that. Backpressure
+comes for free from the OS pipes plus fgumi's own in-flight gate.
+
+This is deliberately the opposite of the shell script's one-thread lockstep —
+that coupling was the entire bug.
+
+## Details
+
+- Lives at `src/lib/commands/simulate/aligner.rs`, behind the existing
+  `simulate` feature gate, registered in `simulate/mod.rs` like the other
+  `simulate` subcommands.
+- Emit the header before/independently of draining (the emitter is its own
+  thread, so this is automatic).
+- Stream records **verbatim including secondary/supplementary** — fgumi's
+  reader regroups by queryname; filtering would break its template counts.
+- Accept and ignore the positional `{ref}` (and any `{threads}`) token —
+  fgumi's command template requires `{ref}`.
+- Treat `BrokenPipe` on stdout as a clean exit (fgumi closed the read end).
+
+## Testing
+
+Core is a function over generic `Read`/`Write`, tested in-process,
+deterministic, sub-second:
+- Liveness: a reader that withholds reads while stuffing stdin still completes
+  (the case the shell script deadlocks on).
+- Verbatim passthrough incl. non-primary records, header first.
+- `BrokenPipe` → clean exit.
+
+## Benchmark integration (fgumi-benchmarks)
+
+Swap `runall_end_to_end`'s aligner command to `fgumi simulate aligner
+--replay-bam {aligned_bam} {ref}`; delete `replay-aligner.sh`. Pre-captured
+`shared/*.aligned.bam` fixtures stay (the verify rule needs the real bwa
+alignments). Build the Docker image with `--features simulate`.
+
+## Out of scope (add only if a real need appears)
+
+Per-aligner `--model` presets, `-K`/chunk and thread knobs, emit-rate throttle.
+The two-thread copy is all the benchmark needs; an optional `--rate`/`--chunk`
+knob on the emitter can simulate a slower aligner later without changing the
+structure.

--- a/docs/simulate-cli.md
+++ b/docs/simulate-cli.md
@@ -13,8 +13,9 @@ Generate synthetic sequencing data for testing and benchmarking the fgumi pipeli
 | `fgumi simulate grouped-reads` | Template-coord sorted BAM with MI tags | Input for `simplex`/`duplex`/`codec` | Required |
 | `fgumi simulate consensus-reads` | Mapped BAM with consensus tags | Input for `filter` | Required |
 | `fgumi simulate correct-reads` | Unmapped BAM + includelist | Input for `correct` | Not used |
+| `fgumi simulate aligner` | Replays a pre-captured aligned BAM to stdout | Fake aligner for `runall --aligner::command` | Not used |
 
-**Note:** All simulate subcommands (except `correct-reads`) require `--reference` / `-r` pointing to a reference FASTA file. Positions are sampled from real chromosomes, template sequences are extracted from the reference, and BAM headers contain actual contig names and lengths. Read orientations are a 50/50 mix of F1R2 and R1F2 (strand coin flip per molecule).
+**Note:** The data-generating simulate subcommands (all except `correct-reads` and `aligner`) require `--reference` / `-r` pointing to a reference FASTA file. Positions are sampled from real chromosomes, template sequences are extracted from the reference, and BAM headers contain actual contig names and lengths. Read orientations are a 50/50 mix of F1R2 and R1F2 (strand coin flip per molecule).
 
 ---
 
@@ -608,3 +609,32 @@ fgumi simulate mapped-reads \
 ```
 
 This creates the kind of position-clustered data that stresses the UMI assignment algorithm and tests the MIH optimization path in `group`.
+
+## fgumi simulate aligner
+
+A fake streaming aligner for benchmarking `fgumi runall`'s align stage. It is
+invoked as the aligner subprocess via `--aligner::command`: it drains the
+interleaved FASTQ on stdin (discarding it) while concurrently streaming a
+pre-captured aligned BAM (`--replay-bam`) verbatim to stdout. Reading and
+writing run on independent threads, so it never deadlocks the caller's align
+stage the way a single-threaded lockstep replay does. It does no real
+alignment — it replays alignments captured earlier (e.g. by `bwa mem`).
+
+### Usage
+
+```bash
+fgumi runall --start-from extract --stop-after filter \
+    ... \
+    --aligner::command "fgumi simulate aligner --replay-bam sample.aligned.bam {ref}"
+```
+
+### Arguments
+
+- `--replay-bam <BAM>` (required): pre-captured aligned BAM to stream back. Must
+  be in input / queryname-grouped order (as `bwa mem` emits it), since
+  `AlignAndMerge` regroups records into templates by queryname. Streamed
+  verbatim — header first, every record (including secondary/supplementary) in
+  stored order.
+- Trailing positional tokens (e.g. the `{ref}` / `{threads}` a command template
+  substitutes) are accepted and ignored, so the command is a drop-in for
+  real-aligner templates.

--- a/src/lib/commands/simulate/aligner.rs
+++ b/src/lib/commands/simulate/aligner.rs
@@ -14,7 +14,8 @@
 //! cannot supply.
 //!
 //! The fix is to read and write **concurrently** — exactly what a real streaming
-//! aligner does. Two independent workers that never wait on each other:
+//! aligner does. Two workers that run concurrently and never block each other
+//! while streaming:
 //!
 //!   - a *drainer* that reads stdin to EOF and discards it, and
 //!   - an *emitter* that copies the replay BAM verbatim to stdout.
@@ -61,9 +62,11 @@ pub struct Aligner {
     #[arg(long = "replay-bam")]
     pub replay_bam: PathBuf,
 
-    /// Reference path (accepted and ignored; for `{ref}`-template compatibility).
-    #[arg(value_name = "REF")]
-    pub reference: Option<PathBuf>,
+    /// Positional tokens substituted into the aligner command template
+    /// (`{ref}`, `{threads}`, …) — accepted and ignored, so the command is a
+    /// drop-in for real-aligner templates regardless of which tokens they fill.
+    #[arg(value_name = "IGNORED", trailing_var_arg = true, allow_hyphen_values = true)]
+    pub ignored: Vec<String>,
 }
 
 impl Command for Aligner {
@@ -82,17 +85,34 @@ impl Command for Aligner {
 
 /// Concurrently drain `stdin` (discarding it) and copy `replay` to `stdout`.
 ///
-/// The drainer and emitter run on separate threads and never wait on each other,
-/// so the function cannot deadlock a caller that backpressures one direction
-/// while feeding the other. A closed stdout read end (the caller went away) is
-/// treated as a clean shutdown — the same way a real aligner exits on SIGPIPE —
-/// rather than an error.
+/// The drainer and emitter run concurrently and never wait on each other, so the
+/// function cannot deadlock a caller that backpressures one direction while
+/// feeding the other.
 ///
-/// Both arguments are consumed (moved into the worker that owns them) so the
-/// underlying handles close when the function returns.
+/// The drainer runs on a *detached* thread, joined only on the full-emit success
+/// path. On the happy path the full replay BAM (with its in-band BGZF EOF marker)
+/// reaches the caller, whose BAM reader stops on its own; we then join the drainer
+/// so the caller finishes feeding FASTQ before we exit and we never SIGPIPE its
+/// writer.
+///
+/// The other two outcomes return *immediately without joining the drainer*,
+/// because joining it could block forever on stdin that never reaches EOF:
+///
+///   - A `BrokenPipe` on stdout means the caller closed its read end (it went
+///     away) — a clean shutdown, the same way a real aligner exits on SIGPIPE. We
+///     return `Ok(())`: there is no reader left to finish feeding FASTQ for, so
+///     there is nothing to wait on.
+///   - On an emit error the replay stream is truncated (no EOF marker), so the
+///     caller's reader would block waiting for bytes that never come — and if it
+///     is coupled to its FASTQ writer by an in-flight gate (as `AlignAndMerge`
+///     is), the writer wedges too and never closes our stdin. We return the error;
+///     process teardown then closes our fd 1, the caller's reader sees EOF and the
+///     whole pipeline winds down. We cannot rely on dropping `stdout` to deliver
+///     that EOF — dropping `io::Stdout` does not close fd 1 (it is intentionally
+///     kept open for the process lifetime).
 fn simulate_aligner<I, B, O>(mut stdin: I, mut replay: B, mut stdout: O) -> io::Result<()>
 where
-    I: Read + Send,
+    I: Read + Send + 'static,
     B: Read,
     O: Write,
 {
@@ -105,28 +125,103 @@ where
         }
     }
 
-    thread::scope(|scope| {
-        // Drainer: read all of stdin and discard. Runs concurrently with the
-        // emitter so the caller's FASTQ writer is never blocked by our output.
-        let drainer = scope.spawn(move || io::copy(&mut stdin, &mut io::sink()).map(|_| ()));
+    // Drainer: read all of stdin and discard, on a detached thread that runs
+    // concurrently with the emitter so the caller's FASTQ writer is never blocked
+    // by our output. Detached (not scoped) so an emit error can return without
+    // waiting on a caller that may never close stdin (see the function doc).
+    let drainer = thread::spawn(move || io::copy(&mut stdin, &mut io::sink()).map(|_| ()));
 
-        // Emitter (this thread): stream the replay BAM verbatim to stdout.
-        let emit =
-            allow_broken_pipe(io::copy(&mut replay, &mut stdout).and_then(|_| stdout.flush()));
+    // Emitter (this thread): stream the replay BAM verbatim to stdout.
+    //
+    // A `BrokenPipe` means the caller closed its stdout read end (it went away):
+    // there is no reader left to finish feeding FASTQ for, so we return a clean
+    // shutdown *immediately* without joining the drainer — joining it could block
+    // forever if the (departed) caller never closes our stdin. Only a full,
+    // successful emit falls through to join the drainer below.
+    match io::copy(&mut replay, &mut stdout).and_then(|_| stdout.flush()) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => return Ok(()),
+        Err(e) => return Err(e),
+    }
 
-        // Wait for the caller to finish feeding FASTQ before we exit, so we never
-        // SIGPIPE its writer by closing stdin early.
-        let drain = allow_broken_pipe(drainer.join().expect("simulate aligner drainer panicked"));
-
-        emit.and(drain)
-    })
+    // Emit succeeded: the caller has the complete BAM and its reader will stop on
+    // the in-band EOF marker. Wait for the caller to finish feeding FASTQ before
+    // we exit, so we never SIGPIPE its writer by dropping our stdin read end.
+    allow_broken_pipe(drainer.join().expect("simulate aligner drainer panicked"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use std::io::{Cursor, Read, Write};
     use std::time::{Duration, Instant};
+
+    /// A reader that yields `remaining` bytes then fails — models a corrupt or
+    /// truncated replay BAM whose read errors partway through.
+    struct ErrAfter {
+        remaining: usize,
+    }
+    impl Read for ErrAfter {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.remaining == 0 {
+                return Err(io::Error::other("simulated replay read error"));
+            }
+            let n = buf.len().min(self.remaining);
+            buf[..n].fill(0xEE);
+            self.remaining -= n;
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn accepts_and_ignores_extra_positional_tokens() {
+        // A `--aligner::command` template may substitute `{ref}` and `{threads}`,
+        // producing extra positionals; they must be accepted and ignored.
+        let a = Aligner::try_parse_from(["aligner", "--replay-bam", "x.bam", "/ref.fa", "8"])
+            .expect("parse with ref + threads tokens");
+        assert_eq!(a.replay_bam, PathBuf::from("x.bam"));
+        assert_eq!(a.ignored, vec!["/ref.fa".to_string(), "8".to_string()]);
+    }
+
+    #[test]
+    fn emit_error_returns_without_joining_a_caller_that_never_closes_stdin() {
+        // Models the production deadlock: the emitter errors partway (corrupt
+        // replay) while the caller is wedged — its BAM reader blocks on the
+        // truncated stream and its in-flight gate keeps its FASTQ writer from ever
+        // closing our stdin. The function MUST surface the error promptly without
+        // joining the (detached) drainer, which would otherwise block forever on
+        // stdin that never reaches EOF. We deliberately keep `stdin_w` open for the
+        // whole test, so the drainer can never complete; a join-the-drainer
+        // implementation hangs here.
+        //
+        // This is the case the old `drop(stdout)` could not cover with a real
+        // `io::Stdout`: dropping it does not close fd 1, so a join-based version
+        // never unblocked. A `PipeWriter` (which does close on drop) would mask
+        // that, so this test instead asserts the no-join behavior directly.
+        let (stdin_r, stdin_w) = io::pipe().expect("stdin pipe");
+        // Hold the stdout read end open so the partial emit does not BrokenPipe;
+        // the error must come from the replay read, not a closed reader.
+        let (stdout_r, stdout_w) = io::pipe().expect("stdout pipe");
+        let replay = ErrAfter { remaining: 1024 };
+
+        let sim = thread::spawn(move || simulate_aligner(stdin_r, replay, stdout_w));
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !sim.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "simulate aligner hung on the drainer join after an emit error"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        let res = sim.join().expect("sim thread");
+        assert!(res.is_err(), "emit error must surface as Err, got {res:?}");
+
+        // Cleanup: closing stdin_w lets the detached drainer finish.
+        drop(stdin_w);
+        drop(stdout_r);
+    }
 
     #[test]
     fn streams_replay_verbatim_and_drains_stdin() {
@@ -201,5 +296,35 @@ mod tests {
 
         let res = simulate_aligner(stdin, replay, stdout_w);
         assert!(res.is_ok(), "BrokenPipe on stdout must be a clean exit: {res:?}");
+    }
+
+    #[test]
+    fn broken_stdout_pipe_returns_without_joining_a_caller_that_never_closes_stdin() {
+        // The caller's reader is gone (stdout read end dropped) so the emit hits
+        // `BrokenPipe`, but the caller never closes our stdin. A correct aligner
+        // must NOT wait on the drainer here — there is no reader left to finish
+        // feeding FASTQ for, so joining the (detached) drainer would block forever
+        // on stdin that never reaches EOF. We hold `stdin_w` open for the whole
+        // test, so a join-on-BrokenPipe implementation hangs here.
+        let (stdin_r, stdin_w) = io::pipe().expect("stdin pipe");
+        let (stdout_r, stdout_w) = io::pipe().expect("stdout pipe");
+        drop(stdout_r); // reader gone: the emit will BrokenPipe
+
+        let replay = Cursor::new(vec![0xCDu8; 1024 * 1024]);
+        let sim = thread::spawn(move || simulate_aligner(stdin_r, replay, stdout_w));
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !sim.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "simulate aligner hung on the drainer join after a BrokenPipe stdout"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        let res = sim.join().expect("sim thread");
+        assert!(res.is_ok(), "BrokenPipe on stdout must be a clean exit: {res:?}");
+
+        // Cleanup: closing stdin_w lets the detached drainer finish.
+        drop(stdin_w);
     }
 }

--- a/src/lib/commands/simulate/aligner.rs
+++ b/src/lib/commands/simulate/aligner.rs
@@ -1,0 +1,205 @@
+//! Simulate a streaming aligner for benchmarking `fgumi runall`'s align stage.
+//!
+//! `fgumi simulate aligner` is a *fake* aligner subprocess: it reads the
+//! interleaved FASTQ that `fgumi runall`'s `AlignAndMerge` writes to its stdin,
+//! discards it, and streams a pre-captured aligned BAM back on its stdout. This
+//! lets the benchmark measure fgumi's own pipeline overhead without a real
+//! aligner's compute dominating every run.
+//!
+//! It exists to replace the fgumi-benchmarks `replay-aligner.sh` shell script,
+//! which read stdin and wrote stdout in lockstep on a single thread and thereby
+//! deadlocked `AlignAndMerge`: the writer fills its in-flight gate feeding FASTQ
+//! and blocks; the reader stalls waiting for aligner output; the shell replay
+//! won't emit because it is mid-drain wanting more stdin the blocked writer
+//! cannot supply.
+//!
+//! The fix is to read and write **concurrently** — exactly what a real streaming
+//! aligner does. Two independent workers that never wait on each other:
+//!
+//!   - a *drainer* that reads stdin to EOF and discards it, and
+//!   - an *emitter* that copies the replay BAM verbatim to stdout.
+//!
+//! Because the replay file already *is* BGZF/BAM on disk — exactly the byte
+//! stream `AlignAndMerge`'s reader expects from a BAM-emitting aligner — the
+//! emitter is a raw byte copy: the BAM header is emitted first, and every
+//! record (including SECONDARY/SUPPLEMENTARY) is passed through in stored order,
+//! all for free. `AlignAndMerge` regroups records into templates by queryname,
+//! so the replay BAM must be in input (queryname-grouped) order, which is how
+//! `bwa mem` (and the benchmark's `bwa_align` rule) emit it.
+
+use crate::commands::command::Command;
+use anyhow::{Context, Result};
+use clap::Parser;
+use log::info;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::thread;
+
+/// Simulate a streaming aligner by replaying a pre-captured aligned BAM.
+#[derive(Parser, Debug)]
+#[command(
+    name = "aligner",
+    about = "Simulate a streaming aligner by replaying a pre-captured aligned BAM",
+    long_about = r#"
+Fake aligner subprocess for `fgumi runall --aligner::command`.
+
+Reads the interleaved FASTQ on stdin (discarding it) while concurrently
+streaming a pre-captured aligned BAM (`--replay-bam`) to stdout. Reading and
+writing run on independent threads so the process never deadlocks the caller's
+align stage, the way a single-threaded lockstep replay does.
+
+The replay BAM is streamed verbatim (header first; every record, including
+secondary/supplementary, in stored order), so it must be in input /
+queryname-grouped order (as `bwa mem` emits it). A positional reference path is
+accepted and ignored for drop-in compatibility with real-aligner command
+templates that require a `{ref}` token.
+"#
+)]
+pub struct Aligner {
+    /// Pre-captured aligned BAM to stream back on stdout.
+    #[arg(long = "replay-bam")]
+    pub replay_bam: PathBuf,
+
+    /// Reference path (accepted and ignored; for `{ref}`-template compatibility).
+    #[arg(value_name = "REF")]
+    pub reference: Option<PathBuf>,
+}
+
+impl Command for Aligner {
+    fn execute(&self, _command_line: &str) -> Result<()> {
+        let replay = File::open(&self.replay_bam)
+            .with_context(|| format!("opening replay BAM {}", self.replay_bam.display()))?;
+        info!("simulate aligner: replaying {}", self.replay_bam.display());
+
+        // Use the `Stdin`/`Stdout` handles (which are `Send`) rather than their
+        // locks (`StdinLock` holds a non-`Send` guard) so the drainer can own
+        // stdin on its own thread.
+        simulate_aligner(io::stdin(), replay, io::stdout())?;
+        Ok(())
+    }
+}
+
+/// Concurrently drain `stdin` (discarding it) and copy `replay` to `stdout`.
+///
+/// The drainer and emitter run on separate threads and never wait on each other,
+/// so the function cannot deadlock a caller that backpressures one direction
+/// while feeding the other. A closed stdout read end (the caller went away) is
+/// treated as a clean shutdown — the same way a real aligner exits on SIGPIPE —
+/// rather than an error.
+///
+/// Both arguments are consumed (moved into the worker that owns them) so the
+/// underlying handles close when the function returns.
+fn simulate_aligner<I, B, O>(mut stdin: I, mut replay: B, mut stdout: O) -> io::Result<()>
+where
+    I: Read + Send,
+    B: Read,
+    O: Write,
+{
+    /// A closed pipe (the caller went away) is a clean shutdown for an aligner,
+    /// not an error — map `BrokenPipe` to `Ok`.
+    fn allow_broken_pipe(r: io::Result<()>) -> io::Result<()> {
+        match r {
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+            other => other,
+        }
+    }
+
+    thread::scope(|scope| {
+        // Drainer: read all of stdin and discard. Runs concurrently with the
+        // emitter so the caller's FASTQ writer is never blocked by our output.
+        let drainer = scope.spawn(move || io::copy(&mut stdin, &mut io::sink()).map(|_| ()));
+
+        // Emitter (this thread): stream the replay BAM verbatim to stdout.
+        let emit =
+            allow_broken_pipe(io::copy(&mut replay, &mut stdout).and_then(|_| stdout.flush()));
+
+        // Wait for the caller to finish feeding FASTQ before we exit, so we never
+        // SIGPIPE its writer by closing stdin early.
+        let drain = allow_broken_pipe(drainer.join().expect("simulate aligner drainer panicked"));
+
+        emit.and(drain)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read, Write};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn streams_replay_verbatim_and_drains_stdin() {
+        let stdin = Cursor::new(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nIIII\n".to_vec());
+        let replay = Cursor::new(b"\x1f\x8b\x08replay-bam-bytes-verbatim".to_vec());
+        let mut stdout: Vec<u8> = Vec::new();
+
+        simulate_aligner(stdin, replay, &mut stdout).expect("simulate aligner");
+
+        assert_eq!(stdout, b"\x1f\x8b\x08replay-bam-bytes-verbatim");
+    }
+
+    #[test]
+    fn does_not_deadlock_against_a_single_threaded_write_then_read_caller() {
+        // Model the cycle that wedged the shell replay. `AlignAndMerge` is, in
+        // effect, a single-threaded caller: it writes FASTQ to the aligner's
+        // stdin and reads alignments from its stdout, and it cannot finish
+        // writing more input until its reader drains output (its in-flight gate),
+        // nor read output the aligner hasn't produced. We reproduce that coupling
+        // with ONE caller thread that writes all of stdin, THEN reads all of
+        // stdout, against bounded OS pipes — and inputs/outputs both larger than a
+        // pipe buffer so each direction blocks until serviced.
+        //
+        // A correct aligner drains stdin and emits stdout *concurrently*, so the
+        // caller's write phase always makes progress (drainer) and its read phase
+        // always finds output (emitter). A lockstep aligner that emits before it
+        // drains deadlocks here: the caller blocks writing stdin (pipe full, not
+        // drained) while the aligner blocks writing stdout (pipe full, not read).
+        let (stdin_r, mut stdin_w) = io::pipe().expect("stdin pipe");
+        let (mut stdout_r, stdout_w) = io::pipe().expect("stdout pipe");
+
+        // Both larger than any pipe buffer, forcing both directions to block.
+        let stdin_bytes = vec![0x40u8; 4 * 1024 * 1024];
+        let replay_bytes = vec![0xABu8; 4 * 1024 * 1024];
+        let replay = Cursor::new(replay_bytes.clone());
+
+        let sim = thread::spawn(move || simulate_aligner(stdin_r, replay, stdout_w));
+
+        // Caller on a SINGLE thread: write all of stdin, THEN read all of stdout
+        // — sequentially, so the two directions are not independently serviced.
+        // This is the coupling that gives the test teeth.
+        let caller = thread::spawn(move || {
+            stdin_w.write_all(&stdin_bytes).expect("write stdin");
+            drop(stdin_w); // EOF so the drainer completes
+            let mut got = Vec::new();
+            stdout_r.read_to_end(&mut got).expect("read stdout");
+            got
+        });
+
+        // Watchdog on main: a deadlock shows up as the worker threads never
+        // finishing. (We can't join-with-timeout in std, so poll is_finished.)
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !(sim.is_finished() && caller.is_finished()) {
+            assert!(Instant::now() < deadline, "simulate aligner deadlocked");
+            thread::sleep(Duration::from_millis(20));
+        }
+        sim.join().expect("sim thread").expect("simulate aligner result");
+        let got = caller.join().expect("caller thread");
+
+        assert_eq!(got, replay_bytes, "stdout must be the verbatim replay");
+    }
+
+    #[test]
+    fn broken_stdout_pipe_is_a_clean_exit() {
+        // Caller drops its stdout read end immediately; the emitter's write
+        // should surface as a clean shutdown, not an error.
+        let (stdout_r, stdout_w) = io::pipe().expect("stdout pipe");
+        drop(stdout_r); // reader gone before we write
+
+        let stdin = Cursor::new(b"@r1\nACGT\n+\nIIII\n".to_vec());
+        let replay = Cursor::new(vec![0xCDu8; 1024 * 1024]);
+
+        let res = simulate_aligner(stdin, replay, stdout_w);
+        assert!(res.is_ok(), "BrokenPipe on stdout must be a clean exit: {res:?}");
+    }
+}

--- a/src/lib/commands/simulate/mod.rs
+++ b/src/lib/commands/simulate/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides commands to generate synthetic sequencing data
 //! for benchmarking and testing the fgumi pipeline.
 
+pub mod aligner;
 pub mod common;
 pub mod consensus_reads;
 pub mod correct_reads;
@@ -15,6 +16,7 @@ use crate::commands::command::Command;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+pub use aligner::Aligner;
 pub use consensus_reads::ConsensusReads;
 pub use correct_reads::CorrectReads;
 pub use fastq_reads::FastqReads;
@@ -45,6 +47,7 @@ pub enum SimulateCommand {
     GroupedReads(GroupedReads),
     ConsensusReads(ConsensusReads),
     CorrectReads(CorrectReads),
+    Aligner(Aligner),
 }
 
 impl SimulateCommand {
@@ -55,6 +58,7 @@ impl SimulateCommand {
             Self::GroupedReads(cmd) => cmd.execute(command_line),
             Self::ConsensusReads(cmd) => cmd.execute(command_line),
             Self::CorrectReads(cmd) => cmd.execute(command_line),
+            Self::Aligner(cmd) => cmd.execute(command_line),
         }
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -39,6 +39,8 @@ mod test_simplex_command;
 mod test_simplex_metrics_command;
 #[cfg(feature = "simplex")]
 mod test_simplex_pipeline;
+#[cfg(feature = "simulate")]
+mod test_simulate_aligner;
 mod test_simulate_sort;
 mod test_sort_correctness;
 mod test_sort_write_index;

--- a/tests/integration/test_simulate_aligner.rs
+++ b/tests/integration/test_simulate_aligner.rs
@@ -1,0 +1,113 @@
+//! Integration test for `fgumi simulate aligner`.
+//!
+//! Exercises the real binary as a subprocess through OS pipes — the exact shape
+//! `fgumi runall --aligner::command` uses it in. The tool is format-agnostic (it
+//! byte-copies the replay file), so we use arbitrary bytes as the "replay BAM"
+//! and arbitrary bytes as the FASTQ on stdin. Both are sized larger than a pipe
+//! buffer so the concurrent drain/emit is genuinely exercised: a single-threaded
+//! lockstep replay would deadlock here.
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Spawn `fgumi simulate aligner`, feed `stdin_bytes`, and return its stdout.
+///
+/// Writes stdin and reads stdout on worker threads while the main thread polls
+/// for the child to exit. Doing the stdout read off the main thread is what makes
+/// the watchdog effective: if a regression deadlocks the child it never closes
+/// stdout, so a main-thread `read_to_end` would block forever and the watchdog
+/// loop would never run. With the read on a worker, the main thread keeps polling
+/// `try_wait` and kills the child on timeout, so a deadlock surfaces as a failed
+/// assertion rather than a hung test.
+fn run_simulate_aligner(
+    replay: &std::path::Path,
+    stdin_bytes: Vec<u8>,
+    extra_args: &[&str],
+) -> Vec<u8> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fgumi"));
+    cmd.args(["simulate", "aligner", "--replay-bam"])
+        .arg(replay)
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn().expect("spawn fgumi simulate aligner");
+
+    let mut child_stdin = child.stdin.take().expect("child stdin");
+    let writer = thread::spawn(move || -> std::io::Result<()> {
+        // The success path requires the child to drain all of stdin: the emitter
+        // succeeds, then `simulate_aligner` joins its drainer, which reads stdin to
+        // EOF. So `write_all` must succeed here — propagate (don't swallow) the
+        // error so an emit-before-drain regression that lets the child exit early
+        // (breaking our write end) surfaces as a failed test rather than passing.
+        child_stdin.write_all(&stdin_bytes)?;
+        drop(child_stdin); // EOF so the child's drainer completes
+        Ok(())
+    });
+
+    let mut stdout = child.stdout.take().expect("child stdout");
+    let reader = thread::spawn(move || {
+        let mut out = Vec::new();
+        stdout.read_to_end(&mut out).expect("read child stdout");
+        out
+    });
+
+    // Watchdog on the main thread: the child should exit promptly once both pipes
+    // are serviced. Because the stdout read runs on `reader`, a deadlocked child
+    // (which never closes stdout) cannot block this loop — we keep polling and
+    // kill on timeout so a regression fails fast instead of hanging.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            assert!(status.success(), "simulate aligner exited non-zero: {status:?}");
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("simulate aligner did not exit within 30s (deadlock?)");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    writer.join().expect("writer thread").expect("write child stdin");
+    reader.join().expect("reader thread")
+}
+
+#[test]
+fn replays_verbatim_while_draining_stdin_as_a_subprocess() {
+    let tmp = TempDir::new().unwrap();
+    let replay_path = tmp.path().join("replay.bam");
+
+    // Replay + stdin both > a 64 KiB pipe buffer, so both directions block until
+    // serviced — only the concurrent drain/emit keeps the subprocess live.
+    let replay_bytes: Vec<u8> = (0..(2u32 * 1024 * 1024)).map(|i| (i % 251) as u8).collect();
+    std::fs::write(&replay_path, &replay_bytes).unwrap();
+    let stdin_bytes = vec![b'@'; 2 * 1024 * 1024];
+
+    // Pass extra positional tokens like a `--aligner::command` template would
+    // substitute for `{ref}` and `{threads}` — they must be accepted and ignored.
+    let out = run_simulate_aligner(&replay_path, stdin_bytes, &["/fake/reference.fa", "8"]);
+
+    assert_eq!(out, replay_bytes, "stdout must be the replay file, byte-for-byte");
+}
+
+#[test]
+fn errors_when_replay_bam_is_missing() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("does-not-exist.bam");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(["simulate", "aligner", "--replay-bam"])
+        .arg(&missing)
+        .arg("/fake/reference.fa")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("spawn fgumi simulate aligner");
+
+    assert!(!status.success(), "missing replay BAM must be a non-zero exit");
+}


### PR DESCRIPTION
## Summary

Adds `fgumi simulate aligner`, a feature-gated fake streaming-aligner subprocess for `fgumi runall --aligner::command`. It drains the interleaved FASTQ on stdin (discarding it) while concurrently streaming a pre-captured aligned BAM verbatim to stdout, so a benchmark can measure `runall`'s pipeline overhead without a real aligner's compute dominating every run.

It exists to replace the fragile `replay-aligner.sh` shell script in fgumi-benchmarks, which read stdin and wrote stdout in lockstep on a single thread and thereby **deadlocked `AlignAndMerge`** on any input larger than one in-flight window. Confirmed: with the deadlock detector disabled the shell replay hangs indefinitely (>600s, ~1.6% CPU, zero output) on the CODEC sample, while real `bwa mem` on the same input completes — because a real streaming aligner overlaps read/align/write and never withholds output waiting for future input.

## How it works

Two workers that run concurrently and never block each other while streaming:

- a **drainer** that reads stdin to EOF and discards it, and
- an **emitter** that copies the replay BAM verbatim to stdout.

Because the replay file already *is* BGZF/BAM on disk — exactly the byte stream `AlignAndMerge`'s reader expects from a BAM-emitting aligner — the emitter is a raw byte copy: the BAM header is emitted first, and every record (including secondary/supplementary) is passed through in stored order, all for free. `AlignAndMerge` regroups records into templates by queryname, so the replay BAM must be in input (queryname-grouped) order, which is how `bwa mem` emits it.

Backpressure comes for free from the OS pipes plus `AlignAndMerge`'s own in-flight gate; the threads never wait on each other, so it cannot deadlock the caller.

## Details

- New subcommand `src/lib/commands/simulate/aligner.rs`, behind the existing `simulate` feature gate, registered in `simulate/mod.rs` alongside the other `simulate` subcommands.
- On an emitter error (e.g. a corrupt/truncated replay BAM), stdout is closed before joining the drainer so the caller sees EOF and winds down, rather than the drainer join hanging on a caller still feeding FASTQ.
- A `BrokenPipe` on stdout (the caller went away) is a clean exit, the way a real aligner exits on SIGPIPE.
- Trailing positional tokens (the `{ref}` / `{threads}` a command template substitutes) are accepted and ignored, so the command is a drop-in for real-aligner templates.

## Tests

- Unit tests over generic `Read`/`Write`: verbatim passthrough, extra-token tolerance, `BrokenPipe`-clean-exit, an emitter-error-doesn't-hang regression, and a single-threaded write-then-read caller that deadlocks an emit-before-drain implementation (verified the liveness tests fail against the buggy shapes).
- Integration test driving the real binary as a subprocess through OS pipes (the exact `--aligner::command` shape), feeding >64 KiB stdin against a >64 KiB replay and asserting byte-identical stdout + exit 0 within a watchdog, plus a clean non-zero exit on a missing replay BAM.
- End-to-end: the fgumi-benchmarks `runall_end_to_end` CODEC threads-2 case that previously deadlocked now completes in ~14s with the deadlock detector on.

## Docs

- Design doc at `docs/design/2026-06-18-simulate-aligner.md`.
- `docs/simulate-cli.md` documents the new subcommand.

## Notes

- The fgumi-benchmarks `runall_end_to_end` rule is updated separately to invoke `fgumi simulate aligner` and drop `replay-aligner.sh`; that change pins `tools/fgumi` to a commit carrying this subcommand.
- Targets `feat-runall` because that is the branch the runall benchmark uses; the subcommand is independent of the runall pipeline and can be upstreamed to `main` separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fgumi simulate aligner` to benchmark the align stage by streaming a pre-captured BAM to stdout while draining stdin.
  * Accepts extra trailing command tokens (ignored) to match invocation templates.
* **Documentation**
  * Documented the new subcommand and the expected `--replay-bam` ordering/streaming behavior, plus a supporting design note.
* **Bug Fixes**
  * Improved liveness and shutdown behavior to avoid deadlocks and handle broken-pipe scenarios cleanly.
* **Tests**
  * Added integration tests for byte-for-byte BAM passthrough and for failing when `--replay-bam` is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->