### PR TITLE
ci: ignore RUSTSEC-2024-0436 (paste unmaintained, tracked in #26)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,18 @@
+# cargo-audit configuration.
+#
+# See: https://github.com/rustsec/rustsec/tree/main/cargo-audit#configuration
+
+[advisories]
+# RUSTSEC-2024-0436: `paste` is unmaintained (archived upstream). This is an
+# "unmaintained" advisory, not a security vulnerability. `paste` is not a direct
+# dependency; it is pulled in transitively via statrs -> nalgebra -> simba.
+#
+# The fix (simba switching paste -> pastey) shipped in simba 0.10.0, which is
+# only reachable through nalgebra 0.35. Our chain is pinned to nalgebra ^0.33 by
+# statrs 0.18, and adopting nalgebra 0.35 upstream also drags in rand 0.10 and an
+# MSRV bump to 1.89, so this is a multi-hop, breaking upstream change.
+#
+# Tracking: https://github.com/fulcrumgenomics/fgumi/issues/26
+# Remove this ignore (and bump statrs) once a statrs release on nalgebra 0.35 is
+# available.
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
## What

Adds `.cargo/audit.toml` ignoring `RUSTSEC-2024-0436` (the `paste` "unmaintained" advisory), with a comment block documenting why and when to remove it.

## Why

`paste` is unmaintained (archived upstream), but this is an **unmaintained advisory, not a security vulnerability** — `paste 1.0.15` is functionally fine. It is not a direct dependency; it enters transitively via `statrs → nalgebra → simba`.

The upstream fix (simba switching `paste → pastey`) shipped in **simba 0.10.0**, which is only reachable through **nalgebra 0.35**. Our tree is pinned to `nalgebra ^0.33` by `statrs 0.18`, and adopting nalgebra 0.35 upstream also pulls in **rand 0.10** and an **MSRV bump to 1.89** — so resolving this for real is a multi-hop, breaking upstream change gated on a new `statrs` release. See #26 for the full chain analysis.

In the meantime this keeps the advisory out of the `cargo audit` CI logs (and stops the auto-filed tracking issue from re-accruing).

## Verification

Verified locally with `cargo-audit 0.22.2`:

- **With** `.cargo/audit.toml`: scan is clean, advisory suppressed, exit 0.
- **Without** it: reports `RUSTSEC-2024-0436` as `1 allowed warning found`, exit 0.

Note that `cargo audit` exits 0 in both cases — `unmaintained` is a warning, not a vulnerability, so CI was never failing on this. This change only silences the warning noise.

## Follow-up

Tracked in #26. Drop this ignore and bump `statrs` once a `statrs` release on nalgebra 0.35 is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a security audit configuration to manage a specific dependency advisory during vulnerability scanning.

**Note:** This change primarily affects the build and development process and does not introduce user-facing features or fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->