### PR TITLE
fix(pipeline): per-stream backpressure in PairRawFastq to avoid R1/R2 join deadlock

### DIFF
--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -154,6 +154,31 @@ impl PairRawFastq {
     }
 }
 
+/// Decide which input branches to pull this dispatch, given backpressure state.
+///
+/// Returns `(pull_a, pull_b)`. The pending-pair buffer must be byte-bounded, but
+/// bounding it by globally refusing to pull deadlocks: when one FASTQ stream
+/// races ahead, the buffer fills with its unmatched chunks, and the chunk needed
+/// to complete the lowest pending pair sits unpulled in the *behind* stream's
+/// queue. So under backpressure we still pull whichever stream is missing from
+/// the front (lowest pending) pair — the pull that lets the front pair emit and
+/// the buffer drain — and throttle only the stream that is already ahead.
+///
+/// - Not over the limit → pull both (normal streaming).
+/// - Over the limit, front pair missing a slot → pull only that (behind) stream.
+/// - Over the limit, front pair already complete (or no pending) → pull neither;
+///   the caller drains via `try_emit_complete` instead of accumulating more.
+fn pull_decision(
+    over_backpressure: bool,
+    front_missing_a: bool,
+    front_missing_b: bool,
+) -> (bool, bool) {
+    if !over_backpressure {
+        return (true, true);
+    }
+    (front_missing_a, front_missing_b)
+}
+
 impl Step2 for PairRawFastq {
     type InputA = FastqRawChunk;
     type InputB = FastqRawChunk;
@@ -201,7 +226,9 @@ impl Step2 for PairRawFastq {
         }
 
         // 2. Catastrophic-desync guard: one stream producing far more data
-        //    than its counterpart balloons the partial-pair buffer.
+        //    than its counterpart balloons the partial-pair buffer. With the
+        //    per-stream backpressure below this should never trip (the ahead
+        //    stream is throttled at 1x), but keep it as a safety net.
         if self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
             return Err(io::Error::other(format!(
                 "PairRawFastq: catastrophic stream desync — pending buffer ({} bytes) \
@@ -210,39 +237,43 @@ impl Step2 for PairRawFastq {
                 self.pending_total_bytes, self.pending_backpressure_bytes
             )));
         }
-        // Soft backpressure: stop pulling new chunks until the buffer drains.
-        if self.pending_total_bytes > self.pending_backpressure_bytes {
-            log::warn!(
-                "PairRawFastq: pending buffer exceeds backpressure limit ({} > {})",
-                self.pending_total_bytes,
-                self.pending_backpressure_bytes
-            );
-            if let Some(pair) = self.try_emit_complete() {
-                if let Err(unpushed) = ctx.outputs.push(pair) {
-                    self.held.put(unpushed);
-                }
-                return Ok(StepOutcome::Progress);
-            }
-            return Ok(StepOutcome::NoProgress);
-        }
 
-        // 3. Drain available chunks from both branches and emit every pair we
-        //    can in this dispatch. Doing this in a loop (rather than one chunk
-        //    per call) amortizes the Serial mutex / dispatch overhead and keeps
-        //    the downstream Parallel `ParseAndZipFastq` workers fed — a single
-        //    pair per call throttles the whole FASTQ front-end at low
-        //    `--threads` where few workers are free to drive this step.
+        // 3. Drain available chunks and emit every pair we can in this dispatch.
+        //    Doing this in a loop (rather than one chunk per call) amortizes the
+        //    Serial mutex / dispatch overhead and keeps the downstream Parallel
+        //    `ParseAndZipFastq` workers fed.
+        //
+        //    Backpressure is PER-STREAM, not global: once the pending buffer is
+        //    over the limit we keep pulling whichever stream is missing from the
+        //    lowest pending pair (the pull that completes it and drains the
+        //    buffer) and throttle only the stream that is ahead. Globally
+        //    refusing to pull here deadlocks — the completing chunk sits unpulled
+        //    in the behind stream's full queue while the buffer never drains
+        //    (a fast aligner makes the front-end run fast enough to desync the
+        //    R1/R2 readers past the limit and trip this).
         let mut pulled = false;
         let mut emitted = false;
         loop {
+            let over_backpressure = self.pending_total_bytes > self.pending_backpressure_bytes;
+            let (front_missing_a, front_missing_b) = match self.pending.values().next() {
+                Some((a, b)) => (a.is_none(), b.is_none()),
+                None => (false, false),
+            };
+            let (pull_a, pull_b) =
+                pull_decision(over_backpressure, front_missing_a, front_missing_b);
+
             let mut pulled_this_iter = false;
-            if let Some(chunk) = ctx.a.pop() {
-                self.buffer_chunk(chunk, /* is_a */ true);
-                pulled_this_iter = true;
+            if pull_a {
+                if let Some(chunk) = ctx.a.pop() {
+                    self.buffer_chunk(chunk, /* is_a */ true);
+                    pulled_this_iter = true;
+                }
             }
-            if let Some(chunk) = ctx.b.pop() {
-                self.buffer_chunk(chunk, /* is_a */ false);
-                pulled_this_iter = true;
+            if pull_b {
+                if let Some(chunk) = ctx.b.pop() {
+                    self.buffer_chunk(chunk, /* is_a */ false);
+                    pulled_this_iter = true;
+                }
             }
             pulled |= pulled_this_iter;
 
@@ -313,6 +344,28 @@ mod tests {
         // deterministic ordinal for clarity.
         let ordinal = chunk_serial * 2 + stream_idx as u64;
         FastqRawChunk { ordinal, stream_idx, chunk_serial, data: data.to_vec() }
+    }
+
+    #[test]
+    fn pull_decision_pulls_both_when_not_backpressured() {
+        assert_eq!(pull_decision(false, true, true), (true, true));
+        assert_eq!(pull_decision(false, false, false), (true, true));
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_pulls_only_the_behind_stream() {
+        // The deadlock fix: when over the limit and the front pair is missing
+        // B, we MUST still pull B (the behind stream) so the pair can complete
+        // and the buffer drain — never refuse the completing pull.
+        assert_eq!(pull_decision(true, false, true), (false, true), "missing B → pull B only");
+        assert_eq!(pull_decision(true, true, false), (true, false), "missing A → pull A only");
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_with_complete_front_pulls_neither() {
+        // Front pair is complete; draining (emit) is the way forward, not pulling
+        // more — so throttle both streams.
+        assert_eq!(pull_decision(true, false, false), (false, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes an intermittent deadlock in `PairRawFastq` (the chains-pipeline step that joins R1/R2 FASTQ chunks) that triggers when the downstream consumer runs fast — e.g. a fast or GPU/streaming aligner, a warm-cache `bwa mem`, or a replayed alignment BAM. Observed on `runall --start-from extract` at roughly 13% of runs on a CODEC-scale sample; the pipeline wedges with all worker threads idle in backoff and ~256 MiB stuck at the front of the pipeline.

## Root cause

`PairRawFastq` buffers partial pairs keyed by `chunk_serial` and emits the lowest serial once both its R1 and R2 chunks are present. Its pending buffer was bounded with **global** backpressure: once `pending_total_bytes` exceeded the cap (256 MiB) it stopped pulling from **both** input branches until the buffer drained.

But the buffer crosses the cap precisely because one reader raced ahead and filled it with that stream's unmatched chunks. The chunk needed to complete the lowest pending pair belongs to the **other (behind)** stream — sitting available in its (full) input queue — yet global backpressure refuses to pull it. The pull that would complete the front pair and drain the buffer is exactly the pull backpressure blocks, so the step spins returning `NoProgress` forever while the readers' output queues stay full. A fast downstream makes the front-end run fast enough to desync the two readers past the cap and trip it.

Evidence: in every wedged run the `PairRawFastq: pending buffer exceeds backpressure limit` warning fires tens of thousands of times and zero times in healthy runs; sampled stacks show the worker threads parked in backoff and the `AlignAndMerge` I/O threads starved upstream; with the deadlock monitor disabled the run never truly hangs only because the same desync rarely recurs — it is a livelock, not a hard hang.

## Fix

Make backpressure **per-stream** instead of global (`pull_decision`). Once over the cap, keep pulling whichever stream is missing from the front (lowest pending) pair — the pull that completes it and drains the buffer — and throttle only the stream that is ahead. The completing pull is never refused, so the step is deadlock-free by construction; the ahead stream is still capped at 1×, so memory stays bounded. When the front pair is already complete, neither stream is pulled and the step drains via `try_emit_complete` instead of accumulating more.

## Tests

- `pull_decision` unit tests cover all three regimes: not-backpressured (pull both), over-cap with the front pair missing one stream (pull only the behind stream), and over-cap with a complete front (pull neither).
- Existing `pairs_in_chunk_serial_order_with_fresh_dense_ordinals` and profile tests still pass.
- End-to-end: a `runall` reproducer that previously deadlocked ~13% of the time now passes 40/40 runs with zero backpressure-limit warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced paired FASTQ file processing with improved stream synchronization and backpressure optimization
  * Optimized buffer management to reduce latency when processing paired input files
  
* **Tests**
  * Added test coverage for paired file processing scenarios under various backpressure conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->