### PR TITLE
ci(docs): fail the docs build on dead internal links via mdbook-linkcheck2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,19 @@ build:
     # Install mdbook
     - cargo install mdbook --version 0.5.2
 
+    # Install the broken-link checker backend. We use the `mdbook-linkcheck2`
+    # fork because the original `mdbook-linkcheck` is pinned to the mdBook 0.4
+    # backend API and cannot parse mdBook 0.5's RenderContext; the fork tracks
+    # mdBook 0.5. With `[output.linkcheck2]` in docs/book.toml this fails the
+    # build on dead internal links (the defense-in-depth that would have caught
+    # the tools/README.html regression -- mdBook itself only *warns*).
+    - cargo install mdbook-linkcheck2 --version 0.12.2
+
     # Generate documentation markdown and build the mdbook site
     - cargo run --package xtask --release -- docs-build
 
-    # Move output to where Read the Docs expects it
+    # Move output to where Read the Docs expects it. With a second output
+    # backend configured, mdBook writes the HTML site to book/html/ (rather
+    # than book/), so copy from there.
     - mkdir -p _readthedocs/html
-    - cp -r docs/book/. _readthedocs/html/
+    - cp -r docs/book/html/. _readthedocs/html/

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -108,6 +108,32 @@ At a minimum, all of the functions and data structures that are a part of the pr
 
 You are encouraged to include [examples](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html) in the function documentation, as these are also run as test cases.
 
+##### Building the documentation site
+
+The user-facing documentation site (published via [Read the Docs](https://fgumi.readthedocs.io/)) is built with [mdBook](https://rust-lang.github.io/mdBook/) from the sources under `docs/src/`. The per-tool and per-metric reference pages are generated from the CLI definitions by the `xtask` crate.
+
+Two tools must be installed locally to build the site:
+
+```bash
+cargo install mdbook --version 0.5.2
+# Broken-link checker backend. We use the mdbook-linkcheck2 fork because the
+# original mdbook-linkcheck is pinned to the mdBook 0.4 backend API and cannot
+# parse mdBook 0.5's RenderContext.
+cargo install mdbook-linkcheck2 --version 0.12.2
+```
+
+Then, from the repository root:
+
+```bash
+# Generate the markdown and build the site (output under docs/book/html/)
+cargo run --package xtask --release -- docs-build
+
+# Or serve it locally with live reload
+cargo run --package xtask --release -- docs
+```
+
+The `linkcheck2` backend fails the build on dead *internal* links (a link to a page that does not exist). This guards against regressions such as a reference page link that resolves to a file mdBook never renders. External (web) links are not followed, and bracketed literal text in the generated reference pages (e.g. `[ACGT]`) is reported only as a non-fatal warning. Because a second output backend is configured, mdBook writes the HTML site to `docs/book/html/` rather than `docs/book/`.
+
 
 #### Feature Flags for Development
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -27,3 +27,20 @@ level = 1
 [output.html.playground]
 editable = false
 runnable = false
+
+# Broken-link checker (mdbook-linkcheck2 fork; see .readthedocs.yaml for why the
+# fork rather than mdbook-linkcheck). Configuring this as an output backend makes
+# `mdbook build` fail when an internal link points at a page that does not exist
+# -- e.g. the tools/README.html regression, where mdBook renders README.md to
+# index.html but does not rewrite links *targeting* README.md. mdBook on its own
+# only warns on such dead links, so the RTD build went green despite the bug.
+#
+# `follow-web-links = false`: do not hit the network. External links are out of
+# scope here and following them makes the build slow and flaky (and offline-broken).
+#
+# The default warning-policy is intentional: bracketed literal text in the
+# generated CLI/metrics docs (e.g. `[ACGT]`, `[cD]`, `[duplex, AB consensus, ...]`)
+# is reported as a non-fatal "incomplete link" *warning* and does not fail the
+# build, while genuine dead links remain hard errors.
+[output.linkcheck2]
+follow-web-links = false


### PR DESCRIPTION
## Summary

Follow-up to #456 (which fixed the broken `tools/README.html` / `metrics/README.html` links). That PR's root cause shipped silently because **nothing fails the build on a dead internal link** — mdBook only *warns*, so the Read the Docs build went green despite the broken link.

This PR adds [`mdbook-linkcheck`](https://github.com/Michael-F-Bryan/mdbook-linkcheck) as an mdBook output backend so that `mdbook build` — which Read the Docs already runs via `cargo run -p xtask -- docs-build` — now **fails** on dead internal links. No new CI job is required; the gate is the existing Read the Docs build.

### Why the `mdbook-linkcheck2` fork rather than `mdbook-linkcheck`

The repo pins `mdbook --version 0.5.2`. The original `mdbook-linkcheck` (last released 0.7.7, Oct 2022) is built against the mdBook **0.4** backend API and cannot parse mdBook 0.5's `RenderContext` — it dies with `missing field 'sections'`. The maintained [`marxin/mdbook-linkcheck2`](https://github.com/marxin/mdbook-linkcheck2) fork tracks mdBook 0.5 and works.

## Changes

- **`.readthedocs.yaml`** — install `mdbook-linkcheck2` 0.12.2; copy the published site from `docs/book/html/` instead of `docs/book/` (adding a second output backend moves mdBook's HTML output into the `html/` subdirectory).
- **`docs/book.toml`** — add `[output.linkcheck2]` with `follow-web-links = false`. The default `warning-policy` is intentional (see below).
- **`docs/DEVELOPING.md`** — document the new local dependency and the `docs/book/html/` output directory.

## Behavior

With the default `warning-policy`:

- **Genuine dead internal links are hard errors** — e.g. a link to `tools/README.md` (a file mdBook never renders) fails the build with exit 101. This is exactly the #456 bug class.
- **Bracketed literal text in the generated CLI/metrics docs is a non-fatal warning** — strings like `[ACGT]`, `[cD]`, and `[duplex, AB consensus, BA consensus]` are CommonMark "shortcut reference links" with no definition; linkcheck2 reports them as `Potential incomplete link` warnings but does not fail the build. There are ~22 of these in the log; they are cosmetic and harmless.

## Verification

Ran the exact Read the Docs flow locally:

- `cargo run -p xtask --release -- docs-build` → exit 0 (warnings only).
- Injecting a broken link (`[x](tools/README.md)`) → `error: File not found: tools/README.md`, exit 101. Gate confirmed.
- Simulated the RTD copy step: `cp -r docs/book/html/. <site>/` yields a correct site root (`index.html`, `tools/index.html` present; no stray `linkcheck2/` directory).

## Possible further follow-up (not in this PR)

This gates only when Read the Docs builds (on merge to `main`, or per-PR if RTD PR previews are enabled). If we want dead links to block *before* merge regardless of RTD, we could add a small docs-build step to `.github/workflows/check.yml`. Left out to keep this PR scoped; happy to add it if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for building and previewing the documentation site locally.
  * Documented the required tools and versions for docs builds.
  * Clarified how generated docs and reference pages are produced.

* **Bug Fixes**
  * Improved broken-link checking so internal documentation link issues are caught during builds.
  * Updated the docs publishing flow to use the new generated HTML output location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->