### PR TITLE
refactor(features)!: collapse consensus features, repair reduced-feature CI, and structural fixes (1/6)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,3 +190,32 @@ jobs:
         # (lib + tests + benches) with no default features to surface
         # regressions at PR time.
         run: cargo check --workspace --no-default-features --all-targets
+
+  fgumi-feature-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # This job runs `cargo check` on PR code, which executes build
+          # scripts and proc macros. Don't leave GITHUB_TOKEN in git config
+          # where that untrusted code could read it (zizmor: artipacked).
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: fgumi reduced-feature compile coverage
+        # All consensus calling (simplex, duplex, codec) in the umbrella `fgumi`
+        # crate is gated behind one `consensus` feature (default-on). `--workspace`
+        # jobs feature-unify across members, so they cannot prove the *reduced*
+        # `fgumi` compiles in isolation. This job checks `fgumi` alone across its
+        # meaningful feature combos so a regression where always-compiled
+        # chain/runall code references the consensus surface (the X1-001 break,
+        # where every reduced-feature build failed to compile) is caught at PR
+        # time. The consensus-off combo is lib + bin only: the test/bench suite
+        # intentionally requires consensus to exercise the consensus callers.
+        run: |
+          cargo check -p fgumi --no-default-features
+          cargo check -p fgumi --no-default-features --features consensus --all-targets
+          cargo check -p fgumi --all-targets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,21 @@ cargo bench
 
 ## Features
 
+- `consensus` *(default-on)* - All consensus calling: the `simplex`, `duplex`,
+  `codec`, `runall`, `simplex-metrics`, and `duplex-metrics` subcommands. This is
+  a single umbrella toggle; the granular `simplex`/`duplex`/`codec` features live
+  one level down in the `fgumi-consensus` crate for embedders that want a reduced
+  library build. Building with `--no-default-features` cleanly drops all consensus
+  code (the root crate still compiles); pass `--features consensus` to add it back.
+- `simulate` - Enable the simulate command for test data generation (implies `consensus`)
 - `compare` - Enable compare subcommand (developer tools)
-- `simulate` - Enable simulate command for test data generation
 - `profile-adjacency` - Enable profiling output for adjacency UMI assigner
 
 Build with features: `cargo build --release --features compare,simulate`
+
+The reduced-feature build (`cargo check -p fgumi --no-default-features`) is
+exercised in CI by the `fgumi-feature-check` job so always-compiled chain/runall
+code can never silently reference a feature-gated consensus module again.
 
 ## Code Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ name = "fgumi-pipeline-core"
 version = "0.3.0"
 dependencies = [
  "ahash",
+ "anyhow",
  "crossbeam-queue",
  "log",
  "noodles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,24 +115,33 @@ mach2 = "0.6"
 nix = { version = "0.31", default-features = false, features = ["fs"] }
 
 [features]
-default = ["simplex", "duplex", "codec"]
-simplex = ["fgumi-consensus/simplex"]
-# duplex and codec depend on simplex (mirrors fgumi-consensus: `duplex = ["simplex"]`
-# and `codec = ["simplex"]`), and their commands share methylation/filter paths
-# that live behind the `simplex` feature in this crate.
-duplex = ["simplex", "fgumi-consensus/duplex"]
-codec = ["simplex", "fgumi-consensus/codec"]
+default = ["consensus"]
+# All consensus calling (simplex, duplex, CODEC) is gated behind a single
+# `consensus` feature in this umbrella crate. The shipped binary always bundles
+# all three callers, so a per-codec split of the *umbrella* crate bought nothing
+# while letting the always-compiled chain/runall layer reference a half-present
+# consensus surface — the X1-001 regression where every reduced-feature build
+# failed to compile. The granular `simplex`/`duplex`/`codec` features are kept
+# one level down in `fgumi-consensus` for embedders that want a reduced library
+# build. `--no-default-features` now cleanly drops all consensus code, restoring
+# the #314 "root crate builds with --no-default-features" guarantee.
+#
+# `fgumi-consensus`'s `duplex` and `codec` features are siblings (each depends on
+# `simplex`, not on each other), so all three must be enabled explicitly.
+consensus = [
+    "fgumi-consensus/simplex",
+    "fgumi-consensus/duplex",
+    "fgumi-consensus/codec",
+]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
 memory-debug = ["fgumi-sort/memory-debug"]
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
-# Enable simulate commands for generating synthetic test data
-simulate = ["simplex"]
+# Enable simulate commands for generating synthetic test data (needs the consensus surface)
+simulate = ["consensus"]
 # Enable profiling output for adjacency UMI assigner
 profile-adjacency = []
-# Enable slow stress tests for concurrency testing
-stress-tests = []
 
 [dev-dependencies]
 rstest = "0"
@@ -145,8 +154,8 @@ trybuild = "1.0"
 [[bench]]
 name = "core_functions"
 harness = false
-# Exercises vanilla consensus / overlap helpers that live behind `simplex`.
-required-features = ["simplex"]
+# Exercises vanilla consensus / overlap helpers that live behind `consensus`.
+required-features = ["consensus"]
 
 [[bench]]
 name = "raw_bam_accessors"

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -39,6 +39,7 @@ pub use reader::{
 };
 pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{
-    BamWriter, BgzfWriterEnum, RawBamWriter, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_writer, write_bai_index, write_bam_header,
+    BamWriter, BgzfWriterEnum, RawBamWriter, bai_sidecar_path, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_writer, write_bai_index, write_bai_sidecar,
+    write_bam_header,
 };

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -1,9 +1,11 @@
 //! BAM writer factories and related types.
 //!
 //! This module provides writer factories for BAM output, including standard BAM writers,
-//! raw-bytes BAM writers, and a sidecar BAI writer (`write_bai_index`). Incremental
-//! indexing during write was removed in Phase 4 of issue #330; BAI generation now lives
-//! in the typed-step `IndexBamFinalizeHook` as a post-pipeline pass.
+//! raw-bytes BAM writers, and BAI sidecar helpers (`write_bai_index` for a prebuilt index,
+//! `write_bai_sidecar` to index a finished BAM and write `<bam>.bai` in one call, and
+//! `bai_sidecar_path` for the path convention). Incremental indexing during write was
+//! removed in Phase 4 of issue #330; BAI generation now lives in the typed-step
+//! `IndexBamFinalizeHook` as a post-pipeline pass that delegates to `write_bai_sidecar`.
 
 use anyhow::{Context, Result};
 use bgzf::CompressionLevel;
@@ -13,7 +15,7 @@ use noodles_bgzf::io::Writer as BgzfWriter;
 use std::fs::File;
 use std::io::{self, Write};
 use std::num::NonZero;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::paths::is_stdout_path;
 use crate::vendored::{MultithreadedWriter, MultithreadedWriterBuilder};
@@ -268,6 +270,52 @@ pub fn write_bai_index<P: AsRef<Path>>(path: P, index: &bai::Index) -> Result<()
     Ok(())
 }
 
+/// Append `.bai` to a BAM path to form its conventional sidecar index path.
+///
+/// This appends to the **full** path (samtools convention) rather than
+/// replacing the final extension:
+///
+/// - `foo.bam` → `foo.bam.bai`
+/// - `foo` (no extension) → `foo.bai`
+/// - `foo.sorted` → `foo.sorted.bai`
+///
+/// Using `Path::with_extension("bam.bai")` instead would replace whatever
+/// follows the last `.`, producing the correct result only for paths that end
+/// in exactly `.bam` and mis-naming every other path (`foo` → `foo.bam.bai`,
+/// `foo.sorted` → `foo.bam.bai`).
+#[must_use]
+pub fn bai_sidecar_path<P: AsRef<Path>>(bam_path: P) -> PathBuf {
+    let mut index_os = bam_path.as_ref().as_os_str().to_owned();
+    index_os.push(".bai");
+    PathBuf::from(index_os)
+}
+
+/// Build a BAI index for a finished coordinate-sorted BAM and write it to the
+/// conventional `<bam_path>.bai` sidecar, returning the path written.
+///
+/// The sidecar path is derived by [`bai_sidecar_path`] (append `.bai` to the
+/// full path), so BAMs whose path does not end in `.bam` still get a correctly
+/// named sidecar.
+///
+/// **Invariant:** the BAM at `bam_path` must be writer-closed before this is
+/// called — [`noodles::bam::fs::index`] re-reads the file from disk to compute
+/// virtual offsets, so any buffered writes must already be flushed.
+///
+/// # Errors
+/// Returns an error if indexing the BAM or writing the BAI sidecar fails.
+pub fn write_bai_sidecar<P: AsRef<Path>>(bam_path: P) -> Result<PathBuf> {
+    let bam_path = bam_path.as_ref();
+
+    let index = noodles::bam::fs::index(bam_path)
+        .with_context(|| format!("Failed to index {}", bam_path.display()))?;
+
+    let index_path = bai_sidecar_path(bam_path);
+    write_bai_index(&index_path, &index)
+        .with_context(|| format!("Failed to write BAI to {}", index_path.display()))?;
+
+    Ok(index_path)
+}
+
 /// Create a BAM writer and write the header in one operation.
 ///
 /// # Arguments
@@ -379,6 +427,21 @@ mod tests {
         );
         builder = builder.add_reference_sequence(b"chr1", ref_seq);
         builder.build()
+    }
+
+    #[test]
+    fn bai_sidecar_path_appends_dot_bai_to_full_path() {
+        // The samtools convention is to append `.bai` to the whole BAM path,
+        // not to replace the final extension. The previous
+        // `with_extension("bam.bai")` only produced the right answer for paths
+        // ending in exactly `.bam`; these cases pin the fix (S3-006 / S5b2-008).
+        assert_eq!(bai_sidecar_path("foo.bam"), PathBuf::from("foo.bam.bai"));
+        // Extensionless path: must become `foo.bai`, not `foo.bam.bai`.
+        assert_eq!(bai_sidecar_path("foo"), PathBuf::from("foo.bai"));
+        // Non-`.bam` extension: must keep the original name and append `.bai`.
+        assert_eq!(bai_sidecar_path("foo.sorted"), PathBuf::from("foo.sorted.bai"));
+        // Path with directory components is preserved.
+        assert_eq!(bai_sidecar_path("/tmp/run1/out.bam"), PathBuf::from("/tmp/run1/out.bam.bai"));
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/Cargo.toml
+++ b/crates/fgumi-pipeline-core/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 ahash = "0.8"
+anyhow = "1.0.102"
 crossbeam-queue = "0.3"
 parking_lot = "0.12"
 log = "0"

--- a/crates/fgumi-pipeline-core/src/finalize.rs
+++ b/crates/fgumi-pipeline-core/src/finalize.rs
@@ -1,0 +1,39 @@
+//! Post-pipeline finalize hook contract.
+//!
+//! [`FinalizeHook`] is the bare trait that lets a chain register
+//! heterogeneous post-pipeline cleanup actions — metrics drains, summary
+//! logging, gate checks, rejects-file finalization, BAI indexing — in a single
+//! `Vec<Box<dyn FinalizeHook>>` that the caller drains after `Pipeline::run`
+//! returns.
+//!
+//! It lives in `fgumi-pipeline-core` (rather than the umbrella `fgumi` crate)
+//! so that any CLI crate built directly on the pipeline core — e.g.
+//! `fgumi-sort-cli` — can implement the same contract without redefining a
+//! parallel trait. Keeping the trait single-sourced here is what lets the sort
+//! finalize hooks be defined once and re-exported by the umbrella, instead of
+//! duplicated across both crates (X1-005).
+//!
+//! The richer machinery built on top of this trait — `BuiltPipeline`,
+//! `drain_finalize`, and the built-in stats/timing hooks — stays in the
+//! umbrella crate, since it references umbrella-only types.
+
+use anyhow::Result;
+
+/// Post-pipeline cleanup. Each stage with metrics, summary logging,
+/// `--min-corrected`-style gates, or rejects-file finalization registers one or
+/// more hooks during chain build. The caller iterates the registered hooks
+/// (typically via `try_for_each`) after `Pipeline::run` returns.
+///
+/// Trait object so heterogeneous hooks (correct's metrics drain, consensus's
+/// summary log, AAM's records-aligned counter, sort's BAI indexer, etc.) can
+/// share a `Vec<Box<dyn FinalizeHook>>`.
+pub trait FinalizeHook: Send {
+    /// Run the post-pipeline action. Called exactly once, after
+    /// `Pipeline::run` returns and before the caller exits.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O / aggregation / gate-check error.
+    /// Callers typically chain via `try_for_each`.
+    fn finalize(self: Box<Self>) -> Result<()>;
+}

--- a/crates/fgumi-pipeline-core/src/lib.rs
+++ b/crates/fgumi-pipeline-core/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod builder;
 pub mod erased;
+pub mod finalize;
 pub mod handles;
 pub mod header;
 pub mod held;
@@ -34,6 +35,7 @@ pub use builder::{
     PipelineConfig,
 };
 pub use erased::{ErasedStep, ErasedStepCtx, TypedStep, TypedStep2};
+pub use finalize::FinalizeHook;
 pub use handles::{HeldRetry, TwoInputHandles, Unpushed};
 pub use header::{AlreadySetError, HeaderHandle};
 pub use held::HeldSlot;

--- a/crates/fgumi-sort-cli/src/chains.rs
+++ b/crates/fgumi-sort-cli/src/chains.rs
@@ -69,11 +69,14 @@ impl FinalizeHook for SortFinalizeHook {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Post-pipeline action that builds a BAI index for a finished
-/// coordinate-sorted BAM, writing `<output>.bam.bai` next to the BAM.
+/// coordinate-sorted BAM, writing the `.bai` sidecar next to the BAM.
 ///
 /// Reads the BAM via `noodles::bam::fs::index` (which walks BGZF block offsets
-/// and computes virtual positions from the on-disk layout) and writes
-/// `<output>.bam.bai` next to the BAM via `fgumi_bam_io::write_bai_index`. This
+/// and computes virtual positions from the on-disk layout) and writes the
+/// sidecar via `fgumi_bam_io::write_bai_sidecar`, which derives the path by
+/// appending `.bai` to the full output path (samtools convention) — so
+/// `foo.bam` → `foo.bam.bai` and a non-`.bam` output like `foo.sorted` →
+/// `foo.sorted.bai`. This
 /// decouples indexing from the sort step itself: the sorter no longer needs
 /// single-threaded BGZF compression to track virtual offsets during write, and
 /// BAI generation lifts cleanly to a hook that any future BAM-with-index chain
@@ -102,8 +105,6 @@ impl FinalizeHook for IndexBamFinalizeHook {
     ///
     /// Returns an error if indexing or writing the BAI sidecar fails.
     fn finalize(self: Box<Self>) -> Result<()> {
-        use fgumi_bam_io::write_bai_index;
-        use noodles::bam;
         use std::time::Instant;
 
         let IndexBamFinalizeHook { output_path } = *self;
@@ -111,18 +112,10 @@ impl FinalizeHook for IndexBamFinalizeHook {
         info!("Indexing BAM: {}", output_path.display());
         let start = Instant::now();
 
-        let index = bam::fs::index(&output_path)
-            .map_err(|e| anyhow::anyhow!("Failed to index {}: {e}", output_path.display()))?;
-
-        // BAI convention: sit next to the BAM with `.bam.bai`, e.g.
-        // `foo.bam` → `foo.bam.bai`. The contract is "append `.bai` to the BAM
-        // path"; `with_extension` happens to produce the right result because
-        // the input always carries a single `.bam` extension. (Phase 4 moves
-        // this body into `fgumi_bam_io::write_bai_sidecar` and fixes the
-        // extensionless-path edge case once.)
-        let index_path = output_path.with_extension("bam.bai");
-        write_bai_index(&index_path, &index)
-            .map_err(|e| anyhow::anyhow!("Failed to write BAI to {}: {e}", index_path.display()))?;
+        // Index + write the `<output>.bai` sidecar in one call; the path is
+        // derived by appending `.bai` to the full BAM path (samtools
+        // convention), correct for any path — not just `*.bam`.
+        let index_path = fgumi_bam_io::write_bai_sidecar(&output_path)?;
         info!("Wrote BAM index: {} ({})", index_path.display(), format_duration(start.elapsed()));
 
         Ok(())
@@ -318,7 +311,7 @@ mod tests {
         let hook = Box::new(IndexBamFinalizeHook { output_path: bam_path.clone() });
         hook.finalize().expect("hook finalize");
 
-        let bai_path = bam_path.with_extension("bam.bai");
+        let bai_path = fgumi_bam_io::bai_sidecar_path(&bam_path);
         assert!(bai_path.exists(), "BAI not created at {}", bai_path.display());
         let index = noodles::bam::bai::fs::read(&bai_path).expect("read bai");
         assert!(!index.reference_sequences().is_empty(), "BAI has no reference sequences");

--- a/crates/fgumi-sort-cli/src/chains.rs
+++ b/crates/fgumi-sort-cli/src/chains.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use bytesize::ByteSize;
 use fgumi_cli_common::{MemoryLimit, OperationTimer, format_duration};
+use fgumi_pipeline_core::FinalizeHook;
 use fgumi_pipeline_io::SortBamFile;
 use fgumi_sort::{RawExternalSorter, SortOrder};
 use log::info;
@@ -26,6 +27,11 @@ use crate::version;
 /// Post-pipeline finalize action for sort. Reads `SortStats` out of the
 /// shared slot, logs the Summary block, and calls
 /// [`OperationTimer::log_completion`].
+///
+/// This is the single definition of the sort summary hook, implementing the
+/// shared [`FinalizeHook`] contract. The umbrella `fgumi` crate re-exports it
+/// (rather than redefining a parallel copy) so its `ChainBuilder::add_sort` can
+/// register it alongside the other stages' hooks (X1-005).
 pub struct SortFinalizeHook {
     /// Shared slot the `SortBamFile` step fills after `sort()` returns.
     pub stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>>,
@@ -35,10 +41,13 @@ pub struct SortFinalizeHook {
     pub timer: OperationTimer,
 }
 
-impl SortFinalizeHook {
-    /// Run the post-pipeline summary logging.
-    pub fn finalize(self) {
-        let SortFinalizeHook { stats_slot, output_path, timer } = self;
+impl FinalizeHook for SortFinalizeHook {
+    /// Run the post-pipeline summary logging. Infallible — always returns
+    /// `Ok(())` — but typed as `Result` to satisfy the [`FinalizeHook`]
+    /// contract so it can share a `Vec<Box<dyn FinalizeHook>>` with the
+    /// fallible hooks.
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let SortFinalizeHook { stats_slot, output_path, timer } = *self;
 
         let stats = stats_slot.lock().take().unwrap_or_default();
         info!("=== Summary ===");
@@ -50,6 +59,8 @@ impl SortFinalizeHook {
         info!("Output: {}", output_path.display());
 
         timer.log_completion(stats.total_records);
+
+        Ok(())
     }
 }
 
@@ -60,26 +71,42 @@ impl SortFinalizeHook {
 /// Post-pipeline action that builds a BAI index for a finished
 /// coordinate-sorted BAM, writing `<output>.bam.bai` next to the BAM.
 ///
+/// Reads the BAM via `noodles::bam::fs::index` (which walks BGZF block offsets
+/// and computes virtual positions from the on-disk layout) and writes
+/// `<output>.bam.bai` next to the BAM via `fgumi_bam_io::write_bai_index`. This
+/// decouples indexing from the sort step itself: the sorter no longer needs
+/// single-threaded BGZF compression to track virtual offsets during write, and
+/// BAI generation lifts cleanly to a hook that any future BAM-with-index chain
+/// can register.
+///
+/// This is the single definition of the BAI indexer hook, implementing the
+/// shared [`FinalizeHook`] contract; the umbrella `fgumi` crate re-exports it
+/// rather than redefining a parallel copy (X1-005).
+///
 /// **Invariant:** the BAM at `output_path` must be writer-closed before
-/// `finalize` runs — guaranteed by `Pipeline::run` returning (which only
-/// happens after every step's writer has dropped).
+/// `finalize` runs. This is guaranteed by `Pipeline::run` returning (which only
+/// happens after every step's writer has dropped); the hook does not call
+/// `fsync` because the same process re-reading via the OS page cache will see
+/// all flushed bytes on every supported local filesystem. A remote/NFS
+/// deployment would need its own close-to-open coherency story; that is out of
+/// scope for this hook.
 pub struct IndexBamFinalizeHook {
     /// Path of the finished coordinate-sorted BAM to index.
     pub output_path: PathBuf,
 }
 
-impl IndexBamFinalizeHook {
+impl FinalizeHook for IndexBamFinalizeHook {
     /// Build and write the BAI index alongside the BAM.
     ///
     /// # Errors
     ///
     /// Returns an error if indexing or writing the BAI sidecar fails.
-    pub fn finalize(self) -> Result<()> {
+    fn finalize(self: Box<Self>) -> Result<()> {
         use fgumi_bam_io::write_bai_index;
         use noodles::bam;
         use std::time::Instant;
 
-        let IndexBamFinalizeHook { output_path } = self;
+        let IndexBamFinalizeHook { output_path } = *self;
 
         info!("Indexing BAM: {}", output_path.display());
         let start = Instant::now();
@@ -88,7 +115,11 @@ impl IndexBamFinalizeHook {
             .map_err(|e| anyhow::anyhow!("Failed to index {}: {e}", output_path.display()))?;
 
         // BAI convention: sit next to the BAM with `.bam.bai`, e.g.
-        // `foo.bam` → `foo.bam.bai`.
+        // `foo.bam` → `foo.bam.bai`. The contract is "append `.bai` to the BAM
+        // path"; `with_extension` happens to produce the right result because
+        // the input always carries a single `.bam` extension. (Phase 4 moves
+        // this body into `fgumi_bam_io::write_bai_sidecar` and fixes the
+        // extensionless-path edge case once.)
         let index_path = output_path.with_extension("bam.bai");
         write_bai_index(&index_path, &index)
             .map_err(|e| anyhow::anyhow!("Failed to write BAI to {}: {e}", index_path.display()))?;
@@ -284,7 +315,7 @@ mod tests {
         }
         writer.finish().expect("finish");
 
-        let hook = IndexBamFinalizeHook { output_path: bam_path.clone() };
+        let hook = Box::new(IndexBamFinalizeHook { output_path: bam_path.clone() });
         hook.finalize().expect("hook finalize");
 
         let bai_path = bam_path.with_extension("bam.bai");

--- a/crates/fgumi-sort-cli/src/sort.rs
+++ b/crates/fgumi-sort-cli/src/sort.rs
@@ -726,7 +726,7 @@ mod tests {
         // (missing) input before touching the output, so this file survives —
         // making the BAI's presence a clean signal of whether the index hook ran.
         write_coordinate_bam(&output);
-        let bai = output.with_extension("bam.bai");
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
         assert!(!bai.exists(), "precondition: no index before the failed sort");
 
         // A Sort configured to write the index on success.

--- a/crates/fgumi-sort-cli/src/sort.rs
+++ b/crates/fgumi-sort-cli/src/sort.rs
@@ -30,7 +30,7 @@ use fgumi_cli_common::{
     Command, CompressionOptions, MemoryLimit, MemoryReserve, OperationTimer, parse_bool,
     parse_memory, parse_memory_reserve, resolve_memory_budget, validate_file_exists,
 };
-use fgumi_pipeline_core::{Pipeline, PipelineConfig};
+use fgumi_pipeline_core::{FinalizeHook, Pipeline, PipelineConfig};
 use fgumi_sam::SamTag;
 use fgumi_sort::{QuerynameComparator, SortOrder, verify_sort_order};
 use log::info;
@@ -469,14 +469,19 @@ impl Sort {
         // the summary logs. The pipeline-run error takes precedence.
         let run_result = pipeline.run(config).map_err(|e| anyhow::anyhow!("Pipeline::run: {e:?}"));
 
-        SortFinalizeHook { stats_slot, output_path: output_path.clone(), timer }.finalize();
+        // Drain the summary hook even on the error path (it is infallible —
+        // always `Ok(())`), then let the pipeline-run error take precedence.
+        let summary_result =
+            Box::new(SortFinalizeHook { stats_slot, output_path: output_path.clone(), timer })
+                .finalize();
 
         // Only write the BAM index after a successful sort: a failed run leaves
         // the output BAM incomplete, so emitting (or overwriting) `.bam.bai`
         // would publish a stale index for a partial file.
         run_result?;
+        summary_result?;
         if self.write_index {
-            IndexBamFinalizeHook { output_path }.finalize()?;
+            Box::new(IndexBamFinalizeHook { output_path }).finalize()?;
         }
         Ok(())
     }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,6 +9,15 @@ license.workspace = true
 publish = false
 
 [features]
+# `consensus` is default-on so doc builds (`cargo run -p xtask -- docs-build`,
+# which uses default features) generate the simplex/duplex/codec command docs.
+# It is its own feature — rather than relying on `fgumi`'s default — so that the
+# workspace `--no-default-features` CI check disables it here too, letting that
+# check exercise a genuinely reduced `fgumi` and catch always-compiled code that
+# references the consensus surface (X1-002). The consensus command imports in
+# `generate_tools.rs` are gated on this feature.
+default = ["consensus"]
+consensus = ["fgumi/consensus"]
 # Mirror the compare feature from the fgumi crate to include the compare tool in docs
 compare = ["fgumi/compare"]
 # Mirror the simulate feature from the fgumi crate to include simulate tools in docs
@@ -19,7 +28,13 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
-fgumi = { path = "../.." }
+# `default-features = false` so the workspace `--no-default-features` CI check
+# actually exercises a reduced `fgumi`. Without it, Cargo feature-unification
+# pulls in `fgumi`'s default (consensus) features under `--workspace`, masking
+# any always-compiled code that references the consensus surface (see X1-002).
+# xtask re-enables consensus (default-on, above) / compare / simulate explicitly
+# for doc generation via its own mirrored features.
+fgumi = { path = "../..", default-features = false }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/xtask/src/generate_tools.rs
+++ b/crates/xtask/src/generate_tools.rs
@@ -66,9 +66,13 @@ fn collect_commands() -> Vec<CommandInfo> {
     #[cfg(feature = "simulate")]
     use fgumi_lib::commands::simulate;
     use fgumi_lib::commands::{
-        clip, codec, correct, dedup, downsample, duplex, duplex_metrics, extract, fastq, filter,
-        group, merge, review, simplex, simplex_metrics, sort, zipper,
+        clip, correct, dedup, downsample, extract, fastq, filter, group, merge, review, sort,
+        zipper,
     };
+    // The consensus command modules are gated behind `fgumi`'s `consensus`
+    // feature; xtask mirrors it as `consensus` (default-on for doc builds).
+    #[cfg(feature = "consensus")]
+    use fgumi_lib::commands::{codec, duplex, duplex_metrics, runall, simplex, simplex_metrics};
 
     // Each command type with its CLI name. The name override is needed because
     // clap derives names from struct names, which may not match the subcommand
@@ -82,15 +86,22 @@ fn collect_commands() -> Vec<CommandInfo> {
         ("sort", <sort::Sort as CommandFactory>::command),
         ("group", <group::GroupReadsByUmi as CommandFactory>::command),
         ("dedup", <dedup::MarkDuplicates as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
         ("simplex", <simplex::Simplex as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
         ("duplex", <duplex::Duplex as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
         ("codec", <codec::Codec as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
+        ("runall", <runall::RunAll as CommandFactory>::command),
         ("filter", <filter::Filter as CommandFactory>::command),
         ("clip", <clip::Clip as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
         ("duplex-metrics", <duplex_metrics::DuplexMetrics as CommandFactory>::command),
         ("review", <review::Review as CommandFactory>::command),
         ("downsample", <downsample::Downsample as CommandFactory>::command),
         ("merge", <merge::Merge as CommandFactory>::command),
+        #[cfg(feature = "consensus")]
         ("simplex-metrics", <simplex_metrics::SimplexMetrics as CommandFactory>::command),
         #[cfg(feature = "compare")]
         ("compare", <compare::Compare as CommandFactory>::command),
@@ -346,14 +357,34 @@ mod tests {
     fn test_collect_commands_finds_all() {
         let commands = collect_commands();
         let names: Vec<_> = commands.iter().map(|(n, ..)| n.as_str()).collect();
+        // Always present (feature-independent commands).
         assert!(names.contains(&"extract"));
         assert!(names.contains(&"group"));
-        assert!(names.contains(&"simplex"));
-        assert!(names.contains(&"duplex"));
         assert!(names.contains(&"filter"));
         assert!(names.contains(&"merge"));
-        assert!(names.contains(&"simplex-metrics"));
-        assert!(names.len() >= 17);
+        // The consensus commands are only collected with the `consensus` feature
+        // (their parser entries are `#[cfg(feature = "consensus")]`-gated).
+        #[cfg(feature = "consensus")]
+        {
+            // Assert every consensus command is discovered explicitly — `runall`
+            // in particular is exposed by `main.rs` under `consensus` but was
+            // previously omitted from `collect_commands()`, leaving its doc page
+            // ungenerated. A bare `names.len()` check is too weak to catch a
+            // single missing entry, so pin each name.
+            assert!(names.contains(&"simplex"));
+            assert!(names.contains(&"duplex"));
+            assert!(names.contains(&"codec"));
+            assert!(names.contains(&"runall"));
+            assert!(names.contains(&"duplex-metrics"));
+            assert!(names.contains(&"simplex-metrics"));
+            // 12 always-present + 6 consensus (simplex, duplex, codec, runall,
+            // duplex-metrics, simplex-metrics). `>=` rather than `==` because the
+            // `compare` / `simulate` features (which Cargo can feature-unify into
+            // a `--workspace` build) add further commands.
+            assert!(names.len() >= 18);
+        }
+        #[cfg(not(feature = "consensus"))]
+        assert!(names.len() >= 12);
     }
 
     #[test]

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -118,7 +118,6 @@ Several Cargo features exist for development and debugging purposes. These are *
 | `memory-debug` | Enables comprehensive memory debugging infrastructure: a monitor thread, hot-path atomic counters, and additional CLI arguments for memory tracking. Requires `libmimalloc-sys` and `sysinfo` dependencies. | `cargo build --features memory-debug` |
 | `dhat-heap` | Enables heap profiling via the `dhat` crate. Replaces the default `mimalloc` allocator with `dhat::Alloc`. | `cargo build --features dhat-heap` |
 | `profile-adjacency` | Enables profiling output for the adjacency UMI assigner. | `cargo build --features profile-adjacency` |
-| `stress-tests` | Enables slow stress tests for concurrency testing. | `cargo nextest run --features stress-tests` |
 | `compare` | Enables the `compare` subcommand for BAM and metrics developer tools. | `cargo build --features compare` |
 | `simulate` | Enables the `simulate` command for generating synthetic test data. | `cargo build --features simulate` |
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -4,18 +4,18 @@
 //! command structs using `#[command(flatten)]`.
 
 use std::path::PathBuf;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use std::sync::Arc;
 
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use crate::logging::OperationTimer;
 use crate::validation::validate_file_exists;
 use bytesize::ByteSize;
 use clap::Args;
 use fgumi_bam_io::is_stdin_path;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_consensus::methylation::RefBaseProvider;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use log::info;
 use noodles::sam::Header;
 
@@ -56,7 +56,7 @@ pub fn resolve_methylation_mode(
 }
 
 /// Methylation reference pair: reference base provider + contig name mapping.
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub type MethylationRef = Option<(
     Arc<dyn fgumi_consensus::methylation::RefBaseProvider + Send + Sync>,
     Arc<Vec<String>>,
@@ -65,7 +65,7 @@ pub type MethylationRef = Option<(
 /// Loads the reference FASTA and builds contig name mapping for methylation-aware modes.
 ///
 /// Returns `None` if methylation mode is disabled. Errors if enabled but `reference` is `None`.
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub fn load_methylation_reference(
     methylation_mode: fgumi_consensus::MethylationMode,
     reference: &Option<PathBuf>,

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -417,9 +417,19 @@ pub struct ThreadingOptions {
 ///
 /// (Named `SchedulerOptions` for historical reasons — the `--scheduler`
 /// strategy flag it once carried was removed in the issue #330 migration,
-/// since the typed-step dispatch model has no pluggable strategy.)
+/// since the typed-step dispatch model has no pluggable strategy. It survives
+/// only as a hidden, deprecated no-op alias so legacy invocations degrade to a
+/// warning rather than a hard clap error — see the `scheduler` field.)
 #[derive(Debug, Clone, Default, Args)]
 pub struct SchedulerOptions {
+    /// DEPRECATED: no-op. The pluggable scheduler strategy was removed in the
+    /// issue #330 typed-step dispatch migration; the typed-step model has no
+    /// strategy to select. Kept as a hidden alias that accepts (and ignores)
+    /// any value so scripts passing the old `--scheduler <strategy>` warn
+    /// instead of hard-failing on an unknown argument (AUDIT-002).
+    #[arg(long = "scheduler", hide = true)]
+    pub scheduler: Option<String>,
+
     /// Print detailed pipeline statistics at completion.
     ///
     /// Shows per-step timing, throughput, contention metrics, and
@@ -766,6 +776,16 @@ pub fn warn_unwired_pipeline_flags(
     scheduler_opts: &SchedulerOptions,
     queue_memory: &QueueMemoryOptions,
 ) {
+    // --scheduler: removed in the issue #330 typed-step dispatch migration
+    // (no pluggable strategy to select). Accepted as a hidden no-op alias so
+    // legacy scripts warn rather than hard-failing on an unknown argument.
+    if scheduler_opts.scheduler.is_some() {
+        log::warn!(
+            "DEPRECATED: --scheduler is a no-op and is ignored; the pluggable \
+             scheduler strategy was removed in the typed-step pipeline migration \
+             (#330). Remove it from your invocation."
+        );
+    }
     // --deadlock-recover: the legacy progressive-doubling recovery
     // addressed a failure mode (a worker pinned on a stuck step under
     // legacy's static scheduler) that doesn't exist in the typed-step
@@ -985,6 +1005,7 @@ mod tests {
             pipeline_stats: true,
             deadlock_timeout: 10,
             deadlock_recover: false,
+            scheduler: None,
         };
         assert!(opts.collect_stats());
     }
@@ -995,6 +1016,7 @@ mod tests {
             pipeline_stats: false,
             deadlock_timeout: 30,
             deadlock_recover: false,
+            scheduler: None,
         };
         assert_eq!(opts.deadlock_timeout_secs(), 30);
     }
@@ -1005,8 +1027,32 @@ mod tests {
             pipeline_stats: false,
             deadlock_timeout: 10,
             deadlock_recover: true,
+            scheduler: None,
         };
         assert!(opts.deadlock_recover_enabled());
+    }
+
+    #[test]
+    fn test_deprecated_scheduler_flag_is_accepted_as_noop() {
+        use clap::Parser;
+
+        // A minimal parser that flattens SchedulerOptions, mirroring how every
+        // pipeline command embeds it. The deprecated `--scheduler <value>` must
+        // parse (not hard-error like an unknown argument) and be captured so the
+        // dispatch path can emit the deprecation warning.
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            scheduler: SchedulerOptions,
+        }
+
+        let cli = TestCli::try_parse_from(["test", "--scheduler", "work-stealing"])
+            .expect("--scheduler must be accepted as a deprecated no-op, not rejected");
+        assert_eq!(cli.scheduler.scheduler.as_deref(), Some("work-stealing"));
+
+        // Absent by default.
+        let cli = TestCli::try_parse_from(["test"]).expect("parses with no args");
+        assert_eq!(cli.scheduler.scheduler, None);
     }
 
     // ========== Tests for QueueMemoryOptions ==========

--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -3,7 +3,7 @@
 //! This module provides shared traits and utilities used by simplex, duplex, and codec
 //! consensus calling commands to reduce code duplication.
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 use crate::consensus::codec_caller::CodecConsensusStats;
 use crate::consensus_caller::ConsensusCallingStats;
 use crate::metrics::consensus::ConsensusMetrics;
@@ -24,6 +24,7 @@ use noodles::sam::header::record::value::map::tag::Other;
 /// `--threads` hint pointing at the SAM-capable multi-threaded path. Shared by
 /// `codec`/`simplex`/`duplex`'s `execute` (their open logic and error message
 /// are identical bar the command name).
+#[cfg(feature = "consensus")]
 pub(crate) fn open_single_threaded_consensus_input(
     input: &std::path::Path,
     reader_opts: fgumi_bam_io::PipelineReaderOpts,
@@ -68,7 +69,7 @@ impl ConsensusStatsOps for ConsensusCallingStats {
     }
 }
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 impl ConsensusStatsOps for CodecConsensusStats {
     fn merge(&mut self, other: &Self) {
         self.total_input_reads += other.total_input_reads;

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -9,7 +9,7 @@
 //!    (min reads, max read error rate, max no-calls, min mean quality)
 
 use crate::alignment_tags::regenerate_alignment_tags_raw;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use crate::consensus_filter::resolve_ref_bases_for_record;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
@@ -402,8 +402,8 @@ impl Filter {
         methylation_mode: fgumi_consensus::MethylationMode,
         ref_names: &[String],
     ) -> Result<(u64, bool)> {
-        // `ref_names` is only consumed by the `simplex`-gated ref-base resolver below.
-        #[cfg(not(feature = "simplex"))]
+        // `ref_names` is only consumed by the `consensus`-gated ref-base resolver below.
+        #[cfg(not(feature = "consensus"))]
         let _ = ref_names;
 
         // Fail fast if we encounter a mapped read without a reference, since masking
@@ -465,10 +465,10 @@ impl Filter {
         }
 
         // Resolve reference bases once for all reference-dependent filters.
-        // The resolver lives in the `simplex`-gated `methylation` module, so the
+        // The resolver lives in the `consensus`-gated `methylation` module, so the
         // reference-dependent methylation filters below are only available when
-        // `simplex` is enabled. Without `simplex` we skip the lookup entirely.
-        #[cfg(feature = "simplex")]
+        // `consensus` is enabled. Without `consensus` we skip the lookup entirely.
+        #[cfg(feature = "consensus")]
         let ref_base_map = {
             let needs_ref_bases = (require_strand_methylation_agreement && is_duplex)
                 || min_conversion_fraction.is_some();
@@ -478,13 +478,13 @@ impl Filter {
                 None
             }
         };
-        #[cfg(not(feature = "simplex"))]
+        #[cfg(not(feature = "consensus"))]
         let ref_base_map: Option<Vec<Option<u8>>> = {
             if (require_strand_methylation_agreement && is_duplex)
                 || min_conversion_fraction.is_some()
             {
                 bail!(
-                    "reference-dependent methylation filters require building fgumi with the `simplex` feature"
+                    "reference-dependent methylation filters require building fgumi with the `consensus` feature"
                 );
             }
             None

--- a/src/lib/commands/mod.rs
+++ b/src/lib/commands/mod.rs
@@ -51,7 +51,7 @@
 )]
 
 pub mod clip;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub mod codec;
 pub mod command;
 pub mod common;
@@ -61,9 +61,9 @@ pub mod consensus_runner;
 pub mod correct;
 pub mod dedup;
 pub mod downsample;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub mod duplex;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub mod duplex_metrics;
 pub mod extract;
 pub mod fastq;
@@ -71,12 +71,12 @@ pub mod filter;
 pub mod group;
 pub mod merge;
 pub mod review;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub mod runall;
 pub mod shared_metrics;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub mod simplex;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub mod simplex_metrics;
 #[cfg(feature = "simulate")]
 pub mod simulate;

--- a/src/lib/consensus/mod.rs
+++ b/src/lib/consensus/mod.rs
@@ -4,11 +4,11 @@
 
 pub use fgumi_consensus::{base_builder, caller, filter, overlapping, sequence, simple_umi, tags};
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::codec_caller;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::duplex_caller;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::vanilla_caller;
 
 // Re-export commonly used items
@@ -20,15 +20,15 @@ pub use fgumi_consensus::{
     log_consensus_statistics, mask_bases, mask_duplex_bases, mean_base_quality, template_passes,
 };
 
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::{DuplexConsensusCaller, DuplexConsensusRead};
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::{
     CodecConsensusCaller, CodecConsensusError, CodecConsensusOptions, CodecConsensusStats,
 };

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -172,11 +172,11 @@ pub use umi::assigner;
 
 // Re-export consensus items for backward compatibility
 pub use consensus::caller as consensus_caller;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub use consensus::duplex_caller as duplex_consensus_caller;
 pub use consensus::filter as consensus_filter;
 pub use consensus::overlapping as overlapping_consensus;
 pub use consensus::simple_umi as simple_umi_consensus;
 pub use consensus::tags as consensus_tags;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub use consensus::vanilla_caller as vanilla_consensus_caller;

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -42,6 +42,8 @@ use crate::pipeline::chains::{
     StageTimingFinalizeHook, build_pipeline_config_for_chain,
 };
 use crate::pipeline::core::builder::PipelineBuilder;
+// Only the `consensus`-gated `FuseState` implements `HeapSize` in this module.
+#[cfg(feature = "consensus")]
 use crate::pipeline::core::item::HeapSize;
 use crate::pipeline::core::topology::{BranchIdx, StepIdx};
 use crate::pipeline::steps::tuning::BamPipelineTuning;
@@ -210,11 +212,13 @@ pub(crate) enum ChainTailKind {
 /// `PipelineBuilder::append_source` / `append_step`, which bypass the
 /// typed-chain API. See the module-level type-erasure note for the runtime
 /// behaviour when a type mismatch is introduced.
+#[cfg(feature = "consensus")]
 pub(crate) struct FuseState {
     scratch: Vec<u8>,
     mi_buf: String,
 }
 
+#[cfg(feature = "consensus")]
 impl HeapSize for FuseState {}
 
 /// Build the `TemplatesToMiGroups` bridge step that fuses an intermediate
@@ -227,6 +231,7 @@ impl HeapSize for FuseState {}
 /// `duplex_strip_strand` controls whether the `/A` `/B` strand suffix is
 /// stripped from the MI key so both strands of a duplex molecule group
 /// together (`true` for duplex; `false` for simplex and codec).
+#[cfg(feature = "consensus")]
 fn templates_to_mi_step(
     limit_bytes: u64,
     duplex_strip_strand: bool,
@@ -956,6 +961,7 @@ impl<'a> ChainBuilder<'a> {
     ///
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
     /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    #[cfg(feature = "consensus")]
     fn finish_consensus_tail(
         &mut self,
         tail: (
@@ -991,6 +997,7 @@ impl<'a> ChainBuilder<'a> {
     /// context. Shared by `add_simplex`/`add_duplex`/`add_codec`, whose
     /// rejects wiring is otherwise identical — only the consensus step's type
     /// (built inline by the caller) differs.
+    #[cfg(feature = "consensus")]
     fn wire_consensus_rejects_branch(
         &self,
         consensus_pt: (StepIdx, BranchIdx),
@@ -2449,6 +2456,32 @@ impl<'a> ChainBuilder<'a> {
         Ok(())
     }
 
+    // ----------------------------------------------------------------------
+    // Consensus stages (simplex / duplex / codec).
+    //
+    // The full method bodies below are compiled only with the `consensus`
+    // feature, which gates the consensus command modules and their option
+    // types. When the crate is built without `consensus`, the consensus CLI
+    // commands and option-bag slots are compiled out, so these stages are
+    // unreachable — but `add_stage`'s match must still resolve all three
+    // `Stage` variants. These stubs provide that resolution and fail loudly
+    // if ever reached.
+    // ----------------------------------------------------------------------
+    #[cfg(not(feature = "consensus"))]
+    fn add_simplex(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
+    #[cfg(not(feature = "consensus"))]
+    fn add_duplex(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
+    #[cfg(not(feature = "consensus"))]
+    fn add_codec(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
     /// Simplex-specific step sequence:
     ///
     /// `GroupByMi` →
@@ -2479,6 +2512,7 @@ impl<'a> ChainBuilder<'a> {
     ///
     /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    #[cfg(feature = "consensus")]
     #[allow(clippy::too_many_lines)]
     fn add_simplex(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::{
@@ -2721,6 +2755,7 @@ impl<'a> ChainBuilder<'a> {
     ///
     /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    #[cfg(feature = "consensus")]
     #[allow(clippy::too_many_lines)]
     fn add_duplex(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::{
@@ -2975,6 +3010,7 @@ impl<'a> ChainBuilder<'a> {
     ///
     /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    #[cfg(feature = "consensus")]
     #[allow(clippy::too_many_lines)]
     fn add_codec(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::warn_unwired_pipeline_flags;

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -337,7 +337,17 @@ pub struct ChainBuilder<'a> {
     pipeline: PipelineBuilder,
 
     /// Post-pipeline cleanup hooks. Populated by `add_<stage>` methods.
+    /// Always drained, even when the run fails (see [`BuiltPipeline::run`]).
     finalize: Vec<Box<dyn FinalizeHook>>,
+
+    /// Post-pipeline hooks that run **only on a fully successful run**.
+    /// Populated by `add_<stage>` methods for actions that publish a derived
+    /// artifact from the run's output (currently only `add_sort`'s
+    /// `IndexBamFinalizeHook`, which writes the `.bai` sidecar by re-reading
+    /// the finished BAM). Gating these mirrors the standalone `fgumi sort`
+    /// flow, where the index write is behind `run_result?`: a failed run
+    /// leaves a partial BAM, so publishing its index would be stale.
+    finalize_on_success: Vec<Box<dyn FinalizeHook>>,
 
     /// Shared progress counter threaded through source + stage steps for
     /// progress logging. `Arc` so the stage step and the finalize hook can
@@ -454,6 +464,7 @@ impl<'a> ChainBuilder<'a> {
             current_tail: None,
             pipeline: PipelineBuilder::new(),
             finalize: Vec::new(),
+            finalize_on_success: Vec::new(),
             progress_records: Arc::new(AtomicU64::new(0)),
             pending_source,
             paired_tail: None,
@@ -1252,7 +1263,12 @@ impl<'a> ChainBuilder<'a> {
         // The timing hook fires first (before per-stage hooks like DedupFinalize).
         self.finalize.insert(0, Box::new(StageTimingFinalizeHook::new_with_label(chain_label)));
 
-        Ok(BuiltPipeline { pipeline, config, finalize: self.finalize })
+        Ok(BuiltPipeline {
+            pipeline,
+            config,
+            finalize: self.finalize,
+            finalize_on_success: self.finalize_on_success,
+        })
     }
 
     // -- private per-stage methods, one per Stage variant --
@@ -2054,20 +2070,24 @@ impl<'a> ChainBuilder<'a> {
             }));
 
             // When the spec asks for a sidecar BAI, queue the
-            // `IndexBamFinalizeHook` *after* `SortFinalizeHook` so the
+            // `IndexBamFinalizeHook` on the *success-gated* finalize list so
+            // it runs after a successful run only — a failed sort leaves a
+            // partial BAM, and publishing (or overwriting) `<output>.bam.bai`
+            // for it would be a stale index (mirrors the standalone
+            // `fgumi sort` flow, which gates the index write behind
+            // `run_result?`). It runs after `SortFinalizeHook` so the
             // "Records written / X records/s" summary lands before the
-            // indexer's "Indexing BAM:" / "Wrote BAM index:" pair. The
-            // hook re-reads the finished BAM and emits
-            // `<output>.bam.bai` next to it (see `IndexBamFinalizeHook`
-            // for the I/O contract). Rule 3 in `chains::validate`
-            // guarantees `BamWithIndex` only appears when the terminal
-            // chain stage is `Stage::Sort`, so a sole-stage
+            // indexer's "Indexing BAM:" / "Wrote BAM index:" pair. The hook
+            // re-reads the finished BAM and emits `<output>.bam.bai` next to
+            // it (see `IndexBamFinalizeHook` for the I/O contract). Rule 3 in
+            // `chains::validate` guarantees `BamWithIndex` only appears when
+            // the terminal chain stage is `Stage::Sort`, so a sole-stage
             // `[Stage::Sort]` chain is the only path that reaches the
-            // Standalone branch with that sink — multi-stage
-            // sort-terminal chains land in the streaming branch below,
-            // where the hook is mirrored.
+            // Standalone branch with that sink — multi-stage sort-terminal
+            // chains land in the streaming branch below, where the hook is
+            // mirrored.
             if matches!(self.spec.sink, SinkSpec::BamWithIndex(_)) {
-                self.finalize.push(Box::new(IndexBamFinalizeHook { output_path }));
+                self.finalize_on_success.push(Box::new(IndexBamFinalizeHook { output_path }));
             }
         } else {
             // ── Streaming sort (Intermediate OR Terminal-after-upstream-stages) ──
@@ -2182,8 +2202,10 @@ impl<'a> ChainBuilder<'a> {
 
                 // Mirror the Standalone-branch BAI hook registration: when
                 // the spec asks for a sidecar BAI, queue the
-                // `IndexBamFinalizeHook` so the indexer runs after the chain
-                // has flushed the final BAM. Multi-stage Sort-terminal
+                // `IndexBamFinalizeHook` on the *success-gated* finalize list
+                // so the indexer runs after the chain has flushed the final
+                // BAM on a successful run only (a failed run leaves a partial
+                // BAM whose index would be stale). Multi-stage Sort-terminal
                 // chains (e.g. `[Stage::Correct, Stage::Sort]`) land here
                 // instead of the Standalone branch (which requires
                 // `current_tail.is_none()`), so without this wire a
@@ -2196,7 +2218,7 @@ impl<'a> ChainBuilder<'a> {
                 // "BamWithIndex triggers the hook in every terminal-sort
                 // path" — is enforced here for future producers.
                 if let SinkSpec::BamWithIndex(p) = &self.spec.sink {
-                    self.finalize.push(Box::new(
+                    self.finalize_on_success.push(Box::new(
                         crate::pipeline::chains::commands::sort::IndexBamFinalizeHook {
                             output_path: p.clone(),
                         },

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -9,13 +9,16 @@
 
 pub mod align;
 pub mod clip;
+#[cfg(feature = "consensus")]
 pub mod codec;
 pub mod correct;
 pub mod dedup;
+#[cfg(feature = "consensus")]
 pub mod duplex;
 pub mod extract;
 pub mod filter;
 pub mod group;
+#[cfg(feature = "consensus")]
 pub mod simplex;
 pub mod sort;
 pub mod zipper;
@@ -27,6 +30,10 @@ pub mod zipper;
 ///
 /// BAM record body size is u32-bounded per the spec; a single record's buffer
 /// cannot exceed `u32::MAX` in practice, so the length cast cannot truncate.
+//
+// Only the consensus command builders (codec/simplex/duplex) call this, so it
+// is gated under `consensus` to avoid a dead-code warning when consensus is off.
+#[cfg(feature = "consensus")]
 pub(crate) fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
     #[allow(clippy::cast_possible_truncation)]
     let block_size = rec.len() as u32;

--- a/src/lib/pipeline/chains/commands/sort.rs
+++ b/src/lib/pipeline/chains/commands/sort.rs
@@ -2,9 +2,12 @@
 //!
 //! Phase 2 (T2.16) held the full ~200-LOC chain construction here.
 //! Phase 3 (T3a.6) lifts that logic into
-//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
-//! now holds the sort-specific types and step factory that the builder
-//! imports: [`SortFinalizeHook`] and [`build_sort_step`].
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; the sort-specific
+//! types and step factory the builder imports (`SortFinalizeHook`,
+//! `IndexBamFinalizeHook`, `build_sort_step`, `log_sort_start`) now live in
+//! the `fgumi-sort-cli` crate and are re-exported from here. This module
+//! itself retains only the `build_sort_chain` delegate and the
+//! source/sink path helpers.
 //!
 //! [`build_sort_chain`] shrinks to a ~10-line delegate.
 //!
@@ -24,131 +27,22 @@
 //!
 //! [`SortBamFile`]: crate::pipeline::steps::sort::SortBamFile
 
-use std::sync::Arc;
-
 use anyhow::{Result, bail};
-use log::info;
 
-use crate::logging::OperationTimer;
 use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook, SinkSpec, SourceSpec};
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, SinkSpec, SourceSpec};
 
-// The sort step factory, its captures bundle, and the startup-banner logger now
-// live in the `fgumi-sort-cli` crate. Re-export them so the umbrella's
-// `ChainBuilder::add_sort` keeps importing them from this module. Their
-// signatures are independent of the umbrella's `FinalizeHook` trait, so they
-// can be shared verbatim. The two finalize hooks below, by contrast, implement
-// the umbrella's `FinalizeHook` trait (which `fgumi-sort-cli`'s plain-method
-// versions do not), so they stay umbrella-local.
-pub(crate) use fgumi_sort_cli::chains::{SortStepCaptures, build_sort_step, log_sort_start};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// SortFinalizeHook
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Post-pipeline finalize hook for sort. Reads `SortStats` out of the
-/// shared slot, logs the Summary block, and calls
-/// `timer.log_completion`.
-///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
-/// `add_sort`.
-pub(crate) struct SortFinalizeHook {
-    pub(crate) stats_slot: Arc<parking_lot::Mutex<Option<fgumi_sort::SortStats>>>,
-    pub(crate) output_path: std::path::PathBuf,
-    pub(crate) timer: OperationTimer,
-}
-
-impl FinalizeHook for SortFinalizeHook {
-    fn finalize(self: Box<Self>) -> Result<()> {
-        let SortFinalizeHook { stats_slot, output_path, timer } = *self;
-
-        let stats = stats_slot.lock().take().unwrap_or_default();
-        info!("=== Summary ===");
-        info!("Records processed: {}", stats.total_records);
-        info!("Records written: {}", stats.output_records);
-        if stats.chunks_written > 0 {
-            info!("Temporary chunks: {}", stats.chunks_written);
-        }
-        info!("Output: {}", output_path.display());
-
-        timer.log_completion(stats.total_records);
-
-        Ok(())
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// IndexBamFinalizeHook
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Post-pipeline finalize hook that builds a BAI index for a finished
-/// coordinate-sorted BAM. Registered by [`ChainBuilder::add_sort`] when
-/// `spec.sink` is [`SinkSpec::BamWithIndex`].
-///
-/// Reads the BAM via `noodles::bam::fs::index` (which walks BGZF block
-/// offsets and computes virtual positions from the on-disk layout) and
-/// writes `<output>.bam.bai` next to the BAM via
-/// `fgumi_bam_io::write_bai_index`. This decouples indexing from the
-/// sort step itself: the sorter no longer needs single-threaded BGZF
-/// compression to track virtual offsets during write, and BAI
-/// generation lifts cleanly to a hook that any future
-/// `SinkSpec::BamWithIndex`-producing chain can register.
-///
-/// **Invariant:** the BAM at `output_path` must be writer-closed before
-/// `finalize` runs. This is guaranteed by `Pipeline::run` returning
-/// (which only happens after every step's writer has dropped); the
-/// hook does not call `fsync` because the same process re-reading via
-/// the OS page cache will see all flushed bytes on every supported
-/// local filesystem. A remote/NFS deployment would need its own
-/// close-to-open coherency story; that is out of scope for this hook.
-///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
-/// `add_sort`.
-///
-/// [`ChainBuilder::add_sort`]: crate::pipeline::chains::builder::ChainBuilder
-/// [`SinkSpec::BamWithIndex`]: crate::pipeline::chains::SinkSpec::BamWithIndex
-pub(crate) struct IndexBamFinalizeHook {
-    pub(crate) output_path: std::path::PathBuf,
-}
-
-impl FinalizeHook for IndexBamFinalizeHook {
-    fn finalize(self: Box<Self>) -> Result<()> {
-        use crate::logging::format_duration;
-        use fgumi_bam_io::write_bai_index;
-        use noodles::bam;
-        use std::time::Instant;
-
-        let IndexBamFinalizeHook { output_path } = *self;
-
-        info!("Indexing BAM: {}", output_path.display());
-        let start = Instant::now();
-
-        let index = bam::fs::index(&output_path)
-            .map_err(|e| anyhow::anyhow!("Failed to index {}: {e}", output_path.display()))?;
-
-        // BAI convention: sit next to the BAM with `.bam.bai`, e.g.
-        // `foo.bam` → `foo.bam.bai`. Implemented as
-        // `Path::with_extension("bam.bai")` to match the legacy
-        // in-sort indexer at `crates/fgumi-sort/src/external.rs`
-        // (pre-Phase-4) and samtools' default. The contract is
-        // "append `.bai` to the BAM path"; `with_extension` happens
-        // to produce the right result because the input always
-        // carries a single `.bam` extension.
-        let index_path = output_path.with_extension("bam.bai");
-        write_bai_index(&index_path, &index)
-            .map_err(|e| anyhow::anyhow!("Failed to write BAI to {}: {e}", index_path.display()))?;
-        info!("Wrote BAM index: {} ({})", index_path.display(), format_duration(start.elapsed()));
-
-        Ok(())
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Step factory
-//
-// `SortStepCaptures`, `build_sort_step`, and `log_sort_start` are re-exported
-// from `fgumi-sort-cli` at the top of this module.
-// ─────────────────────────────────────────────────────────────────────────────
+// The sort step factory, its captures bundle, the startup-banner logger, AND
+// the two finalize hooks (`SortFinalizeHook`, `IndexBamFinalizeHook`) all live
+// in the `fgumi-sort-cli` crate. Re-export them so the umbrella's
+// `ChainBuilder::add_sort` keeps constructing and registering them from this
+// module. The hooks implement the shared `FinalizeHook` trait
+// (`fgumi-pipeline-core`, re-exported as `crate::pipeline::chains::FinalizeHook`),
+// so the umbrella registers them in its `Vec<Box<dyn FinalizeHook>>` directly —
+// no umbrella-local copies (X1-005).
+pub(crate) use fgumi_sort_cli::chains::{
+    IndexBamFinalizeHook, SortFinalizeHook, SortStepCaptures, build_sort_step, log_sort_start,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // build_sort_chain — 10-line delegate
@@ -196,107 +90,5 @@ pub(crate) fn sort_source_path(spec: &ChainSpec) -> Result<std::path::PathBuf> {
 pub(crate) fn sort_sink_path(spec: &ChainSpec) -> std::path::PathBuf {
     match &spec.sink {
         SinkSpec::Bam(p) | SinkSpec::BamWithIndex(p) => p.clone(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fgumi_bam_io::create_raw_bam_writer;
-    use noodles::sam::Header;
-    use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
-    use std::num::NonZeroUsize;
-    use tempfile::tempdir;
-
-    /// Build a minimal two-reference, `SO:coordinate` header for indexer
-    /// round-trip tests. Uses `fgumi_sort::create_output_header` so the
-    /// `@HD SO:coordinate` annotation matches the bytes the real sort
-    /// step emits — `noodles::bam::fs::index` (the indexer the hook
-    /// invokes) rejects BAMs that don't claim coordinate sort order.
-    fn test_header() -> Header {
-        let mut builder = Header::builder();
-        let chr1 = Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("non-zero"));
-        let chr2 = Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("non-zero"));
-        builder = builder.add_reference_sequence(b"chr1", chr1);
-        builder = builder.add_reference_sequence(b"chr2", chr2);
-        let header = builder.build();
-        fgumi_sort::create_output_header(fgumi_sort::SortOrder::Coordinate, &header)
-    }
-
-    /// Build the raw BAM bytes for a single 10-base mapped record.
-    /// Mirrors `fgumi_bam_io::writer::create_test_bam_record` (private to
-    /// that test module). 10M CIGAR + 5-byte packed sequence + 10 quality
-    /// bytes — enough to exercise the indexer's chunk resolution without
-    /// pulling in a fixture file.
-    #[allow(clippy::cast_possible_truncation)]
-    fn record_bytes(ref_id: i32, pos: i32, name: &[u8]) -> Vec<u8> {
-        let name_with_null = name.len() + 1;
-        let padding = (4 - (name_with_null % 4)) % 4;
-        let l_read_name = (name_with_null + padding) as u8;
-
-        let mut record = Vec::with_capacity(64);
-        record.extend_from_slice(&ref_id.to_le_bytes());
-        record.extend_from_slice(&pos.to_le_bytes());
-        record.push(l_read_name);
-        record.push(60_u8); // mapq
-        record.extend_from_slice(&4681_u16.to_le_bytes()); // bin
-        record.extend_from_slice(&1_u16.to_le_bytes()); // n_cigar_op
-        record.extend_from_slice(&0_u16.to_le_bytes()); // flag
-        record.extend_from_slice(&10_u32.to_le_bytes()); // l_seq
-        record.extend_from_slice(&(-1_i32).to_le_bytes()); // next_ref_id
-        record.extend_from_slice(&(-1_i32).to_le_bytes()); // next_pos
-        record.extend_from_slice(&0_i32.to_le_bytes()); // tlen
-        record.extend_from_slice(name);
-        record.push(0);
-        record.extend(std::iter::repeat_n(0_u8, padding));
-        let cigar_op: u32 = 10 << 4; // 10M
-        record.extend_from_slice(&cigar_op.to_le_bytes());
-        record.extend_from_slice(&[0x11_u8; 5]); // packed seq (AAAAAAAAAA)
-        record.extend_from_slice(&[30_u8; 10]); // qualities
-        record
-    }
-
-    /// Smoke test: the hook reads a finished coordinate-sorted BAM and
-    /// emits a parseable BAI alongside it.
-    ///
-    /// Doesn't assert byte-identity with the legacy in-sort indexer
-    /// (that would require the same BGZF block layout, which differs
-    /// between single- and multi-threaded compression). The
-    /// integration tests in `tests/integration/test_sort_write_index.rs`
-    /// exercise the end-to-end semantic correctness via samtools-style
-    /// region queries; this unit test just pins the hook's mechanical
-    /// contract.
-    ///
-    /// TODO(T4.4): once `--write-index` routes through this hook in
-    /// `Sort::execute`, the integration tests in
-    /// `tests/integration/test_sort_write_index.rs` provide
-    /// content-level cross-checks (samtools region queries return the
-    /// same record sets the in-sort indexer would have returned). The
-    /// plan's Risk 1 byte-identity check effectively migrates from
-    /// T4.2 to T4.4 because of the BGZF-layout divergence between the
-    /// legacy single-threaded path and the new multi-threaded
-    /// write + post-write index path.
-    #[test]
-    fn index_bam_finalize_hook_produces_readable_bai() {
-        let dir = tempdir().expect("tempdir");
-        let bam_path = dir.path().join("test.bam");
-
-        let header = test_header();
-        let mut writer =
-            create_raw_bam_writer(&bam_path, &header, 1, 6).expect("create_raw_bam_writer");
-        for (ref_id, pos, name) in
-            [(0_i32, 100_i32, b"r1".as_ref()), (0, 200, b"r2"), (1, 50, b"r3")]
-        {
-            writer.write_raw_record(&record_bytes(ref_id, pos, name)).expect("write");
-        }
-        writer.finish().expect("finish");
-
-        let hook = Box::new(IndexBamFinalizeHook { output_path: bam_path.clone() });
-        hook.finalize().expect("hook finalize");
-
-        let bai_path = bam_path.with_extension("bam.bai");
-        assert!(bai_path.exists(), "BAI not created at {}", bai_path.display());
-        let index = noodles::bam::bai::fs::read(&bai_path).expect("read bai");
-        assert!(!index.reference_sequences().is_empty(), "BAI has no reference sequences",);
     }
 }

--- a/src/lib/pipeline/chains/finalize.rs
+++ b/src/lib/pipeline/chains/finalize.rs
@@ -7,25 +7,12 @@ use anyhow::Result;
 use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
 use crate::pipeline::core::runtime::stats::PipelineStats;
 
-/// Post-pipeline cleanup. Each stage with metrics, summary logging,
-/// `--min-corrected`-style gates, or rejects-file finalization
-/// registers one or more hooks during chain build. The caller iterates
-/// `built.finalize.into_iter().try_for_each(FinalizeHook::finalize)`
-/// after `pipeline.run()` returns.
-///
-/// Trait object so heterogeneous hooks (correct's metrics drain,
-/// consensus's summary log, AAM's records-aligned counter, etc.) can
-/// share a `Vec<Box<dyn FinalizeHook>>`.
-pub trait FinalizeHook: Send {
-    /// Run the post-pipeline action. Called exactly once, after
-    /// `Pipeline::run` returns and before the caller exits.
-    ///
-    /// # Errors
-    ///
-    /// Returns the underlying I/O / aggregation / gate-check error.
-    /// Callers typically chain via `try_for_each`.
-    fn finalize(self: Box<Self>) -> Result<()>;
-}
+// The bare `FinalizeHook` trait lives in `fgumi-pipeline-core` so CLI crates
+// built directly on the pipeline core (e.g. `fgumi-sort-cli`) can implement it
+// without redefining a parallel trait (X1-005). It is re-exported here so the
+// canonical `crate::pipeline::chains::FinalizeHook` path — used by every
+// in-crate `impl FinalizeHook` and by `BuiltPipeline` below — is unchanged.
+pub use crate::pipeline::core::FinalizeHook;
 
 /// Logs [`PipelineStats`] after the pipeline finishes, when
 /// `--pipeline-stats` was requested. Builders construct this and push
@@ -91,12 +78,22 @@ pub struct BuiltPipeline {
     pub pipeline: Pipeline,
     pub config: PipelineConfig,
     pub finalize: Vec<Box<dyn FinalizeHook>>,
+    /// Hooks that run **only after a fully successful run** — the pipeline
+    /// completed and every always-drain `finalize` hook succeeded.
+    ///
+    /// Use this for actions that publish a derived artifact from the output
+    /// the run produced (e.g. writing a `.bai` sidecar by re-reading the
+    /// finished BAM). On the error path the output is incomplete, so running
+    /// these would publish a stale/partial artifact — exactly the
+    /// `IndexBamFinalizeHook` footgun the standalone `fgumi sort` flow guards
+    /// against by gating the index write behind `run_result?`.
+    pub finalize_on_success: Vec<Box<dyn FinalizeHook>>,
 }
 
 impl BuiltPipeline {
     /// Convenience: run the pipeline and drain finalize hooks in order.
     ///
-    /// Finalize hooks are *always* drained in a finally-style path, even
+    /// `finalize` hooks are *always* drained in a finally-style path, even
     /// when `Pipeline::run` fails: the hooks own the metrics drains,
     /// summary logging, `--min-corrected`-style gates, and rejects-file
     /// finalization that must happen regardless of how the run ended.
@@ -105,29 +102,39 @@ impl BuiltPipeline {
     /// (pipeline run first, then hooks in registration order) is
     /// returned.
     ///
+    /// `finalize_on_success` hooks run only once the run and every
+    /// always-drain hook have succeeded — see the field docs.
+    ///
     /// # Errors
     ///
     /// Returns the first pipeline-run error or, if the pipeline
     /// succeeded, the first finalize-hook error.
     pub fn run(self) -> Result<()> {
-        let BuiltPipeline { pipeline, config, finalize } = self;
+        let BuiltPipeline { pipeline, config, finalize, finalize_on_success } = self;
 
         // Capture the run result but do not short-circuit: the finalize
         // hooks must still drain on the error path.
         let run_result = pipeline.run(config).map_err(|e| anyhow::anyhow!("Pipeline::run: {e:?}"));
 
-        drain_finalize(run_result, finalize)
+        drain_finalize(run_result, finalize, finalize_on_success)
     }
 }
 
-/// Drains every finalize hook in registration order, then combines the
-/// pipeline-run result with the first hook error.
+/// Drains every always-run finalize hook in registration order, then — only
+/// if the run and all of those hooks succeeded — runs the success-gated hooks.
 ///
-/// Hooks are always drained — including on the `run_result == Err` path —
-/// and a failing hook does not prevent later hooks from running. The
-/// pipeline-run error takes precedence over any hook error.
-fn drain_finalize(run_result: Result<()>, finalize: Vec<Box<dyn FinalizeHook>>) -> Result<()> {
-    // Drain every hook, keeping the first hook error.
+/// Always-run hooks are drained even on the `run_result == Err` path, and a
+/// failing hook does not prevent later always-run hooks from running. The
+/// pipeline-run error takes precedence over any hook error. Success-gated
+/// hooks are skipped entirely unless everything above succeeded; once running,
+/// the first of them to error short-circuits the rest (they publish derived
+/// artifacts, so there is no "drain everything" obligation on their path).
+fn drain_finalize(
+    run_result: Result<()>,
+    finalize: Vec<Box<dyn FinalizeHook>>,
+    finalize_on_success: Vec<Box<dyn FinalizeHook>>,
+) -> Result<()> {
+    // Drain every always-run hook, keeping the first hook error.
     let mut first_hook_error: Option<anyhow::Error> = None;
     for hook in finalize {
         if let Err(e) = hook.finalize() {
@@ -137,8 +144,15 @@ fn drain_finalize(run_result: Result<()>, finalize: Vec<Box<dyn FinalizeHook>>) 
         }
     }
 
-    // The pipeline-run error takes precedence over hook errors.
-    run_result.and_then(|()| first_hook_error.map_or(Ok(()), Err))
+    // The pipeline-run error takes precedence over hook errors. Resolve the
+    // combined result of the run plus the always-run hooks first.
+    run_result.and_then(|()| first_hook_error.map_or(Ok(()), Err))?;
+
+    // Reached only on full success: now safe to publish derived artifacts.
+    for hook in finalize_on_success {
+        hook.finalize()?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -171,7 +185,7 @@ mod tests {
         // metrics drains / rejects finalization are not skipped.
         let ran = Arc::new(AtomicUsize::new(0));
         let hooks = vec![counting_hook(&ran, false), counting_hook(&ran, false)];
-        let result = drain_finalize(Err(anyhow::anyhow!("pipeline boom")), hooks);
+        let result = drain_finalize(Err(anyhow::anyhow!("pipeline boom")), hooks, vec![]);
         assert_eq!(ran.load(Ordering::SeqCst), 2, "all hooks should run on the error path");
         // The pipeline error takes precedence and is propagated.
         assert!(result.is_err());
@@ -184,7 +198,7 @@ mod tests {
         let ran = Arc::new(AtomicUsize::new(0));
         let hooks =
             vec![counting_hook(&ran, true), counting_hook(&ran, false), counting_hook(&ran, false)];
-        let result = drain_finalize(Ok(()), hooks);
+        let result = drain_finalize(Ok(()), hooks, vec![]);
         assert_eq!(ran.load(Ordering::SeqCst), 3, "all hooks should run despite an early failure");
         // With a successful run, the first hook error is surfaced.
         assert!(result.is_err());
@@ -195,9 +209,63 @@ mod tests {
     fn drain_finalize_ok_when_run_and_hooks_succeed() {
         let ran = Arc::new(AtomicUsize::new(0));
         let hooks = vec![counting_hook(&ran, false)];
-        let result = drain_finalize(Ok(()), hooks);
+        let result = drain_finalize(Ok(()), hooks, vec![]);
         assert_eq!(ran.load(Ordering::SeqCst), 1);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn drain_finalize_runs_success_hooks_only_on_full_success() {
+        // Success-gated hooks run once the pipeline and all always-run hooks
+        // succeed.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Ok(()),
+            vec![counting_hook(&always, false)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_ok());
+        assert_eq!(always.load(Ordering::SeqCst), 1);
+        assert_eq!(on_success.load(Ordering::SeqCst), 1, "success hook should run on full success");
+    }
+
+    #[test]
+    fn drain_finalize_skips_success_hooks_when_pipeline_fails() {
+        // A failed run must not run success-gated hooks — the output is
+        // incomplete, so e.g. a `.bai` sidecar would be stale. The always-run
+        // hooks still drain.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Err(anyhow::anyhow!("pipeline boom")),
+            vec![counting_hook(&always, false)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("pipeline boom"));
+        assert_eq!(always.load(Ordering::SeqCst), 1, "always-run hook still drains on failure");
+        assert_eq!(on_success.load(Ordering::SeqCst), 0, "success hook must not run on failure");
+    }
+
+    #[test]
+    fn drain_finalize_skips_success_hooks_when_an_always_hook_fails() {
+        // If an always-run hook fails (even with a successful pipeline run),
+        // the output is not trustworthy, so success-gated hooks are skipped.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Ok(()),
+            vec![counting_hook(&always, true)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("hook failed"));
+        assert_eq!(
+            on_success.load(Ordering::SeqCst),
+            0,
+            "success hook must not run after a failure"
+        );
     }
 
     #[test]

--- a/src/lib/pipeline/chains/options_bag.rs
+++ b/src/lib/pipeline/chains/options_bag.rs
@@ -7,13 +7,16 @@ use std::path::PathBuf;
 // home, not redefined.
 pub use crate::aligner::AlignerOptions;
 pub use crate::commands::clip::Clip;
+#[cfg(feature = "consensus")]
 pub use crate::commands::codec::CodecOptions;
 pub use crate::commands::correct::CorrectOptions;
 pub use crate::commands::dedup::MarkDuplicates;
+#[cfg(feature = "consensus")]
 pub use crate::commands::duplex::DuplexOptions;
 pub use crate::commands::extract::ExtractOptions;
 pub use crate::commands::filter::FilterOptions;
 pub use crate::commands::group::GroupOptions;
+#[cfg(feature = "consensus")]
 pub use crate::commands::simplex::SimplexOptions;
 pub use crate::commands::sort::SortOptions;
 pub use crate::commands::zipper::ZipperOptions;
@@ -65,7 +68,9 @@ pub struct StageOptionsBag {
     pub zipper: Option<ZipperOptions>,
     pub sort: Option<SortOptions>,
     pub group: Option<GroupOptions>,
+    #[cfg(feature = "consensus")]
     pub duplex: Option<DuplexOptions>,
+    #[cfg(feature = "consensus")]
     pub codec: Option<CodecOptions>,
     /// Dedup options. Holds `MarkDuplicates` directly (approach 2 from
     /// the T2.12 design note) to keep the test surface stable.
@@ -79,6 +84,7 @@ pub struct StageOptionsBag {
     /// Simplex options. Holds the free-standing `SimplexOptions` struct
     /// (same approach as Duplex/Codec), so runall can re-expose the tuning
     /// knobs via `--simplex::*` through `MultiSimplexOptions`.
+    #[cfg(feature = "consensus")]
     pub simplex: Option<SimplexOptions>,
     /// Align (`AlignAndMerge`) options. Carries [`AlignerOptions`] +
     /// reference path + optional aligner-binary override.

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -164,12 +164,26 @@ pub fn validate_stage_opts_present(spec: &ChainSpec) -> Result<()> {
             Stage::Zipper => bag.zipper.is_some(),
             Stage::Sort => bag.sort.is_some(),
             Stage::Group => bag.group.is_some(),
+            #[cfg(feature = "consensus")]
             Stage::Duplex => bag.duplex.is_some(),
+            #[cfg(feature = "consensus")]
             Stage::Codec => bag.codec.is_some(),
             Stage::Dedup => bag.dedup.is_some(),
             Stage::Filter => bag.filter.is_some(),
             Stage::Clip => bag.clip.is_some(),
+            #[cfg(feature = "consensus")]
             Stage::Simplex => bag.simplex.is_some(),
+            // Without the `consensus` feature the consensus option-bag slots do
+            // not exist, so this stage can never be satisfied. Bail with an
+            // explicit feature-disabled error rather than returning `false`,
+            // which would surface the generic "options not provided" message
+            // below and tell reduced-feature callers to populate bag slots that
+            // do not exist. Unreachable in practice — the consensus CLI commands
+            // are compiled out too — but the message is correct if reached.
+            #[cfg(not(feature = "consensus"))]
+            Stage::Duplex | Stage::Codec | Stage::Simplex => {
+                bail!("Stage {stage:?} requires building fgumi with the `consensus` feature");
+            }
             Stage::Align => bag.aligner.is_some(),
             Stage::Extract => bag.extract.is_some(),
             Stage::Downsample => unreachable!(),
@@ -516,6 +530,9 @@ mod tests {
         );
     }
 
+    // These three exercise the consensus option-bag slots, which only exist
+    // with the `consensus` feature.
+    #[cfg(feature = "consensus")]
     #[test]
     fn duplex_after_group_requires_paired_strategy() {
         use crate::assigner::Strategy;
@@ -531,6 +548,7 @@ mod tests {
         assert!(err.to_string().contains("Paired"), "got: {err}");
     }
 
+    #[cfg(feature = "consensus")]
     #[test]
     fn duplex_after_group_with_paired_strategy_accepted() {
         use crate::assigner::Strategy;
@@ -545,6 +563,7 @@ mod tests {
         validate_cross_stage_constraints(&spec).expect("paired strategy should pass");
     }
 
+    #[cfg(feature = "consensus")]
     #[test]
     fn standalone_duplex_skips_paired_check() {
         // Chain has only Stage::Duplex (no Stage::Group). Rule 2 does not fire

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -391,7 +391,7 @@ impl fgumi_sam::ReferenceProvider for ReferenceReader {
     }
 }
 
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 impl fgumi_consensus::methylation::RefBaseProvider for ReferenceReader {
     fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8> {
         let sequence = self.sequences.get(chrom)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ const STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Cyan.on_default());
 use env_logger::Env;
 use fgumi_lib::commands::clip::Clip;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command;
 #[cfg(feature = "compare")]
@@ -22,9 +22,9 @@ use fgumi_lib::commands::compare::CompareMismatch;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::commands::downsample::Downsample;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::duplex::Duplex;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::duplex_metrics::DuplexMetrics;
 use fgumi_lib::commands::extract::Extract;
 use fgumi_lib::commands::fastq::Fastq;
@@ -32,11 +32,11 @@ use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::commands::merge::Merge;
 use fgumi_lib::commands::review::Review;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::runall::RunAll;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::simplex::Simplex;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::simplex_metrics::SimplexMetrics;
 #[cfg(feature = "simulate")]
 use fgumi_lib::commands::simulate::Simulate;
@@ -47,16 +47,20 @@ use log::info;
 /// Commands that require feature flags to be enabled.
 /// Format: (`command_name`, `feature_name`)
 const FEATURE_GATED_COMMANDS: &[(&str, &str)] = &[
-    #[cfg(not(feature = "simplex"))]
-    ("simplex", "simplex"),
-    #[cfg(not(feature = "simplex"))]
-    ("simplex-metrics", "simplex"),
-    #[cfg(not(feature = "duplex"))]
-    ("duplex", "duplex"),
-    #[cfg(not(feature = "duplex"))]
-    ("duplex-metrics", "duplex"),
-    #[cfg(not(feature = "codec"))]
-    ("codec", "codec"),
+    #[cfg(not(feature = "consensus"))]
+    ("simplex", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("simplex-metrics", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("duplex", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("duplex-metrics", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("codec", "consensus"),
+    // `runall` fuses the consensus stages, so it too requires the `consensus`
+    // feature; it was previously omitted from this hint list (S5d-009).
+    #[cfg(not(feature = "consensus"))]
+    ("runall", "consensus"),
     #[cfg(not(feature = "compare"))]
     ("compare", "compare"),
     #[cfg(not(feature = "simulate"))]
@@ -110,16 +114,16 @@ enum Subcommand {
     Dedup(MarkDuplicates),
 
     // Consensus Calling
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 9)]
     Simplex(Simplex),
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 10)]
     Duplex(Duplex),
-    #[cfg(feature = "codec")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 11)]
     Codec(Codec),
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 11)]
     Runall(RunAll),
 
@@ -128,10 +132,10 @@ enum Subcommand {
     Filter(Filter),
     #[command(display_order = 13)]
     Clip(Clip),
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 14)]
     DuplexMetrics(DuplexMetrics),
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 15)]
     SimplexMetrics(SimplexMetrics),
     #[command(display_order = 16)]
@@ -159,19 +163,19 @@ impl Subcommand {
             Self::Merge(cmd) => cmd.execute(command_line),
             Self::Group(cmd) => cmd.execute(command_line),
             Self::Dedup(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "simplex")]
+            #[cfg(feature = "consensus")]
             Self::Simplex(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "duplex")]
+            #[cfg(feature = "consensus")]
             Self::Duplex(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "codec")]
+            #[cfg(feature = "consensus")]
             Self::Codec(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "simplex")]
+            #[cfg(feature = "consensus")]
             Self::Runall(cmd) => cmd.execute(command_line),
             Self::Filter(cmd) => cmd.execute(command_line),
             Self::Clip(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "duplex")]
+            #[cfg(feature = "consensus")]
             Self::DuplexMetrics(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "simplex")]
+            #[cfg(feature = "consensus")]
             Self::SimplexMetrics(cmd) => cmd.execute(command_line),
             Self::Review(cmd) => cmd.execute(command_line),
             Self::Downsample(cmd) => cmd.execute(command_line),

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -92,6 +92,68 @@ pub fn assert_rejects_header_matches_input(
     );
 }
 
+/// Reads a BAM file and returns the multiset of record (read) names it holds.
+///
+/// Used to assert *family routing* — e.g. that a `--min-reads`-rejected family
+/// lands in the rejects BAM and is absent from the kept consensus output —
+/// rather than a weaker count/EOF side effect.
+///
+/// # Panics
+///
+/// Panics if the file cannot be opened, the header cannot be read, or any
+/// record cannot be decoded.
+pub fn read_record_names(path: &std::path::Path) -> Vec<String> {
+    let mut reader = noodles::bam::io::Reader::new(
+        std::fs::File::open(path).expect("Failed to open BAM for record-name read"),
+    );
+    let _header = reader.read_header().expect("Failed to read BAM header");
+    reader
+        .records()
+        .map(|result| {
+            result
+                .expect("Failed to read BAM record")
+                .name()
+                .expect("record missing read name")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Asserts that a `--min-reads`-rejected family was routed correctly: every
+/// record name in `reject_names` is present in `rejects_path` and absent from
+/// the kept output at `kept_path`.
+///
+/// This proves the contract the rejects tests care about — the rejected family
+/// went to the rejects file and did *not* slip into the kept consensus output
+/// (which a miscount of the family size, e.g. counting one paired template as
+/// two reads, would cause). Kept output holds renamed consensus reads, so the
+/// raw rejected read names only ever survive in the rejects file.
+///
+/// # Panics
+///
+/// Panics if any expected reject name is missing from `rejects_path` or present
+/// in `kept_path`.
+pub fn assert_family_rejected_not_kept(
+    rejects_path: &std::path::Path,
+    kept_path: &std::path::Path,
+    reject_names: &[&str],
+) {
+    let in_rejects = read_record_names(rejects_path);
+    let in_kept = read_record_names(kept_path);
+    for &name in reject_names {
+        assert!(
+            in_rejects.iter().any(|n| n == name),
+            "rejected read '{name}' should be present in rejects BAM {} (found {in_rejects:?})",
+            rejects_path.display(),
+        );
+        assert!(
+            !in_kept.iter().any(|n| n == name),
+            "rejected read '{name}' must be absent from kept output {} (found {in_kept:?})",
+            kept_path.display(),
+        );
+    }
+}
+
 /// Asserts that a record has a specific MI (molecule ID) tag value.
 ///
 /// # Panics

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -9,18 +9,18 @@ mod helpers;
 mod test_async_reader;
 mod test_bgzf_eof;
 mod test_clip_command;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 mod test_codec_command;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 mod test_codec_pipeline;
 #[cfg(feature = "compare")]
 mod test_compare_bams;
 mod test_correct_command;
 mod test_dedup_command;
 mod test_downsample_command;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 mod test_duplex_command;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 mod test_duplex_metrics_command;
 #[cfg(all(feature = "compare", feature = "simulate"))]
 mod test_e2e_regression;
@@ -31,13 +31,15 @@ mod test_filter_command;
 mod test_group_command;
 mod test_group_determinism;
 mod test_review_command;
-#[cfg(all(feature = "simplex", feature = "duplex", feature = "codec"))]
+// Always compiled: the non-consensus parity oracles (sort/group/zipper/correct/
+// align) must keep their reduced-feature coverage. The consensus-targeting
+// cases inside are individually `#[cfg(feature = "consensus")]`-gated.
 mod test_runall_parity;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_command;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_metrics_command;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_pipeline;
 #[cfg(feature = "simulate")]
 mod test_simulate_aligner;

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -11,13 +11,16 @@
 
 use clap::Parser;
 use fgumi_lib::commands::clip::Clip;
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::duplex::Duplex;
 use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::commands::group::GroupReadsByUmi;
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::simplex::Simplex;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
@@ -31,6 +34,9 @@ use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 use crate::helpers::assertions::{assert_has_bgzf_eof, assert_rejects_header_matches_input};
+// Only the `#[cfg(feature = "consensus")]` rejects tests use this helper.
+#[cfg(feature = "consensus")]
+use crate::helpers::assertions::assert_family_rejected_not_kept;
 use crate::helpers::bam_generator::{
     create_minimal_header, create_test_reference, create_umi_family, to_record_buf,
 };
@@ -109,6 +115,7 @@ fn create_dedup_reads(name: &[u8], umi: &str, start: i32) -> Vec<RawRecord> {
 }
 
 /// Create a duplex read pair with /A or /B strand MI suffix.
+#[cfg(feature = "consensus")]
 fn create_duplex_pair(
     name: &[u8],
     mi_tag: &str,
@@ -179,6 +186,7 @@ fn create_duplex_pair(
 }
 
 /// Create a single-template family (will be rejected by --min-reads > 1).
+#[cfg(feature = "consensus")]
 fn create_rejected_family(name: &[u8], umi: &str, start: i32) -> Vec<RawRecord> {
     let r1 = {
         let mut b = SamBuilder::new();
@@ -220,6 +228,7 @@ fn create_rejected_family(name: &[u8], umi: &str, start: i32) -> Vec<RawRecord> 
 }
 
 /// Create a CODEC read pair (FR orientation, same position).
+#[cfg(feature = "consensus")]
 fn create_codec_pair(name: &[u8], umi: &str, ref_start: i32) -> (RawRecord, RawRecord) {
     let r1 = {
         let mut b = SamBuilder::new();
@@ -319,6 +328,7 @@ fn test_dedup_output_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_simplex_output_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -346,6 +356,7 @@ fn test_simplex_output_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_duplex_output_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -386,6 +397,7 @@ fn test_duplex_output_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_codec_output_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -626,6 +638,7 @@ fn test_piped_simplex_to_filter_has_bgzf_eof() {
 // Rejects writer BGZF EOF tests
 // ============================================================================
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_simplex_rejects_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -658,8 +671,12 @@ fn test_simplex_rejects_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
     assert_rejects_header_matches_input(&rejects_bam, &input_bam);
+    // The singleton "reject" family must be routed to the rejects BAM and not
+    // slip into the kept consensus output (a miscount of family size would).
+    assert_family_rejected_not_kept(&rejects_bam, &output_bam, &["reject"]);
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_duplex_rejects_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -707,8 +724,12 @@ fn test_duplex_rejects_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
     assert_rejects_header_matches_input(&rejects_bam, &input_bam);
+    // The singleton "reject_a" family must land in the rejects BAM and not in
+    // the kept consensus output.
+    assert_family_rejected_not_kept(&rejects_bam, &output_bam, &["reject_a"]);
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn test_codec_rejects_has_bgzf_eof() {
     let temp_dir = TempDir::new().unwrap();
@@ -748,6 +769,9 @@ fn test_codec_rejects_has_bgzf_eof() {
     assert_has_bgzf_eof(&output_bam);
     assert_has_bgzf_eof(&rejects_bam);
     assert_rejects_header_matches_input(&rejects_bam, &input_bam);
+    // The singleton "reject" pair must land in the rejects BAM and not in the
+    // kept consensus output.
+    assert_family_rejected_not_kept(&rejects_bam, &output_bam, &["reject"]);
 }
 
 #[test]

--- a/tests/integration/test_runall_parity.rs
+++ b/tests/integration/test_runall_parity.rs
@@ -27,6 +27,13 @@
 //! the bottom of this file).
 
 #![allow(clippy::needless_pass_by_value)]
+// The non-consensus parity oracles (sort/group/zipper/correct/align) run in
+// every build; the consensus-targeting cases (`*_simplex/duplex/codec*`) are
+// gated per-test with `#[cfg(feature = "consensus")]` below. In a reduced
+// (`--no-default-features`) build those gated tests compile out, leaving the
+// consensus-only fixtures and helper imports they used unused — silence the
+// resulting warnings in that build only (they are all live under `consensus`).
+#![cfg_attr(not(feature = "consensus"), allow(dead_code, unused_imports))]
 
 use std::ffi::OsString;
 use std::fs;
@@ -288,6 +295,7 @@ fn parity_a_group_to_group() {
 /// Parity therefore holds by construction (same standalone command,
 /// same input); this test pins the delegation glue (input forwarding,
 /// option-struct construction).
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_a_simplex_to_simplex() {
     let tmp = TempDir::new().unwrap();
@@ -309,6 +317,7 @@ fn parity_a_simplex_to_simplex() {
 /// by task 6 of #33; runs through the consensus-only delegation fast
 /// path. See `parity_a_simplex_to_simplex` for the delegation
 /// contract this pins.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_a_duplex_to_duplex() {
     let tmp = TempDir::new().unwrap();
@@ -332,6 +341,7 @@ fn parity_a_duplex_to_duplex() {
 /// UMI, grouped with `--strategy adjacency`) — the documented CODEC
 /// input — so this actually exercises the duplex consensus logic
 /// instead of degenerating to a no-op on simplex single-end data.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_a_codec_to_codec() {
     let tmp = TempDir::new().unwrap();
@@ -387,6 +397,7 @@ fn parity_b_sort_to_group() {
 /// `Sort → Simplex` parity vs staged `fgumi sort | fgumi group | fgumi simplex`.
 /// Unblocked by validator (today); test activation pending end-to-end
 /// verification of the parity scaffold.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_sort_to_simplex() {
     let tmp = TempDir::new().unwrap();
@@ -414,6 +425,7 @@ fn parity_b_sort_to_simplex() {
 /// `create_paired_umi_family` sets MC tags programmatically so the
 /// fixture flows through `GroupByPosition` (which requires MC on
 /// paired-end inputs).
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_sort_to_duplex() {
     let tmp = TempDir::new().unwrap();
@@ -441,6 +453,7 @@ fn parity_b_sort_to_duplex() {
 /// Uses the codec fixture family (paired-end, single-strand UMI,
 /// `--strategy adjacency`) so the consensus stage actually exercises
 /// CODEC's duplex logic.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_sort_to_codec() {
     let tmp = TempDir::new().unwrap();
@@ -465,6 +478,7 @@ fn parity_b_sort_to_codec() {
 }
 
 /// `Group → Simplex` parity vs staged `fgumi group | fgumi simplex`.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_group_to_simplex() {
     let tmp = TempDir::new().unwrap();
@@ -485,6 +499,7 @@ fn parity_b_group_to_simplex() {
 
 /// `Group → Duplex` parity vs staged `fgumi group | fgumi duplex`.
 /// See [`parity_b_sort_to_duplex`] for the MC-tag fixture note.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_group_to_duplex() {
     let tmp = TempDir::new().unwrap();
@@ -506,6 +521,7 @@ fn parity_b_group_to_duplex() {
 /// `Group → Codec` parity vs staged `fgumi group | fgumi codec`.
 /// Uses the codec fixture family; see [`parity_b_sort_to_codec`] for
 /// the rationale.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_b_group_to_codec() {
     let tmp = TempDir::new().unwrap();
@@ -534,6 +550,7 @@ fn parity_b_group_to_codec() {
 // same default filter parameters, so the filtered records must match.
 
 /// `Group → Simplex → Filter` (fused) vs staged consensus BAM + `fgumi filter`.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_group_to_simplex_to_filter() {
     let tmp = TempDir::new().unwrap();
@@ -558,6 +575,7 @@ fn parity_group_to_simplex_to_filter() {
 }
 
 /// `Group → Duplex → Filter` (fused) vs staged consensus BAM + `fgumi filter`.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_group_to_duplex_to_filter() {
     let tmp = TempDir::new().unwrap();
@@ -580,6 +598,7 @@ fn parity_group_to_duplex_to_filter() {
 }
 
 /// `Group → Codec → Filter` (fused) vs staged consensus BAM + `fgumi filter`.
+#[cfg(feature = "consensus")]
 #[test]
 fn parity_group_to_codec_to_filter() {
     let tmp = TempDir::new().unwrap();
@@ -664,6 +683,7 @@ fn deterministic_duplex_fixture(dir: &Path, positions: usize) -> PathBuf {
 /// The fused `group → duplex` pipeline must produce a byte-identical record
 /// stream run-to-run at `--threads 8`, and the same record stream at
 /// `--threads 1` as at `--threads 8` (thread-count-invariant output).
+#[cfg(feature = "consensus")]
 #[test]
 fn runall_duplex_record_stream_is_deterministic() {
     let tmp = TempDir::new().unwrap();
@@ -745,6 +765,7 @@ fn assert_runall_rejects(start: Stage, stop: Stage, expected_stderr_fragment: &s
 /// Cross-flavor terminal: `simplex → duplex` is structurally invalid
 /// (both are terminal consensus stages, so the pipeline cannot
 /// progress past simplex). Rejected by `RunAllStage::validate_with`.
+#[cfg(feature = "consensus")]
 #[test]
 fn rejects_cross_flavor_consensus_pair() {
     assert_runall_rejects(Stage::Simplex, Stage::Duplex, "--start-from");
@@ -752,6 +773,7 @@ fn rejects_cross_flavor_consensus_pair() {
 
 /// Reverse order: `duplex → simplex` violates the linear-stage
 /// ordering rule.
+#[cfg(feature = "consensus")]
 #[test]
 fn rejects_reverse_order_consensus_to_consensus() {
     assert_runall_rejects(Stage::Duplex, Stage::Simplex, "--start-from");
@@ -1535,6 +1557,7 @@ fn aam_to_sort_fused_pipeline_with_mock_aligner() {
 /// tempfile-bridge path because the merged BAM's record order
 /// depends on the in-pipeline vs across-tempfile sort cadence —
 /// instead we assert the consensus BAM is non-empty.
+#[cfg(feature = "consensus")]
 #[test]
 fn aam_to_simplex_fused_pipeline_with_mock_aligner() {
     let tmp = TempDir::new().unwrap();
@@ -1596,6 +1619,7 @@ fn aam_to_simplex_fused_pipeline_with_mock_aligner() {
     }
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn aam_to_duplex_fused_pipeline_with_mock_aligner() {
     let tmp = TempDir::new().unwrap();
@@ -1650,6 +1674,7 @@ fn aam_to_duplex_fused_pipeline_with_mock_aligner() {
     assert!(n_records >= 1, "expected >= 1 record in duplex BAM, got {n_records}");
 }
 
+#[cfg(feature = "consensus")]
 #[test]
 fn aam_to_codec_fused_pipeline_with_mock_aligner() {
     let tmp = TempDir::new().unwrap();
@@ -1714,6 +1739,7 @@ fn aam_to_codec_fused_pipeline_with_mock_aligner() {
 /// turns out to produce 0 simplex consensus reads on a correctly-
 /// wired chain — so a record-count assertion on it can't tell the
 /// wire-up bug shape apart from the "fixture too thin" shape.
+#[cfg(feature = "consensus")]
 #[test]
 fn zipper_to_simplex_fused_pipeline() {
     let tmp = TempDir::new().unwrap();
@@ -1769,6 +1795,7 @@ fn zipper_to_simplex_fused_pipeline() {
 /// everything filtered → header-only BAM, which still satisfies
 /// `meta.len() > 0`). The record-count assertion below makes that
 /// regression visible as a test failure rather than a silent zero.
+#[cfg(feature = "consensus")]
 #[test]
 fn zipper_to_duplex_fused_pipeline() {
     let tmp = TempDir::new().unwrap();
@@ -1808,6 +1835,7 @@ fn zipper_to_duplex_fused_pipeline() {
 /// Same wire-up bug as `zipper_to_duplex_fused_pipeline` guards —
 /// `execute_codec_pipeline` was previously missing its
 /// `else if let Some(zipper) = zipper` arm.
+#[cfg(feature = "consensus")]
 #[test]
 fn zipper_to_codec_fused_pipeline() {
     let tmp = TempDir::new().unwrap();
@@ -2659,6 +2687,7 @@ fn correct_to_group_fused_pipeline() {
 /// requires both R1 + R2 of a pair to emit consensus, so this
 /// produces a header-only BAM by construction. Smoke-test asserts
 /// the chain succeeds + the output BAM opens cleanly.
+#[cfg(feature = "consensus")]
 #[test]
 fn correct_to_simplex_fused_pipeline() {
     let tmp = TempDir::new().unwrap();
@@ -2692,6 +2721,7 @@ fn correct_to_simplex_fused_pipeline() {
 /// well-formed input (proper-pair flags, both R1 and R2 with
 /// matching qnames). Asserts ≥ 1 consensus record — same shape as
 /// `aam_to_duplex_fused_pipeline_with_mock_aligner`.
+#[cfg(feature = "consensus")]
 #[test]
 fn correct_to_duplex_fused_pipeline() {
     let tmp = TempDir::new().unwrap();
@@ -2726,6 +2756,7 @@ fn correct_to_duplex_fused_pipeline() {
 /// paired-end UMI fixture + paired mock aligner (which emits the
 /// FR-overlap shape codec requires). Asserts ≥ 1 consensus record —
 /// same shape as `aam_to_codec_fused_pipeline_with_mock_aligner`.
+#[cfg(feature = "consensus")]
 #[test]
 fn correct_to_codec_fused_pipeline() {
     let tmp = TempDir::new().unwrap();

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -1072,6 +1072,8 @@ fn test_correct_reads_stdin_once(#[case] threads: &str) {
 
 /// codec has a single-threaded fast path (no `--threads`) plus the
 /// multi-threaded chain path; cover both.
+// Uses helpers from the consensus-gated `test_codec_command` module.
+#[cfg(feature = "consensus")]
 #[rstest]
 #[case::single_threaded(None)]
 #[case::multi_threaded(Some("2"))]
@@ -1116,6 +1118,8 @@ fn test_codec_reads_stdin_once(#[case] threads: Option<&str>) {
 
 /// duplex has a single-threaded fast path (no `--threads`) plus the
 /// multi-threaded chain path; cover both.
+// Uses helpers from the consensus-gated `test_duplex_command` module.
+#[cfg(feature = "consensus")]
 #[rstest]
 #[case::single_threaded(None)]
 #[case::multi_threaded(Some("2"))]


### PR DESCRIPTION
**Stack: 1 / 6** · base: `feat-runall`

Foundation layer for the feat-runall fix series. Structural changes everything else builds on.

- **`refactor(features)!`** — collapse the umbrella `simplex`/`duplex`/`codec` features into a single default-on `consensus` flag (the granular features still live one level down in `fgumi-consensus` for reduced-library builds). `--no-default-features` now cleanly drops all consensus code and still compiles; a new `fgumi-feature-check` CI job exercises the reduced-feature build so chain/runall code can never silently reference a gated module again.
- **`fix(cli)`** — accept the removed `--scheduler` flag as a hidden, deprecated no-op (warns and ignores) so existing invocations don't hard-fail.
- **`refactor(pipeline-core)`** — hoist the `FinalizeHook` trait into `fgumi-pipeline-core` so the sort hooks are single-sourced.
- **`fix(bam-io)`** — fix BAI sidecar path naming for non-`.bam`/extensionless outputs (append `.bai`, samtools convention).

⚠️ Breaking: the consensus feature-flag surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public helpers to compute and write BAI sidecar files (consistent `<bam>.bai` naming), used automatically by the sort/index finalize flow.
  * Introduced clearer “consensus” feature gating so consensus-capable commands/options enable consistently across the app and tooling.
* **Bug Fixes**
  * Finalization is more reliable: success-only cleanup now runs only after a fully successful pipeline; index writing follows that success path.
  * Feature-disabled builds now fail with clearer “requires consensus feature” messages for consensus commands.
  * Deprecated `--scheduler` is accepted as a no-op.
* **Chores**
  * Expanded CI compile coverage for additional feature combinations; updated tests and documentation accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->