### PR TITLE
chore: auto-review stacked PRs on non-default base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,10 +30,15 @@ reviews:
   high_level_summary: true
   poem: false
   collapse_walkthrough: false
-  # Review automatically on push; don't review draft PRs.
+  # Review automatically on push; don't review draft PRs. `base_branches: .*`
+  # also auto-reviews PRs whose base is not the default branch (stacked PRs);
+  # without it CodeRabbit posts "auto reviews are disabled on base/target
+  # branches other than the default branch" and skips them.
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - ".*"
   # Never auto-block merges on a review verdict; findings are advisory.
   request_changes_workflow: false
 


### PR DESCRIPTION
Add `reviews.auto_review.base_branches: ['.*']` to `.coderabbit.yaml` so CodeRabbit also runs automatic reviews on PRs whose base is not the default branch (i.e. stacked PRs).

Without this, CodeRabbit only auto-reviews PRs based on the default branch (`main`) and skips every stacked PR with the notice: *"Auto reviews are disabled on base/target branches other than the default branch."* This is exactly what stalls stacked PRs like #447 (base `feat-runall`), which never receive a review.

`base_branches` accepts regex patterns and only *adds* branches to the default (the default branch is always reviewed); `.*` matches all base branches.

Note: CodeRabbit resolves `.coderabbit.yaml` from each PR's base branch, so existing stacked PRs only pick this up once their base branch (`feat-runall`, etc.) carries the change — rebase the stack onto `main` after this merges.