### PR TITLE
fix(docs): write tool/metric index as index.md to fix broken readthedocs link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,6 +2739,7 @@ dependencies = [
  "fgumi",
  "quote",
  "syn 2.0.118",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -21,6 +21,9 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 fgumi = { path = "../.." }
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 # Relaxations for build tool code (heavy string formatting)

--- a/crates/xtask/src/generate_metrics.rs
+++ b/crates/xtask/src/generate_metrics.rs
@@ -63,6 +63,10 @@ pub fn generate(docs_src: &Path) -> Result<Vec<MetricPage>> {
     }
 
     let index = render_metrics_index(&all_metrics);
+    // Name the index `index.md`, never `README.md`: mdBook renders both to
+    // `index.html`, but it does NOT rewrite links that target `README.md` — it
+    // only swaps the extension, producing a dead link to `metrics/README.html`.
+    // Using `index.md` keeps the link and the rendered filename in agreement.
     fs::write(metrics_dir.join("index.md"), index)?;
 
     Ok(pages)

--- a/crates/xtask/src/generate_metrics.rs
+++ b/crates/xtask/src/generate_metrics.rs
@@ -63,7 +63,7 @@ pub fn generate(docs_src: &Path) -> Result<Vec<MetricPage>> {
     }
 
     let index = render_metrics_index(&all_metrics);
-    fs::write(metrics_dir.join("README.md"), index)?;
+    fs::write(metrics_dir.join("index.md"), index)?;
 
     Ok(pages)
 }
@@ -340,7 +340,7 @@ mod tests {
             fields: vec![],
         }];
         let index = render_metrics_index(&metrics);
-        // Link should be relative (no "metrics/" prefix), since README.md lives in metrics/
+        // Link should be relative (no "metrics/" prefix), since index.md lives in metrics/
         assert!(index.contains("(umi-grouping-metrics.md)"));
         assert!(!index.contains("(metrics/umi-grouping-metrics.md)"));
     }

--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -92,7 +92,7 @@ pub fn generate(
 
     // ── Tool Reference ────────────────────────────────────────────────────────
     md.push_str("# Tool Reference\n\n");
-    md.push_str("- [Index](tools/README.md)\n");
+    md.push_str("- [Index](tools/index.md)\n");
 
     let mut by_category: BTreeMap<String, Vec<&ToolPage>> = BTreeMap::new();
     for page in tool_pages {
@@ -139,7 +139,7 @@ pub fn generate(
 
     // ── Metrics Reference ─────────────────────────────────────────────────────
     md.push_str("# Metrics Reference\n\n");
-    md.push_str("- [Index](metrics/README.md)\n");
+    md.push_str("- [Index](metrics/index.md)\n");
 
     // Group metrics by prefix into logical sections
     let metric_groups: &[(&str, &[&str])] = &[

--- a/crates/xtask/src/generate_tools.rs
+++ b/crates/xtask/src/generate_tools.rs
@@ -52,7 +52,7 @@ pub fn generate(docs_src: &Path) -> Result<Vec<ToolPage>> {
     }
 
     let index = render_tools_index(&by_category);
-    fs::write(tools_dir.join("README.md"), index)?;
+    fs::write(tools_dir.join("index.md"), index)?;
 
     Ok(pages)
 }

--- a/crates/xtask/src/generate_tools.rs
+++ b/crates/xtask/src/generate_tools.rs
@@ -52,6 +52,10 @@ pub fn generate(docs_src: &Path) -> Result<Vec<ToolPage>> {
     }
 
     let index = render_tools_index(&by_category);
+    // Name the index `index.md`, never `README.md`: mdBook renders both to
+    // `index.html`, but it does NOT rewrite links that target `README.md` — it
+    // only swaps the extension, producing a dead link to `tools/README.html`.
+    // Using `index.md` keeps the link and the rendered filename in agreement.
     fs::write(tools_dir.join("index.md"), index)?;
 
     Ok(pages)
@@ -354,6 +358,17 @@ mod tests {
         assert!(names.contains(&"merge"));
         assert!(names.contains(&"simplex-metrics"));
         assert!(names.len() >= 17);
+    }
+
+    #[test]
+    fn test_generate_writes_index_not_readme() {
+        // Regression guard for the broken `tools/README.html` link: the index
+        // page must be `index.md`, never `README.md` (see the write site for
+        // why mdBook mishandles links to `README.md`).
+        let tmp = tempfile::tempdir().unwrap();
+        generate(tmp.path()).unwrap();
+        assert!(tmp.path().join("tools/index.md").exists());
+        assert!(!tmp.path().join("tools/README.md").exists());
     }
 
     #[test]

--- a/docs/src/guide/working-with-metrics.md
+++ b/docs/src/guide/working-with-metrics.md
@@ -15,7 +15,7 @@ fgumi commands produce structured metrics files for quality control and analysis
 | `simplex-metrics` | Comprehensive simplex QC metrics | `--output` (prefix) |
 | `group` | Family sizes, grouping metrics, position group sizes | `--metrics` (prefix), `--family-size-histogram`, `--grouping-metrics` |
 
-See the [Metrics Reference](../metrics/README.md) for field-level documentation of each metric type.
+See the [Metrics Reference](../metrics/index.md) for field-level documentation of each metric type.
 
 ## File Formats
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,4 +72,4 @@ cargo build --release
 | `simplex-metrics` | Collect simplex metrics |
 | `merge` | Merge sorted BAM files |
 
-See the [Tool Reference](tools/README.md) for detailed documentation of each command.
+See the [Tool Reference](tools/index.md) for detailed documentation of each command.


### PR DESCRIPTION
## Summary

Fixes the broken https://fgumi.readthedocs.io/en/latest/tools/README.html link (and the equivalent `metrics/README.html`).

**Root cause:** mdBook renders a source file named `README.md` to `index.html` (GitHub-style), but it does **not** rewrite links that *target* `README.md` — it only swaps the extension. So a link to `tools/README.md` became `tools/README.html`, which never exists; the real page is `tools/index.html`.

**Fix:** the doc generators now write the tool/metric index pages as `index.md` instead of `README.md`, and all links point at `index.md`. This removes the `README` special-casing entirely, keeping every link in agreement with the rendered filename.

## Changes

- `generate_tools.rs` / `generate_metrics.rs` — write the index page as `index.md` (with a comment at each write site explaining why `README.md` is unsafe).
- `generate_summary.rs` — sidebar index links → `tools/index.md`, `metrics/index.md`.
- `docs/src/index.md` & `docs/src/guide/working-with-metrics.md` — hand-written links updated to match.
- Added `test_generate_writes_index_not_readme` (xtask) asserting `generate()` writes `tools/index.md` and never `tools/README.md`, as a regression guard.

## Verification

- Rebuilt the book: the home-page link now renders as `tools/index.html` (which exists), a full-book grep for `README.html` is empty, and mdBook reports no broken-link warnings.
- `cargo ci-fmt`, `cargo ci-lint`, and `cargo test -p xtask` (23 tests) all pass.

## Potential follow-up (not in this PR)

The underlying reason this shipped silently is that nothing fails the build on a dead internal link — Read the Docs runs `mdbook build`, but mdBook only *warns* on broken internal links. Adding [`mdbook-linkcheck`](https://github.com/Michael-F-Bryan/mdbook-linkcheck) as an mdBook backend would catch this class of bug across all pages going forward. It's a new tool dependency that both `.readthedocs.yaml` and the local `docs-build` flow would need to install, so I've left it out of this fix — happy to do it in a separate PR if we want the defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command and metrics reference links to use `index.md` pages.
  * Refreshed guide and landing-page links so reference pages open correctly.

* **Bug Fixes**
  * Fixed broken navigation for generated command and metrics documentation by standardizing the reference page filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->