### PR TITLE
docs(bam-io): fix broken intra-doc link to RawRecord

### DIFF
--- a/crates/fgumi-bam-io/src/library.rs
+++ b/crates/fgumi-bam-io/src/library.rs
@@ -6,7 +6,7 @@
 //!
 //! Relocated here from the main crate's `read_info` module so the grouping
 //! domain types (which depend on `LibraryIndex`) can live in this crate
-//! alongside [`crate::RawRecord`]-adjacent helpers and `MemoryEstimate`.
+//! alongside [`fgumi_raw_bam::RawRecord`]-adjacent helpers and `MemoryEstimate`.
 
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
The `fgumi-bam-io` library module doc linked `[`crate::RawRecord`]`, but `RawRecord` lives in the `fgumi-raw-bam` crate, not this one — so the link failed to resolve and `cargo doc -D warnings` errored with `unresolved link to `crate::RawRecord``. This points it at the canonical `fgumi_raw_bam::RawRecord` path already used elsewhere in the crate (e.g. `mem_estimate.rs`).

One-line, comment-only change. `RUSTDOCFLAGS="-D warnings" cargo doc -p fgumi-bam-io --no-deps` now builds clean.

Base is `feat-runall` since the `fgumi-bam-io` crate (and the broken link) only exist on the runall integration branch, not `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a library-level reference in the public docs to use the correct record type name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->