### PR TITLE
fix(consensus): clamp consensus depth at i16::MAX instead of wrapping u16

### DIFF
--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -229,8 +229,13 @@ pub struct ConsensusBaseBuilder {
     /// Kahan summation compensation terms for each base - SIMD vectorized
     compensations: f64x4,
 
-    /// Count of observations for each base
-    observations: [u16; DNA_BASE_COUNT],
+    /// Count of observations for each base.
+    ///
+    /// `u32` (not `u16`) so very deep UMI families — a single position can exceed
+    /// `65_535` reads in high-duplication libraries — accumulate without wrapping.
+    /// The per-base depth is later clamped to `i16::MAX` only at tag emission, to
+    /// match fgbio's `Short` consensus-depth representation.
+    observations: [u32; DNA_BASE_COUNT],
 
     /// Pre-computed correct probabilities adjusted for post-UMI errors
     adjusted_correct_table: Vec<LogProbability>,
@@ -461,7 +466,7 @@ impl ConsensusBaseBuilder {
     ///
     /// This is the sum of observations across all four bases
     #[must_use]
-    pub fn contributions(&self) -> u16 {
+    pub fn contributions(&self) -> u32 {
         self.observations.iter().sum()
     }
 
@@ -472,14 +477,14 @@ impl ConsensusBaseBuilder {
     ///
     /// Returns 0 for invalid bases
     #[must_use]
-    pub fn observations_for_base(&self, base: u8) -> u16 {
+    pub fn observations_for_base(&self, base: u8) -> u32 {
         let idx = BASE_TO_INDEX[base as usize];
         if idx == 255 { 0 } else { self.observations[idx as usize] }
     }
 
     /// Returns the observations for all bases as [A, C, G, T]
     #[must_use]
-    pub fn all_observations(&self) -> [u16; DNA_BASE_COUNT] {
+    pub fn all_observations(&self) -> [u32; DNA_BASE_COUNT] {
         self.observations
     }
 }
@@ -501,6 +506,25 @@ mod tests {
         assert_eq!(base, b'A');
         assert!(qual >= 40); // Should have high quality
         assert_eq!(builder.contributions(), 10);
+    }
+
+    #[test]
+    fn test_contributions_do_not_overflow_at_u16_boundary() {
+        // A UMI family deeper than u16::MAX (e.g. high-duplication cfDNA) must not
+        // wrap the per-base observation counter. With a u16 counter, 70_000 single-base
+        // observations wrapped to 70_000 % 65_536 = 4_464; the depth must stay 70_000.
+        let mut builder = ConsensusBaseBuilder::new(45, 40);
+        let n: u32 = 70_000;
+        for _ in 0..n {
+            builder.add(b'A', 40);
+        }
+
+        assert_eq!(builder.contributions(), n, "consensus depth must not wrap at the u16 boundary");
+        assert_eq!(
+            builder.observations_for_base(b'A'),
+            n,
+            "per-base observation count must not wrap at the u16 boundary"
+        );
     }
 
     #[test]

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1332,14 +1332,19 @@ impl VanillaUmiConsensusCaller {
             }
 
             let (base, qual) = self.consensus_builder.call();
-            let depth = self.consensus_builder.contributions(); // u16
+            let depth = self.consensus_builder.contributions();
 
-            // Record depth
-            depths.push(depth);
+            // fgbio's VanillaUmiConsensusCaller stores per-base depths and errors as
+            // `Short`, clamping anything above i16::MAX (32_767), and derives cD/cM/cE
+            // from those clamped arrays. Mirror that so the consensus tags match fgbio.
+            // The unclamped `depth` is still used for the min-reads threshold below
+            // (as fgbio does at VanillaUmiConsensusCaller.scala:329).
+            let max_short = i16::MAX.unsigned_abs(); // 32_767
+            depths.push(u16::try_from(depth).unwrap_or(u16::MAX).min(max_short));
 
-            // Errors = total contributing bases minus those matching consensus
+            // Errors = total contributing bases minus those matching consensus.
             let error_count = depth - self.consensus_builder.observations_for_base(base);
-            errors.push(error_count);
+            errors.push(u16::try_from(error_count).unwrap_or(u16::MAX).min(max_short));
 
             // Apply minimum depth and quality thresholds
             let (final_base, final_qual) = if (depth as usize) < min_reads {
@@ -2461,6 +2466,64 @@ mod tests {
                 assert_eq!(e, 0, "Position {i} should have 0 errors");
             }
         }
+    }
+
+    #[test]
+    fn test_consensus_depth_saturates_at_i16_max_like_fgbio() {
+        // A UMI family deeper than i16::MAX (32_767) must report consensus depth
+        // saturated at 32_767 — matching fgbio's VanillaUmiConsensusCaller, which
+        // stores depths/errors as `Short` — rather than the true depth (which would
+        // diverge from fgbio) or a wrapped value. cE must use the clamped depth as
+        // its denominator, exactly as fgbio derives it from the clamped arrays.
+        let options =
+            VanillaUmiConsensusOptions { produce_per_base_tags: true, ..Default::default() };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        let read_len = 4;
+        let depth = 40_000u32; // > i16::MAX, so depth must clamp
+        let quals = vec![30u8; read_len];
+        let mut reads = Vec::with_capacity(depth as usize);
+        for i in 0..depth {
+            let mut bases = vec![b'A'; read_len];
+            if i == 0 {
+                bases[0] = b'C'; // a single disagreeing observation at position 0
+            }
+            reads.push(create_consensus_test_read(&format!("r{i}"), &bases, &quals, "UMI1"));
+        }
+
+        let output = consensus_reads_from_raw(&mut caller, reads)
+            .expect("consensus_reads_from_raw should succeed");
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        assert_eq!(consensus.bases, vec![b'A'; read_len]);
+        assert_eq!(
+            consensus.get_int_tag(SamTag::CD).expect("cD present"),
+            32_767,
+            "cD (max depth) must saturate at i16::MAX like fgbio"
+        );
+        assert_eq!(
+            consensus.get_int_tag(SamTag::CM).expect("cM present"),
+            32_767,
+            "cM (min depth) must saturate at i16::MAX like fgbio"
+        );
+        let cd_bases = consensus.get_i16_array_tag(SamTag::CD_BASES).expect("cd present");
+        assert_eq!(
+            cd_bases,
+            vec![32_767i16; read_len],
+            "per-base cd must all saturate at i16::MAX"
+        );
+
+        // cE = total errors / total (clamped) depth = 1 / (i16::MAX * read_len)
+        //    = 1 / (32_767 * 4) = 1 / 131_068.
+        let expected_ce = 1.0f32 / 131_068.0;
+        let ce = consensus.get_float_tag(SamTag::CE).expect("cE present");
+        assert!(
+            (ce - expected_ce).abs() < expected_ce * 0.01,
+            "cE must be computed from the clamped depth: expected ~{expected_ce}, got {ce}"
+        );
     }
 
     /// Port of fgbio test: "calculate the # of errors relative to the most likely consensus call"

--- a/crates/fgumi-raw-bam/src/testutil.rs
+++ b/crates/fgumi-raw-bam/src/testutil.rs
@@ -151,16 +151,16 @@ fn find_i16_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<i16>> {
                 };
                 i += count * elem_size;
             }
-            b'c' => {
+            b'A' | b'c' | b'C' => {
                 i += 1;
             }
-            b's' => {
+            b's' | b'S' => {
                 i += 2;
             }
-            b'i' | b'f' => {
+            b'i' | b'I' | b'f' => {
                 i += 4;
             }
-            b'Z' => {
+            b'Z' | b'H' => {
                 while i < aux.len() && aux[i] != 0 {
                     i += 1;
                 }


### PR DESCRIPTION
## Summary

On very deep UMI families, fgumi silently overflowed the consensus depth counter, corrupting the `cD`/`cM`/`cE` consensus tags and — because the error rate is `errors / depth` — changing a real filter keep/drop decision relative to fgbio. This makes fgumi clamp consensus depth at `i16::MAX` (32_767) exactly as fgbio does.

### How it was found

Benchmarking fgumi against fgbio 4.0.0 on a deep cfDNA panel (`idt-cfdna`), the filter-stage BAM equivalency checks differed for every consensus strategy (simplex edit/identity/adjacency and duplex). The molecule `MI:40915` has **277,312 raw reads** (~138,656 per read-end). fgumi reported `cD = 7_584`, which is exactly `138_656 mod 65_536` — a `u16` wraparound. fgbio reported `cD = 32_767` (`Short.MaxValue`).

### Root cause

`ConsensusBaseBuilder::observations` was `[u16; 4]`, incremented with `+= 1`, and the per-base depth/error vectors were `Vec<u16>`. A single position deeper than 65_535 wrapped the counter (a debug build panics with "attempt to add with overflow"; the release build that runs in production wraps silently). The wrapped depth then:

- corrupts the per-read `cD`/`cM` (max/min depth) and the per-base `cd` array;
- corrupts `cE` (`errors / depth`), which in the `MI:40915` case inflated the error rate past `--max-read-error-rate`, so fgumi **dropped** a consensus read that fgbio **kept** (the 52_756 vs 52_758 record-count difference observed in the benchmark).

This is not a v0.3.1 regression — the `u16` types predate v0.3.0; the path was simply never exercised until a family exceeded 65_535 reads.

### Fix

fgbio's `VanillaUmiConsensusCaller` counts depth in `Int` and clamps the per-base depth/error to `Short.MaxValue` when storing, deriving `cD`/`cM`/`cE` from the clamped arrays (`VanillaUmiConsensusCaller.scala:324-340,380-382`). This mirrors it:

- Widen `observations` / `contributions()` / `observations_for_base()` / `all_observations()` from `u16` to `u32` so the counter never wraps.
- Clamp the per-base depth and error to `i16::MAX` when storing, so `cD`/`cM`/`cE` and the per-base `cd`/`ce` arrays all match fgbio. The **unclamped** depth is still used for the min-reads threshold, exactly as fgbio does (`VanillaUmiConsensusCaller.scala:329`).

**Duplex needs no change.** It builds per-strand consensus through the (now-corrected) vanilla caller and sums the two clamped strand depths as `i32` without re-clamping — which is exactly what fgbio does (`DuplexConsensusCaller.scala:480-489`). Its error accumulation already clamps to `i16::MAX`.

### Test-helper fix

The change also completes the test-only aux-tag scanner `find_i16_array_tag_in_aux` (in `fgumi-raw-bam/testutil`) to skip the unsigned `C`/`S`/`I` (and `A`/`H`) BAM aux types. It previously handled only `c`/`s`/`i`/`f`/`Z`, so when `cD` serializes as `S` (which a value of 32_767 now does) the scanner hit `_ => break` and never reached the per-base array tag. The production BAM reader handles all aux types; this only affected the test helper, and the new test surfaced it.

## Tests

- `base_builder`: 70_000 single-base observations no longer wrap `contributions()` (was `7_584` via `mod 65_536`).
- `vanilla_caller`: a 40_000-read family (one disagreeing observation) reports `cD = cM = 32_767` and `cE = 1 / (32_767 * read_len)` — i.e. computed from the clamped depth, matching fgbio.

`cargo ci-test` (2,214 tests), `cargo ci-fmt`, and `cargo ci-lint` (clippy pedantic, `-D warnings`) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented wraparound when counting observations in very deep UMI families.
  * Updated consensus per-base depth/error handling to saturate at the expected i16-compatible limit, matching fgbio semantics.
* **Changes**
  * Widened per-base observation counters returned by the consensus base builder from `u16` to `u32`.
* **Tests**
  * Added coverage for saturation/overflow boundaries.
  * Expanded test utilities to handle more array tag element types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->