### PR TITLE
docs(sort): correct --write-index threading note (compression is multi-threaded)

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1458,8 +1458,10 @@ impl RawExternalSorter {
     /// Enable writing BAM index alongside output.
     ///
     /// Only valid for coordinate sort. When enabled, writes `<output>.bai`
-    /// alongside the output BAM file. Uses single-threaded compression
-    /// for accurate virtual position tracking.
+    /// alongside the output BAM file. Output BGZF compression stays
+    /// multi-threaded (scales with the configured thread count); BAI virtual
+    /// offsets are recovered from each BGZF block as it finalizes, so indexing
+    /// does not serialize compression.
     #[must_use]
     pub fn write_index(mut self, enabled: bool) -> Self {
         self.write_index = enabled;
@@ -2091,8 +2093,10 @@ impl RawExternalSorter {
     /// Coordinate sort with BAM index generation.
     ///
     /// Similar to `sort_coordinate_optimized` but uses `IndexingBamWriter` to
-    /// build the BAI index incrementally during write. Uses single-threaded
-    /// compression for accurate virtual position tracking.
+    /// build the BAI index incrementally during write. Output BGZF compression
+    /// stays multi-threaded (scales with the configured thread count); BAI
+    /// virtual offsets are recovered from each BGZF block as it finalizes, so
+    /// indexing does not serialize compression.
     #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     fn sort_coordinate_with_index(
         &self,

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -301,8 +301,9 @@ pub struct Sort {
     /// Write BAM index (.bai) alongside output.
     ///
     /// Only valid for coordinate sort. The index file will be written to
-    /// `<output>.bai`. Uses single-threaded compression for accurate virtual
-    /// position tracking.
+    /// `<output>.bai`. Output BGZF compression stays multi-threaded (scales
+    /// with `--threads`); the BAI virtual offsets are recovered from each BGZF
+    /// block as it finalizes, so indexing does not serialize compression.
     #[arg(long = "write-index", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub write_index: bool,
 


### PR DESCRIPTION
## What

Correct a stale doc claim about `fgumi sort --write-index`. The help text and two `RawExternalSorter` doc comments say indexed output:

> Uses single-threaded compression for accurate virtual position tracking.

That's no longer true (and traces back at least to v0.2.0). The indexed write path is **multi-threaded**.

## Why it's wrong

- `fgumi-bam-io::create_indexing_bam_writer` builds a `MultithreadedWriter` with `worker_count = threads.max(1)` (`crates/fgumi-bam-io/src/writer.rs`).
- `RawExternalSorter::merge_chunks_with_index` sets `writer_threads = self.threads` with the comment *"writer gets all threads (merge is output-compression-bound)"* (`crates/fgumi-sort/src/external.rs`).
- Accurate BAI virtual offsets don't require serializing compression — they're recovered from each BGZF block as it finalizes (block-position tracking in `IndexingBamWriter`).

So the only real serialization in the indexed merge is on the **read** side (`reader_concurrency = 1`), not compression. The docs implied a compression-throughput limitation that doesn't exist, which matters for anyone sizing `--threads` for a piped/fused sort.

## Change

Docs only — no behavior change. Updates the three occurrences (CLI help in `src/lib/commands/sort.rs`, and the `write_index()` builder + `sort_coordinate_with_index` doc comments in `crates/fgumi-sort/src/external.rs`).

cc @nh13 for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line help and indexing notes to better explain how BAM/BAI index generation works during sorted output.
  * Clarified that compression remains multi-threaded while index offsets are tracked as each BGZF block finishes, replacing the older wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->