### PR TITLE
fix/perf: per-crate correctness and hot-path optimizations (4/6)

### DIFF
--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -174,6 +174,16 @@ impl Default for GroupKey {
 /// This is the output of the Decode step and input to the Group step.
 /// The key is computed during the parallel Decode step so that the
 /// serial Group step only needs to do fast integer comparisons.
+///
+/// # Cached-UMI invariant
+///
+/// `umi_value_offset` / `umi_value_len` cache the position of the UMI value
+/// *within* `data`. The invariant is: **the cache is only valid while `data` is
+/// unmodified.** Any mutation of `data` that could shift or overwrite the UMI
+/// value bytes invalidates the cache. To enforce this cheaply, the sole
+/// mutable-bytes accessor ([`Self::raw_bytes_mut`]) resets the cache to
+/// [`Self::UMI_OFFSET_UNCACHED`] on hand-out, so a `cached_umi()` read after a
+/// mutation falls back to a re-scan instead of slicing stale bytes.
 #[derive(Debug)]
 pub struct DecodedRecord {
     /// Pre-computed grouping key.
@@ -232,7 +242,18 @@ impl DecodedRecord {
         }
         let start = self.umi_value_offset as usize;
         let end = start.checked_add(self.umi_value_len as usize)?;
-        self.data.as_ref().get(start..end)
+        let value = self.data.as_ref().get(start..end)?;
+        // The cache only ever holds a Z-typed UMI value (NUL-free by the BAM
+        // spec; the trailing NUL is excluded by `set_cached_umi`). If a mutation
+        // shifted the record bytes such that this offset now lands on a different
+        // region, the slice would typically contain an interior NUL — a cheap,
+        // zero-release-cost canary for a stale cache that survived bounds checks.
+        debug_assert!(
+            !value.contains(&0),
+            "stale cached UMI: offset {start} sliced bytes containing an interior NUL \
+             (the record was likely mutated without invalidating the UMI cache)"
+        );
+        Some(value)
     }
 
     /// Returns the cached UMI offset ([`Self::UMI_OFFSET_UNCACHED`] when absent)
@@ -267,7 +288,16 @@ impl DecodedRecord {
     /// or invalidating its pre-computed `GroupKey`. Caller must not
     /// change the record's identity (qname, library bytes, cell barcode)
     /// — those feed `key`, which we don't recompute here.
+    ///
+    /// Handing out mutable bytes resets the cached UMI position to
+    /// [`Self::UMI_OFFSET_UNCACHED`] (see the type-level cached-UMI invariant):
+    /// a length-changing edit before the UMI tag could shift the value while
+    /// leaving the old offset in-bounds, so a later `cached_umi()` would slice
+    /// stale-but-valid bytes. Clearing forces a re-scan instead. This is a
+    /// single field store and the cache is only repopulated by the decode step.
     pub fn raw_bytes_mut(&mut self) -> &mut RawRecord {
+        self.umi_value_offset = Self::UMI_OFFSET_UNCACHED;
+        self.umi_value_len = 0;
         &mut self.data
     }
 
@@ -694,5 +724,48 @@ mod tests {
                 "name_hash parity mismatch",
             );
         }
+    }
+
+    // ========================================================================
+    // DecodedRecord cached-UMI invalidation (S6-002)
+    // ========================================================================
+
+    /// Build a `DecodedRecord` carrying an RX UMI tag with its value position
+    /// cached, exactly as the Decode step's `cache_umi_position` would.
+    fn decoded_with_cached_umi(umi: &[u8]) -> DecodedRecord {
+        use fgumi_raw_bam::SamTag;
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30; 4]);
+        b.add_string_tag(SamTag::RX, umi);
+        let rec = b.build();
+        let bytes = rec.as_ref();
+        let aux_offset =
+            fgumi_raw_bam::aux_data_offset_from_record(bytes).expect("aux offset present");
+        let aux = &bytes[aux_offset..];
+        let (off_in_aux, len) =
+            fgumi_raw_bam::find_string_tag_position(aux, *SamTag::RX).expect("RX tag present");
+        let offset = u32::try_from(aux_offset).expect("aux offset fits u32") + off_in_aux;
+        let mut d = DecodedRecord::from_raw_bytes(rec, GroupKey::default());
+        d.set_cached_umi(offset, len);
+        d
+    }
+
+    #[test]
+    fn cached_umi_returns_value_then_raw_bytes_mut_invalidates() {
+        // The cache resolves to the UMI value up front; handing out mutable bytes
+        // must reset the cache to the sentinel so a later read re-scans rather
+        // than slicing stale-but-in-range bytes (see the cached-UMI invariant).
+        let mut decoded = decoded_with_cached_umi(b"ACGTACGT");
+        assert_eq!(decoded.cached_umi(), Some(b"ACGTACGT".as_ref()), "cache populated up front");
+        assert_ne!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+
+        let _ = decoded.raw_bytes_mut();
+
+        assert_eq!(
+            decoded.cached_umi_position().0,
+            DecodedRecord::UMI_OFFSET_UNCACHED,
+            "raw_bytes_mut resets the cache to the uncached sentinel",
+        );
+        assert!(decoded.cached_umi().is_none(), "cached_umi returns None after mutation");
     }
 }

--- a/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
+++ b/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
@@ -1,22 +1,32 @@
-//! Multithreaded BGZF writer with position tracking.
+//! Multithreaded BGZF writer with coarse progress counters.
 //!
 //! This module provides [`MultithreadedWriter`], a parallel BGZF compression writer
-//! that maintains block ordering and supports position tracking for building indexes
-//! during concurrent writes.
+//! that maintains block ordering and exposes a few coarse progress counters.
 //!
 //! Some accessors and constructors are only exercised by tests; the
 //! `dead_code` allow at module scope keeps them available for the test harness.
 
 #![allow(dead_code)]
 //!
-//! # Position Tracking
+//! # Progress Counters (not an exact block→offset index)
 //!
-//! The writer provides APIs to track compressed file positions, enabling construction
-//! of BAM indexes (BAI/CSI) without a second pass through the file:
+//! The writer exposes a few coarse counters describing how far compression and
+//! output have progressed:
 //!
-//! - [`current_block_number`](MultithreadedWriter::current_block_number): Block number being filled
-//! - [`buffer_offset`](MultithreadedWriter::buffer_offset): Bytes in current block's staging buffer
-//! - [`block_info_receiver`](MultithreadedWriter::block_info_receiver): Channel for block completion notifications
+//! - [`current_block_number`](MultithreadedWriter::current_block_number): the block index
+//!   currently being filled (incremented when a block is *enqueued* for compression)
+//! - [`buffer_offset`](MultithreadedWriter::buffer_offset): bytes in the current block's staging buffer
+//! - [`position`](MultithreadedWriter::position): total compressed bytes flushed by the writer thread
+//! - [`blocks_written`](MultithreadedWriter::blocks_written): count of blocks flushed by the writer thread
+//!
+//! **These counters are NOT an exact block→compressed-offset map and must not be used
+//! to build BAI/CSI virtual offsets.** `current_block_number` advances at enqueue time
+//! while `position`/`blocks_written` reflect only what the writer thread has already
+//! flushed, so with multiple blocks in flight there is no way to recover the unique
+//! compressed start offset of a given block from these globals. Index construction
+//! that needs exact offsets must obtain them another way (e.g. a real per-block
+//! position API, or a second pass that re-reads the finished BGZF stream — the latter
+//! is what fgumi's BAI generation does).
 
 use std::io::{self, Write};
 use std::mem;
@@ -26,7 +36,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
 
 use bytes::{Bytes, BytesMut};
-use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
+use crossbeam_channel::{Receiver, Sender, bounded};
 
 use bgzf::{BgzfError, CompressionLevel, Compressor};
 
@@ -57,28 +67,6 @@ type BgzfResult<T> = Result<T, BgzfError>;
 // Types
 // ============================================================================
 
-/// Information about a completed BGZF block.
-///
-/// Sent through [`BlockInfoRx`] when a block is written to the output.
-/// Use this to resolve virtual file positions for BAM index construction.
-#[derive(Debug, Clone, Copy)]
-pub struct BlockInfo {
-    /// The block number (0-indexed, assigned when block is sent for compression).
-    pub block_number: u64,
-    /// The compressed file position where this block starts.
-    pub compressed_start: u64,
-    /// The size of the compressed block (including header and footer).
-    pub compressed_size: usize,
-    /// The size of the uncompressed data in this block.
-    pub uncompressed_size: usize,
-}
-
-/// Receiver for [`BlockInfo`] notifications.
-///
-/// Clone this receiver and use `try_recv()` or `recv()` to receive
-/// block completion notifications as they occur.
-pub type BlockInfoRx = Receiver<BlockInfo>;
-
 // Internal channel types
 type FrameParts = (Vec<u8>, u32, usize); // (compressed_data, crc32, uncompressed_size)
 type BufferedTx = Sender<BgzfResult<FrameParts>>;
@@ -87,7 +75,6 @@ type DeflateTx = Sender<(Bytes, BufferedTx)>;
 type DeflateRx = Receiver<(Bytes, BufferedTx)>;
 type WriteTx = Sender<(BufferedRx, u64)>;
 type WriteRx = Receiver<(BufferedRx, u64)>;
-type BlockInfoTx = Sender<BlockInfo>;
 
 // ============================================================================
 // State
@@ -99,7 +86,6 @@ enum State<W> {
         deflater_handles: Vec<JoinHandle<()>>,
         write_tx: WriteTx,
         deflate_tx: DeflateTx,
-        block_info_rx: BlockInfoRx,
     },
     Done,
 }
@@ -116,8 +102,7 @@ enum State<W> {
 ///
 /// # Thread Safety
 ///
-/// The writer itself is not `Send` or `Sync`, but the [`BlockInfoRx`] receiver
-/// can be cloned and used from other threads.
+/// The writer itself is not `Send` or `Sync`.
 pub struct MultithreadedWriter<W>
 where
     W: Write + Send + 'static,
@@ -170,28 +155,16 @@ where
         // Create channels
         let (deflate_tx, deflate_rx) = bounded(worker_count.get());
         let (write_tx, write_rx) = bounded(worker_count.get());
-        let (block_info_tx, block_info_rx) = unbounded();
 
         // Spawn deflater workers
         let deflater_handles = spawn_deflaters(compression_level, worker_count, deflate_rx);
 
         // Spawn writer thread
-        let writer_handle = spawn_writer(
-            inner,
-            write_rx,
-            Arc::clone(&position),
-            Arc::clone(&blocks_written),
-            block_info_tx,
-        );
+        let writer_handle =
+            spawn_writer(inner, write_rx, Arc::clone(&position), Arc::clone(&blocks_written));
 
         Self {
-            state: State::Running {
-                writer_handle,
-                deflater_handles,
-                write_tx,
-                deflate_tx,
-                block_info_rx,
-            },
+            state: State::Running { writer_handle, deflater_handles, write_tx, deflate_tx },
             buf: BytesMut::with_capacity(blocksize),
             blocksize,
             current_block_number: 0,
@@ -200,24 +173,14 @@ where
         }
     }
 
-    // === Position Tracking APIs ===
+    // === Progress Counters (coarse; not an exact block→offset index) ===
 
-    /// Returns the receiver for block completion notifications.
+    /// Returns the index of the block currently being filled.
     ///
-    /// Returns `None` if the writer has already been finished.
-    #[must_use]
-    pub fn block_info_receiver(&self) -> Option<&BlockInfoRx> {
-        match &self.state {
-            State::Running { block_info_rx, .. } => Some(block_info_rx),
-            State::Done => None,
-        }
-    }
-
-    /// Returns the next block number to be assigned.
-    ///
-    /// This is incremented each time a block is sent for compression.
-    /// Use this value when caching index entries to correlate with
-    /// [`BlockInfo::block_number`] in completion notifications.
+    /// This is incremented each time a block is *enqueued* for compression, so it
+    /// runs ahead of the writer thread. It is a block *identifier*, not a position:
+    /// it cannot be combined with [`position`](Self::position) to recover a block's
+    /// exact compressed offset (see the module-level "Progress Counters" note).
     #[inline]
     #[must_use]
     pub fn current_block_number(&self) -> u64 {
@@ -273,13 +236,7 @@ where
         let state = mem::replace(&mut self.state, State::Done);
 
         match state {
-            State::Running {
-                writer_handle,
-                mut deflater_handles,
-                write_tx,
-                deflate_tx,
-                block_info_rx: _,
-            } => {
+            State::Running { writer_handle, mut deflater_handles, write_tx, deflate_tx } => {
                 // Drop channels to signal shutdown
                 drop(deflate_tx);
 
@@ -496,19 +453,17 @@ fn spawn_writer<W>(
     write_rx: WriteRx,
     position: Arc<AtomicU64>,
     blocks_written: Arc<AtomicU64>,
-    block_info_tx: BlockInfoTx,
 ) -> JoinHandle<BgzfResult<W>>
 where
     W: Write + Send + 'static,
 {
     thread::spawn(move || {
-        while let Ok((buffered_rx, block_number)) = write_rx.recv() {
+        while let Ok((buffered_rx, _block_number)) = write_rx.recv() {
             // Wait for compression result
-            let (compressed_data, _crc32, uncompressed_size) = buffered_rx
+            let (compressed_data, _crc32, _uncompressed_size) = buffered_rx
                 .recv()
                 .map_err(|_| BgzfError::Io(io::Error::other("Compression channel closed")))??;
 
-            let compressed_start = position.load(Ordering::Acquire);
             let compressed_size = compressed_data.len();
 
             // Write compressed block
@@ -517,14 +472,6 @@ where
             // Update position
             position.fetch_add(compressed_size as u64, Ordering::Release);
             blocks_written.fetch_add(1, Ordering::Release);
-
-            // Send block info notification
-            let _ = block_info_tx.send(BlockInfo {
-                block_number,
-                compressed_start,
-                compressed_size,
-                uncompressed_size,
-            });
         }
 
         // Write EOF marker
@@ -596,30 +543,26 @@ mod tests {
     }
 
     #[test]
-    fn test_block_info_notifications() {
+    fn test_block_counters_track_flushed_blocks() {
         let mut writer = MultithreadedWriter::with_worker_count(
             NonZero::new(2).expect("non-zero value 2"),
             Vec::new(),
             CompressionLevel::new(6).expect("valid compression level 6"),
         );
 
-        let rx = writer
-            .block_info_receiver()
-            .expect("block_info_receiver should return a receiver")
-            .clone();
-
         writer.write_all(b"block1").expect("write_all should succeed");
         writer.flush().expect("flush should succeed");
         writer.write_all(b"block2").expect("write_all should succeed");
         writer.flush().expect("flush should succeed");
 
+        // Two blocks were sent for compression.
+        assert_eq!(writer.current_block_number(), 2);
+
         writer.finish().expect("finish should succeed");
 
-        let infos: Vec<_> = rx.try_iter().collect();
-        assert_eq!(infos.len(), 2);
-        assert_eq!(infos[0].block_number, 0);
-        assert_eq!(infos[1].block_number, 1);
-        assert!(infos[1].compressed_start > 0);
+        // Both blocks reached the writer thread (position advanced past 0).
+        assert_eq!(writer.blocks_written(), 2);
+        assert!(writer.position() > 0);
     }
 
     #[test]
@@ -682,12 +625,18 @@ mod tests {
 
     #[test]
     fn test_builder() {
-        let writer = Builder::default()
+        let mut writer = Builder::default()
             .set_compression_level(CompressionLevel::new(9).expect("valid compression level 9"))
             .set_worker_count(NonZero::new(4).expect("non-zero value 4"))
             .set_blocksize(32768)
             .build_from_writer(Vec::new());
 
-        assert!(writer.block_info_receiver().is_some());
+        writer.write_all(b"builder roundtrip").expect("write_all should succeed");
+        let data = writer.finish().expect("finish should succeed");
+
+        let mut reader = Reader::new(&data[..]);
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).expect("read_to_end should succeed");
+        assert_eq!(buf, b"builder roundtrip");
     }
 }

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -534,10 +534,12 @@ fn decompress_and_verify(
 /// * `LEN == uncompressed_size` — the deflate frame's LEN agrees with the
 ///   BGZF footer's ISIZE field.
 ///
-/// NLEN (one's complement of LEN) is not checked. NLEN doesn't cover the
-/// payload bytes, so a corrupt NLEN with an intact payload would pass the
-/// framing check anyway; the BGZF footer's CRC32 is the authoritative
-/// integrity check on the data itself.
+/// NLEN (one's complement of LEN) is intentionally skipped: the BGZF footer
+/// CRC32 (verified below on the copied bytes) is authoritative over the
+/// payload, so a mismatched NLEN with a CRC-correct payload is accepted, and a
+/// corrupt payload is caught by CRC regardless of NLEN. (This is a deliberate
+/// "trust CRC over deflate framing" choice — NLEN doesn't cover the payload
+/// bytes, so it adds nothing the CRC doesn't already guarantee.)
 ///
 /// CRC32 verification against the BGZF footer is still performed on the
 /// copied bytes (the BGZF spec mandates it, and the bypass is intended to
@@ -668,6 +670,42 @@ mod tests {
         let mut reader = Cursor::new(Vec::<u8>::new());
         let result = read_raw_block(&mut reader).expect("reading raw BGZF block should succeed");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_truncated_block_errors() {
+        // Regression guard for the `read_to_end`-based ingest path: a header that
+        // advertises a `block_size` larger than the bytes actually supplied must
+        // surface as a "truncated BGZF block" `UnexpectedEof`, NOT silently
+        // succeed. `read_to_end` returns `Ok` on early EOF, so the manual length
+        // check (and the `.take()` that bounds it) is the sole guard restoring
+        // `read_exact`'s short-block error semantics. Dropping or mis-bounding
+        // that check would regress here.
+
+        // Build a valid 18-byte header that passes magic/method/FEXTRA/BC checks.
+        let mut data = vec![0u8; BGZF_HEADER_SIZE];
+        data[0] = 0x1f; // magic
+        data[1] = 0x8b; // magic
+        data[2] = 0x08; // CM = DEFLATE
+        data[3] = 0x04; // FLG = FEXTRA
+        data[12] = b'B'; // BC subfield id
+        data[13] = b'C';
+        // BSIZE = block_size - 1. Advertise a block of 100 bytes total, i.e. it
+        // claims `100 - 18 = 82` body bytes follow the header.
+        let block_size: usize = 100;
+        let bsize = u16::try_from(block_size - 1).expect("bsize fits u16");
+        data[16..18].copy_from_slice(&bsize.to_le_bytes());
+
+        // Append only a partial body: far fewer than the advertised 82 bytes.
+        data.extend_from_slice(&[0u8; 10]);
+
+        let mut reader = Cursor::new(data);
+        let err = read_raw_block(&mut reader).expect_err("truncated block must error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("truncated BGZF block"),
+            "expected a truncated-block error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/fgumi-bgzf/src/writer.rs
+++ b/crates/fgumi-bgzf/src/writer.rs
@@ -184,6 +184,29 @@ impl InlineBgzfCompressor {
         std::mem::take(&mut self.completed_blocks)
     }
 
+    /// Return a drained block buffer to the internal pool for reuse by a later
+    /// [`compress_current_buffer`](Self::compress_current_buffer).
+    ///
+    /// Consumers that drive the compressor with [`write_all`](Self::write_all) +
+    /// [`flush`](Self::flush) + [`take_blocks`](Self::take_blocks) (rather than
+    /// [`write_blocks_to`](Self::write_blocks_to), which recycles automatically)
+    /// otherwise leave `buffer_pool` empty, so every block compression allocates
+    /// a fresh output `Vec`. Such a consumer can hand back any block `Vec` it is
+    /// done with via this method to restore the recycling.
+    ///
+    /// The buffer is cleared before being pooled. The pool is bounded to a small
+    /// number of buffers so a bursty consumer cannot grow it without limit; once
+    /// full, the handed-back buffer is simply dropped.
+    pub fn recycle_buffer(&mut self, mut buffer: Vec<u8>) {
+        /// Cap on pooled buffers. A single compressor processes one block at a
+        /// time, so a handful of recycled buffers fully covers steady state.
+        const MAX_POOLED_BUFFERS: usize = 4;
+        if self.buffer_pool.len() < MAX_POOLED_BUFFERS {
+            buffer.clear();
+            self.buffer_pool.push(buffer);
+        }
+    }
+
     /// Write all completed compressed blocks directly to output and recycle buffers.
     ///
     /// This is efficient for single-threaded use as it writes blocks directly
@@ -361,6 +384,40 @@ mod tests {
 
         // Both should produce identical output
         assert_eq!(output1, output2);
+    }
+
+    #[test]
+    fn test_recycle_buffer_reuses_pool_without_corrupting_output() {
+        let data = b"recycle pool roundtrip data";
+
+        // Reference output from a fresh compressor.
+        let mut reference = InlineBgzfCompressor::new(6);
+        reference.write_all(data).expect("write");
+        reference.flush().expect("flush");
+        let expected: Vec<u8> = reference.take_blocks().into_iter().flat_map(|b| b.data).collect();
+
+        // Compressor that hands its drained block buffer back to the pool, then
+        // compresses again — the recycled buffer must not corrupt the output.
+        let mut compressor = InlineBgzfCompressor::new(6);
+        compressor.write_all(data).expect("write");
+        compressor.flush().expect("flush");
+        for block in compressor.take_blocks() {
+            compressor.recycle_buffer(block.data);
+        }
+        compressor.write_all(data).expect("write");
+        compressor.flush().expect("flush");
+        let second: Vec<u8> = compressor.take_blocks().into_iter().flat_map(|b| b.data).collect();
+        assert_eq!(second, expected);
+    }
+
+    #[test]
+    fn test_recycle_buffer_is_bounded() {
+        let mut compressor = InlineBgzfCompressor::new(6);
+        // Hand back far more buffers than the cap; the pool must stay bounded.
+        for _ in 0..100 {
+            compressor.recycle_buffer(vec![0u8; 64]);
+        }
+        assert!(compressor.buffer_pool.len() <= 4, "pool must be capped");
     }
 
     #[test]

--- a/crates/fgumi-cli-common/Cargo.toml
+++ b/crates/fgumi-cli-common/Cargo.toml
@@ -12,10 +12,13 @@ anyhow = "1.0.102"
 bytesize = "2.3"
 clap = { version = "4", features = ["derive", "string"] }
 enum_dispatch = "0.3.13"
-log = "0"
+log = "0.4"
 num_cpus = "1.16"
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 thiserror = "2"
 
 [dev-dependencies]
-rstest = "0"
+rstest = "0.26"
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-cli-common/src/lib.rs
+++ b/crates/fgumi-cli-common/src/lib.rs
@@ -185,6 +185,8 @@ pub fn format_duration(duration: std::time::Duration) -> String {
 ///
 /// assert_eq!(format_rate(1000, Duration::from_secs(1)), "1,000 items/s");
 /// assert_eq!(format_rate(600, Duration::from_secs(60)), "10 items/s");
+/// // Below one item per second the units switch to items/min.
+/// assert_eq!(format_rate(30, Duration::from_secs(60)), "30.0 items/min");
 /// ```
 #[must_use]
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -295,9 +297,9 @@ pub fn parse_memory_size(size_str: &str) -> FgumiResult<u64> {
         if mb_value > 1_000_000 {
             return Err(FgumiError::InvalidMemorySize {
                 reason: format!(
-                    "Plain number memory size too large: {} MiB. Use human-readable format like '{}GB' instead.",
+                    "Plain number memory size too large: {} MiB. Use human-readable format like '{}GiB' instead.",
                     mb_value,
-                    mb_value / 1000
+                    mb_value / 1024
                 ),
             });
         }
@@ -746,5 +748,54 @@ mod tests {
         // available = total.saturating_sub(margin) = 0; target = max(0, MIN) = MIN;
         // budget = MIN.min(0) = 0.
         assert_eq!(budget, 0);
+    }
+
+    #[test]
+    fn test_resolve_memory_budget_threads_zero_bails() {
+        // `threads == 0` is an invalid input and must bail before any
+        // per-thread arithmetic.
+        let err = resolve_memory_budget_with_total(
+            MemoryLimit::Fixed(512 * 1024 * 1024),
+            MemoryReserve::Auto,
+            0,
+            true,
+            32 * 1024 * 1024 * 1024,
+        )
+        .expect_err("threads == 0 must be rejected");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--threads must be at least 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_resolve_memory_budget_fixed_per_thread_overflow() {
+        // Fixed(usize::MAX) × 2 threads overflows the `checked_mul`, which must
+        // surface an error rather than wrap.
+        let err = resolve_memory_budget_with_total(
+            MemoryLimit::Fixed(usize::MAX),
+            MemoryReserve::Auto,
+            2,
+            true,
+            32 * 1024 * 1024 * 1024,
+        )
+        .expect_err("Fixed per-thread multiplication must overflow");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("overflowed"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_resolve_memory_budget_auto_per_thread_overflow() {
+        // Construct an Auto config whose per-thread floor × threads overflows:
+        // with `total == usize::MAX` and a tiny reserve, `available` is enormous,
+        // so `(available / threads).max(MIN) * threads` overflows `usize`.
+        let err = resolve_memory_budget_with_total(
+            MemoryLimit::Auto,
+            MemoryReserve::Fixed(0),
+            usize::MAX,
+            true,
+            usize::MAX,
+        )
+        .expect_err("Auto per-thread multiplication must overflow");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("auto memory budget overflowed"), "got: {msg}");
     }
 }

--- a/crates/fgumi-cli-macros/src/lib.rs
+++ b/crates/fgumi-cli-macros/src/lib.rs
@@ -106,7 +106,7 @@ pub fn multi_options(attr: TokenStream, item: TokenStream) -> TokenStream {
         /// the runall command. Carries the same fields as the original
         /// options struct but exposes each via `--<prefix>::<flag>` and
         /// groups them under a help heading.
-        #[derive(clap::Args, Debug, Clone)]
+        #[derive(::clap::Args, Debug, Clone)]
         #[command(next_help_heading = #heading)]
         pub struct #multi_struct_name {
             #(#multi_field_tokens)*
@@ -117,7 +117,7 @@ pub fn multi_options(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// options struct. Returns `Err` if any field that was
             /// required (no default + non-`Option`) was not supplied
             /// on the command line.
-            pub fn validate(self) -> anyhow::Result<#struct_name> {
+            pub fn validate(self) -> ::anyhow::Result<#struct_name> {
                 let opts = self;
                 Ok(#struct_name {
                     #(#validate_field_tokens)*
@@ -250,7 +250,13 @@ fn generate_field_tokens(
     let is_required = !is_option && !is_vec && !has_default;
 
     if is_required {
-        let required_doc = format!("{doc_comment} Required when {prefix} is selected.");
+        // Avoid a leading space when the source field has no doc comment
+        // (`doc_comment` is then the empty string).
+        let required_doc = if doc_comment.is_empty() {
+            format!("Required when {prefix} is selected.")
+        } else {
+            format!("{doc_comment} Required when {prefix} is selected.")
+        };
         let error_msg = format!("--{long_name} is required when {prefix} is selected");
 
         multi_field_tokens.push(quote! {
@@ -260,7 +266,7 @@ fn generate_field_tokens(
         });
         validate_field_tokens.push(quote! {
             #field_ident: opts.#prefixed_ident
-                .ok_or_else(|| anyhow::anyhow!(#error_msg))?,
+                .ok_or_else(|| ::anyhow::anyhow!(#error_msg))?,
         });
         from_original_field_tokens.push(quote! {
             #prefixed_ident: Some(opts.#field_ident),
@@ -271,8 +277,9 @@ fn generate_field_tokens(
         // and no `default_value_t` rewrite is possible (clap rejects
         // `default_value_t` on `Vec<T>`, and the macro strips any string
         // `default_value`).
+        let doc_attr = doc_attr_tokens(&doc_comment);
         multi_field_tokens.push(quote! {
-            #[doc = #doc_comment]
+            #doc_attr
             #[arg(long = #long_name #(#preserved)*)]
             pub #prefixed_ident: #field_type,
         });
@@ -307,8 +314,9 @@ fn generate_field_tokens(
         // generated code to compile and match the original's CLI
         // default.
         let default_attr = quote! { , default_value_t = #struct_name::default().#field_ident };
+        let doc_attr = doc_attr_tokens(&doc_comment);
         multi_field_tokens.push(quote! {
-            #[doc = #doc_comment]
+            #doc_attr
             #[arg(long = #long_name #default_attr #(#preserved)*)]
             pub #prefixed_ident: #field_type,
         });
@@ -476,6 +484,21 @@ fn extract_long_override(field: &syn::Field) -> Option<String> {
         }
     }
     None
+}
+
+/// Build a `#[doc = "..."]` attribute token for a Multi-struct field, or an
+/// empty token stream when the source field had no doc comment.
+///
+/// Emitting `#[doc = ""]` for an undocumented field is harmless but produces a
+/// stray empty doc attribute in the generated code; returning nothing keeps the
+/// generated output clean and avoids a leading-space artifact in concatenated
+/// doc strings.
+fn doc_attr_tokens(doc_comment: &str) -> proc_macro2::TokenStream {
+    if doc_comment.is_empty() {
+        quote! {}
+    } else {
+        quote! { #[doc = #doc_comment] }
+    }
 }
 
 /// Join all `#[doc = "..."]` attributes into a single trimmed string.

--- a/crates/fgumi-cli-macros/tests/smoke.rs
+++ b/crates/fgumi-cli-macros/tests/smoke.rs
@@ -175,15 +175,22 @@ fn macro_treats_vec_t_as_repeating_pass_through() {
     assert_eq!(opts.repeated_paths, vec![1, 2, 3]);
 }
 
-/// Coverage for two attribute-handling fixes:
+/// Coverage for four attribute-handling fixes:
 ///
 ///   * `skip_with_expr` uses `#[arg(skip = expr)]`. The macro must use
 ///     the provided expression verbatim in `validate()` rather than
 ///     hard-wiring `BazOptions::default().skip_with_expr`.
+///   * `bare_skipped` uses a bare `#[arg(skip)]` (no `= expr`). The
+///     macro must fall back to `BazOptions::default().bare_skipped`
+///     (the struct default), NOT `u32::default()`.
 ///   * `conditionally_required` carries `#[arg(required = true)]`. The
 ///     macro must strip the `required = ...` name-value form so the
 ///     generated Multi field (an `Option<T>`) is not forced by clap
 ///     during parsing — required-ness is handled by `validate()`.
+///   * `tmp_dirs` carries `#[arg(long = "tmp-dir")]`, a `long` override
+///     that differs from the kebab of the field name. The macro must
+///     honor the override so the Multi flag is `--baz::tmp-dir`, NOT
+///     `--baz::tmp-dirs`.
 #[multi_options("baz", "Baz Options")]
 #[derive(Args, Debug, Clone, PartialEq)]
 pub struct BazOptions {
@@ -192,19 +199,37 @@ pub struct BazOptions {
     #[arg(skip = 99u32)]
     pub skip_with_expr: u32,
 
+    /// Bare-skipped field. Not exposed on the CLI; `validate()` must
+    /// pull its value from `BazOptions::default()`, not `u32::default()`.
+    #[arg(skip)]
+    pub bare_skipped: u32,
+
     /// Required (non-default) field that also carries `required = true`.
     /// The Multi side must wrap this as `Option<T>` and not propagate
     /// `required = true` to clap.
     #[arg(long, required = true)]
     pub conditionally_required: u32,
+
+    /// Repeatable field with a `long` override (`--tmp-dir`, not
+    /// `--tmp-dirs`). The Multi side must derive `--baz::tmp-dir`.
+    #[arg(long = "tmp-dir", action = clap::ArgAction::Append)]
+    pub tmp_dirs: Vec<u32>,
 }
 
 impl Default for BazOptions {
     fn default() -> Self {
         // `skip_with_expr`'s Default is deliberately non-zero (and different
         // from the `skip = 99u32` expression) so the test proves the macro
-        // emits the skip expression, not this Default value.
-        Self { skip_with_expr: 1, conditionally_required: 0 }
+        // emits the skip expression, not this Default value. `bare_skipped`'s
+        // Default is deliberately non-zero (and different from `u32::default()`
+        // == 0) so the bare-skip test proves the macro pulls from this struct
+        // Default rather than the field type's Default.
+        Self {
+            skip_with_expr: 1,
+            bare_skipped: 77,
+            conditionally_required: 0,
+            tmp_dirs: Vec::new(),
+        }
     }
 }
 
@@ -212,10 +237,64 @@ impl Default for BazOptions {
 fn skip_with_expr_uses_provided_expression_not_default() {
     // The skip expression is `99`, while `BazOptions::default().skip_with_expr`
     // is `0`. validate() must yield `99`, proving the expression is honored.
-    let multi = MultiBazOptions { baz_conditionally_required: Some(5) };
+    let multi = MultiBazOptions { baz_conditionally_required: Some(5), baz_tmp_dirs: Vec::new() };
     let opts = multi.validate().expect("validate should succeed");
     assert_eq!(opts.skip_with_expr, 99, "skip = 99 expression must be used verbatim");
     assert_eq!(opts.conditionally_required, 5);
+}
+
+#[test]
+fn bare_skip_falls_back_to_struct_default_not_type_default() {
+    // `bare_skipped` is `#[arg(skip)]` (no `= expr`), so the macro must
+    // populate it from `BazOptions::default().bare_skipped` (== 77), NOT
+    // `u32::default()` (== 0). It is not a CLI flag, so MultiBazOptions does
+    // not carry it.
+    let multi = MultiBazOptions { baz_conditionally_required: Some(1), baz_tmp_dirs: Vec::new() };
+    let opts = multi.validate().expect("validate should succeed");
+    assert_eq!(
+        opts.bare_skipped, 77,
+        "bare #[arg(skip)] must use the struct Default (77), not u32::default() (0)"
+    );
+}
+
+#[test]
+fn long_override_renames_multi_flag() {
+    // `tmp_dirs` carries `#[arg(long = "tmp-dir")]`, so the Multi flag must be
+    // `--baz::tmp-dir` (honoring the override), and `--baz::tmp-dirs` (the
+    // kebab of the field name) must be rejected.
+    #[derive(Parser, Debug)]
+    struct Wrapper {
+        #[command(flatten)]
+        baz_opts: MultiBazOptions,
+    }
+
+    // The overridden flag name parses.
+    let wrapper = Wrapper::try_parse_from([
+        "test-prog",
+        "--baz::conditionally-required",
+        "1",
+        "--baz::tmp-dir",
+        "3",
+        "--baz::tmp-dir",
+        "4",
+    ])
+    .expect("--baz::tmp-dir should parse");
+    let opts = wrapper.baz_opts.validate().expect("validate after parse");
+    assert_eq!(opts.tmp_dirs, vec![3, 4]);
+
+    // The field-name kebab (`--baz::tmp-dirs`) must NOT be a valid flag,
+    // proving the macro honored the `long = "tmp-dir"` override.
+    let err = Wrapper::try_parse_from([
+        "test-prog",
+        "--baz::conditionally-required",
+        "1",
+        "--baz::tmp-dirs",
+        "3",
+    ]);
+    assert!(
+        err.is_err(),
+        "--baz::tmp-dirs must be rejected (override renamed it to --baz::tmp-dir)"
+    );
 }
 
 #[test]

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1272,10 +1272,6 @@ impl CodecConsensusCaller {
 
     /// Builds the output record from the consensus and writes raw bytes into `output`.
     #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Result return type kept for API consistency with other callers"
-    )]
-    #[expect(
         clippy::too_many_arguments,
         reason = "all_records needed separately from source_raws for UMI consensus"
     )]
@@ -1300,13 +1296,15 @@ impl CodecConsensusCaller {
         // rather than allocating a `String` per read; the counter fallback
         // still formats the integer suffix.
         if let Some(umi_str) = umi {
-            self.bam_builder.build_record_joined_name(
+            // UMI is data-controlled; reject an over-long joined name with a
+            // typed error rather than panicking.
+            self.bam_builder.try_build_record_joined_name(
                 self.read_name_prefix.as_bytes(),
                 umi_str.as_bytes(),
                 flag,
                 &consensus.bases,
                 &consensus.quals,
-            );
+            )?;
         } else {
             let read_name = format!("{}:{}", self.read_name_prefix, self.consensus_counter);
             self.bam_builder.build_record(

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1041,10 +1041,6 @@ impl DuplexConsensusCaller {
         clippy::too_many_lines,
         reason = "BAM record construction has many sequential tag-writing steps"
     )]
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Result return type kept for API consistency with other consensus record builders"
-    )]
     pub(crate) fn duplex_read_into(
         builder: &mut UnmappedSamBuilder,
         output: &mut ConsensusOutput,
@@ -1077,14 +1073,16 @@ impl DuplexConsensusCaller {
 
         // Build the record (name, flags, bases, quals). The read name is
         // `<prefix>:<umi>`; compose it straight into the record buffer rather
-        // than allocating a fresh `String` per output read.
-        builder.build_record_joined_name(
+        // than allocating a fresh `String` per output read. The UMI is
+        // data-controlled, so reject an over-long joined name with a typed
+        // error rather than panicking.
+        builder.try_build_record_joined_name(
             read_name_prefix.as_bytes(),
             umi.as_bytes(),
             flag,
             &consensus.bases,
             &consensus.quals,
-        );
+        )?;
 
         // 1. MI tag (string)
         builder.append_string_tag(SamTag::MI, umi.as_bytes());

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1248,7 +1248,7 @@ impl VanillaUmiConsensusCaller {
             &depths,
             &errors,
             methylation.as_ref(),
-        );
+        )?;
 
         Ok((true, surviving_count, surviving_reads))
     }
@@ -1373,7 +1373,7 @@ impl VanillaUmiConsensusCaller {
         depths: &[u16],
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
-    ) {
+    ) -> Result<()> {
         let mut flag = flags::UNMAPPED;
         match read_type {
             ReadType::R1 => {
@@ -1386,14 +1386,16 @@ impl VanillaUmiConsensusCaller {
         }
 
         // Read name is `<prefix>:<umi>`; compose it straight into the record
-        // buffer rather than allocating a fresh `String` per output read.
-        self.bam_builder.build_record_joined_name(
+        // buffer rather than allocating a fresh `String` per output read. The
+        // UMI is data-controlled, so reject an over-long joined name with a
+        // typed error rather than panicking.
+        self.bam_builder.try_build_record_joined_name(
             self.read_name_prefix.as_bytes(),
             umi.as_bytes(),
             flag,
             bases,
             quals,
-        );
+        )?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());
@@ -1476,6 +1478,7 @@ impl VanillaUmiConsensusCaller {
         // Write record with block_size prefix
         self.bam_builder.write_with_block_size(&mut output.data);
         output.count += 1;
+        Ok(())
     }
 }
 

--- a/crates/fgumi-dna/src/dna.rs
+++ b/crates/fgumi-dna/src/dna.rs
@@ -77,6 +77,13 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 /// let mut s = b"acgt".to_vec();
 /// reverse_complement_in_place(&mut s);
 /// assert_eq!(s, b"ACGT"); // normalized to uppercase, same as reverse_complement
+///
+/// // The cases above are self-reverse-complementary, so they hide the
+/// // complement step. This one makes complementation visible: reverse(AAGG)
+/// // is GGAA, then complementing each base gives CCTT.
+/// let mut s = b"AAGG".to_vec();
+/// reverse_complement_in_place(&mut s);
+/// assert_eq!(s, b"CCTT");
 /// ```
 pub fn reverse_complement_in_place(seq: &mut [u8]) {
     seq.reverse();

--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -679,6 +679,18 @@ impl Pipeline {
         for (idx, step) in self.steps.iter().enumerate() {
             let profile = step.profile();
             let n_branches = self.graph.branch_count(super::topology::StepIdx(idx));
+            // Render the *effective* (post-collapse) ordering so the diagnostic
+            // matches the transport actually built. Single-input Serial /
+            // Exclusive producers collapse declared `ByOrdinal` / `ByItemOrdinal`
+            // to `None` (no reorder stage); `Step2` producers (input_arity == 2)
+            // and `Parallel` producers keep their declared ordering verbatim.
+            // Using the shared `effective_branch_orderings` helper keeps `dag()`
+            // and `build_output_set` from drifting.
+            let effective_orderings = if step.input_arity() == 2 {
+                profile.branch_ordering.clone()
+            } else {
+                super::erased::effective_branch_orderings(profile.kind, &profile.branch_ordering)
+            };
             let _ = write!(
                 s,
                 "  [{idx}] {name:<24} {kind:?} sticky={sticky} branches={n_branches}",
@@ -704,8 +716,7 @@ impl Pipeline {
                         .get(branch_usize)
                         .copied()
                         .unwrap_or(super::queues::QueueSpec::Unbounded);
-                    let ordering = profile
-                        .branch_ordering
+                    let ordering = effective_orderings
                         .get(branch_usize)
                         .copied()
                         .unwrap_or(super::reorder::BranchOrdering::None);
@@ -810,6 +821,17 @@ impl Pipeline {
 
         // 2. Build per-step contexts (input + output handles).
         let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+
+        // 2-pre-monitor invariant: if the deadlock monitor will be armed, every
+        // output transport must be ByteBounded so `in_flight_bytes` can see a
+        // wedge on it. A CountBounded/Unbounded edge is invisible to the probe
+        // and would silently disable fail-fast on that edge. Checked here (debug
+        // builds only) while `steps` is still alive — it is consumed by
+        // `build_worker_storage` below. Test chains use CountBounded/Unbounded
+        // but do not arm the monitor, so this only fires for a fail-fast run.
+        if deadlock_timeout_secs > 0 && stats_arc.is_some() {
+            assert_monitor_visible_transports(&steps, &graph);
+        }
 
         // 2a. If a total queue-memory budget was supplied, evenly
         // redistribute it across all byte-bounded queues now (before
@@ -1077,14 +1099,20 @@ const DEADLOCK_FATAL_MULTIPLE: u64 = 6;
 /// on byte-bounded edges.
 ///
 /// LIMITATION: only `ByteBounded` branches register a queue handle (see
-/// `build_chain_contexts_inner`), so `CountBounded`/`Unbounded` transports — and
-/// any reorder stash on such a branch — do not contribute here. The only current
-/// `CountBounded` user is the sort spill→merge path, whose `SortMerge` is
-/// deadlock-free by construction (the cooperative slot-refill that fixed issue
-/// #330 BUG #3), so a wedge there is not reachable and the monitor correctly
-/// stays quiet during a slow merge (where in-flight on byte-bounded edges is 0).
-/// Extending the probe to count-based queues for defense-in-depth is tracked
-/// separately.
+/// `build_chain_contexts_inner`), so a `CountBounded`/`Unbounded` transport — and
+/// any reorder stash on such a branch — would not contribute here, making the
+/// monitor blind to a wedge living entirely on such an edge.
+///
+/// This is safe because **no production pipeline edge uses
+/// `CountBounded`/`Unbounded`**: every production step profile declares
+/// `QueueSpec::ByteBounded`, so the probe covers every production transport.
+/// (The sort spill→merge path is fully byte-bounded too — its deadlock-free
+/// backpressure is the internal `SortMergeSlot` slot table, not a pipeline
+/// `CountBounded` edge.) `assert_monitor_visible_transports` enforces this
+/// invariant in debug builds whenever the monitor is armed, so a future step
+/// that declares a monitor-blind transport on a fail-fast pipeline trips loudly
+/// rather than silently losing the wedge verdict. Extending the probe to
+/// count-based queues for full defense-in-depth is tracked separately.
 fn in_flight_bytes(contexts: &crate::runtime::contexts::ChainContexts) -> u64 {
     contexts
         .bounded_queues
@@ -1094,6 +1122,60 @@ fn in_flight_bytes(contexts: &crate::runtime::contexts::ChainContexts) -> u64 {
                 + rq.reorder_cap.as_ref().map_or(0, |r| r.current_buffer_bytes())
         })
         .sum()
+}
+
+/// Return the first `(step_name, QueueSpec)` whose output transport is invisible
+/// to the deadlock monitor's [`in_flight_bytes`] probe — i.e. a `CountBounded`
+/// or `Unbounded` branch, which registers no byte-probe handle. `None` means
+/// every output transport is monitor-visible (`ByteBounded`).
+///
+/// Used by [`assert_monitor_visible_transports`] to pin the "no production edge
+/// is monitor-blind" invariant the [`in_flight_bytes`] doc relies on. Iterates
+/// every branch the graph declares for each step (`0..branch_count`) rather than
+/// just the explicit `output_queues` entries: a step may declare fewer specs than
+/// it has branches, and `dag()`/context-building resolve those missing branches
+/// to `QueueSpec::Unbounded`. Using the same `unwrap_or(Unbounded)` fallback here
+/// keeps the guard from overlooking an implicit (and therefore monitor-blind)
+/// Unbounded branch.
+fn first_monitor_blind_transport(
+    steps: &[Box<dyn super::erased::ErasedStep>],
+    graph: &super::topology::ChainGraph,
+) -> Option<(&'static str, super::queues::QueueSpec)> {
+    use super::queues::QueueSpec;
+    for (step_idx, step) in steps.iter().enumerate() {
+        let profile = step.profile();
+        for branch in 0..graph.branch_count(super::topology::StepIdx(step_idx)) {
+            let spec = profile.output_queues.get(branch).copied().unwrap_or(QueueSpec::Unbounded);
+            match spec {
+                QueueSpec::ByteBounded { .. } => {}
+                QueueSpec::CountBounded { .. } | QueueSpec::Unbounded => {
+                    return Some((profile.name, spec));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Debug-build invariant check (run only when the deadlock monitor is armed):
+/// every production output transport must be `ByteBounded` so the
+/// [`in_flight_bytes`] probe can see a wedge on it. A `CountBounded`/`Unbounded`
+/// edge would be invisible to the monitor, silently disabling fail-fast on that
+/// edge — exactly the blind spot this guard exists to catch. The framework still
+/// permits `CountBounded`/`Unbounded` for `#[cfg(test)]` chains (which do not arm
+/// the monitor), so this only fires for a real fail-fast pipeline.
+fn assert_monitor_visible_transports(
+    steps: &[Box<dyn super::erased::ErasedStep>],
+    graph: &super::topology::ChainGraph,
+) {
+    debug_assert!(
+        first_monitor_blind_transport(steps, graph).is_none(),
+        "deadlock monitor is armed but step '{}' declares a {:?} output transport, \
+         which is invisible to the in_flight_bytes probe — a wedge on that edge would \
+         silently disable fail-fast. Production transports must be QueueSpec::ByteBounded.",
+        first_monitor_blind_transport(steps, graph).map_or("?", |(name, _)| name),
+        first_monitor_blind_transport(steps, graph).map(|(_, spec)| spec),
+    );
 }
 
 /// Background deadlock monitor body. Polls `stats` every `poll_interval`,
@@ -1521,6 +1603,45 @@ mod tests {
     }
 
     #[test]
+    fn apply_initial_queue_budget_floors_each_queue_at_min_when_budget_tiny() {
+        // When `total / n_queues < MIN_PER_QUEUE_BYTES`, the budget pass floors
+        // each transport at `MIN_PER_QUEUE_BYTES` even though the effective total
+        // then exceeds the user's budget — starvation (a zero/tiny-budget queue
+        // that always rejects pushes, wedging the producer) is the worse failure
+        // mode. A regression dropping the `.max(MIN_PER_QUEUE_BYTES)` would not be
+        // caught by the lean/huge cases the sibling test covers.
+        use crate::queues::{BoundedQueueHandle, ByteBoundedQueue};
+        use crate::runtime::contexts::RegisteredQueue;
+        use crate::topology::{BranchIdx, StepIdx};
+
+        // Four registered queues, each constructed at the 1 MiB floor.
+        let handles: Vec<Arc<ByteBoundedQueue<u32>>> =
+            (0..4).map(|_| Arc::new(ByteBoundedQueue::<u32>::new(MIN_PER_QUEUE_BYTES))).collect();
+        let registered: Vec<RegisteredQueue> = handles
+            .iter()
+            .enumerate()
+            .map(|(i, h)| RegisteredQueue {
+                producer_step_name: "TestStep",
+                producer_step: StepIdx(i),
+                branch: BranchIdx(0),
+                handle: Arc::clone(h) as Arc<dyn BoundedQueueHandle>,
+                reorder_cap: None,
+            })
+            .collect();
+
+        // total = 1 byte over 4 queues → per_queue would be 0, floored to 1 MiB.
+        apply_initial_queue_budget(&registered, 1);
+        for h in &handles {
+            assert_eq!(
+                h.limit_bytes(),
+                MIN_PER_QUEUE_BYTES,
+                "each queue's transport limit must be floored to MIN_PER_QUEUE_BYTES \
+                 when the per-queue share underflows the floor"
+            );
+        }
+    }
+
+    #[test]
     fn reorder_cap_tracks_per_queue_clamped_to_floor_and_ceiling() {
         let ceiling = crate::reorder::DEFAULT_REORDER_OVERFLOW_BYTES;
         // Mid-range per_queue passes through unchanged.
@@ -1723,6 +1844,32 @@ mod tests {
         assert!(dag.contains("→ SinkU32"), "DAG missing source→sink wiring: {dag}");
     }
 
+    #[test]
+    fn dag_renders_effective_collapsed_ordering_for_serial_exclusive() {
+        // `StubSource` is `Exclusive` and declares `BranchOrdering::ByOrdinal`,
+        // but `build_output_set` collapses that to `None` (no reorder stage) for
+        // single-input Serial/Exclusive producers. `dag()` must render the
+        // *effective* ordering so the diagnostic matches the transport actually
+        // built — it must not print the un-collapsed declared `ByOrdinal`.
+        let builder = PipelineBuilder::new();
+        builder.chain(StubSource).chain(StubSinkU32).into_sink_marker();
+        let pipeline = builder.build().unwrap();
+        let dag = pipeline.dag();
+        // The source's output branch line is `.0: <queue> <ordering> → SinkU32`.
+        let source_branch_line = dag
+            .lines()
+            .find(|l| l.contains("→ SinkU32"))
+            .expect("DAG must have the source→sink branch line");
+        assert!(
+            source_branch_line.contains("None"),
+            "DAG must render the collapsed (effective) ordering `None`: {source_branch_line}"
+        );
+        assert!(
+            !source_branch_line.contains("ByOrdinal"),
+            "DAG must NOT render the un-collapsed declared `ByOrdinal`: {source_branch_line}"
+        );
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // Pipeline::run smoke tests
     // ─────────────────────────────────────────────────────────────────────
@@ -1767,6 +1914,59 @@ mod tests {
                 ctx.outputs.push(n).map_err(|_| {
                     std::io::Error::other("Unbounded queue rejected push (impossible)")
                 })?;
+                Ok(StepOutcome::Progress)
+            } else {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Byte-bounded twin of [`SharedCountingSource`] for the monitor-armed
+    /// fail-fast test. The deadlock monitor's `in_flight_bytes` probe only sees
+    /// `ByteBounded` transports, and `assert_monitor_visible_transports` (a
+    /// debug-build invariant) rejects an `Unbounded`/`CountBounded` source on a
+    /// monitor-armed run. Using this source lets
+    /// `pipeline_run_reraises_worker_panic_with_monitor_enabled` actually reach
+    /// the monitor startup/shutdown path instead of tripping that assertion
+    /// first (and passing for the wrong reason).
+    #[derive(Clone)]
+    struct SharedCountingByteBoundedSource {
+        remaining: Arc<AtomicU32>,
+    }
+    impl Step for SharedCountingByteBoundedSource {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "SharedSourceByteBounded",
+                kind: StepKind::Parallel,
+                sticky: false,
+                // ByteBounded so the monitor probe can see this edge; sized large
+                // enough that the handful of items pushed before the sink panics
+                // never hit backpressure.
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: 1 << 20 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            let n = self.remaining.load(AtomicOrd::Acquire);
+            if n == 0 {
+                return Ok(StepOutcome::Finished);
+            }
+            if self
+                .remaining
+                .compare_exchange(n, n - 1, AtomicOrd::AcqRel, AtomicOrd::Acquire)
+                .is_ok()
+            {
+                // ByteBounded can reject under backpressure: hand the claimed
+                // item's budget back and retry next dispatch rather than erroring.
+                if ctx.outputs.push(n).is_err() {
+                    self.remaining.fetch_add(1, AtomicOrd::AcqRel);
+                    return Ok(StepOutcome::NoProgress);
+                }
                 Ok(StepOutcome::Progress)
             } else {
                 Ok(StepOutcome::NoProgress)
@@ -1912,8 +2112,12 @@ mod tests {
         // peer observes `is_done()` and exits, letting every join complete.
         let remaining = Arc::new(AtomicU32::new(1_000));
         let builder = PipelineBuilder::new();
+        // ByteBounded source so the monitor-visible-transports invariant holds and
+        // the test reaches the real monitor startup/shutdown path (a plain
+        // `SharedCountingSource` declares an `Unbounded` edge, which the debug
+        // `assert_monitor_visible_transports` would reject before the monitor runs).
         builder
-            .chain(SharedCountingSource { remaining: Arc::clone(&remaining) })
+            .chain(SharedCountingByteBoundedSource { remaining: Arc::clone(&remaining) })
             .chain(PanickingSink)
             .into_sink_marker();
         let pipeline = builder.build().unwrap();
@@ -2206,6 +2410,113 @@ mod tests {
         // No progress with work stuck for >= the fatal threshold: a genuine
         // wedge — fail fast instead of hanging forever.
         assert_eq!(classify_stall(false, 60, 10, 60, 4096), StallVerdict::Wedged);
+    }
+
+    /// A step with a single output branch of the given `QueueSpec`, used to
+    /// exercise the monitor-visibility transport check.
+    fn step_with_output_spec(
+        name: &'static str,
+        spec: QueueSpec,
+    ) -> Box<dyn crate::erased::ErasedStep> {
+        #[derive(Clone)]
+        struct SpecStep {
+            name: &'static str,
+            spec: QueueSpec,
+        }
+        impl Step for SpecStep {
+            type Input = u32;
+            type Outputs = Single<u32>;
+            fn profile(&self) -> StepProfile {
+                StepProfile {
+                    name: self.name,
+                    kind: StepKind::Serial,
+                    sticky: false,
+                    output_queues: vec![self.spec],
+                    branch_ordering: vec![BranchOrdering::None],
+                }
+            }
+            fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+        Box::new(crate::erased::TypedStep::new(SpecStep { name, spec }))
+    }
+
+    /// A `ChainGraph` whose per-step branch count matches each step's declared
+    /// `output_queues` length — the common shape where every branch has a spec.
+    fn graph_matching_specs(
+        steps: &[Box<dyn crate::erased::ErasedStep>],
+    ) -> crate::topology::ChainGraph {
+        let mut g = crate::topology::ChainGraph::new();
+        for step in steps {
+            g.register_step(step.profile().name, step.profile().output_queues.len());
+        }
+        g
+    }
+
+    #[test]
+    fn first_monitor_blind_transport_finds_count_and_unbounded() {
+        // All-ByteBounded: every transport is monitor-visible.
+        let visible = vec![
+            step_with_output_spec("A", QueueSpec::ByteBounded { limit_bytes: 1 << 20 }),
+            step_with_output_spec("B", QueueSpec::ByteBounded { limit_bytes: 1 << 20 }),
+        ];
+        assert!(first_monitor_blind_transport(&visible, &graph_matching_specs(&visible)).is_none());
+
+        // A CountBounded branch is flagged (it registers no byte probe).
+        let with_count = vec![
+            step_with_output_spec("A", QueueSpec::ByteBounded { limit_bytes: 1 << 20 }),
+            step_with_output_spec("Blind", QueueSpec::CountBounded { capacity: 8 }),
+        ];
+        let (name, spec) =
+            first_monitor_blind_transport(&with_count, &graph_matching_specs(&with_count)).unwrap();
+        assert_eq!(name, "Blind");
+        assert!(matches!(spec, QueueSpec::CountBounded { .. }));
+
+        // Unbounded is flagged too.
+        let with_unbounded = vec![step_with_output_spec("U", QueueSpec::Unbounded)];
+        assert!(
+            first_monitor_blind_transport(&with_unbounded, &graph_matching_specs(&with_unbounded))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn first_monitor_blind_transport_flags_implicit_unbounded_branch() {
+        // A step whose graph branch count exceeds its declared `output_queues`:
+        // the extra branch resolves to `QueueSpec::Unbounded` (matching `dag()`
+        // and context-building), which is monitor-blind and must be flagged even
+        // though the step declared only one explicit, ByteBounded spec.
+        let steps = vec![step_with_output_spec(
+            "HasImplicitBranch",
+            QueueSpec::ByteBounded { limit_bytes: 1 << 20 },
+        )];
+        let mut graph = crate::topology::ChainGraph::new();
+        graph.register_step("HasImplicitBranch", 2); // 2 branches, 1 explicit spec
+        let (name, spec) = first_monitor_blind_transport(&steps, &graph).unwrap();
+        assert_eq!(name, "HasImplicitBranch");
+        assert!(matches!(spec, QueueSpec::Unbounded), "implicit 2nd branch is Unbounded");
+    }
+
+    #[test]
+    fn assert_monitor_visible_transports_passes_for_all_byte_bounded() {
+        // The armed-monitor invariant holds (does not panic) when every output
+        // transport is ByteBounded.
+        let steps = vec![
+            step_with_output_spec("A", QueueSpec::ByteBounded { limit_bytes: 1 << 20 }),
+            step_with_output_spec("B", QueueSpec::ByteBounded { limit_bytes: 1 << 20 }),
+        ];
+        assert_monitor_visible_transports(&steps, &graph_matching_specs(&steps));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "invisible to the in_flight_bytes probe")]
+    fn assert_monitor_visible_transports_panics_on_count_bounded_in_debug() {
+        // In debug builds, a monitor-blind transport on an armed pipeline trips
+        // the invariant instead of silently losing the wedge verdict.
+        let steps = vec![step_with_output_spec("Blind", QueueSpec::CountBounded { capacity: 8 })];
+        assert_monitor_visible_transports(&steps, &graph_matching_specs(&steps));
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/erased.rs
+++ b/crates/fgumi-pipeline-core/src/erased.rs
@@ -33,6 +33,36 @@ use super::step::{
     Affinity, OutputHandles, OutputsViewAny, Step, StepCtx, StepKind, StepOutcome, StepProfile,
 };
 
+/// The branch orderings the framework actually *builds* for a single-input
+/// producer of the given [`StepKind`], given its declared profile orderings.
+///
+/// `Serial` / `Exclusive` producers emit items in arrival order by construction
+/// (the framework's mutex serializes pushes; an Exclusive-owned step has a
+/// single dispatcher), so inserting a `ReorderStage` on their output edges is
+/// pure overhead. The framework collapses any declared
+/// `ByOrdinal` / `ByItemOrdinal` to [`BranchOrdering::None`] for those kinds —
+/// `build_queues` then constructs the direct transport with no reorder stage.
+/// `Parallel` producers keep their declared orderings verbatim.
+///
+/// This is the single source of truth for the collapse rule, shared by
+/// [`TypedStep::build_output_set`] (which constructs the transport) and
+/// `Pipeline::dag` (which must render the *effective* — post-collapse —
+/// ordering so the diagnostic matches the transport actually built). Note
+/// `Step2` producers (`TypedStep2`) do **not** collapse, so this helper is only
+/// for single-input steps.
+#[must_use]
+pub(crate) fn effective_branch_orderings(
+    kind: StepKind,
+    declared: &[BranchOrdering],
+) -> Vec<BranchOrdering> {
+    match kind {
+        StepKind::Parallel => declared.to_vec(),
+        StepKind::Serial | StepKind::Exclusive => {
+            declared.iter().map(|_| BranchOrdering::None).collect()
+        }
+    }
+}
+
 /// Type-erased step interface used by the worker loop.
 pub trait ErasedStep: Send + 'static {
     fn profile(&self) -> StepProfile;
@@ -45,6 +75,20 @@ pub trait ErasedStep: Send + 'static {
     /// the optimizer cannot elide them). Adapters cache the name at
     /// construction and return it here for free.
     fn name(&self) -> &'static str;
+
+    /// The step's [`StepKind`], returned WITHOUT building a `StepProfile`.
+    ///
+    /// The setup passes (`pool::assign_exclusive_owners`,
+    /// `pool::assign_sticky_owners`, `storage::build_worker_storage`) read the
+    /// kind per step; going through `profile()` there heap-allocates the
+    /// profile's two `Vec`s per read (a virtual call, so the optimizer cannot
+    /// elide them). Adapters cache the kind at construction and return it free.
+    fn kind(&self) -> StepKind;
+
+    /// Whether the step is `sticky`, returned WITHOUT building a `StepProfile`.
+    /// Same rationale as [`Self::kind`]: the sticky-owner assignment passes read
+    /// it per step. Adapters cache it at construction.
+    fn sticky(&self) -> bool;
 
     /// Forward `Step::affinity` for worker-eligibility gating. Only
     /// consulted for `Serial` steps; the runtime calls this once during
@@ -193,6 +237,11 @@ pub struct TypedStep<S: Step> {
     /// construction so `ErasedStep::name()` (read per dispatch) never
     /// rebuilds the profile's `Vec`s. See the `ErasedStep::name` doc.
     name: &'static str,
+    /// `StepKind`, cached at construction so the setup passes read it without
+    /// rebuilding the profile's `Vec`s. See the `ErasedStep::kind` doc.
+    kind: StepKind,
+    /// `sticky` flag, cached at construction for the same reason as `kind`.
+    sticky: bool,
     /// Cached downcast of `ctx.input` after the first dispatch.
     /// `'static` is a lie — the actual lifetime is bounded by
     /// `ChainContexts` — enforced via the `// SAFETY:` comment below.
@@ -204,8 +253,19 @@ pub struct TypedStep<S: Step> {
 
 impl<S: Step> TypedStep<S> {
     pub fn new(step: S) -> Self {
-        let name = step.profile().name;
-        Self { inner: step, name, cached_input: None, cached_outputs: None, _phantom: PhantomData }
+        let profile = step.profile();
+        let name = profile.name;
+        let kind = profile.kind;
+        let sticky = profile.sticky;
+        Self {
+            inner: step,
+            name,
+            kind,
+            sticky,
+            cached_input: None,
+            cached_outputs: None,
+            _phantom: PhantomData,
+        }
     }
 
     /// Resolve the typed input handle from the dispatch context, caching
@@ -292,6 +352,14 @@ where
         self.name
     }
 
+    fn kind(&self) -> StepKind {
+        self.kind
+    }
+
+    fn sticky(&self) -> bool {
+        self.sticky
+    }
+
     fn affinity(&self) -> Affinity {
         self.inner.affinity()
     }
@@ -339,12 +407,8 @@ where
         // documents what the consumer needs); the framework is just
         // smart enough to skip the wrap when the producer can already
         // satisfy that need.
-        let effective_orderings: Vec<BranchOrdering> = match profile.kind {
-            StepKind::Parallel => profile.branch_ordering.clone(),
-            StepKind::Serial | StepKind::Exclusive => {
-                profile.branch_ordering.iter().map(|_| BranchOrdering::None).collect()
-            }
-        };
+        let effective_orderings =
+            effective_branch_orderings(profile.kind, &profile.branch_ordering);
         <S::Outputs as StepOutputs>::build_queues(&profile.output_queues, &effective_orderings)
     }
 
@@ -407,6 +471,10 @@ pub struct TypedStep2<S: Step2> {
     inner: S,
     /// Static step name, cached at construction. See `ErasedStep::name`.
     name: &'static str,
+    /// `StepKind`, cached at construction. See `ErasedStep::kind`.
+    kind: StepKind,
+    /// `sticky` flag, cached at construction. See `ErasedStep::sticky`.
+    sticky: bool,
     cached_inputs: Option<&'static TwoInputHandles<S::InputA, S::InputB>>,
     cached_outputs: Option<&'static OutputHandles<S::Outputs>>,
     _phantom: PhantomData<fn() -> S>,
@@ -414,8 +482,19 @@ pub struct TypedStep2<S: Step2> {
 
 impl<S: Step2> TypedStep2<S> {
     pub fn new(step: S) -> Self {
-        let name = step.profile().name;
-        Self { inner: step, name, cached_inputs: None, cached_outputs: None, _phantom: PhantomData }
+        let profile = step.profile();
+        let name = profile.name;
+        let kind = profile.kind;
+        let sticky = profile.sticky;
+        Self {
+            inner: step,
+            name,
+            kind,
+            sticky,
+            cached_inputs: None,
+            cached_outputs: None,
+            _phantom: PhantomData,
+        }
     }
 
     #[allow(unsafe_code)]
@@ -486,6 +565,14 @@ impl<S: Step2> ErasedStep for TypedStep2<S> {
 
     fn name(&self) -> &'static str {
         self.name
+    }
+
+    fn kind(&self) -> StepKind {
+        self.kind
+    }
+
+    fn sticky(&self) -> bool {
+        self.sticky
     }
 
     fn affinity(&self) -> Affinity {
@@ -624,13 +711,15 @@ impl<S: Step2> ErasedStep for TypedStep2<S> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::handles::BranchInputHandle;
     use crate::outputs::Single;
     use crate::queues::QueueSpec;
     use crate::reorder::BranchOrdering;
     use crate::step::{
-        InputHandle, OutputHandles, Step, StepCtx, StepKind, StepOutcome, StepProfile,
+        InputHandle, OutputHandles, Step, StepCtx, StepCtx2, StepKind, StepOutcome, StepProfile,
     };
 
     /// Trivial step: u32 → u32+1 (single output).
@@ -673,6 +762,98 @@ mod tests {
         let (queue_set, outputs_view) = producer.build_output_set();
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
         (queue_set, outputs)
+    }
+
+    #[rstest]
+    #[case(StepKind::Serial, false)]
+    #[case(StepKind::Serial, true)]
+    #[case(StepKind::Parallel, false)]
+    #[case(StepKind::Parallel, true)]
+    #[case(StepKind::Exclusive, false)]
+    #[case(StepKind::Exclusive, true)]
+    fn cached_kind_and_sticky_match_profile(#[case] kind: StepKind, #[case] sticky: bool) {
+        // The `kind()` / `sticky()` accessors return values cached at
+        // construction (so the setup passes don't rebuild the profile's `Vec`s).
+        // They must agree with `profile()` for every kind/sticky combination,
+        // or a stale cache could mis-route worker assignment. Each combination is
+        // an independent `#[case]` so a failure isolates the offending pair.
+        #[derive(Clone)]
+        struct Tagged(StepKind, bool);
+        impl Step for Tagged {
+            type Input = u32;
+            type Outputs = Single<u32>;
+            fn profile(&self) -> StepProfile {
+                StepProfile {
+                    name: "Tagged",
+                    kind: self.0,
+                    sticky: self.1,
+                    output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                    branch_ordering: vec![BranchOrdering::None],
+                }
+            }
+            fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+                Ok(StepOutcome::NoProgress)
+            }
+            fn new_worker_copy(&self) -> Self {
+                self.clone()
+            }
+        }
+
+        let erased: Box<dyn ErasedStep> = Box::new(TypedStep::new(Tagged(kind, sticky)));
+        let profile = erased.profile();
+        assert_eq!(erased.kind(), profile.kind, "kind() must match profile for {kind:?}");
+        assert_eq!(
+            erased.sticky(),
+            profile.sticky,
+            "sticky() must match profile for {kind:?}/{sticky}"
+        );
+    }
+
+    #[rstest]
+    #[case(StepKind::Serial, false)]
+    #[case(StepKind::Serial, true)]
+    #[case(StepKind::Parallel, false)]
+    #[case(StepKind::Parallel, true)]
+    #[case(StepKind::Exclusive, false)]
+    #[case(StepKind::Exclusive, true)]
+    fn cached_kind_and_sticky_match_profile_step2(#[case] kind: StepKind, #[case] sticky: bool) {
+        // Mirror `cached_kind_and_sticky_match_profile` for the `Step2` adapter.
+        // `TypedStep2::{new, kind, sticky}` caches the same metadata at
+        // construction, and runtime setup reads `ErasedStep::kind()`/`sticky()`
+        // for ALL erased steps — `Step` and `Step2` alike (e.g. zipper's merge
+        // step). A stale `TypedStep2` cache could mis-route owner assignment for
+        // a merge step just as a `TypedStep` cache could, so pin both paths.
+        #[derive(Clone)]
+        struct Tagged2(StepKind, bool);
+        impl Step2 for Tagged2 {
+            type InputA = u32;
+            type InputB = u32;
+            type Outputs = Single<u32>;
+            fn profile(&self) -> StepProfile {
+                StepProfile {
+                    name: "Tagged2",
+                    kind: self.0,
+                    sticky: self.1,
+                    output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                    branch_ordering: vec![BranchOrdering::None],
+                }
+            }
+            fn try_run(&mut self, _ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+                Ok(StepOutcome::NoProgress)
+            }
+            fn new_worker_copy(&self) -> Self {
+                self.clone()
+            }
+        }
+
+        let erased: Box<dyn ErasedStep> = Box::new(TypedStep2::new(Tagged2(kind, sticky)));
+        let profile = erased.profile();
+        assert_eq!(erased.kind(), profile.kind, "kind() must match profile for {kind:?}");
+        assert_eq!(
+            erased.sticky(),
+            profile.sticky,
+            "sticky() must match profile for {kind:?}/{sticky}"
+        );
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/handles.rs
+++ b/crates/fgumi-pipeline-core/src/handles.rs
@@ -38,6 +38,7 @@
 //! points are deferred.
 
 use std::any::Any;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
@@ -226,6 +227,21 @@ pub struct BranchInputHandle<T: Send + HeapSize + 'static> {
 enum BranchInputInner<T: Send + HeapSize + 'static> {
     Direct(Arc<dyn ItemQueue<T>>),
     Ordered(Arc<ReorderStage<T>>),
+    /// A permanently-empty, permanently-drained handle that owns no transport.
+    /// Used for source steps' dummy input (their input is implicitly drained
+    /// from t=0; the worker loop never pops from it), avoiding a per-source
+    /// `SegQueue` allocation just to report `is_drained() == true`.
+    AlwaysDrained(PhantomData<fn() -> T>),
+}
+
+impl<T: Send + HeapSize + 'static> BranchInputHandle<T> {
+    /// Construct a zero-state input handle that is always empty and always
+    /// drained, owning no backing queue. Used for source steps, whose input is
+    /// implicitly drained from the start and never popped.
+    #[must_use]
+    pub fn always_drained() -> Self {
+        Self { inner: BranchInputInner::AlwaysDrained(PhantomData) }
+    }
 }
 
 impl<T: Send + HeapSize + 'static> InputHandle<T> for BranchInputHandle<T> {
@@ -233,6 +249,7 @@ impl<T: Send + HeapSize + 'static> InputHandle<T> for BranchInputHandle<T> {
         match &self.inner {
             BranchInputInner::Direct(q) => q.try_pop(),
             BranchInputInner::Ordered(stage) => stage.try_pop_in_order(),
+            BranchInputInner::AlwaysDrained(_) => None,
         }
     }
 
@@ -240,6 +257,7 @@ impl<T: Send + HeapSize + 'static> InputHandle<T> for BranchInputHandle<T> {
         match &self.inner {
             BranchInputInner::Direct(q) => q.is_drained() && q.is_empty(),
             BranchInputInner::Ordered(stage) => stage.is_drained(),
+            BranchInputInner::AlwaysDrained(_) => true,
         }
     }
 }
@@ -1289,6 +1307,19 @@ pub(crate) fn build_unit_queues(
 #[cfg(test)]
 mod handle_tests {
     use super::*;
+
+    #[test]
+    fn always_drained_handle_is_empty_and_drained() {
+        // The zero-state source input handle owns no transport: it pops nothing
+        // and reports drained from the start, so a source step sees its
+        // (implicit) input as immediately end-of-stream.
+        let h = BranchInputHandle::<()>::always_drained();
+        assert_eq!(h.pop(), None, "always-drained handle yields no items");
+        assert!(h.is_drained(), "always-drained handle reports drained");
+        // Idempotent: still drained, still empty after repeated reads.
+        assert_eq!(h.pop(), None);
+        assert!(h.is_drained());
+    }
 
     #[test]
     fn count_bounded_fifo_round_trip() {

--- a/crates/fgumi-pipeline-core/src/queues.rs
+++ b/crates/fgumi-pipeline-core/src/queues.rs
@@ -143,11 +143,6 @@ impl<T: Send + 'static> ItemQueue<T> for CountBoundedQueue<T> {
 /// profiles (≈260 samples vs legacy on CODEC 8M).
 const BYTE_BOUNDED_QUEUE_SLOT_CAPACITY: usize = 1024;
 
-/// One-shot guard so the "slot cap hit before byte budget" warning
-/// (see `ByteBoundedQueue::try_push`) is emitted at most once per process,
-/// keeping the hot-path cost to a single relaxed swap after the first hit.
-static SLOT_CAP_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
 /// Memory-bounded transport. Backed by
 /// `crossbeam_queue::ArrayQueue<(T, u64)>` plus an atomic byte counter.
 /// `try_push` rejects when the running byte counter has already reached
@@ -189,6 +184,13 @@ pub struct ByteBoundedQueue<T: Send + HeapSize + 'static> {
     /// best-effort backpressure heuristic, not a correctness gate).
     limit_bytes: AtomicU64,
     drained: AtomicBool,
+    /// Per-instance one-shot guard so the "slot cap hit before byte budget"
+    /// warning (see `try_push`) is emitted at most once *per queue*, not once
+    /// per process. A process-global flag would silence the warning for every
+    /// later queue (e.g. a second `runall` stage, or many pipelines in one
+    /// long-lived host / test harness) after the first occurrence. The hot-path
+    /// cost is a single relaxed swap after the first hit.
+    slot_cap_warned: AtomicBool,
 }
 
 impl<T: Send + HeapSize + 'static> ByteBoundedQueue<T> {
@@ -205,6 +207,7 @@ impl<T: Send + HeapSize + 'static> ByteBoundedQueue<T> {
             current_bytes: AtomicU64::new(0),
             limit_bytes: AtomicU64::new(limit_bytes),
             drained: AtomicBool::new(false),
+            slot_cap_warned: AtomicBool::new(false),
         }
     }
 
@@ -304,7 +307,7 @@ impl<T: Send + HeapSize + 'static> ItemQueue<T> for ByteBoundedQueue<T> {
                 // preserved (the producer retries) but throughput silently
                 // suffers. Surface it once so it is observable rather than a
                 // silent foot-gun; near-zero cost after the first hit.
-                if !SLOT_CAP_WARNED.swap(true, Ordering::Relaxed) {
+                if !self.slot_cap_warned.swap(true, Ordering::Relaxed) {
                     log::warn!(
                         "ByteBoundedQueue hit its {BYTE_BOUNDED_QUEUE_SLOT_CAPACITY}-slot count \
                          cap before the byte budget; small items are degrading byte-backpressure \
@@ -434,6 +437,39 @@ mod tests {
             q.try_push(Heavy(Vec::new())).is_err(),
             "push #{} must reject on the slot cap, not the byte budget",
             BYTE_BOUNDED_QUEUE_SLOT_CAPACITY + 1
+        );
+    }
+
+    #[test]
+    fn slot_cap_warn_flag_is_per_instance_not_process_global() {
+        // The "slot cap hit before byte budget" warn-once guard lives on the
+        // queue instance, so a second queue (e.g. a later runall stage, or a new
+        // pipeline in a long-lived host) still warns on its own first hit — the
+        // signal is not silenced process-wide by an earlier queue.
+        let fill_to_slot_cap = |q: &ByteBoundedQueue<Heavy>| {
+            for _ in 0..BYTE_BOUNDED_QUEUE_SLOT_CAPACITY {
+                q.try_push(Heavy(Vec::new())).expect("push within slot cap");
+            }
+            // This push trips the slot cap and (first time) sets the flag.
+            assert!(q.try_push(Heavy(Vec::new())).is_err(), "push must reject on slot cap");
+        };
+
+        let q1 = ByteBoundedQueue::<Heavy>::new(1_000_000);
+        assert!(!q1.slot_cap_warned.load(Ordering::Relaxed));
+        fill_to_slot_cap(&q1);
+        assert!(q1.slot_cap_warned.load(Ordering::Relaxed), "first queue must warn on its hit");
+
+        // A fresh queue starts un-warned even though q1 already warned, so it
+        // will warn on its own first hit (per-queue, not process-global).
+        let q2 = ByteBoundedQueue::<Heavy>::new(1_000_000);
+        assert!(
+            !q2.slot_cap_warned.load(Ordering::Relaxed),
+            "a second queue must NOT inherit the first queue's warned state"
+        );
+        fill_to_slot_cap(&q2);
+        assert!(
+            q2.slot_cap_warned.load(Ordering::Relaxed),
+            "second queue must warn on its own hit"
         );
     }
 

--- a/crates/fgumi-pipeline-core/src/reorder.rs
+++ b/crates/fgumi-pipeline-core/src/reorder.rs
@@ -362,6 +362,8 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
                     // Transport full: overflow into the stash. The cap was
                     // already checked above; `next_serial` is exempt either
                     // way, so the must-accept liveness guarantee holds.
+                    // `usize → u64` is a lossless widen on every supported
+                    // (≤64-bit) target, so this cast never truncates.
                     let item_bytes = seq.item.heap_size() as u64;
                     state.buffer.insert(seq.ordinal, (seq.item, item_bytes));
                     state.buffer_bytes = state.buffer_bytes.saturating_add(item_bytes);
@@ -385,6 +387,14 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
 
     /// Consumer-side pop. Returns `Some(T)` if `next_serial` is available,
     /// `None` if still waiting for it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the in-order ordinal counter would overflow `u64` (i.e.
+    /// `next_serial == u64::MAX`). Branch ordinals start at 0 and increment, so
+    /// this is unreachable on any real workload (~1.8e19 items on one edge); the
+    /// guard exists only to fail loudly rather than silently wrap and wait
+    /// forever for ordinal 0.
     pub fn try_pop_in_order(&self) -> Option<T> {
         let mut state = self.state.lock();
         let next = state.next_serial;
@@ -397,6 +407,8 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
         // doesn't pay it again.
         if !state.buffer.contains_key(&next) {
             while let Some(seq) = self.transport.try_pop() {
+                // `usize → u64` is a lossless widen on every supported
+                // (≤64-bit) target, so this cast never truncates.
                 let bytes = seq.item.heap_size() as u64;
                 state.buffer.insert(seq.ordinal, (seq.item, bytes));
                 state.buffer_bytes = state.buffer_bytes.saturating_add(bytes);
@@ -408,7 +420,13 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
 
         if let Some((item, item_bytes)) = state.buffer.remove(&next) {
             state.buffer_bytes = state.buffer_bytes.saturating_sub(item_bytes);
-            let new_next = next + 1;
+            // Advance the in-order cursor. `ByOrdinal` ordinals come from an
+            // `AtomicU64` allocator and `ByItemOrdinal` from upstream item
+            // ordinals; both start at 0 and increment, so `u64::MAX` is
+            // unreachable on any real workload (~1.8e19 items on one edge).
+            // `checked_add` makes that invariant explicit: a wrap here would
+            // silently wait forever for ordinal 0, so we fail loudly instead.
+            let new_next = next.checked_add(1).expect("reorder ordinal overflow (next_serial)");
             state.next_serial = new_next;
             // Update the cache: is the NEW next_serial in the buffer?
             // Producers reading post-update see the right state.
@@ -693,14 +711,41 @@ mod tests {
             })
             .collect();
 
+        // Deadline guard: this test proves deadlock-freedom, so a liveness
+        // regression must *fail fast* rather than hang the whole `nextest` run
+        // until a global harness timeout (if any) fires. 30s is generous —
+        // 256 tiny items drain in milliseconds when healthy — so it only trips
+        // on a genuine wedge, not on a slow CI host. Mirrors the
+        // bounded-convergence guard the single-threaded sibling uses.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         let mut out: Vec<usize> = Vec::with_capacity(total);
         while out.len() < total {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "concurrent reorder drain did not complete within 30s ({} of {total} drained) — \
+                 likely a deadlock/livelock regression",
+                out.len(),
+            );
             match stage.try_pop_in_order() {
                 Some(Heavy(v)) => out.push(v),
                 None => thread::yield_now(),
             }
         }
+        // Bound producer completion with the same deadline. The drain loop above
+        // only proves the *consumer* made progress; if a regression let
+        // `out.len()` reach `total` (e.g. a double-emit) while a producer is
+        // still stuck in its `try_push` retry loop, an unbounded `join()` would
+        // hang the run forever. Poll `is_finished()` against the deadline so a
+        // stuck producer fails fast instead.
         for p in producers {
+            while !p.is_finished() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "a producer thread did not finish within 30s — likely a stuck try_push \
+                     retry loop (liveness regression)",
+                );
+                thread::yield_now();
+            }
             p.join().unwrap();
         }
         assert_eq!(out, (0..total).collect::<Vec<_>>(), "all drain in serial order, none lost");

--- a/crates/fgumi-pipeline-core/src/runtime/contexts.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/contexts.rs
@@ -21,10 +21,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 use crate::erased::ErasedStep;
-use crate::handles::{BranchInputHandle, OutputQueueSet, build_branch};
+use crate::handles::{BranchInputHandle, OutputQueueSet};
 use crate::item::HeapSize;
-use crate::queues::QueueSpec;
-use crate::reorder::BranchOrdering;
 use crate::topology::{BranchIdx, ChainGraph, StepIdx};
 
 /// Per-step input + outputs handles. The worker loop hands these to
@@ -194,11 +192,12 @@ fn build_chain_contexts_inner(
 }
 
 /// Construct a `BranchInputHandle<()>` that's already drained — for source
-/// steps whose input is implicitly empty + drained from t=0.
+/// steps whose input is implicitly empty + drained from t=0. Uses the zero-state
+/// `always_drained` handle (no backing queue), so building a source costs no
+/// `SegQueue` allocation for a handle whose only job is to report
+/// `is_drained() == true` (the worker loop never pops from a source's input).
 fn dummy_unit_input_handle() -> Box<dyn Any + Send + Sync> {
-    let branch = build_branch::<()>(QueueSpec::Unbounded, BranchOrdering::None);
-    branch.output.mark_drained();
-    Box::new(branch.input)
+    Box::new(BranchInputHandle::<()>::always_drained())
 }
 
 /// Find the (producer, branch) that produces the given consumer step.
@@ -294,7 +293,9 @@ mod tests {
 
     use crate::erased::TypedStep;
     use crate::outputs::Single;
-    use crate::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+    use crate::queues::QueueSpec;
+    use crate::reorder::BranchOrdering;
+    use crate::step::{InputHandle, Step, StepCtx, StepKind, StepOutcome, StepProfile};
 
     #[derive(Clone)]
     struct StubSource;
@@ -395,9 +396,15 @@ mod tests {
         assert_eq!(ctx.outputs.len(), n);
         assert!(ctx.bounded_queues.is_empty());
 
+        let source = ctx.inputs[0]
+            .downcast_ref::<BranchInputHandle<()>>()
+            .expect("source must have a dummy unit input handle");
+        // Pin the `always_drained()` invariant: a source's input is implicitly
+        // drained from t=0, so a regression that swapped it back to a real
+        // (never-draining) queue would be caught here, not just the downcast.
         assert!(
-            ctx.inputs[0].downcast_ref::<BranchInputHandle<()>>().is_some(),
-            "source must have a dummy unit input handle"
+            source.is_drained(),
+            "source's dummy unit input handle must report drained (always_drained invariant)"
         );
         for i in 1..n {
             assert!(

--- a/crates/fgumi-pipeline-core/src/runtime/driver.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/driver.rs
@@ -58,6 +58,16 @@ pub fn run_worker_loop(
     // worklist.
     let mut live = LiveSteps::from_entries(entries);
 
+    // Cache whether this worker's sticky owner (if any) is still dispatchable,
+    // so the hot sticky fast-path does not run a linear `live.contains` scan on
+    // every outer-loop iteration (the sticky path exists precisely to shave
+    // per-iteration overhead). `sticky_owner` is fixed for the worker's
+    // lifetime; the step leaves `live` exactly when it returns `Finished`,
+    // either via the sticky block below or via round-robin dispatch — both
+    // sites flip this flag false. A `None` sticky owner is permanently "not
+    // live" so the fast path is skipped entirely.
+    let mut sticky_live = worker.sticky_owner.is_some_and(|idx| live.contains(idx));
+
     loop {
         if signal.is_done() {
             break;
@@ -78,7 +88,7 @@ pub fn run_worker_loop(
         // / Err. Remove from the worklist on Finished (source drain) or
         // observed input drain (mid-step drain). Gated on the step still
         // being live — once removed, the sticky fast-path is disabled.
-        if let Some(owned_idx) = worker.sticky_owner.filter(|idx| live.contains(*idx)) {
+        if let Some(owned_idx) = worker.sticky_owner.filter(|_| sticky_live) {
             let mut mark_skip = false;
             loop {
                 if signal.is_done() {
@@ -118,13 +128,28 @@ pub fn run_worker_loop(
             }
             if mark_skip {
                 live.remove(owned_idx);
+                // The sticky owner finished here; disable the fast path.
+                sticky_live = false;
             }
         }
 
         // 2. Round-robin priority dispatch over all live steps.
         if !signal.is_done() {
-            did_work |=
-                round_robin_dispatch(entries, &mut live, contexts, drain_counters, signal, stats);
+            let outcome = round_robin_dispatch(
+                entries,
+                &mut live,
+                worker.sticky_owner,
+                contexts,
+                drain_counters,
+                signal,
+                stats,
+            );
+            did_work |= outcome.did_work;
+            if outcome.removed_sticky_owner {
+                // The sticky owner finished during round-robin; disable the
+                // fast path so subsequent iterations skip the sticky block.
+                sticky_live = false;
+            }
         }
 
         // 3. Exponential-backoff sleep on no-progress; reset on progress.
@@ -139,18 +164,31 @@ pub fn run_worker_loop(
     }
 }
 
+/// Result of one round-robin pass: whether any step did useful work (caller
+/// resets backoff), and whether the worker's sticky owner finished during the
+/// pass (caller clears its `sticky_live` cache so the sticky fast-path is not
+/// re-attempted on a removed step).
+struct RoundRobinOutcome {
+    did_work: bool,
+    removed_sticky_owner: bool,
+}
+
 /// One pass of the round-robin dispatch over this worker's live steps, in
-/// chain order. Returns `true` if any step did useful work (caller resets
-/// backoff). Finished steps are removed from `live` at end-of-pass (deferred
+/// chain order. Finished steps are removed from `live` at end-of-pass (deferred
 /// so the in-progress walk over `live.order()` is not mutated underneath it).
+/// `sticky_owner` (if any) is reported back via
+/// [`RoundRobinOutcome::removed_sticky_owner`] when it finishes here, so the
+/// caller can disable the per-iteration sticky fast-path without a linear
+/// `live.contains` scan.
 fn round_robin_dispatch(
     entries: &mut [WorkerStepEntry],
     live: &mut LiveSteps,
+    sticky_owner: Option<StepIdx>,
     contexts: &Arc<ChainContexts>,
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
-) -> bool {
+) -> RoundRobinOutcome {
     let mut did_work = false;
     // Steps that finished this pass, removed from `live` after the walk. A
     // step is visited at most once per pass (the cursor only advances; we
@@ -205,10 +243,11 @@ fn round_robin_dispatch(
             break;
         }
     }
+    let removed_sticky_owner = sticky_owner.is_some_and(|owner| finished.contains(&owner));
     for step_idx in finished {
         live.remove(step_idx);
     }
-    did_work
+    RoundRobinOutcome { did_work, removed_sticky_owner }
 }
 
 /// Outcome of dispatching one step, plus the `name` captured *during* the
@@ -336,8 +375,20 @@ fn dispatch_one_step(
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
-    use crate::topology::ChainGraph;
+    use crate::erased::{ErasedStep, TypedStep};
+    use crate::handles::BranchInputHandle;
+    use crate::outputs::Single;
+    use crate::queues::QueueSpec;
+    use crate::reorder::BranchOrdering;
+    use crate::runtime::contexts::build_chain_contexts;
+    use crate::runtime::storage::DrainGate;
+    use crate::step::{InputHandle, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+    use crate::topology::{BranchIdx, ChainGraph};
+    use parking_lot::Mutex;
 
     #[test]
     fn run_worker_loop_exits_on_signal_done() {
@@ -352,5 +403,210 @@ mod tests {
         signal.cancel();
         run_worker_loop(&mut worker, &mut entries, &contexts, &drain_counters, &signal, None);
         // If we reach this line, the loop exited cleanly.
+    }
+
+    // ── Test steps for dispatch-level coverage ──────────────────────────────
+
+    /// `() → u32` source that returns `Finished` immediately.
+    #[derive(Clone)]
+    struct SrcFinished;
+    impl Step for SrcFinished {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "Src",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::Finished)
+        }
+    }
+
+    /// `u32 → u32` step that always returns `Finished`. Used both as a
+    /// `Parallel` body (counter-gated output close) and a `Serial` body
+    /// (`DrainGate` short-circuit). The `runs` counter records every `try_run`
+    /// so the short-circuit test can prove a worker did NOT re-run the step.
+    #[derive(Clone)]
+    struct FinishStep {
+        kind: StepKind,
+        runs: Arc<AtomicUsize>,
+    }
+    impl Step for FinishStep {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "Finish",
+                kind: self.kind,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            self.runs.fetch_add(1, Ordering::Relaxed);
+            Ok(StepOutcome::Finished)
+        }
+        fn new_worker_copy(&self) -> Self {
+            // Clones share the `runs` counter so the test can total runs across
+            // every Parallel clone.
+            self.clone()
+        }
+    }
+
+    #[derive(Clone)]
+    struct SinkStep;
+    impl Step for SinkStep {
+        type Input = u32;
+        type Outputs = ();
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "Sink",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            // Drain any inputs, then finish once the upstream edge is drained so
+            // the worker loop can terminate (a real sink finishes on drain).
+            while ctx.input.pop().is_some() {}
+            if ctx.input.is_drained() {
+                Ok(StepOutcome::Finished)
+            } else {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+    }
+
+    /// Build `Src → Finish → Sink` (Finish having the given kind) and return the
+    /// erased steps + the wired graph. The `Finish` step's `try_run` counter is
+    /// returned so tests can assert how many times it actually ran.
+    fn three_step_chain(
+        finish_kind: StepKind,
+    ) -> (Vec<Box<dyn ErasedStep>>, ChainGraph, Arc<AtomicUsize>) {
+        let runs = Arc::new(AtomicUsize::new(0));
+        let mut graph = ChainGraph::new();
+        let src = graph.register_step("Src", 1);
+        let mid = graph.register_step("Finish", 1);
+        let sink = graph.register_step("Sink", 0);
+        graph.wire(src, BranchIdx(0), mid);
+        graph.wire(mid, BranchIdx(0), sink);
+        let steps: Vec<Box<dyn ErasedStep>> = vec![
+            Box::new(TypedStep::new(SrcFinished)),
+            Box::new(TypedStep::new(FinishStep { kind: finish_kind, runs: Arc::clone(&runs) })),
+            Box::new(TypedStep::new(SinkStep)),
+        ];
+        (steps, graph, runs)
+    }
+
+    /// A `Parallel` step's shared output queue must be closed exactly once — by
+    /// the LAST clone to finish (the one that takes the `StepDrainCounter` to
+    /// 0). Earlier finishers must leave the downstream input un-drained so a
+    /// sibling could still push.
+    #[test]
+    fn parallel_last_finisher_closes_shared_output_exactly_once() {
+        const N: usize = 4;
+        let (steps, graph, _runs) = three_step_chain(StepKind::Parallel);
+        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let mid = StepIdx(1);
+        let counter = StepDrainCounter::new(N);
+        let signal = PipelineSignal::new();
+
+        // One `Owned` clone per worker, each sharing `contexts.outputs[mid]`.
+        let mut clones: Vec<WorkerStepEntry> =
+            (0..N).map(|_| WorkerStepEntry::Owned { step: steps[mid.0].clone_boxed() }).collect();
+
+        let sink_input = contexts.inputs[2].downcast_ref::<BranchInputHandle<u32>>().unwrap();
+
+        for (i, clone) in clones.iter_mut().enumerate() {
+            assert!(
+                !InputHandle::is_drained(sink_input),
+                "downstream input drained before the last clone finished (after {i} of {N})"
+            );
+            let info = dispatch_one_step(clone, mid, &contexts, &counter, &signal, None).unwrap();
+            assert!(matches!(info.result, Ok(StepOutcome::Finished)));
+        }
+        assert!(
+            InputHandle::is_drained(sink_input),
+            "downstream input must be drained once the last Parallel clone finished"
+        );
+    }
+
+    /// Once one worker finishes a `Serial` step (setting the shared `DrainGate`),
+    /// a second `dispatch_one_step` short-circuits to a synthetic `Finished`
+    /// WITHOUT re-acquiring the mutex or re-running the step.
+    #[test]
+    fn serial_drain_gate_short_circuits_second_worker() {
+        let (steps, graph, runs) = three_step_chain(StepKind::Serial);
+        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let mid = StepIdx(1);
+        let counter = StepDrainCounter::new(1);
+        let signal = PipelineSignal::new();
+
+        let shared = Arc::new(Mutex::new(steps.into_iter().nth(1).unwrap()));
+        let drain = Arc::new(DrainGate::default());
+
+        // Worker 1 finishes the step: runs once, sets the latch.
+        let mut entry1 =
+            WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
+        let info1 =
+            dispatch_one_step(&mut entry1, mid, &contexts, &counter, &signal, None).unwrap();
+        assert!(matches!(info1.result, Ok(StepOutcome::Finished)));
+        assert_eq!(runs.load(Ordering::Relaxed), 1, "step ran exactly once on the first worker");
+        assert!(drain.is_finished(), "first finisher must set the DrainGate latch");
+
+        // Worker 2 dispatches the same step: short-circuit, no re-run.
+        let mut entry2 =
+            WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
+        let info2 =
+            dispatch_one_step(&mut entry2, mid, &contexts, &counter, &signal, None).unwrap();
+        assert!(matches!(info2.result, Ok(StepOutcome::Finished)));
+        assert_eq!(
+            info2.name, "<finished-serial-step>",
+            "second worker takes the latch short-circuit"
+        );
+        assert_eq!(
+            runs.load(Ordering::Relaxed),
+            1,
+            "the Serial step must NOT be re-run after the DrainGate latch is set"
+        );
+    }
+
+    /// A sticky-owned source driven through `run_worker_loop` completes and the
+    /// loop exits even though the cached `sticky_live` flag (not a per-iteration
+    /// `live.contains` scan) gates the fast path. Exercises the S1b-006 cache:
+    /// the sticky step is removed once it returns `Finished`, after which the
+    /// fast path must be disabled and the loop must terminate.
+    #[test]
+    fn sticky_owner_completes_and_loop_exits() {
+        let mut graph = ChainGraph::new();
+        let src = graph.register_step("Src", 1);
+        let sink = graph.register_step("Sink", 0);
+        graph.wire(src, BranchIdx(0), sink);
+        let steps: Vec<Box<dyn ErasedStep>> =
+            vec![Box::new(TypedStep::new(SrcFinished)), Box::new(TypedStep::new(SinkStep))];
+        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+
+        // Single worker; the source (idx 0) is its Exclusive sticky owner, the
+        // sink (idx 1) is Exclusive owned by the same worker for this 1-worker
+        // run.
+        let mut entries: Vec<WorkerStepEntry> = vec![
+            WorkerStepEntry::Exclusive { step: steps.into_iter().next().unwrap() },
+            WorkerStepEntry::Exclusive { step: Box::new(TypedStep::new(SinkStep)) },
+        ];
+        let drain_counters = vec![StepDrainCounter::new(1), StepDrainCounter::new(1)];
+        let signal = PipelineSignal::new();
+        let mut worker = WorkerCore::new(0, Some(src), Some(src));
+
+        // The source finishes immediately; the sink then sees its input drained
+        // and finishes too. `run_worker_loop` must return (no hang).
+        run_worker_loop(&mut worker, &mut entries, &contexts, &drain_counters, &signal, None);
     }
 }

--- a/crates/fgumi-pipeline-core/src/runtime/fused.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/fused.rs
@@ -176,13 +176,22 @@ pub fn run_fused_single_thread(
             // In release builds the `debug_assert!` is compiled out, so record
             // the stall as an error before breaking. Otherwise the loop would
             // exit and map to `Ok`, silently truncating the output instead of
-            // surfacing the broken invariant.
+            // surfacing the broken invariant. Name the still-unfinished steps so
+            // the error points at the wedged step(s) rather than just the
+            // synthetic "fused-driver" name.
+            let stalled_steps: Vec<&'static str> = finished
+                .iter()
+                .enumerate()
+                .filter(|(_, f)| !**f)
+                .map(|(i, _)| steps[i].name())
+                .collect();
             signal.record_error(PipelineError::Io {
                 step: "fused-driver",
-                source: std::io::Error::other(
-                    "fused single-thread driver stalled: no step progressed and \
-                     not all steps have finished",
-                ),
+                source: std::io::Error::other(format!(
+                    "fused single-thread driver stalled: no step progressed and not all \
+                     steps have finished; unfinished step(s): {}",
+                    stalled_steps.join(", "),
+                )),
             });
             break 'drive;
         }

--- a/crates/fgumi-pipeline-core/src/runtime/pool.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/pool.rs
@@ -17,7 +17,7 @@ pub fn assign_exclusive_owners(
     steps: &[Box<dyn ErasedStep>],
     n_threads: usize,
 ) -> Result<Vec<Option<usize>>, PipelineError> {
-    let total_exclusive = steps.iter().filter(|s| s.profile().kind == StepKind::Exclusive).count();
+    let total_exclusive = steps.iter().filter(|s| s.kind() == StepKind::Exclusive).count();
     if total_exclusive > n_threads {
         return Err(PipelineError::NotEnoughThreads {
             required: total_exclusive,
@@ -28,7 +28,7 @@ pub fn assign_exclusive_owners(
     let mut owners: Vec<Option<usize>> = vec![None; steps.len()];
     let mut next_owner = 0usize;
     for (idx, step) in steps.iter().enumerate() {
-        if step.profile().kind == StepKind::Exclusive {
+        if step.kind() == StepKind::Exclusive {
             owners[idx] = Some(next_owner);
             next_owner += 1;
         }
@@ -66,8 +66,7 @@ pub fn assign_sticky_owners(
 
     // First pass: Exclusive-sticky owners (highest priority).
     for (step_usize, step) in steps.iter().enumerate() {
-        let profile = step.profile();
-        if profile.kind == StepKind::Exclusive && profile.sticky {
+        if step.kind() == StepKind::Exclusive && step.sticky() {
             if let Some(owner) = exclusive_owners[step_usize] {
                 if owner < n_workers && sticky[owner].is_none() {
                     sticky[owner] = Some(StepIdx(step_usize));
@@ -78,8 +77,7 @@ pub fn assign_sticky_owners(
 
     // Second pass: Serial-sticky-Affinity owners (only fill empty slots).
     for (step_usize, step) in steps.iter().enumerate() {
-        let profile = step.profile();
-        if profile.kind == StepKind::Serial && profile.sticky {
+        if step.kind() == StepKind::Serial && step.sticky() {
             let target = match step.affinity() {
                 crate::step::Affinity::None => continue,
                 crate::step::Affinity::Reader => 0,

--- a/crates/fgumi-pipeline-core/src/runtime/storage.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/storage.rs
@@ -92,7 +92,7 @@ pub fn build_worker_storage(
         (0..n_workers).map(|_| Vec::with_capacity(steps.len())).collect();
 
     for (step_idx, step) in steps.into_iter().enumerate() {
-        let kind = step.profile().kind;
+        let kind = step.kind();
         match kind {
             StepKind::Parallel => {
                 // Each worker gets its own clone; the original goes to worker N-1.

--- a/crates/fgumi-pipeline-core/src/runtime/worker_core.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/worker_core.rs
@@ -67,6 +67,23 @@ mod tests {
     #[test]
     fn backoff_doubles_then_caps() {
         let mut w = WorkerCore::new(0, None, None);
+        // Pin the doubling sequence before the cap: 1 → 2 → 4 → 8 → … . The
+        // initial value is 1, and each `increase_backoff` doubles it. Asserting
+        // only the final cap would pass a buggy `increase_backoff` that jumped
+        // straight to the cap or incremented by a constant, so check the
+        // sequence too.
+        assert_eq!(w.current_backoff_us(), BACKOFF_INITIAL_US);
+        let mut expected = BACKOFF_INITIAL_US;
+        for _ in 0..10 {
+            w.increase_backoff();
+            expected = (expected * 2).min(BACKOFF_MAX_US);
+            assert_eq!(
+                w.current_backoff_us(),
+                expected,
+                "backoff must double each step until it saturates"
+            );
+        }
+        // Many more doublings saturate at the cap and stay there.
         for _ in 0..50 {
             w.increase_backoff();
         }

--- a/crates/fgumi-pipeline-core/src/tests.rs
+++ b/crates/fgumi-pipeline-core/src/tests.rs
@@ -6,6 +6,7 @@
 //! lives in Phase 2. These tests confirm the Phase 1 pieces support the
 //! unified report-`Finished` completion contract end-to-end.
 
+use std::collections::VecDeque;
 use std::io;
 use std::sync::Arc;
 
@@ -399,7 +400,11 @@ impl Step for WideQueueSource {
 /// completion contract.
 #[derive(Clone)]
 struct ReportsFinishedBuffer {
-    buffered: Vec<u32>,
+    // A `VecDeque` so the flush-first drain pops the FIFO front in O(1). Real
+    // steps process millions of records: a `Vec` with `remove(0)` would be O(n)
+    // per flushed item (quadratic drain). Step authors copying this worked
+    // example must keep the front-drain O(1) — never `Vec::remove(0)`.
+    buffered: VecDeque<u32>,
 }
 impl Step for ReportsFinishedBuffer {
     type Input = u32;
@@ -416,10 +421,10 @@ impl Step for ReportsFinishedBuffer {
     fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
         // 1. Flush-first: push held items until the queue rejects one.
         let mut pushed = false;
-        while let Some(&item) = self.buffered.first() {
+        while let Some(&item) = self.buffered.front() {
             match ctx.outputs.push(item) {
                 Ok(()) => {
-                    self.buffered.remove(0);
+                    self.buffered.pop_front();
                     pushed = true;
                 }
                 Err(_unpushed) => break, // queue full — yield, retry next pass
@@ -430,7 +435,7 @@ impl Step for ReportsFinishedBuffer {
         }
         // 2. Consume input.
         if let Some(n) = ctx.input.pop() {
-            self.buffered.push(n);
+            self.buffered.push_back(n);
             return Ok(StepOutcome::Progress);
         }
         // 3. Completion: input drained AND nothing held — never push again.
@@ -459,7 +464,7 @@ fn run_reports_finished_pipeline(threads: usize, n_items: u32) {
         let builder = Pipeline::builder();
         builder
             .chain(WideQueueSource { remaining: n_items })
-            .chain(ReportsFinishedBuffer { buffered: Vec::new() })
+            .chain(ReportsFinishedBuffer { buffered: VecDeque::new() })
             .chain(DrainReproSink { received: received_for_run })
             .into_sink_marker();
         let pipeline = builder.build().expect("pipeline build");

--- a/crates/fgumi-pipeline-core/src/topology.rs
+++ b/crates/fgumi-pipeline-core/src/topology.rs
@@ -2,6 +2,16 @@
 //! `PipelineBuilder::build()` to assert all-outputs-wired and by the
 //! runtime to construct queue topology.
 
+/// Static branch-index display names covering every branch up to [`MAX_ARITY`].
+/// Output branch counts are bounded by `MAX_ARITY` at registration, so a valid
+/// branch index always maps to a name and the build-error message never prints a
+/// placeholder. Out-of-range indices fall back to `"?"` (never hit in practice,
+/// but keeps the function total).
+fn branch_name(branch: usize) -> &'static str {
+    const BRANCH_NAMES: [&str; crate::outputs::MAX_ARITY] = ["0", "1", "2", "3"];
+    BRANCH_NAMES.get(branch).copied().unwrap_or("?")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StepIdx(pub usize);
 
@@ -21,6 +31,13 @@ pub struct ChainGraph {
     consumer_input_slots: Vec<Option<usize>>,
     /// `branch_count[step]` — number of output branches for that step.
     branch_counts: Vec<usize>,
+    /// `branch_offsets[step]` — running prefix sum of `branch_counts` *before*
+    /// `step` (i.e. `sum(branch_counts[..step])`). This is the base index into
+    /// the flat `consumers` / `consumer_input_slots` arrays for `step`'s first
+    /// output branch, so `consumer_slot_index` is O(1) instead of re-summing the
+    /// prefix on every call. Pushed once per step in
+    /// [`Self::register_step_with_input_arity`]; static thereafter.
+    branch_offsets: Vec<usize>,
     /// `input_arities[step]` — number of input branches for that
     /// step (1 for single-input [`Step`] impls, 2 for [`Step2`],
     /// N for future `StepN`). Defaults to 1 via [`Self::register_step`];
@@ -53,6 +70,9 @@ impl ChainGraph {
         input_arity: usize,
     ) -> StepIdx {
         let idx = StepIdx(self.branch_counts.len());
+        // The offset for this step is the total branch count of all prior steps,
+        // i.e. the current length of the flat `consumers` array before we grow it.
+        self.branch_offsets.push(self.consumers.len());
         self.branch_counts.push(branch_count);
         self.input_arities.push(input_arity);
         self.step_names.push(name);
@@ -143,14 +163,7 @@ impl ChainGraph {
                 let producer = StepIdx(producer_usize);
                 let slot = self.consumer_slot_index(producer, BranchIdx(branch));
                 if self.consumers[slot].is_none() {
-                    let name = match branch {
-                        0 => "0",
-                        1 => "1",
-                        2 => "2",
-                        3 => "3",
-                        _ => "?",
-                    };
-                    return Some((producer, BranchIdx(branch), name));
+                    return Some((producer, BranchIdx(branch), branch_name(branch)));
                 }
             }
         }
@@ -193,11 +206,10 @@ impl ChainGraph {
             self.step_names[producer.0],
             branch_count
         );
-        let mut offset = 0;
-        for &count in &self.branch_counts[..producer.0] {
-            offset += count;
-        }
-        offset + branch.0
+        // `branch_offsets[producer]` is the precomputed prefix sum of all prior
+        // steps' branch counts (maintained in `register_step_with_input_arity`),
+        // so this is O(1) rather than re-summing `branch_counts[..producer.0]`.
+        self.branch_offsets[producer.0] + branch.0
     }
 }
 
@@ -250,6 +262,36 @@ mod tests {
         let (producer, branch, _) = g.first_unwired().unwrap();
         assert_eq!(producer, StepIdx(1));
         assert_eq!(branch, BranchIdx(1));
+    }
+
+    #[test]
+    fn branch_offsets_route_multi_branch_consumers_correctly() {
+        // Several multi-branch producers in a row: the precomputed branch
+        // offsets must keep each (producer, branch) edge mapped to a distinct
+        // flat slot so `consumer`/`consumer_input_slot` return the right links.
+        let mut g = ChainGraph::new();
+        let src = g.register_step("Source", 1); // offset 0, slot 0
+        let fan3 = g.register_step("Fan3", 3); // offset 1, slots 1..4
+        let fan2 = g.register_step("Fan2", 2); // offset 4, slots 4..6
+        let s0 = g.register_step("S0", 0);
+        let s1 = g.register_step("S1", 0);
+        let s2 = g.register_step("S2", 0);
+        let s3 = g.register_step("S3", 0);
+
+        g.wire(src, BranchIdx(0), fan3);
+        g.wire(fan3, BranchIdx(0), s0);
+        g.wire(fan3, BranchIdx(1), fan2);
+        g.wire(fan3, BranchIdx(2), s1);
+        g.wire(fan2, BranchIdx(0), s2);
+        g.wire(fan2, BranchIdx(1), s3);
+
+        assert!(g.first_unwired().is_none());
+        assert_eq!(g.consumer(src, BranchIdx(0)), Some(fan3));
+        assert_eq!(g.consumer(fan3, BranchIdx(0)), Some(s0));
+        assert_eq!(g.consumer(fan3, BranchIdx(1)), Some(fan2));
+        assert_eq!(g.consumer(fan3, BranchIdx(2)), Some(s1));
+        assert_eq!(g.consumer(fan2, BranchIdx(0)), Some(s2));
+        assert_eq!(g.consumer(fan2, BranchIdx(1)), Some(s3));
     }
 
     #[test]

--- a/crates/fgumi-pipeline-io/src/lib.rs
+++ b/crates/fgumi-pipeline-io/src/lib.rs
@@ -1,5 +1,19 @@
 #![deny(unsafe_code)]
 
+//! BAM-pipeline I/O layer for the fgumi typed-step pipeline.
+//!
+//! Provides the source, sink, and sort typed-step building blocks plus the
+//! record-batch and BGZF-block buffer types shared across the fgumi pipeline:
+//!
+//!   * [`source`] — BAM ingest steps ([`ReadBgzfBlocks`] and the
+//!     `read_bam*` helpers) that turn a reader into decompressed blocks.
+//!   * [`sink`] — BAM output steps ([`WriteBgzfFile`]).
+//!   * [`sort`] — in-pipeline sort steps ([`SortAndSpill`], [`SortMerge`],
+//!     [`SortBamFile`], [`SortSpillDecompress`]).
+//!   * [`types`] — the record-batch / decompressed-block buffers
+//!     ([`RecordBatch`], [`DecompressedBlock`], [`BgzfBlock`], …) exchanged
+//!     between steps.
+
 pub mod sink;
 pub mod sort;
 pub mod source;

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -129,6 +129,41 @@ impl UnmappedSamBuilder {
         );
     }
 
+    /// Fallible variant of [`Self::build_record_joined_name`] for callers whose
+    /// name parts are **data-controlled** (e.g. a consensus read name composed
+    /// from an `RX`/`MI` tag of arbitrary, attacker-controllable length).
+    ///
+    /// Returns an [`io::Error`] of kind [`io::ErrorKind::InvalidData`] when the
+    /// joined name (`prefix` + `:` + `suffix`) would be 255 bytes or longer
+    /// (BAM's `l_read_name` is a single byte including the NUL terminator),
+    /// instead of panicking. On success the record is built exactly as
+    /// [`Self::build_record_joined_name`] would.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the joined name is 255 bytes or longer.
+    pub fn try_build_record_joined_name(
+        &mut self,
+        prefix: &[u8],
+        suffix: &[u8],
+        flag: u16,
+        bases: &[u8],
+        quals: &[u8],
+    ) -> std::io::Result<()> {
+        let name_len = prefix.len() + 1 + suffix.len(); // +1 for the ':' separator
+        if name_len >= 255 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "consensus read name too long ({name_len} bytes, max 254); \
+                     the composing UMI/MI tag value is over-long"
+                ),
+            ));
+        }
+        self.build_record_joined_name(prefix, suffix, flag, bases, quals);
+        Ok(())
+    }
+
     /// Shared record builder: writes the fixed header, the read name (via
     /// `write_name`, which must append exactly `name_len` bytes), the packed
     /// sequence, and the quality scores.
@@ -671,6 +706,44 @@ mod tests {
         assert_eq!(joined.as_bytes(), formatted.as_bytes());
         assert_eq!(read_name(joined.as_bytes()), b"consensus:1/A");
         assert_eq!(l_read_name(joined.as_bytes()), 14); // "consensus:1/A" (13) + NUL
+    }
+
+    #[test]
+    fn test_try_build_record_joined_name_ok_matches_infallible() {
+        let bases = b"ACGT";
+        let quals: [u8; 4] = [30, 30, 30, 30];
+
+        let mut fallible = UnmappedSamBuilder::new();
+        fallible
+            .try_build_record_joined_name(b"cons", b"1/A", flags::UNMAPPED, bases, &quals)
+            .expect("name fits");
+
+        let mut infallible = UnmappedSamBuilder::new();
+        infallible.build_record_joined_name(b"cons", b"1/A", flags::UNMAPPED, bases, &quals);
+
+        assert_eq!(fallible.as_bytes(), infallible.as_bytes());
+    }
+
+    #[test]
+    fn test_try_build_record_joined_name_boundary_254_ok_255_err() {
+        let bases = b"AC";
+        let quals: [u8; 2] = [30, 30];
+
+        // prefix(127) + ':' + suffix(126) = 254 → OK.
+        let prefix = vec![b'A'; 127];
+        let suffix_ok = vec![b'B'; 126];
+        let mut ok = UnmappedSamBuilder::new();
+        ok.try_build_record_joined_name(&prefix, &suffix_ok, flags::UNMAPPED, bases, &quals)
+            .expect("254-byte name must be accepted");
+        assert_eq!(l_read_name(ok.as_bytes()), 255); // 254 name bytes + NUL
+
+        // One more byte → 255 → typed InvalidData error, no panic.
+        let suffix_err = vec![b'B'; 127];
+        let mut err_builder = UnmappedSamBuilder::new();
+        let err = err_builder
+            .try_build_record_joined_name(&prefix, &suffix_err, flags::UNMAPPED, bases, &quals)
+            .expect_err("255-byte name must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     proptest::proptest! {

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -113,10 +113,10 @@ pub use tags::{
     TagValue, TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
     array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
     find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
-    find_string_tag_in_record, find_string_tag_position, find_tag_type, find_uint8_tag,
-    normalize_int_tag_to_smallest_signed, remove_tag, reverse_array_tag_in_place,
-    reverse_complement_string_tag_in_place, reverse_string_tag_in_place, update_int_tag,
-    update_string_tag,
+    find_string_tag_in_record, find_string_tag_position, find_tag_type,
+    find_two_string_tags_in_record, find_uint8_tag, normalize_int_tag_to_smallest_signed,
+    remove_tag, reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
+    reverse_string_tag_in_place, update_int_tag, update_string_tag,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -173,9 +173,11 @@ where
 
 /// Reads the 4-byte BAM record `block_size` prefix (little-endian u32).
 ///
-/// Returns 0 at EOF (no bytes available before the prefix starts). Handles a
-/// prefix split across reader boundaries by issuing a 1-byte read first (to
-/// detect clean EOF) followed by a `read_exact` of the remaining 3 bytes.
+/// Returns 0 only at a clean EOF before any prefix byte is read (no bytes
+/// available before the prefix starts); a prefix truncated after 1-3 bytes
+/// returns an error rather than 0. Handles a prefix split across reader
+/// boundaries by issuing a 1-byte read first (to detect clean EOF) followed by
+/// a `read_exact` of the remaining 3 bytes.
 ///
 /// Exposed for the sort ingest borrow-in-place path
 /// (`PooledInputStream::next_record_borrowed`), which reads the prefix itself so

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -95,6 +95,73 @@ pub fn find_string_tag_in_record(bam: &[u8], tag: impl AsTagBytes) -> Option<&[u
     find_string_tag(aux, tag)
 }
 
+/// Find two string (Z-type) tags in a complete BAM record in a **single** aux-data
+/// walk, returning each value's bytes (without the NUL terminator) or `None` if that
+/// tag is absent or not Z-type.
+///
+/// Equivalent to calling [`find_string_tag_in_record`] twice, but it walks the aux
+/// block only once — relevant on hot paths that need both an MI tag and a cell-barcode
+/// tag per record. The returned slices borrow the record's aux data.
+#[inline]
+#[must_use]
+pub fn find_two_string_tags_in_record(
+    bam: &[u8],
+    first: impl AsTagBytes,
+    second: impl AsTagBytes,
+) -> (Option<&[u8]>, Option<&[u8]>) {
+    let first = u16::from_le_bytes(*first.as_tag_bytes());
+    let second = u16::from_le_bytes(*second.as_tag_bytes());
+    let aux = aux_data_slice(bam);
+
+    let mut first_done = false;
+    let mut second_done = false;
+    let mut first_val: Option<&[u8]> = None;
+    let mut second_val: Option<&[u8]> = None;
+    let mut p = 0;
+    while p + 3 <= aux.len() {
+        let entry_u16 = u16::from_le_bytes([aux[p], aux[p + 1]]);
+        let val_type = aux[p + 2];
+
+        // Each tag resolves on its FIRST matching entry, exactly as
+        // `find_string_tag_in_record` does (it returns the first tag match and
+        // yields a value only if that match is a NUL-terminated `Z` entry). A
+        // non-`Z` (or unterminated) first match resolves the tag to `None`; we
+        // must NOT skip it and pick up a later `Z` duplicate, or the two-tag
+        // walk would disagree with two single-tag lookups on malformed aux.
+        let matches_first = entry_u16 == first && !first_done;
+        let matches_second = entry_u16 == second && !second_done;
+        if matches_first || matches_second {
+            let value = if val_type == b'Z' {
+                let start = p + 3;
+                aux[start..].iter().position(|&b| b == 0).map(|len| &aux[start..start + len])
+            } else {
+                None
+            };
+            // Independent (not `else`) so a single entry resolves both slots
+            // when `first == second`, preserving the "call twice" contract.
+            if matches_first {
+                first_done = true;
+                first_val = value;
+            }
+            if matches_second {
+                second_done = true;
+                second_val = value;
+            }
+        }
+
+        // Stop once both tags have been resolved (each to a value or `None`).
+        if first_done && second_done {
+            break;
+        }
+
+        match tag_value_size(val_type, &aux[p + 3..]) {
+            Some(size) => p += 3 + size,
+            None => break,
+        }
+    }
+    (first_val, second_val)
+}
+
 /// Find the byte range `[start, end)` of an entire tag entry (tag+type+value) in aux data.
 ///
 /// Returns offsets relative to the start of `aux_data`.
@@ -2081,6 +2148,88 @@ mod tests {
         let aux = b"RXZhello\x00";
         let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
         assert_eq!(find_string_tag_in_record(&rec, SamTag::RX), Some(b"hello".as_ref()));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_both_present_either_order() {
+        // MI before CB.
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+
+        // CB before MI: result is independent of aux ordering and of arg order.
+        let aux = b"CBZACGT\x00MIZ7\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_agrees_with_single_lookups() {
+        // Interleave a non-Z tag to make the walk non-trivial.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"NMC");
+        aux.push(3);
+        aux.extend_from_slice(b"MIZ42\x00");
+        aux.extend_from_slice(b"CBZTGCA\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_first_match_wins_on_malformed_dup() {
+        // A non-Z MI entry precedes a Z MI duplicate. `find_string_tag_in_record`
+        // resolves the FIRST MI match (non-Z → None) and never reaches the later
+        // Z duplicate; the two-tag walk must match that rather than skipping the
+        // non-Z entry and returning the later Z value.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MIC"); // MI, type 'C' (uint8) ...
+        aux.push(9); //                ... 1-byte value (non-Z → MI resolves None)
+        aux.extend_from_slice(b"MIZ77\x00"); // later Z duplicate — must be ignored
+        aux.extend_from_slice(b"CBZACGT\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, None, "first (non-Z) MI match resolves the tag to None");
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+        // Must agree with two independent single-tag lookups.
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_missing_second_returns_none() {
+        let aux = b"MIZ7\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, None);
+    }
+
+    #[test]
+    fn test_find_two_string_tags_identical_tags_fills_both() {
+        // When both arguments name the same tag, the helper must stay equivalent
+        // to calling `find_string_tag_in_record` twice — i.e. both slots filled,
+        // not `(Some, None)`.
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (a, b) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::MI);
+        assert_eq!(a, Some(b"7".as_ref()));
+        assert_eq!(b, Some(b"7".as_ref()));
+        assert_eq!(a, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(b, find_string_tag_in_record(&rec, SamTag::MI));
+
+        // Identical tags, both absent → both None.
+        let aux = b"CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (a, b) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::MI);
+        assert_eq!(a, None);
+        assert_eq!(b, None);
     }
 
     #[test]

--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -246,6 +246,15 @@ use fgumi_raw_bam::{self, RawRecordView, RawTagsEditor};
 ///
 /// Returns `Ok(true)` if tags were regenerated, `Ok(false)` for unmapped reads.
 ///
+/// A record that is *mapped*-flagged but carries a negative reference sequence
+/// ID (`ref_id < 0`) is degenerate/contradictory: there is no reference to
+/// compute tags against. Rather than leaving whatever stale NM/UQ/MD were on
+/// the record, this strips them and returns `Ok(false)` — the same fail-closed
+/// behavior as the unmapped branch, and consistent with fgbio's
+/// `regenerateNmUqMdTags`, which nulls NM/UQ/MD whenever a read has no usable
+/// alignment. This guarantees the raw path never emits stale alignment tags on
+/// malformed input.
+///
 /// # Errors
 ///
 /// Returns an error if the record is too short, the reference sequence ID is not found
@@ -281,6 +290,16 @@ pub fn regenerate_alignment_tags_raw(
     // Get reference sequence ID and look up name in header
     let ref_seq_id = RawRecordView::new(record).ref_id();
     if ref_seq_id < 0 {
+        // Degenerate: a mapped-flagged record with no reference sequence ID has
+        // nothing to recompute tags against. Fail closed by stripping any stale
+        // NM/UQ/MD (matching the unmapped branch above and fgbio's
+        // `regenerateNmUqMdTags`, which nulls these tags when a read has no
+        // usable alignment) so the malformed record never carries stale
+        // alignment tags downstream.
+        let mut editor = RawTagsEditor::from_vec(record);
+        editor.remove(SamTag::NM);
+        editor.remove(SamTag::UQ);
+        editor.remove(SamTag::MD);
         return Ok(false);
     }
     let ref_seqs = header.reference_sequences();
@@ -982,6 +1001,45 @@ mod tests {
             Some("1C2"),
             "MD should be 1C2"
         );
+
+        Ok(())
+    }
+
+    /// A mapped-flagged record with a negative reference ID is degenerate: there
+    /// is no reference to compute tags against. The raw path must fail closed by
+    /// stripping any stale NM/UQ/MD (matching the unmapped branch and fgbio's
+    /// `regenerateNmUqMdTags`), not leave them in place.
+    #[test]
+    fn test_regenerate_alignment_tags_raw_strips_tags_on_negative_ref_id() -> Result<()> {
+        let (_fasta, reference) = create_test_reference()?;
+        let header = create_test_header();
+
+        // Start from a valid mapped record and regenerate real NM/UQ/MD onto it.
+        let mut record_buf = create_mapped_record("ATGT", &[30, 30, 25, 30], "4M", 1);
+        regenerate_alignment_tags(&mut record_buf, &header, &reference)?;
+        let mut raw = encode_record_buf_to_raw(&header, &record_buf)?;
+
+        // Sanity: the stale tags are present before we corrupt the ref ID.
+        let aux_off = fgumi_raw_bam::aux_data_offset_from_record(&raw).unwrap_or(raw.len());
+        assert!(
+            fgumi_raw_bam::find_int_tag(&raw[aux_off..], SamTag::NM).is_some(),
+            "precondition: NM present before forcing a negative ref ID"
+        );
+
+        // Force a negative reference sequence ID (BAM refID = first 4 bytes, i32 LE)
+        // while leaving the record mapped-flagged: the degenerate edge case.
+        raw[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        assert!(!RawRecordView::new(&raw).is_unmapped(), "record must stay mapped-flagged");
+
+        let regenerated = regenerate_alignment_tags_raw(&mut raw, &header, &reference)?;
+        assert!(!regenerated, "degenerate negative-ref-id record reports no regeneration");
+
+        // The stale alignment tags must have been stripped, not left behind.
+        let aux_off = fgumi_raw_bam::aux_data_offset_from_record(&raw).unwrap_or(raw.len());
+        let aux = &raw[aux_off..];
+        assert_eq!(fgumi_raw_bam::find_int_tag(aux, SamTag::NM), None, "NM must be stripped");
+        assert_eq!(fgumi_raw_bam::find_int_tag(aux, SamTag::UQ), None, "UQ must be stripped");
+        assert_eq!(fgumi_raw_bam::find_string_tag(aux, SamTag::MD), None, "MD must be stripped");
 
         Ok(())
     }

--- a/crates/fgumi-sort-cli/src/version.rs
+++ b/crates/fgumi-sort-cli/src/version.rs
@@ -31,3 +31,32 @@ pub fn set_version_override(version: String) -> bool {
 pub fn version_string() -> String {
     VERSION_OVERRIDE.get().cloned().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The override is a process-global `OnceLock`, so its first-write-wins
+    /// contract and the `version_string` fallback must be exercised in ONE test
+    /// (a second test could observe state left by the first). This test must be
+    /// the only thing in the crate's test binary that sets the override.
+    #[test]
+    fn set_version_override_is_first_write_wins_and_drives_version_string() {
+        // Before any override is installed, `version_string` falls back to the
+        // Cargo package version. This test is the only thing in the crate's test
+        // binary that touches the override, so the fallback is still observable
+        // here — assert it so a broken fallback is caught in the same one-shot test.
+        assert_eq!(version_string(), env!("CARGO_PKG_VERSION"));
+
+        // First write installs the value and reports success.
+        assert!(set_version_override("X".to_string()), "first set must install the value");
+        // A second write is ignored (first-write-wins) and reports failure.
+        assert!(
+            !set_version_override("Y".to_string()),
+            "second set must be ignored, leaving the first value"
+        );
+        // `version_string` reflects the first-installed override, not the Cargo
+        // fallback nor the second (ignored) value.
+        assert_eq!(version_string(), "X");
+    }
+}

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -482,12 +482,15 @@ impl<K: RawSortKey> GenericKeyedChunkWriter<K> {
     ///
     /// Returns an error if writing to the underlying writer fails.
     #[inline]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
         if !K::EMBEDDED_IN_RECORD {
             key.write_to(&mut self.writer)?;
         }
-        self.writer.write_all(&(record.len() as u32).to_le_bytes())?;
+        // The merge reader reads this 4-byte length prefix back; a checked cast
+        // fails loud before a truncated prefix could desync the spill stream.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
+        self.writer.write_all(&record_len.to_le_bytes())?;
         self.writer.write_all(record)?;
         Ok(())
     }

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -87,8 +87,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::codec::SpillCodec;
 
 /// Per-slot decompressed-block queue cap. Bounds in-flight
-/// decompressed memory: `num_slots × PHASE2_DECOMP_CAP × ~256 KB`.
-/// Matches `worker_pool::PHASE2_DECOMP_CAP` numerically.
+/// decompressed memory: `num_slots × PHASE2_DECOMP_CAP ×` per-entry size,
+/// where each entry is a decompressed BGZF block or zstd frame ranging from
+/// ~64 KB (BGZF) up to 256 KB (zstd worst case). Matches
+/// `worker_pool::PHASE2_DECOMP_CAP` numerically.
 ///
 /// Hard cap — there is no admission escape. Producers skip a slot
 /// when its queue is at this cap, returning to it on a later
@@ -125,11 +127,11 @@ pub struct SortMergeSlot {
     /// Disk reader. Held only while reading raw bytes from disk.
     /// One worker at a time per slot via `try_lock`.
     pub reader: Mutex<SortMergeReader>,
-    /// Bounded queue of decompressed BGZF blocks, FIFO. Pushed by
-    /// the producer (`SortSpillDecompress`) after read + inline
-    /// decompress; popped by the consumer (`SortMerge` via
-    /// `slot_try_load_block`). Bounded at `PHASE2_DECOMP_CAP`;
-    /// producer skips when at cap.
+    /// Bounded queue of decompressed blocks (each a BGZF block or a zstd
+    /// frame, per this slot's `codec`), FIFO. Pushed by the producer
+    /// (`SortSpillDecompress`) after read + inline decompress; popped by the
+    /// consumer (`SortMerge` via `slot_try_load_block`). Bounded at
+    /// `PHASE2_DECOMP_CAP`; producer skips when at cap.
     pub decompressed: Mutex<VecDeque<Vec<u8>>>,
     /// Set true once the producer detects EOF on the disk reader
     /// AND has pushed any final batch of decompressed blocks to

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -97,8 +97,12 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
     /// # Panics
     ///
     /// Panics if called after [`start_finish`](Self::start_finish) has been called.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        // The on-disk spill frame prefixes each record with a 4-byte little-endian
+        // length that the merge reader (`external.rs`) reads back; a checked cast
+        // fails loud before a truncated prefix could desync the spill stream.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
         let staging = self.staging.as_mut().expect("write_record called after start_finish");
         if K::EMBEDDED_IN_RECORD {
             // Fast path: key is part of the record bytes, no extra serialization.
@@ -107,7 +111,7 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
             if staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
                 staging.flush()?;
             }
-            staging.buf().extend_from_slice(&(record.len() as u32).to_le_bytes());
+            staging.buf().extend_from_slice(&record_len.to_le_bytes());
             if record.len() > BGZF_MAX_BLOCK_SIZE.saturating_sub(4) {
                 staging.write_chunked(record)?;
             } else {
@@ -127,7 +131,7 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
                 staging.flush()?;
             }
             staging.buf().extend_from_slice(&self.key_buf);
-            staging.buf().extend_from_slice(&(record.len() as u32).to_le_bytes());
+            staging.buf().extend_from_slice(&record_len.to_le_bytes());
             staging.write_chunked(record)?;
         }
         Ok(())

--- a/crates/fgumi-sort/src/read_ahead.rs
+++ b/crates/fgumi-sort/src/read_ahead.rs
@@ -167,6 +167,13 @@ impl RawReadAheadReader {
     ///
     /// Returns `Some(err)` if the background thread stopped due to a read error
     /// rather than clean EOF. Call this after exhausting the iterator.
+    ///
+    /// This only reliably reflects background errors when iteration ran to its
+    /// natural EOF (`next_record` returned `None`). If the consumer stops early
+    /// and drops the reader before EOF, `Drop` drops the channel receiver, which
+    /// can make the background thread's `tx.send` fail so it breaks out of its
+    /// loop *before* recording any subsequent read error — that error is then
+    /// lost. Do not rely on `take_error()` after an early `break`.
     #[must_use]
     pub fn take_error(&self) -> Option<std::io::Error> {
         self.error_slot.lock().ok()?.take()

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -1465,37 +1465,46 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         let t_start = std::time::Instant::now();
 
         // Count UMIs using compact BitEnc representation (saves ~60-70% memory)
-        // We store index into raw_umis to avoid cloning strings
-        // Also build a map from BitEnc -> unique_index for result lookup
+        // We store index into raw_umis to avoid cloning strings.
         //
-        // Cache each read's encoding here so the final result map can reuse it
-        // instead of re-running `BitEnc::from_umi_str` over every raw UMI a
-        // second time. `encoded_per_read[i]` is the encoding of `raw_umis[i]`
-        // (`None` for an invalid UMI), so it stays aligned with `raw_umis`.
-        let mut encoded_per_read: Vec<Option<BitEnc>> = Vec::with_capacity(raw_umis.len());
-        let mut umi_counts: Vec<(BitEnc, usize, usize)> = {
-            // Map from BitEnc -> (count, first_raw_index)
-            let mut counts: AHashMap<BitEnc, (usize, usize)> =
+        // To map each read to its final assignment without a per-read hash
+        // lookup, assign every distinct UMI a dense *pre-sort* index at first
+        // sight, and cache that index per read in `presort_idx_per_read[i]`
+        // (`None` for an invalid UMI; stays aligned with `raw_umis`). After the
+        // sort we build a plain `Vec` permutation `presort_to_sorted` so the
+        // final result loop is pure array indexing — no `BitEnc::from_umi_str`
+        // re-run and no `AHashMap` probe per read.
+        let mut presort_idx_per_read: Vec<Option<usize>> = Vec::with_capacity(raw_umis.len());
+        // (BitEnc, count, first_raw_index, presort_idx)
+        let mut umi_counts: Vec<(BitEnc, usize, usize, usize)> = {
+            // Map from BitEnc -> (count, first_raw_index, presort_idx)
+            let mut counts: AHashMap<BitEnc, (usize, usize, usize)> =
                 AHashMap::with_capacity(raw_umis.len() / 4); // Estimate ~4 reads per UMI
 
             for (i, umi) in raw_umis.iter().enumerate() {
                 // Convert to compact representation (skips dashes in paired UMIs)
                 let Some(encoded) = BitEnc::from_umi_str(umi) else {
                     // UMI contains invalid characters - skip it
-                    encoded_per_read.push(None);
+                    presort_idx_per_read.push(None);
                     continue;
                 };
-                encoded_per_read.push(Some(encoded));
 
-                if let Some((count, _idx)) = counts.get_mut(&encoded) {
+                if let Some((count, _idx, presort_idx)) = counts.get_mut(&encoded) {
                     *count += 1;
+                    presort_idx_per_read.push(Some(*presort_idx));
                 } else {
-                    // Store index into raw_umis instead of cloning
-                    counts.insert(encoded, (1, i));
+                    // First sighting: assign the next dense pre-sort index.
+                    let presort_idx = counts.len();
+                    presort_idx_per_read.push(Some(presort_idx));
+                    // Store index into raw_umis instead of cloning.
+                    counts.insert(encoded, (1, i, presort_idx));
                 }
             }
-            // Convert to Vec<(BitEnc, count, first_raw_index)>
-            counts.into_iter().map(|(enc, (count, idx))| (enc, count, idx)).collect()
+            // Convert to Vec<(BitEnc, count, first_raw_index, presort_idx)>
+            counts
+                .into_iter()
+                .map(|(enc, (count, idx, presort_idx))| (enc, count, idx, presort_idx))
+                .collect()
         };
 
         // Handle case where all UMIs had invalid characters
@@ -1509,16 +1518,30 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         // Sort by descending count, then by original string for determinism
         umi_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| raw_umis[a.2].cmp(&raw_umis[b.2])));
 
-        // Build lookup from BitEnc to sorted index (after sorting)
-        let bitenc_to_unique_idx: AHashMap<BitEnc, usize> =
-            umi_counts.iter().enumerate().map(|(idx, (enc, _, _))| (*enc, idx)).collect();
+        // Build the pre-sort -> sorted permutation as a dense `Vec` (indices are
+        // `0..umi_counts.len()`), then drop the pre-sort field so the graph
+        // helpers keep their `(BitEnc, count, first_raw_index)` tuple shape.
+        let mut presort_to_sorted = vec![0usize; umi_counts.len()];
+        for (sorted_idx, &(_, _, _, presort_idx)) in umi_counts.iter().enumerate() {
+            presort_to_sorted[presort_idx] = sorted_idx;
+        }
+        let umi_counts: Vec<(BitEnc, usize, usize)> =
+            umi_counts.into_iter().map(|(enc, count, idx, _)| (enc, count, idx)).collect();
 
         #[cfg(feature = "profile-adjacency")]
         let t_after_sort = std::time::Instant::now();
 
         if umi_counts.len() == 1 {
+            // Exactly one *encodable* UMI, but the batch may still contain reads
+            // with invalid (non-encodable) UMIs. Those must stay `MoleculeId::None`
+            // — exactly as the general path below maps them — rather than being
+            // folded into the single molecule. A `vec![id; raw_umis.len()]` here
+            // would mis-assign e.g. the middle read of `["AAAAAA","XXXXXX","AAAAAA"]`.
             let id = MoleculeId::Single(self.next_id());
-            return vec![id; raw_umis.len()];
+            return presort_idx_per_read
+                .iter()
+                .map(|presort_idx| if presort_idx.is_some() { id } else { MoleculeId::None })
+                .collect();
         }
 
         // Check all UMIs have same length (in bases, not string length)
@@ -1541,17 +1564,14 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         // Assign IDs to nodes and build result Vec
         let unique_assignments = self.assign_ids_to_nodes_bitenc(&nodes, &roots, &umi_counts);
 
-        // Map each input UMI to its MoleculeId using the encoding cached during
-        // the count pass (no second `BitEnc::from_umi_str` over every read).
-        let result: Vec<MoleculeId> = encoded_per_read
+        // Map each input UMI to its MoleculeId by pure array indexing: the
+        // cached pre-sort index → sorted unique index (`presort_to_sorted`) →
+        // assignment. No `BitEnc::from_umi_str` re-run and no per-read hash probe.
+        let result: Vec<MoleculeId> = presort_idx_per_read
             .iter()
-            .map(|enc| {
-                if let Some(enc) = enc {
-                    if let Some(&unique_idx) = bitenc_to_unique_idx.get(enc) {
-                        return unique_assignments[unique_idx];
-                    }
-                }
-                MoleculeId::None // Invalid UMI
+            .map(|presort_idx| match presort_idx {
+                Some(presort_idx) => unique_assignments[presort_to_sorted[*presort_idx]],
+                None => MoleculeId::None, // Invalid UMI
             })
             .collect();
 
@@ -1697,19 +1717,29 @@ impl PairedUmiAssigner {
     ///
     /// Returns error if UMI doesn't contain exactly one '-'
     fn split(umi: &str) -> Result<(&str, &str)> {
-        // Use byte operations for faster lookup since UMIs are ASCII
+        // Use byte operations for faster lookup since UMIs are ASCII. A single
+        // pass finds the first '-' and detects any second '-' (rejecting it),
+        // rather than a `position()` scan followed by a second `contains()` scan
+        // of the remainder.
         let bytes = umi.as_bytes();
-        if let Some(pos) = bytes.iter().position(|&b| b == b'-') {
-            // Check for additional dashes after first
-            if bytes[pos + 1..].contains(&b'-') {
-                return Err(anyhow::anyhow!(
-                    "UMI '{umi}' is not a valid paired UMI (expected format: 'A-B', found multiple '-')"
-                ));
+        let mut first_dash: Option<usize> = None;
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'-' {
+                if first_dash.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "UMI '{umi}' is not a valid paired UMI (expected format: 'A-B', found multiple '-')"
+                    ));
+                }
+                first_dash = Some(i);
             }
-            // SAFETY: '-' is a single byte ASCII, so splitting at its position is valid UTF-8
-            Ok((&umi[..pos], &umi[pos + 1..]))
-        } else {
-            Err(anyhow::anyhow!("UMI '{umi}' is not a valid paired UMI (expected format: 'A-B')"))
+        }
+        match first_dash {
+            // SAFETY: '-' is a single ASCII byte, so splitting at its position
+            // yields valid UTF-8 boundaries.
+            Some(pos) => Ok((&umi[..pos], &umi[pos + 1..])),
+            None => Err(anyhow::anyhow!(
+                "UMI '{umi}' is not a valid paired UMI (expected format: 'A-B')"
+            )),
         }
     }
 
@@ -2196,6 +2226,72 @@ mod tests {
         assert_ne!(map.get("AAAA"), map.get("GGGG"), "GGGG should be separate");
     }
 
+    /// Per-read result mapping must stay correct when reads are interleaved so
+    /// that the pre-sort unique index and the post-sort unique index differ.
+    /// Exercises the `presort_to_sorted` permutation that replaced the per-read
+    /// `bitenc_to_unique_idx` hash lookup.
+    #[test]
+    fn test_adjacency_per_read_mapping_with_interleaved_counts() {
+        let assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD);
+
+        // First-seen order: AAAAAA, CCCCCC, GGGGGG. Final counts: GGGGGG(5) >
+        // AAAAAA(3) > CCCCCC(1), so the descending-count sort permutes the order,
+        // forcing presort_idx != sorted_idx for every UMI.
+        let umis: Vec<String> = vec![
+            "AAAAAA", "CCCCCC", "GGGGGG", // first sightings, in this order
+            "AAAAAA", "GGGGGG", "AAAAAA", "GGGGGG", "GGGGGG", "GGGGGG",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+        let assignments = assigner.assign(&umis);
+        assert_eq!(assignments.len(), umis.len());
+
+        // With 0 edits each distinct UMI is its own group; every read must carry
+        // exactly its own UMI's id, and identical UMIs must share an id.
+        let map = build_assignment_map(&umis, &assignments);
+        for (umi, id) in umis.iter().zip(assignments.iter()) {
+            assert_eq!(map.get(umi), Some(id), "read {umi} mis-mapped after sort permutation");
+        }
+        let distinct: HashSet<_> = assignments.iter().map(MoleculeId::base_id_string).collect();
+        assert_eq!(distinct.len(), 3, "three distinct UMIs → three groups");
+    }
+
+    /// A read whose UMI has invalid characters must map to `MoleculeId::None`
+    /// while the valid reads around it still map correctly (the cached pre-sort
+    /// index is `None` for invalid reads). Uses two distinct valid UMIs so the
+    /// single-unique-UMI fast path (which assigns one id to every read) is not
+    /// taken and the per-read `presort_to_sorted` mapping is exercised.
+    #[test]
+    fn test_adjacency_invalid_umi_maps_to_none() {
+        let assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD);
+        let umis: Vec<String> = ["AAAAAA", "XXXXXX", "AAAAAA", "CCCCCC", "CCCCCC"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let assignments = assigner.assign(&umis);
+        assert_eq!(assignments[1], MoleculeId::None, "invalid UMI → None");
+        assert_ne!(assignments[0], MoleculeId::None);
+        assert_eq!(assignments[0], assignments[2], "valid AAAAAA reads share an id");
+        assert_eq!(assignments[3], assignments[4], "valid CCCCCC reads share an id");
+        assert_ne!(assignments[0], assignments[3], "distinct UMIs → distinct ids");
+    }
+
+    /// Regression: with exactly ONE unique encodable UMI the assigner takes the
+    /// single-unique-UMI fast path. An invalid UMI in that same batch must still
+    /// map to `MoleculeId::None`, not inherit the lone molecule's id.
+    #[test]
+    fn test_adjacency_invalid_umi_maps_to_none_single_unique_fast_path() {
+        let assigner = AdjacencyUmiAssigner::new(0, 1, DEFAULT_INDEX_THRESHOLD);
+        let umis: Vec<String> =
+            ["AAAAAA", "XXXXXX", "AAAAAA"].into_iter().map(str::to_string).collect();
+        let assignments = assigner.assign(&umis);
+        assert_eq!(assignments[1], MoleculeId::None, "invalid UMI → None even on the fast path");
+        assert_ne!(assignments[0], MoleculeId::None, "valid AAAAAA read keeps a molecule id");
+        assert_eq!(assignments[0], assignments[2], "both valid AAAAAA reads share the same id");
+    }
+
     // ========================================================================
     // PairedUmiAssigner Tests
     // ========================================================================
@@ -2332,6 +2428,9 @@ mod tests {
     #[case("-ACT", true, Some(("", "ACT")), "empty first part")]
     #[case("ACTACT", false, None, "no delimiter")]
     #[case("A-B-C", false, None, "multiple delimiters")]
+    #[case("AB-CD-", false, None, "trailing second dash")]
+    #[case("--", false, None, "two adjacent dashes")]
+    #[case("", false, None, "empty string has no delimiter")]
     fn test_paired_split(
         #[case] umi: &str,
         #[case] should_succeed: bool,

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -720,12 +720,9 @@ impl Extract {
     /// Names with fewer than 8 fields are treated as not containing a UMI and
     /// produce `None`. Any `+` characters in the extracted UMI (used by some
     /// demultiplexers to delimit dual UMIs) are normalized to `-`.
-    fn extract_read_name_and_umi(
-        header: &Vec<u8>,
-        extract_umis: bool,
-    ) -> (Vec<u8>, Option<Vec<u8>>) {
+    fn extract_read_name_and_umi(header: &[u8], extract_umis: bool) -> (Vec<u8>, Option<Vec<u8>>) {
         // Remove @ prefix if present
-        let name_bytes = if header.starts_with(b"@") { &header[1..] } else { header.as_slice() };
+        let name_bytes = if header.starts_with(b"@") { &header[1..] } else { header };
 
         // Split on space to get just the name part
         let name_part = name_bytes.find_byte(b' ').map_or(name_bytes, |pos| &name_bytes[..pos]);

--- a/src/lib/commands/simulate/aligner.rs
+++ b/src/lib/commands/simulate/aligner.rs
@@ -65,6 +65,14 @@ pub struct Aligner {
     /// Positional tokens substituted into the aligner command template
     /// (`{ref}`, `{threads}`, …) — accepted and ignored, so the command is a
     /// drop-in for real-aligner templates regardless of which tokens they fill.
+    ///
+    /// Because this field is `trailing_var_arg` + `allow_hyphen_values`, once the
+    /// first positional token is seen *every* remaining token — including
+    /// flag-like ones such as `-t 8` or even `--replay-bam` itself — is swallowed
+    /// into `ignored` rather than parsed. Therefore `--replay-bam` MUST be
+    /// supplied before any positional token; placing it after a positional makes
+    /// it disappear into `ignored` and the command fails with a missing
+    /// `--replay-bam` error.
     #[arg(value_name = "IGNORED", trailing_var_arg = true, allow_hyphen_values = true)]
     pub ignored: Vec<String>,
 }
@@ -326,5 +334,94 @@ mod tests {
 
         // Cleanup: closing stdin_w lets the detached drainer finish.
         drop(stdin_w);
+    }
+
+    #[test]
+    fn replayed_bytes_are_a_valid_bam_the_readers_accept() {
+        // End-to-end: the module's whole purpose is to feed a *BAM stream*
+        // (header + records + in-band BGZF EOF) to a real BAM reader. Write a
+        // small valid BAM to a temp file, replay it through `simulate_aligner`
+        // capturing stdout, then decode the captured bytes with the project's
+        // BAM reader and assert the header and record count round-trip. A
+        // regression that dropped a flush or truncated the tail would pass the
+        // opaque-byte tests above but fail here.
+        use fgumi_bam_io::PipelineReaderOpts;
+        use fgumi_raw_bam::RawRecord;
+        use fgumi_raw_bam::testutil::make_bam_bytes;
+        use noodles::sam::Header;
+
+        const N_RECORDS: usize = 5;
+        const HEADER_MARKER: &str = "simulate-aligner-e2e-marker";
+
+        // A header with an identifiable comment so we can assert it survives.
+        let header = Header::builder().add_comment(HEADER_MARKER).build();
+
+        let replay_path = tempfile::NamedTempFile::new().expect("replay temp").into_temp_path();
+        let mut writer =
+            fgumi_bam_io::create_raw_bam_writer(&replay_path, &header, 1, 1).expect("writer");
+        for i in 0..N_RECORDS {
+            let name = format!("read_{i}");
+            let record_bytes = make_bam_bytes(
+                -1,  // tid (unmapped)
+                -1,  // pos
+                0x4, // flag (unmapped)
+                name.as_bytes(),
+                &[], // cigar_ops
+                0,   // seq_len
+                -1,  // mate_tid
+                -1,  // mate_pos
+                &[], // aux_data
+            );
+            writer.write_raw_record(&record_bytes).expect("write record");
+        }
+        writer.finish().expect("finish writer");
+
+        // Replay the BAM through the aligner, capturing the verbatim stdout.
+        let replay = File::open(&replay_path).expect("open replay");
+        let stdin = Cursor::new(b"@r1\nACGT\n+\nIIII\n".to_vec());
+        let mut captured: Vec<u8> = Vec::new();
+        simulate_aligner(stdin, replay, &mut captured).expect("simulate aligner");
+
+        // Decode the captured bytes with the project's BAM reader by routing
+        // them back through a temp file (the reader factory takes a path).
+        let out_path = tempfile::NamedTempFile::new().expect("out temp").into_temp_path();
+        std::fs::write(&out_path, &captured).expect("write captured bytes");
+
+        let (mut reader, got_header) = fgumi_bam_io::create_raw_bam_reader_with_opts(
+            &out_path,
+            1,
+            PipelineReaderOpts::default(),
+        )
+        .expect("reader accepts replayed bytes");
+
+        // Header round-trips: the marker comment survives the verbatim copy.
+        let comments: Vec<String> = got_header.comments().iter().map(|c| c.to_string()).collect();
+        assert!(
+            comments.iter().any(|c| c == HEADER_MARKER),
+            "header comment must round-trip, got comments: {comments:?}"
+        );
+
+        // Record count round-trips, and the reader stops cleanly on the in-band
+        // BGZF EOF marker (read_record returns 0 rather than erroring).
+        let mut record = RawRecord::default();
+        let mut n = 0;
+        while reader.read_record(&mut record).expect("read replayed record") > 0 {
+            n += 1;
+        }
+        assert_eq!(n, N_RECORDS, "record count must round-trip through the replay");
+    }
+
+    #[test]
+    fn replay_bam_flag_after_a_positional_is_swallowed_into_ignored() {
+        // `ignored` is trailing_var_arg + allow_hyphen_values, so once the first
+        // positional is seen every later token — including `--replay-bam` — is
+        // captured into `ignored` rather than parsed. Placing `--replay-bam`
+        // after a positional therefore makes it disappear and parsing fails with
+        // the required-arg error. This pins the ordering constraint documented on
+        // the `ignored` field.
+        let err = Aligner::try_parse_from(["aligner", "/ref.fa", "--replay-bam", "x.bam"])
+            .expect_err("--replay-bam after a positional must fail to parse");
+        // clap reports the missing required `--replay-bam`.
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 }

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -708,50 +708,75 @@ fn build_consensus_record(
     // count is spread one-per-base. The read-level error tag is the resulting
     // rate (sum of per-base errors / sum of per-base depths).
     let read_len = seq.len();
-    let per_base_arrays =
-        |max_depth: i32, min_depth: i32, error_count: i32| -> (Vec<i16>, Vec<i16>) {
-            let clamp = |v: i32| i16::try_from(v).unwrap_or(i16::MAX);
-            let mut depths = vec![clamp(max_depth); read_len];
-            if read_len >= 2 {
-                // Anchor the per-base minimum at the summary min (max stays the fill).
-                depths[read_len - 1] = clamp(min_depth);
-            }
-            let mut errors = vec![0i16; read_len];
-            let n = usize::try_from(error_count).unwrap_or(0).min(read_len);
-            for slot in errors.iter_mut().take(n) {
-                *slot = 1;
-            }
-            (depths, errors)
-        };
+
+    // Per-base depth/error arrays are written into reusable thread-local scratch
+    // buffers rather than freshly-allocated `Vec`s. `build_consensus_record` runs
+    // once per read (millions for a benchmark fixture) under `into_par_iter`, and
+    // each record previously allocated two `Vec<i16>` for simplex plus four more
+    // for duplex. Since `add_array_i16` copies the slice into the record's aux
+    // bytes, the arrays are transient and the same two buffers can be refilled
+    // for each strand in sequence (cd, then ad, then bd) without changing any
+    // emitted value. The thread-local keeps the reuse safe across the parallel
+    // generation loop (each rayon worker gets its own buffers).
+    thread_local! {
+        static PER_BASE_SCRATCH: std::cell::RefCell<(Vec<i16>, Vec<i16>)> =
+            const { std::cell::RefCell::new((Vec::new(), Vec::new())) };
+    }
+    // Fills `depths`/`errors` (cleared first) with the per-base arrays for one
+    // strand: depth is `max_depth` everywhere, with the summary `min_depth`
+    // anchored at the last base; error is one-per-base from the front for
+    // `error_count` bases.
+    let fill_per_base = |depths: &mut Vec<i16>,
+                         errors: &mut Vec<i16>,
+                         max_depth: i32,
+                         min_depth: i32,
+                         error_count: i32| {
+        let clamp = |v: i32| i16::try_from(v).unwrap_or(i16::MAX);
+        depths.clear();
+        depths.resize(read_len, clamp(max_depth));
+        if read_len >= 2 {
+            // Anchor the per-base minimum at the summary min (max stays the fill).
+            depths[read_len - 1] = clamp(min_depth);
+        }
+        errors.clear();
+        errors.resize(read_len, 0i16);
+        let n = usize::try_from(error_count).unwrap_or(0).min(read_len);
+        for slot in errors.iter_mut().take(n) {
+            *slot = 1;
+        }
+    };
     let error_rate = |errors: &[i16], depths: &[i16]| -> f32 {
         let total_errors: i64 = errors.iter().map(|&e| i64::from(e)).sum();
         let total_depth: i64 = depths.iter().map(|&d| i64::from(d)).sum();
         if total_depth > 0 { (total_errors as f64 / total_depth as f64) as f32 } else { 0.0 }
     };
 
-    // Single-strand consensus summary + per-base arrays.
-    let (cd_bases, ce_bases) = per_base_arrays(cd, cm, ce);
-    b.add_int_tag(SamTag::CD, cd)
-        .add_int_tag(SamTag::CM, cm)
-        .add_float_tag(SamTag::CE, error_rate(&ce_bases, &cd_bases));
-    b.add_array_i16(SamTag::CD_BASES, &cd_bases).add_array_i16(SamTag::CE_BASES, &ce_bases);
+    PER_BASE_SCRATCH.with_borrow_mut(|(depths, errors)| {
+        // Single-strand consensus summary + per-base arrays.
+        fill_per_base(depths, errors, cd, cm, ce);
+        b.add_int_tag(SamTag::CD, cd)
+            .add_int_tag(SamTag::CM, cm)
+            .add_float_tag(SamTag::CE, error_rate(errors, depths));
+        b.add_array_i16(SamTag::CD_BASES, depths).add_array_i16(SamTag::CE_BASES, errors);
 
-    // Add duplex-specific tags if present: per-strand summary (aD/bD/aM/bM int,
-    // aE/bE float rate) plus the per-base strand depth/error arrays filter needs.
-    if let Some((ad, bd, am, bm, ae, be)) = duplex_tags {
-        let (ad_bases, ae_bases) = per_base_arrays(ad, am, ae);
-        let (bd_bases, be_bases) = per_base_arrays(bd, bm, be);
-        b.add_int_tag(SamTag::AD, ad)
-            .add_int_tag(SamTag::BD, bd)
-            .add_int_tag(SamTag::AM, am)
-            .add_int_tag(SamTag::BM, bm)
-            .add_float_tag(SamTag::AE, error_rate(&ae_bases, &ad_bases))
-            .add_float_tag(SamTag::BE, error_rate(&be_bases, &bd_bases));
-        b.add_array_i16(SamTag::AD_BASES, &ad_bases)
-            .add_array_i16(SamTag::AE_BASES, &ae_bases)
-            .add_array_i16(SamTag::BD_BASES, &bd_bases)
-            .add_array_i16(SamTag::BE_BASES, &be_bases);
-    }
+        // Add duplex-specific tags if present: per-strand summary (aD/bD/aM/bM
+        // int, aE/bE float rate) plus the per-base strand depth/error arrays
+        // filter needs. The same scratch buffers are refilled per strand.
+        if let Some((ad, bd, am, bm, ae, be)) = duplex_tags {
+            b.add_int_tag(SamTag::AD, ad)
+                .add_int_tag(SamTag::BD, bd)
+                .add_int_tag(SamTag::AM, am)
+                .add_int_tag(SamTag::BM, bm);
+
+            fill_per_base(depths, errors, ad, am, ae);
+            b.add_float_tag(SamTag::AE, error_rate(errors, depths));
+            b.add_array_i16(SamTag::AD_BASES, depths).add_array_i16(SamTag::AE_BASES, errors);
+
+            fill_per_base(depths, errors, bd, bm, be);
+            b.add_float_tag(SamTag::BE, error_rate(errors, depths));
+            b.add_array_i16(SamTag::BD_BASES, depths).add_array_i16(SamTag::BE_BASES, errors);
+        }
+    });
 
     // Add methylation tags if enabled.
     if let Some(meth) = methylation {
@@ -1927,6 +1952,112 @@ mod tests {
             r2_ct, r1_ct_rev,
             "R2 ct tag should be reversed relative to R1: R1={r1_ct:?}, R2={r2_ct:?}"
         );
+    }
+
+    #[test]
+    fn test_r2_per_base_depth_error_arrays_are_read_oriented_not_reversed() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
+        // Unlike the methylation cu/ct arrays (which ARE reversed for R2 because
+        // they annotate reference-oriented evidence), the per-base depth/error
+        // arrays cd/ce (and the duplex ad/ae/bd/be) are built fresh from the
+        // scalar summaries and are *read-oriented*: each read's "low-depth tail"
+        // is anchored at its own last base. `fgumi simplex`/`duplex` emit cd/ce
+        // in read order, so the simulator deliberately does NOT reverse them for
+        // R2. This test pins that intended orientation so a future change that
+        // started reversing them (or stopped anchoring the min at the last
+        // index) is caught.
+        let seq = b"ACGTA";
+        let quals = vec![40; seq.len()];
+
+        // Distinct max/min so the anchored min is identifiable, and a non-zero
+        // error count so the per-base error array is non-trivial. Duplex tags are
+        // present so ad/ae/bd/be are emitted too.
+        let cd = 8; // max depth (array fill)
+        let cm = 3; // min depth (anchored at last base)
+        let ce = 2; // error count (spread one-per-base from the front)
+        let duplex = Some((7, 6, 2, 1, 1, 1)); // (ad, bd, am, bm, ae, be)
+
+        let r1_raw = build_consensus_record(
+            "test/1",
+            seq,
+            &quals,
+            true,
+            false,
+            0,
+            100,
+            cd,
+            cm,
+            ce,
+            duplex,
+            None,
+            MethylationMode::Disabled,
+        );
+        let r1 = to_record_buf(&r1_raw);
+
+        // R2 is the reverse complement, matching generate_consensus_pair.
+        let r2_seq = reverse_complement(seq);
+        let r2_raw = build_consensus_record(
+            "test/2",
+            &r2_seq,
+            &quals,
+            false,
+            true,
+            0,
+            100,
+            cd,
+            cm,
+            ce,
+            duplex,
+            None,
+            MethylationMode::Disabled,
+        );
+        let r2 = to_record_buf(&r2_raw);
+
+        let array_tag = |rec: &noodles::sam::alignment::RecordBuf, tag: SamTag| -> Vec<i16> {
+            match rec.data().get(&Tag::from(*tag)) {
+                Some(Value::Array(Array::Int16(arr))) => arr.clone(),
+                other => panic!("expected Int16 array for tag {:?}, got {other:?}", *tag),
+            }
+        };
+
+        // Every per-base array must be IDENTICAL between R1 and R2 (read-oriented,
+        // not reversed), and the depth array's min must sit at the LAST index on
+        // both reads.
+        for tag in [
+            SamTag::CD_BASES,
+            SamTag::CE_BASES,
+            SamTag::AD_BASES,
+            SamTag::AE_BASES,
+            SamTag::BD_BASES,
+            SamTag::BE_BASES,
+        ] {
+            let r1_arr = array_tag(&r1, tag);
+            let r2_arr = array_tag(&r2, tag);
+            assert_eq!(
+                r1_arr, r2_arr,
+                "per-base array {:?} must be read-oriented (same for R1 and R2), \
+                 not reversed: R1={r1_arr:?}, R2={r2_arr:?}",
+                *tag
+            );
+            let mut reversed = r1_arr.clone();
+            reversed.reverse();
+            // Sanity: with our asymmetric inputs the array is not palindromic, so
+            // "same as R1" is a strictly stronger claim than "reverse of R1".
+            assert_ne!(
+                r1_arr, reversed,
+                "test input for {:?} must be non-palindromic to be meaningful",
+                *tag
+            );
+        }
+
+        // The depth arrays anchor their min at the last base on BOTH reads.
+        let r1_cd = array_tag(&r1, SamTag::CD_BASES);
+        let r2_cd = array_tag(&r2, SamTag::CD_BASES);
+        assert_eq!(*r1_cd.last().unwrap(), cm as i16, "R1 cd min anchored at last base");
+        assert_eq!(*r2_cd.last().unwrap(), cm as i16, "R2 cd min anchored at last base");
     }
 
     #[test]

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -69,11 +69,13 @@ pub struct ConsensusReads {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum consensus depth (cM tag)
+    /// Minimum consensus depth (cM tag). Must satisfy 0 <= min <= max <= 32767
+    /// (per-base depth arrays are emitted as i16).
     #[arg(long = "min-depth", default_value = "1")]
     pub min_depth: i32,
 
-    /// Maximum consensus depth (cD tag)
+    /// Maximum consensus depth (cD tag). Must satisfy 0 <= min <= max <= 32767
+    /// (per-base depth arrays are emitted as i16).
     #[arg(long = "max-depth", default_value = "10")]
     pub max_depth: i32,
 
@@ -85,7 +87,13 @@ pub struct ConsensusReads {
     #[arg(long = "depth-stddev", default_value = "2.0")]
     pub depth_stddev: f64,
 
-    /// Mean error rate (cE tag)
+    /// Mean per-base error rate used to derive the simulated error *count*
+    /// (`ce = round(read_length * error_rate)`). NOTE: this is the per-base
+    /// error / read-length input rate, not the value of the emitted read-level
+    /// `cE` tag. The `cE`/`aE`/`bE` tags are written as the real-caller rate
+    /// `sum(per-base errors) / sum(per-base depths)` (matching
+    /// `fgumi simplex`/`duplex` output), so the emitted `cE` is roughly this
+    /// requested rate divided by the mean simulated depth.
     #[arg(long = "error-rate-mean", default_value = "0.01")]
     pub error_rate_mean: f64,
 
@@ -117,12 +125,27 @@ pub struct ConsensusReads {
     pub reference: PathBuf,
 }
 
+/// Header line for the truth TSV emitted by `--truth`.
+///
+/// The depth columns (`cD`/`cM`/`aD`/`bD`/`aM`/`bM`) carry the same integer
+/// counts as the matching BAM tags. The error columns are suffixed `_count`
+/// (`cE_count`/`aE_count`/`bE_count`) because the BAM's read-level `cE`/`aE`/`bE`
+/// tags are FLOAT error *rates* (`sum(per-base errors) / sum(per-base depths)`,
+/// the real-caller formula — see `build_consensus_record`), whereas the truth
+/// records the simulated per-read error *count*. Naming them `_count` keeps the
+/// TSV from silently disagreeing with the BAM it validates.
+const TRUTH_TSV_HEADER: &str =
+    "read_name\tchrom\tpos\tstrand\tcD\tcM\tcE_count\taD\tbD\taM\tbM\taE_count\tbE_count";
+
 /// A generated consensus read pair ready for output.
 struct ConsensusReadPair {
     read_name: String,
     r1_record: RawRecord,
     r2_record: RawRecord,
-    /// Truth data: (cD, cM, cE, aD, bD, aM, bM, aE, bE)
+    /// Truth data: per-read integer counts
+    /// `(cD, cM, cE_count, aD, bD, aM, bM, aE_count, bE_count)`. The error
+    /// entries are counts, not the FLOAT rates emitted as the BAM `cE`/`aE`/`bE`
+    /// tags — see [`TRUTH_TSV_HEADER`].
     truth: (i32, i32, i32, i32, i32, i32, i32, i32, i32),
     /// Chromosome name for truth output.
     chrom_name: String,
@@ -170,6 +193,7 @@ impl Command for ConsensusReads {
                 self.methylation_depth_mean
             );
         }
+        validate_depth_bounds(self.min_depth, self.max_depth)?;
 
         info!("Generating consensus reads");
         info!("  Output: {}", self.output.display());
@@ -262,7 +286,7 @@ impl Command for ConsensusReads {
                 let truth_file = File::create(truth_path)
                     .with_context(|| format!("Failed to create {}", truth_path.display()))?;
                 let mut w = BufWriter::new(truth_file);
-                writeln!(w, "read_name\tchrom\tpos\tstrand\tcD\tcM\tcE\taD\tbD\taM\tbM\taE\tbE")?;
+                writeln!(w, "{TRUTH_TSV_HEADER}")?;
                 Some(w)
             } else {
                 None
@@ -366,7 +390,12 @@ fn generate_consensus_pair(
     // Generate minimum depth (cM) - at most cD
     let cm = sample_depth(&depth_dist, params.min_depth, cd, &mut rng).min(cd);
 
-    // Generate error count based on error rate
+    // Generate the error *count* from the sampled per-base error rate. NOTE:
+    // `ce` is `read_length * error_rate` (a count), which is then spread
+    // one-per-base in the per-base arrays. The emitted read-level cE/aE/bE tag
+    // is NOT this rate but `sum(per-base errors) / sum(per-base depths)` — the
+    // real `vanilla_caller` formula (see `build_consensus_record` and the
+    // `--error-rate-mean` doc).
     let error_rate = error_dist.sample(&mut rng).clamp(0.0, 1.0);
     let ce = (params.read_length as f64 * error_rate).round() as i32;
 
@@ -378,9 +407,14 @@ fn generate_consensus_pair(
         let ad = ((cd as f64) * a_frac).round() as i32;
         let bd = cd - ad;
 
-        // Min depths for each strand
-        let am = (ad.min(cm)).max(0);
-        let bm = (bd.min(cm)).max(0);
+        // Min depths for each strand. The real duplex/codec callers (and fgbio)
+        // derive cM = min(aD_i + bD_i); because both per-strand depth arrays ramp
+        // monotonically to their last base, that minimum equals aM + bM. Split cM
+        // by the same strand fraction used for cD so aM + bM == cM exactly, while
+        // keeping aM <= aD and bM <= bD. The clamp bounds are well-ordered because
+        // cM <= cD == aD + bD, so (cM - bD) <= aD and (cM - bD) <= cM.
+        let am = (((cm as f64) * a_frac).round() as i32).clamp((cm - bd).max(0), ad.min(cm));
+        let bm = cm - am;
 
         // Errors distributed proportionally
         let ae = ((ce as f64) * a_frac).round() as i32;
@@ -390,6 +424,13 @@ fn generate_consensus_pair(
     } else {
         (0, 0, 0, 0, 0, 0)
     };
+
+    // A single-base read cannot carry distinct max/min depths: its only base is
+    // emitted at the minimum depth (see `fill_per_base`'s `read_len == 1` arm),
+    // so collapse each summary maximum (cD/aD/bD) down to its minimum
+    // (cM/aM/bM) here — upstream of both the record tags and the truth tuple —
+    // so they stay self-consistent and cE/aE/bE are computed over the right depth.
+    let (cd, ad, bd) = if params.read_length == 1 { (cm, am, bm) } else { (cd, ad, bd) };
 
     // Generate methylation annotation if enabled
     let methylation = if params.methylation_mode.is_enabled() {
@@ -633,6 +674,24 @@ fn sample_depth(dist: &LogNormal<f64>, min: i32, max: i32, rng: &mut impl Rng) -
     sample.clamp(min, max)
 }
 
+/// Validates the consensus depth bounds before generation. The per-base `cd`/`ce`
+/// (`CD_BASES`/`CE_BASES`) and strand (`AD_BASES`/`BD_BASES`) arrays are emitted
+/// as `i16`; without this guard `fill_per_base`'s saturating cast would silently
+/// make those arrays diverge from the `cD`/`cM` summary tags (and the truth TSV)
+/// once a depth exceeds `i16::MAX`, and a negative `--min-depth` could emit
+/// negative depths. Reject those inputs up front instead.
+fn validate_depth_bounds(min_depth: i32, max_depth: i32) -> Result<()> {
+    if min_depth < 0 || max_depth < min_depth || max_depth > i32::from(i16::MAX) {
+        anyhow::bail!(
+            "--min-depth/--max-depth must satisfy 0 <= min <= max <= {}, got {}..={}",
+            i16::MAX,
+            min_depth,
+            max_depth,
+        );
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_consensus_record(
     name: &str,
@@ -697,16 +756,33 @@ fn build_consensus_record(
 
     // `fgumi filter` masks bases using the PER-BASE depth/error arrays and reads
     // the read-level error tags (cE / aE / bE) as FLOAT rates — exactly what
-    // `fgumi simplex`/`duplex` emit (see `vanilla_caller`). Without the per-base
-    // arrays every base reads as zero depth and the read is rejected outright;
-    // with the error tags written as integer counts, filter's `find_float_tag`
-    // skips them. Emit both faithfully so the output honors its documented
-    // "suitable for input to `fgumi filter`" contract.
+    // `fgumi simplex`/`duplex` emit (see `vanilla_caller`/`duplex_caller`). Simplex
+    // filtering reads the combined `CD_BASES`/`CE_BASES`; duplex filtering reads the
+    // per-strand `AD_BASES`/`BD_BASES`. Without the per-base arrays every base reads
+    // as zero depth and the read is rejected outright; with the error tags written
+    // as integer counts, filter's `find_float_tag` skips them. Emit them faithfully
+    // so the output honors its documented "suitable for input to `fgumi filter`"
+    // contract.
     //
-    // Build per-base arrays consistent with the read-level summary tags: depth
-    // spans [min, max] (min == cM/aM/bM, max == cD/aD/bD) and the total error
-    // count is spread one-per-base. The read-level error tag is the resulting
-    // rate (sum of per-base errors / sum of per-base depths).
+    // Each per-base depth array is a linear ramp from its max at the first base
+    // down to its min at the last base, with the error count spread one-per-base.
+    // The ramp — rather than "max everywhere with min only at the last base" — lets
+    // a `fgumi filter --min-reads` threshold mask a realistic contiguous low-depth
+    // *run* of interior bases instead of at most the single final base.
+    //
+    // Summary tags follow the real callers:
+    //   * Simplex: `cD`/`cM` are the ramp max/min; `cE = sum(ce)/sum(cd)`.
+    //   * Duplex: only the per-strand `aD`/`aM` (ramp max/min) and `bD`/`bM` are
+    //     ramp endpoints. The combined `cD`/`cM`/`cE` are derived from the
+    //     element-wise SUM of the two strand arrays — `cD = max(aD_i + bD_i)`,
+    //     `cM = min(aD_i + bD_i)`, `cE = sum(ae + be) / sum(aD + bD)` — matching
+    //     `duplex_caller`/`codec_caller`/fgbio, which emit no combined per-base
+    //     array for duplex (see the `build_consensus_record` emission block below).
+    //
+    // The read-level error rate is the resulting `sum(errors)/sum(depths)` — the
+    // formula the real callers emit (errors over total depth), NOT the simulator's
+    // per-base `--error-rate-mean` input. See the `--error-rate-mean` arg doc for
+    // the relationship to the requested rate.
     let read_len = seq.len();
 
     // Per-base depth/error arrays are written into reusable thread-local scratch
@@ -714,18 +790,25 @@ fn build_consensus_record(
     // once per read (millions for a benchmark fixture) under `into_par_iter`, and
     // each record previously allocated two `Vec<i16>` for simplex plus four more
     // for duplex. Since `add_array_i16` copies the slice into the record's aux
-    // bytes, the arrays are transient and the same two buffers can be refilled
-    // for each strand in sequence (cd, then ad, then bd) without changing any
-    // emitted value. The thread-local keeps the reuse safe across the parallel
-    // generation loop (each rayon worker gets its own buffers).
+    // bytes, the arrays are transient and the same buffers can be refilled. There
+    // are two depth/error pairs — `(a_depths, a_errors, b_depths, b_errors)`:
+    // simplex uses only the first pair, while duplex needs both strands live at
+    // once to derive the combined `cD`/`cM`/`cE` summary from their element-wise
+    // sum. The thread-local keeps the reuse safe across the parallel generation
+    // loop (each rayon worker gets its own buffers).
+    type PerBaseScratch = (Vec<i16>, Vec<i16>, Vec<i16>, Vec<i16>);
     thread_local! {
-        static PER_BASE_SCRATCH: std::cell::RefCell<(Vec<i16>, Vec<i16>)> =
-            const { std::cell::RefCell::new((Vec::new(), Vec::new())) };
+        static PER_BASE_SCRATCH: std::cell::RefCell<PerBaseScratch> =
+            const {
+                std::cell::RefCell::new((Vec::new(), Vec::new(), Vec::new(), Vec::new()))
+            };
     }
     // Fills `depths`/`errors` (cleared first) with the per-base arrays for one
-    // strand: depth is `max_depth` everywhere, with the summary `min_depth`
-    // anchored at the last base; error is one-per-base from the front for
-    // `error_count` bases.
+    // strand: depth is a linear ramp from `max_depth` (first base) to
+    // `min_depth` (last base) so interior bases span the full [min, max] range;
+    // error is one-per-base from the front for `error_count` bases. A
+    // single-base read carries `min_depth` so it still honors the summary
+    // minimum (it cannot carry both endpoints).
     let fill_per_base = |depths: &mut Vec<i16>,
                          errors: &mut Vec<i16>,
                          max_depth: i32,
@@ -733,10 +816,20 @@ fn build_consensus_record(
                          error_count: i32| {
         let clamp = |v: i32| i16::try_from(v).unwrap_or(i16::MAX);
         depths.clear();
-        depths.resize(read_len, clamp(max_depth));
-        if read_len >= 2 {
-            // Anchor the per-base minimum at the summary min (max stays the fill).
-            depths[read_len - 1] = clamp(min_depth);
+        depths.reserve(read_len);
+        match read_len {
+            0 => {}
+            1 => depths.push(clamp(min_depth)),
+            _ => {
+                // depth[i] = round(max - (max - min) * i / (read_len - 1)),
+                // giving depth[0] == max and depth[read_len-1] == min.
+                let span = i64::from(max_depth) - i64::from(min_depth);
+                let last = (read_len - 1) as i64;
+                for i in 0..read_len {
+                    let v = i64::from(max_depth) - (span * i as i64 + last / 2) / last;
+                    depths.push(clamp(i32::try_from(v).unwrap_or(i32::MAX)));
+                }
+            }
         }
         errors.clear();
         errors.resize(read_len, 0i16);
@@ -751,30 +844,69 @@ fn build_consensus_record(
         if total_depth > 0 { (total_errors as f64 / total_depth as f64) as f32 } else { 0.0 }
     };
 
-    PER_BASE_SCRATCH.with_borrow_mut(|(depths, errors)| {
-        // Single-strand consensus summary + per-base arrays.
-        fill_per_base(depths, errors, cd, cm, ce);
-        b.add_int_tag(SamTag::CD, cd)
-            .add_int_tag(SamTag::CM, cm)
-            .add_float_tag(SamTag::CE, error_rate(errors, depths));
-        b.add_array_i16(SamTag::CD_BASES, depths).add_array_i16(SamTag::CE_BASES, errors);
+    PER_BASE_SCRATCH.with_borrow_mut(|(a_depths, a_errors, b_depths, b_errors)| {
+        match duplex_tags {
+            // Simplex: `cD`/`cM`/`cE` and the per-base `cd`/`ce` arrays all derive
+            // from the single consensus depth/error ramp (matches `vanilla_caller`
+            // and fgbio's `VanillaUmiConsensusCaller`, which DO emit per-base
+            // `cd`/`ce` for single-strand consensus).
+            None => {
+                fill_per_base(a_depths, a_errors, cd, cm, ce);
+                b.add_int_tag(SamTag::CD, cd)
+                    .add_int_tag(SamTag::CM, cm)
+                    .add_float_tag(SamTag::CE, error_rate(a_errors, a_depths));
+                b.add_array_i16(SamTag::CD_BASES, a_depths)
+                    .add_array_i16(SamTag::CE_BASES, a_errors);
+            }
+            // Duplex: `cD`/`cM`/`cE` are derived from the element-wise SUM of the
+            // two strand depth/error arrays — `cD = max(aD_i + bD_i)`, `cM = min`,
+            // `cE = total errors / total combined depth` — and ONLY the per-strand
+            // `cd`/`ce` arrays (AD_BASES/AE_BASES, BD_BASES/BE_BASES) are emitted.
+            // No combined per-base CD_BASES/CE_BASES is written. This mirrors the
+            // real `duplex_caller`/`codec_caller` and fgbio's
+            // `DuplexConsensusCaller`, which omit the per-base combined arrays for
+            // duplex (`filter`'s duplex path reads the strand arrays). The passed
+            // `cd`/`cm`/`ce` are intentionally unused here.
+            Some((ad, bd, am, bm, ae, be)) => {
+                fill_per_base(a_depths, a_errors, ad, am, ae);
+                fill_per_base(b_depths, b_errors, bd, bm, be);
 
-        // Add duplex-specific tags if present: per-strand summary (aD/bD/aM/bM
-        // int, aE/bE float rate) plus the per-base strand depth/error arrays
-        // filter needs. The same scratch buffers are refilled per strand.
-        if let Some((ad, bd, am, bm, ae, be)) = duplex_tags {
-            b.add_int_tag(SamTag::AD, ad)
-                .add_int_tag(SamTag::BD, bd)
-                .add_int_tag(SamTag::AM, am)
-                .add_int_tag(SamTag::BM, bm);
+                // Combined per-base depth/error summary across both strands.
+                let mut cd_max = 0i32;
+                let mut cd_min = i32::MAX;
+                let mut total_depth = 0i64;
+                for (&a_d, &b_d) in a_depths.iter().zip(b_depths.iter()) {
+                    let total = i32::from(a_d) + i32::from(b_d);
+                    cd_max = cd_max.max(total);
+                    cd_min = cd_min.min(total);
+                    total_depth += i64::from(total);
+                }
+                let total_errors: i64 =
+                    a_errors.iter().chain(b_errors.iter()).map(|&e| i64::from(e)).sum();
+                // Empty read (read_len == 0): no per-base entries → zero summary.
+                let cd_min = if a_depths.is_empty() { 0 } else { cd_min };
+                let combined_rate = if total_depth > 0 {
+                    (total_errors as f64 / total_depth as f64) as f32
+                } else {
+                    0.0
+                };
+                b.add_int_tag(SamTag::CD, cd_max)
+                    .add_int_tag(SamTag::CM, cd_min)
+                    .add_float_tag(SamTag::CE, combined_rate);
 
-            fill_per_base(depths, errors, ad, am, ae);
-            b.add_float_tag(SamTag::AE, error_rate(errors, depths));
-            b.add_array_i16(SamTag::AD_BASES, depths).add_array_i16(SamTag::AE_BASES, errors);
-
-            fill_per_base(depths, errors, bd, bm, be);
-            b.add_float_tag(SamTag::BE, error_rate(errors, depths));
-            b.add_array_i16(SamTag::BD_BASES, depths).add_array_i16(SamTag::BE_BASES, errors);
+                // Per-strand summary (aD/bD/aM/bM int, aE/bE float rate) plus the
+                // per-base strand depth/error arrays `filter` needs.
+                b.add_int_tag(SamTag::AD, ad)
+                    .add_int_tag(SamTag::BD, bd)
+                    .add_int_tag(SamTag::AM, am)
+                    .add_int_tag(SamTag::BM, bm);
+                b.add_float_tag(SamTag::AE, error_rate(a_errors, a_depths));
+                b.add_array_i16(SamTag::AD_BASES, a_depths)
+                    .add_array_i16(SamTag::AE_BASES, a_errors);
+                b.add_float_tag(SamTag::BE, error_rate(b_errors, b_depths));
+                b.add_array_i16(SamTag::BD_BASES, b_depths)
+                    .add_array_i16(SamTag::BE_BASES, b_errors);
+            }
         }
     });
 
@@ -831,6 +963,48 @@ mod tests {
     use super::*;
     use crate::commands::simulate::common::generate_random_sequence;
     use crate::simulate::create_rng;
+
+    #[test]
+    fn truth_tsv_header_names_error_columns_as_counts() {
+        // The BAM emits read-level cE/aE/bE as FLOAT error rates, but the truth
+        // TSV stores the simulated integer error *counts* (`ConsensusReadPair.
+        // truth`). The error columns must be suffixed `_count` so the TSV never
+        // silently disagrees with the BAM it is meant to validate; the depth
+        // columns keep their bare tag names because they match the integer BAM
+        // tags exactly.
+        let cols: Vec<&str> = TRUTH_TSV_HEADER.split('\t').collect();
+        assert_eq!(
+            cols,
+            vec![
+                "read_name",
+                "chrom",
+                "pos",
+                "strand",
+                "cD",
+                "cM",
+                "cE_count",
+                "aD",
+                "bD",
+                "aM",
+                "bM",
+                "aE_count",
+                "bE_count",
+            ],
+        );
+        // The nine data columns line up 1:1 with the 9-element `truth` tuple.
+        assert_eq!(
+            cols.len() - 4,
+            9,
+            "data columns (after read_name/chrom/pos/strand) must match the truth tuple arity"
+        );
+        // No bare rate-valued tag name leaks through as a count column.
+        for bare in ["cE", "aE", "bE"] {
+            assert!(
+                !cols.contains(&bare),
+                "bare `{bare}` would collide with the BAM's rate-valued tag; use `{bare}_count`"
+            );
+        }
+    }
 
     /// Decode a raw BAM record into a noodles `RecordBuf` for higher-level test
     /// assertions.
@@ -1057,6 +1231,174 @@ mod tests {
                 ),
                 other => panic!("{rate_tag:?} should be a float error rate, got {other:?}"),
             }
+        }
+    }
+
+    /// Duplex reads must derive `cD`/`cM`/`cE` from the element-wise SUM of the
+    /// two strand depth arrays (`cD = max(aD_i + bD_i)`, `cM = min`, `cE = total
+    /// errors / total depth`) and must NOT emit a combined per-base
+    /// `CD_BASES`/`CE_BASES` array — exactly matching `duplex_caller`,
+    /// `codec_caller`, and fgbio's `DuplexConsensusCaller`, which omit the
+    /// per-base combined arrays for duplex (`filter`'s duplex path reads the
+    /// strand arrays).
+    #[test]
+    fn test_build_consensus_record_duplex_cd_is_strand_sum() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
+        let seq = b"ACGTACGTAC"; // length 10
+        let quals = vec![40u8; seq.len()];
+        // Intentionally inconsistent passed cd/cm/ce: the duplex path must IGNORE
+        // them and recompute the summary from the strand arrays.
+        let raw = build_consensus_record(
+            "dx/1",
+            seq,
+            &quals,
+            true,
+            false,
+            0,
+            100,
+            999,                      // bogus cd — must be ignored in duplex
+            999,                      // bogus cm — must be ignored in duplex
+            999,                      // bogus ce — must be ignored in duplex
+            Some((6, 4, 3, 2, 2, 1)), // (ad, bd, am, bm, ae, be)
+            None,
+            MethylationMode::Disabled,
+        );
+        let record = to_record_buf(&raw);
+        let int_tag = |tag: SamTag| -> i32 {
+            match record.data().get(&Tag::from(*tag)) {
+                Some(BufValue::Int32(v)) => *v,
+                Some(BufValue::Int8(v)) => i32::from(*v),
+                Some(BufValue::Int16(v)) => i32::from(*v),
+                Some(BufValue::UInt8(v)) => i32::from(*v),
+                Some(BufValue::UInt16(v)) => i32::from(*v),
+                other => panic!("expected int tag for {:?}, got {other:?}", *tag),
+            }
+        };
+        let float_tag = |tag: SamTag| -> f32 {
+            match record.data().get(&Tag::from(*tag)) {
+                Some(BufValue::Float(v)) => *v,
+                other => panic!("expected float tag for {:?}, got {other:?}", *tag),
+            }
+        };
+        let i16_array = |tag: SamTag| -> Vec<i16> {
+            match record.data().get(&Tag::from(*tag)) {
+                Some(BufValue::Array(Array::Int16(v))) => v.clone(),
+                other => panic!("expected i16 array for {:?}, got {other:?}", *tag),
+            }
+        };
+
+        // No combined per-base arrays in duplex (matches fgbio/duplex/codec callers).
+        assert!(
+            record.data().get(&Tag::from(*SamTag::CD_BASES)).is_none(),
+            "CD_BASES must NOT be emitted in duplex mode"
+        );
+        assert!(
+            record.data().get(&Tag::from(*SamTag::CE_BASES)).is_none(),
+            "CE_BASES must NOT be emitted in duplex mode"
+        );
+
+        let ad = i16_array(SamTag::AD_BASES);
+        let bd = i16_array(SamTag::BD_BASES);
+        let ae = i16_array(SamTag::AE_BASES);
+        let be = i16_array(SamTag::BE_BASES);
+        let combined_depth: Vec<i32> =
+            ad.iter().zip(&bd).map(|(&a, &b)| i32::from(a) + i32::from(b)).collect();
+
+        // cD/cM are the max/min of the per-base strand-sum.
+        assert_eq!(
+            int_tag(SamTag::CD),
+            *combined_depth.iter().max().unwrap(),
+            "cD == max(aD_i + bD_i)"
+        );
+        assert_eq!(
+            int_tag(SamTag::CM),
+            *combined_depth.iter().min().unwrap(),
+            "cM == min(aD_i + bD_i)"
+        );
+        // cE is total errors over total combined depth.
+        let total_err: i32 = ae.iter().chain(&be).map(|&e| i32::from(e)).sum();
+        let total_dep: i32 = combined_depth.iter().sum();
+        let expected_ce = total_err as f64 / total_dep as f64;
+        assert!(
+            (f64::from(float_tag(SamTag::CE)) - expected_ce).abs() < 1e-6,
+            "cE == total errors / total combined depth"
+        );
+    }
+
+    #[test]
+    fn test_validate_depth_bounds() {
+        // Valid ranges pass.
+        assert!(validate_depth_bounds(0, 0).is_ok());
+        assert!(validate_depth_bounds(1, 10).is_ok());
+        assert!(validate_depth_bounds(5, 5).is_ok());
+        assert!(validate_depth_bounds(0, i32::from(i16::MAX)).is_ok());
+        // Negative minimum is rejected.
+        assert!(validate_depth_bounds(-1, 10).is_err());
+        // max < min is rejected.
+        assert!(validate_depth_bounds(10, 5).is_err());
+        // max above i16::MAX is rejected (per-base arrays are i16; would saturate).
+        assert!(validate_depth_bounds(1, i32::from(i16::MAX) + 1).is_err());
+    }
+
+    /// In duplex mode the per-strand minimum depths must sum to the total minimum
+    /// (`aM + bM == cM`) and each must not exceed its strand max — so the emitted
+    /// `cM` (derived from the strand-sum) matches the truth tuple. Exercised
+    /// across seeds and a wide depth range so the sampled cM is usually < cD.
+    #[test]
+    fn test_generate_consensus_pair_duplex_strand_mins_sum_to_total() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let ref_genome = Arc::new(ReferenceGenome::load(fasta.path()).unwrap());
+        let params = Arc::new(GenerationParams {
+            read_length: 10,
+            min_depth: 1,
+            max_depth: 20,
+            depth_mean: 10.0,
+            depth_stddev: 5.0,
+            error_rate_mean: 0.1,
+            error_rate_stddev: 0.05,
+            duplex: true,
+            consensus_quality: 40,
+            methylation_mode: MethylationMode::Disabled,
+            methylation_depth_dist: create_depth_distribution(5.0, 2.5),
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+            ref_genome: Arc::clone(&ref_genome),
+        });
+        let strand_bias = StrandBiasModel::new(5.0, 5.0);
+
+        let int_tag = |rec: &noodles::sam::alignment::RecordBuf, tag: SamTag| -> i32 {
+            match rec.data().get(&Tag::from(*tag)) {
+                Some(BufValue::Int32(v)) => *v,
+                Some(BufValue::Int8(v)) => i32::from(*v),
+                Some(BufValue::Int16(v)) => i32::from(*v),
+                Some(BufValue::UInt8(v)) => i32::from(*v),
+                Some(BufValue::UInt16(v)) => i32::from(*v),
+                other => panic!("expected int tag for {:?}, got {other:?}", *tag),
+            }
+        };
+
+        for seed in 0..64u64 {
+            let pair = generate_consensus_pair(0, seed, &params, &strand_bias);
+            let (cd, cm, _ce, ad, bd, am, bm, _ae, _be) = pair.truth;
+            assert_eq!(ad + bd, cd, "truth aD + bD == cD (seed {seed})");
+            assert_eq!(am + bm, cm, "truth aM + bM == cM (seed {seed})");
+            assert!(am <= ad && bm <= bd, "each strand min <= its max (seed {seed})");
+
+            // Emitted cD/cM (derived from the strand-sum) match the truth tuple.
+            let r1 = to_record_buf(&pair.r1_record);
+            assert_eq!(int_tag(&r1, SamTag::CD), cd, "BAM cD == truth cD (seed {seed})");
+            assert_eq!(int_tag(&r1, SamTag::CM), cm, "BAM cM == truth cM (seed {seed})");
         }
     }
 
@@ -1346,10 +1688,16 @@ mod tests {
 
     #[test]
     fn test_build_consensus_record_high_error_count() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
         let seq = b"ACGT";
         let quals = vec![40; 4];
 
-        // High error count (more errors than bases)
+        // High error count (cE=100, far more errors than the 4 bases): the
+        // per-base error array saturates at one error per base.
+        let (cd, cm, ce) = (10_i32, 5_i32, 100_i32);
         let raw = build_consensus_record(
             "test/1",
             seq,
@@ -1358,16 +1706,126 @@ mod tests {
             false, // is_reverse
             0,     // chrom_idx
             100,   // local_pos
-            10,
-            5,
-            100,
+            cd,
+            cm,
+            ce,
             None,
             None,
             MethylationMode::Disabled,
         );
         let record = to_record_buf(&raw);
-
         assert!(record.name().is_some());
+
+        let read_i16_array = |tag: SamTag| -> Vec<i16> {
+            match record.data().get(&Tag::from(tag)) {
+                Some(BufValue::Array(Array::Int16(vals))) => vals.clone(),
+                other => panic!("expected an i16 array tag, got {other:?}"),
+            }
+        };
+        let cd_bases = read_i16_array(SamTag::CD_BASES);
+        let ce_bases = read_i16_array(SamTag::CE_BASES);
+
+        // Errors saturate at one-per-base: every base carries an error.
+        assert_eq!(ce_bases, vec![1, 1, 1, 1], "per-base errors saturate at one per base");
+        let total_errors: i32 = ce_bases.iter().map(|&e| i32::from(e)).sum();
+        let total_depth: i32 = cd_bases.iter().map(|&d| i32::from(d)).sum();
+        assert_eq!(total_errors, seq.len() as i32, "saturated error count == read length");
+
+        // The read-level cE tag is the saturated rate sum(ce)/sum(cd), matching
+        // the real-caller formula (S8-001), pinned here so the saturation path is
+        // tested rather than silently divergent.
+        match record.data().get(&Tag::from(SamTag::CE)) {
+            Some(BufValue::Float(rate)) => {
+                let expected = f64::from(total_errors) / f64::from(total_depth);
+                assert!(
+                    (f64::from(*rate) - expected).abs() < 1e-6,
+                    "cE should equal sum(ce)/sum(cd): got {rate}, expected {expected}"
+                );
+            }
+            other => panic!("cE should be a float error rate, got {other:?}"),
+        }
+    }
+
+    /// S8-002: the per-base depth array is a ramp spanning [cM, cD], so interior
+    /// bases — not just the final one — fall below a `--min-reads` threshold
+    /// between cM and cD. Endpoints honor the summary tags (max == cD at the
+    /// first base, min == cM at the last).
+    #[test]
+    fn test_build_consensus_record_per_base_depth_is_a_ramp() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
+        let seq = b"ACGTACGTAC"; // length 10
+        let quals = vec![40u8; seq.len()];
+        let (cd, cm, ce) = (20_i32, 4_i32, 1_i32);
+        let raw = build_consensus_record(
+            "ramp/1",
+            seq,
+            &quals,
+            true,
+            false,
+            0,
+            100,
+            cd,
+            cm,
+            ce,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
+        let record = to_record_buf(&raw);
+        let cd_bases = match record.data().get(&Tag::from(SamTag::CD_BASES)) {
+            Some(BufValue::Array(Array::Int16(vals))) => vals.clone(),
+            other => panic!("expected CD_BASES i16 array, got {other:?}"),
+        };
+
+        assert_eq!(cd_bases.len(), seq.len());
+        assert_eq!(i32::from(cd_bases[0]), cd, "first base depth == cD (max)");
+        assert_eq!(i32::from(cd_bases[seq.len() - 1]), cm, "last base depth == cM (min)");
+        // Monotonically non-increasing ramp (no flat max-everywhere plateau).
+        for w in cd_bases.windows(2) {
+            assert!(w[0] >= w[1], "depth ramp must be non-increasing: {w:?}");
+        }
+        // A threshold strictly between cM and cD masks MORE than one base — the
+        // whole gap S8-002 was about (the old layout masked at most one).
+        let threshold = cd.midpoint(cm);
+        let masked = cd_bases.iter().filter(|&&d| i32::from(d) < threshold).count();
+        assert!(masked > 1, "a mid threshold should mask a run of bases, masked={masked}");
+    }
+
+    /// A single-base read carries the summary minimum (it cannot carry both
+    /// endpoints); the ramp must not panic on `read_len == 1`.
+    #[test]
+    fn test_build_consensus_record_single_base_depth_honors_min() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+
+        let seq = b"A";
+        let quals = vec![40u8; 1];
+        let (cd, cm, ce) = (9_i32, 3_i32, 0_i32);
+        let raw = build_consensus_record(
+            "single/1",
+            seq,
+            &quals,
+            true,
+            false,
+            0,
+            100,
+            cd,
+            cm,
+            ce,
+            None,
+            None,
+            MethylationMode::Disabled,
+        );
+        let record = to_record_buf(&raw);
+        let cd_bases = match record.data().get(&Tag::from(SamTag::CD_BASES)) {
+            Some(BufValue::Array(Array::Int16(vals))) => vals.clone(),
+            other => panic!("expected CD_BASES i16 array, got {other:?}"),
+        };
+        assert_eq!(cd_bases, vec![3], "single base honors the summary minimum cM");
     }
 
     #[test]
@@ -1978,7 +2436,8 @@ mod tests {
         let cd = 8; // max depth (array fill)
         let cm = 3; // min depth (anchored at last base)
         let ce = 2; // error count (spread one-per-base from the front)
-        let duplex = Some((7, 6, 2, 1, 1, 1)); // (ad, bd, am, bm, ae, be)
+        let duplex_tags = (7, 6, 2, 1, 1, 1); // (ad, bd, am, bm, ae, be)
+        let duplex = Some(duplex_tags);
 
         let r1_raw = build_consensus_record(
             "test/1",
@@ -2025,15 +2484,9 @@ mod tests {
 
         // Every per-base array must be IDENTICAL between R1 and R2 (read-oriented,
         // not reversed), and the depth array's min must sit at the LAST index on
-        // both reads.
-        for tag in [
-            SamTag::CD_BASES,
-            SamTag::CE_BASES,
-            SamTag::AD_BASES,
-            SamTag::AE_BASES,
-            SamTag::BD_BASES,
-            SamTag::BE_BASES,
-        ] {
+        // both reads. Duplex mode emits only the per-strand arrays (no combined
+        // CD_BASES/CE_BASES — see `build_consensus_record`).
+        for tag in [SamTag::AD_BASES, SamTag::AE_BASES, SamTag::BD_BASES, SamTag::BE_BASES] {
             let r1_arr = array_tag(&r1, tag);
             let r2_arr = array_tag(&r2, tag);
             assert_eq!(
@@ -2053,11 +2506,18 @@ mod tests {
             );
         }
 
-        // The depth arrays anchor their min at the last base on BOTH reads.
-        let r1_cd = array_tag(&r1, SamTag::CD_BASES);
-        let r2_cd = array_tag(&r2, SamTag::CD_BASES);
-        assert_eq!(*r1_cd.last().unwrap(), cm as i16, "R1 cd min anchored at last base");
-        assert_eq!(*r2_cd.last().unwrap(), cm as i16, "R2 cd min anchored at last base");
+        // The strand depth arrays anchor their min at the last base on BOTH reads
+        // (aM/bM are the per-strand minima), so the expected last-base values are
+        // `am` and `bm` from the duplex tuple `(ad, bd, am, bm, ae, be)`.
+        let (_ad, _bd, am, bm, _ae, _be) = duplex_tags;
+        let r1_ad = array_tag(&r1, SamTag::AD_BASES);
+        let r2_ad = array_tag(&r2, SamTag::AD_BASES);
+        assert_eq!(*r1_ad.last().unwrap(), am as i16, "R1 aD min anchored at last base");
+        assert_eq!(*r2_ad.last().unwrap(), am as i16, "R2 aD min anchored at last base");
+        let r1_bd = array_tag(&r1, SamTag::BD_BASES);
+        let r2_bd = array_tag(&r2, SamTag::BD_BASES);
+        assert_eq!(*r1_bd.last().unwrap(), bm as i16, "R1 bD min anchored at last base");
+        assert_eq!(*r2_bd.last().unwrap(), bm as i16, "R2 bD min anchored at last base");
     }
 
     #[test]
@@ -2108,5 +2568,83 @@ mod tests {
 
         // Chrom name should be set
         assert_eq!(pair.chrom_name, "chr1");
+    }
+
+    #[test]
+    fn single_base_read_collapses_summary_depths() {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value as BufValue;
+        use noodles::sam::alignment::record_buf::data::field::value::Array;
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let ref_genome = Arc::new(ReferenceGenome::load(fasta.path()).unwrap());
+
+        // A wide depth range so the sampled cD would normally exceed cM.
+        let params = Arc::new(GenerationParams {
+            read_length: 1,
+            min_depth: 1,
+            max_depth: 20,
+            depth_mean: 10.0,
+            depth_stddev: 5.0,
+            error_rate_mean: 0.2,
+            error_rate_stddev: 0.05,
+            duplex: true,
+            consensus_quality: 40,
+            methylation_mode: MethylationMode::Disabled,
+            methylation_depth_dist: create_depth_distribution(5.0, 2.5),
+            cpg_methylation_rate: 0.75,
+            conversion_rate: 0.98,
+            ref_genome: Arc::clone(&ref_genome),
+        });
+        let strand_bias = StrandBiasModel::new(5.0, 5.0);
+
+        let int_eq = |rec: &noodles::sam::alignment::RecordBuf, a: SamTag, b: SamTag| {
+            rec.data().get(&Tag::from(*a)) == rec.data().get(&Tag::from(*b))
+        };
+        let i16_array = |rec: &noodles::sam::alignment::RecordBuf, tag: SamTag| -> Vec<i16> {
+            match rec.data().get(&Tag::from(*tag)) {
+                Some(BufValue::Array(Array::Int16(v))) => v.clone(),
+                other => panic!("expected i16 array for {:?}, got {other:?}", *tag),
+            }
+        };
+
+        // A one-base read cannot carry distinct max/min depths. Across seeds, each
+        // summary max must equal its min — in the truth tuple and the BAM tags —
+        // and the lone per-base depth must match the collapsed summary.
+        for seed in 0..64u64 {
+            let pair = generate_consensus_pair(0, seed, &params, &strand_bias);
+            let (cd, cm, _ce, ad, bd, am, bm, _ae, _be) = pair.truth;
+            assert_eq!(cd, cm, "truth cD must equal cM for a 1-base read (seed {seed})");
+            assert_eq!(ad, am, "truth aD must equal aM for a 1-base read (seed {seed})");
+            assert_eq!(bd, bm, "truth bD must equal bM for a 1-base read (seed {seed})");
+
+            let r1 = to_record_buf(&pair.r1_record);
+            assert!(int_eq(&r1, SamTag::CD, SamTag::CM), "BAM cD==cM (seed {seed})");
+            assert!(int_eq(&r1, SamTag::AD, SamTag::AM), "BAM aD==aM (seed {seed})");
+            assert!(int_eq(&r1, SamTag::BD, SamTag::BM), "BAM bD==bM (seed {seed})");
+            // Duplex omits the combined CD_BASES; the lone per-base entry lives on
+            // each strand array, and aM + bM == cM == the combined single depth.
+            assert!(
+                r1.data().get(&Tag::from(*SamTag::CD_BASES)).is_none(),
+                "duplex must not emit CD_BASES (seed {seed})"
+            );
+            assert_eq!(
+                i16_array(&r1, SamTag::AD_BASES),
+                vec![am as i16],
+                "single per-base aD must match the collapsed strand min (seed {seed})"
+            );
+            assert_eq!(
+                i16_array(&r1, SamTag::BD_BASES),
+                vec![bm as i16],
+                "single per-base bD must match the collapsed strand min (seed {seed})"
+            );
+            assert_eq!(am + bm, cm, "aM + bM == cM for a 1-base duplex read (seed {seed})");
+        }
     }
 }

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -107,7 +107,7 @@ type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
 
 /// Borrowed MI tag transformation, shared by `MiGrouper` and `MiGroupIterator`
 /// (whose stored transforms differ only in `Send + Sync` bounds).
-type MiTransform<'a> = Option<&'a dyn Fn(&[u8]) -> String>;
+pub(crate) type MiTransform<'a> = Option<&'a dyn Fn(&[u8]) -> String>;
 
 /// Type alias for raw-byte record filter function.
 type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
@@ -118,7 +118,7 @@ type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
 /// group by byte-equality of its tag value(s) rather than by building an
 /// owned `String` per record. The display label handed to `MiGroup` / the
 /// iterator output is materialized from these bytes only once per group.
-struct MiKey {
+pub(crate) struct MiKey {
     /// MI tag bytes, already transformed if a transform is configured.
     mi: Vec<u8>,
     /// Cell tag bytes, present (`Some`) only when cell-barcode grouping is
@@ -128,25 +128,43 @@ struct MiKey {
 }
 
 impl MiKey {
+    /// Locate the MI (and, when cell grouping is enabled, the cell) tag value(s)
+    /// for a record. When a cell tag is configured both are found in a **single**
+    /// aux-data walk; otherwise only the MI tag is looked up. Returns `None` when
+    /// the record has no MI tag (the record is then skipped). The boolean tracks
+    /// whether cell grouping is enabled so callers can distinguish a configured
+    /// cell tag that is absent on the record (`Some(b"")`) from no cell tag at all.
+    #[inline]
+    fn locate_values(
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+    ) -> Option<(&[u8], Option<&[u8]>)> {
+        match cell_tag {
+            Some(ct) => {
+                // Single aux-block walk for both the MI and the cell tag.
+                let (mi, cell) = fgumi_raw_bam::find_two_string_tags_in_record(bam, tag, ct);
+                Some((mi?, Some(cell.unwrap_or(b""))))
+            }
+            None => Some((fgumi_raw_bam::find_string_tag_in_record(bam, tag)?, None)),
+        }
+    }
+
     /// Extract the grouping key from raw BAM bytes, allocating the owned key
     /// bytes. Used when a new group begins. Returns `None` when the record has
     /// no MI tag (the record is then skipped).
-    fn from_record(
+    pub(crate) fn from_record(
         bam: &[u8],
         tag: [u8; 2],
         cell_tag: Option<[u8; 2]>,
         transform: MiTransform,
     ) -> Option<Self> {
-        let value = fgumi_raw_bam::find_string_tag_in_record(bam, tag)?;
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
         let mi = match transform {
             Some(transform) => transform(value).into_bytes(),
             None => value.to_vec(),
         };
-        let cell = cell_tag.map(|ct| {
-            fgumi_raw_bam::find_string_tag_in_record(bam, ct)
-                .map(<[u8]>::to_vec)
-                .unwrap_or_default()
-        });
+        let cell = cell_value.map(<[u8]>::to_vec);
         Some(Self { mi, cell })
     }
 
@@ -154,22 +172,20 @@ impl MiKey {
     /// `None` when the record has no MI tag (the record is then skipped).
     /// Allocation-free on the no-transform path: the record's tag bytes are
     /// compared against the stored key directly instead of building an owned key.
-    fn matches_record(
+    pub(crate) fn matches_record(
         &self,
         bam: &[u8],
         tag: [u8; 2],
         cell_tag: Option<[u8; 2]>,
         transform: MiTransform,
     ) -> Option<bool> {
-        let value = fgumi_raw_bam::find_string_tag_in_record(bam, tag)?;
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
         let mi_eq = match transform {
             Some(transform) => transform(value).as_bytes() == self.mi.as_slice(),
             None => value == self.mi.as_slice(),
         };
-        let cell_eq = match (cell_tag, &self.cell) {
-            (Some(ct), Some(want)) => {
-                fgumi_raw_bam::find_string_tag_in_record(bam, ct).unwrap_or(b"") == want.as_slice()
-            }
+        let cell_eq = match (cell_value, &self.cell) {
+            (Some(have), Some(want)) => have == want.as_slice(),
             // `cell_tag` is fixed for a grouper's lifetime, so the stored key's
             // cell presence always matches the configuration; the mixed arms are
             // unreachable.
@@ -181,7 +197,7 @@ impl MiKey {
 
     /// Build the display label. With a cell tag this is `"MI\tCELL"`,
     /// matching the legacy composite key; otherwise it is just the MI value.
-    fn label(&self) -> String {
+    pub(crate) fn label(&self) -> String {
         let mi = String::from_utf8_lossy(&self.mi);
         match &self.cell {
             Some(cell) => format!("{mi}\t{}", String::from_utf8_lossy(cell)),

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -209,7 +209,7 @@ fn run_codec_consensus_batch(
                 batch_stats.merge(state.caller.statistics());
                 if track_rejects {
                     for raw in &state.caller.take_rejected_reads() {
-                        super::append_framed_bytes(&mut rejects_bytes, raw);
+                        super::append_framed_bytes(&mut rejects_bytes, raw)?;
                     }
                 }
             }
@@ -220,7 +220,7 @@ fn run_codec_consensus_batch(
                     batch_stats.merge(state.caller.statistics());
                     if track_rejects {
                         for raw in &state.caller.take_rejected_reads() {
-                            super::append_framed_bytes(&mut rejects_bytes, raw);
+                            super::append_framed_bytes(&mut rejects_bytes, raw)?;
                         }
                     }
                 } else {

--- a/src/lib/pipeline/chains/commands/dedup.rs
+++ b/src/lib/pipeline/chains/commands/dedup.rs
@@ -308,13 +308,21 @@ pub(crate) fn build_serialize_step(
                             // and applies the MI tag — encapsulates the
                             // split-borrow needed for scratch + mi_buf.
                             let tagged = state.apply_mi_tag(raw, assign_tag_bytes);
-                            #[allow(clippy::cast_possible_truncation)]
-                            let block_size = tagged.len() as u32;
+                            let block_size = u32::try_from(tagged.len()).map_err(|_| {
+                                std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    format!("BAM record too large ({} bytes)", tagged.len()),
+                                )
+                            })?;
                             output.extend_from_slice(&block_size.to_le_bytes());
                             output.extend_from_slice(tagged);
                         } else {
-                            #[allow(clippy::cast_possible_truncation)]
-                            let block_size = raw.len() as u32;
+                            let block_size = u32::try_from(raw.len()).map_err(|_| {
+                                std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    format!("BAM record too large ({} bytes)", raw.len()),
+                                )
+                            })?;
                             output.extend_from_slice(&block_size.to_le_bytes());
                             output.extend_from_slice(raw);
                         }

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -286,7 +286,7 @@ fn run_duplex_consensus_batch(
         batch_stats.merge(&state.caller.statistics());
         if track_rejects {
             for raw in &state.caller.take_rejected_reads() {
-                super::append_framed_bytes(&mut rejects_bytes, raw);
+                super::append_framed_bytes(&mut rejects_bytes, raw)?;
             }
         }
     }

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -28,15 +28,24 @@ pub mod zipper;
 /// command builders' rejects-serialization paths (codec/simplex/duplex), which
 /// emit raw record bytes into a `DecompressedBlock` buffer.
 ///
-/// BAM record body size is u32-bounded per the spec; a single record's buffer
-/// cannot exceed `u32::MAX` in practice, so the length cast cannot truncate.
+/// BAM record body size is u32-bounded per the spec and the canonical builder
+/// (`fgumi-raw-bam`) already panics on overflow, so a single record's buffer
+/// cannot exceed `u32::MAX` in practice. The length prefix is nonetheless
+/// written through a checked `u32::try_from` (mirroring `filter.rs` and the
+/// builder) so the length cannot silently truncate if that invariant is ever
+/// broken — a loud `InvalidData` error is strictly safer than a corrupt frame.
 //
 // Only the consensus command builders (codec/simplex/duplex) call this, so it
 // is gated under `consensus` to avoid a dead-code warning when consensus is off.
 #[cfg(feature = "consensus")]
-pub(crate) fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) {
-    #[allow(clippy::cast_possible_truncation)]
-    let block_size = rec.len() as u32;
+pub(crate) fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) -> std::io::Result<()> {
+    let block_size = u32::try_from(rec.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("BAM record too large ({} bytes)", rec.len()),
+        )
+    })?;
     dst.extend_from_slice(&block_size.to_le_bytes());
     dst.extend_from_slice(rec);
+    Ok(())
 }

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -247,7 +247,7 @@ fn run_simplex_consensus_batch(
             batch_stats.record_rejection(RejectionReason::InsufficientReads, raw_records.len());
             if track_rejects {
                 for raw in &raw_records {
-                    super::append_framed_bytes(&mut rejects_bytes, raw.as_ref());
+                    super::append_framed_bytes(&mut rejects_bytes, raw.as_ref())?;
                 }
             }
             continue;
@@ -274,7 +274,7 @@ fn run_simplex_consensus_batch(
         batch_stats.merge(&state.caller.statistics());
         if track_rejects {
             for raw in &state.caller.take_rejected_reads() {
-                super::append_framed_bytes(&mut rejects_bytes, raw);
+                super::append_framed_bytes(&mut rejects_bytes, raw)?;
             }
         }
     }

--- a/src/lib/pipeline/steps/align_and_merge.rs
+++ b/src/lib/pipeline/steps/align_and_merge.rs
@@ -1150,11 +1150,15 @@ impl BamTemplateStream {
             }
             // `scratch.clone()` here (and below) is intentional: the
             // same `scratch` buffer is reused for the *next*
-            // `read_record` call, so we can't `mem::take` it
-            // without leaving the next read with an uninitialized
-            // record. A `RawRecord` pool would be the next
-            // optimisation if a profile points here, but at 10k–100k
-            // records/sec the clones are cheap.
+            // `read_record` call (this call's loop and the following
+            // `next_template` call's first read), so we can't
+            // `mem::take` it without surrendering the capacity reuse
+            // that the scratch buffer exists to provide — each taken
+            // record would start a fresh allocation. The accepted
+            // follow-up (deferred, no profile points here today) is a
+            // small `RawRecord` free-list so `next_template` can swap a
+            // recycled buffer in rather than clone; at 10k–100k
+            // records/sec the clones are cheap. See S5a1-007.
             records.push(self.scratch.clone());
         }
 

--- a/src/lib/pipeline/steps/bgzf/compress.rs
+++ b/src/lib/pipeline/steps/bgzf/compress.rs
@@ -73,6 +73,51 @@ impl Clone for BgzfCompress {
     }
 }
 
+impl BgzfCompress {
+    /// Drain the compressor's physical BGZF blocks and assemble the single
+    /// output `BgzfBlock` byte buffer.
+    ///
+    /// INVARIANT: each block's `serial` is `InlineBgzfCompressor`'s monotonic
+    /// per-worker counter; it has no relation to the pipeline-wide
+    /// `batch_serial`. We deliberately drop it (read only `child.data`) and
+    /// inherit the parent's `batch_serial` for the emitted `BgzfBlock`. Future
+    /// code must NOT propagate `child.serial` into the framework's ordinal stream.
+    ///
+    /// The output is the concatenation of the physical block bytes (a valid BGZF
+    /// stream is just independent blocks back to back). When there is exactly one
+    /// physical block — the common case, since a batch usually fits in one 64 KiB
+    /// block — its buffer is moved out directly (no scratch allocation and no
+    /// concatenating memcpy); this is byte-identical to concatenating a single
+    /// block. For the multi-block case the bytes are concatenated into the
+    /// per-worker scratch (then `mem::replace`d out so the replacement stays in a
+    /// fixed mimalloc size class), and each drained child buffer is handed back to
+    /// the compressor's pool so the next compression reuses it.
+    fn assemble_output_bytes(&mut self) -> Vec<u8> {
+        let mut children = self.compressor.take_blocks();
+        match children.len() {
+            // No physical blocks — reachable from the all-clean rejects path,
+            // where an empty `DecompressedBlock` produces no BGZF output. Return
+            // an empty `Vec` rather than `mem::replace`-ing out the scratch:
+            // after a prior multi-block batch the scratch retains a
+            // `COMPRESS_SCRATCH_CAPACITY` allocation, and handing that out as an
+            // "empty" output would inflate queue memory/backpressure on the
+            // ordinal-preserving fast path.
+            0 => Vec::new(),
+            1 => children.pop().expect("len == 1").data,
+            _ => {
+                for child in children {
+                    self.output_scratch.extend_from_slice(&child.data);
+                    self.compressor.recycle_buffer(child.data);
+                }
+                std::mem::replace(
+                    &mut self.output_scratch,
+                    Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+                )
+            }
+        }
+    }
+}
+
 impl Step for BgzfCompress {
     type Input = DecompressedBlock;
     type Outputs = OrderedBytesSingle<BgzfBlock>;
@@ -115,24 +160,7 @@ impl Step for BgzfCompress {
         // Compress and harvest physical BGZF blocks.
         self.compressor.write_all(&bytes)?;
         self.compressor.flush()?;
-        let children = self.compressor.take_blocks();
-        // INVARIANT: `child.serial` here is `InlineBgzfCompressor`'s
-        // monotonic per-worker counter; it has no relation to the
-        // pipeline-wide `batch_serial`. We deliberately drop it (read
-        // only `child.data`) and inherit the parent's `batch_serial` for
-        // the emitted `BgzfBlock`. Future code must NOT propagate
-        // `child.serial` into the framework's ordinal stream.
-
-        // Concatenate the physical block bytes into the per-worker
-        // scratch, then mem::replace it out — single mimalloc size class
-        // every call.
-        for child in children {
-            self.output_scratch.extend_from_slice(&child.data);
-        }
-        let bytes = std::mem::replace(
-            &mut self.output_scratch,
-            Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
-        );
+        let bytes = self.assemble_output_bytes();
 
         let out = BgzfBlock { batch_serial, bytes, uncompressed_size };
         match ctx.outputs.push(out) {
@@ -179,5 +207,107 @@ mod tests {
         for b in &blocks {
             assert_eq!(&b.data[..2], &[0x1f, 0x8b], "BGZF magic");
         }
+    }
+
+    /// Reference assembly: the straightforward concatenation the move/recycle
+    /// fast path must reproduce byte-for-byte.
+    fn reference_concat(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut c = InlineBgzfCompressor::new(level);
+        c.write_all(input).unwrap();
+        c.flush().unwrap();
+        let mut out = Vec::new();
+        for block in c.take_blocks() {
+            out.extend_from_slice(&block.data);
+        }
+        out
+    }
+
+    /// Drive `assemble_output_bytes` on a fresh step over `input`.
+    fn assemble(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut s = BgzfCompress::new(level, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        s.assemble_output_bytes()
+    }
+
+    #[test]
+    fn single_block_fast_path_is_byte_identical() {
+        // Small input → one physical block → move fast path.
+        let input = b"the quick brown fox jumps over the lazy dog";
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        assert_eq!(s.compressor.take_blocks().len(), 1, "input should fit one block");
+
+        let assembled = assemble(1, input);
+        assert_eq!(assembled, reference_concat(1, input));
+        assert_eq!(&assembled[..2], &[0x1f, 0x8b], "valid BGZF magic");
+    }
+
+    #[test]
+    fn multi_block_concat_path_is_byte_identical() {
+        // Input larger than one 64 KiB block forces the multi-block concat +
+        // recycle path; output must still match the plain concatenation.
+        let mut input = Vec::with_capacity(200 * 1024);
+        for i in 0..(200 * 1024u32) {
+            input.push((i % 251) as u8);
+        }
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(&input).unwrap();
+        s.compressor.flush().unwrap();
+        assert!(s.compressor.take_blocks().len() > 1, "input should span >1 block");
+
+        let assembled = assemble(1, &input);
+        assert_eq!(assembled, reference_concat(1, &input));
+    }
+
+    #[test]
+    fn recycle_buffer_repopulates_pool_for_reuse() {
+        // After the multi-block path recycles buffers, a subsequent compression
+        // reuses them, and output remains byte-identical to a fresh compressor.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        let mut s = BgzfCompress::new(1, 1024);
+
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let first = s.assemble_output_bytes();
+        assert_eq!(first, reference_concat(1, &big));
+
+        // Second block through the same (now pool-primed) compressor.
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let second = s.assemble_output_bytes();
+        assert_eq!(second, reference_concat(1, &big), "recycled buffers must not corrupt output");
+    }
+
+    #[test]
+    fn empty_batch_returns_unallocated_vec() {
+        // An all-clean rejects batch produces no physical BGZF blocks. The
+        // assembled output must be a truly empty `Vec`, not the per-worker
+        // scratch — otherwise an "empty" output carries a retained
+        // `COMPRESS_SCRATCH_CAPACITY` allocation and inflates queue memory.
+        let mut s = BgzfCompress::new(1, 1024);
+
+        // Fresh compressor, nothing written → no blocks.
+        let fresh = s.assemble_output_bytes();
+        assert!(fresh.is_empty());
+        assert_eq!(fresh.capacity(), 0, "empty output must not carry a scratch allocation");
+
+        // After a real multi-block batch (which routes through the scratch and
+        // replaces it with a `COMPRESS_SCRATCH_CAPACITY` Vec), a following empty
+        // batch must still return an unallocated Vec.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let multi = s.assemble_output_bytes();
+        assert!(!multi.is_empty(), "multi-block batch should produce output");
+
+        let after = s.assemble_output_bytes(); // no new input → empty batch
+        assert!(after.is_empty());
+        assert_eq!(
+            after.capacity(),
+            0,
+            "empty batch after a multi-block batch must not retain scratch"
+        );
     }
 }

--- a/src/lib/pipeline/steps/boundaries/bam.rs
+++ b/src/lib/pipeline/steps/boundaries/bam.rs
@@ -99,9 +99,11 @@ impl Step for FindBamBoundaries {
 
         // Process up to `MAX_BATCHES_PER_LOCK` inputs per `try_run` to
         // amortize the Serial mutex acquisition. Each iteration pops one
-        // input, runs find_boundaries, and (if records were produced)
-        // pushes one output. We stop early on push rejection (held the
-        // unpushed; subsequent iterations would contend on backpressure)
+        // input, runs find_boundaries, and pushes at most one output —
+        // header-only or carryover-only inputs are fully absorbed and produce
+        // no output (the loop `continue`s, and `did_work` still records the
+        // consumed input as Progress). We stop early on push rejection (held
+        // the unpushed; subsequent iterations would contend on backpressure)
         // or on input exhaustion.
         let mut did_work = false;
         for _ in 0..MAX_BATCHES_PER_LOCK {

--- a/src/lib/pipeline/steps/boundaries/state.rs
+++ b/src/lib/pipeline/steps/boundaries/state.rs
@@ -147,6 +147,22 @@ impl BoundaryState {
     /// # Errors
     ///
     /// Returns an I/O error if the BAM header is malformed.
+    ///
+    /// # Record-level validation
+    ///
+    /// This function does NOT validate individual record `block_size` values
+    /// against a malformed (but self-consistent) BAM stream. The per-record
+    /// cross-check below (offset delta vs. the stored prefix) is a
+    /// `debug_assertions`-only regression tripwire for this scanner's own
+    /// arithmetic — it re-reads the same `block_size` bytes the scan already
+    /// trusted, so it can only catch an internal bookkeeping bug, never input
+    /// corruption. Authoritative release-build validation of record structure
+    /// (out-of-bounds record end, trailing partial record) is performed
+    /// downstream by `parse_records` / `parse_record_ranges` on the same bytes,
+    /// which hard-error in all build modes. The `offsets` vector this returns
+    /// is not consumed in release builds (`FindBamBoundaries` forwards only
+    /// `buffer`), so promoting the cross-check to release would re-validate a
+    /// tautology at a per-record cost for no correctness benefit.
     pub fn find_boundaries(&mut self, decompressed: &[u8]) -> io::Result<BoundaryBatch> {
         // Step 1: Combine leftover with new data into reusable work_buffer
         // This avoids allocating a new Vec on every call
@@ -208,7 +224,14 @@ impl BoundaryState {
         // Extract the records buffer - this allocation is unavoidable as we return ownership
         let buffer = self.work_buffer[start_cursor..cursor].to_vec();
 
-        // Validate: verify each record's block_size matches the offset difference
+        // Debug-only regression tripwire (NOT input validation): cross-check
+        // each record's stored block_size prefix against the offset delta this
+        // scan just computed. Both derive from the same bytes with no
+        // intervening mutation, so this only catches an internal arithmetic /
+        // indexing bug in the scan above — a corrupt-but-self-consistent
+        // block_size passes trivially. Authoritative release validation lives
+        // in parse_records / parse_record_ranges downstream (see the
+        // `find_boundaries` doc comment).
         #[cfg(debug_assertions)]
         for i in 0..offsets.len().saturating_sub(1) {
             let start = offsets[i];

--- a/src/lib/pipeline/steps/extract.rs
+++ b/src/lib/pipeline/steps/extract.rs
@@ -59,47 +59,92 @@ pub fn build_extract_step(
         "ExtractStep",
         output_byte_limit,
         move |batch: FastqTemplateBatch| -> io::Result<BamTemplateBatch> {
-            let serial = batch.batch_serial;
-            let mut templates = Vec::with_capacity(batch.templates.len());
-
-            for fq_template in &batch.templates {
-                // Convert each FastqRecord into a FastqSet via its read structure.
-                if fq_template.records.len() != read_structures.len() {
-                    log::debug!(
-                        "Template has {} records but expected {} (read_structures.len())",
-                        fq_template.records.len(),
-                        read_structures.len()
-                    );
-                }
-
-                let mut fastq_sets: Vec<FastqSet> = Vec::with_capacity(fq_template.records.len());
-                for (record, rs) in fq_template.records.iter().zip(read_structures.iter()) {
-                    let fastq_set = FastqSet::from_record_with_structure(
-                        record.name(),
-                        record.sequence(),
-                        record.quality(),
-                        rs,
-                        &[], // No skip reasons
-                    )
-                    .map_err(io::Error::other)?;
-                    fastq_sets.push(fastq_set);
-                }
-
-                let combined = FastqSet::combine_readsets(fastq_sets);
-
-                let raw_records = make_raw_records_from_fastq_set(&combined, &extract_opts)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-                let template = Template::from_records(raw_records)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-                templates.push(template);
-            }
-
-            let count = templates.len() as u64;
-            records_emitted.fetch_add(count, Ordering::Relaxed);
-            Ok(BamTemplateBatch::new(serial, templates))
+            extract_batch(&read_structures, &extract_opts, &records_emitted, &batch)
         },
     )
+}
+
+/// Convert one [`FastqTemplateBatch`] into a [`BamTemplateBatch`], applying read
+/// structures, extracting tags, and assembling `Template`s. This is the body of
+/// the [`build_extract_step`] closure, factored out so it can be unit-tested
+/// directly (the closure inside `ProcessOrdered` is otherwise unreachable).
+///
+/// `records_emitted` is incremented by the number of templates produced.
+///
+/// # Errors
+///
+/// Returns `io::ErrorKind::InvalidData` if a template's record count does not
+/// equal the read-structure count (an internal-invariant violation — see the
+/// per-template guard below), or if read-structure application / tag extraction
+/// / template assembly fails for any record.
+pub(crate) fn extract_batch(
+    read_structures: &[ReadStructure],
+    extract_opts: &ExtractOptions,
+    records_emitted: &AtomicU64,
+    batch: &FastqTemplateBatch,
+) -> io::Result<BamTemplateBatch> {
+    let serial = batch.batch_serial;
+    let mut templates = Vec::with_capacity(batch.templates.len());
+
+    for fq_template in &batch.templates {
+        // Convert each FastqRecord into a FastqSet via its read structure. The
+        // per-template record count must equal the read-structure count: this
+        // is an internal invariant enforced upstream (CLI parse validates
+        // `inputs.len() == read_structures.len()`, and the zipper rejects
+        // per-chunk stream desync), so a mismatch here indicates a pipeline
+        // logic regression, NOT malformed user input. Fail loud rather than
+        // letting the `.zip()` below silently truncate sequencing reads. A
+        // `debug_assert_eq!` surfaces it loudly in test/debug builds; the
+        // release `Err` makes it a safe abort instead of silent data loss (do
+        // not rely on the debug assert alone — that re-introduces the
+        // silent-truncation gap in release builds).
+        debug_assert_eq!(
+            fq_template.records.len(),
+            read_structures.len(),
+            "ExtractStep: template record count != read-structure count (internal invariant \
+             violated)"
+        );
+        if fq_template.records.len() != read_structures.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "ExtractStep internal invariant violated in batch_serial {serial}: template \
+                     {:?} has {} record(s) but {} read structure(s) were provided; counts are \
+                     validated equal at CLI parse and enforced per-chunk by the zipper, so this \
+                     indicates a pipeline logic error, not malformed input",
+                    String::from_utf8_lossy(&fq_template.name),
+                    fq_template.records.len(),
+                    read_structures.len(),
+                ),
+            ));
+        }
+
+        let mut fastq_sets: Vec<FastqSet> = Vec::with_capacity(fq_template.records.len());
+        for (record, rs) in fq_template.records.iter().zip(read_structures.iter()) {
+            let fastq_set = FastqSet::from_record_with_structure(
+                record.name(),
+                record.sequence(),
+                record.quality(),
+                rs,
+                &[], // No skip reasons
+            )
+            .map_err(io::Error::other)?;
+            fastq_sets.push(fastq_set);
+        }
+
+        let combined = FastqSet::combine_readsets(fastq_sets);
+
+        let raw_records = make_raw_records_from_fastq_set(&combined, extract_opts)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        let template = Template::from_records(raw_records)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        templates.push(template);
+    }
+
+    let count = templates.len() as u64;
+    records_emitted.fetch_add(count, Ordering::Relaxed);
+    Ok(BamTemplateBatch::new(serial, templates))
 }
 
 #[cfg(test)]
@@ -231,5 +276,88 @@ mod tests {
         assert_eq!(template.read_count(), 2);
         assert!(template.r1.is_some());
         assert!(template.r2.is_some());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a2-002: end-to-end coverage of the extract batch conversion, including
+    // the S5a2-001 record-count / read-structure mismatch hard-error.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use crate::fastq_parse::FastqRecord;
+    use crate::grouper::FastqTemplate;
+    use crate::pipeline::core::item::Ordered;
+
+    /// Build a `FastqRecord` from a name/sequence (quality = all `I`).
+    fn fq_record(name: &str, seq: &str) -> FastqRecord {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        FastqRecord::from_slice(format!("@{name}\n{seq}\n+\n{qual}\n").as_bytes()).unwrap()
+    }
+
+    /// A paired-end `FastqTemplateBatch`: each template has two records (R1+R2).
+    fn paired_template_batch(batch_serial: u64, n_templates: usize) -> FastqTemplateBatch {
+        let templates = (0..n_templates)
+            .map(|i| FastqTemplate {
+                name: format!("read{i}").into_bytes(),
+                records: vec![
+                    fq_record(&format!("read{i}"), "ACGTG"),
+                    fq_record(&format!("read{i}"), "TGCAA"),
+                ],
+            })
+            .collect();
+        FastqTemplateBatch::new(batch_serial, templates)
+    }
+
+    /// `extract_batch` propagates the input `batch_serial` to the output and
+    /// bumps `records_emitted` by the number of templates converted.
+    #[test]
+    fn extract_batch_propagates_serial_and_counts_templates() {
+        let read_structures = vec!["5T".parse::<ReadStructure>().unwrap(); 2];
+        let opts = default_extract_opts();
+        let emitted = AtomicU64::new(0);
+
+        let batch = paired_template_batch(7, 3);
+        let out = extract_batch(&read_structures, &opts, &emitted, &batch).unwrap();
+
+        assert_eq!(out.ordinal(), 7, "output batch_serial must equal the input batch_serial");
+        assert_eq!(out.templates.len(), 3, "all templates converted");
+        assert_eq!(emitted.load(Ordering::Relaxed), 3, "records_emitted bumped by template count");
+    }
+
+    /// A template whose record count differs from `read_structures.len()` is a
+    /// structural invariant violation: `extract_batch` must hard-error with
+    /// `InvalidData` rather than silently truncating reads via `zip`. (S5a2-001)
+    #[test]
+    fn extract_batch_errors_on_record_count_mismatch() {
+        // Two read structures but a template carrying only ONE record.
+        let read_structures = vec!["5T".parse::<ReadStructure>().unwrap(); 2];
+        let opts = default_extract_opts();
+        let emitted = AtomicU64::new(0);
+
+        let short_template =
+            FastqTemplate { name: b"read0".to_vec(), records: vec![fq_record("read0", "ACGTG")] };
+        let batch = FastqTemplateBatch::new(0, vec![short_template]);
+
+        // In debug builds the `debug_assert_eq!` fires first; catch the panic so
+        // the test asserts the loud-failure contract in both build profiles. In
+        // release the `Err(InvalidData)` path is taken.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            extract_batch(&read_structures, &opts, &emitted, &batch)
+        }));
+
+        match result {
+            Err(_panic) => { /* debug_assert_eq! fired — loud failure, contract met */ }
+            Ok(Ok(_)) => panic!("expected a mismatch error or assertion, but conversion succeeded"),
+            Ok(Err(err)) => {
+                assert_eq!(
+                    err.kind(),
+                    io::ErrorKind::InvalidData,
+                    "mismatch must surface as InvalidData"
+                );
+                assert!(
+                    err.to_string().contains("internal invariant violated"),
+                    "error must be framed as an internal invariant: {err}"
+                );
+            }
+        }
     }
 }

--- a/src/lib/pipeline/steps/group/mi.rs
+++ b/src/lib/pipeline/steps/group/mi.rs
@@ -13,9 +13,7 @@
 
 use std::io;
 
-use fgumi_raw_bam::find_string_tag_in_record;
-
-use crate::mi_group::MiGroup;
+use crate::mi_group::{MiGroup, MiKey, MiTransform};
 use crate::pipeline::core::Unpushed;
 use crate::pipeline::core::held::HeldSlot;
 use crate::pipeline::core::item::{HeapSize, Ordered};
@@ -98,9 +96,12 @@ pub struct GroupByMi {
     /// (and stored on the emitted `MiGroup`). When unset, the raw MI
     /// bytes are used as a UTF-8 lossy string.
     mi_transform: Option<MiTransformFn>,
-    /// Run-length state: the MI value currently being accumulated.
-    current_mi: Option<String>,
-    /// Run-length state: records accumulated for `current_mi`.
+    /// Run-length state: the grouping key currently being accumulated, stored as
+    /// raw comparison bytes so run-boundary detection stays allocation-free on
+    /// the common (no-transform) path. The owned display label is materialized
+    /// only once per group (at the group boundary) via [`MiKey::label`].
+    current_key: Option<MiKey>,
+    /// Run-length state: records accumulated for `current_key`.
     current_records: Vec<fgumi_raw_bam::RawRecord>,
     /// Self-managed monotonic ordinal — each emitted *batch* gets the
     /// next value. Required for `BranchOrdering::ByItemOrdinal`'s
@@ -135,7 +136,7 @@ impl GroupByMi {
             cell_tag: None,
             record_filter: None,
             mi_transform: None,
-            current_mi: None,
+            current_key: None,
             current_records: Vec::new(),
             next_ordinal: 0,
             accumulator: Vec::with_capacity(target_batch_count),
@@ -178,25 +179,11 @@ impl GroupByMi {
         self
     }
 
-    /// Compute the composite group key for a record's bytes:
-    /// `MI` alone, or `MI\tCELL` when `cell_tag` is set. When
-    /// `mi_transform` is installed, the raw MI bytes are piped through
-    /// it before forming the key.
-    /// Returns `None` if the record lacks an MI tag.
-    fn group_key(&self, bam: &[u8]) -> Option<String> {
-        let mi_value = find_string_tag_in_record(bam, self.tag)?;
-        let mut key = if let Some(ref transform) = self.mi_transform {
-            transform(mi_value)
-        } else {
-            String::from_utf8_lossy(mi_value).into_owned()
-        };
-        if let Some(ct) = self.cell_tag {
-            key.push('\t');
-            if let Some(cell_value) = find_string_tag_in_record(bam, ct) {
-                key.push_str(&String::from_utf8_lossy(cell_value));
-            }
-        }
-        Some(key)
+    /// Borrow the installed MI-transform closure (if any) as the
+    /// `Option<&dyn Fn>` shape [`MiKey`] expects.
+    #[inline]
+    fn transform(&self) -> MiTransform<'_> {
+        self.mi_transform.as_ref().map(|t| t.as_ref() as &dyn Fn(&[u8]) -> String)
     }
 
     /// Run the optional filter against a record's bytes; returns `true`
@@ -209,12 +196,51 @@ impl GroupByMi {
         }
     }
 
-    /// Flush the run-in-progress into the accumulator (if non-empty).
+    /// Accumulate one raw record into the current MI run, opening a new run (and
+    /// flushing the previous one) at a group boundary. Run-boundary detection is
+    /// an allocation-free byte comparison against the stored key on the common
+    /// (no-transform) path; the owned key is built only when a new run begins.
+    /// Records that fail the optional filter, or that carry no MI tag, are
+    /// dropped (matching `MiGrouper`).
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord) {
+        // Optional filter (mirrors `MiGrouper::should_keep`).
+        if !self.passes_filter(raw.as_ref()) {
+            return;
+        }
+        let same_group = match &self.current_key {
+            Some(key) => {
+                match key.matches_record(raw.as_ref(), self.tag, self.cell_tag, self.transform()) {
+                    Some(matches) => matches,
+                    // No MI tag on this record: skip it.
+                    None => return,
+                }
+            }
+            None => false,
+        };
+        if same_group {
+            self.current_records.push(raw);
+        } else {
+            // New run (or first record). Build the owned key once at the
+            // boundary; `from_record` returns `None` (skip) without an MI tag.
+            let Some(key) =
+                MiKey::from_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+            else {
+                return;
+            };
+            self.flush_current_group();
+            self.current_key = Some(key);
+            self.current_records.push(raw);
+        }
+    }
+
+    /// Flush the run-in-progress into the accumulator (if non-empty). The owned
+    /// display label is materialized here — once per group — from the stored key
+    /// bytes, rather than per record.
     fn flush_current_group(&mut self) {
-        if let Some(mi) = self.current_mi.take() {
+        if let Some(key) = self.current_key.take() {
             if !self.current_records.is_empty() {
                 let records = std::mem::take(&mut self.current_records);
-                self.accumulator.push(MiGroup::new(mi, records));
+                self.accumulator.push(MiGroup::new(key.label(), records));
             }
         }
     }
@@ -276,29 +302,7 @@ impl Step for GroupByMi {
             did_work = true;
             let DecodedRecordBatch { records, .. } = batch;
             for decoded in records {
-                let raw = decoded.into_raw_bytes();
-                // Optional filter (mirrors `MiGrouper::should_keep`).
-                if !self.passes_filter(raw.as_ref()) {
-                    continue;
-                }
-                // Records without MI are skipped (matches `MiGrouper`).
-                let Some(mi) = self.group_key(raw.as_ref()) else {
-                    continue;
-                };
-                match &self.current_mi {
-                    Some(current) if current == &mi => {
-                        self.current_records.push(raw);
-                    }
-                    Some(_) => {
-                        self.flush_current_group();
-                        self.current_mi = Some(mi);
-                        self.current_records.push(raw);
-                    }
-                    None => {
-                        self.current_mi = Some(mi);
-                        self.current_records.push(raw);
-                    }
-                }
+                self.process_record(decoded.into_raw_bytes());
             }
             if self.accumulator.len() >= self.target_batch_count {
                 break;
@@ -331,6 +335,164 @@ impl Step for GroupByMi {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fgumi_raw_bam::RawRecord;
+
+    /// Build a minimal unmapped raw BAM record carrying a single Z-type tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tag(tag: &str, value: &str) -> RawRecord {
+        raw_with_tags(&[(tag, value)])
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying the given Z-type tags
+    /// in the supplied aux-block order.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tags(tags: &[(&str, &str)]) -> RawRecord {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        let mut aux: Vec<u8> = Vec::new();
+        for (tag, value) in tags {
+            let t = tag.as_bytes();
+            aux.extend_from_slice(&[t[0], t[1], b'Z']);
+            aux.extend_from_slice(value.as_bytes());
+            aux.push(0);
+        }
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
+        let mut buf = vec![0u8; total];
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[8] = l_read_name;
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+        let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
+        RawRecord::from(buf)
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying no aux tags.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_without_tag() -> RawRecord {
+        raw_with_tags(&[])
+    }
+
+    /// Drive a sequence of records through [`GroupByMi::process_record`], close
+    /// the final run, and return `(label, record_count)` per completed group.
+    fn run_grouping(step: &mut GroupByMi, records: Vec<RawRecord>) -> Vec<(String, usize)> {
+        for raw in records {
+            step.process_record(raw);
+        }
+        step.flush_current_group();
+        step.accumulator.iter().map(|g| (g.mi.clone(), g.records.len())).collect()
+    }
+
+    #[test]
+    fn single_mi_run_forms_one_group() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records: Vec<RawRecord> = (0..1000).map(|_| raw_with_tag("MI", "7")).collect();
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("7".to_string(), 1000)]);
+    }
+
+    #[test]
+    fn distinct_mi_values_split_runs_and_label_once() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "2"),
+            raw_with_tag("MI", "1"), // non-adjacent: a fresh run, not merged
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1), ("1".to_string(), 1)]);
+    }
+
+    #[test]
+    fn records_without_mi_are_skipped() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_without_tag(), // skipped, no current run yet
+            raw_with_tag("MI", "5"),
+            raw_without_tag(), // skipped, current run preserved
+            raw_with_tag("MI", "5"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("5".to_string(), 2)]);
+    }
+
+    #[test]
+    fn cell_tag_composite_key_splits_and_labels() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        // Same MI, different CB → distinct groups; aux order varies to exercise
+        // the single-pass dual-tag lookup regardless of tag ordering.
+        let records = vec![
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]),
+            raw_with_tags(&[("CB", "ACGT"), ("MI", "1")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\tACGT".to_string(), 2), ("1\tTGCA".to_string(), 2)]);
+    }
+
+    #[test]
+    fn missing_cell_tag_uses_empty_suffix() {
+        use crate::sam::SamTag;
+        // With a cell tag configured, a record that lacks `CB` keys on an empty
+        // cell suffix (`MI\t`), distinct from a record that carries `CB`. Guards
+        // against a future aux-lookup change silently merging or splitting MI
+        // groups when the configured cell tag is absent.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        let records = vec![
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]), // → "1\tACGT"
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\t".to_string(), 2), ("1\tACGT".to_string(), 1)]);
+    }
+
+    #[test]
+    fn mi_transform_groups_strands_together() {
+        use crate::sam::SamTag;
+        // Strip a trailing "/A" or "/B" so both strands of a molecule group.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_mi_transform(|mi: &[u8]| {
+            let s = String::from_utf8_lossy(mi);
+            s.split('/').next().unwrap_or("").to_string()
+        });
+        let records =
+            vec![raw_with_tag("MI", "1/A"), raw_with_tag("MI", "1/B"), raw_with_tag("MI", "2/A")];
+        let groups = run_grouping(&mut step, records);
+        // Label is the transformed key, materialized once per group.
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1)]);
+    }
+
+    #[test]
+    fn record_filter_drops_records() {
+        use crate::sam::SamTag;
+        // Filter out any record whose MI tag value is "skip".
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_record_filter(|bam: &[u8]| {
+            fgumi_raw_bam::find_string_tag_in_record(bam, *SamTag::MI) != Some(b"skip")
+        });
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "skip"), // dropped, run "1" preserved
+            raw_with_tag("MI", "1"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2)]);
+    }
 
     #[test]
     fn profile_advertises_serial_byordinal() {

--- a/src/lib/pipeline/steps/group/queryname.rs
+++ b/src/lib/pipeline/steps/group/queryname.rs
@@ -42,9 +42,14 @@ pub const DEFAULT_TARGET_BATCH_COUNT: usize = 1000;
 /// when an emit is rejected by downstream backpressure, the partial
 /// state stays buffered until the held slot drains.
 pub struct GroupByQueryname {
-    /// Run-length state: queryname currently being accumulated.
-    current_name: Option<Vec<u8>>,
-    /// Run-length state: cached `name_hash` for fast pre-check.
+    /// Run-length state: queryname currently being accumulated, kept in a
+    /// reusable buffer so each template boundary refills (`clear` +
+    /// `extend_from_slice`) rather than re-allocating a fresh `Vec`. Only
+    /// meaningful while a run is active (`current_name_hash.is_some()`).
+    current_name: Vec<u8>,
+    /// Run-length state: cached `name_hash` for fast pre-check. `Some` iff a
+    /// run is currently active; doubles as the run-active flag so the
+    /// `current_name` allocation survives across template boundaries.
     current_name_hash: Option<u64>,
     /// Run-length state: records accumulated for `current_name`.
     current_records: Vec<fgumi_raw_bam::RawRecord>,
@@ -71,7 +76,7 @@ impl GroupByQueryname {
     #[must_use]
     pub fn with_target_batch_count(output_byte_limit: u64, target_batch_count: usize) -> Self {
         Self {
-            current_name: None,
+            current_name: Vec::new(),
             current_name_hash: None,
             current_records: Vec::new(),
             next_ordinal: 0,
@@ -83,15 +88,40 @@ impl GroupByQueryname {
         }
     }
 
-    /// Flush the run-in-progress into the accumulator (if non-empty).
+    /// Flush the run-in-progress into the accumulator (if non-empty). The
+    /// `current_name` buffer is retained (only the run-active flag is cleared)
+    /// so its allocation is reused by the next template boundary.
     fn flush_current_template(&mut self) -> io::Result<()> {
         if !self.current_records.is_empty() {
             let records = std::mem::take(&mut self.current_records);
             let template = Template::from_records(records)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             self.accumulator.push(template);
-            self.current_name = None;
             self.current_name_hash = None;
+        }
+        Ok(())
+    }
+
+    /// Accumulate one raw record into the current template run, opening a new
+    /// run (and flushing the previous one) at a queryname boundary. The cached
+    /// `name_hash` pre-check short-circuits most inequality before the byte
+    /// compare; the `current_name` buffer is reused across boundaries.
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord, name_hash: u64) -> io::Result<()> {
+        let read_name = fgumi_raw_bam::read_name(raw.as_ref());
+        // A run is active iff `current_name_hash` is `Some`.
+        let same_template = match self.current_name_hash {
+            Some(h) => h == name_hash && self.current_name == read_name,
+            None => false,
+        };
+        if same_template {
+            self.current_records.push(raw);
+        } else {
+            self.flush_current_template()?;
+            // Reuse the buffer: clear + refill rather than allocate.
+            self.current_name.clear();
+            self.current_name.extend_from_slice(read_name);
+            self.current_name_hash = Some(name_hash);
+            self.current_records.push(raw);
         }
         Ok(())
     }
@@ -151,19 +181,7 @@ impl Step for GroupByQueryname {
             for decoded in records {
                 let name_hash = decoded.key.name_hash;
                 let raw = decoded.into_raw_bytes();
-                let read_name = fgumi_raw_bam::read_name(raw.as_ref());
-                let same_template = match (self.current_name_hash, self.current_name.as_deref()) {
-                    (Some(h), Some(name)) => h == name_hash && name == read_name,
-                    _ => false,
-                };
-                if same_template {
-                    self.current_records.push(raw);
-                } else {
-                    self.flush_current_template()?;
-                    self.current_name = Some(read_name.to_vec());
-                    self.current_name_hash = Some(name_hash);
-                    self.current_records.push(raw);
-                }
+                self.process_record(raw, name_hash)?;
             }
             if self.accumulator.len() >= self.target_batch_count {
                 break;
@@ -197,6 +215,83 @@ impl Step for GroupByQueryname {
 mod tests {
     use super::*;
     use crate::pipeline::core::item::Ordered;
+    use fgumi_bam_io::library::LibraryIndex;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder};
+
+    use fgumi_raw_bam::flags;
+
+    /// Build a minimal mapped raw record with the given read name and flags.
+    fn raw_named(name: &[u8], flag: u16) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flag);
+        b.build()
+    }
+
+    /// Drive each `(name, flag)` record through [`GroupByQueryname::process_record`],
+    /// close the final run, and return `(name, record_count)` per template in order.
+    fn run_grouping(
+        step: &mut GroupByQueryname,
+        records: &[(&[u8], u16)],
+    ) -> Vec<(Vec<u8>, usize)> {
+        for (name, flag) in records {
+            let raw = raw_named(name, *flag);
+            let name_hash = LibraryIndex::hash_name(Some(name));
+            step.process_record(raw, name_hash).expect("process_record");
+        }
+        step.flush_current_template().expect("flush");
+        step.accumulator.iter().map(|t| (t.name.clone(), t.records().len())).collect()
+    }
+
+    const R1: u16 = flags::PAIRED | flags::FIRST_SEGMENT;
+    const R2: u16 = flags::PAIRED | flags::LAST_SEGMENT;
+
+    #[test]
+    fn consecutive_same_name_forms_one_template() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![(b"read1", R1), (b"read1", R2)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(groups, vec![(b"read1".to_vec(), 2)]);
+    }
+
+    #[test]
+    fn distinct_and_nonadjacent_names_split_runs() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        // read1 appears again non-adjacently → a fresh template, not merged.
+        let records: Vec<(&[u8], u16)> =
+            vec![(b"read1", R1), (b"read1", R2), (b"read2", R1), (b"read1", R1)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![(b"read1".to_vec(), 2), (b"read2".to_vec(), 1), (b"read1".to_vec(), 1)]
+        );
+    }
+
+    #[test]
+    fn buffer_reuse_across_boundaries_preserves_grouping() {
+        // Short-then-long-then-short name transitions exercise the reused
+        // `current_name` buffer (clear + refill); grouping must stay exact.
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![
+            (b"a", R1),
+            (b"a", R2),
+            (b"longer_name", R1),
+            (b"b", R1),
+            (b"b", R2),
+            (b"another_longer_name", R1),
+            (b"c", R1),
+        ];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![
+                (b"a".to_vec(), 2),
+                (b"longer_name".to_vec(), 1),
+                (b"b".to_vec(), 2),
+                (b"another_longer_name".to_vec(), 1),
+                (b"c".to_vec(), 1),
+            ]
+        );
+    }
 
     #[test]
     fn profile_advertises_serial_byordinal() {

--- a/src/lib/pipeline/steps/parse/bam.rs
+++ b/src/lib/pipeline/steps/parse/bam.rs
@@ -169,10 +169,21 @@ pub(crate) fn parse_record_ranges(bytes: &[u8]) -> io::Result<Vec<(u32, u32)>> {
 }
 
 /// Walk record-aligned bytes and produce `Vec<RawRecord>` (one heap
-/// allocation per record). Convenience wrapper for test paths and the
-/// `SerializeBamRecords` round-trip; the production
-/// `ParseBamRecords` step uses [`parse_record_ranges`] for the
-/// zero-alloc path.
+/// allocation per record, via `to_vec()`).
+///
+/// Used by:
+/// - the `SerializeBamRecords` round-trip and test paths;
+/// - the production [`DecodeRecords`](super::decode::DecodeRecords) step, whose
+///   downstream `DecodedRecord::from_raw_bytes` takes an **owned** `RawRecord`
+///   (it stores the bytes, unlike `ParseBamRecords` which only emits ranges into
+///   the shared block) — so the production decode path does allocate one `Vec`
+///   per record here. This is inherent to the owned-per-record `DecodedRecord`
+///   representation; sharing the block buffer across a batch's records (e.g.
+///   `Arc<[u8]>` + per-record range) is a `DecodedRecord` representation change
+///   deferred behind a benchmark.
+///
+/// The other production parser, the `ParseBamRecords` step, instead uses
+/// [`parse_record_ranges`] for its zero-alloc path.
 ///
 /// # Errors
 ///

--- a/src/lib/pipeline/steps/parse/bam.rs
+++ b/src/lib/pipeline/steps/parse/bam.rs
@@ -176,8 +176,11 @@ pub(crate) fn parse_record_ranges(bytes: &[u8]) -> io::Result<Vec<(u32, u32)>> {
 ///
 /// # Errors
 ///
-/// Returns `Err` if a record runs past the buffer end or
-/// `block_size` is too small for a valid BAM record.
+/// Returns `Err` if a record runs past the buffer end, or if the buffer ends
+/// with a trailing partial record (the final `block_size` does not consume the
+/// remaining bytes exactly). It does NOT enforce a per-record minimum body
+/// size, so a `block_size` below the BAM fixed-field minimum is accepted here
+/// and rejected (if at all) by later decode of the record body.
 pub(crate) fn parse_records(bytes: &[u8]) -> io::Result<Vec<RawRecord>> {
     let mut records = Vec::new();
     let mut cursor = 0;

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -40,6 +40,66 @@ use crate::pipeline::steps::parse::bam::parse_records;
 use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock, RecordBatch};
 use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
 
+/// Fail closed on a raw BAM record body too short for the unchecked field
+/// accessors used during group-key extraction.
+///
+/// The parse steps that feed this one ([`parse_records`] and the
+/// `RecordBatch` walked by [`DecodeFromRecords`]) accept any record whose
+/// `block_size` prefix is internally consistent — they do **not** enforce a
+/// per-record minimum body size (see `parse_records`' contract). Both
+/// [`name_hash_key`] and [`compute_group_key_from_raw`] then call
+/// `fgumi_raw_bam::read_name`, which reads `raw[8]` (`l_read_name`, including
+/// the trailing NUL) and slices `raw[32..32 + l_read_name - 1]` with **no**
+/// bounds check; the full-key path additionally reads the 32-byte fixed header
+/// (`flags`, `ref_id`, mate fields, …). A truncated or malformed record would
+/// therefore panic on out-of-bounds indexing. We reject it here with
+/// `InvalidData` before any key is computed so the pipeline surfaces a clean
+/// error instead of unwinding a worker thread.
+///
+/// ## Minimum-length reasoning
+///
+/// - `raw.len() >= MIN_BAM_RECORD_LEN` (32) covers every fixed-offset field,
+///   including the `raw[8]` read of `l_read_name` itself.
+/// - A `>= MIN_BAM_RECORD_LEN` check alone is **not** sufficient: with
+///   `l_read_name` as large as 255 the name slice
+///   `raw[32..32 + l_read_name - 1]` ends well past a 32-byte record. So when
+///   `l_read_name > 1` we additionally require
+///   `raw.len() >= 32 + l_read_name - 1` (the exclusive end of that slice).
+///   When `l_read_name <= 1`, `read_name` returns `&[]` without slicing, so the
+///   32-byte header is enough.
+fn validate_record_for_decode(raw: &[u8]) -> io::Result<()> {
+    if raw.len() < fgumi_raw_bam::MIN_BAM_RECORD_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "DecodeRecords: BAM record too short for group-key extraction \
+                 ({} byte(s) < {}-byte fixed header)",
+                raw.len(),
+                fgumi_raw_bam::MIN_BAM_RECORD_LEN,
+            ),
+        ));
+    }
+    // `raw[8]` is in bounds because `raw.len() >= MIN_BAM_RECORD_LEN` (>= 9).
+    // `read_name` only slices the name region when `l_read_name > 1`; that
+    // slice's exclusive end index is `32 + l_read_name - 1`, which must not run
+    // past the record end.
+    let l_read_name = raw[8] as usize;
+    if l_read_name > 1 {
+        let name_end = 32 + l_read_name - 1;
+        if name_end > raw.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "DecodeRecords: BAM record read-name region runs past record end \
+                     (l_read_name={l_read_name} needs {name_end} byte(s), record is {} byte(s))",
+                    raw.len(),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Cache the UMI tag's value position on a `DecodedRecord` during decode.
 ///
 /// Looks up `umi_tag` in the record's aux data and, when present and Z-typed,
@@ -144,7 +204,11 @@ impl Step for DecodeRecords {
         let umi_tag = self.key_config.umi_tag;
         let decoded: Vec<DecodedRecord> = records
             .into_iter()
-            .map(|raw| {
+            .map(|raw| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(raw.as_ref())?;
                 // Queryname-grouping stages (e.g. correct) read only
                 // `key.name_hash`; skip the CIGAR position walk + aux-tag pass.
                 let key = if name_hash_only {
@@ -158,9 +222,9 @@ impl Step for DecodeRecords {
                 if let Some(umi_tag) = umi_tag {
                     cache_umi_position(&mut decoded, umi_tag);
                 }
-                decoded
+                Ok(decoded)
             })
-            .collect();
+            .collect::<io::Result<Vec<_>>>()?;
 
         let out = DecodedRecordBatch::new(batch_serial, decoded);
         match ctx.outputs.push(out) {
@@ -250,14 +314,26 @@ impl Step for DecodeFromRecords {
 
         let library_index: &Arc<_> = &self.key_config.library_index;
         let cell_tag = self.key_config.cell_tag;
+        let name_hash_only = self.key_config.name_hash_only;
         let umi_tag = self.key_config.umi_tag;
         // `DecodedRecord` owns its bytes (via `RawRecord`), so we materialize
         // a heap-allocated copy here. The `RecordBatch`'s shared backing
         // buffer is dropped once this batch is consumed.
         let decoded: Vec<DecodedRecord> = batch
             .iter_record_bytes()
-            .map(|bytes| {
-                let key = compute_group_key_from_raw(bytes, library_index, cell_tag);
+            .map(|bytes| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(bytes)?;
+                // Mirror `DecodeRecords::try_run`: queryname-grouping stages
+                // (e.g. correct) read only `key.name_hash`, so skip the CIGAR
+                // position walk + aux-tag pass when `name_hash_only` is set.
+                let key = if name_hash_only {
+                    name_hash_key(bytes)
+                } else {
+                    compute_group_key_from_raw(bytes, library_index, cell_tag)
+                };
                 let mut decoded = DecodedRecord::from_raw_bytes(
                     fgumi_raw_bam::RawRecord::from(bytes.to_vec()),
                     key,
@@ -267,9 +343,9 @@ impl Step for DecodeFromRecords {
                 if let Some(umi_tag) = umi_tag {
                     cache_umi_position(&mut decoded, umi_tag);
                 }
-                decoded
+                Ok(decoded)
             })
-            .collect();
+            .collect::<io::Result<Vec<_>>>()?;
 
         let out = DecodedRecordBatch::new(batch_serial, decoded);
         match ctx.outputs.push(out) {
@@ -351,6 +427,88 @@ mod tests {
                 GroupKey { name_hash: full.name_hash, ..GroupKey::default() },
                 "name_hash_only must leave all non-name fields at default"
             );
+        }
+    }
+
+    // ========================================================================
+    // Fail-closed validation of undersized / malformed records
+    // ========================================================================
+
+    /// A record body shorter than the 32-byte BAM fixed header must be rejected
+    /// with `InvalidData` rather than panicking in the unchecked field
+    /// accessors. Mirrors the 8-byte records built by
+    /// `parse_records_decodes_block_size_prefix` in `bam.rs` — exactly the
+    /// shape `parse_records` accepts but the key extractors cannot decode.
+    #[test]
+    fn validate_record_for_decode_rejects_record_shorter_than_fixed_header() {
+        let too_short = [0u8; 8];
+        let err = validate_record_for_decode(&too_short).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A record long enough for the fixed header but whose declared
+    /// `l_read_name` runs past the record end must also be rejected. This is
+    /// the case a bare `len >= MIN_BAM_RECORD_LEN` check would miss: without
+    /// the read-name bound, `read_name` would slice `raw[32..32 + 50 - 1]` on a
+    /// 32-byte record and panic.
+    #[test]
+    fn validate_record_for_decode_rejects_truncated_read_name() {
+        let mut rec = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        rec[8] = 50; // l_read_name claims 49 name bytes + NUL, none of which exist
+        let err = validate_record_for_decode(&rec).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The boundary cases that must be accepted: a 32-byte record with an empty
+    /// name (`l_read_name <= 1`, where `read_name` never slices) and a real
+    /// well-formed record built by `SamBuilder`. Proves the guard does not
+    /// reject valid input.
+    #[test]
+    fn validate_record_for_decode_accepts_minimal_and_valid_records() {
+        use fgumi_raw_bam::SamBuilder;
+
+        // 32-byte record, l_read_name = 1 (just the NUL): read_name short-circuits.
+        let mut minimal = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        minimal[8] = 1;
+        validate_record_for_decode(&minimal).expect("minimal empty-name record is valid");
+
+        // A real record exercising read_name's slice path.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30u8; 4]);
+        let raw = b.build();
+        validate_record_for_decode(raw.as_ref()).expect("well-formed record is valid");
+    }
+
+    /// End-to-end fail-closed proof: the same undersized record fed through the
+    /// `DecodeRecords` map logic (the production `name_hash_only` and full-key
+    /// branches) yields an `io::Error`, not a panic. Reproduces the map +
+    /// `collect::<io::Result<Vec<_>>>()` shape used by `try_run`.
+    #[test]
+    fn decode_map_fails_closed_on_undersized_record_for_both_key_branches() {
+        use fgumi_bam_io::{GroupKey, LibraryIndex};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let lib = LibraryIndex::default();
+        let cell_tag = Some(Tag::from([b'C', b'B']));
+        // Below the fixed-header minimum — would panic in `read_name` if it
+        // reached the key extractors.
+        let undersized: &[u8] = &[0u8; 8];
+
+        for name_hash_only in [true, false] {
+            let result: io::Result<Vec<GroupKey>> = [undersized]
+                .into_iter()
+                .map(|raw| -> io::Result<GroupKey> {
+                    validate_record_for_decode(raw)?;
+                    let key = if name_hash_only {
+                        name_hash_key(raw)
+                    } else {
+                        compute_group_key_from_raw(raw, &lib, cell_tag)
+                    };
+                    Ok(key)
+                })
+                .collect();
+            let err = result.expect_err("undersized record must fail closed");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         }
     }
 

--- a/src/lib/pipeline/steps/parse/sam.rs
+++ b/src/lib/pipeline/steps/parse/sam.rs
@@ -25,8 +25,7 @@ use crate::pipeline::core::queues::QueueSpec;
 use crate::pipeline::core::reorder::BranchOrdering;
 use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
 use crate::pipeline::steps::types::{DecodedRecordBatch, SamChunk};
-use fgumi_bam_io::compute_group_key_from_raw;
-use fgumi_bam_io::{DecodedRecord, GroupKeyConfig};
+use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
 
 /// Parse every line in `chunk` and produce a `DecodedRecordBatch` carrying
 /// the chunk's batch serial. SAM lines are encoded into BAM record body
@@ -49,6 +48,7 @@ pub fn parse_sam_chunk_into_decoded(
 
     let library_index = &key_config.library_index;
     let cell_tag = key_config.cell_tag;
+    let name_hash_only = key_config.name_hash_only;
 
     let mut sam_record = sam::Record::default();
     let mut encoder = bam::io::Writer::from(Vec::<u8>::with_capacity(4096));
@@ -76,11 +76,27 @@ pub fn parse_sam_chunk_into_decoded(
         }
         encoder.get_mut().clear();
         encoder.write_alignment_record(header, &sam_record)?;
-        // Strip the 4-byte little-endian `block_size` prefix that
-        // `bam::io::Writer` prepends; what remains is the raw BAM
-        // record body, the same shape `DecodedRecord` expects.
-        let body_bytes: Vec<u8> = encoder.get_ref()[4..].to_vec();
-        let key = compute_group_key_from_raw(&body_bytes, library_index, cell_tag);
+        // `DecodedRecord` takes ownership of the body bytes, so swap the
+        // encoder's inner buffer out (replacing it with a pre-sized fresh one
+        // for the next record) and strip the 4-byte little-endian `block_size`
+        // prefix that `bam::io::Writer` prepends in place. This avoids the extra
+        // full-body memcpy that `get_ref()[4..].to_vec()` performed per record
+        // (this is the hot SAM parse loop). The replacement is sized to the
+        // outgoing buffer's capacity so the encoder keeps room for the next
+        // record instead of re-growing a zero-capacity `Vec` from scratch (which
+        // `std::mem::take` would leave behind).
+        let next_capacity = encoder.get_mut().capacity().max(4096);
+        let mut body_bytes =
+            std::mem::replace(encoder.get_mut(), Vec::with_capacity(next_capacity));
+        body_bytes.drain(..4);
+        // Match the BAM decode path (`DecodeFromRecords`): under
+        // `name_hash_only` the key is the name hash alone, so SAM- and
+        // BAM-ingested records group identically.
+        let key = if name_hash_only {
+            name_hash_key(&body_bytes)
+        } else {
+            compute_group_key_from_raw(&body_bytes, library_index, cell_tag)
+        };
         decoded.push(DecodedRecord::from_raw_bytes(body_bytes, key));
     }
 
@@ -357,6 +373,43 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
             bam_decoded.raw_bytes(),
             "SAM and BAM paths must produce byte-identical DecodedRecord.raw_bytes()",
         );
+    }
+
+    /// Under `name_hash_only`, the SAM parse path must key records by the read
+    /// name hash alone — identical to the BAM `DecodeFromRecords` path — so
+    /// SAM- and BAM-ingested reads group together. Regression for the SAM path
+    /// previously ignoring `name_hash_only` and always computing the full
+    /// position/library key.
+    #[test]
+    fn parse_sam_chunk_honors_name_hash_only() {
+        let header = parse_header(SAM_TEXT);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let key_config = GroupKeyConfig::name_hash_only(library_index);
+
+        let chunk = sam_chunk_from_records(0);
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records.len(), 2);
+
+        for rec in &batch.records {
+            let raw = rec.raw_bytes();
+            assert_eq!(
+                rec.key,
+                fgumi_bam_io::name_hash_key(raw),
+                "name_hash_only SAM key must be the name-hash key, not the full group key",
+            );
+            // The fixture reads are mapped (chr1:10 / chr1:20), so the full
+            // position/library key differs from the name-hash key — confirming
+            // the branch actually changed paths.
+            assert_ne!(
+                rec.key,
+                fgumi_bam_io::compute_group_key_from_raw(
+                    raw,
+                    &key_config.library_index,
+                    key_config.cell_tag,
+                ),
+                "name_hash_only key must differ from the full position/library key for a mapped read",
+            );
+        }
     }
 
     #[test]

--- a/src/lib/pipeline/steps/serialize_processed.rs
+++ b/src/lib/pipeline/steps/serialize_processed.rs
@@ -145,7 +145,6 @@ pub fn build_serialize_processed_groups_step(
 /// [`build_serialize_processed_groups_step`]) and the single-threaded writer
 /// in [`crate::commands::group`] so they can't drift in MI-injection
 /// semantics.
-#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn emit_templates_raw_with_mi(
     templates: &[Template],
     base_mi: u64,
@@ -166,11 +165,21 @@ pub(crate) fn emit_templates_raw_with_mi(
                 scratch.clear();
                 scratch.extend_from_slice(raw);
                 fgumi_raw_bam::update_string_tag(scratch, assign_tag_bytes, mi_buf.as_bytes());
-                let block_size = scratch.len() as u32;
+                let block_size = u32::try_from(scratch.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", scratch.len()),
+                    )
+                })?;
                 emit(&block_size.to_le_bytes())?;
                 emit(scratch)?;
             } else {
-                let block_size = raw.len() as u32;
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", raw.len()),
+                    )
+                })?;
                 emit(&block_size.to_le_bytes())?;
                 emit(raw)?;
             }

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -117,6 +117,17 @@ impl PairRawFastq {
         }
     }
 
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few
+    /// bytes so a skewed-completion scenario can cross it with a handful of
+    /// small chunks rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
     /// Buffer a chunk from stream A (slot 0) or stream B (slot 1).
     fn buffer_chunk(&mut self, chunk: FastqRawChunk, is_a: bool) {
         self.pending_total_bytes += chunk.data.len();
@@ -425,5 +436,314 @@ mod tests {
         assert_eq!(p1.data_b, b"raw_b1");
 
         assert_eq!(step.pending_total_bytes, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // X3-003: drive the paired-FASTQ source through a REAL fused chain under
+    // back-pressure with skewed stream completion, on a watchdog thread.
+    //
+    // The in-module `pull_decision` tests above only check the decision
+    // predicate in isolation. This test exercises the actual `PairRawFastq`
+    // step inside a `Pipeline` with a tiny byte limit and one stream (R1)
+    // racing far ahead of the other (R2): R1 emits ALL its chunks before R2
+    // emits any. The partial-pair buffer crosses the limit while the front
+    // pair is missing R2; the deadlock fix must keep pulling R2 (the behind
+    // stream) so the front pair completes and the buffer drains. A regression
+    // that globally refuses to pull under back-pressure wedges the step, and
+    // the watchdog fires.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig, Step, StepCtx};
+
+    /// Bytes per emitted raw chunk. Sized so that buffering a SINGLE unmatched
+    /// leader chunk already crosses the pairing step's soft byte limit — that
+    /// way the partial-pair buffer is over-limit with the front pair missing
+    /// its R2 slot, which is exactly the state where a "refuse all pulls under
+    /// back-pressure" regression deadlocks (it will not pull the available R2
+    /// chunk that would complete the front pair and drain the buffer).
+    const X3_CHUNK_BYTES: usize = 1024;
+    /// Number of chunk serials each stream emits.
+    const X3_N_SERIALS: u64 = 16;
+    /// Soft backpressure limit for the pairing step under test. Sized so a
+    /// single buffered unmatched chunk crosses the SOFT limit (1x) but stays
+    /// under the HARD desync limit (2x): `768 < 1024 (one chunk) < 1536`. This
+    /// puts the step in the over-soft-limit / front-pair-incomplete regime that
+    /// the deadlock fix targets, WITHOUT tripping the catastrophic-desync abort.
+    const X3_SOFT_LIMIT_BYTES: usize = 768;
+    /// Per-source output-queue byte limit. Small (a few chunks) so a
+    /// back-pressured pairing step leaves a source's output queue full and that
+    /// source cannot drain — the precondition for the deadlock to manifest (if
+    /// the streams always drained, `finalize_pairs` would flush everything even
+    /// under a refuse-to-pull regression, masking the bug).
+    const X3_SOURCE_QUEUE_BYTES: u64 = 4 * 1024;
+    /// R2 holds back until R1 has emitted this many chunks, so the front pair
+    /// (serial 0) is reliably buffered R1-first and over the limit with its R2
+    /// slot still missing. Kept minimal (just enough to order the front pair) so
+    /// it does not also stall the FIXED path, which over the limit pulls ONLY
+    /// the behind stream.
+    const X3_LAG_UNTIL: usize = 1;
+
+    /// Serial source emitting `FastqRawChunk`s for ONE stream, serials `0..N`,
+    /// at the given `stream_idx`. Mirrors the per-stream `ReadFastqInputs`
+    /// reader: one chunk per dispatch, each carrying a globally-unique ordinal.
+    ///
+    /// To force the skewed-completion regime the deadlock fix targets, the
+    /// stream is optionally gated on a shared "leader progress" counter: the
+    /// leader (R1) increments it on every emit, and the laggard (R2) refuses to
+    /// emit (`NoProgress`) until the leader has raced `lag_until` chunks ahead.
+    /// This piles the leader's unmatched chunks in `PairRawFastq`'s partial-pair
+    /// buffer past the byte limit while the front pair is still missing R2 —
+    /// exactly the state where a "refuse all pulls under back-pressure"
+    /// regression deadlocks (the completing R2 chunk is available but never
+    /// pulled).
+    struct OneStreamSource {
+        stream_idx: usize,
+        next_serial: u64,
+        n_serials: u64,
+        held: HeldSlot<Unpushed<FastqRawChunk>>,
+        output_byte_limit: u64,
+        /// Shared leader-progress counter (chunks the leader has emitted).
+        leader_progress: Arc<AtomicUsize>,
+        /// If `Some(n)`, this is the laggard: do not emit until the leader has
+        /// emitted at least `n` chunks. If `None`, this is the leader.
+        lag_until: Option<usize>,
+    }
+
+    impl OneStreamSource {
+        fn leader(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: None,
+            }
+        }
+
+        fn laggard(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+            lag_until: usize,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: Some(lag_until),
+            }
+        }
+    }
+
+    impl Step for OneStreamSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqRawChunk>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "OneStreamSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            // Distinct workers so R1 and R2 can race independently (mirrors the
+            // production per-stream reader affinities).
+            Affinity::Worker(self.stream_idx)
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            if self.next_serial >= self.n_serials {
+                return Ok(StepOutcome::Finished);
+            }
+
+            // Laggard: stall until the leader has raced far enough ahead to
+            // pile its chunks past the byte limit with the front pair missing.
+            if let Some(lag_until) = self.lag_until {
+                if self.leader_progress.load(AtomicOrd::Acquire) < lag_until {
+                    return Ok(StepOutcome::NoProgress);
+                }
+            }
+
+            let chunk_serial = self.next_serial;
+            self.next_serial += 1;
+
+            // Globally-unique ordinal across both streams (N == 2):
+            // serial*2 + stream_idx.
+            let ordinal = chunk_serial * 2 + self.stream_idx as u64;
+            let chunk = FastqRawChunk {
+                ordinal,
+                stream_idx: self.stream_idx,
+                chunk_serial,
+                data: vec![b'A'; X3_CHUNK_BYTES],
+            };
+            match ctx.outputs.push(chunk) {
+                Ok(()) => {
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial (single-consumer) sink that records each paired batch's
+    /// `chunk_serial` in the exact order it is emitted. A `Serial` sink — not
+    /// `Parallel` — is what lets the test assert true emission order: a single
+    /// worker drains the queue in FIFO order, so the recorded sequence is the
+    /// real downstream order rather than a multi-consumer interleaving.
+    #[derive(Clone)]
+    struct PairSink {
+        seen_serials: Arc<Mutex<Vec<u64>>>,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for PairSink {
+        type Input = PairedRawFastqBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "PairSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    // Each emitted pair must carry equal-length R1/R2 data.
+                    assert_eq!(batch.data_a.len(), X3_CHUNK_BYTES);
+                    assert_eq!(batch.data_b.len(), X3_CHUNK_BYTES);
+                    self.seen_serials.lock().unwrap().push(batch.chunk_serial);
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// End-to-end: two per-stream sources (R1 races ahead, R2 lags) feed
+    /// `PairRawFastq` (tiny byte limit) which feeds a collecting sink. Driven on
+    /// a watchdog thread so the deadlock regression surfaces as a timeout. The
+    /// run must complete and emit every pair in `chunk_serial` order.
+    #[test]
+    fn pair_fastq_does_not_deadlock_under_backpressure_with_skewed_streams() {
+        use std::time::{Duration, Instant};
+
+        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        // R1 (leader) races ahead; R2 (laggard) stalls until R1 has emitted
+        // `X3_LAG_UNTIL` chunks, forcing the partial-pair buffer over the limit
+        // with the front pair missing R2.
+        let leader_progress = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let leader_for_thread = Arc::clone(&leader_progress);
+        let worker = std::thread::Builder::new()
+            .name("pair-fastq-x3-003".into())
+            .spawn(move || -> io::Result<()> {
+                let r1 = OneStreamSource::leader(
+                    0,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    Arc::clone(&leader_for_thread),
+                );
+                let r2 = OneStreamSource::laggard(
+                    1,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    leader_for_thread,
+                    X3_LAG_UNTIL,
+                );
+                let pair =
+                    PairRawFastq::new(64 * 1024).with_backpressure_bytes(X3_SOFT_LIMIT_BYTES);
+                let sink = PairSink { seen_serials: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                let r1_tail = builder.append_source(r1);
+                let r2_tail = builder.append_source(r2);
+                let pair_tail = builder.append_step2(pair, r1_tail, r2_tail);
+                builder.append_step(sink, pair_tail);
+
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // 3 workers: R1, R2, and a free worker for pairing/sink.
+                pipeline
+                    .run(PipelineConfig { threads: 3, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "PairRawFastq pipeline did not finish within 30s — likely the X3-003 \
+                 refuse-to-pull-under-backpressure deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full output: one pair per serial, every serial present AND in order.
+        // The single-consumer `PairSink` records the true emission order, so we
+        // assert the sequence directly (no sort) to prove `PairRawFastq` emits
+        // pairs in contiguous `chunk_serial` order, not merely as a set.
+        let serials = seen.lock().unwrap().clone();
+        assert_eq!(
+            serials.len(),
+            usize::try_from(X3_N_SERIALS).unwrap(),
+            "expected one emitted pair per serial, got {}",
+            serials.len()
+        );
+        let expected: Vec<u64> = (0..X3_N_SERIALS).collect();
+        assert_eq!(serials, expected, "every chunk_serial must be paired exactly once, in order");
     }
 }

--- a/src/lib/pipeline/steps/source/read_fastq.rs
+++ b/src/lib/pipeline/steps/source/read_fastq.rs
@@ -149,13 +149,20 @@ fn read_fastq_raw_bytes_from_bufread(
             break;
         }
         if data[line_start] != b'@' {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
+            // A lone newline (blank line between records) is a common
+            // hand-edit/corruption artifact; give it a clearer message than
+            // the raw "got '\n'" the generic branch would produce.
+            let message = if data[line_start] == b'\n' {
+                "Unexpected blank line in FASTQ stream (expected a record \
+                 starting with '@')"
+                    .to_string()
+            } else {
                 format!(
                     "Expected FASTQ record to start with '@', got '{}'",
                     data[line_start] as char
-                ),
-            ));
+                )
+            };
+            return Err(io::Error::new(io::ErrorKind::InvalidData, message));
         }
         if data.last() != Some(&b'\n') {
             data.push(b'\n');
@@ -239,7 +246,6 @@ pub struct ReadFastqInputs {
     sticky: bool,
     batch_record_count: usize,
     next_chunk_serial: u64,
-    current_stream: usize,
     pending: VecDeque<FastqRawChunk>,
     held: HeldSlot<Unpushed<FastqRawChunk>>,
     output_byte_limit: u64,
@@ -327,7 +333,6 @@ impl ReadFastqInputs {
             sticky,
             batch_record_count: batch_record_count.max(1),
             next_chunk_serial: 0,
-            current_stream: 0,
             pending: VecDeque::new(),
             held: HeldSlot::new(),
             output_byte_limit,
@@ -389,18 +394,21 @@ impl Step for ReadFastqInputs {
         {
             let mut guard = self.readers.lock();
             let readers = guard.as_mut().expect("ReadFastqInputs: readers missing");
+            debug_assert_eq!(
+                readers.len(),
+                self.n_streams,
+                "reader count must match the declared stream count"
+            );
 
-            // Read from each stream starting at current_stream, wrapping around.
-            for offset in 0..self.n_streams {
-                let idx = (self.current_stream + offset) % self.n_streams;
+            // Read one chunk from every non-exhausted stream this cycle. Each
+            // cycle reads all streams, so there is no rotation offset.
+            for (idx, reader) in readers.iter_mut().enumerate() {
                 if self.exhausted[idx] {
                     continue;
                 }
 
-                let (data, records_read) = read_fastq_raw_bytes_from_bufread(
-                    readers[idx].as_mut(),
-                    self.batch_record_count,
-                )?;
+                let (data, records_read) =
+                    read_fastq_raw_bytes_from_bufread(reader.as_mut(), self.batch_record_count)?;
 
                 if records_read == 0 {
                     self.exhausted[idx] = true;
@@ -420,8 +428,7 @@ impl Step for ReadFastqInputs {
             }
         }
 
-        // Advance round-robin and serial.
-        self.current_stream = 0;
+        // Advance to the next round-robin cycle.
         self.next_chunk_serial += 1;
 
         if !any_read {

--- a/src/lib/pipeline/steps/source/zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/zip_fastq.rs
@@ -58,6 +58,20 @@ impl Ordered for FastqTemplateBatch {
 
 const DEFAULT_PENDING_BACKPRESSURE_BYTES: usize = 256 * 1024 * 1024;
 
+/// Outcome of a full egress drain attempt ([`ZipFastqRecords::drain_complete`]).
+enum DrainStop {
+    /// The lowest serial is incomplete (or `pending` is empty): nothing more to
+    /// emit right now. `emitted` records whether at least one batch left.
+    Exhausted { emitted: bool },
+    /// A downstream push could not complete; the unpushed batch is now in
+    /// `self.held`. The caller must stop draining immediately (no further serial
+    /// may be emitted while the single held slot is occupied) and return
+    /// `Progress` — parking a complete serial in `held` is real forward progress,
+    /// and the held-slot retry preamble on the next dispatch flushes it before
+    /// any more work runs (see the `try_run` call site).
+    Held,
+}
+
 pub struct ZipFastqRecords {
     n_streams: usize,
     pending: BTreeMap<u64, Vec<Option<FastqChunkBatch>>>,
@@ -69,8 +83,18 @@ pub struct ZipFastqRecords {
 }
 
 impl ZipFastqRecords {
+    /// Construct a zipper for `n_streams` FASTQ streams.
+    ///
+    /// # Preconditions
+    ///
+    /// `n_streams >= 1`. The count is wired from the FASTQ-input count, which
+    /// is always at least one, and `try_emit_complete` indexes
+    /// `stream_records[0]`, so a zero-stream configuration would panic on that
+    /// index. A `debug_assert!` makes an accidental zero-stream wiring fail
+    /// loudly in debug/test builds.
     #[must_use]
     pub fn new(n_streams: usize, output_byte_limit: u64) -> Self {
+        debug_assert!(n_streams >= 1, "ZipFastqRecords requires n_streams >= 1, got {n_streams}");
         Self {
             n_streams,
             pending: BTreeMap::new(),
@@ -79,6 +103,52 @@ impl ZipFastqRecords {
             held: HeldSlot::new(),
             output_byte_limit,
             next_batch_serial: 0,
+        }
+    }
+
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few KiB
+    /// so a lag-then-burst scenario can cross the soft/hard thresholds with a
+    /// handful of small records rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
+    /// Egress: emit every currently-complete consecutive lowest serial.
+    ///
+    /// Loops [`Self::try_emit_complete`] until it yields `None` (the lowest
+    /// serial is incomplete or `pending` is empty) or a downstream push fails.
+    /// On a failed push the unpushed batch is stashed in `self.held` and the
+    /// loop stops — the single held slot can hold only one item, so no further
+    /// serial may be emitted until it flushes on a later dispatch.
+    ///
+    /// Backpressure never gates this: draining is the only action that relieves
+    /// pending-byte pressure, so it must always run. Bounded: each successful
+    /// emit removes one key from `pending` (in `try_emit_complete`), so the loop
+    /// runs at most `pending.len()` times and strictly shrinks `pending`.
+    ///
+    /// Precondition: `self.held` is empty (the held-slot preamble in `try_run`
+    /// guarantees this by returning `Contention` on a failed retry).
+    fn drain_complete(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<DrainStop> {
+        debug_assert!(
+            !self.held.is_held(),
+            "drain_complete requires an empty held slot — the try_run preamble must clear it"
+        );
+        let mut emitted = false;
+        loop {
+            match self.try_emit_complete()? {
+                None => return Ok(DrainStop::Exhausted { emitted }),
+                Some(template_batch) => match ctx.outputs.push(template_batch) {
+                    Ok(()) => emitted = true,
+                    Err(unpushed) => {
+                        self.held.put(unpushed);
+                        return Ok(DrainStop::Held);
+                    }
+                },
+            }
         }
     }
 
@@ -188,7 +258,9 @@ impl Step for ZipFastqRecords {
     }
 
     fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
-        // 1. Drain held slot.
+        // ── (a) Held-slot retry preamble ────────────────────────────────────
+        // Single-occupancy: if the retry still can't push, re-hold and return
+        // Contention so control never reaches egress/ingress with a full slot.
         if let Some(unpushed) = self.held.take() {
             match ctx.outputs.retry(unpushed) {
                 Ok(()) => {}
@@ -199,39 +271,85 @@ impl Step for ZipFastqRecords {
             }
         }
 
-        // 2. Check pending backpressure (D3).
-        if self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+        // ── (b) Full egress drain — ALWAYS runs, before any backpressure gate.
+        // Draining the complete lowest serials is the ONLY action that relieves
+        // pending-byte pressure, so it must never be throttled (the previous
+        // code returned NoProgress/Err on backpressure *before* emitting, which
+        // wedged the step whenever the lowest serial was already complete but
+        // over the soft limit — see issue notes for S5a1-001).
+        match self.drain_complete(ctx)? {
+            // `Held` means a complete serial was removed from `pending` (bytes
+            // subtracted) and parked in the held slot for retry — that is real
+            // forward progress ("held one for later"), not mutex contention.
+            // Misreporting it as `Contention` on this liveness-critical
+            // backpressure path would understate progress to the driver.
+            DrainStop::Held => return Ok(StepOutcome::Progress),
+            DrainStop::Exhausted { emitted } => {
+                // If anything was emitted, report Progress now: pressure dropped
+                // and the next dispatch re-evaluates ingress against the new
+                // (lower) byte total. We deliberately do NOT also pop input this
+                // dispatch — that keeps the held-slot single-occupancy reasoning
+                // trivial and gives the driver a clean re-dispatch point.
+                if emitted {
+                    return Ok(StepOutcome::Progress);
+                }
+                // Nothing emitted ⇒ the lowest serial is incomplete (or pending
+                // is empty). Fall through to the desync check / ingress gate.
+            }
+        }
+
+        // Reaching here: `pending` is empty OR its lowest serial is incomplete,
+        // and the held slot is empty.
+
+        // ── (c) Hard desync abort — predicated on a genuinely-stuck serial ───
+        // Abort ONLY when the lowest serial is still incomplete after a full
+        // drain AND the buffer is over the hard limit. A complete lowest serial
+        // is drained in (b) before this check, so a non-empty `pending` here
+        // means the lowest serial is incomplete; if bytes are also over 2x, one
+        // stream is producing unboundedly more than its counterpart — a real
+        // desync. (The old predicate fired on bytes alone, false-aborting an
+        // in-sync but ahead stream whose lowest serial was emittable.)
+        let lowest_incomplete = !self.pending.is_empty();
+        if lowest_incomplete && self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+            let (&serial, _) = self.pending.iter().next().expect("pending non-empty");
             return Err(io::Error::other(format!(
-                "ZipFastqRecords: catastrophic stream desync — pending buffer ({} bytes) \
-                 exceeds 2x backpressure limit ({} bytes). One FASTQ stream is producing \
-                 far more data than its counterpart.",
+                "ZipFastqRecords: catastrophic stream desync — lowest chunk_serial {serial} \
+                 is still incomplete while pending buffer ({} bytes) exceeds 2x backpressure \
+                 limit ({} bytes). One FASTQ stream is producing far more data than its \
+                 counterpart.",
                 self.pending_total_bytes, self.pending_backpressure_bytes
             )));
         }
+
+        // ── (c') Advisory soft limit — throttle ingress, never starve egress ─
+        // Over the soft limit we prefer not to grow `pending`. But if the lowest
+        // serial is incomplete, the chunk that completes it (and lets egress
+        // drain) is itself still queued in `ctx.input`; refusing all ingress
+        // would re-introduce a stall. So we only hard-refuse new input when the
+        // buffer is over the soft limit AND nothing is waiting to be completed
+        // (`pending` empty — a pure precautionary throttle). When a completion
+        // is pending we warn and fall through to the pop: admitting a completing
+        // chunk relieves pressure, and unbounded growth from a genuinely-
+        // desynced stream is caught by the hard arm above.
         if self.pending_total_bytes > self.pending_backpressure_bytes {
+            if self.pending.is_empty() {
+                return Ok(StepOutcome::NoProgress);
+            }
             log::warn!(
-                "ZipFastqRecords: pending buffer exceeds backpressure limit ({} > {})",
+                "ZipFastqRecords: pending buffer exceeds backpressure limit ({} > {}); lowest \
+                 serial incomplete, continuing ingress to complete it",
                 self.pending_total_bytes,
                 self.pending_backpressure_bytes
             );
-            return Ok(StepOutcome::NoProgress);
         }
 
-        // 3. Pop a chunk from input.
+        // ── (d) Ingress: pop one input chunk + insert, then drain again ──────
         let Some(batch) = ctx.input.pop() else {
-            // No input this call. Emit any pending complete entry first.
-            if let Some(template_batch) = self.try_emit_complete()? {
-                if let Err(unpushed) = ctx.outputs.push(template_batch) {
-                    self.held.put(unpushed);
-                }
-                return Ok(StepOutcome::Progress);
-            }
-            // Nothing emittable. If upstream is drained, finalize. `held` is
-            // empty here (step 1 returned `Contention` otherwise), so the
-            // remaining work is the residual `pending` walk: every remaining
-            // entry must be complete (all streams ended cleanly) — a `None`
-            // slot means a stream ended early (out of sync). `Finished` once
-            // `pending` is fully drained.
+            // No input this call. Egress already ran in (b) and emitted nothing,
+            // so the lowest serial is incomplete. If upstream is drained, this
+            // is the residual-completion / EOF path: every remaining entry must
+            // be complete (all streams ended cleanly) — a `None` slot means a
+            // stream ended early (out of sync).
             if ctx.input.is_drained() {
                 if let Some((&serial, slots)) = self.pending.iter().next() {
                     for (idx, slot) in slots.iter().enumerate() {
@@ -242,11 +360,10 @@ impl Step for ZipFastqRecords {
                             )));
                         }
                     }
-                    // All slots present but `try_emit_complete` did not emit:
-                    // unreachable (a complete lowest entry always emits). Fail
-                    // loud — returning `NoProgress` here would hang (input is
-                    // drained, so the step would never be re-fed and never
-                    // reach `Finished`).
+                    // All slots present but the full drain in (b) emitted
+                    // nothing: unreachable (a complete lowest entry always
+                    // emits). Fail loud — returning NoProgress here would hang
+                    // (input is drained, so the step is never re-fed).
                     return Err(io::Error::other(format!(
                         "ZipFastqRecords: chunk_serial {serial} has all streams present but \
                          did not emit — internal invariant violated",
@@ -257,7 +374,6 @@ impl Step for ZipFastqRecords {
             return Ok(StepOutcome::NoProgress);
         };
 
-        // 4. Insert into pending.
         let chunk_serial = batch.chunk_serial;
         let stream_idx = batch.stream_idx;
         let batch_bytes: usize = batch.records.iter().map(HeapSize::heap_size).sum();
@@ -268,13 +384,14 @@ impl Step for ZipFastqRecords {
         slots[stream_idx] = Some(batch);
         self.pending_total_bytes += batch_bytes;
 
-        // 5. Try to emit if the lowest serial is complete.
-        if let Some(template_batch) = self.try_emit_complete()? {
-            if let Err(unpushed) = ctx.outputs.push(template_batch) {
-                self.held.put(unpushed);
-            }
-        }
-
+        // The new chunk may have completed the lowest serial. Run the full drain
+        // again so a completion is emitted immediately (one unified egress
+        // path). Held single-occupancy holds: the preamble guaranteed the slot
+        // empty and this drain only `put`s after a `take`-confirmed empty slot.
+        // Both drain outcomes are forward progress here — this dispatch consumed
+        // an input chunk, and `Held` additionally parked a freshly dequeued
+        // serial for retry — so report `Progress` either way (never `Contention`).
+        self.drain_complete(ctx)?;
         Ok(StepOutcome::Progress)
     }
 }
@@ -473,5 +590,255 @@ mod tests {
         assert_eq!(p.kind, StepKind::Serial);
         assert!(!p.sticky);
         assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a1-001 regression: lag-then-burst over the soft backpressure limit.
+    //
+    // The buggy code returned NoProgress/Err on backpressure *before* draining
+    // the (already-complete) lowest serial, so once `pending` crossed the soft
+    // limit with the lowest serial incomplete and input still queued, the step
+    // wedged forever (NoProgress on every re-dispatch, never popping the chunk
+    // that would complete the serial). The test below drives the REAL `try_run`
+    // through a `Pipeline` with a tiny soft limit and a lag-then-burst stream
+    // pattern; under the bug it deadlocks and the watchdog fires, under the fix
+    // it completes and emits every zipped template in order.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::step::Affinity;
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig};
+
+    /// `(batch_serial, template names)` recorded by the collecting sink.
+    type SeenBatches = Arc<Mutex<Vec<(u64, Vec<Vec<u8>>)>>>;
+
+    /// Bytes per FASTQ record this source emits. Sized so a small run of
+    /// records crosses the few-KiB soft limit the test sets on the zipper.
+    const TEST_RECORD_SEQ_LEN: usize = 200;
+    /// Number of chunk serials emitted per stream.
+    const TEST_N_SERIALS: u64 = 12;
+    /// Soft backpressure limit for the zipper under test. Sized so the lagging
+    /// streams (streams 0 and 1, `TEST_N_SERIALS` records each at
+    /// `TEST_RECORD_SEQ_LEN` bytes) cross the soft limit before the stream-2
+    /// burst arrives, yet stay UNDER the 2x hard-desync limit — the lag is a
+    /// legitimately-ahead in-sync stream, not a genuine desync, so the hard arm
+    /// must NOT fire. (~12 records/stream * 2 streams * ~280 B ≈ 6.7 KiB, which
+    /// is > soft (5 KiB) and < hard (10 KiB).)
+    const TEST_SOFT_LIMIT_BYTES: usize = 5 * 1024;
+
+    fn big_record(name: &str) -> FastqRecord {
+        let seq: String = std::iter::repeat_n('A', TEST_RECORD_SEQ_LEN).collect();
+        make_record(name, &seq)
+    }
+
+    /// Serial source that emits `FastqChunkBatch` items in a deliberately
+    /// skewed order: all of streams 0 and 1 (serials `0..N`) FIRST, then all of
+    /// stream 2 in a burst. The leading streams pile up incomplete lowest
+    /// serials in the zipper (stream 2's slot is missing) and push it over the
+    /// soft limit before the completing burst arrives.
+    struct LagThenBurstSource {
+        /// Emission plan: each entry is `(stream_idx, chunk_serial)`.
+        plan: Vec<(usize, u64)>,
+        next: usize,
+        n_streams_total: usize,
+        held: HeldSlot<Unpushed<FastqChunkBatch>>,
+        output_byte_limit: u64,
+    }
+
+    impl LagThenBurstSource {
+        fn new(n_serials: u64, n_streams_total: usize, output_byte_limit: u64) -> Self {
+            let mut plan = Vec::new();
+            // Streams 0..n-1 first (the "lag"): every serial of every leading
+            // stream before any of the final stream.
+            for stream_idx in 0..n_streams_total - 1 {
+                for serial in 0..n_serials {
+                    plan.push((stream_idx, serial));
+                }
+            }
+            // Final stream in a burst: a run of consecutive lowest serials
+            // becomes complete at once.
+            for serial in 0..n_serials {
+                plan.push((n_streams_total - 1, serial));
+            }
+            Self { plan, next: 0, n_streams_total, held: HeldSlot::new(), output_byte_limit }
+        }
+    }
+
+    impl Step for LagThenBurstSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqChunkBatch>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "LagThenBurstSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            Affinity::Reader
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            let Some(&(stream_idx, chunk_serial)) = self.plan.get(self.next) else {
+                return Ok(StepOutcome::Finished);
+            };
+            self.next += 1;
+
+            // Trailing non-digit so `strip_read_suffix` does not eat the serial
+            // (it strips a `_`/`/`/`.`/`:` + `1`/`2` pair-suffix).
+            let name = format!("read{chunk_serial}x");
+            let record = big_record(&name);
+            let total_bytes = record.heap_size();
+            let ordinal = chunk_serial * self.n_streams_total as u64 + stream_idx as u64;
+            let chunk =
+                FastqChunkBatch::new(ordinal, stream_idx, chunk_serial, vec![record], total_bytes);
+
+            match ctx.outputs.push(chunk) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial (single-consumer) sink that records, per emitted batch, its
+    /// `batch_serial` and the names of the templates it carries, so the test can
+    /// assert full drain and correct zipping/order. A `Serial` sink drains the
+    /// queue in FIFO order on one worker, so the recorded sequence is the true
+    /// emission order — letting the test assert ordering directly instead of
+    /// sorting (which would only prove set equality).
+    #[derive(Clone)]
+    struct CollectingSink {
+        seen: SeenBatches,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for CollectingSink {
+        type Input = FastqTemplateBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "CollectingSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    let names: Vec<Vec<u8>> =
+                        batch.templates.iter().map(|t| t.name.clone()).collect();
+                    self.seen.lock().unwrap().push((batch.batch_serial, names));
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Drive `ZipFastqRecords` through a real `Pipeline` under a lag-then-burst
+    /// stream pattern that crosses its (shrunk) soft backpressure limit, on a
+    /// watchdog thread so a deadlock regression surfaces as a timeout rather
+    /// than hanging the test runner.
+    ///
+    /// Pre-fix this deadlocks: the zipper crosses the soft limit while the
+    /// lowest serial is incomplete, returns `NoProgress` before draining/popping,
+    /// and never admits the completing burst → the watchdog fires. Post-fix the
+    /// advisory soft limit admits the completing chunks, egress fully drains,
+    /// and the run completes with every template zipped in order.
+    #[test]
+    fn zip_does_not_deadlock_on_lag_then_burst_over_soft_limit() {
+        use std::time::{Duration, Instant};
+
+        let n_streams = 3usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let worker = std::thread::Builder::new()
+            .name("zip-lag-burst".into())
+            .spawn(move || -> io::Result<()> {
+                let source = LagThenBurstSource::new(TEST_N_SERIALS, n_streams, 64 * 1024);
+                let zip = ZipFastqRecords::new(n_streams, 64 * 1024)
+                    .with_backpressure_bytes(TEST_SOFT_LIMIT_BYTES);
+                let sink = CollectingSink { seen: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // A modest thread count keeps the Serial zipper single-driven
+                // while letting the source/sink run on other workers.
+                pipeline
+                    .run(PipelineConfig { threads: 2, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        // Generous timeout: the run completes in well under a second on a
+        // healthy system; 30 s leaves headroom for slow CI while still failing
+        // fast on the deadlock regression.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "ZipFastqRecords pipeline did not finish within 30s — likely the S5a1-001 \
+                 backpressure-starves-egress deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full drain: one batch per serial, exactly TEST_N_SERIALS batches.
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.len(),
+            usize::try_from(TEST_N_SERIALS).unwrap(),
+            "expected one emitted batch per serial (full drain), got {}",
+            seen.len()
+        );
+
+        // Correctness + order: the single-consumer sink records the true emission
+        // order, so assert `batch_serial`s are contiguous 0..N directly (no sort)
+        // — proving `ZipFastqRecords` emits in order, not merely as a set. Each
+        // batch carries the single expected zipped template `read_<serial>`.
+        for (i, (serial, names)) in seen.iter().enumerate() {
+            assert_eq!(*serial, i as u64, "batch serials must be contiguous and in order");
+            assert_eq!(names.len(), 1, "each chunk carried exactly one record");
+            assert_eq!(
+                names[0],
+                format!("read{i}x").into_bytes(),
+                "template name must match the source record for serial {i}"
+            );
+        }
     }
 }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -137,13 +137,32 @@ impl Template {
     ///
     /// Returns `None` when no UMI cache is set, when neither R1 nor R2 is
     /// present, or when the cached position would slice outside the record.
+    ///
+    /// # Cached-UMI invariant
+    ///
+    /// `cached_umi_position` is only valid while the primary record's bytes are
+    /// unmodified. Mutating accessors ([`Template::records_mut`],
+    /// [`Template::fix_mate_info`]) rewrite aux bytes (MS/MC/MQ via
+    /// remove/append tag) that can shift the cached UMI offset, so they clear
+    /// `cached_umi_position` to `None`; a `cached_umi()` read after a mutation
+    /// then falls back to scanning aux data instead of slicing stale bytes.
     #[must_use]
     pub fn cached_umi(&self) -> Option<&[u8]> {
         let (offset, len) = self.cached_umi_position?;
         let raw = self.r1().or_else(|| self.r2())?;
         let start = offset as usize;
         let end = start.checked_add(len as usize)?;
-        raw.as_ref().get(start..end)
+        let value = raw.as_ref().get(start..end)?;
+        // The cache only ever holds a Z-typed UMI value (NUL-free by the BAM
+        // spec; the trailing NUL is excluded when caching). An interior NUL
+        // means the offset drifted onto a different region — a cheap,
+        // zero-release-cost canary for a stale cache that survived bounds checks.
+        debug_assert!(
+            !value.contains(&0),
+            "stale cached UMI: offset {start} sliced bytes containing an interior NUL \
+             (the template was likely mutated without invalidating the UMI cache)"
+        );
+        Some(value)
     }
 
     /// Approximate heap footprint in bytes — the sum of all member records'
@@ -175,7 +194,13 @@ impl Template {
     }
 
     /// Returns mutable access to all records.
+    ///
+    /// Clears `cached_umi_position` (see the cached-UMI invariant on
+    /// [`Template::cached_umi`]): a caller may rewrite aux bytes that shift the
+    /// cached UMI offset, so the cache is invalidated and the next
+    /// [`Template::cached_umi`] read falls back to scanning aux data.
     pub fn records_mut(&mut self) -> &mut [RawRecord] {
+        self.cached_umi_position = None;
         &mut self.records
     }
 
@@ -464,6 +489,11 @@ impl Template {
     #[allow(clippy::too_many_lines)]
     pub fn fix_mate_info(&mut self) -> Result<()> {
         use fgumi_raw_bam;
+
+        // Rewrites aux bytes (mate score/cigar/quality tags) that can shift the
+        // cached UMI offset; invalidate the cache so a later `cached_umi()` read
+        // re-scans rather than slicing stale bytes (see `Template::cached_umi`).
+        self.cached_umi_position = None;
 
         let rr = &mut self.records;
 
@@ -2694,5 +2724,40 @@ mod tests {
         let aux = fgumi_raw_bam::aux_data_slice(primary);
         let expected = fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).expect("RX present");
         assert_eq!(template.cached_umi(), Some(expected));
+    }
+
+    #[test]
+    fn records_mut_invalidates_umi_cache() {
+        // A populated cache must be cleared when records_mut hands out mutable
+        // access, since the caller may rewrite aux bytes and shift the UMI offset
+        // (see the cached-UMI invariant on Template::cached_umi).
+        let r1 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"ACGTACGT");
+        let mut template =
+            Template::from_decoded_records(vec![decoded_with_cached_umi(r1)]).expect("builds");
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()), "cache populated up front");
+
+        let _ = template.records_mut();
+
+        assert!(template.cached_umi_position.is_none(), "records_mut clears the cache");
+        assert!(template.cached_umi().is_none(), "cached_umi falls back after mutation");
+    }
+
+    #[test]
+    fn fix_mate_info_invalidates_umi_cache() {
+        // fix_mate_info rewrites mate aux tags, which can shift the UMI offset, so
+        // the cache must be cleared to force a re-scan on the next read.
+        let r1 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ1, b"ACGTACGT");
+        let r2 = raw_with_umi(b"read1", FLAG_PAIRED | FLAG_READ2, b"OTHERUMI");
+        let mut template = Template::from_decoded_records(vec![
+            decoded_with_cached_umi(r1),
+            decoded_with_cached_umi(r2),
+        ])
+        .expect("builds");
+        assert_eq!(template.cached_umi(), Some(b"ACGTACGT".as_ref()), "cache populated up front");
+
+        template.fix_mate_info().expect("fix_mate_info succeeds");
+
+        assert!(template.cached_umi_position.is_none(), "fix_mate_info clears the cache");
+        assert!(template.cached_umi().is_none(), "cached_umi falls back after mutation");
     }
 }


### PR DESCRIPTION
**Stack: 4 / 6** · base: `nh/runall-fix-3-sort-engine`

The bulk of the smaller per-crate correctness fixes and hot-path optimizations. Grouped because the crates are largely independent.

- **cli** — `multi_options` macro emits absolute crate paths; cli-common lint gate, dep pins, and budget-resolution tests; pipeline-io crate doc.
- **bgzf / simulate** — drop the dead BlockInfo channel from the vendored writer; cover truncated-block errors; ramp per-base consensus depth and reuse scratch buffers in simulate.
- **fastq** — drain `ZipFastqRecords` egress fully so backpressure can't starve emission; hard-error on extract count mismatch; honor `name_hash_only` and drop a per-record SAM body copy; exercise the paired-FASTQ deadlock fix end-to-end.
- **serialize** — route record framers through checked `u32::try_from`; invalidate the cached UMI position on record mutation (with an invariant + debug_assert + tests).
- **consensus / grouping (perf)** — allocation-free GroupByMi run-boundary detection and single aux scan; reuse GroupByQueryname buffers; recycle BgzfCompress buffers; drop a per-read hash lookup in the adjacency assigner; reject over-long consensus read names instead of panicking. Output preserved (byte-identity tested).
- **pipeline-core (perf)** — O(1) branch-slot lookup; cache sticky-owner liveness off the worker hot loop; guard reorder ordinal overflow; per-queue slot-cap warning; zero-alloc always-drained source handle. Scheduling/ordering/backpressure semantics preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added buffer recycling support to the inline BGZF compressor.
  * Added a helper to extract two aux string tags in a single scan.
* **Bug Fixes**
  * Prevented stale cached UMI results after record mutations (with added safety checks).
  * Improved BGZF truncation handling and reader/writer error behavior for malformed or oversized inputs.
  * Hardened decode to fail-closed on malformed records; improved error propagation during framed reject generation.
  * Added checked 32-bit length-prefixing to avoid truncation when writing BAM-framed records.
* **Refactor**
  * Simplified multithreaded BGZF writer progress reporting by removing per-block completion notifications.
* **Documentation**
  * Updated clarifications for BGZF handling and CLI parsing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->