### PR TITLE
fix(sort): harden the runall-sort Phase-2 engine, restore CLI flags, slim dead code (3/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ dhat-heap.json
 docs/bench/
 docs/design/*
 !docs/design/deterministic-mi-numbering.md
+# Tracked: cited from worker_pool.rs / merge_slots.rs, so it must be committed
+# (a dangling design-doc citation is exactly what S3-003 / NEW-003 fixed).
+!docs/design/sort-phase2-unification-deferral.md
+# Tracked: cited from read_ahead.rs (S3-015 deferral); must be committed so the
+# code's PERF NOTE citation does not dangle.
+!docs/design/sort-queryname-arena-deferral.md
 scripts/bench-*.sh
 scripts/parity-*.sh
 /TRACKER.md

--- a/crates/fgumi-pipeline-io/src/sort/and_spill.rs
+++ b/crates/fgumi-pipeline-io/src/sort/and_spill.rs
@@ -185,19 +185,23 @@ impl SortAndSpill {
                 records_ingested_so_far: total_records,
             });
         }
-        let slot_count = u32::try_from(pending_events.len()).expect("spill count fits in u32");
-        let mut memory_chunk_count: u32 = 0;
+        // Derive both announced counts the same way — `u32::try_from` on the
+        // number of pushed events — so the two overflow guards are symmetric and
+        // can't drift (a `slot_count` cast that panics differently from a
+        // `memory_chunk_count` accumulator would mask a protocol bug).
+        let slot_count = u32::try_from(pending_events.len()).expect("spill slot count fits in u32");
+        let memory_events_start = pending_events.len();
         for chunk in memory_chunks {
             if chunk.is_empty() {
                 continue;
             }
-            memory_chunk_count =
-                memory_chunk_count.checked_add(1).expect("memory chunk count fits in u32");
             pending_events.push_back(SortPhase1Event::MemoryChunk {
                 chunk: Arc::new(chunk),
                 records_ingested_so_far: total_records,
             });
         }
+        let memory_chunk_count = u32::try_from(pending_events.len() - memory_events_start)
+            .expect("memory chunk count fits in u32");
         if pending_events.is_empty() {
             return Ok(None);
         }

--- a/crates/fgumi-pipeline-io/src/sort/merge.rs
+++ b/crates/fgumi-pipeline-io/src/sort/merge.rs
@@ -27,6 +27,15 @@ pub const DEFAULT_TARGET_BATCH_COUNT: usize = 1024;
 /// Max output batches emitted per `try_run` invocation in `Merging`.
 const MAX_DRAIN_BATCHES_PER_LOCK: usize = 8;
 
+/// Initial reservation for an output-batch byte buffer, before any batch has
+/// been emitted to size the next one from. Kept modest on purpose: most batches
+/// fill on the record-count cap well below the output-queue byte budget, so
+/// reserving the full budget for every buffer chronically over-allocates (and
+/// inflates the byte-bounded queue's capacity-based accounting). Buffers grow
+/// on demand via `extend_from_slice`, so under-reserving only costs a few
+/// startup reallocations.
+const INITIAL_OUTPUT_BUFFER_BYTES: usize = 64 * 1024;
+
 #[derive(Default)]
 struct MemoryChunksByKind {
     coordinate: Vec<Vec<(RawCoordinateKey, RawRecord)>>,
@@ -118,7 +127,7 @@ fn absorb_phase2_event(
     total_records: &mut u64,
     expected_slot_count: &mut Option<u32>,
     expected_memory_chunk_count: &mut Option<u32>,
-) {
+) -> io::Result<()> {
     match event {
         SortPhase2Event::SpillReady { slot, path: _, records_ingested_so_far } => {
             if let std::collections::hash_map::Entry::Vacant(e) = slot_index.entry(slot.file_id) {
@@ -128,16 +137,17 @@ fn absorb_phase2_event(
             *total_records = (*total_records).max(records_ingested_so_far);
         }
         SortPhase2Event::MemoryChunk { chunk, records_ingested_so_far } => {
-            let inner = Arc::try_unwrap(chunk).unwrap_or_else(|arc| match arc.as_ref() {
-                MemoryChunkErased::Coordinate(v) => MemoryChunkErased::Coordinate(v.clone()),
-                MemoryChunkErased::QuerynameLex(v) => MemoryChunkErased::QuerynameLex(v.clone()),
-                MemoryChunkErased::QuerynameNatural(v) => {
-                    MemoryChunkErased::QuerynameNatural(v.clone())
-                }
-                MemoryChunkErased::TemplateCoordinate(v) => {
-                    MemoryChunkErased::TemplateCoordinate(v.clone())
-                }
-            });
+            // The MemoryChunk `Arc` is created uniquely in `SortAndSpill` and only
+            // ever *moved* (never cloned) through `SortSpillDecompress` to here, so
+            // it must be uniquely owned at this single consumer. Fail closed on a
+            // shared `Arc` rather than silently deep-cloning a potentially large
+            // record vector on the merge setup path.
+            let inner = Arc::try_unwrap(chunk).map_err(|_| {
+                io::Error::other(
+                    "SortMerge: MemoryChunk Arc unexpectedly shared at the merge consumer \
+                     (protocol invariant: memory chunks are moved, never cloned)",
+                )
+            })?;
             memory_chunks.push(inner);
             *total_records = (*total_records).max(records_ingested_so_far);
         }
@@ -146,18 +156,23 @@ fn absorb_phase2_event(
             memory_chunk_count,
             total_records: ar_total,
         } => {
-            if expected_slot_count.is_some() {
-                log::warn!(
+            // The Phase-2 protocol emits exactly one `AllAnnounced` (the last event
+            // from `SortAndSpill`). A second one is a protocol violation; fail
+            // closed rather than overwrite the prior expectations and risk masking
+            // the bug behind a silently-different completion target.
+            if expected_slot_count.is_some() || expected_memory_chunk_count.is_some() {
+                return Err(io::Error::other(format!(
                     "SortMerge: duplicate AllAnnounced — prior {expected_slot_count:?}/\
                      {expected_memory_chunk_count:?}, new {slot_count}/{memory_chunk_count}; \
-                     using the new values",
-                );
+                     the Phase-2 protocol emits exactly one AllAnnounced",
+                )));
             }
             *expected_slot_count = Some(slot_count);
             *expected_memory_chunk_count = Some(memory_chunk_count);
             *total_records = (*total_records).max(ar_total);
         }
     }
+    Ok(())
 }
 
 fn slot_set_complete(
@@ -242,7 +257,12 @@ impl SortMerge {
     /// # Panics
     ///
     /// Panics if `self.state` is not `WaitingForSetup`.
-    fn absorb_events_into_setup(&mut self, ctx: &mut StepCtx<'_, Self>) -> usize {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on a Phase-2 protocol violation (a duplicate
+    /// `AllAnnounced`, or a `MemoryChunk` whose `Arc` is unexpectedly shared).
+    fn absorb_events_into_setup(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<usize> {
         let SortMergeState::WaitingForSetup {
             slots,
             slot_index,
@@ -264,10 +284,10 @@ impl SortMerge {
                 total_records,
                 expected_slot_count,
                 expected_memory_chunk_count,
-            );
+            )?;
             absorbed += 1;
         }
-        absorbed
+        Ok(absorbed)
     }
 
     fn is_ready_to_merge(&self) -> bool {
@@ -300,9 +320,16 @@ impl SortMerge {
             unreachable!("next_batch called outside Merging state");
         };
 
+        let buffer_floor = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap);
         let flush = |builder: &mut RecordBatchBuilder, next_ordinal: &mut u64| {
             *next_ordinal += 1;
-            let next_builder = RecordBatchBuilder::with_capacity(*next_ordinal, bytes_cap, target);
+            // Size the next buffer to the batch we just filled, clamped to
+            // `[buffer_floor, bytes_cap]`. Count-bound batches stay small; a
+            // byte-bound batch carries ~`bytes_cap` forward. This avoids
+            // reserving the full byte budget for every (typically count-bound)
+            // batch — see `INITIAL_OUTPUT_BUFFER_BYTES`.
+            let hint = builder.total_bytes().clamp(buffer_floor, bytes_cap);
+            let next_builder = RecordBatchBuilder::with_capacity(*next_ordinal, hint, target);
             std::mem::replace(builder, next_builder).build()
         };
         let flush_partial = |builder: &mut RecordBatchBuilder, next_ordinal: &mut u64| {
@@ -404,7 +431,10 @@ impl SortMerge {
         slots.sort_by_key(|s| s.file_id);
         let driver = build_driver(self.sort_order, slots, memory_chunks, total_records);
         let bytes_cap = usize::try_from(self.output_byte_limit).unwrap_or(usize::MAX);
-        let builder = RecordBatchBuilder::with_capacity(0, bytes_cap, self.target_batch_count);
+        // Seed the first buffer modestly; subsequent buffers are sized from the
+        // prior batch's actual byte length (see `next_batch`).
+        let initial_bytes = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap);
+        let builder = RecordBatchBuilder::with_capacity(0, initial_bytes, self.target_batch_count);
         self.state = SortMergeState::Merging { driver, builder, next_ordinal: 0 };
     }
 }
@@ -438,7 +468,7 @@ impl Step for SortMerge {
             // already byte-bounded, so backpressure belongs on the producer, not
             // on a consumer-side drain cap. A cap here would cycle a full upstream
             // queue through repeated partial drains and add producer contention.
-            let absorbed = self.absorb_events_into_setup(ctx);
+            let absorbed = self.absorb_events_into_setup(ctx)?;
             if !self.is_ready_to_merge() {
                 if absorbed > 0 {
                     return Ok(StepOutcome::Progress);

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -566,6 +566,112 @@ fn test_sort_merge_fails_closed_on_incomplete_setup() {
     assert!(msg.contains("setup incomplete at input drain"), "unexpected error message: {msg}");
 }
 
+// ── SortMerge output-buffer sizing + duplicate-AllAnnounced regression ───────
+
+/// Drive `SortMerge` over `events` and return the *batches* it emits (not the
+/// flattened records), so tests can inspect per-batch buffer capacity.
+fn collect_merge_batches(
+    events: Vec<crate::sort::protocol::SortPhase2Event>,
+    output_byte_limit: u64,
+    target_batch_count: usize,
+) -> Result<Vec<RecordBatch>> {
+    let received: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let source = Phase2EventSource::new(events, output_byte_limit);
+    let merge = SortMerge::with_target_batch_count(
+        SortOrder::Coordinate,
+        output_byte_limit,
+        target_batch_count,
+    );
+    let sink = VecSink { received: Arc::clone(&received), kind: StepKind::Serial };
+
+    let builder = Pipeline::builder();
+    builder.chain(source).chain(merge).chain(sink).into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads: 1, ..Default::default() })?;
+
+    Ok(std::mem::take(&mut *received.lock()))
+}
+
+/// Wrap `records` as a single coordinate-sorted in-memory chunk event. All keys
+/// are `default()` (equal) — order does not matter for the buffer-sizing and
+/// duplicate-announcement assertions, only that the chunk merges cleanly.
+fn coordinate_memory_chunk_event(
+    records: Vec<RawRecord>,
+) -> crate::sort::protocol::SortPhase2Event {
+    use crate::sort::protocol::MemoryChunkErased;
+    let total = records.len() as u64;
+    let pairs = records.into_iter().map(|r| (fgumi_sort::RawCoordinateKey::default(), r)).collect();
+    crate::sort::protocol::SortPhase2Event::MemoryChunk {
+        chunk: Arc::new(MemoryChunkErased::Coordinate(pairs)),
+        records_ingested_so_far: total,
+    }
+}
+
+/// Count-bound output batches must not each reserve the full output-queue byte
+/// budget. Drive a many-small-record merge that emits several count-capped
+/// batches and assert their total resident capacity stays well under one byte
+/// budget — it would be ~`num_batches * byte_limit` if every buffer reserved
+/// the full budget (the pre-fix behavior).
+#[test]
+fn test_sort_merge_does_not_over_reserve_output_buffers() {
+    use fgumi_pipeline_core::item::HeapSize;
+
+    let (_header, records) = synthesize_records(600, 7);
+    let byte_limit: u64 = 1 << 20; // 1 MiB
+    let target = 256;
+    let events = vec![
+        coordinate_memory_chunk_event(records),
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 1,
+            total_records: 600,
+        },
+    ];
+    let batches = collect_merge_batches(events, byte_limit, target).expect("merge should succeed");
+
+    let emitted: usize = batches.iter().map(|b| b.iter_record_bytes().count()).sum();
+    assert_eq!(emitted, 600, "all records must be emitted");
+    assert!(
+        batches.len() >= 2,
+        "workload must span multiple count-bound batches, got {}",
+        batches.len()
+    );
+    let total_heap: usize = batches.iter().map(HeapSize::heap_size).sum();
+    assert!(
+        (total_heap as u64) < byte_limit,
+        "output buffers over-reserved: {total_heap} bytes across {} batches \
+         (would exceed one byte budget if each reserved the full {byte_limit})",
+        batches.len(),
+    );
+}
+
+/// The Phase-2 protocol emits exactly one `AllAnnounced`. A second one is a
+/// protocol violation; `SortMerge` must fail closed rather than overwrite its
+/// completion expectations. The first announcement over-promises (2 chunks) so
+/// setup never completes and the duplicate is still absorbed in setup.
+#[test]
+fn test_sort_merge_fails_closed_on_duplicate_all_announced() {
+    let (_header, records) = synthesize_records(1, 1);
+    let byte_limit: u64 = 1 << 20;
+    let events = vec![
+        coordinate_memory_chunk_event(records),
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 2,
+            total_records: 1,
+        },
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 2,
+            total_records: 1,
+        },
+    ];
+    let err = collect_merge_batches(events, byte_limit, 256)
+        .expect_err("duplicate AllAnnounced must error");
+    let msg = err.to_string();
+    assert!(msg.contains("duplicate AllAnnounced"), "unexpected error: {msg}");
+}
+
 fn read_all_records(path: &std::path::Path) -> Vec<Vec<u8>> {
     let (mut reader, _hdr) = fgumi_bam_io::create_raw_bam_reader_with_opts(
         path,

--- a/crates/fgumi-sort-cli/src/chains.rs
+++ b/crates/fgumi-sort-cli/src/chains.rs
@@ -151,6 +151,9 @@ pub struct SortStepCaptures {
     /// holds the other end; the step fills it when `RawExternalSorter::sort`
     /// returns.
     pub stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>>,
+    /// Wrap the sorter's input in a userspace async prefetch reader (the
+    /// standalone `--async-reader` flag). Off for the fused runall sort.
+    pub async_reader: bool,
 }
 
 /// Build the `SortBamFile` step, constructing and fully configuring the
@@ -171,6 +174,9 @@ pub fn build_sort_step(cap: SortStepCaptures) -> Result<SortBamFile> {
         .threads(cap.num_sorter_threads)
         .output_compression(cap.output_compression)
         .temp_compression(cap.sort.temp_compression)
+        .spill_codec(cap.sort.temp_codec)
+        .key_types(cap.sort.key_types.unwrap_or_default())
+        .async_reader(cap.async_reader)
         .pg_info(version::version_string(), cap.command_line);
 
     if matches!(cap.sort.max_memory, MemoryLimit::Auto) {

--- a/crates/fgumi-sort-cli/src/sort.rs
+++ b/crates/fgumi-sort-cli/src/sort.rs
@@ -32,7 +32,7 @@ use fgumi_cli_common::{
 };
 use fgumi_pipeline_core::{FinalizeHook, Pipeline, PipelineConfig};
 use fgumi_sam::SamTag;
-use fgumi_sort::{QuerynameComparator, SortOrder, verify_sort_order};
+use fgumi_sort::{KeyTypesSpec, QuerynameComparator, SortOrder, SpillCodec, verify_sort_order};
 use log::info;
 use parking_lot::Mutex;
 
@@ -306,6 +306,25 @@ pub struct SortOptions {
     #[arg(long = "temp-compression", default_value = "1", value_parser = clap::value_parser!(u32).range(0..=9))]
     pub temp_compression: u32,
 
+    /// Codec for temporary spill files: `zstd` (default) or `bgzf`.
+    ///
+    /// Spill files are internal to the sort and never read by other tools, so
+    /// `zstd` is the default — it is faster than `bgzf` on every axis. Pass
+    /// `bgzf` for the legacy on-disk format, or to use `--temp-compression 0`
+    /// (uncompressed spill), which zstd does not support.
+    #[arg(long = "temp-codec", default_value = "zstd")]
+    pub temp_codec: SpillCodec,
+
+    /// Expert override for which sort-key lanes to provision (template-coordinate
+    /// order only).
+    ///
+    /// Omitted (default) auto-detects the narrowest key from the first record.
+    /// Accepts `full`, `none` (or empty), or a comma/space list of `cb`,
+    /// `library`, `mi` (`library`/`mi` both map to the shared tertiary lane).
+    /// Ignored for non-template-coordinate orders.
+    #[arg(long = "key-types", value_parser = parse_key_types)]
+    pub key_types: Option<KeyTypesSpec>,
+
     /// Sort order (chain-builder slot).
     ///
     /// Carried here so the chain builder can read it from the bag without
@@ -323,9 +342,41 @@ impl Default for SortOptions {
             memory_per_thread: true,
             tmp_dirs: Vec::new(),
             temp_compression: 1,
+            temp_codec: SpillCodec::default(),
+            key_types: None,
             order: SortOrderArg::TemplateCoordinate,
         }
     }
+}
+
+/// Parse `--key-types` into a [`KeyTypesSpec`].
+///
+/// `full` | `none`/`""` | comma/space list of `cb`,`library`,`mi`. Unknown
+/// tokens are rejected. `library`, `mi`, and `library,mi` all map to the shared
+/// `tertiary` lane.
+pub(crate) fn parse_key_types(s: &str) -> Result<KeyTypesSpec, String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("full") {
+        return Ok(KeyTypesSpec::Full);
+    }
+    if s.is_empty() || s.eq_ignore_ascii_case("none") {
+        return Ok(KeyTypesSpec::None);
+    }
+    let mut cb = false;
+    let mut tertiary = false;
+    for tok in s.split([',', ' ']).filter(|t| !t.is_empty()) {
+        match tok.to_ascii_lowercase().as_str() {
+            "cb" => cb = true,
+            "library" | "mi" => tertiary = true,
+            other => {
+                return Err(format!(
+                    "unknown --key-types token '{other}', expected 'full', 'none', \
+                     or a list of 'cb','library','mi'"
+                ));
+            }
+        }
+    }
+    Ok(KeyTypesSpec::Explicit { cb, tertiary })
 }
 
 /// Environment variable name for the fallback temp-dir list, parsed as a
@@ -409,6 +460,28 @@ impl Command for Sort {
             bail!("--write-index is only valid for coordinate sort");
         }
 
+        // Up-front guard (S3-002): zstd has no uncompressed mode, so reject the
+        // `--temp-compression 0` + `--temp-codec zstd` combination before the run
+        // starts rather than failing late. (The engine also enforces this via
+        // `ensure_spill_codec_compat`, but catching it here gives a CLI-level
+        // message and avoids any setup work.)
+        if self.options.temp_compression == 0 && matches!(self.options.temp_codec, SpillCodec::Zstd)
+        {
+            bail!(
+                "--temp-compression 0 is only supported with --temp-codec bgzf; \
+                 zstd does not have an uncompressed mode. Pass --temp-codec bgzf \
+                 to keep uncompressed spill, or use a zstd level >= 1."
+            );
+        }
+
+        // `--key-types` only applies to template-coordinate sort; warn if set for
+        // any other order so the override is not silently ignored.
+        if self.options.key_types.is_some()
+            && !matches!(self.order, SortOrderArg::TemplateCoordinate)
+        {
+            info!("--key-types is ignored for --order {:?}", self.order);
+        }
+
         // Copy order into SortOptions so the step factory can read it.
         let mut sort_opts = self.options.clone();
         sort_opts.order = self.order;
@@ -454,6 +527,7 @@ impl Sort {
             output_compression: self.compression.compression_level,
             command_line: command_line.to_string(),
             stats_slot: Arc::clone(&stats_slot),
+            async_reader: self.async_reader,
         })?;
 
         // SortBamFile has `Input = ()` and `Outputs = ()`, so it registers via
@@ -667,6 +741,112 @@ mod tests {
         assert_eq!(sort.options.memory_reserve, defaults.memory_reserve);
         assert_eq!(sort.options.memory_per_thread, defaults.memory_per_thread);
         assert_eq!(sort.options.temp_compression, defaults.temp_compression);
+        assert_eq!(sort.options.temp_codec, defaults.temp_codec);
+        assert_eq!(sort.options.temp_codec, SpillCodec::Zstd, "default spill codec is zstd");
+        assert_eq!(sort.options.key_types, defaults.key_types);
+        assert_eq!(sort.options.key_types, None, "--key-types defaults to Auto (None)");
+    }
+
+    #[rstest]
+    #[case::default_omitted(&["sort", "-i", "in.bam", "-o", "out.bam"], SpillCodec::Zstd)]
+    #[case::explicit_zstd(
+        &["sort", "-i", "in.bam", "-o", "out.bam", "--temp-codec", "zstd"],
+        SpillCodec::Zstd
+    )]
+    #[case::explicit_bgzf(
+        &["sort", "-i", "in.bam", "-o", "out.bam", "--temp-codec", "bgzf"],
+        SpillCodec::Bgzf
+    )]
+    fn test_temp_codec_parses(#[case] args: &[&str], #[case] expected: SpillCodec) {
+        let sort = Sort::try_parse_from(args).expect("parse");
+        assert_eq!(sort.options.temp_codec, expected);
+    }
+
+    #[test]
+    fn test_parse_key_types() {
+        assert_eq!(parse_key_types("full").unwrap(), KeyTypesSpec::Full);
+        assert_eq!(parse_key_types("none").unwrap(), KeyTypesSpec::None);
+        assert_eq!(parse_key_types("").unwrap(), KeyTypesSpec::None);
+        assert_eq!(
+            parse_key_types("cb").unwrap(),
+            KeyTypesSpec::Explicit { cb: true, tertiary: false }
+        );
+        // `library` and `mi` both map to the shared tertiary lane.
+        assert_eq!(
+            parse_key_types("library").unwrap(),
+            KeyTypesSpec::Explicit { cb: false, tertiary: true }
+        );
+        assert_eq!(
+            parse_key_types("mi").unwrap(),
+            KeyTypesSpec::Explicit { cb: false, tertiary: true }
+        );
+        assert_eq!(
+            parse_key_types("cb, mi").unwrap(),
+            KeyTypesSpec::Explicit { cb: true, tertiary: true }
+        );
+        assert!(parse_key_types("bogus").is_err(), "unknown token must be rejected");
+    }
+
+    #[test]
+    fn test_temp_compression_zero_with_zstd_rejected_up_front() {
+        // zstd has no uncompressed mode — the combination must be rejected
+        // before the sort runs (S3-002). Use a valid input so the up-front
+        // config guard, not input validation, is what fires.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("in.bam");
+        let output = dir.path().join("out.bam");
+        write_coordinate_bam(&input);
+
+        let sort = Sort::try_parse_from([
+            "sort",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "--temp-compression",
+            "0",
+            "--temp-codec",
+            "zstd",
+        ])
+        .expect("parse");
+        let err = sort.execute("fgumi sort").expect_err("zstd + level 0 must be rejected");
+        assert!(
+            err.to_string().contains("only supported with --temp-codec bgzf"),
+            "unexpected error: {err}"
+        );
+        assert!(!output.exists(), "no output should be written when the config is rejected");
+    }
+
+    #[test]
+    fn test_temp_compression_zero_with_bgzf_runs() {
+        // bgzf supports uncompressed (level-0) spill, so the combination is
+        // accepted and the sort completes.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("in.bam");
+        let output = dir.path().join("out.bam");
+        write_coordinate_bam(&input);
+
+        let sort = Sort::try_parse_from([
+            "sort",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "--order",
+            "coordinate",
+            // Bound the memory reservation: the default is 768 MiB per thread,
+            // which a single-record test should not reserve (especially under
+            // nextest's concurrent execution).
+            "--max-memory",
+            "16MiB",
+            "--temp-compression",
+            "0",
+            "--temp-codec",
+            "bgzf",
+        ])
+        .expect("parse");
+        sort.execute("fgumi sort").expect("bgzf level-0 spill must sort successfully");
+        assert!(output.exists(), "sorted output not written");
     }
 
     /// Write a minimal valid coordinate-sorted BAM (one mapped record) to

--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -16,6 +16,16 @@ use std::sync::Arc;
 /// Padding beyond `BGZF_MAX_BLOCK_SIZE` for the staging buffer capacity.
 const STAGING_PADDING: usize = 4096;
 
+/// Nominal upper bound on the uncompressed size of a single staging frame (one
+/// `CompressJob`'s `data`). The staging buffer flushes at `BGZF_MAX_BLOCK_SIZE`
+/// and is sized with `STAGING_PADDING` of headroom, so a flushed frame is
+/// bounded by this for normal record sizes. Consumers that size a decompression
+/// buffer for these frames (the zstd Phase-2 path in `worker_pool`) link their
+/// capacity to this constant via a compile-time assertion so the two cannot
+/// silently drift apart.
+pub(crate) const STAGING_FRAME_MAX_UNCOMPRESSED_BYTES: usize =
+    BGZF_MAX_BLOCK_SIZE + STAGING_PADDING;
+
 /// Staging buffer that accumulates data and submits full blocks to the pool.
 pub(crate) struct StagingBuffer {
     pool: Arc<SortWorkerPool>,

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -833,12 +833,6 @@ impl<K: RawSortKey + Default + 'static> MemorySources<K> {
 /// recently read record's bytes; `Memory`/`MemoryOwned` borrow directly from
 /// their backing store, eliminating the per-record memcpy on the in-memory path.
 enum ChunkSource<K: RawSortKey + Default + 'static> {
-    /// Disk-based chunk with prefetching reader (legacy path with per-source threads).
-    Disk {
-        reader: GenericKeyedChunkReader<K>,
-        /// Bytes for the current record (filled by the most recent `advance`).
-        scratch: Vec<u8>,
-    },
     /// In-memory chunk from an inline-buffer sort (coordinate / template).
     /// All records borrow their bytes from a shared `Arc<SegmentedBuf>`;
     /// `current_bytes` borrows them directly (zero-copy).
@@ -867,7 +861,6 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     /// record's bytes without copying.
     fn advance(&mut self, consumer: Option<&mut MainThreadChunkConsumer<K>>) -> Result<Option<K>> {
         match self {
-            ChunkSource::Disk { reader, scratch } => reader.next_record(scratch),
             ChunkSource::PoolDisk { source_id, scratch } => {
                 let c = consumer.ok_or_else(|| {
                     anyhow::anyhow!(
@@ -907,11 +900,11 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     /// Caller MUST have received `Some(_)` from a prior `advance`. The merge
     /// loops uphold this: the init loop only retains a source whose first
     /// `advance` returned `Some`, and the main loop only calls this on the
-    /// active tree winner — so the `Disk`/`PoolDisk` empty-scratch case is
+    /// active tree winner — so the `PoolDisk` empty-scratch case is
     /// unreachable.
     fn current_bytes(&self) -> &[u8] {
         match self {
-            ChunkSource::Disk { scratch, .. } | ChunkSource::PoolDisk { scratch, .. } => scratch,
+            ChunkSource::PoolDisk { scratch, .. } => scratch,
             ChunkSource::Memory { chunk, idx } => {
                 debug_assert!(*idx != usize::MAX, "current_bytes called before advance");
                 chunk.record_bytes(*idx)
@@ -1044,8 +1037,19 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 if let Some(data) = guard.try_pop_next() {
                     drop(guard);
                     let st = &mut self.parser_state[source_id];
-                    st.current_buf = data;
+                    let exhausted = std::mem::replace(&mut st.current_buf, data);
                     st.current_pos = 0;
+                    // Recycle the just-exhausted block back to the shared
+                    // decompression buffer pool so zstd workers can reuse the
+                    // allocation for the next frame (BGZF decompress returns its
+                    // own buffers and does not check out, so skip it there). The
+                    // initial `current_buf` is a zero-capacity `Vec` that was
+                    // never checked out, so don't return it to the pool.
+                    if matches!(file.codec, crate::codec::SpillCodec::Zstd)
+                        && exhausted.capacity() != 0
+                    {
+                        file.buffer_pool.checkin(exhausted);
+                    }
                     return Ok(true);
                 }
             }
@@ -1069,6 +1073,19 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
 
             // Source produced everything it ever will?
             if file.is_drained() {
+                // Recycle the terminal zstd block: nothing replaces `current_buf`
+                // after a source drains, so without this the last decompression
+                // allocation for each source lingers in `parser_state` until the
+                // whole merge ends — one retained buffer per spill file. (BGZF
+                // returns its own buffers and never checks out; the initial
+                // zero-capacity `Vec` was never checked out either.)
+                let st = &mut self.parser_state[source_id];
+                if matches!(file.codec, crate::codec::SpillCodec::Zstd)
+                    && st.current_buf.capacity() != 0
+                {
+                    file.buffer_pool.checkin(std::mem::take(&mut st.current_buf));
+                    st.current_pos = 0;
+                }
                 return Ok(false);
             }
 
@@ -2434,10 +2451,12 @@ impl RawExternalSorter {
             // Sort remaining records into separate sub-array chunks (avoids
             // intermediate merge back into a single sorted buffer). The
             // queryname path accumulates records as individual `RawRecord`
-            // allocations upstream (per-record alloc already paid), so we
-            // sort the keyed `Vec`s in place and pack the owned `RawRecord`s
-            // into `MemorySources::Owned` for the merge interface — unlike
-            // the inline-buffer paths (coordinate, template), which produce
+            // allocations upstream (per-record alloc already paid; this is the
+            // documented S3-015 tradeoff — see
+            // docs/design/sort-queryname-arena-deferral.md), so we sort the
+            // keyed `Vec`s in place and pack the owned `RawRecord`s into
+            // `MemorySources::Owned` for the merge interface — unlike the
+            // inline-buffer paths (coordinate, template), which produce
             // `InMemoryChunk`s sharing an `Arc<SegmentedBuf>`.
             let keyed_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if entries.is_empty() {
                 Vec::new()
@@ -2829,41 +2848,32 @@ impl RawExternalSorter {
 
     /// Build chunk sources from disk files and in-memory chunks.
     ///
-    /// When `pool_decompress` is true, disk sources become `PoolDisk` variants —
-    /// workers read and decompress in the background, main thread parses records.
-    /// No per-source threads are spawned.
-    ///
-    /// When `pool_decompress` is false, disk sources use `GenericKeyedChunkReader`
-    /// with its own per-source background thread. Used by the indexing path, which
-    /// does not yet support pool-integrated decompression.
+    /// Disk files become `PoolDisk` sources: pool workers read and decompress
+    /// them via work-stealing while the main thread parses records, so no
+    /// per-source threads are spawned. In-memory chunks are appended as-is.
+    /// (The index/verify path does not call this — it builds
+    /// `GenericKeyedChunkReader` directly via `run_merge_loop`.)
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
         memory_chunks: MemorySources<K>,
-        reader_concurrency: usize,
-        pool_decompress: bool,
         pool: &Arc<SortWorkerPool>,
     ) -> Result<Vec<ChunkSource<K>>> {
         let num_disk = chunk_files.len();
         let num_memory = memory_chunks.num_non_empty();
         let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
 
-        if pool_decompress && !chunk_files.is_empty() {
-            // Pool-integrated path: install per-file Phase 2 state on the
-            // pool, then create one PoolDisk source per file. Workers
-            // cooperatively read+decompress all files via work-stealing.
+        if !chunk_files.is_empty() {
+            // Install per-file Phase 2 state on the pool, then create one
+            // PoolDisk source per file. Workers cooperatively read+decompress
+            // all files via work-stealing. (The legacy per-source-reader-thread
+            // `ChunkSource::Disk` branch was removed in S3-003 slimming: it was
+            // never reachable — `merge_chunks_generic` is the only caller and
+            // always used the pool path; the index/verify path builds
+            // `GenericKeyedChunkReader` directly via `run_merge_loop`.)
             pool.set_phase2_files(chunk_files)?;
 
             for source_id in 0..num_disk {
                 sources.push(ChunkSource::PoolDisk { source_id, scratch: Vec::new() });
-            }
-        } else {
-            // Legacy path: per-source reader threads (used by indexing path)
-            let sem = make_reader_semaphore(reader_concurrency);
-            for path in chunk_files {
-                sources.push(ChunkSource::Disk {
-                    reader: GenericKeyedChunkReader::<K>::open(path, Some(Arc::clone(&sem)))?,
-                    scratch: Vec::new(),
-                });
             }
         }
 
@@ -2891,7 +2901,6 @@ impl RawExternalSorter {
         use crate::pooled_bam_writer::PooledBamWriter;
         use crate::worker_pool::phase;
 
-        let reader_concurrency: usize = 1;
         let num_disk = chunk_files.len();
 
         if num_disk > 0 {
@@ -2902,13 +2911,7 @@ impl RawExternalSorter {
             );
         }
 
-        let mut sources = Self::build_chunk_sources::<K>(
-            chunk_files,
-            memory_chunks,
-            reader_concurrency,
-            true,
-            pool,
-        )?;
+        let mut sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, pool)?;
 
         let num_sources = sources.len();
         debug!("Merging from {num_sources} sources...");
@@ -5539,6 +5542,14 @@ mod tests {
         RawReadAheadReader::new(reader).count() as u64
     }
 
+    /// Read every record body of a BAM file into a `Vec<Vec<u8>>` for exact
+    /// output comparison.
+    fn read_all_bam_records(path: &std::path::Path) -> Vec<Vec<u8>> {
+        use crate::read_ahead::RawReadAheadReader;
+        let (reader, _) = create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        RawReadAheadReader::new(reader).map(|r| r.as_ref().to_vec()).collect()
+    }
+
     /// Verifies that sort with consolidation preserves all records.
     ///
     /// Uses a tiny memory limit and low `max_temp_files` to force many chunks and
@@ -5678,6 +5689,67 @@ mod tests {
         let expected = (num_pairs * 2) as u64;
         let observed = count_bam_records(&output);
         assert_eq!(observed, expected, "semaphore-capped merge lost data");
+    }
+
+    /// S3-008: the zstd Phase-2 decompress path recycles block buffers through
+    /// the shared pool (worker checks out, merge consumer checks back in).
+    /// Force many zstd spill chunks so the pool is cycled well past its
+    /// capacity, and assert the recycled-buffer merge output is byte-identical
+    /// to an in-memory sort of the same input (recycling must not corrupt,
+    /// reorder, drop, or duplicate records).
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_zstd_phase2_buffer_recycling_preserves_output(#[case] sort_order: SortOrder) {
+        use fgumi_sam::SamBuilder;
+
+        let num_pairs = 300;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i}"))
+                .start1((i * 7 % 4000) + 1)
+                .start2((i * 7 % 4000) + 101)
+                .build();
+        }
+
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = dir.path().join("input.bam");
+        builder.write_bam(&input).expect("failed to write BAM");
+
+        // Spilled zstd sort: a tiny memory limit forces many chunks → many
+        // Phase-2 zstd decompress blocks cycled through the recycling pool.
+        let spilled = dir.path().join("spilled.bam");
+        let stats = RawExternalSorter::new(sort_order)
+            .memory_limit(16 * 1024)
+            .threads(2)
+            .spill_codec(crate::codec::SpillCodec::Zstd)
+            .temp_compression(3)
+            .output_compression(0)
+            .sort(&input, &spilled)
+            .expect("spilled zstd sort should succeed");
+        assert!(
+            stats.chunks_written >= 3,
+            "expected several zstd spill chunks to cycle the buffer pool, got {}",
+            stats.chunks_written
+        );
+
+        // In-memory reference sort (no spill, no Phase-2 decompression).
+        let in_memory = dir.path().join("in_memory.bam");
+        RawExternalSorter::new(sort_order)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .output_compression(0)
+            .sort(&input, &in_memory)
+            .expect("in-memory sort should succeed");
+
+        assert_eq!(
+            read_all_bam_records(&spilled),
+            read_all_bam_records(&in_memory),
+            "zstd-spilled recycled-buffer merge must match the in-memory sort exactly",
+        );
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -441,6 +441,12 @@ impl RecordBuffer {
         // (`u64::MAX`) so a single unmapped read doesn't widen `bytes_needed`
         // to the full 8 bytes; unmapped reads still sort to the tail because
         // their key truncates to all-`0xFF` under any width.
+        //
+        // CORRECTNESS-CRITICAL: this running max is what makes the radix pass
+        // sizing in `radix_sort_record_refs_with_max` correct. Any new
+        // `sort_key` producer feeding this buffer MUST keep `max_sort_key` in
+        // sync here (or pass a true max to the radix sort) — a key in
+        // `(max_sort_key, u64::MAX)` would silently mis-sort in release builds.
         self.refs.push(RecordRef { sort_key, offset, len, padding: 0 });
         if sort_key != u64::MAX {
             self.max_sort_key = self.max_sort_key.max(sort_key);
@@ -1693,8 +1699,18 @@ pub fn radix_sort_record_refs(refs: &mut [RecordRef]) {
 /// width, so they sort *after* every other key and remain stable among
 /// themselves. This lets a coordinate sort size the passes from the maximum
 /// *mapped* key (~5–6 bytes) instead of the full 8 even when unmapped reads are
-/// present. A key strictly between `max_key` and `u64::MAX` would under-size the
-/// byte count and mis-order records — debug builds assert against this.
+/// present.
+///
+/// CORRECTNESS-CRITICAL precondition: a key strictly between `max_key` and
+/// `u64::MAX` under-sizes `bytes_needed`, so its high bytes are never examined
+/// and the record is **silently mis-ordered in release builds** (a wrong
+/// permutation — never a panic or memory-unsafety, since the scatter indexes
+/// only correctly-sized `counts`/`dst`). The invariant holds today because the
+/// sole key source (`extract_coordinate_key_inline`) emits only a mapped key
+/// `<= max` or `u64::MAX`, and `RecordBuffer::push_coordinate` tracks the
+/// running max on every push. The debug assert below cross-checks the per-key
+/// bound, but there is deliberately **no release guard** (this is a per-record
+/// hot path); any future `sort_key` producer must uphold this contract.
 #[allow(clippy::uninit_vec, unsafe_code)]
 pub fn radix_sort_record_refs_with_max(refs: &mut [RecordRef], max_key: u64) {
     let n = refs.len();

--- a/crates/fgumi-sort/src/memory_probe.rs
+++ b/crates/fgumi-sort/src/memory_probe.rs
@@ -88,8 +88,10 @@ mod platform_ffi {
 
     /// Read the current process resident-set size in bytes.
     ///
-    /// Returns `None` if the platform sampler is unavailable (e.g. `/proc` is not
-    /// mounted on a non-Linux host and the `sysinfo` fallback fails).
+    /// Returns `None` on platforms without a sampler (anything other than Linux
+    /// or macOS), or if the platform sampler fails (e.g. `/proc/self/status` is
+    /// unreadable). There is no `sysinfo` fallback — the samplers below are the
+    /// only sources.
     ///
     /// # Implementation
     ///
@@ -97,11 +99,11 @@ mod platform_ffi {
     ///   no allocations on the hot path beyond the status string itself.
     /// - **macOS**: reads `phys_footprint` from `task_info(TASK_VM_INFO)`. This is
     ///   what Activity Monitor reports as "Memory" and excludes purgeable
-    ///   `MADV_FREE` pages, unlike `task_basic_info::resident_size` (which sysinfo
-    ///   uses). For sort memory diagnosis we need this metric — Darwin keeps
-    ///   freed pages in `resident_size` until kernel pressure forces eviction,
-    ///   which produces a misleading ~30 GiB peak when mimalloc has actually
-    ///   already purged them.
+    ///   `MADV_FREE` pages, unlike the older `task_basic_info::resident_size`
+    ///   metric. For sort memory diagnosis we need `phys_footprint` — Darwin
+    ///   keeps freed pages in `resident_size` until kernel pressure forces
+    ///   eviction, which produces a misleading ~30 GiB peak when mimalloc has
+    ///   actually already purged them.
     #[cfg(target_os = "macos")]
     #[must_use]
     pub fn process_rss_bytes() -> Option<u64> {
@@ -435,7 +437,7 @@ pub struct MergeProbe {
 impl MergeProbe {
     /// Sample the RSS every this-many merged records when probe logging is on.
     /// Chosen to give ~20 samples on a 200M-record merge — fine-grained enough
-    /// to see the growth-curve shape, sparse enough that the sysinfo/proc
+    /// to see the growth-curve shape, sparse enough that the RSS
     /// sampling overhead is negligible.
     pub const SAMPLE_INTERVAL_RECORDS: u64 = 1_000_000;
 
@@ -542,8 +544,8 @@ mod tests {
 
     #[test]
     fn test_process_rss_bytes_returns_plausible_value() {
-        // Every host we target has either /proc/self/status or a working
-        // sysinfo fallback, so this should not return None in CI.
+        // Every host we target is Linux (/proc/self/status) or macOS
+        // (task_info), so this should not return None in CI.
         let rss = process_rss_bytes().expect("RSS sampling should work on supported platforms");
         // 1 MiB is a safe lower bound for any running Rust process.
         assert!(rss >= 1024 * 1024, "RSS {rss} is implausibly small");

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -7,8 +7,8 @@
 //! queue, parses records, drives the k-way merge) via
 //! `Arc<SortMergeSlot>` clones.
 //!
-//! # Per-slot bounded queue design (v4 — see
-//! `docs/design/sort-step-split-parity-fix.md`)
+//! # Per-slot bounded queue design (v4 — see commit `9c39dea` / PR #389 and
+//! `docs/design/sort-phase2-unification-deferral.md`)
 //!
 //! Each slot carries a bounded queue of decompressed BGZF blocks
 //! (`PHASE2_DECOMP_CAP` entries). Backpressure lives here — the
@@ -61,6 +61,22 @@
 //! eliminating the `raw_blocks` queue, the in-flight counter, the
 //! reorder buffer (FIFO suffices because one worker reads per slot
 //! at a time via the reader lock), and the gap-filler escape.
+//!
+//! ## The OTHER Phase-2 implementation (`worker_pool.rs`) still has all of
+//! this — by design.
+//!
+//! Standalone file-to-file `fgumi sort` uses `worker_pool::Phase2FileState`
+//! plus the gap-filler this module dropped. That path is NOT broken: its merge
+//! consumer is a parked OS thread (no framework Skip), so the v4 deadlock
+//! cannot occur there, and its single-reader/**multi-decompressor** topology
+//! genuinely needs the reorder buffer + in-flight counter (a plain FIFO
+//! suffices HERE only because read-and-decompress is one inline op, so blocks
+//! decompress strictly in read order). Unifying the two drivers is a deferred
+//! goal — see commit `9d6d7e9` / PR #395 and
+//! `docs/design/sort-phase2-unification-deferral.md` — gated on this streaming
+//! path gaining file-to-file drive + `--write-index` + `--verify` + a
+//! deadlock-safe consumer.
+// TODO(#395): unify the two Phase-2 sort drivers — see docs/design/sort-phase2-unification-deferral.md
 
 use std::collections::VecDeque;
 use std::fs::File;

--- a/crates/fgumi-sort/src/read_ahead.rs
+++ b/crates/fgumi-sort/src/read_ahead.rs
@@ -553,6 +553,18 @@ impl RecordSource {
 impl Iterator for RecordSource {
     type Item = RawRecord;
 
+    // PERF NOTE (S3-015): the `Direct` arm below allocates a fresh `RawRecord`
+    // per `next()`. This is INHERENT to owned iteration, not a missed reuse: the
+    // sole hot consumer (`sort_queryname_keyed`) *stores* every yielded record
+    // in its in-memory `entries` buffer until spill, so each live record needs
+    // its own buffer — a scratch + `mem::take` would just hand out the scratch's
+    // buffer and leave an empty one behind, reallocating on the very next read
+    // (identical to `RawRecord::default()`). The principled fix is to put the
+    // queryname path on the same byte arena the coordinate/template paths
+    // already use (copy bytes once into a `SegmentedBuf`, store `(key, range)`
+    // refs, pool the keys), which makes this owned `Iterator::next` dead. That
+    // is a design + sort-bench effort tracked in
+    // `docs/design/sort-queryname-arena-deferral.md`.
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::ReadAhead(r, _) => r.next(),

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -115,10 +115,21 @@ pub(crate) fn read_length_prefix<R: std::io::Read + ?Sized>(
 }
 
 /// Cap on uncompressed size of a zstd spill frame. Production frames are
-/// bounded by the staging buffer (`BGZF_MAX_BLOCK_SIZE` + padding ~= 68 KB);
-/// this leaves slack but stays small enough that per-frame allocations don't
-/// dominate the merge phase when there are many tens of thousands of frames.
+/// bounded by the staging buffer (`STAGING_FRAME_MAX_UNCOMPRESSED_BYTES` ~= 68
+/// KB); this leaves slack (which absorbs atypically large records, e.g. long
+/// reads) but stays small enough that per-frame allocations don't dominate the
+/// merge phase when there are many tens of thousands of frames. The
+/// compile-time assertion below links it to the producer's frame bound so a
+/// future bump to `BGZF_MAX_BLOCK_SIZE`/`STAGING_PADDING` cannot silently leave
+/// this cap too small (which would turn into runtime `decompress_to_buffer`
+/// failures instead of a build error).
 const ZSTD_FRAME_DECOMP_CAP: usize = 256 * 1024;
+
+const _: () = assert!(
+    ZSTD_FRAME_DECOMP_CAP >= crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES,
+    "ZSTD_FRAME_DECOMP_CAP must cover the producer's max uncompressed staging frame; \
+     bump ZSTD_FRAME_DECOMP_CAP if BGZF_MAX_BLOCK_SIZE or STAGING_PADDING grow",
+);
 
 /// Hard cap on the `u32 LE` length prefix of any zstd spill frame. Frames are
 /// produced one per ~64 KiB of input by `handle_compress_job`; even
@@ -434,9 +445,35 @@ impl Clone for BufferPool {
 /// releases a permit after each `write_all`. At most `capacity` compressed
 /// blocks exist anywhere in the pipeline simultaneously, bounding the reorder
 /// buffer to `capacity × BGZF_MAX_BLOCK_SIZE` bytes.
+///
+/// The sender is held in an `ArcSwapOption` rather than a `Mutex<Option<_>>` so
+/// `release()` — called after every block write on the I/O-writer hot path —
+/// is lock-free. `close()` swaps the sender out (dropping it) to disconnect the
+/// channel and wake any producers parked in `acquire()`.
+///
+/// # Closure liveness
+///
+/// `release()` and `close()` are both called by the **single I/O-writer thread**
+/// (`io_writer_loop`): `release()` from within `io_writer_loop_inner`, and
+/// `close()` only *after* that inner loop returns. They are therefore never
+/// concurrent, so a `release()` cannot be mid-`try_send` when `close()` runs.
+/// Even if a future caller invoked `close()` from another thread, liveness still
+/// holds: `release()`'s `load_full()` yields a short-lived local `Arc<Sender>`
+/// that is dropped at the end of the call, so `store(None)` disconnects the
+/// channel as soon as that in-flight clone (if any) drops — a parked `acquire()`
+/// wakes with `Err` within that window, never permanently. The disconnect alone
+/// handles a producer *already parked* in `rx.recv()`; the `closed` flag below
+/// additionally makes `acquire()` **fail closed** for *new* calls, so they don't
+/// keep draining the channel's still-buffered permits after a write error.
 pub(crate) struct PermitPool {
-    tx: std::sync::Mutex<Option<Sender<()>>>,
+    tx: arc_swap::ArcSwapOption<Sender<()>>,
     rx: Receiver<()>,
+    /// Set by `close()` before the sender is dropped. `acquire()` checks it
+    /// around `recv()` so a pool closed on writer error rejects new acquirers
+    /// immediately rather than handing out the permits still buffered in the
+    /// channel (the initial unacquired permits plus any released ones) until
+    /// the channel disconnects.
+    closed: AtomicBool,
 }
 
 impl PermitPool {
@@ -446,34 +483,49 @@ impl PermitPool {
         for _ in 0..capacity {
             tx.try_send(()).expect("fresh channel has capacity for initial permits");
         }
-        Self { tx: std::sync::Mutex::new(Some(tx)), rx }
+        Self { tx: arc_swap::ArcSwapOption::from_pointee(tx), rx, closed: AtomicBool::new(false) }
     }
 
     /// Acquire a permit, blocking until one is available.
     ///
-    /// Returns an error if the pool has been closed (I/O writer exited with an error).
+    /// Returns an error if the pool has been closed (I/O writer exited with an
+    /// error). Fails closed: the `closed` flag is checked both before blocking
+    /// (so a post-close caller never starts draining buffered permits) and after
+    /// `recv()` returns (so a permit handed out concurrently with `close()` is
+    /// rejected rather than used), in addition to the channel-disconnect `Err`.
     pub(crate) fn acquire(&self) -> anyhow::Result<()> {
-        self.rx.recv().map_err(|_| anyhow::anyhow!("permit pool closed: I/O writer thread exited"))
+        if self.closed.load(Ordering::Acquire) {
+            anyhow::bail!("permit pool closed: I/O writer thread exited");
+        }
+        let recv_result = self.rx.recv();
+        if self.closed.load(Ordering::Acquire) {
+            anyhow::bail!("permit pool closed: I/O writer thread exited");
+        }
+        recv_result.map_err(|_| anyhow::anyhow!("permit pool closed: I/O writer thread exited"))
     }
 
     /// Release a permit back to the pool after a block has been written to disk.
+    ///
+    /// Lock-free: loads the sender via `arc-swap` (no mutex on this per-block
+    /// hot path) and `try_send`s a permit. A no-op once the pool is closed (the
+    /// sender has been swapped out, or the channel has disconnected).
     pub(crate) fn release(&self) {
-        if let Ok(guard) = self.tx.lock() {
-            if let Some(tx) = guard.as_ref() {
-                let _ = tx.try_send(());
-            }
+        if let Some(tx) = self.tx.load_full() {
+            let _ = tx.try_send(());
         }
     }
 
     /// Close the pool, unblocking any threads waiting on `acquire()`.
     ///
-    /// Drops the sending half of the channel so that `rx.recv()` in `acquire()`
-    /// returns `Err`, which is mapped to an `anyhow` error. Called by
-    /// `io_writer_loop` on write error to prevent producers from parking forever.
+    /// Sets the `closed` flag (so new/just-woken `acquire()` calls fail closed
+    /// instead of consuming still-buffered permits), then swaps out (drops) the
+    /// sending half so that `rx.recv()` in `acquire()` returns `Err` once the
+    /// channel disconnects. Called by `io_writer_loop` on write error to prevent
+    /// producers from parking forever. The channel disconnects once any
+    /// `release()` clone in flight is dropped.
     pub(crate) fn close(&self) {
-        if let Ok(mut guard) = self.tx.lock() {
-            guard.take(); // drops the Sender, closing the channel
-        }
+        self.closed.store(true, Ordering::Release);
+        self.tx.store(None);
     }
 }
 
@@ -515,6 +567,28 @@ pub(crate) struct Phase2Reader {
 /// file. The locks here are deliberately fine-grained so different workers can
 /// be reading, decompressing, and the main thread can be popping records all
 /// concurrently as long as they touch different sub-states.
+///
+/// # Two Phase-2 merge implementations (deliberate split — see commit `9d6d7e9` / PR #395)
+///
+/// This pool path drives standalone file-to-file `fgumi sort` (it keeps the
+/// engine, zstd spill, `--write-index`, and `--verify`). A SECOND, slimmer
+/// Phase-2 lives in `merge_slots.rs` (`SortMergeSlot`) for the fused in-pipeline
+/// `runall` sort. That path REMOVED the `raw_blocks` FIFO, `decomp_in_flight`,
+/// the reorder buffer, and the gap-filler because its cooperative-step consumer
+/// deadlocked at production scale (see its module header).
+///
+/// This pool path is IMMUNE to that v4 deadlock: its merge consumer is a parked
+/// OS thread (`external.rs::advance_to_next_block`), not a framework step the
+/// engine can Skip; and its single-reader gapless-FIFO serials guarantee the
+/// stuck serial is always either at the `raw_blocks` head (so the gap-filler
+/// fires) or in-flight in a worker's decompressor. Do NOT delete the gap-filler
+/// or the reorder buffer to "match" `merge_slots` — single-*reader* is not
+/// single-*decompressor* here (workers decompress in parallel, so completion
+/// order ≠ pop order), and removing them reintroduces a real deadlock and/or
+/// out-of-order merge output. The split is intentional and deferred-for-now
+/// (see commit `9c39dea` / PR #389 and
+/// `docs/design/sort-phase2-unification-deferral.md`).
+// TODO(#395): unify the two Phase-2 sort drivers — see docs/design/sort-phase2-unification-deferral.md
 pub(crate) struct Phase2FileState {
     /// Disk reader. Held only while popping bytes from disk.
     pub(crate) reader: Mutex<Phase2Reader>,
@@ -537,10 +611,21 @@ pub(crate) struct Phase2FileState {
     /// `is_drained` to avoid a race where the consumer exits while a worker
     /// is mid-decompress.
     pub(crate) decomp_in_flight: AtomicUsize,
+    /// Recycling pool for decompressed-block buffers, shared with the worker
+    /// pool's Phase-1 staging pool (idle once Phase 1 finishes). The zstd
+    /// Phase-2 decompress path checks out a buffer here instead of allocating a
+    /// fresh `Vec` per frame, and the merge consumer checks exhausted blocks
+    /// back in (see `MainThreadChunkConsumer::advance_to_next_block`). BGZF
+    /// decompression returns its own buffer, so it does not participate.
+    pub(crate) buffer_pool: BufferPool,
 }
 
 impl Phase2FileState {
-    pub(crate) fn new(reader: BufReader<std::fs::File>, codec: SpillCodec) -> Self {
+    pub(crate) fn new(
+        reader: BufReader<std::fs::File>,
+        codec: SpillCodec,
+        buffer_pool: BufferPool,
+    ) -> Self {
         Self {
             reader: Mutex::new(Phase2Reader { inner: reader, next_serial: 0, eof: false }),
             reader_eof: AtomicBool::new(false),
@@ -548,6 +633,7 @@ impl Phase2FileState {
             raw_blocks: Mutex::new(VecDeque::with_capacity(PHASE2_RAW_CAP)),
             decompressed: Mutex::new(ReorderBuffer::new()),
             decomp_in_flight: AtomicUsize::new(0),
+            buffer_pool,
         }
     }
 
@@ -1561,11 +1647,17 @@ impl SortWorkerPool {
                             Ok(n) => {
                                 // Copy the `n` decompressed bytes (≤ one
                                 // staging-buffer's worth, typically ~65 KB)
-                                // into a fresh Vec for the consumer. The
-                                // scratch buffer keeps its 256 KiB capacity
-                                // so the next frame on this worker reuses it
+                                // into a buffer checked out from the shared
+                                // recycling pool (rather than a fresh `Vec` per
+                                // frame). The merge consumer checks the buffer
+                                // back in once it has drained the block. The
+                                // scratch buffer keeps its 256 KiB capacity so
+                                // the next frame on this worker reuses it
                                 // without reallocating.
-                                worker.zstd_decompress_buf[..n].to_vec()
+                                let mut out = file.buffer_pool.checkout();
+                                out.clear();
+                                out.extend_from_slice(&worker.zstd_decompress_buf[..n]);
+                                out
                             }
                             Err(e) => {
                                 log::error!(
@@ -1924,7 +2016,7 @@ impl SortWorkerPool {
                 anyhow::anyhow!("Failed to seek chunk file {}: {e}", path.display())
             })?;
             let reader = BufReader::with_capacity(2 * 1024 * 1024, file);
-            states.push(Phase2FileState::new(reader, codec));
+            states.push(Phase2FileState::new(reader, codec, self.buffer_pool.clone()));
         }
 
         let mut guard = self.shared.phase2_files.write().expect("phase2_files rwlock poisoned");
@@ -2136,6 +2228,66 @@ mod tests {
         let pool = BufferPool::new(4);
         let buf = pool.checkout();
         assert!(buf.is_empty());
+    }
+
+    /// `PermitPool` must behave as a bounded semaphore: `capacity` initial
+    /// permits, `release()` (lock-free) returns permits, and `close()` makes a
+    /// subsequent blocking `acquire()` error instead of parking forever.
+    #[test]
+    fn test_permit_pool_acquire_release_close() {
+        let pool = PermitPool::new(2);
+        // Drain the two initial permits.
+        pool.acquire().expect("permit 1");
+        pool.acquire().expect("permit 2");
+
+        // Release one and re-acquire it.
+        pool.release();
+        pool.acquire().expect("re-acquire released permit");
+
+        // Closing unblocks/erros a subsequent acquire rather than parking.
+        pool.close();
+        assert!(pool.acquire().is_err(), "acquire after close must error");
+        // release() after close is a harmless no-op.
+        pool.release();
+    }
+
+    /// A producer parked in `acquire()` (pool fully drained) must be woken with
+    /// `Err` when `close()` runs from another thread — it must not hang. This
+    /// pins the closure-liveness property of the lock-free `ArcSwapOption`
+    /// sender even in the (currently unused) cross-thread close case.
+    #[test]
+    fn test_permit_pool_close_wakes_parked_acquire() {
+        use std::sync::Arc as StdArc;
+        let pool = StdArc::new(PermitPool::new(1));
+        pool.acquire().expect("drain the lone permit");
+
+        let waiter = {
+            let pool = StdArc::clone(&pool);
+            std::thread::spawn(move || pool.acquire())
+        };
+        // Give the waiter time to park in `rx.recv()`, then close from here.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        pool.close();
+
+        let result = waiter.join().expect("waiter thread joins");
+        assert!(result.is_err(), "close() must wake the parked acquire() with Err, not hang");
+    }
+
+    /// Fail closed: a pool closed before any `acquire()` must reject acquirers
+    /// immediately, even though the channel still holds its `capacity` initial
+    /// permits. Without the `closed` flag, `recv()` would hand those buffered
+    /// permits out (`Ok`) until the channel drained, so a writer-error `close()`
+    /// would not stop producers promptly.
+    #[test]
+    fn test_permit_pool_close_fails_closed_with_buffered_permits() {
+        let pool = PermitPool::new(4); // 4 initial permits still buffered in the channel
+        pool.close();
+        for i in 0..4 {
+            assert!(
+                pool.acquire().is_err(),
+                "acquire() #{i} after close must fail closed despite buffered permits",
+            );
+        }
     }
 
     #[test]
@@ -2404,7 +2556,7 @@ mod tests {
     fn empty_phase2_file() -> Phase2FileState {
         let tmp = tempfile::tempfile().expect("failed to create tempfile");
         let reader = BufReader::with_capacity(1024, tmp);
-        Phase2FileState::new(reader, SpillCodec::Bgzf)
+        Phase2FileState::new(reader, SpillCodec::Bgzf, BufferPool::new(4))
     }
 
     /// Build a tiny placeholder raw block whose contents we never decode.
@@ -2469,8 +2621,56 @@ mod tests {
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
     }
 
+    /// FORWARD-PROGRESS GUARD (S3-025) — the exact scenario the cooperative
+    /// `merge_slots` Phase-2 path deadlocked on: EVERY file's reorder buffer at
+    /// `PHASE2_DECOMP_CAP` simultaneously, each stuck on its `next_seq` gap. The
+    /// pool path must stay live: the gap-filler exception admits each file's
+    /// next-expected serial regardless of the global cap pressure, so the
+    /// consumer can pop and drain rather than stalling globally. This pins the
+    /// liveness property the by-construction immunity (and the deferred
+    /// two-driver split) rests on, without standing up a real BAM merge.
     #[test]
-    fn test_admission_at_cap_stuck_wrong_head_rejects() {
+    fn test_phase2_gap_filler_admits_for_every_file_at_cap_simultaneously() {
+        const K: usize = 4;
+        let files: Vec<Phase2FileState> = (0..K).map(|_| empty_phase2_file()).collect();
+        // Put every file simultaneously at cap with a gap at serial 0 and its
+        // gap-filler waiting at the raw-blocks head.
+        for file in &files {
+            {
+                let mut dec = file.decompressed.lock().expect("dec lock");
+                for s in 1..=PHASE2_DECOMP_CAP as u64 {
+                    dec.insert(s, vec![0u8; 4]);
+                }
+                assert!(!dec.can_pop(), "each file should be stuck waiting for serial 0");
+            }
+            file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        }
+        // No file may be starved: each admits its own gap-filler at next_seq.
+        for (i, file) in files.iter().enumerate() {
+            let popped = SortWorkerPool::try_pop_raw_for_decompress(file);
+            assert!(
+                popped.is_some(),
+                "file {i}: gap-filler must admit despite all files at cap (no global stall)"
+            );
+            assert_eq!(popped.expect("admitted").0, 0, "admitted block must be next_seq 0");
+            assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
+        }
+    }
+
+    /// INVARIANT GUARD — pins the cap predicate's rejection branch, not a
+    /// reachable production state.
+    ///
+    /// Premise (reorder buffer stuck on `next_seq = 0` while `raw_blocks` head
+    /// is `CAP + 1`) is unreachable on the live path: serial 0 cannot leave
+    /// `raw_blocks` without being inserted into the reorder buffer (the
+    /// `Phase2FileState` single-reader gapless-FIFO invariant). The test exists
+    /// so that a future "simplification" of `try_pop_raw_for_decompress` which
+    /// drops the `head_serial == next_seq` conjunct — which would defeat the
+    /// `PHASE2_DECOMP_CAP` soft memory bound by admitting non-gap-filler blocks
+    /// over the cap — fails loudly here. Its sibling
+    /// `test_admission_at_cap_stuck_admits_gap_filler` covers the reachable case.
+    #[test]
+    fn test_admission_at_cap_stuck_wrong_head_rejects_invariant_guard() {
         let file = empty_phase2_file();
         // Same setup as gap-filler test, but the head raw is NOT the
         // gap-filler — admission must reject and the merge must rely on

--- a/docs/design/sort-phase2-unification-deferral.md
+++ b/docs/design/sort-phase2-unification-deferral.md
@@ -1,0 +1,77 @@
+# Sort Phase-2 merge: two drivers, unification deferred
+
+## Status: DEFERRED (not a feat-runall blocker)
+
+fgumi's external sort has **two** Phase-2 (merge) drivers, and they exist by
+design:
+
+- **Pool / standalone** (`crates/fgumi-sort/src/worker_pool.rs`,
+  `external.rs::merge_chunks_generic`) — drives standalone file-to-file
+  `fgumi sort`. Work-stealing pool reads + decompresses spill blocks in
+  parallel; the merge consumer is a **parked OS thread**
+  (`advance_to_next_block`). Keeps `--write-index`, `--verify`, zstd spill.
+- **Streaming / runall** (`crates/fgumi-sort/src/merge_slots.rs`,
+  `external.rs::MergeDriver`) — drives the fused in-pipeline `runall` sort. A
+  cooperative `try_run` state machine that yields (`Stalled`/`WouldBlock`)
+  instead of blocking, so it composes with the typed-step pipeline framework.
+
+Unifying these onto a single driver is a deliberate **future** refactor with its
+own design + bench gate + deadlock re-analysis. It is intentionally NOT done in
+the feat-runall line.
+
+## What is already shared (so the duplication is smaller than it looks)
+
+- `LoserTree<K>` (`loser_tree.rs`) — the actual k-way merge / tie-break
+  primitive. Both drivers use the one implementation.
+- `RawSortKey` comparators and the `keys.rs` key types.
+- `ReorderBuffer` (`fgumi-bam-io`) — also used by Phase-1 read-ahead, so it is a
+  shared utility, not pool-specific duplication.
+
+What genuinely differs is the **driver** (the outer drive loop and the
+read/decompress topology), not the merge core.
+
+## Why the streaming path dropped the pool's machinery
+
+The pre-v4 streaming slot also carried a `raw_blocks` FIFO, a `decomp_in_flight`
+counter, a reorder buffer, and a cap+gap-filler admission rule. That design
+**deadlocked at production scale**: the framework's drain protocol could Skip
+workers during a transient "all slots at cap simultaneously" window. v4 collapsed
+read-and-decompress into one inline op per worker per slot, which made a plain
+bounded FIFO correct (blocks decompress strictly in read order) and removed the
+deadlock surface.
+
+The pool path keeps all of that machinery and is **immune** to the same
+deadlock, because (a) its consumer is a parked OS thread the engine cannot Skip,
+and (b) it is single-*reader* but **multi-*decompressor*** — workers decompress
+in parallel, so completion order ≠ pop order, and the reorder buffer +
+in-flight counter are a *correctness* dependency (they re-order out-of-order
+completions and close the `is_drained` truncation race), not redundancy.
+
+## Prerequisites before unification is even attemptable
+
+1. The streaming path gains a true file-to-file drive (BAM source +
+   bgzf-decompress + parse → SortAndSpill → SortSpillDecompress → SortMerge →
+   serialize → WriteBgzfFile).
+2. `--write-index` (`.bai`) wired onto/alongside that chain (the pool path has
+   it via `IndexBamFinalizeHook`, PR #393; the streaming step does not).
+3. `--verify` ported (today a separate read-and-check path, designed to stay
+   legacy).
+4. A deadlock-safe consumer for the file-to-file case — the streaming consumer
+   is the cooperative `try_run` model that hit the v4 production deadlock.
+
+## Explicit risk
+
+Routing standalone sort through the streaming path **re-opens the v4
+cooperative-consumer deadlock** that standalone sort is currently immune to
+(parked OS thread). Until all four prerequisites land, it is a net capability
+LOSS + added risk and buys no shipped feature.
+
+## Safe-to-pursue-independently sub-step (does NOT require the above)
+
+Factor the shared **per-winner merge-emit core**: both drivers already share
+`LoserTree`, so extract a `MergeSource<K>` trait (`try_next_record`) + a single
+`merge_emit(tree, sources, emit_fn)` core that the pool's blocking loop and the
+streaming state machine both call one-winner-at-a-time. Keep the
+blocking-vs-cooperative **outer** drive separate — that is the deadlock-relevant
+axis and must NOT be merged. MED risk (hot-loop perf; needs a sort bench
+matrix), but carries no deadlock surface.

--- a/docs/design/sort-queryname-arena-deferral.md
+++ b/docs/design/sort-queryname-arena-deferral.md
@@ -1,0 +1,69 @@
+# Queryname sort: arena unification deferred
+
+## Status: DEFERRED (not a feat-runall blocker)
+
+The in-memory Phase-1 buffer for the **queryname** sort orders stores
+`Vec<(K, RawRecord)>` — one owned record-byte allocation *and* one owned key
+allocation per record. The **coordinate** and **template-coordinate** orders do
+not: the inline-buffer work (#432) copies each record's bytes once into a shared
+segmented byte arena (`RecordBuffer` / `SegmentedBuf` in `inline.rs`) and stores
+only `RecordRef { sort_key, offset, len }` entries, which are radix/comparison
+-sorted and then written by slicing the arena. The owned `RecordSource::Iterator`
+`Direct` arm (`read_ahead.rs`) — and its per-record `RawRecord` allocation — is
+used **only** by the queryname path.
+
+This is the substance of finding **S3-015**. The reviewer's suggested fix
+(hold a scratch `RawRecord` in the `Direct` variant and `mem::take` it out per
+`next()`) is a **no-op**: `mem::take` hands the caller the scratch's buffer and
+leaves an empty (capacity-0) `Vec` behind, so the next `read_raw_record`
+`resize` reallocates exactly as `RawRecord::default()` does today. No reuse is
+possible on owned iteration because `sort_queryname_keyed` *retains* every
+yielded record in its `entries` buffer until spill — each live record genuinely
+needs its own buffer.
+
+## Why the queryname path is the holdout
+
+Coordinate/template keys are fixed-width packed integers (`u64`/`u96`/…), so the
+`RecordRef`-style entry carries the key inline and the arena holds bytes only.
+Queryname keys are **variable-length byte strings** (the read name), so the
+naive entry can't be a fixed-width field — which is why this path fell back to
+owning both the record and the key.
+
+## The principled solution
+
+Extend the inline arena to the queryname path so all three orders share one
+zero-per-record-allocation representation:
+
+1. **Record bytes** → the shared `SegmentedBuf` arena (offset/len ref), exactly
+   like coordinate/template. Records are copied in once via
+   `RecordSource::next_record_borrowed` (the borrow-in-place path), so the owned
+   `Iterator::next` `Direct` arm becomes dead and can be removed.
+2. **Keys** → one of:
+   - a parallel **key-arena**: name bytes pooled with offset/len refs (no
+     per-key `Vec`), entries become `(KeyRef, RecordRef)`; or
+   - a **small inline key**: a name hash + tiebreak stored inline, with the full
+     name re-derived from the record slice (via the arena) at comparison time
+     for the rare hash-collision path.
+
+The sort then sorts `(key, ref)` entries; spill and final write slice the arena.
+This collapses coordinate, template-coordinate, and queryname onto one
+`KeyedRecordBuffer<K>`-style abstraction.
+
+## Prerequisites / why it is deferred
+
+- A `KeyedRecordBuffer<K>` (or generalization of `RecordBuffer`) that holds a
+  variable-length key alongside each `RecordRef`, plus the key-arena or
+  inline-key comparator.
+- The spill writer (`PooledChunkWriter`) and merge packing (`MemorySources`)
+  must consume `(key, range)` slices instead of owned `RawRecord`s on the
+  queryname path (the coordinate/template paths already do the arena form).
+- A **sort bench matrix** (queryname-lex and queryname-natural, in-memory and
+  multi-spill, single- and multi-threaded) to confirm the arena form does not
+  regress comparison-sort throughput — the keyed comparison is hotter than the
+  packed-integer radix, so the key representation must be benched, not assumed.
+
+Until those land, the per-record allocation on the queryname path is an
+accepted, documented tradeoff (see the `sort_queryname_keyed` comment noting the
+owned-`RawRecord` accumulation, and the `RecordSource::Iterator` `Direct` arm
+PERF NOTE). It is correctness-neutral; only allocation churn is at stake, which
+`force_mi_collect()` after each spill already mitigates.

--- a/src/lib/pipeline/chains/build.rs
+++ b/src/lib/pipeline/chains/build.rs
@@ -31,7 +31,7 @@
 use anyhow::{Result, bail};
 
 use crate::pipeline::chains::{
-    BuiltPipeline, ChainSpec, Stage,
+    BuiltPipeline, ChainSpec,
     builder::{ChainBuilder, StagePosition},
     validate::{
         validate_cross_stage_constraints, validate_stage_opts_present, validate_stage_progression,
@@ -81,8 +81,9 @@ pub fn build_for(spec: ChainSpec) -> Result<BuiltPipeline> {
     }
 
     // Sort-terminal special case: SortBamFile is self-contained (reads/writes
-    // files directly). Skip add_source and add_sink.
-    let sort_terminal = matches!(spec.stages.as_slice(), [Stage::Sort]);
+    // files directly). Skip add_source and add_sink. Single-sourced with
+    // `ChainBuilder::new`'s header-open skip via `ChainSpec::is_sort_terminal`.
+    let sort_terminal = spec.is_sort_terminal();
 
     let mut chain = ChainBuilder::new(&spec)?;
 

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -445,8 +445,9 @@ impl<'a> ChainBuilder<'a> {
         // Opening the source here would be wasted work — and for a stdin input
         // it would drain the pipe before `SortBamFile` reads it, leaving the
         // engine to fail on an empty stdin. The header resolved here is unused
-        // by the sort-terminal branch, so skip the open entirely.
-        let sort_terminal = matches!(spec.stages.as_slice(), [Stage::Sort]);
+        // by the sort-terminal branch, so skip the open entirely. Single-sourced
+        // with `build_for`'s source/sink skip via `ChainSpec::is_sort_terminal`.
+        let sort_terminal = spec.is_sort_terminal();
         let (header, pending_source) = if sort_terminal {
             (Header::default(), None)
         } else {
@@ -2047,6 +2048,7 @@ impl<'a> ChainBuilder<'a> {
                 output_compression: self.spec.compression.compression_level,
                 command_line: self.spec.command_line.clone(),
                 stats_slot: Arc::clone(&stats_slot),
+                async_reader: self.spec.async_reader,
             })?;
 
             // Register SortBamFile as a source (Input = (), Outputs = ()).

--- a/src/lib/pipeline/chains/spec.rs
+++ b/src/lib/pipeline/chains/spec.rs
@@ -32,3 +32,19 @@ pub struct ChainSpec {
     /// For `@PG` line injection into the output header.
     pub command_line: String,
 }
+
+impl ChainSpec {
+    /// Whether this is the standalone sort-terminal chain (`[Stage::Sort]`).
+    ///
+    /// This layout is special: `build_for` skips `add_source`/`add_sink` and the
+    /// terminal `SortBamFile` step opens and reads the input itself. Both the
+    /// source/sink skip in `build_for` and the header-open skip in
+    /// `ChainBuilder::new` MUST agree on this predicate — if they drift, a
+    /// sort-terminal chain could open its source twice (draining a stdin pipe
+    /// before the sort engine reads it). Single-source the test here so the two
+    /// call sites cannot disagree.
+    #[must_use]
+    pub fn is_sort_terminal(&self) -> bool {
+        matches!(self.stages.as_slice(), [Stage::Sort])
+    }
+}

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -337,6 +337,17 @@ mod tests {
     }
 
     #[test]
+    fn is_sort_terminal_only_for_lone_sort() {
+        // The single-sourced predicate that both `build_for` (source/sink skip)
+        // and `ChainBuilder::new` (header-open skip) rely on.
+        assert!(empty_spec(vec![Stage::Sort]).is_sort_terminal());
+        assert!(!empty_spec(vec![]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Group, Stage::Sort]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Sort, Stage::Group]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Correct, Stage::Sort]).is_sort_terminal());
+    }
+
+    #[test]
     fn good_chain_accepted() {
         let spec = empty_spec(vec![Stage::Sort, Stage::Group, Stage::Simplex]);
         validate_stage_progression(&spec).expect("good chain should validate");


### PR DESCRIPTION
**Stack: 3 / 6** · base: `nh/runall-fix-2-rejects-codec`

Hardening and cleanup of the runall-sort Phase-2 (merge) engine, plus restored sort CLI flags.

- **Phase-2 protocol** — `SortMerge` fails closed on a duplicate `AllAnnounced` and on an unexpectedly-shared `MemoryChunk` Arc (instead of warn-and-overwrite / silent deep-clone); symmetric `u32` overflow guards; adaptive output-batch buffer sizing so a batch no longer reserves the full queue byte budget.
- **zstd Phase-2** — decompressed frame buffers are recycled through the worker pool's buffer pool; a compile-time assertion ties the decompress cap to the producer's frame bound.
- **PermitPool** — `release()` is now lock-free on the I/O-writer hot path (arc-swap).
- **CLI** — restore `--temp-codec` and `--key-types` and wire `--async-reader`; reject `--temp-codec zstd` + `--temp-compression 0` up front.
- **Cleanup** — slim dead Phase-2 plumbing; document the deliberate two-driver split and a queryname-arena deferral; strengthen the radix max-key contract and RSS-sampler docs; single-source the sort-terminal predicate; add a gap-filler forward-progress guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async input prefetching for standalone sort runs.
  * Added CLI options for temporary spill codec selection and customizable template-coordinate key lanes.
* **Bug Fixes**
  * Sort merge now fails fast on protocol/invariant violations, including duplicate “all announced” setup.
  * Improved merge output buffering to avoid over-reserving memory.
  * Improved zstd spill staging/decompression buffer recycling to preserve byte-identical output.
  * Added an upfront guard rejecting incompatible temp-compression settings for zstd.
* **Documentation**
  * Added/updated design notes explaining deferred Phase-2 and queryname arena unification work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->