### PR TITLE
docs: overhaul the user guide and document fgumi runall

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Please make sure you click the link below to view the contribution guidelines, then fill out the requested information below. **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->
+<!-- Please review the contribution guidelines in CONTRIBUTING.md (https://github.com/fulcrumgenomics/fgumi/blob/main/CONTRIBUTING.md) before filling out the information below. **IMPORTANT: Please open an issue before creating a Pull Request.** -->
 
 ## Summary of changes
 
@@ -21,7 +21,7 @@ If you know who should review your PR, please tag them here. -->
 - [ ] Yes
 - [ ] No
 
-<!-- If this introduces a breaking change, please describe the impact and migration path for the existing applications below. Remember to add a `BREAKING CHANGE:` footer to your commit message when you merge this PR. -->
+<!-- If this introduces a breaking change, describe the impact and the migration path for existing users below, and add a `BREAKING CHANGE:` footer to the relevant commit message. -->
 
 ### :heavy_check_mark: Checklist
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,11 @@ build:
     # Install mdbook
     - cargo install mdbook --version 0.5.2
 
-    # Generate documentation markdown and build the mdbook site
-    - cargo run --package xtask --release -- docs-build
+    # Generate documentation markdown and build the mdbook site. A debug build
+    # is used deliberately: xtask only emits Markdown and shells out to the
+    # mdbook binary, so an optimized build adds compile time (and peak memory)
+    # with byte-identical output.
+    - cargo run --package xtask -- docs-build
 
     # Move output to where Read the Docs expects it
     - mkdir -p _readthedocs/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,15 @@
 # Contributing to fgumi
 
+For a full developer guide — project layout, the development lifecycle, and the release process — see [docs/DEVELOPING.md](docs/DEVELOPING.md). [CLAUDE.md](CLAUDE.md) documents the code architecture and key design patterns.
+
 ## Development Setup
 
 ### Prerequisites
 
-- Rust (stable toolchain)
-- cargo-nextest (for running tests)
+- Rust 1.87.0 or newer (the project uses edition 2024)
+- [cargo-nextest](https://nexte.st/) for running tests (`cargo install cargo-nextest --locked`)
+
+The `cargo ci-*` commands below are project-specific aliases defined in [`.cargo/config.toml`](.cargo/config.toml); they wrap the formatting, lint, and test invocations CI runs.
 
 ### Install Git Hooks
 
@@ -49,6 +53,19 @@ git commit --no-verify -m "message"
 - Run `cargo fmt` before committing
 - Fix all clippy warnings
 - Add backticks around identifiers in doc comments (e.g., `` `read_name` ``)
+
+## Commit Messages
+
+Use the [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>[(scope)][!]: <description>`. Common types are `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, and `chore`.
+
+```text
+feat(group): add paired adjacency strategy
+fix(codec): handle empty consensus families
+```
+
+## Branch Naming
+
+Name branches `<issue-number>/<user>/<type>-<description>`, e.g. `42/jdidion/fix-fibonacci-calculation`. Never commit directly to `main` or `dev`; use a feature branch.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation at docs.rs](https://img.shields.io/docsrs/fgumi)](https://docs.rs/fgumi)
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgumi/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgumi)
 [![Bioconda](https://img.shields.io/conda/vn/bioconda/fgumi.svg?label=bioconda)](https://bioconda.github.io/recipes/fgumi/README.html)
-[![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgumi/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18702470.svg)](https://doi.org/10.5281/zenodo.18702470)
 
 # fgumi
@@ -12,13 +12,10 @@
 **⚠️ RESEARCH PREVIEW - USE AT YOUR OWN RISK**
 
 This software is currently a **research preview**. While we have extensively
-tested these tools across a wide variety of vendor-provided data, **no
-guarantees are made** regarding correctness or stability.
+tested these tools across a wide variety of vendor-provided data, we make **no
+guarantees** regarding correctness or stability.
 
-We are targeting **June 1, 2026** to recommend fgumi over
-[fgbio](https://github.com/fulcrumgenomics/fgbio) for production use.
-
-Fulcrum Genomics Unique Molecular Indexing (UMI) Tools - a suite of high-performance tools for working with UMI-tagged sequencing data.
+High-performance tools for UMI-tagged sequencing data, from Fulcrum Genomics.
 
 <p>
 <a href="https://fulcrumgenomics.com">
@@ -58,22 +55,30 @@ The diagram shows the workflow from FASTQ files to filtered consensus reads:
 - **Green**: CODEC consensus
 - **Orange**: Optional UMI correction for fixed UMI sets
 
+## Where to Use fgumi
+
+- **Command line** — install and run fgumi directly on your data; see the [Getting Started guide](docs/src/guide/getting-started.md).
+- **Nextflow** — [fastquorum](https://github.com/fulcrumgenomics/fastquorum) provides an end-to-end FASTQ-to-consensus workflow built on fgumi.
+- **Latch.bio** — run fgumi in the cloud through a point-and-click interface via [Latch.bio](https://latch.bio), no installation required.
+
 ## Resources
 
 * [Documentation](https://docs.rs/fgumi)
-* [Best Practice Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/best-practices.md): Recommended workflow from FASTQ to consensus
-* [Performance Tuning Guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/performance-tuning.md): Threading, memory, and compression optimization
-* [Snakemake Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/FastqToConsensus-RnD.smk): Reference implementation
-* [Metrics](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/working-with-metrics.md): Output metrics documentation
-* [Developing](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/DEVELOPING.md): Developer guide
-* [Compare CLI](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/compare-cli.md): Compare command documentation (feature-gated)
-* [Simulate CLI](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/simulate-cli.md): Simulate command documentation (feature-gated)
+* [Getting Started](docs/src/guide/getting-started.md): Tutorial workflow from FASTQ to consensus
+* [Running Pipelines](docs/src/guide/running-pipelines.md): `fgumi runall` and when to use it
+* [Best Practice Pipeline](docs/src/guide/best-practices.md): Recommended workflow from FASTQ to consensus
+* [Performance Tuning Guide](docs/src/guide/performance-tuning.md): Threading, memory, and compression optimization
+* [Snakemake Pipeline](docs/FastqToConsensus-RnD.smk): Reference implementation
+* [Metrics](docs/src/guide/working-with-metrics.md): Output metrics documentation
+* [Developing](docs/DEVELOPING.md): Developer guide
+* [Compare CLI](docs/compare-cli.md): Compare command documentation (feature-gated)
+* [Simulate CLI](docs/simulate-cli.md): Simulate command documentation (feature-gated)
 * [Releases](https://github.com/fulcrumgenomics/fgumi/releases)
 * [Issues](https://github.com/fulcrumgenomics/fgumi/issues): Report a bug or request a feature
 * [Pull requests](https://github.com/fulcrumgenomics/fgumi/pulls): Submit a patch or new feature
 * [Discussions](https://github.com/fulcrumgenomics/fgumi/discussions): Ask a question
-* [Contributors guide](https://github.com/fulcrumgenomics/fgumi/blob/main/CONTRIBUTING.md)
-* [License](https://github.com/fulcrumgenomics/fgumi/blob/main/LICENSE): Released under the MIT license
+* [Contributors guide](CONTRIBUTING.md)
+* [License](LICENSE): Released under the MIT license
 
 ## Installation
 
@@ -115,11 +120,12 @@ Enable with: `cargo build --release --features <feature>`
 
 | Command | Description | Equivalent Tool(s) |
 |---------|-------------|------------------|
-| `extract` | Extract UMIs from FASTQ files | `fgbio ExtractUmisFromBam` |
-| `correct` | Correct UMIs based on sequence similarity | `fgbio CorrectUmis` |
-| `zipper` | Restore original FASTQ from unaligned BAM | `fgbio ZipperBams`, `picard MergeBamAlignment` |
-| `fastq` | Convert BAM to FASTQ format | `samtools fastq` |
-| `sort` | Sort BAM by coordinate/queryname/template | — |
+| `extract` | Extract UMIs from FASTQ and create an unmapped BAM | `fgbio FastqToBam` + `fgbio ExtractUmisFromBam` |
+| `correct` | Correct UMIs in a BAM to a fixed set of UMIs | `fgbio CorrectUmis` |
+| `fastq` | Convert BAM to interleaved FASTQ for an aligner | `samtools fastq` |
+| `zipper` | Merge an aligned BAM with its unmapped BAM, restoring tags | `fgbio ZipperBams`, `picard MergeBamAlignment` |
+| `sort` | Sort by coordinate, queryname, or template-coordinate | `samtools sort` |
+| `merge` | Merge pre-sorted BAM files into one sorted BAM | `samtools merge` |
 | `group` | Group reads by UMI | `fgbio GroupReadsByUmi` |
 | `dedup` | Mark/remove UMI-aware duplicates | `gatk UmiAwareMarkDuplicatesWithMateCigar`, `umi-tools dedup` |
 | `simplex` | Call single-strand consensus reads | `fgbio CallMolecularConsensusReads` |
@@ -127,9 +133,11 @@ Enable with: `cargo build --release --features <feature>`
 | `codec` | Call CODEC consensus | `fgbio CallCodecConsensusReads` |
 | `filter` | Filter consensus reads | `fgbio FilterConsensusReads` |
 | `clip` | Clip overlapping read pairs | `fgbio ClipBam` |
-| `duplex-metrics` | Collect duplex metrics | `fgbio CollectDuplexSeqMetrics` |
+| `simplex-metrics` | Collect simplex QC metrics | — |
+| `duplex-metrics` | Collect duplex QC metrics | `fgbio CollectDuplexSeqMetrics` |
 | `review` | Review consensus variants | `fgbio ReviewConsensusVariants` |
 | `downsample` | Downsample BAM by UMI family | N/A |
+| `runall` | Fused multi-stage pipeline (extract → … → filter, no intermediate BAMs) | N/A |
 | `compare <cmd>` | Compare files (feature-gated) | N/A |
 | `simulate <cmd>` | Generate test data (feature-gated) | N/A |
 
@@ -141,6 +149,8 @@ fgumi <command> --help
 ```
 
 ### Basic Workflow
+
+> **Tip:** the multi-stage steps below can run as a single `fgumi runall` command — same output, no intermediate BAMs. See [Running Pipelines](docs/src/guide/running-pipelines.md). The individual commands are shown here so each stage is visible and tunable.
 
 1. **Extract UMIs** from FASTQ:
 ```bash
@@ -165,7 +175,7 @@ fgumi correct \
 ```bash
 fgumi fastq --input unaligned.bam \
   | bwa mem -p ref.fa - \
-  | fgumi zipper --unmapped unaligned.bam \
+  | fgumi zipper --unmapped unaligned.bam --reference ref.fa \
   | fgumi sort --output sorted.bam --order template-coordinate
 ```
 
@@ -232,12 +242,12 @@ fgumi supports multi-threading and memory management for optimal performance:
 > 2. **Queue memory < total process memory:** Actual RSS will be higher due to
 >    UMI data structures, decompressors, thread stacks, and working buffers.
 >
-> See the [Performance Tuning Guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/performance-tuning.md)
+> See the [Performance Tuning Guide](docs/src/guide/performance-tuning.md)
 > for detailed guidance, including scenario-based configurations and troubleshooting.
 
 ## Performance
 
-fgumi is written in Rust for maximum performance.
+fgumi is written in Rust and tuned for high-throughput BAM processing.
 
 ### Command-Level Optimizations
 
@@ -283,6 +293,6 @@ Development of fgumi is supported by [Fulcrum Genomics](https://www.fulcrumgenom
 ## Disclaimer
 
 This software is under active development.
-While we make a best effort to test this software and to fix issues as they are reported, this software is provided as-is without any warranty (see the [license](https://github.com/fulcrumgenomics/fgumi/blob/main/LICENSE) for details).
+While we make a best effort to test this software and to fix issues as they are reported, this software is provided as-is without any warranty (see the [license](LICENSE) for details).
 Please submit an [issue](https://github.com/fulcrumgenomics/fgumi/issues), and better yet a [pull request](https://github.com/fulcrumgenomics/fgumi/pulls) as well, if you discover a bug or identify a missing feature.
 Please contact [Fulcrum Genomics](https://www.fulcrumgenomics.com) if you are considering using this software or are interested in sponsoring its development.

--- a/crates/fgumi-bam-io/README.md
+++ b/crates/fgumi-bam-io/README.md
@@ -5,11 +5,28 @@ BAM I/O factories and pipeline primitives for the [fgumi](https://github.com/ful
 This crate provides:
 
 - BAM and raw-BAM reader/writer factories built on top of `noodles` and libdeflate-backed BGZF
-- BAI index writing
-- The `ProgressTracker` used by fgumi's pipelines
-- The `ReorderBuffer` used to maintain output order through parallel workers
-- The `MemoryEstimate` trait used by fgumi's pipeline backpressure
-- A vendored, position-tracking variant of noodles' multithreaded BGZF writer
+- BAI sidecar writing (`.bam.bai` convention)
+- `ProgressTracker` — thread-safe progress reporting for fgumi's pipelines
+- `ReorderBuffer` — maintains sequential output order across parallel workers
+- the `MemoryEstimate` trait used for fgumi's pipeline backpressure
+- a vendored, position-tracking variant of noodles' multithreaded BGZF writer
+
+## Usage
+
+Open a BAM reader and create a writer with the same header (single-threaded; pass a higher
+thread count for multithreaded BGZF compression):
+
+```rust,no_run
+use fgumi_bam_io::reader::create_bam_reader;
+use fgumi_bam_io::writer::create_bam_writer;
+use std::path::Path;
+
+// Open a reader (1 decompression thread) and a writer that reuses the header
+// (1 compression thread, fast compression level 1).
+let (mut reader, header) = create_bam_reader(Path::new("input.bam"), 1).unwrap();
+let mut writer = create_bam_writer(Path::new("output.bam"), &header, 1, 1).unwrap();
+// ... read records from `reader` and write them to `writer` ...
+```
 
 ## Status
 

--- a/crates/fgumi-sort/README.md
+++ b/crates/fgumi-sort/README.md
@@ -13,9 +13,16 @@ their own BAM sort tools without taking on the rest of fgumi.
 
 ## Performance
 
-External merge-sort with parallel radix sort over packed sort keys, K-way merge via a
-loser tree, async I/O prefetch, libdeflate-backed BGZF, and free-space-aware temp-dir
-round-robin. Faster than `samtools sort` on the workloads it targets.
+External merge-sort built from:
+
+- parallel radix sort over packed sort keys for in-memory chunks
+- K-way merge via a loser tree to combine spill files
+- async I/O prefetch and spill compression (BGZF legacy / Zstd default)
+- free-space-aware, round-robin spill across multiple temp directories
+
+Designed to outperform `samtools sort` on the large-BAM sort workloads it
+targets; actual speedup depends on the data, sort order, thread count, and
+hardware.
 
 ## Usage
 

--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -52,7 +52,7 @@ pub fn generate(
 
     // Consensus sub-group
     let consensus = [
-        ("Consensus Calling", "guide/consensus-calling.md"),
+        ("Simplex Consensus Calling", "guide/consensus-calling.md"),
         ("Duplex Consensus Calling", "guide/duplex-consensus-calling.md"),
     ];
     let consensus_exists = consensus.iter().any(|(_, p)| docs_src.join(p).exists());
@@ -65,16 +65,11 @@ pub fn generate(
         }
     }
 
-    // Methylation sub-group
-    let methylation = [("Pipeline Guide", "guide/methylation.md")];
-    let methylation_exists = methylation.iter().any(|(_, p)| docs_src.join(p).exists());
-    if methylation_exists {
-        md.push_str("- [Methylation]()\n");
-        for (title, path) in &methylation {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
+    // Methylation — single page, so render as a top-level leaf rather than a
+    // collapsible section wrapping one child.
+    let methylation = ("Methylation", "guide/methylation.md");
+    if docs_src.join(methylation.1).exists() {
+        let _ = writeln!(md, "- [{}]({})", methylation.0, methylation.1);
     }
 
     // Advanced Topics sub-group
@@ -177,11 +172,21 @@ pub fn generate(
             .iter()
             .filter(|p| prefixes.iter().any(|pfx| p.name.starts_with(pfx)))
             .collect();
-        if !matches.is_empty() {
-            let _ = writeln!(md, "- [{group_name}]()");
-            for page in &matches {
-                let _ = writeln!(md, "  - [{}]({})", page.name, page.path);
-                assigned.insert(page.name.as_str());
+        match matches.as_slice() {
+            [] => {}
+            // A group with a single page collapses to a top-level leaf so the
+            // sidebar doesn't hide one entry behind a fold toggle; the label is
+            // humanized (`ConsensusMetrics` -> `Consensus Metrics`).
+            [single] => {
+                let _ = writeln!(md, "- [{}]({})", humanize_metric_name(&single.name), single.path);
+                assigned.insert(single.name.as_str());
+            }
+            _ => {
+                let _ = writeln!(md, "- [{group_name}]()");
+                for page in &matches {
+                    let _ = writeln!(md, "  - [{}]({})", page.name, page.path);
+                    assigned.insert(page.name.as_str());
+                }
             }
         }
     }
@@ -200,4 +205,18 @@ pub fn generate(
 
     fs::write(docs_src.join("SUMMARY.md"), md)?;
     Ok(())
+}
+
+/// Insert a space before each interior capital letter so a CamelCase metric name
+/// reads as a normal label when its section collapses to a single leaf entry
+/// (e.g. `ConsensusMetrics` -> `Consensus Metrics`).
+fn humanize_metric_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, ch) in name.char_indices() {
+        if i > 0 && ch.is_ascii_uppercase() {
+            out.push(' ');
+        }
+        out.push(ch);
+    }
+    out
 }

--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -28,6 +28,12 @@ pub fn generate(
         let _ = writeln!(md, "- [{}]({})", entry.0, entry.1);
     }
 
+    // Running Pipelines — fgumi runall vs individual commands
+    let running = ("Running Pipelines", "guide/running-pipelines.md");
+    if docs_src.join(running.1).exists() {
+        let _ = writeln!(md, "- [{}]({})", running.0, running.1);
+    }
+
     // Core Concepts sub-group
     let core_concepts = [
         ("Read Structures", "guide/read-structures.md"),
@@ -82,6 +88,19 @@ pub fn generate(
     if advanced_exists {
         md.push_str("- [Advanced Topics]()\n");
         for (title, path) in &advanced {
+            if docs_src.join(path).exists() {
+                let _ = writeln!(md, "  - [{title}]({path})");
+            }
+        }
+    }
+
+    // Reference sub-group
+    let reference =
+        [("Glossary", "guide/glossary.md"), ("Troubleshooting", "guide/troubleshooting.md")];
+    let reference_exists = reference.iter().any(|(_, p)| docs_src.join(p).exists());
+    if reference_exists {
+        md.push_str("- [Reference]()\n");
+        for (title, path) in &reference {
             if docs_src.join(path).exists() {
                 let _ = writeln!(md, "  - [{title}]({path})");
             }

--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -34,6 +34,15 @@ pub fn generate(
         let _ = writeln!(md, "- [{}]({})", running.0, running.1);
     }
 
+    // Methylation — a single standalone guide, so it renders as a top-level leaf
+    // rather than a collapsible section wrapping one child. Standalone pages are
+    // listed before the collapsible groups so the sidebar's plain links and
+    // expandable section headers form two visually distinct zones.
+    let methylation = ("Methylation", "guide/methylation.md");
+    if docs_src.join(methylation.1).exists() {
+        let _ = writeln!(md, "- [{}]({})", methylation.0, methylation.1);
+    }
+
     // Core Concepts sub-group
     let core_concepts = [
         ("Read Structures", "guide/read-structures.md"),
@@ -63,13 +72,6 @@ pub fn generate(
                 let _ = writeln!(md, "  - [{title}]({path})");
             }
         }
-    }
-
-    // Methylation — single page, so render as a top-level leaf rather than a
-    // collapsible section wrapping one child.
-    let methylation = ("Methylation", "guide/methylation.md");
-    if docs_src.join(methylation.1).exists() {
-        let _ = writeln!(md, "- [{}]({})", methylation.0, methylation.1);
     }
 
     // Advanced Topics sub-group
@@ -167,6 +169,12 @@ pub fn generate(
 
     let mut assigned: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
+    // Partition categories into single-page ones (rendered as flat leaves) and
+    // multi-page ones (collapsible groups). Leaves are emitted before groups so
+    // the part's plain links and expandable section headers form two visually
+    // distinct zones, matching the User Guide layout.
+    let mut single_page_metrics: Vec<&MetricPage> = Vec::new();
+    let mut grouped_metrics: Vec<(&str, Vec<&MetricPage>)> = Vec::new();
     for (group_name, prefixes) in metric_groups {
         let matches: Vec<&MetricPage> = metric_pages
             .iter()
@@ -174,20 +182,25 @@ pub fn generate(
             .collect();
         match matches.as_slice() {
             [] => {}
-            // A group with a single page collapses to a top-level leaf so the
-            // sidebar doesn't hide one entry behind a fold toggle; the label is
-            // humanized (`ConsensusMetrics` -> `Consensus Metrics`).
-            [single] => {
-                let _ = writeln!(md, "- [{}]({})", humanize_metric_name(&single.name), single.path);
-                assigned.insert(single.name.as_str());
-            }
-            _ => {
-                let _ = writeln!(md, "- [{group_name}]()");
-                for page in &matches {
-                    let _ = writeln!(md, "  - [{}]({})", page.name, page.path);
-                    assigned.insert(page.name.as_str());
-                }
-            }
+            [single] => single_page_metrics.push(single),
+            _ => grouped_metrics.push((group_name, matches)),
+        }
+    }
+
+    // Single-page categories first, as top-level leaves with a humanized label
+    // (`ConsensusMetrics` -> `Consensus Metrics`) so they aren't hidden behind a
+    // fold toggle that wraps a single entry.
+    for single in &single_page_metrics {
+        let _ = writeln!(md, "- [{}]({})", humanize_metric_name(&single.name), single.path);
+        assigned.insert(single.name.as_str());
+    }
+
+    // Then the collapsible multi-page groups.
+    for (group_name, matches) in &grouped_metrics {
+        let _ = writeln!(md, "- [{group_name}]()");
+        for page in matches {
+            let _ = writeln!(md, "  - [{}]({})", page.name, page.path);
+            assigned.insert(page.name.as_str());
         }
     }
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -99,6 +99,8 @@ For example, the following command will run all CI checks:
 cargo ci-test && cargo ci-fmt && cargo ci-lint
 ```
 
+To run `cargo ci-fmt` and `cargo ci-lint` automatically before each commit, install the pre-commit hooks with `./scripts/install-hooks.sh`. Set `FGUMI_PRECOMMIT_TEST=1` to also run the tests in the hook.
+
 When a particular topic is not covered by Fulcrum best practices, you can [start a Discussion](https://github.com/fulcrumgenomics/fgumi/discussions) or search online (e.g., [Idiomatic Rust](https://github.com/mre/idiomatic-rust)).
 
 #### Documentation
@@ -118,19 +120,19 @@ Several Cargo features exist for development and debugging purposes. These are *
 | `memory-debug` | Enables comprehensive memory debugging infrastructure: a monitor thread, hot-path atomic counters, and additional CLI arguments for memory tracking. Requires `libmimalloc-sys` and `sysinfo` dependencies. | `cargo build --features memory-debug` |
 | `dhat-heap` | Enables heap profiling via the `dhat` crate. Replaces the default `mimalloc` allocator with `dhat::Alloc`. | `cargo build --features dhat-heap` |
 | `profile-adjacency` | Enables profiling output for the adjacency UMI assigner. | `cargo build --features profile-adjacency` |
-| `compare` | Enables the `compare` subcommand for BAM and metrics developer tools. | `cargo build --features compare` |
-| `simulate` | Enables the `simulate` command for generating synthetic test data. | `cargo build --features simulate` |
+| `compare` | Enables the `compare` subcommand for BAM and metrics developer tools (see [compare-cli.md](compare-cli.md)). | `cargo build --features compare` |
+| `simulate` | Enables the `simulate` command for generating synthetic test data (see [simulate-cli.md](simulate-cli.md)). | `cargo build --features simulate` |
 
 None of these features are included in release builds or `cargo dist` artifacts.
 
 #### Testing
 
 In general, every addition of (non-trivial) code to the project must be accompanied by unit tests that, at a minimum, exercise all the "happy paths" (i.e., non-error cases) through the code.
-It is strongly recommended to also test at least the most commonly expected error cases to make sure they are handled correctly.
+Also test at least the most commonly expected error cases to make sure they are handled correctly.
 Most importantly, every bugfix *must* be accompanied by at least one regression test.
 
 Please read the [documentation](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) on unit testing in Rust if you haven't already done so.
-We use [`rstest`](https://docs.rs/rstest/latest/rstest/) for writing tests, and we use [`nextest`](https://nexte.st/) for running tests in CI and recommend you use it locally.
+We use [`rstest`](https://docs.rs/rstest/latest/rstest/) for parameterized tests and [`proptest`](https://docs.rs/proptest/latest/proptest/) for property-based tests, and we use [`nextest`](https://nexte.st/) for running tests in CI and recommend you use it locally.
 The Cargo `ci-test` alias will run the project tests in the same way they are run in CI.
 
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -22,7 +22,7 @@ enable = true
 
 [output.html.fold]
 enable = true
-level = 1
+level = 0
 
 [output.html.playground]
 editable = false

--- a/docs/compare-cli.md
+++ b/docs/compare-cli.md
@@ -50,6 +50,8 @@ fgumi compare bams <BAM1> <BAM2> [OPTIONS]
 | `-t, --threads` | INT | 1 | Threads for BGZF decompression and comparison |
 | `--batch-size` | INT | 10000 | Records per batch for parallel processing |
 
+`--max-diffs` caps how many differences are *printed*, not how much is compared: the full files are still scanned, and the exit code reflects whether any difference exists regardless of the cap.
+
 ### Comparison Fields
 
 The tool compares:

--- a/docs/design/sort-queryname-arena-deferral.md
+++ b/docs/design/sort-queryname-arena-deferral.md
@@ -12,7 +12,8 @@ only `RecordRef { sort_key, offset, len }` entries, which are radix/comparison
 `Direct` arm (`read_ahead.rs`) — and its per-record `RawRecord` allocation — is
 used **only** by the queryname path.
 
-This is the substance of finding **S3-015**. The reviewer's suggested fix
+This is the substance of code-review finding **S3-015** (the per-record key + record-byte
+allocation in the queryname Phase-1 buffer). The reviewer's suggested fix
 (hold a scratch `RawRecord` in the `Direct` variant and `mem::take` it out per
 `next()`) is a **no-op**: `mem::take` hands the caller the scratch's buffer and
 leaves an empty (capacity-0) `Vec` behind, so the next `read_raw_record`

--- a/docs/simulate-cli.md
+++ b/docs/simulate-cli.md
@@ -573,6 +573,16 @@ Three distribution types are supported:
 3. **Empirical**: Load from `fgumi group -f` histogram output
    - Parameter: `--family-size-dist /path/to/histogram.tsv`
 
+Use **log-normal** as the default model of PCR amplification, **negative binomial** when you want an alternative over-dispersed model, and **empirical** to reproduce the family-size profile of a specific real dataset.
+
+### Reproducibility
+
+Pass `--seed <INT>` to make a run reproducible: the same seed, the same fgumi version, and the same inputs produce the same reads in the same order, which is what makes simulated data usable as regression-test fixtures. Omit `--seed` for a fresh random draw each run. The simulated reads are independent of the thread count for a given seed; note that the thread count can change the gzip block framing of a `.gz` output, so compare decompressed records rather than raw compressed bytes.
+
+### Methylation Simulation
+
+The `--methylation-*` options apply only when simulating EM-Seq / TAPs data; leave them unset for standard (non-bisulfite) libraries. They let you generate reads with realistic C→T conversion and `MM`/`ML` methylation tags so you can exercise the methylation-aware consensus and filter paths. See the [Methylation Pipeline Guide](src/guide/methylation.md).
+
 ### Quality Score Model
 
 Quality scores follow a three-phase model:

--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -1,6 +1,8 @@
-# fgumi Best Practice FASTQ -> Consensus Pipeline
+# Best Practices: FASTQ → Consensus Pipeline
 
-This document describes the recommended best practice pipeline for processing FASTQ files through to consensus sequences using fgumi.
+This guide describes the recommended pipeline for processing FASTQ files through to consensus sequences with fgumi.
+
+> **Tip:** Use [`fgumi runall`](running-pipelines.md) to fuse supported runs of these stages into one command — same output, no intermediate BAMs. This guide shows the stages separately so you can see and tune each one.
 
 ## Tools Required
 
@@ -9,7 +11,7 @@ This pipeline uses only fgumi and a read aligner:
 - **fgumi** (version 0.1 or higher)
 - **bwa mem** (version 0.7.17 or higher recommended)
 
-Unlike fgbio-based pipelines, **no samtools is required** - fgumi provides native `fastq`, `sort`, and `merge` commands.
+Unlike fgbio-based pipelines, **no samtools `sort`/`merge` is required for the pipeline itself** — fgumi provides native `fastq`, `sort`, and `merge` commands. (You do still need a reference sequence dictionary (`.dict`) alongside the FASTA for `fgumi zipper`; create it once with `samtools dict` or Picard `CreateSequenceDictionary`.) In fact, you should **not** substitute `samtools sort` for `fgumi sort` ahead of `group`, `dedup`, or `downsample`: samtools ignores the `tc` tag and orders secondary/supplementary reads incorrectly for those commands (see [Troubleshooting](troubleshooting.md)).
 
 ## Common Configuration Options
 
@@ -37,7 +39,7 @@ fgumi group --input in.bam --output out.bam --strategy adjacency
 fgumi group --input in.bam --output out.bam --strategy adjacency --threads 8
 ```
 
-Thread allocation is automatically optimized per-command based on workload profiling.
+Without `--threads`, commands run on a single-threaded fast path. Pass `--threads N` to parallelize; each command splits the N threads across reading, its workers, and writing.
 
 ### Memory
 
@@ -95,6 +97,15 @@ A["fgumi simplex/duplex"]-->B["fgumi fastq | bwa mem | fgumi zipper | fgumi filt
 
 ---
 
+## Choosing your path
+
+**Phase 1 (FASTQ → grouped BAM) is universal** — every workflow runs it. The difference is in Phase 2, where you turn grouped reads into filtered consensus reads:
+
+- **Phase 2a (R&D)** writes an intermediate consensus BAM, so you can re-run filtering with different thresholds without re-calling consensus. Choose it while you are tuning parameters.
+- **Phase 2b (high-throughput)** fuses consensus calling and filtering into pipes for speed. Choose it once your parameters are locked in.
+
+Both phases produce the same result for the same parameters. Within either phase, you can replace a run of stages with a single [`fgumi runall`](running-pipelines.md) command — the callouts below show where.
+
 ## Phase 1: FASTQ to Grouped BAM
 
 ### Step 1.1: UMI Extraction
@@ -151,7 +162,7 @@ Key points:
 - `fgumi fastq` converts BAM to interleaved FASTQ for the aligner
 - `-p` tells bwa mem to expect interleaved paired-end reads
 - `-K 150000000` sets batch size (improves reproducibility)
-- **`-Y` is critical**: Use soft-clipping for supplementary alignments to preserve bases
+- **`-Y` is critical**: soft-clip (rather than hard-clip) supplementary alignments so their bases are preserved — `fgumi zipper` and the consensus callers need the full read sequence to transfer UMI tags and call consensus correctly
 - `fgumi zipper` transfers tags from unmapped BAM to aligned reads
 - `fgumi zipper` accepts SAM or BAM on stdin or `--input`. For best performance, pipe
   uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`); SAM is fine for aligners
@@ -399,7 +410,21 @@ fgumi sort \
 
 For production use where filtering parameters are established, combine steps for better throughput.
 
-**Stage 1: Group and call consensus in a single pipe:**
+> **Recommended:** run Step 2b.1 as a single `fgumi runall` command instead of a pipe — it fuses
+> sort, group, and consensus in memory with no intermediate BAM:
+>
+> ```bash
+> fgumi runall \
+>   --start-from sort --stop-after consensus --consensus simplex \
+>   --input aligned.bam --output consensus.bam \
+>   --group::strategy adjacency --simplex::min-reads 1 \
+>   --simplex::output-per-base-tags true \
+>   --threads 8
+> ```
+>
+> See [Running Pipelines](running-pipelines.md).
+
+### Step 2b.1: Group and Call Consensus (manual pipe)
 
 ```bash
 fgumi group --input aligned.bam --strategy adjacency --threads 4 --compression-level 1 \
@@ -407,7 +432,7 @@ fgumi group --input aligned.bam --strategy adjacency --threads 4 --compression-l
     --output consensus.bam --threads 4 --compression-level 1
 ```
 
-**Stage 2: Align, filter, and sort in a single pipe:**
+### Step 2b.2: Re-align, Filter, and Sort
 
 ```bash
 fgumi fastq --input consensus.bam \
@@ -417,7 +442,7 @@ fgumi fastq --input consensus.bam \
   | fgumi sort --input /dev/stdin --output filtered.bam --order coordinate --threads 4
 ```
 
-Note: The two stages cannot be combined into a single pipeline because `fgumi zipper --unmapped` needs random access to the consensus BAM. For most use cases, the R&D pipeline with intermediate files provides better debuggability and flexibility.
+Note: Steps 2b.1 and 2b.2 cannot be fused into one pipe because re-aligning the consensus reads in Step 2b.2 requires the consensus BAM to be materialized first (via `fgumi zipper --unmapped`). `fgumi runall` fuses the in-memory stages *within* Step 2b.1; the consensus re-alignment in Step 2b.2 remains a separate pass. For most use cases, the R&D pipeline with intermediate files (Phase 2a) provides better debuggability and flexibility.
 
 ---
 
@@ -479,7 +504,11 @@ fgumi dedup --input sorted.bam --output deduped.bam \
 
 ## Recommended Parameters by Application
 
+Pick a starting point by how you trade sensitivity against specificity for your assay, then tune from there.
+
 ### Variant Calling (High Sensitivity)
+
+Maximize the number of consensus reads (keep singletons, tolerate more error) when you would rather not miss a true variant — e.g. germline or high-depth somatic calling.
 
 ```bash
 fgumi simplex --min-reads 1 --min-input-base-quality 10
@@ -488,6 +517,8 @@ fgumi filter --min-reads 2 --max-base-error-rate 0.2 --max-no-call-fraction 0.3
 
 ### Variant Calling (High Specificity)
 
+Suppress false positives with duplex consensus and stringent thresholds, at the cost of yield — e.g. low-frequency somatic calling where a wrong call is costly.
+
 ```bash
 fgumi duplex --min-reads 1 --min-input-base-quality 20
 fgumi filter --min-reads 10,5,3 --max-base-error-rate 0.1 --max-no-call-fraction 0.1 \
@@ -495,6 +526,8 @@ fgumi filter --min-reads 10,5,3 --max-base-error-rate 0.1 --max-no-call-fraction
 ```
 
 ### Liquid Biopsy / ctDNA
+
+Detect very-low-frequency variants in cell-free DNA, where input is limited so duplex thresholds are relaxed slightly relative to high-specificity calling while still requiring strand agreement.
 
 ```bash
 fgumi duplex --min-reads 1 --min-input-base-quality 20

--- a/docs/src/guide/consensus-calling.md
+++ b/docs/src/guide/consensus-calling.md
@@ -8,6 +8,20 @@ Reads with the same molecular identifier (MI tag) are examined base-by-base to d
 2. Computing the maximum posterior probability base
 3. Adjusting the output consensus base quality
 
+> **Output is unmapped.** `simplex`, `duplex`, and `codec` all emit an **unmapped** BAM — inferring the consensus alignment directly is error-prone, so the consensus reads must be re-aligned before filtering or variant calling. The usual next step is `fgumi fastq | <aligner> | fgumi zipper | fgumi sort` (see [Getting Started](getting-started.md) and [Best Practices](best-practices.md)). The consensus callers can also write per-read and per-base evidence tags (`cD`, `cM`, `cE`, and the duplex `a*`/`b*` variants); per-base tags are enabled by default — set `--output-per-base-tags false` to disable them — and see [Tracking Reads](tracking-reads.md) for their meaning.
+
+## Choosing a Consensus Method
+
+fgumi has three consensus callers. Pick the one that matches your library preparation:
+
+| Method | Command | Use when | Grouping strategy |
+|--------|---------|----------|-------------------|
+| **Simplex** (single-strand) | `fgumi simplex` | Reads carry a single UMI per molecule and you want to collapse PCR/sequencing duplicates. The most common choice. | `adjacency` |
+| **Duplex** (double-strand) | `fgumi duplex` | The library tags both strands of each molecule (duplex UMIs), and you want the lowest error rate by requiring both strands to agree. | `paired` (required) |
+| **CODEC** | `fgumi codec` | The library was prepared with the CODEC protocol, where a single read pair sequences both strands. | `adjacency` |
+
+Duplex is the most error-suppressing but needs both strands observed, so it yields fewer consensus reads; simplex retains the most reads. When unsure, your library prep kit determines the answer — duplex UMIs require `fgumi duplex`, and only CODEC libraries should use `fgumi codec`. See [Duplex Consensus Calling](duplex-consensus-calling.md) for the duplex model.
+
 ## Glossary
 
 | Symbol | Description |
@@ -78,11 +92,17 @@ Q_call = -10 * log10(Pr_err')
 
 The final consensus base quality represents the probability of error across the entire process: from sample extraction through library preparation, UMI integration, amplification, and sequencing.
 
-Any consensus base with quality below the minimum threshold is masked to `N`.
+Any consensus base whose quality falls below `--min-consensus-base-quality` (default 2) is masked to `N`.
 
 ## Caveats
 
-- Each end of a pair is treated independently; overlapping bases within a pair are jointly called by default (disable with `--consensus-call-overlapping-bases false`)
-- Indel errors in the reads are not considered in the consensus model
-- `simplex` and `codec` do not accept a `--sort-order` flag; consensus reads are emitted as
-  unmapped and should be sorted by the downstream pipeline (`fgumi zipper` + `fgumi sort`)
+- Overlapping bases within a read pair are jointly called by default; pass `--consensus-call-overlapping-bases false` to treat each end of the pair independently
+- Indel errors in the reads are not modeled. The caller compares reads base-by-base at each position, so it assumes the reads of a family are already in phase (as aligned reads of the same molecule generally are). An indel in a raw read would shift its bases out of phase and is not corrected here — it instead shows up as elevated disagreement (and thus lower consensus quality) at the affected positions.
+- `simplex` and `codec` do not accept a `--sort-order` flag; the unmapped consensus reads are
+  re-aligned and sorted by the downstream pipeline (`fgumi fastq | <aligner> | fgumi zipper | fgumi sort`)
+
+## See Also
+
+- [Duplex Consensus Calling](duplex-consensus-calling.md) — the two-strand model and its parameters
+- [Tracking Reads](tracking-reads.md) — the per-read and per-base consensus tags
+- [Best Practices](best-practices.md) — recommended consensus and filter parameters by application

--- a/docs/src/guide/duplex-consensus-calling.md
+++ b/docs/src/guide/duplex-consensus-calling.md
@@ -23,11 +23,11 @@ Starting from a group of reads identified as originating from the same double-st
 
 ### Splitting Reads into Groups
 
-Reads are split by strand of origin (A or B) and whether they are sequencing read 1 or 2. R1s from strand A correspond to R2s from strand B, and vice versa.
+Reads are split by their strand sub-family (`A` or `B`, assigned by `fgumi group --strategy paired` from sequencing order — see [Tracking Reads](tracking-reads.md)) and by whether they are sequencing read 1 or 2. R1s from the `A` sub-family correspond to R2s from the `B` sub-family, and vice versa, which is why the duplex consensuses are formed from A1+B2 and A2+B1.
 
 ### Quality Trimming
 
-Reads can be end-trimmed to remove low-quality bases. This is highly recommended as it reduces disagreements in the consensus and fewer no-calls (`N`s). Trimming uses the same running-sum algorithm as BWA.
+Pass `--trim` to end-trim low-quality bases before consensus calling. This is highly recommended: it reduces consensus disagreements and no-calls (`N`s). Trimming uses the same running-sum algorithm as BWA.
 
 ### Masking Low-Quality Bases
 
@@ -35,7 +35,7 @@ Bases below the minimum quality threshold are converted to `N`s so they are not 
 
 ### Trimming to Insert Length
 
-Reads longer than the insert length read into adapter sequence. For duplex data, A1 and B2 reads may read into *different* adapter sequences. Calling consensus across different adapters produces many disagreements and no-calls, potentially causing consensus reads to be erroneously filtered. Reads are therefore trimmed to insert length before consensus calling.
+Reads longer than the insert length read into adapter sequence. For duplex data, A1 and B2 reads may read into *different* adapter sequences. Calling consensus across different adapters produces many disagreements and no-calls, potentially causing consensus reads to be erroneously filtered. fgumi therefore trims reads to the insert length before consensus calling.
 
 ### CIGAR Filtering
 
@@ -67,20 +67,25 @@ The final duplex R1 and R2 are produced by merging the appropriate A and B reads
 
 ### For Simplex Consensus
 
-`fgumi simplex` and `fgumi filter` accept a single `--min-reads` value.
+`fgumi simplex` accepts a single `--min-reads` value.
 
 ### For Duplex Consensus
 
-`fgumi duplex` and `fgumi filter` accept one, two, or three `--min-reads` values. If fewer than three values are supplied, the last is repeated (e.g. `80 40` becomes `80 40 40`, `10` becomes `10 10 10`).
+`fgumi duplex` and `fgumi filter` accept one, two, or three `--min-reads` values. When you supply fewer than three, the last is repeated — `80 40` becomes `80 40 40`, and `10` becomes `10 10 10`.
 
-The values control:
-1. **First value**: minimum total raw reads across both single-strand consensuses for the final duplex read
-2. **Second value**: minimum reads for the single-strand consensus with *more* support
-3. **Third value**: minimum reads for the single-strand consensus with *less* support
+| Position | Applies to | Meaning |
+|----------|-----------|---------|
+| 1st | the final **duplex** read | minimum total raw reads across both strands |
+| 2nd | the **better-supported** single-strand consensus | minimum reads for the strand with *more* support |
+| 3rd | the **less-supported** single-strand consensus | minimum reads for the strand with *less* support |
 
-If values two and three differ, the more stringent value must come first.
+The 2nd value must be at least the 3rd: it applies to the strand that has *more* reads, so it makes no sense to demand more reads from the weaker strand than the stronger one.
 
-**Example:** `--min-reads 7 3 1` requires:
-- At least 7 total raw reads supporting the duplex consensus
-- At least 3 raw reads for the better-supported single-strand consensus
-- At least 1 raw read for the other single-strand consensus
+**Example:** `--min-reads 7 3 1` requires at least 7 total raw reads supporting the duplex consensus, at least 3 raw reads for the better-supported single-strand consensus, and at least 1 raw read for the other.
+
+## See Also
+
+- [Consensus Calling](consensus-calling.md) — the underlying single-strand model
+- [Tracking Reads](tracking-reads.md) — how `/A`·`/B` strand labels and the per-strand tags are assigned
+- [UMI Grouping](umi-grouping.md) — the `paired` strategy that duplex requires
+- [Working with Metrics](working-with-metrics.md) — duplex QC metrics

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -10,14 +10,16 @@ This guide walks through a basic fgumi workflow from FASTQ files to filtered con
 
 ## Basic Workflow
 
+This guide runs each stage as its own command so you can see the whole pipeline. Once you are comfortable with the stages, you can collapse supported runs of them into a single [`fgumi runall`](running-pipelines.md) command — same output, no intermediate files. We point out where along the way.
+
 ### 1. Extract UMIs from FASTQ
 
-Extract UMIs from FASTQ reads and create an unmapped BAM. The `--read-structures` argument tells fgumi where UMI bases are located in each read. See [Read Structures](read-structures.md) for details.
+Extract UMIs from the FASTQ reads and create an unmapped BAM. The `--read-structures` argument tells fgumi where the UMI bases sit in each read; here `8M+T` means the first 8 bases of R1 are the UMI followed by template, and `+T` means R2 is all template. Adjust these to match your library — see [Read Structures](read-structures.md).
 
 ```bash
 fgumi extract \
   --inputs R1.fastq.gz R2.fastq.gz \
-  --read-structures +T +M \
+  --read-structures 8M+T +T \
   --output unaligned.bam \
   --sample MySample \
   --library MyLibrary
@@ -37,19 +39,20 @@ fgumi correct \
 
 ### 3. Align and Sort
 
-Use fgumi's streaming pipeline to align with BWA and sort into template-coordinate order in a single pass:
+Aligners read and write plain reads, so they drop the UMI tags carried on the unmapped BAM. The workflow therefore aligns the reads, then uses `fgumi zipper` to copy the UMI (and other) tags from the original unmapped BAM back onto the aligned reads — you cannot pipe the aligner straight into `sort` without losing the UMIs. fgumi runs all of this as one streaming pass:
 
 ```bash
 fgumi fastq --input unaligned.bam \
   | bwa mem -p ref.fa - \
-  | fgumi zipper --unmapped unaligned.bam \
+  | fgumi zipper --unmapped unaligned.bam --reference ref.fa \
   | fgumi sort --output sorted.bam --order template-coordinate
 ```
 
-This pipes reads through:
-1. `fastq` — converts unmapped BAM to interleaved FASTQ
+This pipes reads through four stages:
+
+1. `fastq` — converts the unmapped BAM to interleaved FASTQ
 2. `bwa mem` — aligns reads to the reference
-3. `zipper` — merges aligned reads with original unmapped BAM to restore UMI tags
+3. `zipper` — merges aligned reads with the original unmapped BAM to restore UMI tags
 4. `sort` — sorts into template-coordinate order for grouping
 
 > **Note:** `fgumi zipper` accepts SAM or BAM input, on stdin or via `--input`. For best
@@ -58,15 +61,9 @@ This pipes reads through:
 > side. SAM is fine for aligners that can't emit BAM; compressed BAM on a pipe is not
 > recommended (wasted CPU on both ends).
 
-For single-cell data, the `CB` cell barcode tag is automatically included in the
-template-coordinate sort key, keeping templates from different cells at the same locus separate:
-
-```bash
-fgumi fastq --input unaligned.bam \
-  | bwa mem -p ref.fa - \
-  | fgumi zipper --unmapped unaligned.bam \
-  | fgumi sort --output sorted.bam --order template-coordinate
-```
+For single-cell data, `fgumi sort` automatically adds the `CB` cell barcode tag to the
+template-coordinate sort key, so reads from different cells at the same genomic position stay
+separate. No extra flags are needed.
 
 ### 3b. (Optional) Merge Multiple BAMs
 
@@ -129,7 +126,9 @@ See [UMI Grouping](umi-grouping.md) for details on grouping strategies.
 
 ### 5. Call Consensus Reads
 
-Choose the consensus calling method based on your library preparation:
+Choose the consensus method based on your library preparation: `simplex` for single-strand UMI
+libraries, `duplex` for double-stranded duplex libraries, and `codec` for CODEC. If you are
+unsure, see [Choosing a Consensus Method](consensus-calling.md#choosing-a-consensus-method).
 
 **Simplex consensus** (single-strand):
 ```bash
@@ -153,6 +152,24 @@ fgumi codec \
 ```
 
 See [Consensus Calling](consensus-calling.md) and [Duplex Consensus Calling](duplex-consensus-calling.md) for details.
+
+> **Do it in one command.** Steps 3–5 — align, sort, group, and call consensus — can run as a
+> single streaming `fgumi runall` invocation that starts from the unmapped BAM produced in step 1,
+> with no intermediate BAMs and byte-for-byte identical output:
+>
+> ```bash
+> fgumi runall \
+>   --start-from align --stop-after consensus --consensus simplex \
+>   --input unaligned.bam --ref ref.fa --output consensus.bam \
+>   --aligner::preset bwa \
+>   --group::strategy adjacency --simplex::min-reads 1 \
+>   --threads 8
+> ```
+>
+> (`runall` runs the aligner for you via `--aligner::preset` and inserts the sort step
+> automatically.) See
+> [Running Pipelines](running-pipelines.md) for the full stage model and more examples. The
+> step-by-step commands remain useful for inspecting intermediates or collecting per-stage metrics.
 
 ### 6. (Optional) Collect QC Metrics
 
@@ -213,6 +230,8 @@ fgumi clip \
 
 ## What's Next
 
+- [Running Pipelines](running-pipelines.md) — fuse these steps with `fgumi runall`, and when to prefer it over individual commands
 - [Best Practices](best-practices.md) — recommended parameter settings and pipeline configuration
 - [Performance Tuning](performance-tuning.md) — threading, memory, and compression optimization
 - [Working with Metrics](working-with-metrics.md) — understanding fgumi's output metrics
+- [Glossary](glossary.md) and [Troubleshooting](troubleshooting.md) — terminology reference and fixes for common errors

--- a/docs/src/guide/glossary.md
+++ b/docs/src/guide/glossary.md
@@ -1,0 +1,45 @@
+# Glossary
+
+Definitions of the terms and tags used throughout this guide.
+
+## Concepts
+
+**UMI (Unique Molecular Identifier).** A short, often random, sequence attached to each original molecule before amplification. Reads that share a UMI and a mapping position are presumed to come from the same source molecule, which lets fgumi collapse PCR and sequencing duplicates into a consensus.
+
+**Template.** The pair of reads (R1 and R2) sequenced from one molecule. fgumi groups and sorts by template, not by individual reads.
+
+**Read structure.** A compact description of where UMI, template, sample-barcode, cell-barcode, and skip bases sit within each sequencing read, e.g. `8M+T` = an 8 bp UMI followed by all remaining template bases. See [Read Structures](read-structures.md).
+
+**Family / family size.** A *family* is the set of reads grouped to one source molecule; *family size* is how many templates it contains (on paired-end data a read pair counts as one template), matching the `family_sizes.txt` histogram. The distribution of family sizes is a key QC signal — see [Working with Metrics](working-with-metrics.md).
+
+**Simplex (single-strand) consensus.** A consensus built from reads of a single strand of the source molecule. Produced by `fgumi simplex`. See [Consensus Calling](consensus-calling.md).
+
+**Duplex (double-strand) consensus.** A consensus that combines evidence from *both* strands of the source molecule, which suppresses errors that occur on only one strand. Produced by `fgumi duplex`. See [Duplex Consensus Calling](duplex-consensus-calling.md).
+
+**CODEC.** A library protocol (Bae et al. 2023) in which a single read pair sequences both strands of the duplex molecule, so even one read pair can yield a duplex consensus. Produced by `fgumi codec`.
+
+**Template-coordinate order.** A sort order that keeps all reads of a template together and orders templates by the outer 5′ coordinates of the pair. It is the required input order for `fgumi group`, `fgumi dedup`, and `fgumi downsample`, and is produced by `fgumi sort --order template-coordinate`. (Use `fgumi sort`, not `samtools sort`, ahead of these commands — see [Troubleshooting](troubleshooting.md).)
+
+**Phred quality.** A base-quality score `Q = -10·log₁₀(P_error)`; higher is better (Q30 ≈ 1 error in 1000).
+
+**Pre-UMI / post-UMI error rate.** The consensus model splits sequencing error into errors that occur *before* the UMI is integrated into the molecule (`--error-rate-pre-umi`) and *after* (`--error-rate-post-umi`). See [Consensus Calling](consensus-calling.md).
+
+## Strand labels
+
+**`/A` and `/B`.** Suffixes on the `MI` tag that `fgumi group --strategy paired` assigns to the two single-strand sub-families of one duplex molecule (e.g. `1/A` and `1/B`). The `/A` sub-family is the read pair whose read 1 5′ end comes at or before read 2's, ignoring soft-clipping and reference strand. See [Tracking Reads](tracking-reads.md).
+
+**AB / BA strand.** The two strand orientations combined into a duplex consensus. Per-strand thresholds in `fgumi duplex` and `fgumi filter` take up to three values, `[duplex, AB, BA]`.
+
+## BAM tags
+
+| Tag | Set by | Meaning |
+|-----|--------|---------|
+| `RX` | `extract` | Raw UMI bases (input to `group`/`correct`). |
+| `QX` | `extract` | UMI base qualities (optional). |
+| `OX` | `correct` | Original UMI, before correction. |
+| `MI` | `group` | Molecule ID assigning each read to a UMI family; carries `/A`·`/B` suffixes under the `paired` strategy. |
+| `CB` | upstream | Cell barcode for single-cell data; reads are partitioned by `CB` before grouping, sorting, and deduplication. Not corrected by fgumi. |
+| `tc` | `zipper` | Template-coordinate sort key added to secondary/supplementary reads so they sort and deduplicate correctly. |
+| `pa` | `zipper` | Primary-alignment template sort-key coordinates on secondary/supplementary reads. |
+
+Consensus callers add a family of per-read and per-base tags (`cD`, `cM`, `cE`, `cd`, `ce`, and the `a*`/`b*` single-strand variants for duplex). See [Tracking Reads](tracking-reads.md) for the full scheme.

--- a/docs/src/guide/methylation.md
+++ b/docs/src/guide/methylation.md
@@ -18,7 +18,7 @@ Both EM-Seq and TAPs detect cytosine methylation by converting one class of cyto
 C→T conversion affects consensus calling: at a reference C position, reads showing T are not errors — they represent conversion events. Standard consensus calling would treat C/T disagreements as sequencing errors and penalize quality. Methylation mode recognizes these as conversion events and tracks per-base evidence through consensus calling.
 
 **UMI sequences:**
-- **EM-Seq**: UMIs should be synthesized with methylated cytosines (5mC) to protect them from enzymatic conversion. Unmethylated C in UMIs is a library prep issue.
+- **EM-Seq**: UMIs should be synthesized with methylated cytosines (5mC) so the enzymatic conversion leaves them intact. If a fixed-UMI design instead used ordinary (unmethylated) C, those bases convert to T on the top strand (or to A on the bottom strand), and each converted base must be absorbed by `--max-mismatches` during correction (see [Workflow B](#step-2-umi-correction)).
 - **TAPs**: UMIs are unaffected — synthetic oligonucleotides contain unmethylated cytosines, which TAPs does not convert.
 
 ---
@@ -260,7 +260,7 @@ fgumi correct \
   --threads 8
 ```
 
-If your UMI design includes unmethylated cytosines, add `--allow-c-to-t`. This flag applies uniformly across all UMI segments regardless of read-pair index, since both R1 and R2 UMI segments are in forward orientation. Only C-to-T tolerance is needed; G-to-A tolerance is not required.
+In EM-Seq, the ideal is to synthesize fixed UMIs with methylated cytosines (5mC) so the conversion leaves them unchanged — this is strongly preferred. If instead your UMIs contain ordinary cytosines, the conversion turns each into a T on the top strand (or an A on the bottom strand), and `fgumi correct` simply sees that as a mismatch against the whitelist: it will correct only if `--max-mismatches` is high enough to absorb the converted bases, which also lowers specificity. There is no dedicated conversion-aware correction mode; raise `--max-mismatches` to suit your UMI length and expected conversion count, or (better) protect the UMIs with 5mC. (`--revcomp` only reverse-complements the whole hyphenated UMI before matching; it is unrelated to conversion.)
 
 ### Steps 3-8: Alignment through Final Sort
 
@@ -283,7 +283,7 @@ When methylation mode is enabled, consensus reads carry additional BAM tags for 
 
 ### Duplex Output Tags
 
-All simplex tags above (combined from both strands), plus per-strand tags:
+All simplex tags above (combined from both strands), plus per-strand tags. The `AB` and `BA` labels denote the two strand orientations of the duplex molecule (see the [Glossary](glossary.md#strand-labels)):
 
 | Tag | Type | Description |
 |-----|------|-------------|
@@ -416,3 +416,9 @@ If many reads fail `--min-conversion-fraction`:
 ### Using the Wrong Methylation Mode
 
 If you use `--methylation-mode em-seq` for TAPs data (or vice versa), the methylation probabilities will be inverted — methylated positions will show low probability and vice versa. If downstream analysis shows unexpected methylation patterns, verify you used the correct mode for your chemistry.
+
+## See Also
+
+- [Consensus Calling](consensus-calling.md) and [Duplex Consensus Calling](duplex-consensus-calling.md) — the consensus models methylation mode builds on
+- [Best Practices](best-practices.md) — the standard (non-methylation) pipeline this guide extends
+- [Working with Metrics](working-with-metrics.md) — QC for methylation runs

--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -20,6 +20,7 @@ fgumi is the Rust successor to [fgbio](https://github.com/fulcrumgenomics/fgbio)
 | *(no equivalent)* | `simplex-metrics` | New: simplex QC metrics (yield, family sizes, UMI counts) |
 | *(samtools merge)* | `merge` | k-way merge of pre-sorted BAMs; supports all sort orders |
 | `ReviewConsensusVariants` | `review` | |
+| *(no equivalent)* | `runall` | New: fuse a whole multi-stage pipeline into one streaming command |
 
 ## Key Differences
 
@@ -34,11 +35,15 @@ fgumi supports Unix pipe-based streaming for the alignment workflow:
 ```bash
 fgumi fastq --input unaligned.bam \
   | bwa mem -p -K 150000000 -Y ref.fa - \
-  | fgumi zipper --unmapped unaligned.bam \
+  | fgumi zipper --unmapped unaligned.bam --reference ref.fa \
   | fgumi sort --output sorted.bam --order template-coordinate
 ```
 
 This replaces multiple separate fgbio/picard steps (SortBam, ZipperBams/MergeBamAlignment) with a single streaming pass. `fgumi zipper` accepts SAM or BAM on stdin or via `--input`; for best performance, pipe uncompressed BAM from the aligner (e.g. `bwa-mem3 mem --bam=0`).
+
+### Fused Pipeline (`runall`)
+
+fgbio has no equivalent to `fgumi runall`, which fuses an entire pipeline — extract, correct, align, zipper, sort, group, consensus, and filter — into one in-memory command. Where an fgbio workflow chains many tools and writes a BAM between each, `runall` streams records directly between stages and writes none. Choose the slice with `--start-from` and `--stop-after`; the output is identical to running the individual commands. See [Running Pipelines](running-pipelines.md).
 
 ### Merging Multiple BAMs
 
@@ -144,3 +149,9 @@ fgumi focuses on UMI-based tools. The following fgbio tools do **not** have fgum
 - FASTQ/FASTA utilities (e.g., `FastqToBam`, `HardMaskFasta`)
 
 Continue using fgbio for these tools.
+
+## See Also
+
+- [Getting Started](getting-started.md) — the fgumi workflow end to end
+- [Running Pipelines](running-pipelines.md) — `fgumi runall`, which has no fgbio equivalent
+- [Best Practices](best-practices.md) — recommended parameters by application

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -39,6 +39,10 @@ For memory-constrained environments, pass `--max-memory auto` to detect (cgroup-
 - **Behavior**: Uses unified 7-step pipeline with work-stealing scheduler
 - **Best for**: Large files, high-performance systems, production workloads
 
+> **`fgumi runall`:** all fused stages share a single `--threads` thread pool, so set `--threads`
+> once at the top level rather than per stage. Memory tuning applies to the whole chain — see the
+> [Memory Management](#memory-management) section below.
+
 ## Memory Management
 
 fgumi's unified memory management controls pipeline queue memory to prevent out-of-memory conditions while maintaining throughput.
@@ -101,7 +105,10 @@ backward compatibility, but new scripts should use the `--max-memory` flags.
 For sequential workloads like BAM and FASTQ processing, I/O throughput is often the
 bottleneck — not CPU. Two areas to check: OS readahead and volume throughput.
 
-### OS Readahead
+### OS Readahead (Linux)
+
+> The `blockdev` commands below are Linux-specific. On macOS and other platforms, use
+> `--async-reader` (below) instead.
 
 The Linux kernel prefetches file data into the page cache ahead of the application.
 The default readahead window is typically 128 KB, which fgumi's decompression threads
@@ -397,3 +404,9 @@ fgumi group --max-memory auto
 ```
 
 The new parameters provide host-aware (`auto`) sizing and human-readable formats while maintaining backward compatibility.
+
+## See Also
+
+- [Best Practices](best-practices.md) — recommended pipelines these settings apply to
+- [Running Pipelines](running-pipelines.md) — how threading and memory apply to a fused `runall` run
+- [Troubleshooting](troubleshooting.md) — diagnosing out-of-memory and slow-I/O symptoms

--- a/docs/src/guide/read-structures.md
+++ b/docs/src/guide/read-structures.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-A *Read Structure* is a string that describes how the bases in a sequencing run should be allocated into logical reads. It serves a similar purpose to the `--use-bases-mask` in Illumina's bcl-convert, but provides additional capabilities.
+A *Read Structure* is a string that describes how the bases in a sequencing read should be allocated into logical segments. It serves a similar purpose to `--use-bases-mask` in Illumina's bcl-convert, but provides additional capabilities. (If you are familiar with bcl-convert, read structures are the more flexible equivalent.)
 
-A Read Structure is a sequence of `<number><operator>` pairs (called *segments*). The last segment may use `+` instead of a number to mean "whatever bases remain." fgumi uses the [`read-structure`](https://crates.io/crates/read-structure) crate for parsing and validation.
+A read structure is a sequence of `<length><operator>` segments, where `<length>` is a positive integer or, in the final segment, `+`. For example, `8M+T` means **8** bases of UMI (`M`), then **all remaining** bases (`+`) of template (`T`). Only the last segment may use `+`, to mean "whatever bases remain."
 
-Read structures are used primarily in `fgumi extract` to specify where UMI bases, template bases, and other sequences are located in each FASTQ read.
+You supply one read structure per FASTQ, primarily to `fgumi extract`, to tell it where the UMI, template, sample-barcode, cell-barcode, and skip bases sit in each read.
 
 ## Operators
 
@@ -55,7 +55,17 @@ Per-read structures: `5C30S5C3S8M+T`, `8B`, `+T`
 
 R1 contains two cell barcodes separated by linker sequences, then a UMI, then template.
 
-## Formal Grammar
+## Troubleshooting
+
+`fgumi extract` rejects a read structure whose fixed-length segments add up to more bases than a read contains, or whose number of read structures does not match the number of input FASTQs. If you hit an error:
+
+- Count the fixed-length bases in each structure and confirm they fit within the read length; use `+` for the final segment so it absorbs whatever remains.
+- Supply exactly one read structure per FASTQ, in the same order as `--inputs`.
+- If all UMI families come out as singletons afterward, the `M` segment is likely the wrong length or in the wrong read — see [Troubleshooting](troubleshooting.md).
+
+## Technical Details
+
+Most users never need this section — the operators, rules, and examples above cover real read structures. It is included for completeness. fgumi uses the [`read-structure`](https://crates.io/crates/read-structure) crate for parsing and validation; the full grammar is:
 
 ```text
 <read-structure>     ::= <fixed-structure> <segment>
@@ -68,3 +78,8 @@ R1 contains two cell barcodes separated by linker sequences, then a UMI, then te
 <non-zero-digit>     ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 <digit>              ::= "0" | <non-zero-digit>
 ```
+
+## See Also
+
+- [Getting Started](getting-started.md) — read structures in the context of `fgumi extract`
+- [UMI Grouping](umi-grouping.md) — what happens to the extracted UMIs next

--- a/docs/src/guide/running-pipelines.md
+++ b/docs/src/guide/running-pipelines.md
@@ -1,0 +1,146 @@
+# Running Pipelines
+
+Most fgumi work is a *pipeline*: extract UMIs, align, sort, group, call consensus, filter. You can run each stage as its own command — writing a BAM to disk between every step — or fuse a run of stages into a single streaming process with `fgumi runall`.
+
+## When to use `runall`
+
+> **Rule of thumb:** run a single stage with its own command (`fgumi sort`, `fgumi group`, `fgumi simplex`, …). Chain **two or more** stages with `fgumi runall`.
+
+`runall` streams records directly from one stage to the next, so every intermediate BAM a sequential run would write is elided. Its output is **byte-for-byte identical** to running the equivalent standalone commands in turn — the same algorithm, just without the round-trips to disk.
+
+Reach for individual commands when you want to inspect or reuse an intermediate BAM (for example, to try several filter settings against one consensus BAM), or when you need a per-stage metrics file that `runall` does not emit (see [Caveats](#caveats)).
+
+`runall` processes one input. If you have several BAMs from separate sequencing runs, combine them first with `fgumi merge --order template-coordinate`, then point `runall` at the merged file with `--start-from group`. Use `--start-from sort` only for raw aligned input that still needs sorting.
+
+## The stage model
+
+`runall` understands a fixed, linearly ordered set of stages:
+
+```text
+extract < correct < align < zipper < sort < group < consensus < filter
+```
+
+| Stage | What it does | Reads |
+|-------|--------------|-------|
+| `extract` | UMIs from FASTQ → unmapped BAM | FASTQ (`--extract::inputs`) — the only stage that reads FASTQ rather than a BAM |
+| `correct` | Correct UMIs against a fixed whitelist | unmapped BAM (`--input`) |
+| `align` | Run the aligner subprocess and zipper-merge the result | unmapped BAM (`--input`) + `--ref` + an aligner (`--aligner::preset` or `--aligner::command`) |
+| `zipper` | Merge a mapped BAM with its unmapped BAM, restoring tags | mapped BAM (`--input`) + `--unmapped` + `--ref` (with a companion `.dict`) |
+| `sort` | Sort into template-coordinate order | aligned BAM (`--input`) |
+| `group` | Group reads by UMI, assigning MI tags | template-coordinate-sorted BAM (`--input`) |
+| `consensus` | Call consensus (algorithm set by `--consensus`) | grouped, MI-tagged BAM (`--input`) |
+| `filter` | Filter/mask consensus reads | consensus BAM (`--input`) |
+
+## Selecting the slice to run
+
+Pick the slice with `--start-from` and `--stop-after` (both required). `--start-from` declares the state of your input; `--stop-after` names the last stage to run. They must satisfy `start-from ≤ stop-after` in the order above, and `--stop-after` cannot be `align` — it is start-only, so the valid stop stages are `extract`, `correct`, `zipper`, `sort`, `group`, `consensus`, and `filter`. Both are required because `runall` cannot infer either one: the same BAM could be valid input to several stages, and you may want to stop anywhere along the chain.
+
+> **Important — match the input to `--start-from`.** `runall` validates the stage *range* but **cannot** verify that your input file is actually in the state `--start-from` claims. If you pass, for example, a raw unsorted BAM to `--start-from group`, the run may fail in a later stage or silently produce incorrect output, depending on what the mismatched input trips. Confirm your input matches the declared start stage (the [stage model](#the-stage-model) table lists what each stage expects).
+
+When the slice reaches the `consensus` stage, choose the algorithm with `--consensus`:
+
+| `--consensus` | Consensus caller | Required grouping strategy |
+|---------------|------------------|----------------------------|
+| `simplex` | single-strand ([Consensus Calling](consensus-calling.md)) | `adjacency` (or `identity`/`edit`) |
+| `duplex` | double-strand ([Duplex Consensus Calling](duplex-consensus-calling.md)) | **`paired`** |
+| `codec` | CODEC duplex from single read pairs | `adjacency` (or `identity`/`edit`) |
+
+The algorithm is chosen by `--consensus`, **not** by the stage name. `--stop-after consensus` produces the same BAM as the matching `fgumi simplex`/`duplex`/`codec` command. **`--consensus duplex` requires `--group::strategy paired`** (so MIs carry the `/A`·`/B` strand suffixes duplex needs); `simplex` and `codec` require a non-paired strategy. Mismatching these is a hard error.
+
+### Automatically inserted stages
+
+You only name the *first* and *last* stages; `runall` fills in any stages in between that the chain requires. The one case that surprises people: the `align` and `zipper` stages emit reads in queryname order, but `group` needs template-coordinate order, so `runall` always inserts a `sort` step between them. For example, `--start-from extract --stop-after consensus` expands to extract → align → sort → group → consensus, and `--start-from zipper --stop-after group` expands to zipper → sort → group. You never write the inserted `sort` yourself, but you can still tune it with `--sort::*` flags.
+
+## Per-stage options
+
+Tune any stage with prefixed flags of the form `--<stage>::<flag>`. These mirror the standalone command's options exactly:
+
+| Standalone | `runall` |
+|------------|----------|
+| `fgumi sort --max-memory 4G` | `--sort::max-memory 4G` |
+| `fgumi group --strategy adjacency` | `--group::strategy adjacency` |
+| `fgumi duplex --min-reads 1,1,0` | `--duplex::min-reads 1,1,0` |
+| `fgumi extract --read-structures +T +T` | `--extract::read-structures +T +T` |
+
+Cross-cutting options stay at the top level: `--threads`, `--compression-level`, `--max-memory`, `--ref`, `--rejects`, `--stats`, `--raw-tag` (default `RX`), `--assign-tag` (default `MI`), `--methylation-mode`. Run `fgumi runall --help` for the full, grouped list.
+
+## Examples
+
+Each example chains two or more stages, so each one is a job for `runall` rather than a sequence of standalone commands.
+
+**Sort → group → simplex consensus**, replacing three commands and two intermediate BAMs:
+
+```bash
+fgumi runall \
+  --start-from sort --stop-after consensus --consensus simplex \
+  --input unsorted.bam --output consensus.bam \
+  --group::strategy adjacency --group::edits 1 \
+  --simplex::min-reads 1 \
+  --threads 8
+```
+
+**Group → duplex consensus** (duplex requires the `paired` strategy):
+
+```bash
+fgumi runall \
+  --start-from group --stop-after consensus --consensus duplex \
+  --input sorted.bam --output duplex.bam \
+  --group::strategy paired --group::edits 1 \
+  --duplex::min-reads 1,1,0 \
+  --threads 8
+```
+
+**Consensus → filter, fused** — no intermediate consensus BAM is written:
+
+```bash
+fgumi runall \
+  --start-from group --stop-after filter --consensus simplex \
+  --input sorted.bam --output filtered.bam \
+  --group::strategy adjacency \
+  --simplex::min-reads 1 \
+  --filter::min-reads 1 --filter::max-read-error-rate 0.025 \
+  --threads 8
+```
+
+**FASTQ → consensus**, the whole pipeline in one command (`runall` inserts `align`, `sort`, and `group`):
+
+```bash
+fgumi runall \
+  --start-from extract --stop-after consensus --consensus simplex \
+  --extract::inputs R1.fq.gz R2.fq.gz \
+  --extract::read-structures 8M+T +T \
+  --extract::sample MySample --extract::library MyLibrary \
+  --ref ref.fa --aligner::preset bwa --output consensus.bam \
+  --group::strategy adjacency \
+  --simplex::min-reads 1 \
+  --threads 8
+```
+
+## `runall` vs. individual commands
+
+| | `runall` | Individual commands |
+|---|----------|---------------------|
+| Intermediate BAMs | none (in-memory) | written to disk between stages |
+| Output | identical to the command chain | the same bytes |
+| Per-stage metrics/histograms | not emitted | available (e.g. `fgumi group --metrics`) |
+| Inspect/reuse an intermediate | no | yes — the BAM is on disk |
+| Best for | production runs, multi-stage chains | single stages, debugging, metrics, experimentation |
+
+For the recommended end-to-end pipelines and parameter choices, see [Best Practices](best-practices.md).
+
+## Caveats
+
+- **No per-stage metrics.** Fused chains do not emit the metrics or histograms that standalone stages do (`fgumi group --metrics`, `simplex-metrics`, `duplex-metrics`). Run the standalone stage when you need them — see [Working with Metrics](working-with-metrics.md).
+- **No `--stop-after align`.** Raw aligner output before the zipper-merge has lost every original tag, so the earliest stop after `--start-from align` is `zipper`.
+- **Input state is not validated** against `--start-from` — see the warning under [Selecting the slice to run](#selecting-the-slice-to-run).
+- **UMI rejects are discarded when `correct` is fused mid-chain.** To capture them, run `fgumi correct --rejects` as a separate step.
+- **Strategy constraints.** `--consensus duplex` requires `--group::strategy paired`; `--consensus simplex` and `--consensus codec` require a non-paired strategy.
+- **Methylation limits.** `--methylation-mode` is not supported with `--start-from align` or with `--consensus codec`; use it with `simplex` or `duplex`. See [Methylation](methylation.md).
+- **`zipper` start needs a dictionary.** `--start-from zipper` requires `--ref` with a companion `.dict` file (create one with `samtools dict`).
+
+## See Also
+
+- [Getting Started](getting-started.md) — the step-by-step tutorial these stages come from
+- [Best Practices](best-practices.md) — recommended end-to-end pipelines and parameters
+- [Troubleshooting](troubleshooting.md) — fixes for common `runall` and sort-order errors
+- [Glossary](glossary.md) — UMI, template-coordinate, strand labels, and BAM tags

--- a/docs/src/guide/tracking-reads.md
+++ b/docs/src/guide/tracking-reads.md
@@ -2,11 +2,13 @@
 
 This guide describes conventions for tracking reads from raw data through grouping and duplex consensus calling. It covers how molecular identifiers relate to strand assignment and how consensus tags encode single-strand and duplex information.
 
-## Top and Bottom Strand for Raw Reads
+You need this page when you filter or interpret duplex consensus reads by strand, query the per-strand consensus tags in a downstream tool, or debug why reads landed in the wrong molecule. For routine pipelines, the defaults handle all of this automatically.
 
-`fgumi group` assigns the same molecular ID to raw reads from the same source molecule, with trailing `/A` and `/B` to indicate which strand they belong to (top or bottom, AB or BA).
+## Strand Labels (`/A` and `/B`) for Raw Reads
 
-**Convention:** The `/A` raw reads are those where the 5' unclipped position of read one (of the pair) is less than or equal to the 5' unclipped position of read two. The 5' unclipped position is relative to sequencing order, not the reference genome strand.
+`fgumi group --strategy paired` assigns the same molecular ID base to raw reads from one source molecule, with a trailing `/A` or `/B` marking which of the two strands a read pair came from.
+
+**Convention:** a read pair is labeled `/A` when read 1's 5′ end comes at or before read 2's 5′ end *in sequencing order* (ignoring soft-clipping and independent of the reference strand); otherwise it is `/B`.
 
 For example:
 
@@ -45,3 +47,17 @@ SAM tags used for single-strand and duplex consensus reads:
 | Per-base quals | `aq` | `bq` | (quals) |
 
 **Convention:** The second letter in the tag is lowercase for per-base values and uppercase for per-read values.
+
+### Reading a duplex consensus read's tags
+
+For a duplex consensus read built from molecule `1` (raw reads tagged `1/A` and `1/B`):
+
+- `cD` is the final duplex depth; `aD` and `bD` are the depths of the `/A` and `/B` single-strand consensuses that were combined.
+- A high `cD` with a small value for one of the single-strand consensuses means the duplex rests on one well-covered strand and one thinly-covered strand — exactly the case the per-strand `--min-reads` thresholds control (their order is by support, not by `/A` vs `/B`). See [Duplex Consensus Calling](duplex-consensus-calling.md).
+- The per-base `ad`/`ae` (and `bd`/`be`) arrays let `fgumi filter` mask individual low-support or high-error bases.
+
+## See Also
+
+- [Duplex Consensus Calling](duplex-consensus-calling.md) — how the `/A`·`/B` strands become a duplex consensus
+- [UMI Grouping](umi-grouping.md) — where the `MI` tags and strand labels are assigned
+- [Working with Metrics](working-with-metrics.md) — interpreting the resulting QC metrics

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting
+
+Common errors and unexpected results, with their causes and fixes.
+
+## `fgumi extract` rejects the read structures
+
+**Cause.** The number of read structures does not match the number of `--inputs` FASTQs, or a structure's fixed-length segments add up to more bases than a read contains.
+
+**Fix.** Supply exactly one read structure per FASTQ, in the same order as `--inputs`, and use `+` for the final segment so it absorbs whatever bases remain (e.g. `8M+T` rather than `8M142T` when read length varies). See [Read Structures](read-structures.md) for the syntax and worked examples.
+
+## "Input BAM must be template-coordinate sorted"
+
+```text
+Input BAM must be template-coordinate sorted (header must advertise
+SO:unsorted, GO:query, and SS:template-coordinate).
+```
+
+**Cause.** `fgumi group`, `fgumi dedup`, and `fgumi downsample` require template-coordinate order, and the input is in some other order.
+
+**Fix.** Sort with fgumi (not samtools — see below):
+
+```bash
+fgumi sort -i input.bam -o sorted.bam --order template-coordinate
+```
+
+## `samtools sort` output gives wrong grouping or dedup results
+
+**Cause.** `fgumi zipper` writes a `tc` tag on secondary/supplementary reads so they sort and deduplicate correctly. `samtools sort --template-coordinate` ignores the `tc` tag, so its output orders those reads incorrectly for `fgumi group`/`dedup`.
+
+**Fix.** Always sort with `fgumi sort --order template-coordinate` after `fgumi zipper`. Reserve `samtools sort` for plain coordinate or queryname sorting of BAMs that will not feed `group`, `dedup`, or `downsample`.
+
+## Every UMI family has size 1 (all singletons)
+
+**Cause.** Reads from the same molecule are not being grouped together. Common reasons:
+
+- The UMI length in `--read-structures` is wrong, so the wrong bases are stored in `RX`.
+- UMI diversity is high relative to depth (genuinely few duplicates).
+- The `identity` grouping strategy is splitting families on sequencing errors in the UMI.
+
+**Fix.** Verify the read structure against your library design ([Read Structures](read-structures.md)); switch from `identity` to `adjacency` so single-base UMI errors are tolerated ([UMI Grouping](umi-grouping.md)); and inspect the family-size histogram from `fgumi group --metrics` ([Working with Metrics](working-with-metrics.md)).
+
+## Low consensus yield
+
+**Cause.** `--min-reads` is set higher than most families can satisfy, or families are too small.
+
+**Fix.** Lower `--min-reads` (it is always safe to call with `--min-reads 1` and filter later), confirm UMI extraction, and run `fgumi simplex-metrics` / `fgumi duplex-metrics` on the grouped BAM to see how yield scales with depth.
+
+## Excessive duplex strand disagreement / many no-calls
+
+**Cause.** The two strands disagree at many positions, often from low input base quality or reads extending past the insert.
+
+**Fix.** Raise `--min-input-base-quality`, enable `--trim` to remove low-quality read ends, and tune the per-strand `--min-reads` triple `[duplex, AB, BA]`. See [Duplex Consensus Calling](duplex-consensus-calling.md).
+
+## Out-of-memory / process killed
+
+**Cause.** `--max-memory` bounds only the pipeline queue, and it is *per thread* by default, so total RSS scales with `--threads`. A high thread count can exceed host RAM.
+
+**Fix.** On a fixed-RAM host, use `--max-memory auto` (self-throttles to the host) or set a fixed total budget with `--max-memory <N> --memory-per-thread false`; reduce `--threads`. See the [Performance Tuning](performance-tuning.md) memory section for the full model.
+
+## `fgumi runall` produces wrong or empty output (input doesn't match `--start-from`)
+
+**Cause.** `runall` cannot verify that your input file is actually in the state `--start-from` claims. If the input is in a different state — e.g. a raw unsorted BAM passed to `--start-from group`, or an ungrouped BAM passed to `--start-from consensus` — the pipeline runs on whatever it finds and silently produces wrong (or empty) results rather than erroring.
+
+**Fix.** Make the input match the declared start stage. Check the BAM's sort order in its header (`samtools view -H in.bam | grep @HD`) and confirm the expected tags are present (`RX` after extract, `MI` after group). The [stage model table](running-pipelines.md#the-stage-model) lists what each start stage expects. When in doubt, start from an earlier stage so `runall` does the upstream work itself.
+
+## `--stop-after align` is rejected (runall)
+
+**Cause.** Raw aligner output before the zipper-merge has lost every original tag, so `align` is not a valid stop point.
+
+**Fix.** Use `--stop-after zipper` as the earliest stop after `--start-from align`. See [Running Pipelines](running-pipelines.md).
+
+## `fgumi group` rejects `--strategy paired` with another flag
+
+```text
+Paired strategy cannot be used with --min-umi-length
+--no-umi cannot be used with --strategy paired
+```
+
+**Cause.** The `paired` strategy (for duplex data) is incompatible with `--min-umi-length` and `--no-umi`.
+
+**Fix.** Drop the conflicting flag. Use `paired` only for duplex workflows; use `adjacency` for simplex and CODEC.

--- a/docs/src/guide/umi-grouping.md
+++ b/docs/src/guide/umi-grouping.md
@@ -53,7 +53,7 @@ Grouping is performed by one of four strategies:
 
 ### identity
 
-Only reads with identical UMI sequences are grouped together. This is simpler and faster than other strategies, but should usually be avoided because sequencing errors in the UMI will split reads from the same molecule into separate groups. Useful for data exploration.
+Groups only reads with identical UMI sequences. It is the simplest and fastest strategy, but a single sequencing error in a UMI splits one molecule into separate groups — so use it only for data exploration, not production grouping.
 
 ### edit
 
@@ -61,7 +61,7 @@ Reads are clustered into groups such that each read within a group has at least 
 
 ### adjacency
 
-A version of the directed adjacency method described in [umi_tools](http://dx.doi.org/10.1101/051755) that allows for errors between UMIs but only when there is a count gradient. **Recommended for most simplex and CODEC workflows.**
+A version of the directed adjacency method described in [umi_tools](http://dx.doi.org/10.1101/051755). It merges UMIs that differ by a few bases, but only when the read counts form a *count gradient* — a high-count UMI absorbs a near-identical low-count one (the low-count UMI is treated as a sequencing error of the abundant parent), while two similarly abundant UMIs are kept separate (they are likely distinct molecules). **Recommended for most simplex and CODEC workflows.**
 
 ### paired
 
@@ -124,9 +124,9 @@ Note: `position_group_sizes.txt` is only available via `--metrics`. The individu
 
 ### Family sizes
 
-The `family_sizes.txt` file is a histogram of how many reads belong to each UMI family. A large
-fraction of singleton families may indicate UMI collisions, over-sequencing, or UMI extraction
-errors.
+The `family_sizes.txt` file is a histogram of how many templates belong to each UMI family (on paired-end data a read pair counts as one template). A large
+fraction of singleton families usually indicates insufficient sequencing depth relative to library
+complexity, or a UMI extraction error (the wrong bases ending up in `RX`).
 
 ### Grouping metrics
 
@@ -178,4 +178,9 @@ Because 5' coordinates are strand-aware, reads from opposite strands with the sa
 position will not be grouped together (they belong to different strands of the same duplex
 molecule).
 
-See also: [Consensus Calling](consensus-calling.md), [Duplex Consensus Calling](duplex-consensus-calling.md), [Best Practices](best-practices.md)
+## See Also
+
+- [Consensus Calling](consensus-calling.md) and [Duplex Consensus Calling](duplex-consensus-calling.md) — the next stage after grouping
+- [Tracking Reads](tracking-reads.md) — the `MI` tag and `/A`·`/B` strand labels grouping assigns
+- [Working with Metrics](working-with-metrics.md) — interpreting the grouping metrics
+- [Best Practices](best-practices.md) — grouping in the recommended workflow

--- a/docs/src/guide/working-with-metrics.md
+++ b/docs/src/guide/working-with-metrics.md
@@ -68,9 +68,17 @@ pass_rate	0.8542
 The `position_group_sizes.txt` file is only written when using `--metrics`; it is not available
 through the individual `--family-size-histogram`/`--grouping-metrics` flags.
 
-A large fraction of singleton families in `family_sizes.txt` may indicate UMI collisions,
-over-sequencing, or incorrect read structures. A distribution skewed toward large values in
-`position_group_sizes.txt` may indicate UMI exhaustion or very high on-target duplication.
+`family_sizes.txt` is a histogram — one row per family size, with counts and cumulative fractions:
+
+```text
+family_size	count	fraction	fraction_gt_or_eq_size
+1	8200	0.41	1.000
+2	5100	0.255	0.590
+3	3400	0.17	0.335
+4	1800	0.09	0.165
+```
+
+**Rules of thumb.** A healthy library shows most families at size 2 or greater, with a tail of larger families. A *large* fraction of singletons (size 1) usually points to insufficient depth relative to library complexity, or an incorrect read structure putting the wrong bases in `RX`. A `position_group_sizes.txt` distribution skewed toward large values points to UMI exhaustion or very high on-target duplication. See [Troubleshooting](troubleshooting.md) if singletons dominate.
 
 ## Duplex Metrics
 
@@ -165,3 +173,9 @@ fgumi compare metrics file1.txt file2.txt --precision 6 --rel-tol 1e-6
 This is useful for validating that pipeline changes produce equivalent results. See the [compare documentation](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/compare-cli.md) for details.
 
 > **Note:** `fgumi compare` is a developer tool not included in standard builds. Build with `--features compare` to enable it: `cargo build --release --features compare`.
+
+## See Also
+
+- [UMI Grouping](umi-grouping.md) — the grouping metrics and what they reveal about library quality
+- [Consensus Calling](consensus-calling.md) — the consensus statistics reported via `--stats`
+- [Best Practices](best-practices.md) — where metrics fit in the recommended workflow

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 <h1><span style="color:#26a8e0">fg</span><span style="color:#38b44a">umi</span></h1>
 
-High-performance tools for UMI-tagged sequencing data: extraction, grouping, and consensus calling.
+High-performance tools for UMI-tagged sequencing data: UMI extraction and correction, alignment support, grouping, deduplication, simplex/duplex/CODEC consensus calling, filtering, and QC metrics.
 
 ![fgumi Pipeline](images/fgumi_subway.png)
 
@@ -52,24 +52,29 @@ cargo build --release
 
 ## Available Commands
 
-| Command | Description |
-|---------|-------------|
-| `extract` | Extract UMIs from FASTQ files |
-| `correct` | Correct UMIs based on sequence similarity |
-| `fastq` | Convert BAM to FASTQ format |
-| `zipper` | Restore original FASTQ from unaligned BAM |
-| `sort` | Sort BAM by coordinate/queryname/template |
-| `group` | Group reads by UMI |
-| `dedup` | Mark/remove UMI-aware duplicates |
-| `simplex` | Call single-strand consensus reads |
-| `duplex` | Call duplex consensus reads |
-| `codec` | Call CODEC consensus |
-| `filter` | Filter consensus reads |
-| `clip` | Clip overlapping read pairs |
-| `duplex-metrics` | Collect duplex metrics |
-| `review` | Review consensus variants |
-| `downsample` | Downsample BAM by UMI family |
-| `simplex-metrics` | Collect simplex metrics |
-| `merge` | Merge sorted BAM files |
+> **Running more than one stage?** Use [`fgumi runall`](guide/running-pipelines.md) to fuse the whole pipeline into a single streaming command — no intermediate BAMs, identical output. Use the individual commands below for a single stage, to inspect an intermediate, or to collect per-stage metrics.
 
-See the [Tool Reference](tools/README.md) for detailed documentation of each command.
+The commands below are grouped by pipeline stage.
+
+| Stage | Command | Description |
+|-------|---------|-------------|
+| UMI extraction | `extract` | Extract UMIs from FASTQ and create an unmapped BAM |
+| UMI extraction | `correct` | Correct UMIs in a BAM to a fixed set of UMIs |
+| Alignment support | `fastq` | Convert BAM to interleaved FASTQ for an aligner |
+| Alignment support | `zipper` | Merge an aligned BAM with its unmapped BAM, restoring tags |
+| Alignment support | `sort` | Sort by coordinate, queryname, or template-coordinate |
+| Alignment support | `merge` | Merge pre-sorted BAM files into one sorted BAM |
+| Grouping & dedup | `group` | Group reads by UMI to identify reads from the same molecule |
+| Grouping & dedup | `dedup` | Mark or remove PCR duplicates using UMI information |
+| Consensus | `simplex` | Call single-strand consensus reads |
+| Consensus | `duplex` | Call duplex (double-strand) consensus reads |
+| Consensus | `codec` | Call CODEC duplex consensus reads |
+| Post-consensus | `filter` | Filter and mask consensus reads by quality |
+| Post-consensus | `clip` | Clip overlapping bases in read pairs |
+| QC metrics | `simplex-metrics` | Collect QC metrics for simplex data |
+| QC metrics | `duplex-metrics` | Collect QC metrics for duplex data |
+| QC metrics | `review` | Extract data to review consensus variant calls |
+| Utilities | `downsample` | Downsample a BAM by UMI family |
+| Utilities | `runall` | Fused multi-stage pipeline (extract → … → filter, no intermediate BAMs) |
+
+See the [Tool Reference](tools/README.md) for detailed documentation of each command, and [Running Pipelines](guide/running-pipelines.md) for `runall`.

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -182,16 +182,38 @@ h1, h2, h3, h4, h5, h6 {
     text-decoration: none;
 }
 
-/* Section header spans (no-link items like "Core Concepts"). These are not
-   navigable — they only expand/collapse — so use a dimmed version of the link
-   color rather than link-blue, which would read as clickable. The fold chevron
-   plus the lower emphasis signals "expandable group". */
+/* Section header spans (no-link draft chapters like "Core Concepts").
+   sidebar-brand.js makes the whole row fold its section on click, so render
+   the header as interactive (blue, pointer cursor) — blue now consistently
+   means "clickable" across both navigable links and foldable headers. */
 .sidebar .chapter-link-wrapper > span {
-    color: rgba(226, 232, 240, 0.55) !important;
+    color: var(--fg-blue) !important;
     font-size: 0.8rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+/* Top-level standalone pages (Home, Getting Started, Running Pipelines,
+   Methylation, the section Indexes, single-page metrics) are real links, not
+   draft-chapter spans, so they would otherwise pick up the light link color and
+   look out of place among the blue section headers. Color them blue to match
+   when not the current page; the active rule below keeps the current page white
+   with the green accent bar. Nested child pages keep the default link color. */
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active) {
+    color: var(--fg-blue) !important;
+}
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active):hover {
+    color: var(--fg-sky) !important;
+}
+
+/* mdBook 0.5 injects the *current* page's in-page headings into the left
+   sidebar as an always-expanded ".on-this-page" outline under the active entry.
+   That makes the active item (e.g. Home, or a guide page's "Workflow" steps)
+   the one thing in the sidebar that cannot be collapsed, clashing with the
+   uniform collapsible sections. Hide it; the page's headings remain visible in
+   the page body itself. */
+.sidebar .on-this-page {
+    display: none !important;
 }
 
 /* Active page — green left-bar accent */
@@ -204,9 +226,11 @@ h1, h2, h3, h4, h5, h6 {
 .sidebar a.active::before {
     content: '';
     position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
+    /* Sit in the left gutter rather than flush against the text, so there is a
+       clear gap between the accent bar and the active label. */
+    left: -0.6rem;
+    top: 0.1rem;
+    bottom: 0.1rem;
     width: 3px;
     background: var(--fg-green);
     border-radius: 0 2px 2px 0;

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -182,11 +182,16 @@ h1, h2, h3, h4, h5, h6 {
     text-decoration: none;
 }
 
-/* Section header spans (no-link items like "Core Concepts") */
+/* Section header spans (no-link items like "Core Concepts"). These are not
+   navigable — they only expand/collapse — so use a dimmed version of the link
+   color rather than link-blue, which would read as clickable. The fold chevron
+   plus the lower emphasis signals "expandable group". */
 .sidebar .chapter-link-wrapper > span {
-    color: var(--fg-blue) !important;
+    color: rgba(226, 232, 240, 0.55) !important;
     font-size: 0.8rem;
-    font-weight: 500;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
 }
 
 /* Active page — green left-bar accent */

--- a/docs/theme/sidebar-brand.js
+++ b/docs/theme/sidebar-brand.js
@@ -5,7 +5,7 @@
 (function () {
     // Selectively clear only sidebar visibility state (not theme preference).
     // Bumping this version resets fold/sidebar state for all returning visitors.
-    var SIDEBAR_VERSION = '3';
+    var SIDEBAR_VERSION = '4';
     if (localStorage.getItem('fg-sidebar-version') !== SIDEBAR_VERSION) {
         localStorage.removeItem('sidebar');
         localStorage.setItem('fg-sidebar-version', SIDEBAR_VERSION);
@@ -164,12 +164,39 @@
         }
     }
 
+    // ── Whole-row fold for draft-chapter section headers ──────────────────────
+    // Section headers (Core Concepts, Consensus Calling, ...) are mdBook "draft
+    // chapters": non-link <span>s that fold their children. mdBook only wires
+    // its fold handler to the small ❱ arrow (a.chapter-fold-toggle), so by
+    // default clicking the header *text* does nothing. Delegate clicks at the
+    // document level (the TOC is injected asynchronously by mdBook's toc.js, so
+    // a stable ancestor is the reliable place to listen) and forward a click on
+    // anywhere in a draft header row to that existing toggle — reusing mdBook's
+    // own fold logic and persistence rather than reimplementing it.
+    function enableDraftHeaderFold() {
+        document.addEventListener('click', function (e) {
+            // Clicks can land on a Text node (e.g. directly on header text), and
+            // closest() is an Element-only method — normalize to an element first
+            // so the handler never throws and silently skips the fold.
+            var target = e.target instanceof Element ? e.target : e.target.parentElement;
+            if (!target) return;
+            // Real anchors (child page links, the ❱ arrow itself, brand links)
+            // handle their own clicks — don't hijack or double-toggle them.
+            if (target.closest('a')) return;
+            var wrapper = target.closest('.chapter-link-wrapper');
+            if (!wrapper) return;
+            var toggle = wrapper.querySelector('a.chapter-fold-toggle');
+            if (toggle) toggle.click();
+        });
+    }
+
     // ── Init ──────────────────────────────────────────────────────────────────
     function init() {
         injectBrand();
         injectFooter();
         injectBreadcrumb();
         colorMenuTitle();
+        enableDraftHeaderFold();
     }
 
     if (document.readyState === 'loading') {

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -27,81 +27,6 @@ use log::info;
 use noodles::sam::alignment::record::data::field::Tag;
 use std::io::Write as IoWrite;
 
-/// Call CODEC consensus reads from template-coordinate sorted BAM
-///
-/// CODEC is a sequencing protocol where a single read-pair sequences both strands of the
-/// original duplex molecule. R1 sequences one strand, R2 sequences the opposite strand,
-/// enabling duplex consensus calling from individual read-pairs.
-///
-/// The algorithm:
-/// 1. Groups reads by molecule ID (MI tag)
-/// 2. For each molecule:
-///    - Clips read pairs where they extend past mate ends
-///    - Filters R1s and R2s for compatible alignments
-///    - Checks for sufficient overlap
-///    - Calls single-strand consensus from R1s and R2s separately
-///    - Combines into duplex consensus
-///    - Applies quality masking
-/// 3. Outputs unmapped consensus fragments (not paired-end)
-///
-/// ## Input Requirements
-///
-/// - BAM must be template-coordinate sorted (or queryname sorted)
-/// - Reads must be aligned (mapped)
-/// - Required tags:
-///   - `RX`: Raw UMI bases
-///   - `MI`: Molecule ID (from `group`)
-///   - `CB`: Cell barcode (optional, for single-cell data)
-///
-/// ## Grouping Strategy
-///
-/// Must use `adjacency` or `identity` grouping (NOT `paired`).
-/// MI tags should not have /A or /B suffixes.
-///
-/// ## Output
-///
-/// - Output BAM contains unmapped consensus fragments (not paired-end)
-/// - Each consensus represents a full duplex molecule
-/// - Includes rich per-base and per-read tags
-///
-/// Consensus reads have a number of additional optional tags set in the resulting BAM file.
-/// The tag names follow a pattern where the first letter (a, b or c) denotes that the tag
-/// applies to the first single strand consensus (a), second single-strand consensus (b) or
-/// the final duplex consensus (c). The second letter captures the meaning of the tag
-/// (e.g. d=depth, m=min depth, e=errors/error-rate) and is upper case for values that are
-/// one per read and lower case for values that are one per base.
-///
-/// The tags break down into those that are single-valued per read:
-///
-///   consensus depth      \[aD,bD,cD\] (int)  : the maximum depth of raw reads
-///   consensus min depth  \[aM,bM,cM\] (int)  : the minimum depth of raw reads
-///   consensus error rate \[aE,bE,cE\] (float): the fraction of bases disagreeing with consensus
-///
-/// And those that have a value per base:
-///
-///   consensus depth  \[ad,bd\] (short[]): the count of bases contributing to consensus
-///   consensus errors \[ae,be\] (short[]): the count of disagreeing bases
-///   consensus bases  \[ac,bc\] (string) : the single-strand consensus bases
-///   consensus quals  \[aq,bq\] (string) : the single-strand consensus qualities
-///
-/// ## Examples
-///
-/// Basic usage:
-/// ```bash
-/// fgumi codec -i grouped.bam -o codec_consensus.bam
-/// ```
-///
-/// With quality thresholds and statistics:
-/// ```bash
-/// fgumi codec \
-///   -i grouped.bam \
-///   -o codec_consensus.bam \
-///   -r rejects.bam \
-///   -s stats.txt \
-///   -m 15 \
-///   -M 3 \
-///   -d 10
-/// ```
 /// Codec-specific tuning, flattened into both the standalone `Codec`
 /// command (as bare `--min-duplex-length`, `--outer-bases-qual`, …) and
 /// the `RunAll` command (as `--codec::min-duplex-length`, etc. via the
@@ -126,7 +51,7 @@ pub struct CodecOptions {
     #[arg(short = 'm', long = "min-input-base-quality", default_value = "10")]
     pub min_input_base_quality: u8,
 
-    /// Produce per-base tags (cd, ce) in addition to per-read tags
+    /// Produce per-base tags (ad/bd, ae/be, ac/bc, aq/bq) in addition to per-read tags
     #[arg(short = 'B', long = "output-per-base-tags", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = super::common::parse_bool)]
     pub output_per_base_tags: bool,
 
@@ -293,27 +218,57 @@ impl CodecOptions {
 #[command(
     name = "codec",
     about = "\x1b[38;5;180m[CONSENSUS]\x1b[0m      \x1b[36mCall CODEC consensus reads from grouped BAM\x1b[0m",
-    long_about = "\
-Calls CODEC duplex consensus reads from a grouped, MI-tagged BAM.
+    long_about = r#"
+Calls duplex consensus reads from CODEC sequencing data.
 
-CODEC libraries read both strands of a duplex molecule within a single read pair \
-(R1 covers one strand, R2 the other), so the two strands are paired by position \
-within each MI group rather than by the `/A` `/B` strand suffix used by the \
-standard duplex caller. The two single-strand consensuses are then reconciled \
-into one duplex consensus per molecule.
+CODEC (Bae et al. 2023) is a protocol in which a single read pair sequences both strands of the
+original duplex molecule: R1 comes from one strand and R2 from the opposite strand, so even a
+single read pair can yield a duplex consensus. Prior to running this tool, group reads with
+`group` using the `adjacency` (or `identity`/`edit`) strategy — NOT `paired`; MI tags must not
+carry `/A` or `/B` suffixes (CODEC pairs the two strands by position within each MI group).
+
+For each molecule the tool clips read pairs that extend past their mate, filters R1s and R2s for
+compatible alignments, requires sufficient duplex overlap, calls a single-strand consensus from
+the R1s and from the R2s separately, then combines the two into a duplex consensus and applies
+quality masking. The consensus reads produced are unmapped single fragments (not paired-end) and
+should be aligned afterwards.
+
+Input must be template-coordinate sorted (or queryname sorted) and carry `RX` (raw UMI) and `MI`
+(molecule ID, from `group`) tags; `CB` (cell barcode) is used when present.
+
+Methylation-aware consensus calling (`--methylation-mode`) is not supported for CODEC; use
+`simplex` or `duplex` for EM-seq / TAPs workflows.
 
 Quality-reduction and duplex-disagreement knobs:
 
-* `--single-strand-qual` caps the reported quality of bases supported by only one \
-  strand (single-strand regions), since those bases lack duplex confirmation.
-* `--outer-bases-qual` / `--outer-bases-length` cap the quality of the outermost \
-  N bases of each read, which are more error-prone (adapter/ligation artifacts).
-* `--min-duplex-length` sets the minimum overlap (in bases) required for a region \
-  to be called as duplex.
-* `--max-duplex-disagreements` / `--max-duplex-disagreement-rate` bound how much \
-  the two strands may disagree before the molecule is rejected.
+* `--single-strand-qual` caps the reported quality of bases supported by only one strand
+  (single-strand regions), since those bases lack duplex confirmation.
+* `--outer-bases-qual` / `--outer-bases-length` cap the quality of the outermost N bases of each
+  read, which are more error-prone (adapter/ligation artifacts).
+* `--min-duplex-length` sets the minimum overlap (in bases) required for a region to be called as
+  duplex.
+* `--max-duplex-disagreements` / `--max-duplex-disagreement-rate` bound how much the two strands
+  may disagree before the molecule is rejected.
 
-Reads that fail these thresholds can be captured with `--rejects`."
+Reads that fail these thresholds can be captured with `--rejects`.
+
+Consensus reads carry optional per-read and per-base tags. The first letter (a, b, c) marks the
+first single-strand consensus (a), the second single-strand consensus (b), or the final duplex
+consensus (c); the second letter is the quantity, upper case for per-read values and lower case
+for per-base values:
+
+  consensus depth      [aD,bD,cD] (int)  : maximum depth of raw reads
+  consensus min depth  [aM,bM,cM] (int)  : minimum depth of raw reads
+  consensus error rate [aE,bE,cE] (float): fraction of raw bases disagreeing with the consensus
+  consensus depth      [ad,bd] (short[]) : per-base count of contributing reads
+  consensus errors     [ae,be] (short[]) : per-base count of disagreeing reads
+  consensus bases      [ac,bc] (string)  : single-strand consensus bases
+  consensus quals      [aq,bq] (string)  : single-strand consensus qualities
+
+Example:
+
+  fgumi codec -i grouped.bam -o codec_consensus.bam --min-reads 1
+"#
 )]
 pub struct Codec {
     /// Input/output BAM options

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -838,8 +838,8 @@ different cells are never grouped together, even if they share a UMI sequence an
 The cell barcode is read from the standard `CB` tag. No correction or
 error-handling is performed on cell barcodes; they must be corrected upstream.
 
-Multi-threaded operation is supported via --threads N, which spawns N pipeline threads
-allocated based on the command's workload profile to optimize performance.
+Pass --threads N to run the pipeline on N threads, split across reading, the UMI-assignment
+workers, and writing.
 
 Example: --threads 8 spawns 8 pipeline threads (2 reader, 4 workers, 2 writer)
 

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -97,9 +97,9 @@ impl std::fmt::Display for RunAllMode {
 }
 
 /// Pipeline stage marker for the `--start-from` / `--stop-after`
-/// runall stage flags. Stages are linearly ordered for the sort and
-/// group phases, with three parallel terminal consensus modes
-/// (`Simplex`, `Duplex`, `Codec`).
+/// runall stage flags. Stages are linearly ordered:
+/// `Extract < Correct < AlignAndMerge < Zipper < Sort < Group <
+/// Consensus < Filter` (see [`RunAllStage::ord`]).
 ///
 /// **Stage semantics — "the input is positioned AT this stage's
 /// entry":**
@@ -112,22 +112,20 @@ impl std::fmt::Display for RunAllMode {
 ///   `fgumi sort`). `--start-from group` skips the sort step.
 ///   `--stop-after group` writes the grouped BAM (output of
 ///   `fgumi group`) and stops.
-/// * `Simplex` / `Duplex` / `Codec` — BAM is sorted and grouped
-///   (MI tags assigned). `--start-from <consensus>` skips sort
-///   and group. `--stop-after <consensus>` runs the corresponding
-///   consensus caller and writes the consensus BAM (output of
-///   `fgumi simplex`/`duplex`/`codec`).
+/// * `Consensus` — BAM is sorted and grouped (MI tags assigned,
+///   output of `fgumi group`). `--start-from consensus` skips sort
+///   and group. `--stop-after consensus` runs the consensus caller
+///   chosen by `--consensus {simplex,duplex,codec}` and writes the
+///   consensus BAM (output of `fgumi simplex`/`duplex`/`codec`). The
+///   algorithm is selected by `--consensus`, not by a stage variant.
 ///
-/// **Linear order**: `AlignAndMerge < Zipper < Sort < Group <
-/// {Simplex, Duplex, Codec}`. The three consensus stages are terminal
-/// and mutually exclusive — `--stop-after` may name at most one
-/// consensus stage per run.
+/// `AlignAndMerge` is a valid `--start-from` but not a valid
+/// `--stop-after` (see [`StopAfter`]): raw aligner output before the
+/// zipper-merge has lost every original tag.
 ///
 /// **Case-insensitive parsing**: `sort`, `Sort`, `SORT` all match
-/// when the CLI argument uses `#[arg(value_enum, ignore_case = true)]`.
-/// (clap 4's default is case-SENSITIVE; the `ignore_case = true`
-/// attribute opts in to case-insensitive matching. Task 2 wires this
-/// up on the `--start-from` / `--stop-after` flags.)
+/// because the `--start-from` / `--stop-after` flags use
+/// `#[arg(value_enum, ignore_case = true)]`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
 #[clap(rename_all = "kebab-case")]
 pub enum RunAllStage {
@@ -335,38 +333,43 @@ impl std::fmt::Display for RunAllStage {
     name = "runall",
     about = "\x1b[38;5;166m[UTILITIES]\x1b[0m      \x1b[36mFused multi-stage pipeline (correct + align + zipper + sort + group + consensus, no intermediate BAM)\x1b[0m",
     long_about = "\
-Fuses UMI correction, alignment+merge, sort, group, and consensus calling into a \
-single in-memory pipeline, selected by `--start-from` and `--stop-after` (both \
-required).
+Fuses extract, UMI correction, alignment + zipper-merge, sort, group, and \
+consensus calling (optionally followed by filter) into a single in-memory \
+pipeline. Select the slice to run with `--start-from` and `--stop-after` (both \
+required); the stages run in the fixed order extract < correct < align < zipper \
+< sort < group < consensus < filter. Records flow directly between stages in \
+memory, so every intermediate BAM a sequential run would write is elided, and \
+the output is byte-for-byte identical to running the equivalent standalone \
+commands in turn.
 
-* `--start-from correct` accepts an extracted unmapped BAM and runs UMI \
-  correction against a fixed whitelist (`--correct::umi-files` / \
-  `--correct::umis`). Currently only supports `--stop-after correct` (writes the \
-  corrected unmapped BAM); cross-stage chaining to align is a follow-up.
-* `--start-from align` accepts an unmapped BAM with UMI tags and a reference \
-  FASTA; spawns the aligner subprocess (bwa-mem3 / bwa / user-supplied command \
-  via `--aligner::*`), zipper-merges the result, then chains downstream.
-* `--start-from zipper` accepts a queryname-sorted mapped BAM (`--input`) plus \
-  the matching unmapped BAM (`--unmapped`) and the reference FASTA (`--ref`); \
-  runs the zipper merge, then chains downstream.
-* `--start-from sort` accepts raw unsorted aligned BAM and runs the in-pipeline \
-  sort step before group + consensus.
-* `--start-from group` accepts a BAM already sorted by template-coordinate \
-  (output of `fgumi sort`) and skips the sort step.
-* `--start-from consensus` accepts a grouped (MI-tagged) BAM and runs only \
-  the consensus caller chosen by `--consensus {simplex,duplex,codec}`.
+`--start-from` declares the state of the input and selects the upstream work:
 
-`--stop-after consensus` runs the consensus caller chosen by `--consensus \
-{simplex,duplex,codec}`; output is the same consensus BAM that `fgumi \
-{simplex,duplex,codec}` produces. `--stop-after filter` additionally fuses a \
-post-consensus `fgumi filter` pass into the same pipeline (tunable via \
-`--filter::*`); the consensus output is decoded in memory and streamed \
-straight into filter, so no intermediate consensus BAM is written. Every \
-intermediate BAM that a multi-stage sequential run would write is elided — \
-records flow directly between stages in memory.
+* `extract` reads FASTQ via `--extract::inputs` / `--extract::read-structures` \
+  (no `--input`).
+* `correct` reads an unmapped BAM via `--input` and corrects UMIs against \
+  `--correct::umis` / `--correct::umi-files`.
+* `align` reads an unmapped BAM via `--input`, runs the aligner subprocess \
+  (`--aligner::preset` or `--aligner::command`) against `--ref`, and \
+  zipper-merges the result.
+* `zipper` reads a queryname-sorted mapped BAM via `--input` plus the matching \
+  unmapped BAM via `--unmapped` and the reference (`--ref` + `.dict`).
+* `sort` reads a raw unsorted aligned BAM via `--input`.
+* `group` reads a template-coordinate-sorted BAM via `--input`.
+* `consensus` reads a grouped (MI-tagged) BAM via `--input`.
+* `filter` reads a consensus BAM via `--input`.
 
-This command always uses the new typed-step pipeline framework; there is \
-no legacy fallback."
+The consensus algorithm is chosen by `--consensus {simplex,duplex,codec}`, not \
+by a stage name; `--stop-after consensus` produces the same BAM as the matching \
+`fgumi {simplex,duplex,codec}` command. `--stop-after filter` fuses a \
+post-consensus `fgumi filter` pass (tunable via `--filter::*`) into the same \
+pipeline, so no intermediate consensus BAM is written. Tune any stage with its \
+prefixed flags: `--sort::max-memory`, `--group::strategy`, `--duplex::min-reads`, \
+and so on.
+
+`--stop-after align` is not allowed: raw aligner output before the zipper-merge \
+has lost every original tag, so the earliest stop after `--start-from align` is \
+`zipper`. The validator checks the requested stage range but cannot verify that \
+the on-disk input actually matches `--start-from` — make sure it does."
 )]
 #[allow(clippy::struct_excessive_bools)]
 pub struct RunAll {
@@ -539,65 +542,39 @@ pub struct RunAll {
     pub duplex_opts: crate::commands::duplex::MultiDuplexOptions,
 
     // ───────── pipeline stage control (#33) ─────────
-    /// Pipeline stage to START FROM. Required.
+    /// Pipeline stage to start from: extract, correct, align, zipper, sort, group, consensus, or filter (required, case-insensitive).
     ///
-    /// Declares the state of the input BAM and selects which work
-    /// runall does upstream of the terminal `--stop-after` stage:
+    /// Declares the state of the input and selects the upstream work
+    /// runall performs before the terminal `--stop-after` stage. See the
+    /// command description for what each start stage reads (FASTQ for
+    /// `extract`; `--input` plus, for `zipper`, `--unmapped`; a
+    /// template-coordinate-sorted BAM for `group`; a grouped MI-tagged
+    /// BAM for `consensus`; and so on).
     ///
-    /// * `sort` — input is raw unsorted BAM; the chain includes
-    ///   the in-pipeline sort step before group + consensus.
-    /// * `group` — input is sorted by template-coordinate (output
-    ///   of `fgumi sort`); the chain skips sort and runs
-    ///   group + consensus.
-    /// * `simplex` / `duplex` / `codec` — input is sorted and
-    ///   grouped (MI-tagged, output of `fgumi group`); the chain
-    ///   runs through the named consensus caller. Mutually exclusive
-    ///   with each other and terminal (`--stop-after` must equal
-    ///   `--start-from`).
+    /// **Input-state hazard:** the validator checks that
+    /// `start_from.ord() <= stop_after.ord()` but cannot verify that the
+    /// on-disk input actually matches the declared stage. Passing, say, a
+    /// raw-unsorted BAM to `--start-from group` will not raise a clear
+    /// error; the chain runs on whatever it finds. Make sure the input
+    /// matches the declared start stage.
     ///
-    /// **Executor honesty note (task 5 of #33):** The consensus-start
-    /// row (`--start-from consensus` with `--consensus {simplex,duplex,codec}`)
-    /// accepts input that is already MI-tagged but the executor does not yet specialize
-    /// — it runs the same chain as `--start-from group`
-    /// (`GroupByPosition` + `ProcessGroups` + `MiAssign` + consensus). On
-    /// a properly pre-grouped input the output is byte-identical to
-    /// the standalone consensus command (`fgumi simplex` /
-    /// `fgumi duplex` / `fgumi codec`) because the grouping
-    /// algorithm is deterministic; a true consensus-only optimized
-    /// branch is queued as follow-up work and gated by the parity
-    /// tests.
-    ///
-    /// **Input-state hazard:** the validator cannot check whether
-    /// the on-disk BAM actually matches the declared `start_from`.
-    /// Passing a raw-unsorted BAM to `--start-from simplex`, or a
-    /// sorted-but-not-grouped BAM to `--start-from simplex`, will
-    /// not produce a clear error today; the chain will run on
-    /// whatever it finds. Make sure the input matches the declared
-    /// start stage.
-    ///
-    /// Case-insensitive. Must satisfy `start_from.ord() <=
-    /// stop_after.ord()` and the consensus-terminal rules
-    /// (see [`RunAllStage::validate_with`]).
+    /// Must satisfy `start_from.ord() <= stop_after.ord()` (see
+    /// [`RunAllStage::validate_with`]).
     #[arg(long = "start-from", value_enum, ignore_case = true)]
     pub start_from: RunAllStage,
 
-    /// Pipeline stage to STOP AFTER. Required.
+    /// Pipeline stage to stop after: extract, correct, zipper, sort, group, consensus, or filter (required, case-insensitive).
     ///
-    /// Determines the terminal stage of the chain:
+    /// Determines the terminal stage of the chain. `--stop-after
+    /// consensus` writes the consensus BAM produced by the caller chosen
+    /// with `--consensus`; `--stop-after filter` fuses a post-consensus
+    /// filter pass into the same pipeline.
     ///
-    /// * `sort` — write the sorted BAM and stop (equivalent to
-    ///   `fgumi sort` output).
-    /// * `group` — write the grouped BAM (with MI tags) and stop
-    ///   (equivalent to `fgumi group` output).
-    /// * `simplex` / `duplex` / `codec` — run the named consensus
-    ///   caller and write the consensus BAM (equivalent to
-    ///   `fgumi simplex` / `duplex` / `codec` output).
-    ///
-    /// Case-insensitive. Must satisfy `start_from.ord() <=
-    /// stop_after.ord()` and the consensus-terminal rules
-    /// (`RunAllStage::validate_with`). `align` is intentionally absent
-    /// (see [`StopAfter`]); use [`RunAll::stop_after_stage`] to read this
-    /// as a [`RunAllStage`].
+    /// `align` is intentionally not a valid stop: raw aligner output
+    /// before the zipper-merge has lost every original tag, so the
+    /// earliest stop after `--start-from align` is `zipper`. Must satisfy
+    /// `start_from.ord() <= stop_after.ord()` (`RunAllStage::validate_with`);
+    /// use [`RunAll::stop_after_stage`] to read this as a [`RunAllStage`].
     #[arg(long = "stop-after", value_enum, ignore_case = true)]
     pub stop_after: StopAfter,
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -207,8 +207,9 @@ source molecule. The likelihood model is as follows:
    preparation, through preparing the library for sequencing (e.g. amplification, target selection), and finally,
    through sequencing.
 
-This tool assumes that reads with the same tag are grouped together (consecutive in the file). Also, this tool
-calls each end of a pair independently, and does not jointly call bases that overlap within a pair. Insertion or
+This tool assumes that reads with the same tag are grouped together (consecutive in the file). By default it
+jointly consensus-calls the bases that overlap within a read pair before UMI consensus calling; pass
+`--consensus-call-overlapping-bases false` to call each end of the pair independently instead. Insertion or
 deletion errors in the reads are not considered in the consensus model.
 
 The consensus reads produced are unaligned, due to the difficulty and error-prone nature of inferring the consensus

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -927,7 +927,7 @@ impl Command for Zipper {
     }
 }
 
-/// Typed-step pipeline merger for the `--use-new-pipeline` path.
+/// Typed-step pipeline merger for the zipper merge stage.
 ///
 /// Implements [`Step2`] over two `BamTemplateBatch` streams (unmapped
 /// `InputA` and mapped `InputB`) and emits merged


### PR DESCRIPTION
## Summary

This overhauls the fgumi documentation and closes the headline gap on this branch: `fgumi runall` — the fused multi-stage pipeline — was undocumented in the hand-written guide. The PR documents it end to end, threads a single positioning rule through the book, fixes a number of accuracy bugs, and brings the whole mdBook to a consistent, high-quality bar.

**The guiding rule, used consistently across every page:** run a single stage with its own command (`fgumi sort`, `fgumi group`, …); chain two or more stages with `fgumi runall` — same bytes out, no intermediate BAMs.

## What's new

- **Running Pipelines** (`docs/src/guide/running-pipelines.md`) — the runall reference the book was missing: the stage model and ordering, the `--start-from` / `--stop-after` / `--consensus` surface, the per-stage `--<stage>::<flag>` scheme, worked examples drawn from the integration tests, a runall-vs-individual-commands decision, and the fused-chain caveats (no per-stage metrics, no `--stop-after align`, input state not validated, `--consensus duplex` requires `--group::strategy paired`, etc.).
- **Glossary** and **Troubleshooting** pages, wired into the generated `SUMMARY` under a new Reference group.

## Accuracy fixes worth calling out

- `best-practices.md` claimed "thread allocation is automatically optimized per-command" — false; commands are single-threaded unless `--threads N` is passed.
- `index.md` and `README.md` described `zipper` as "Restore original FASTQ from unaligned BAM," which is not what zipper does.
- `getting-started.md` had a command block duplicated verbatim where a cell-barcode variant was intended.
- `simplex` command help claimed overlapping pair bases are never jointly called, contradicting `--consensus-call-overlapping-bases` (default true).
- `codec` had no command-level help at all (`long_about = None`); its description had been mis-attached to the options struct.
- README's "targeting June 1, 2026 for production" date was stale; the `.github/PULL_REQUEST_TEMPLATE.md` told contributors to "click the link below" with no link present.

## Tool Reference is generated — edits landed in the right place

The mdBook's Tool Reference (`docs/src/tools/`), Metrics Reference (`docs/src/metrics/`), and `SUMMARY.md` are generated by `cargo run -p xtask -- generate-docs` and are gitignored. Improvements to tool pages therefore live in the clap `about` / `long_about` / `#[arg(help=…)]` strings (the `docs(rust)` commit), and the new guide pages required wiring in `generate_summary.rs`.

## Other changes

- Copy-edit and cross-link every guide page; add consistent "See Also" navigation throughout.
- Refresh `README.md`, `CONTRIBUTING.md` (Rust version, `cargo ci-*` aliases, Conventional Commits, branch naming), `docs/DEVELOPING.md` (compare/simulate feature docs, pre-commit hooks), and the `fgumi-sort` / `fgumi-bam-io` crate READMEs.
- Tighten the standalone `compare-cli.md` / `simulate-cli.md` developer docs and self-contain one design-doc reference.

## Suggested reading order

1. `docs(rust): tighten command help…` — the clap strings the Tool Reference is built from.
2. `docs(book): document fgumi runall and overhaul the user guide` — the core change; start with `running-pipelines.md`, then `getting-started.md` and `best-practices.md`.
3. `docs: refresh README…` and `docs: tighten standalone CLI docs…` — the surrounding non-book docs.

## Verification

- `cargo run -p xtask -- generate-docs --features consensus,compare,simulate` + `mdbook build docs` — builds clean, no warnings; all SUMMARY links and intra-page anchors resolve.
- `cargo ci-fmt`, `cargo ci-lint`, and `cargo ci-test` (2137 tests) all pass.
- Documentation quality was assessed by independent review passes and iterated to an A+ bar (consistent voice and navigation, runall integrated throughout, accuracy verified against the CLI surface).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new guide pages: **Running Pipelines (runall)**, **Troubleshooting**, **Glossary**, and **Migration from fgbio**.
  * Expanded and clarified **Getting Started**, **Best Practices**, **Consensus/Duplex/Codec** guidance, **Methylation**, **Performance Tuning**, and multiple workflow/parameter explanations.
  * Updated README and crate READMEs, including tool descriptions, `fgumi runall` guidance, and revised research/production disclaimer wording.
* **Documentation Site / UX**
  * Improved sidebar folding and navigation styling/behavior.
  * Refreshed generated book sidebar structure for better link organization.
* **Chores**
  * Updated contribution and testing/pre-commit guidance plus docs build settings; refreshed CLI help text wording for runall/codec/simplex/group/zipper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->