### PR TITLE
feat(pipeline-core): occupancy instrumentation + detached/unified-driver runtime

### DIFF
--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -37,6 +37,50 @@ impl std::fmt::Display for BuildError {
 
 impl std::error::Error for BuildError {}
 
+/// How much pipeline instrumentation to collect. Off by default (zero overhead:
+/// queues stay non-instrumented and no sampler thread spawns). Each higher level
+/// is a superset of the one below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InstrumentationLevel {
+    /// No edge instrumentation. The pool hot path takes its existing zero-cost
+    /// route; this is the production default.
+    #[default]
+    Off,
+    /// Per-edge throughput/occupancy/latency counters + the occupancy sampler +
+    /// the end-of-run edge table and bottleneck verdict.
+    Summary,
+    /// `Summary` plus a per-tick occupancy/throughput timeline TSV.
+    Timeline,
+    /// `Timeline` plus direct dwell/park-time latency (Detached edges).
+    Deep,
+}
+
+impl InstrumentationLevel {
+    /// `true` for any level above `Off` (edge metrics are collected).
+    #[must_use]
+    pub fn is_on(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// `true` if the background occupancy sampler should run.
+    #[must_use]
+    pub fn samples(self) -> bool {
+        self.is_on()
+    }
+
+    /// `true` if the per-tick timeline TSV should be written.
+    #[must_use]
+    pub fn timeline(self) -> bool {
+        matches!(self, Self::Timeline | Self::Deep)
+    }
+
+    /// `true` if direct dwell/park-time latency should be recorded.
+    #[must_use]
+    pub fn deep(self) -> bool {
+        matches!(self, Self::Deep)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
     pub threads: usize,
@@ -70,6 +114,21 @@ pub struct PipelineConfig {
     /// Floor of 1 MiB per queue is enforced regardless of the
     /// rebalancer's decisions to prevent pathological starvation.
     pub queue_memory_total: Option<u64>,
+    /// How much per-edge instrumentation to collect (default `Off` = zero
+    /// overhead). Threaded into queue construction (instrumented transports) and
+    /// the occupancy sampler. See [`InstrumentationLevel`].
+    pub instrumentation: InstrumentationLevel,
+    /// Where to write the per-tick timeline TSV when
+    /// `instrumentation.timeline()`. `None` → a default `pipeline-trace.tsv`.
+    pub trace_path: Option<std::path::PathBuf>,
+    /// Per-worker dispatch-order policy. The default
+    /// [`ChainOrderScheduler`](crate::runtime::ChainOrderScheduler) walks live
+    /// steps upstream-first (historical behaviour). A chain may opt into
+    /// [`DrainFirstScheduler`](crate::runtime::DrainFirstScheduler) to walk
+    /// downstream-first (drain buffered work before producing more) — e.g. the
+    /// sort chain, to overlap its serial boundary/key scan with the parallel
+    /// inflate instead of starving it behind inflate on the shared pool.
+    pub scheduler: Arc<dyn super::runtime::Scheduler>,
 }
 
 impl Default for PipelineConfig {
@@ -79,6 +138,9 @@ impl Default for PipelineConfig {
             stats: None,
             deadlock_timeout_secs: 0,
             queue_memory_total: None,
+            instrumentation: InstrumentationLevel::Off,
+            trace_path: None,
+            scheduler: Arc::new(super::runtime::ChainOrderScheduler),
         }
     }
 }
@@ -100,12 +162,30 @@ impl PipelineConfig {
         self
     }
 
+    /// Builder-style helper to set the per-worker dispatch-order policy.
+    /// Defaults to [`ChainOrderScheduler`](crate::runtime::ChainOrderScheduler)
+    /// (upstream-first); pass
+    /// [`DrainFirstScheduler`](crate::runtime::DrainFirstScheduler) to walk
+    /// downstream-first.
+    #[must_use]
+    pub fn with_scheduler(mut self, scheduler: Arc<dyn super::runtime::Scheduler>) -> Self {
+        self.scheduler = scheduler;
+        self
+    }
+
     /// Builder-style helper to set the total queue-memory budget.
     /// `None` keeps per-step `ByteBounded` limits at their static
     /// values; `Some(total)` enables the rebalancer.
     #[must_use]
     pub fn with_queue_memory_total(mut self, total: Option<u64>) -> Self {
         self.queue_memory_total = total;
+        self
+    }
+
+    /// Builder-style helper to set the instrumentation level (default `Off`).
+    #[must_use]
+    pub fn with_instrumentation(mut self, level: InstrumentationLevel) -> Self {
+        self.instrumentation = level;
         self
     }
 }
@@ -757,16 +837,18 @@ impl Pipeline {
 
         use super::runtime::{
             StepDrainCounter, WorkerCore, assign_exclusive_owners, assign_sticky_owners,
-            build_chain_contexts, build_worker_storage, is_fusible_chain, run_fused_single_thread,
-            run_worker_loop,
+            build_chain_contexts, build_worker_storage, extract_detached_steps,
+            run_detached_driver, run_fused_single_thread, run_worker_loop,
+            should_fuse_single_thread,
         };
-        use super::step::StepKind;
+        use super::step::{DetachedGroup, StepKind};
         use super::topology::StepIdx;
 
-        let Self { steps, graph, signal } = self;
+        let Self { mut steps, graph, signal } = self;
         let n_threads = config.threads;
         let stats_arc = config.stats;
         let deadlock_timeout_secs = config.deadlock_timeout_secs;
+        let scheduler = Arc::clone(&config.scheduler);
         assert!(n_threads > 0, "PipelineConfig::threads must be > 0");
         if let Some(stats) = stats_arc.as_ref() {
             assert_eq!(
@@ -795,7 +877,9 @@ impl Pipeline {
         // `--threads ≥ 2` fall through to the scheduled worker pool below. The
         // deadlock monitor / queue rebalancer are not spawned: a single-worker
         // inline drive cannot deadlock and has no bounded queues to rebalance.
-        if n_threads == 1 && is_fusible_chain(&steps, &graph) {
+        // Instrumentation forces the scheduled path (see `should_fuse_single_thread`):
+        // the fused path has no per-edge metrics / occupancy sampler / verdict.
+        if should_fuse_single_thread(n_threads, config.instrumentation, &steps, &graph) {
             log::debug!(
                 "Using fused single-thread pipeline ({} steps, direct buffers)",
                 steps.len()
@@ -821,14 +905,14 @@ impl Pipeline {
         let sticky_owners = assign_sticky_owners(&steps, &owners, n_threads);
 
         // 2. Build per-step contexts (input + output handles).
-        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let contexts = Arc::new(build_chain_contexts(&steps, &graph, config.instrumentation));
 
         // 2-pre-monitor invariant: if the deadlock monitor will be armed, every
         // output transport must be ByteBounded so `in_flight_bytes` can see a
         // wedge on it. A CountBounded/Unbounded edge is invisible to the probe
-        // and would silently disable fail-fast on that edge. Checked here (in
-        // every build, release included — the blind spot only matters in a real
-        // fail-fast run) while `steps` is still alive — it is consumed by
+        // and would silently disable fail-fast on that edge. Checked here in
+        // every build (not debug-only — it returns a real `PipelineError`) while
+        // `steps` is still alive, before it is consumed by
         // `build_worker_storage` below. Test chains use CountBounded/Unbounded
         // but do not arm the monitor, so this only fires for a fail-fast run.
         if deadlock_timeout_secs > 0 && stats_arc.is_some() {
@@ -852,11 +936,23 @@ impl Pipeline {
             .map(|step| {
                 let initial = match step.profile().kind {
                     StepKind::Parallel => n_threads,
-                    StepKind::Serial | StepKind::Exclusive => 1,
+                    // `Detached` runs on a single dedicated thread, so (like
+                    // `Serial`/`Exclusive`) exactly one finisher closes its
+                    // output edge.
+                    StepKind::Serial | StepKind::Exclusive | StepKind::Detached => 1,
                 };
                 StepDrainCounter::new(initial)
             })
             .collect();
+
+        // 3a. Extract `Detached` steps' real instances for their dedicated
+        // threads, leaving same-position placeholders so `build_worker_storage`
+        // (which Skips Detached on every worker) and the `step_idx`-aligned
+        // `ChainContexts` stay correct. The contexts were already built from
+        // `&steps` above, so each extracted step's input/output handles live in
+        // `contexts[step_idx]`. Done before `build_worker_storage` consumes
+        // `steps`. Empty for every non-sort chain (nothing declares Detached).
+        let detached_steps = extract_detached_steps(&mut steps);
 
         // 4. Build per-worker step storage (consumes `steps`).
         let mut worker_entries = build_worker_storage(steps, &owners, n_threads);
@@ -927,6 +1023,95 @@ impl Pipeline {
                 (None, None)
             };
 
+        // 4c. Optional occupancy sampler (`--pipeline-trace`). Polls each
+        // byte-bounded edge's depth into its `EdgeMetrics` histogram on a fixed
+        // cadence. Runs whenever instrumentation samples AND there are edges to
+        // sample (`contexts.edges` is empty at level `Off` and on the fused
+        // single-thread fast path, so this stays inert there). Read-only over
+        // the live queues — never perturbs the worker hot path.
+        let (sampler_stop, sampler_handle) =
+            if config.instrumentation.samples() && !contexts.edges.is_empty() {
+                let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let stop_clone = Arc::clone(&stop);
+                let contexts_clone = Arc::clone(&contexts);
+                // Timeline TSV path only when the level requests it.
+                let trace_path = if config.instrumentation.timeline() {
+                    Some(
+                        config
+                            .trace_path
+                            .clone()
+                            .unwrap_or_else(|| std::path::PathBuf::from("pipeline-trace.tsv")),
+                    )
+                } else {
+                    None
+                };
+                let handle = thread::Builder::new()
+                    .name("fgumi-occupancy-sampler".to_string())
+                    .spawn(move || {
+                        crate::runtime::sampler::run_occupancy_sampler(
+                            &stop_clone,
+                            &contexts_clone.edges,
+                            crate::runtime::sampler::DEFAULT_SAMPLE_INTERVAL,
+                            trace_path,
+                        );
+                    })
+                    .expect("failed to spawn occupancy sampler thread");
+                (Some(stop), Some(handle))
+            } else {
+                (None, None)
+            };
+
+        // 4d. Spawn one dedicated OS thread per `Detached` driver GROUP, in chain
+        // order, BEFORE the workers — same lifecycle slot as the monitor /
+        // rebalancer / sampler. Each thread drives its group with the SAME
+        // `run_worker_loop` the pool uses (via `run_detached_driver`), off the
+        // work-stealing pool, so a Detached step never consumes a pool worker
+        // slot (the "N + 2" threading). A group with one step is the legacy
+        // one-thread-per-detached-step case (`DetachedGroup::PerStep`); a
+        // `Shared` group co-locates several steps on one driver thread. Joined
+        // after the workers (step 6d). Empty for every non-sort chain, so this
+        // is a no-op there.
+        let detached_handles: Vec<thread::JoinHandle<()>> = detached_steps
+            .into_iter()
+            .map(|group| {
+                let contexts_clone = Arc::clone(&contexts);
+                let signal_clone = Arc::clone(&signal_arc);
+                let drain_counters_clone: Vec<Arc<StepDrainCounter>> =
+                    drain_counters.iter().map(Arc::clone).collect();
+                let stats_clone = stats_arc.as_ref().map(Arc::clone);
+                let thread_name = match group.label() {
+                    DetachedGroup::Shared(label) => format!("fgumi-driver-{label}"),
+                    DetachedGroup::PerStep => {
+                        format!("fgumi-detached-{}", group.primary_name())
+                    }
+                };
+                thread::Builder::new()
+                    .name(thread_name)
+                    .spawn(move || {
+                        // Catch a driver-thread panic so we can signal
+                        // cancellation before unwinding — a wedged pool worker
+                        // parked on this group's (now-dead) edge only exits on
+                        // `is_done()`. Re-raise after signalling so the join in
+                        // step 6d still collects the payload.
+                        if let Err(panic) =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                run_detached_driver(
+                                    group,
+                                    &contexts_clone,
+                                    &drain_counters_clone,
+                                    &signal_clone,
+                                    stats_clone.as_ref(),
+                                );
+                            }))
+                        {
+                            signal_clone.cancel();
+                            std::panic::resume_unwind(panic);
+                        }
+                    })
+                    .expect("failed to spawn detached driver thread")
+            })
+            .collect();
+
         // Holds the first worker panic payload; re-raised after helper threads
         // are cleaned up so monitor/rebalancer shutdown always executes.
         let mut worker_panic: Option<Box<dyn std::any::Any + Send>> = None;
@@ -972,6 +1157,7 @@ impl Pipeline {
                     &drain_counters,
                     &signal_arc,
                     stats_arc.as_ref(),
+                    scheduler.as_ref(),
                 );
             })) {
                 signal_arc.cancel();
@@ -991,6 +1177,7 @@ impl Pipeline {
                 let drain_counters_clone: Vec<Arc<StepDrainCounter>> =
                     drain_counters.iter().map(Arc::clone).collect();
                 let stats_clone = stats_arc.as_ref().map(Arc::clone);
+                let scheduler_clone = Arc::clone(&scheduler);
 
                 let handle = thread::Builder::new()
                     .name(format!("fgumi-worker-{worker_id}"))
@@ -1016,6 +1203,7 @@ impl Pipeline {
                                     &drain_counters_clone,
                                     &signal_clone,
                                     stats_clone.as_ref(),
+                                    scheduler_clone.as_ref(),
                                 );
                             }))
                         {
@@ -1034,6 +1222,21 @@ impl Pipeline {
                     if worker_panic.is_none() {
                         worker_panic = Some(panic);
                     }
+                }
+            }
+        }
+
+        // 6d. Join the Detached step threads (after the workers). The sort
+        // writer (Detached, consuming the pool's Compress output) and merge
+        // (Detached, producing to the pool's Serialize input) finish their final
+        // flush only after their pool peers have drained, so joining them here —
+        // after the worker join, before the monitor stop — captures the full
+        // chain completion (and any Detached-thread panic) in the same deferred
+        // re-raise path the workers use. A no-op when no step is Detached.
+        for h in detached_handles {
+            if let Err(panic) = h.join() {
+                if worker_panic.is_none() {
+                    worker_panic = Some(panic);
                 }
             }
         }
@@ -1058,13 +1261,27 @@ impl Pipeline {
             let _ = handle.join();
         }
 
+        if let Some(stop) = sampler_stop {
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        if let Some(handle) = sampler_handle {
+            let _ = handle.join();
+        }
+
         // 6c. End-of-run stats snapshot — emitted at info-level so
         // bench profiling can see which step accumulated the most
         // wall-clock time inside `try_run`. Only logged when stats
         // were enabled (`with_stats(...)` on the config); cheap
         // either way.
         if let Some(stats) = stats_arc.as_ref() {
-            let snapshot = stats.snapshot();
+            // When instrumentation is on, fold the per-edge table + bottleneck
+            // verdict into the snapshot (the edges live in `contexts`, only
+            // reachable here inside `run`); otherwise the edge-less snapshot.
+            let snapshot = if config.instrumentation.is_on() {
+                stats.snapshot_with_edges(&contexts.edges, stats.elapsed_ns())
+            } else {
+                stats.snapshot()
+            };
             log::info!("Pipeline end-of-run stats:");
             for line in format!("{snapshot}").lines() {
                 log::info!("{line}");
@@ -1552,10 +1769,39 @@ mod tests {
     use super::*;
     use std::io;
 
+    use rstest::rstest;
+
     use crate::outputs::Single;
     use crate::queues::QueueSpec;
     use crate::reorder::BranchOrdering;
     use crate::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+    // Each case pins one level's (is_on/samples, timeline, deep) predicates, so a
+    // failure identifies the specific level that regressed. `samples()` tracks
+    // `is_on()`, so the two share the `is_on` column.
+    #[rstest]
+    #[case(InstrumentationLevel::Off, false, false, false)]
+    #[case(InstrumentationLevel::Summary, true, false, false)]
+    #[case(InstrumentationLevel::Timeline, true, true, false)]
+    #[case(InstrumentationLevel::Deep, true, true, true)]
+    fn instrumentation_level_predicates(
+        #[case] level: InstrumentationLevel,
+        #[case] is_on: bool,
+        #[case] timeline: bool,
+        #[case] deep: bool,
+    ) {
+        assert_eq!(level.is_on(), is_on);
+        assert_eq!(level.samples(), is_on);
+        assert_eq!(level.timeline(), timeline);
+        assert_eq!(level.deep(), deep);
+    }
+
+    #[test]
+    fn instrumentation_defaults_are_off() {
+        assert_eq!(InstrumentationLevel::default(), InstrumentationLevel::Off);
+        assert_eq!(PipelineConfig::default().instrumentation, InstrumentationLevel::Off);
+        assert!(PipelineConfig::default().trace_path.is_none());
+    }
 
     #[test]
     fn apply_initial_queue_budget_sets_registered_reorder_cap() {
@@ -1986,9 +2232,8 @@ mod tests {
                 // ordinal and retry it on a later tick. Holding a claimed item
                 // counts as progress per the `StepOutcome` contract ("pushed or
                 // held an item" — see `step.rs`) and matches the production
-                // held-slot sources (`sort::merge` / `sort::and_spill`), so the
-                // scheduler's deadlock accounting sees the claim as forward
-                // motion rather than a stall.
+                // held-slot source (`sort::merge`), so the scheduler's deadlock
+                // accounting sees the claim as forward motion rather than a stall.
                 if ctx.outputs.push(n).is_ok() {
                     Ok(StepOutcome::Progress)
                 } else {
@@ -2068,6 +2313,114 @@ mod tests {
         let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
         assert!(result.is_ok(), "run failed: {:?}", result.err());
         assert_eq!(received.load(AtomicOrd::Relaxed), 50);
+    }
+
+    /// A `u32 -> u32` pass-through step that runs on a dedicated Detached
+    /// thread. Pops one item per `try_run`, pushes it on (holding on
+    /// output-full backpressure), finishes once its input drains.
+    #[derive(Clone)]
+    struct DetachedPassThrough {
+        held: Option<u32>,
+    }
+    impl Step for DetachedPassThrough {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "DetachedPassThrough",
+                kind: StepKind::Detached,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 8 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            if let Some(v) = self.held.take() {
+                if ctx.outputs.push(v).is_err() {
+                    self.held = Some(v);
+                    return Ok(StepOutcome::Contention);
+                }
+                return Ok(StepOutcome::Progress);
+            }
+            match ctx.input.pop() {
+                Some(v) => match ctx.outputs.push(v) {
+                    Ok(()) => Ok(StepOutcome::Progress),
+                    Err(unpushed) => {
+                        self.held = Some(unpushed.into_item());
+                        Ok(StepOutcome::Contention)
+                    }
+                },
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+    }
+
+    /// L2.3: a `source(Parallel) -> passthrough(Detached) -> sink(Parallel)`
+    /// chain runs to completion at `--threads 4` with the Detached step on its
+    /// own dedicated thread (off the pool). All N items flow through.
+    #[test]
+    fn detached_step_runs_and_drains_multithreaded() {
+        let remaining = Arc::new(AtomicU32::new(200));
+        let received = Arc::new(AtomicU32::new(0));
+
+        let builder = PipelineBuilder::new();
+        builder
+            .chain(SharedCountingSource { remaining: Arc::clone(&remaining) })
+            .chain(DetachedPassThrough { held: None })
+            .chain(ParallelCountingSink { received: Arc::clone(&received) })
+            .into_sink_marker();
+        let pipeline = builder.build().unwrap();
+
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+        assert_eq!(
+            received.load(AtomicOrd::Relaxed),
+            200,
+            "all items flowed through Detached step"
+        );
+    }
+
+    /// L2.3: a chain with a Detached step and ZERO items (source finishes
+    /// immediately) cleanly drains the Detached thread and the run completes.
+    #[test]
+    fn detached_step_zero_items_run_completes() {
+        let remaining = Arc::new(AtomicU32::new(0));
+        let received = Arc::new(AtomicU32::new(0));
+
+        let builder = PipelineBuilder::new();
+        builder
+            .chain(SharedCountingSource { remaining: Arc::clone(&remaining) })
+            .chain(DetachedPassThrough { held: None })
+            .chain(ParallelCountingSink { received: Arc::clone(&received) })
+            .into_sink_marker();
+        let pipeline = builder.build().unwrap();
+
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+        assert_eq!(received.load(AtomicOrd::Relaxed), 0);
+    }
+
+    /// L2.3 step 7: at `--threads 1` the fusible linear chain runs the Detached
+    /// step **inline** in the fused single-thread driver — no dedicated thread
+    /// is spawned (the fused path returns before `extract_detached_steps`), yet
+    /// the Detached step still drives to completion.
+    #[test]
+    fn detached_collapses_inline_at_t1() {
+        let remaining = Arc::new(AtomicU32::new(30));
+        let received = Arc::new(AtomicU32::new(0));
+
+        let builder = PipelineBuilder::new();
+        builder
+            .chain(SharedCountingSource { remaining: Arc::clone(&remaining) })
+            .chain(DetachedPassThrough { held: None })
+            .chain(ParallelCountingSink { received: Arc::clone(&received) })
+            .into_sink_marker();
+        let pipeline = builder.build().unwrap();
+
+        let result = pipeline.run(PipelineConfig { threads: 1, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+        assert_eq!(received.load(AtomicOrd::Relaxed), 30);
     }
 
     /// Sink whose worker loop panics the moment it pops an item — used to drive
@@ -2445,6 +2798,35 @@ mod tests {
         assert_eq!(classify_stall(false, 60, 10, 60, 4096), StallVerdict::Wedged);
     }
 
+    /// L2.4: a Detached step legitimately blocked on EMPTY input (slow upstream)
+    /// must NOT trip the monitor. The Detached merge's data flows through the
+    /// internal `SortMergeSlot` table — invisible to `in_flight_bytes` — and its
+    /// framework input edge (setup events) is drained early, so while it waits
+    /// for decompress the byte-bounded edges feeding it are EMPTY:
+    /// `in_flight_bytes == 0` → `Starving` (progress-shaped), never `Wedged`,
+    /// no matter how long the wait. The starvation guard already encodes this;
+    /// this test pins the Detached interpretation against a regression.
+    #[test]
+    fn monitor_no_false_positive_on_idle_detached() {
+        // Long stall, well past the fatal threshold, but nothing is stuck on a
+        // visible byte-bounded edge (the Detached step is parked on its empty
+        // input). Must be Starving, not Wedged.
+        assert_eq!(classify_stall(false, 600, 10, 60, 0), StallVerdict::Starving);
+        // And the instant the slow producer feeds it, global progress advances.
+        assert_eq!(classify_stall(true, 600, 10, 60, 0), StallVerdict::Progressing);
+    }
+
+    /// L2.4 (revision item 10): a *genuine* wedge of the Detached merge still
+    /// trips fatal. If the merge is truly stuck, its pool upstream (decompress)
+    /// can't push to the full slots either, so the byte-bounded spill→decompress
+    /// edge stays FULL with no progress — `in_flight_bytes > 0` past the fatal
+    /// window → `Wedged`. The slot-table blindness does not hide a real wedge,
+    /// because the upstream byte edge always reflects it.
+    #[test]
+    fn monitor_still_trips_on_genuine_detached_wedge() {
+        assert_eq!(classify_stall(false, 60, 10, 60, 1_048_576), StallVerdict::Wedged);
+    }
+
     /// A step with a single output branch of the given `QueueSpec`, used to
     /// exercise the monitor-visibility transport check.
     fn step_with_output_spec(
@@ -2718,12 +3100,22 @@ mod tests {
             handle,
             reorder_cap: Some(cap),
         };
-        let contexts = ChainContexts { inputs: vec![], outputs: vec![], bounded_queues: vec![rq] };
+        let contexts = ChainContexts {
+            inputs: vec![],
+            outputs: vec![],
+            bounded_queues: vec![rq],
+            edges: vec![],
+        };
         // 200 (transport) + 300 (reorder stash).
         assert_eq!(in_flight_bytes(&contexts), 500);
 
         // An empty registry reads zero — the starvation (idle) signal.
-        let empty = ChainContexts { inputs: vec![], outputs: vec![], bounded_queues: vec![] };
+        let empty = ChainContexts {
+            inputs: vec![],
+            outputs: vec![],
+            bounded_queues: vec![],
+            edges: vec![],
+        };
         assert_eq!(in_flight_bytes(&empty), 0);
     }
 }

--- a/crates/fgumi-pipeline-core/src/erased.rs
+++ b/crates/fgumi-pipeline-core/src/erased.rs
@@ -30,7 +30,8 @@ use super::queues::QueueSpec;
 use super::reorder::BranchOrdering;
 use super::signal::PipelineSignal;
 use super::step::{
-    Affinity, OutputHandles, OutputsViewAny, Step, StepCtx, StepKind, StepOutcome, StepProfile,
+    Affinity, DetachedGroup, OutputHandles, OutputsViewAny, Step, StepCtx, StepKind, StepOutcome,
+    StepProfile,
 };
 
 /// The branch orderings the framework actually *builds* for a single-input
@@ -57,7 +58,10 @@ pub(crate) fn effective_branch_orderings(
 ) -> Vec<BranchOrdering> {
     match kind {
         StepKind::Parallel => declared.to_vec(),
-        StepKind::Serial | StepKind::Exclusive => {
+        // Single-producer kinds emit in-order from one thread, so a downstream
+        // reorder stage is redundant. `Detached` is single-producer too (one
+        // dedicated thread), so it collapses like `Serial`/`Exclusive`.
+        StepKind::Serial | StepKind::Exclusive | StepKind::Detached => {
             declared.iter().map(|_| BranchOrdering::None).collect()
         }
     }
@@ -95,6 +99,12 @@ pub trait ErasedStep: Send + 'static {
     /// `build_worker_storage` to decide which workers get a `Shared`
     /// entry vs a `Skip` placeholder.
     fn affinity(&self) -> Affinity;
+
+    /// Forward `Step::detached_group` — which dedicated driver thread a
+    /// `Detached` step runs on. Read once by `extract_detached_steps` to group
+    /// detached steps onto shared driver threads (the N+2 model). Only
+    /// meaningful for `Detached` kinds.
+    fn detached_group(&self) -> DetachedGroup;
 
     /// Dispatch `S::try_run` after downcasting queue handles.
     ///
@@ -160,7 +170,10 @@ pub trait ErasedStep: Send + 'static {
 
     /// Build this step's output queue set + outputs view from the profile's
     /// per-branch queue specs and ordering directives.
-    fn build_output_set(&self) -> (OutputQueueSet, OutputsViewAny);
+    fn build_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny);
 
     /// Like [`Self::build_output_set`] but forces every output branch to a
     /// **direct, unbounded** transport (no byte bound, no reorder stage).
@@ -172,7 +185,10 @@ pub trait ErasedStep: Send + 'static {
     /// because the consumer is driven in the same pass over the chain. Each
     /// sub-step emits a bounded number of items per `try_run`, so the buffer
     /// stays shallow (the fused-chain bounded-fan-out invariant).
-    fn build_fused_output_set(&self) -> (OutputQueueSet, OutputsViewAny);
+    fn build_fused_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny);
 
     /// Wrap a typed `OutputsViewAny` into `Box<OutputHandles<S::Outputs>>`
     /// (type-erased as `Any`). The runtime stores this box per step so the
@@ -364,6 +380,10 @@ where
         self.inner.affinity()
     }
 
+    fn detached_group(&self) -> DetachedGroup {
+        self.inner.detached_group()
+    }
+
     fn try_run_erased(&mut self, ctx: &mut ErasedStepCtx<'_>) -> io::Result<StepOutcome> {
         let input = self.resolve_input(ctx);
         let outputs = self.resolve_outputs(ctx);
@@ -391,7 +411,10 @@ where
         Box::new(handle)
     }
 
-    fn build_output_set(&self) -> (OutputQueueSet, OutputsViewAny) {
+    fn build_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny) {
         let profile = self.inner.profile();
         // Producers with `StepKind::Serial` or `StepKind::Exclusive` emit
         // items in arrival order by construction (the framework's mutex
@@ -409,17 +432,24 @@ where
         // satisfy that need.
         let effective_orderings =
             effective_branch_orderings(profile.kind, &profile.branch_ordering);
-        <S::Outputs as StepOutputs>::build_queues(&profile.output_queues, &effective_orderings)
+        <S::Outputs as StepOutputs>::build_queues(
+            &profile.output_queues,
+            &effective_orderings,
+            level,
+        )
     }
 
-    fn build_fused_output_set(&self) -> (OutputQueueSet, OutputsViewAny) {
+    fn build_fused_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny) {
         // Force a direct, unbounded transport on every branch: at one worker
         // FIFO is already correct (no reorder), and the consumer is driven in
         // the same pass (no backpressure). Arity comes from the profile.
         let n = self.inner.profile().output_queues.len();
         let specs = vec![QueueSpec::Unbounded; n];
         let orderings = vec![BranchOrdering::None; n];
-        <S::Outputs as StepOutputs>::build_queues(&specs, &orderings)
+        <S::Outputs as StepOutputs>::build_queues(&specs, &orderings, level)
     }
 
     fn wrap_outputs_view(&self, view: OutputsViewAny) -> Box<dyn Any + Send + Sync> {
@@ -579,6 +609,10 @@ impl<S: Step2> ErasedStep for TypedStep2<S> {
         self.inner.affinity()
     }
 
+    fn detached_group(&self) -> DetachedGroup {
+        self.inner.detached_group()
+    }
+
     fn try_run_erased(&mut self, ctx: &mut ErasedStepCtx<'_>) -> io::Result<StepOutcome> {
         let inputs = self.resolve_inputs(ctx);
         let outputs = self.resolve_outputs(ctx);
@@ -648,7 +682,10 @@ impl<S: Step2> ErasedStep for TypedStep2<S> {
         Box::new(TwoInputHandles::<S::InputA, S::InputB>::new(a, b))
     }
 
-    fn build_output_set(&self) -> (OutputQueueSet, OutputsViewAny) {
+    fn build_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny) {
         // Unlike `TypedStep::build_output_set`, a `Step2` does NOT collapse a
         // `ByOrdinal` / `ByItemOrdinal` output to `None` for `Serial` /
         // `Exclusive` kinds — the ordering is passed through verbatim and the
@@ -677,17 +714,21 @@ impl<S: Step2> ErasedStep for TypedStep2<S> {
         <S::Outputs as StepOutputs>::build_queues(
             &self.inner.profile().output_queues,
             &self.inner.profile().branch_ordering,
+            level,
         )
     }
 
-    fn build_fused_output_set(&self) -> (OutputQueueSet, OutputsViewAny) {
+    fn build_fused_output_set(
+        &self,
+        level: crate::builder::InstrumentationLevel,
+    ) -> (OutputQueueSet, OutputsViewAny) {
         // `Step2` never appears in a linear (single-input) fused chain, so this
         // is unreachable in practice; provided for trait completeness with the
         // same direct+unbounded semantics as the single-input adapter.
         let n = self.inner.profile().output_queues.len();
         let specs = vec![QueueSpec::Unbounded; n];
         let orderings = vec![BranchOrdering::None; n];
-        <S::Outputs as StepOutputs>::build_queues(&specs, &orderings)
+        <S::Outputs as StepOutputs>::build_queues(&specs, &orderings, level)
     }
 
     fn wrap_outputs_view(&self, view: OutputsViewAny) -> Box<dyn Any + Send + Sync> {
@@ -759,7 +800,8 @@ mod tests {
     /// chain link by manually constructing the upstream side.
     fn build_addone_outputs() -> (OutputQueueSet, OutputHandles<Single<u32>>) {
         let producer: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
-        let (queue_set, outputs_view) = producer.build_output_set();
+        let (queue_set, outputs_view) =
+            producer.build_output_set(crate::builder::InstrumentationLevel::Off);
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
         (queue_set, outputs)
     }
@@ -871,7 +913,8 @@ mod tests {
         let input_any = consumer.build_input_handle(&mut producer_set, 0);
 
         // Consumer needs its own output set + view to run.
-        let (consumer_set, consumer_view) = consumer.build_output_set();
+        let (consumer_set, consumer_view) =
+            consumer.build_output_set(crate::builder::InstrumentationLevel::Off);
         let consumer_outputs: OutputHandles<Single<u32>> = OutputHandles::new(consumer_view);
 
         let signal = PipelineSignal::new();
@@ -895,7 +938,8 @@ mod tests {
         let mut consumer: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
         let input_any = consumer.build_input_handle(&mut producer_set, 0);
 
-        let (_consumer_set, consumer_view) = consumer.build_output_set();
+        let (_consumer_set, consumer_view) =
+            consumer.build_output_set(crate::builder::InstrumentationLevel::Off);
         let consumer_outputs: OutputHandles<Single<u32>> = OutputHandles::new(consumer_view);
 
         let signal = PipelineSignal::new();
@@ -932,7 +976,8 @@ mod tests {
     #[test]
     fn build_output_set_uses_profile_queues_and_ordering() {
         let typed: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
-        let (mut queue_set, _outputs_view) = typed.build_output_set();
+        let (mut queue_set, _outputs_view) =
+            typed.build_output_set(crate::builder::InstrumentationLevel::Off);
         assert_eq!(queue_set.n_branches(), 1);
         // Verify the queue is u32-typed by taking the input handle.
         let input = queue_set.take_typed_input::<u32>(0);
@@ -957,7 +1002,8 @@ mod tests {
     #[test]
     fn wrap_outputs_view_yields_typed_outputs_handles() {
         let typed: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
-        let (mut queue_set, view) = typed.build_output_set();
+        let (mut queue_set, view) =
+            typed.build_output_set(crate::builder::InstrumentationLevel::Off);
         let outputs_any = typed.wrap_outputs_view(view);
 
         // Downcast back to OutputHandles<Single<u32>> and push.
@@ -974,7 +1020,8 @@ mod tests {
     fn mark_outputs_drained_propagates_to_consumer_input() {
         // Producer is an AddOne; its outputs feed a consumer's input.
         let producer: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
-        let (mut producer_set, producer_view) = producer.build_output_set();
+        let (mut producer_set, producer_view) =
+            producer.build_output_set(crate::builder::InstrumentationLevel::Off);
         let producer_outputs_any = producer.wrap_outputs_view(producer_view);
 
         let consumer: Box<dyn ErasedStep> = Box::new(TypedStep::new(AddOne));
@@ -1039,7 +1086,8 @@ mod tests {
         let input_any = splitter.build_input_handle(&mut producer_set, 0);
 
         // Splitter's own output set has two branches.
-        let (mut splitter_set, splitter_view) = splitter.build_output_set();
+        let (mut splitter_set, splitter_view) =
+            splitter.build_output_set(crate::builder::InstrumentationLevel::Off);
         let splitter_outputs: OutputHandles<(u32, u32)> = OutputHandles::new(splitter_view);
 
         let signal = PipelineSignal::new();
@@ -1135,7 +1183,8 @@ mod tests {
         }
 
         let step: Box<dyn ErasedStep> = Box::new(TypedStep2::new(OutOfOrderMerge));
-        let (mut queue_set, view) = step.build_output_set();
+        let (mut queue_set, view) =
+            step.build_output_set(crate::builder::InstrumentationLevel::Off);
         let outputs_any = step.wrap_outputs_view(view);
         let outputs = outputs_any
             .downcast_ref::<OutputHandles<OrderedBytesSingle<Ord32>>>()

--- a/crates/fgumi-pipeline-core/src/handles.rs
+++ b/crates/fgumi-pipeline-core/src/handles.rs
@@ -223,6 +223,12 @@ impl<T: Send + HeapSize + 'static> BranchOutputHandle<T> {
 /// Consumer-side input handle for one branch. Implements `InputHandle<T>`.
 pub struct BranchInputHandle<T: Send + HeapSize + 'static> {
     inner: BranchInputInner<T>,
+    /// `Some` only on an instrumented edge. The **consumer-pop** side of the
+    /// edge's `EdgeMetrics` is recorded here (not at the transport queue),
+    /// because an ordered edge pops through a `ReorderStage` that drains the
+    /// transport in bulk — `pop` here is the real consumer pop. Shares the same
+    /// `Arc<EdgeMetrics>` as the producer transport (push side).
+    metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
 }
 
 enum BranchInputInner<T: Send + HeapSize + 'static> {
@@ -241,17 +247,34 @@ impl<T: Send + HeapSize + 'static> BranchInputHandle<T> {
     /// implicitly drained from the start and never popped.
     #[must_use]
     pub fn always_drained() -> Self {
-        Self { inner: BranchInputInner::AlwaysDrained(PhantomData) }
+        Self { inner: BranchInputInner::AlwaysDrained(PhantomData), metrics: None }
     }
 }
 
 impl<T: Send + HeapSize + 'static> InputHandle<T> for BranchInputHandle<T> {
     fn pop(&self) -> Option<T> {
-        match &self.inner {
-            BranchInputInner::Direct(q) => q.try_pop(),
-            BranchInputInner::Ordered(stage) => stage.try_pop_in_order(),
-            BranchInputInner::AlwaysDrained(_) => None,
+        // A `None` from an `Ordered` edge is *reorder-blocked* (not starved) while
+        // the reorder stage still holds out-of-order items waiting for an earlier
+        // ordinal — counting that as an empty pop inflates `pop_empties` and can
+        // misclassify a backlogged edge as starved. The `reorder_blocked` flag is
+        // reported by the SAME locked pop, so shared (`Parallel`) consumers can't
+        // observe a torn `(item, blocked)` pair. Direct / always-drained branches
+        // have no reorder buffer, so a `None` there is always a true empty pop.
+        let (item, reorder_blocked) = match &self.inner {
+            BranchInputInner::Direct(q) => (q.try_pop(), false),
+            BranchInputInner::Ordered(stage) => stage.try_pop_in_order_reporting_blocked(),
+            BranchInputInner::AlwaysDrained(_) => (None, false),
+        };
+        if let Some(m) = &self.metrics {
+            if let Some(it) = &item {
+                // usize→u64 is lossless on every target we build for.
+                #[allow(clippy::cast_possible_truncation)]
+                m.record_pop(it.heap_size() as u64);
+            } else if !reorder_blocked {
+                m.record_empty();
+            }
         }
+        item
     }
 
     fn is_drained(&self) -> bool {
@@ -294,6 +317,10 @@ pub(crate) struct Branch<T: Send + HeapSize + 'static> {
     pub(crate) output: BranchOutputHandle<T>,
     pub(crate) input: BranchInputHandle<T>,
     pub(crate) bounded_queue_handle: Option<BranchBudgetHandles>,
+    /// `Some` on an instrumented edge — the shared `EdgeMetrics` (also held by
+    /// the transport queue for push counts and the input handle for pop counts).
+    /// Collected into the edge registry by `contexts.rs` Pass 1.5.
+    pub(crate) metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
 }
 
 /// Build one branch from a queue spec + ordering directive, where `T` does
@@ -304,37 +331,62 @@ pub(crate) struct Branch<T: Send + HeapSize + 'static> {
 /// Panics on `QueueSpec::ByteBounded` (requires `T: HeapSize`; use the
 /// byte-aware build path) or on `BranchOrdering::ByItemOrdinal` (requires
 /// `T: Ordered`; use `build_branch_ordered`).
+/// Mint a per-edge [`EdgeMetrics`] when instrumentation is on, else `None`.
+/// Called once per branch in the `build_branch*` constructors; the same handle
+/// is shared by the transport (push counts) and the input handle (pop counts).
+fn edge_metrics(
+    level: crate::builder::InstrumentationLevel,
+) -> Option<Arc<crate::runtime::metrics::EdgeMetrics>> {
+    level.is_on().then(crate::runtime::metrics::EdgeMetrics::new)
+}
+
 pub(crate) fn build_branch<T: Send + HeapSize + 'static>(
     spec: QueueSpec,
     ordering: BranchOrdering,
+    level: crate::builder::InstrumentationLevel,
 ) -> Branch<T> {
     match (spec, ordering) {
         (QueueSpec::CountBounded { capacity }, BranchOrdering::None) => {
-            let q: Arc<dyn ItemQueue<T>> = Arc::new(CountBoundedQueue::<T>::new(capacity));
-            direct_branch(q, None)
+            let m = edge_metrics(level);
+            let q: Arc<dyn ItemQueue<T>> =
+                Arc::new(CountBoundedQueue::<T>::maybe_instrumented(capacity, m.clone()));
+            direct_branch(q, None, m)
         }
         (QueueSpec::CountBounded { capacity }, BranchOrdering::ByOrdinal) => {
+            let m = edge_metrics(level);
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> =
-                Arc::new(CountBoundedQueue::<Sequenced<T>>::new(capacity));
+                Arc::new(CountBoundedQueue::<Sequenced<T>>::maybe_instrumented(
+                    // Ordered transport is NOT instrumented: push/reject are recorded
+                    // at the ReorderStage boundary (a stash turns a full-transport
+                    // `Err` into an accepted `Ok`). Pop side is on the input handle.
+                    capacity, None,
+                ));
             ordered_branch(
                 transport,
                 OrdinalSource::Allocated(Arc::new(AtomicU64::new(0))),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 None,
+                m,
             )
         }
         (QueueSpec::Unbounded, BranchOrdering::None) => {
-            let q: Arc<dyn ItemQueue<T>> = Arc::new(UnboundedQueue::<T>::new());
-            direct_branch(q, None)
+            let m = edge_metrics(level);
+            let q: Arc<dyn ItemQueue<T>> =
+                Arc::new(UnboundedQueue::<T>::maybe_instrumented(m.clone()));
+            direct_branch(q, None, m)
         }
         (QueueSpec::Unbounded, BranchOrdering::ByOrdinal) => {
+            let m = edge_metrics(level);
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> =
-                Arc::new(UnboundedQueue::<Sequenced<T>>::new());
+                // Ordered transport is NOT instrumented — push/reject recorded at
+                // the ReorderStage boundary (see the count-bounded note above).
+                Arc::new(UnboundedQueue::<Sequenced<T>>::maybe_instrumented(None));
             ordered_branch(
                 transport,
                 OrdinalSource::Allocated(Arc::new(AtomicU64::new(0))),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 None,
+                m,
             )
         }
         (_, BranchOrdering::ByItemOrdinal) => {
@@ -367,26 +419,38 @@ pub(crate) fn build_branch<T: Send + HeapSize + 'static>(
 pub(crate) fn build_branch_ordered<T: Send + HeapSize + Ordered + 'static>(
     spec: QueueSpec,
     ordering: BranchOrdering,
+    level: crate::builder::InstrumentationLevel,
 ) -> Branch<T> {
     match (spec, ordering) {
         (QueueSpec::CountBounded { capacity }, BranchOrdering::ByItemOrdinal) => {
+            let m = edge_metrics(level);
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> =
-                Arc::new(CountBoundedQueue::<Sequenced<T>>::new(capacity));
+                Arc::new(CountBoundedQueue::<Sequenced<T>>::maybe_instrumented(
+                    // Ordered transport is NOT instrumented: push/reject are recorded
+                    // at the ReorderStage boundary (a stash turns a full-transport
+                    // `Err` into an accepted `Ok`). Pop side is on the input handle.
+                    capacity, None,
+                ));
             ordered_branch(
                 transport,
                 OrdinalSource::ItemSerial(|item: &T| item.ordinal()),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 None,
+                m,
             )
         }
         (QueueSpec::Unbounded, BranchOrdering::ByItemOrdinal) => {
+            let m = edge_metrics(level);
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> =
-                Arc::new(UnboundedQueue::<Sequenced<T>>::new());
+                // Ordered transport is NOT instrumented — push/reject recorded at
+                // the ReorderStage boundary (see the count-bounded note above).
+                Arc::new(UnboundedQueue::<Sequenced<T>>::maybe_instrumented(None));
             ordered_branch(
                 transport,
                 OrdinalSource::ItemSerial(|item: &T| item.ordinal()),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 None,
+                m,
             )
         }
         (QueueSpec::ByteBounded { .. }, _) => {
@@ -397,7 +461,7 @@ pub(crate) fn build_branch_ordered<T: Send + HeapSize + Ordered + 'static>(
                  combined case."
             );
         }
-        (other, ord) => build_branch::<T>(other, ord),
+        (other, ord) => build_branch::<T>(other, ord, level),
     }
 }
 
@@ -406,18 +470,27 @@ pub(crate) fn build_branch_ordered<T: Send + HeapSize + Ordered + 'static>(
 pub(crate) fn build_branch_ordered_bytes<T: Send + HeapSize + Ordered + 'static>(
     spec: QueueSpec,
     ordering: BranchOrdering,
+    level: crate::builder::InstrumentationLevel,
 ) -> Branch<T> {
     use crate::queues::BoundedQueueHandle;
 
     match (spec, ordering) {
         (QueueSpec::ByteBounded { limit_bytes }, BranchOrdering::None) => {
-            let q = Arc::new(ByteBoundedQueue::<T>::new(limit_bytes));
+            let m = edge_metrics(level);
+            let q = Arc::new(ByteBoundedQueue::<T>::maybe_instrumented(limit_bytes, m.clone()));
             let handle: Arc<dyn BoundedQueueHandle> = Arc::clone(&q) as Arc<dyn BoundedQueueHandle>;
             let q_dyn: Arc<dyn ItemQueue<T>> = q;
-            direct_branch(q_dyn, Some(handle))
+            direct_branch(q_dyn, Some(handle), m)
         }
         (QueueSpec::ByteBounded { limit_bytes }, BranchOrdering::ByOrdinal) => {
-            let transport_concrete = Arc::new(ByteBoundedQueue::<Sequenced<T>>::new(limit_bytes));
+            let m = edge_metrics(level);
+            let transport_concrete = Arc::new(
+                // Ordered transport is NOT instrumented — see the note on the
+                // count-bounded ordered transport above; push/reject are recorded
+                // at the ReorderStage boundary. The byte `handle` (occupancy /
+                // budget resize) is derived from this same queue and is unaffected.
+                ByteBoundedQueue::<Sequenced<T>>::maybe_instrumented(limit_bytes, None),
+            );
             let handle: Arc<dyn BoundedQueueHandle> =
                 Arc::clone(&transport_concrete) as Arc<dyn BoundedQueueHandle>;
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> = transport_concrete;
@@ -434,10 +507,18 @@ pub(crate) fn build_branch_ordered_bytes<T: Send + HeapSize + Ordered + 'static>
                 OrdinalSource::Allocated(Arc::new(AtomicU64::new(0))),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 Some(handle),
+                m,
             )
         }
         (QueueSpec::ByteBounded { limit_bytes }, BranchOrdering::ByItemOrdinal) => {
-            let transport_concrete = Arc::new(ByteBoundedQueue::<Sequenced<T>>::new(limit_bytes));
+            let m = edge_metrics(level);
+            let transport_concrete = Arc::new(
+                // Ordered transport is NOT instrumented — see the note on the
+                // count-bounded ordered transport above; push/reject are recorded
+                // at the ReorderStage boundary. The byte `handle` (occupancy /
+                // budget resize) is derived from this same queue and is unaffected.
+                ByteBoundedQueue::<Sequenced<T>>::maybe_instrumented(limit_bytes, None),
+            );
             let handle: Arc<dyn BoundedQueueHandle> =
                 Arc::clone(&transport_concrete) as Arc<dyn BoundedQueueHandle>;
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> = transport_concrete;
@@ -446,9 +527,10 @@ pub(crate) fn build_branch_ordered_bytes<T: Send + HeapSize + Ordered + 'static>
                 OrdinalSource::ItemSerial(|item: &T| item.ordinal()),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 Some(handle),
+                m,
             )
         }
-        (other, ord) => build_branch_ordered::<T>(other, ord),
+        (other, ord) => build_branch_ordered::<T>(other, ord, level),
     }
 }
 
@@ -464,18 +546,27 @@ pub(crate) fn build_branch_ordered_bytes<T: Send + HeapSize + Ordered + 'static>
 pub(crate) fn build_branch_byte_aware<T: Send + HeapSize + 'static>(
     spec: QueueSpec,
     ordering: BranchOrdering,
+    level: crate::builder::InstrumentationLevel,
 ) -> Branch<T> {
     use crate::queues::BoundedQueueHandle;
 
     match (spec, ordering) {
         (QueueSpec::ByteBounded { limit_bytes }, BranchOrdering::None) => {
-            let q = Arc::new(ByteBoundedQueue::<T>::new(limit_bytes));
+            let m = edge_metrics(level);
+            let q = Arc::new(ByteBoundedQueue::<T>::maybe_instrumented(limit_bytes, m.clone()));
             let handle: Arc<dyn BoundedQueueHandle> = Arc::clone(&q) as Arc<dyn BoundedQueueHandle>;
             let q_dyn: Arc<dyn ItemQueue<T>> = q;
-            direct_branch(q_dyn, Some(handle))
+            direct_branch(q_dyn, Some(handle), m)
         }
         (QueueSpec::ByteBounded { limit_bytes }, BranchOrdering::ByOrdinal) => {
-            let transport_concrete = Arc::new(ByteBoundedQueue::<Sequenced<T>>::new(limit_bytes));
+            let m = edge_metrics(level);
+            let transport_concrete = Arc::new(
+                // Ordered transport is NOT instrumented — see the note on the
+                // count-bounded ordered transport above; push/reject are recorded
+                // at the ReorderStage boundary. The byte `handle` (occupancy /
+                // budget resize) is derived from this same queue and is unaffected.
+                ByteBoundedQueue::<Sequenced<T>>::maybe_instrumented(limit_bytes, None),
+            );
             let handle: Arc<dyn BoundedQueueHandle> =
                 Arc::clone(&transport_concrete) as Arc<dyn BoundedQueueHandle>;
             let transport: Arc<dyn ItemQueue<Sequenced<T>>> = transport_concrete;
@@ -484,6 +575,7 @@ pub(crate) fn build_branch_byte_aware<T: Send + HeapSize + 'static>(
                 OrdinalSource::Allocated(Arc::new(AtomicU64::new(0))),
                 Some(DEFAULT_REORDER_OVERFLOW_BYTES),
                 Some(handle),
+                m,
             )
         }
         (QueueSpec::ByteBounded { .. }, BranchOrdering::ByItemOrdinal) => {
@@ -492,21 +584,23 @@ pub(crate) fn build_branch_byte_aware<T: Send + HeapSize + 'static>(
                  use `build_branch_ordered_bytes` instead."
             );
         }
-        (other, ord) => build_branch::<T>(other, ord),
+        (other, ord) => build_branch::<T>(other, ord, level),
     }
 }
 
 fn direct_branch<T: Send + HeapSize + 'static>(
     q: Arc<dyn ItemQueue<T>>,
     transport_handle: Option<Arc<dyn crate::queues::BoundedQueueHandle>>,
+    metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
 ) -> Branch<T> {
     // A direct (unordered) branch has no reorder stage, so no reorder cap.
     let bounded_queue_handle =
         transport_handle.map(|transport| BranchBudgetHandles { transport, reorder_cap: None });
     Branch {
         output: BranchOutputHandle { inner: BranchOutputInner::Direct(Arc::clone(&q)) },
-        input: BranchInputHandle { inner: BranchInputInner::Direct(q) },
+        input: BranchInputHandle { inner: BranchInputInner::Direct(q), metrics: metrics.clone() },
         bounded_queue_handle,
+        metrics,
     }
 }
 
@@ -515,11 +609,21 @@ fn ordered_branch<T: Send + HeapSize + 'static>(
     ordinal_source: OrdinalSource<T>,
     max_overflow_bytes: Option<u64>,
     transport_handle: Option<Arc<dyn crate::queues::BoundedQueueHandle>>,
+    metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
 ) -> Branch<T> {
-    let stage = Arc::new(match max_overflow_bytes {
-        Some(cap) => ReorderStage::<T>::with_max_overflow_bytes(transport, cap),
-        None => ReorderStage::<T>::new(transport),
-    });
+    // A byte-bounded ordered edge carries a `transport_handle`; count/unbounded
+    // ones don't. Record the push side's byte size only on the byte-bounded ones
+    // (matching the queue's own byte accounting). Push/reject are recorded at the
+    // ReorderStage boundary — NOT on the transport — because a must-accept stash
+    // turns a full-transport `Err` into an accepted `Ok` (see `push_metrics`).
+    let record_item_bytes = transport_handle.is_some();
+    let stage = Arc::new(
+        match max_overflow_bytes {
+            Some(cap) => ReorderStage::<T>::with_max_overflow_bytes(transport, cap),
+            None => ReorderStage::<T>::new(transport),
+        }
+        .with_push_metrics(metrics.clone(), record_item_bytes),
+    );
     // Pair the transport-limit setter with this stage's overflow-cap setter so
     // the budget pass sizes both from one per-edge budget. Cloned (and coerced
     // to the trait object) before the stage is moved into the input handle.
@@ -530,8 +634,12 @@ fn ordered_branch<T: Send + HeapSize + 'static>(
         output: BranchOutputHandle {
             inner: BranchOutputInner::Ordered { stage: Arc::clone(&stage), ordinal_source },
         },
-        input: BranchInputHandle { inner: BranchInputInner::Ordered(stage) },
+        input: BranchInputHandle {
+            inner: BranchInputInner::Ordered(stage),
+            metrics: metrics.clone(),
+        },
         bounded_queue_handle,
+        metrics,
     }
 }
 
@@ -557,6 +665,11 @@ pub(crate) struct BranchEntry {
     /// builder collects these into a registry so the budget pass +
     /// optional queue-memory rebalancer can set/reallocate budget.
     pub(crate) bounded_queue_handle: Option<BranchBudgetHandles>,
+    /// `Some` iff this edge is instrumented (`--pipeline-trace`); the shared
+    /// `EdgeMetrics` (also held by the transport for push counts and the input
+    /// handle for pop counts). Collected into the edge registry by `contexts.rs`
+    /// Pass 1.5. Cleared (`None`) by `take_typed_input`'s placeholder.
+    pub(crate) metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
 }
 
 impl OutputQueueSet {
@@ -583,7 +696,7 @@ impl OutputQueueSet {
     ) -> BranchInputHandle<T> {
         let entry = std::mem::replace(
             &mut self.branches[branch_idx],
-            BranchEntry { input_handle: Box::new(()), bounded_queue_handle: None },
+            BranchEntry { input_handle: Box::new(()), bounded_queue_handle: None, metrics: None },
         );
         let handle: Box<BranchInputHandle<T>> =
             entry.input_handle.downcast::<BranchInputHandle<T>>().unwrap_or_else(|_| {
@@ -777,6 +890,31 @@ impl<T: Send + HeapSize + 'static> OutputHandles<Single<T>> {
             .downcast_ref::<SingleOutputsView<T>>()
             .expect("Single<T> outputs view downcast failed");
         view.primary.retry(unpushed)
+    }
+
+    /// Retry a step's held output slot, re-holding on backpressure.
+    ///
+    /// The single canonical definition of the held-slot re-hold invariant for
+    /// the `Single<T>` output shape — mirror of the `OrderedBytesSingle<T>`
+    /// variant. If the slot holds an
+    /// item, [`retry`](Self::retry) it; on rejection put it **back** in the slot
+    /// (so it is never dropped) and report [`HeldRetry::StillHeld`]. Used by step
+    /// flush-first preambles so each step doesn't re-implement the
+    /// take/retry/put-back dance (a copy that forgot the put-back would silently
+    /// drop a final batch). **Never spins** — the caller maps `StillHeld` to a
+    /// yield (`NoProgress`/`Contention`) and retries on the next dispatch.
+    #[inline]
+    pub fn retry_held(&self, held: &mut crate::held::HeldSlot<Unpushed<T>>) -> HeldRetry {
+        match held.take() {
+            None => HeldRetry::WasEmpty,
+            Some(unpushed) => match self.retry(unpushed) {
+                Ok(()) => HeldRetry::Flushed,
+                Err(again) => {
+                    held.put(again);
+                    HeldRetry::StillHeld
+                }
+            },
+        }
     }
 }
 
@@ -1117,6 +1255,7 @@ impl OutputHandles<()> {
 pub(crate) fn build_single_queues<T: Send + HeapSize + 'static>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny) {
     assert_eq!(specs.len(), 1, "Single<T>::build_queues requires 1 spec");
     assert_eq!(ordering.len(), 1, "Single<T>::build_queues requires 1 ordering");
@@ -1126,12 +1265,13 @@ pub(crate) fn build_single_queues<T: Send + HeapSize + 'static>(
     // outputs without item-carried serials) and delegates every non-byte spec
     // straight back to `build_branch::<T>`, so count/unbounded paths are
     // unchanged.
-    let branch = build_branch_byte_aware::<T>(specs[0], ordering[0]);
+    let branch = build_branch_byte_aware::<T>(specs[0], ordering[0], level);
     let view = SingleOutputsView { primary: branch.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![BranchEntry {
         input_handle: Box::new(branch.input),
         bounded_queue_handle: branch.bounded_queue_handle,
+        metrics: branch.metrics,
     }]);
     (queue_set, outputs_view)
 }
@@ -1141,16 +1281,18 @@ pub(crate) fn build_single_queues<T: Send + HeapSize + 'static>(
 pub(crate) fn build_single_queues_ordered_bytes<T: Send + HeapSize + Ordered + 'static>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny) {
     assert_eq!(specs.len(), 1, "OrderedBytesSingle<T>::build_queues requires 1 spec");
     assert_eq!(ordering.len(), 1, "OrderedBytesSingle<T>::build_queues requires 1 ordering");
 
-    let branch = build_branch_ordered_bytes::<T>(specs[0], ordering[0]);
+    let branch = build_branch_ordered_bytes::<T>(specs[0], ordering[0], level);
     let view = OrderedBytesSingleOutputsView { primary: branch.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![BranchEntry {
         input_handle: Box::new(branch.input),
         bounded_queue_handle: branch.bounded_queue_handle,
+        metrics: branch.metrics,
     }]);
     (queue_set, outputs_view)
 }
@@ -1158,6 +1300,7 @@ pub(crate) fn build_single_queues_ordered_bytes<T: Send + HeapSize + Ordered + '
 pub(crate) fn build_tuple2_queues<A, B>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny)
 where
     A: Send + HeapSize + 'static,
@@ -1166,18 +1309,20 @@ where
     assert_eq!(specs.len(), 2, "(A, B)::build_queues requires 2 specs");
     assert_eq!(ordering.len(), 2, "(A, B)::build_queues requires 2 orderings");
 
-    let ba = build_branch::<A>(specs[0], ordering[0]);
-    let bb = build_branch::<B>(specs[1], ordering[1]);
+    let ba = build_branch::<A>(specs[0], ordering[0], level);
+    let bb = build_branch::<B>(specs[1], ordering[1], level);
     let view = Tuple2OutputsView { a: ba.output, b: bb.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![
         BranchEntry {
             input_handle: Box::new(ba.input),
             bounded_queue_handle: ba.bounded_queue_handle,
+            metrics: ba.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bb.input),
             bounded_queue_handle: bb.bounded_queue_handle,
+            metrics: bb.metrics,
         },
     ]);
     (queue_set, outputs_view)
@@ -1191,6 +1336,7 @@ where
 pub(crate) fn build_tuple2_queues_ordered_bytes<A, B>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny)
 where
     A: Send + HeapSize + Ordered + 'static,
@@ -1199,18 +1345,20 @@ where
     assert_eq!(specs.len(), 2, "OrderedBytesTuple2<A, B>::build_queues requires 2 specs");
     assert_eq!(ordering.len(), 2, "OrderedBytesTuple2<A, B>::build_queues requires 2 orderings");
 
-    let ba = build_branch_ordered_bytes::<A>(specs[0], ordering[0]);
-    let bb = build_branch_ordered_bytes::<B>(specs[1], ordering[1]);
+    let ba = build_branch_ordered_bytes::<A>(specs[0], ordering[0], level);
+    let bb = build_branch_ordered_bytes::<B>(specs[1], ordering[1], level);
     let view = Tuple2OutputsView { a: ba.output, b: bb.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![
         BranchEntry {
             input_handle: Box::new(ba.input),
             bounded_queue_handle: ba.bounded_queue_handle,
+            metrics: ba.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bb.input),
             bounded_queue_handle: bb.bounded_queue_handle,
+            metrics: bb.metrics,
         },
     ]);
     (queue_set, outputs_view)
@@ -1219,6 +1367,7 @@ where
 pub(crate) fn build_tuple3_queues<A, B, C>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny)
 where
     A: Send + HeapSize + 'static,
@@ -1228,23 +1377,26 @@ where
     assert_eq!(specs.len(), 3, "(A, B, C)::build_queues requires 3 specs");
     assert_eq!(ordering.len(), 3, "(A, B, C)::build_queues requires 3 orderings");
 
-    let ba = build_branch::<A>(specs[0], ordering[0]);
-    let bb = build_branch::<B>(specs[1], ordering[1]);
-    let bc = build_branch::<C>(specs[2], ordering[2]);
+    let ba = build_branch::<A>(specs[0], ordering[0], level);
+    let bb = build_branch::<B>(specs[1], ordering[1], level);
+    let bc = build_branch::<C>(specs[2], ordering[2], level);
     let view = Tuple3OutputsView { a: ba.output, b: bb.output, c: bc.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![
         BranchEntry {
             input_handle: Box::new(ba.input),
             bounded_queue_handle: ba.bounded_queue_handle,
+            metrics: ba.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bb.input),
             bounded_queue_handle: bb.bounded_queue_handle,
+            metrics: bb.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bc.input),
             bounded_queue_handle: bc.bounded_queue_handle,
+            metrics: bc.metrics,
         },
     ]);
     (queue_set, outputs_view)
@@ -1253,6 +1405,7 @@ where
 pub(crate) fn build_tuple4_queues<A, B, C, D>(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny)
 where
     A: Send + HeapSize + 'static,
@@ -1263,28 +1416,32 @@ where
     assert_eq!(specs.len(), 4, "(A, B, C, D)::build_queues requires 4 specs");
     assert_eq!(ordering.len(), 4, "(A, B, C, D)::build_queues requires 4 orderings");
 
-    let ba = build_branch::<A>(specs[0], ordering[0]);
-    let bb = build_branch::<B>(specs[1], ordering[1]);
-    let bc = build_branch::<C>(specs[2], ordering[2]);
-    let bd = build_branch::<D>(specs[3], ordering[3]);
+    let ba = build_branch::<A>(specs[0], ordering[0], level);
+    let bb = build_branch::<B>(specs[1], ordering[1], level);
+    let bc = build_branch::<C>(specs[2], ordering[2], level);
+    let bd = build_branch::<D>(specs[3], ordering[3], level);
     let view = Tuple4OutputsView { a: ba.output, b: bb.output, c: bc.output, d: bd.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };
     let queue_set = OutputQueueSet::new(vec![
         BranchEntry {
             input_handle: Box::new(ba.input),
             bounded_queue_handle: ba.bounded_queue_handle,
+            metrics: ba.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bb.input),
             bounded_queue_handle: bb.bounded_queue_handle,
+            metrics: bb.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bc.input),
             bounded_queue_handle: bc.bounded_queue_handle,
+            metrics: bc.metrics,
         },
         BranchEntry {
             input_handle: Box::new(bd.input),
             bounded_queue_handle: bd.bounded_queue_handle,
+            metrics: bd.metrics,
         },
     ]);
     (queue_set, outputs_view)
@@ -1293,6 +1450,7 @@ where
 pub(crate) fn build_unit_queues(
     specs: &[QueueSpec],
     ordering: &[BranchOrdering],
+    _level: crate::builder::InstrumentationLevel,
 ) -> (OutputQueueSet, OutputsViewAny) {
     assert_eq!(specs.len(), 0, "()::build_queues requires 0 specs");
     assert_eq!(ordering.len(), 0, "()::build_queues requires 0 orderings");
@@ -1323,8 +1481,97 @@ mod handle_tests {
     }
 
     #[test]
+    fn build_branch_mints_metrics_iff_on() {
+        use crate::builder::InstrumentationLevel as L;
+        let on = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 4 },
+            BranchOrdering::None,
+            L::Summary,
+        );
+        assert!(on.metrics.is_some(), "level on → edge metrics minted");
+        let off = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 4 },
+            BranchOrdering::None,
+            L::Off,
+        );
+        assert!(off.metrics.is_none(), "level off → no metrics (hot path metric-free)");
+    }
+
+    #[test]
+    fn metrics_shared_between_transport_push_and_input_handle_pop() {
+        // Producer-push (transport) and consumer-pop (input handle) share one
+        // EdgeMetrics: push lands via the queue, pop/empty via the input handle.
+        use crate::builder::InstrumentationLevel as L;
+        let b = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 4 },
+            BranchOrdering::None,
+            L::Summary,
+        );
+        let m = b.metrics.clone().expect("metrics present");
+        b.output.push(7).unwrap();
+        assert_eq!(b.input.pop(), Some(7));
+        assert_eq!(b.input.pop(), None); // empty
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 1, "producer push counted at the transport");
+        assert_eq!(s.popped_items, 1, "consumer pop counted at the input handle");
+        assert_eq!(s.pop_empties, 1, "empty pop counted at the input handle");
+    }
+
+    #[test]
+    fn ordered_reorder_blocked_pop_is_not_counted_empty() {
+        // Regression: an ordered edge's `try_pop_in_order` returns `None` both
+        // when the edge is genuinely starved AND when it is only reorder-blocked
+        // (later ordinals are buffered while it waits for the next in-order
+        // ordinal). Counting the reorder-blocked case as an empty pop inflates
+        // `pop_empties` and can misclassify a backlogged edge as starved, so
+        // the pop path must skip `record_empty()` while the reorder buffer holds
+        // out-of-order items.
+        use crate::runtime::metrics::EdgeMetrics;
+
+        let transport: Arc<dyn ItemQueue<Sequenced<u32>>> =
+            Arc::new(CountBoundedQueue::<Sequenced<u32>>::new(8));
+        let stage = Arc::new(ReorderStage::new(transport));
+        // Buffer ordinal 1 while ordinal 0 is still absent: the next in-order
+        // pop is blocked, not starved.
+        stage.try_push(1, 100).unwrap();
+
+        let m = EdgeMetrics::new();
+        let handle = BranchInputHandle {
+            inner: BranchInputInner::Ordered(stage.clone()),
+            metrics: Some(m.clone()),
+        };
+
+        // Reorder-blocked: yields nothing yet, but there is buffered work.
+        assert_eq!(handle.pop(), None, "next ordinal (0) absent → no in-order item");
+        assert_eq!(
+            m.snapshot().pop_empties,
+            0,
+            "a reorder-blocked pop is backlog, not starvation — must not count as empty"
+        );
+
+        // Now the missing ordinal arrives and both items drain in order; still
+        // no empty pops recorded.
+        stage.try_push(0, 50).unwrap();
+        assert_eq!(handle.pop(), Some(50));
+        assert_eq!(handle.pop(), Some(100));
+        assert_eq!(m.snapshot().pop_empties, 0, "in-order drains record no empties");
+
+        // Genuinely drained now: this pop IS a starved/empty pop.
+        assert_eq!(handle.pop(), None);
+        assert_eq!(
+            m.snapshot().pop_empties,
+            1,
+            "an empty pop with no buffered work is a true empty pop"
+        );
+    }
+
+    #[test]
     fn count_bounded_fifo_round_trip() {
-        let b = build_branch::<u32>(QueueSpec::CountBounded { capacity: 4 }, BranchOrdering::None);
+        let b = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 4 },
+            BranchOrdering::None,
+            crate::builder::InstrumentationLevel::Off,
+        );
         b.output.push(1).unwrap();
         b.output.push(2).unwrap();
         assert_eq!(b.input.pop(), Some(1));
@@ -1334,8 +1581,11 @@ mod handle_tests {
 
     #[test]
     fn count_bounded_ordered_emits_in_order() {
-        let b =
-            build_branch::<u32>(QueueSpec::CountBounded { capacity: 8 }, BranchOrdering::ByOrdinal);
+        let b = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 8 },
+            BranchOrdering::ByOrdinal,
+            crate::builder::InstrumentationLevel::Off,
+        );
         // Single producer pushes ordinals 0,1,2 in arrival order.
         b.output.push(100).unwrap();
         b.output.push(200).unwrap();
@@ -1347,7 +1597,11 @@ mod handle_tests {
 
     #[test]
     fn drained_signal_propagates() {
-        let b = build_branch::<u32>(QueueSpec::CountBounded { capacity: 4 }, BranchOrdering::None);
+        let b = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 4 },
+            BranchOrdering::None,
+            crate::builder::InstrumentationLevel::Off,
+        );
         b.output.push(1).unwrap();
         b.output.mark_drained();
         // Marker set but item still buffered: not drained.
@@ -1358,7 +1612,11 @@ mod handle_tests {
 
     #[test]
     fn unbounded_branch_works() {
-        let b = build_branch::<u32>(QueueSpec::Unbounded, BranchOrdering::None);
+        let b = build_branch::<u32>(
+            QueueSpec::Unbounded,
+            BranchOrdering::None,
+            crate::builder::InstrumentationLevel::Off,
+        );
         for i in 0..1024 {
             b.output.push(i).unwrap();
         }
@@ -1380,6 +1638,7 @@ mod handle_tests {
         let b = build_branch_byte_aware::<Bytes>(
             QueueSpec::ByteBounded { limit_bytes: 1000 },
             BranchOrdering::None,
+            crate::builder::InstrumentationLevel::Off,
         );
         b.output.push(Bytes(vec![0; 500])).unwrap();
         let popped = b.input.pop().unwrap();
@@ -1389,8 +1648,11 @@ mod handle_tests {
     #[test]
     #[should_panic(expected = "ByteBounded requires `T: HeapSize`")]
     fn byte_bounded_panics_in_non_heap_aware_builder() {
-        let _ =
-            build_branch::<u32>(QueueSpec::ByteBounded { limit_bytes: 1000 }, BranchOrdering::None);
+        let _ = build_branch::<u32>(
+            QueueSpec::ByteBounded { limit_bytes: 1000 },
+            BranchOrdering::None,
+            crate::builder::InstrumentationLevel::Off,
+        );
     }
 
     #[test]
@@ -1406,11 +1668,48 @@ mod handle_tests {
         let (mut queue_set, outputs_view) = <Single<u32> as StepOutputs>::build_queues(
             &[QueueSpec::ByteBounded { limit_bytes: 1000 }],
             &[BranchOrdering::None],
+            crate::builder::InstrumentationLevel::Off,
         );
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
         outputs.push(7).unwrap();
         let input = queue_set.take_typed_input::<u32>(0);
         assert_eq!(input.pop(), Some(7));
+    }
+
+    #[test]
+    fn single_retry_held_drains_then_reholds() {
+        // Exercises `OutputHandles<Single<T>>::retry_held`: empty → WasEmpty,
+        // a rejected push re-held → StillHeld while the queue is full → Flushed
+        // once a slot frees, with the held item never dropped.
+        use crate::held::HeldSlot;
+        use crate::outputs::{Single, StepOutputs};
+        use crate::step::OutputHandles;
+        let (mut queue_set, outputs_view) = <Single<u32> as StepOutputs>::build_queues(
+            &[QueueSpec::CountBounded { capacity: 1 }],
+            &[BranchOrdering::None],
+            crate::builder::InstrumentationLevel::Off,
+        );
+        let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
+        let mut held: HeldSlot<Unpushed<u32>> = HeldSlot::new();
+
+        // Empty slot → WasEmpty (queue untouched).
+        assert!(matches!(outputs.retry_held(&mut held), HeldRetry::WasEmpty));
+
+        // Fill the capacity-1 queue; the next push is rejected and re-held.
+        outputs.push(1).unwrap();
+        let rejected = outputs.push(2).expect_err("capacity-1 queue must reject the 2nd push");
+        held.put(rejected);
+
+        // Queue still full → StillHeld; the item is put back, not dropped.
+        assert!(matches!(outputs.retry_held(&mut held), HeldRetry::StillHeld));
+        assert!(held.is_held());
+
+        // Drain one item; the held push now flushes.
+        let input = queue_set.take_typed_input::<u32>(0);
+        assert_eq!(input.pop(), Some(1));
+        assert!(matches!(outputs.retry_held(&mut held), HeldRetry::Flushed));
+        assert!(!held.is_held());
+        assert_eq!(input.pop(), Some(2));
     }
 
     #[test]
@@ -1422,6 +1721,7 @@ mod handle_tests {
         let b = build_branch_byte_aware::<Bytes>(
             QueueSpec::ByteBounded { limit_bytes: 1000 },
             BranchOrdering::ByOrdinal,
+            crate::builder::InstrumentationLevel::Off,
         );
         b.output.push(Bytes(vec![0; 100])).unwrap();
         let popped = b.input.pop().unwrap();
@@ -1434,6 +1734,7 @@ mod handle_tests {
         let _ = build_branch::<u32>(
             QueueSpec::CountBounded { capacity: 4 },
             BranchOrdering::ByItemOrdinal,
+            crate::builder::InstrumentationLevel::Off,
         );
     }
 
@@ -1454,6 +1755,7 @@ mod handle_tests {
         let b = build_branch_ordered::<OrdItem>(
             QueueSpec::CountBounded { capacity: 8 },
             BranchOrdering::ByItemOrdinal,
+            crate::builder::InstrumentationLevel::Off,
         );
         // Push out of order: ordinals 2, 0, 1.
         b.output.push(OrdItem { ord: 2, v: 200 }).unwrap();
@@ -1476,6 +1778,7 @@ mod handle_tests {
         let b = build_branch_ordered_bytes::<OrdItem>(
             QueueSpec::ByteBounded { limit_bytes: 4096 },
             BranchOrdering::ByItemOrdinal,
+            crate::builder::InstrumentationLevel::Off,
         );
         b.output.push(OrdItem { ord: 1, v: 1 }).unwrap();
         b.output.push(OrdItem { ord: 0, v: 0 }).unwrap();
@@ -1489,8 +1792,11 @@ mod handle_tests {
         // through an ordered branch, draining one at a time. Without the
         // Unpushed<T> retry, the third push would burn an ordinal on
         // backpressure and stall the reorder stage.
-        let b =
-            build_branch::<u32>(QueueSpec::CountBounded { capacity: 2 }, BranchOrdering::ByOrdinal);
+        let b = build_branch::<u32>(
+            QueueSpec::CountBounded { capacity: 2 },
+            BranchOrdering::ByOrdinal,
+            crate::builder::InstrumentationLevel::Off,
+        );
 
         // Pump 5 items through the branch, draining sequentially. Capacity 2
         // means every push after the second hits backpressure once.
@@ -1541,6 +1847,7 @@ mod handle_tests {
         let (mut set, _view) = build_single_queues::<u32>(
             &[QueueSpec::CountBounded { capacity: 4 }],
             &[BranchOrdering::None],
+            crate::builder::InstrumentationLevel::Off,
         );
         let _input: BranchInputHandle<u32> = set.take_typed_input::<u32>(0);
     }
@@ -1559,8 +1866,11 @@ mod build_queues_tests {
     #[test]
     fn single_round_trip() {
         let (specs, ordering) = count_specs(1, 4);
-        let (mut queue_set, outputs_view) =
-            <Single<u32> as StepOutputs>::build_queues(&specs, &ordering);
+        let (mut queue_set, outputs_view) = <Single<u32> as StepOutputs>::build_queues(
+            &specs,
+            &ordering,
+            crate::builder::InstrumentationLevel::Off,
+        );
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
         outputs.push(7).unwrap();
 
@@ -1571,8 +1881,11 @@ mod build_queues_tests {
     #[test]
     fn tuple_2_round_trip() {
         let (specs, ordering) = count_specs(2, 2);
-        let (mut queue_set, outputs_view) =
-            <(u32, String) as StepOutputs>::build_queues(&specs, &ordering);
+        let (mut queue_set, outputs_view) = <(u32, String) as StepOutputs>::build_queues(
+            &specs,
+            &ordering,
+            crate::builder::InstrumentationLevel::Off,
+        );
         let outputs: OutputHandles<(u32, String)> = OutputHandles::new(outputs_view);
 
         let v = outputs.view();
@@ -1588,8 +1901,11 @@ mod build_queues_tests {
     #[test]
     fn tuple_3_round_trip() {
         let (specs, ordering) = count_specs(3, 2);
-        let (mut queue_set, outputs_view) =
-            <(u32, u64, String) as StepOutputs>::build_queues(&specs, &ordering);
+        let (mut queue_set, outputs_view) = <(u32, u64, String) as StepOutputs>::build_queues(
+            &specs,
+            &ordering,
+            crate::builder::InstrumentationLevel::Off,
+        );
         let outputs: OutputHandles<(u32, u64, String)> = OutputHandles::new(outputs_view);
 
         let v = outputs.view();
@@ -1606,7 +1922,11 @@ mod build_queues_tests {
     fn tuple_4_round_trip() {
         let (specs, ordering) = count_specs(4, 2);
         let (mut queue_set, outputs_view) =
-            <(u32, u64, String, Vec<u8>) as StepOutputs>::build_queues(&specs, &ordering);
+            <(u32, u64, String, Vec<u8>) as StepOutputs>::build_queues(
+                &specs,
+                &ordering,
+                crate::builder::InstrumentationLevel::Off,
+            );
         let outputs: OutputHandles<(u32, u64, String, Vec<u8>)> = OutputHandles::new(outputs_view);
 
         let v = outputs.view();
@@ -1623,7 +1943,8 @@ mod build_queues_tests {
 
     #[test]
     fn unit_build_queues_yields_empty_set() {
-        let (queue_set, outputs_view) = <() as StepOutputs>::build_queues(&[], &[]);
+        let (queue_set, outputs_view) =
+            <() as StepOutputs>::build_queues(&[], &[], crate::builder::InstrumentationLevel::Off);
         let outputs: OutputHandles<()> = OutputHandles::new(outputs_view);
         outputs.noop();
         assert_eq!(queue_set.n_branches(), 0);
@@ -1632,8 +1953,11 @@ mod build_queues_tests {
     #[test]
     fn mark_all_drained_propagates_to_input_handle() {
         let (specs, ordering) = count_specs(1, 4);
-        let (mut queue_set, outputs_view) =
-            <Single<u32> as StepOutputs>::build_queues(&specs, &ordering);
+        let (mut queue_set, outputs_view) = <Single<u32> as StepOutputs>::build_queues(
+            &specs,
+            &ordering,
+            crate::builder::InstrumentationLevel::Off,
+        );
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
 
         let input = queue_set.take_typed_input::<u32>(0);
@@ -1646,8 +1970,11 @@ mod build_queues_tests {
     fn ordered_branch_preserves_emission_order_through_typed_path() {
         let specs = vec![QueueSpec::CountBounded { capacity: 8 }];
         let ordering = vec![BranchOrdering::ByOrdinal];
-        let (mut queue_set, outputs_view) =
-            <Single<u32> as StepOutputs>::build_queues(&specs, &ordering);
+        let (mut queue_set, outputs_view) = <Single<u32> as StepOutputs>::build_queues(
+            &specs,
+            &ordering,
+            crate::builder::InstrumentationLevel::Off,
+        );
         let outputs: OutputHandles<Single<u32>> = OutputHandles::new(outputs_view);
 
         outputs.push(10).unwrap();

--- a/crates/fgumi-pipeline-core/src/outputs.rs
+++ b/crates/fgumi-pipeline-core/src/outputs.rs
@@ -13,7 +13,7 @@
 //!
 //! Each `StepOutputs` impl provides:
 //!   - `arity()` — number of independent output channels.
-//!   - `build_queues(specs, ordering) -> (OutputQueueSet, OutputsViewAny)` —
+//!   - `build_queues(specs, ordering, level) -> (OutputQueueSet, OutputsViewAny)` —
 //!     constructs the typed queues + reorder operators (where applicable)
 //!     and the type-erased view the framework stores. Implemented in
 //!     `handles.rs` (one impl per arity).
@@ -46,6 +46,7 @@ pub trait StepOutputs: Send + 'static {
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny);
 
     /// Mark all output branches drained, dispatching through the typed
@@ -69,8 +70,9 @@ impl<T: Send + HeapSize + 'static> StepOutputs for Single<T> {
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_single_queues::<T>(specs, ordering)
+        super::handles::build_single_queues::<T>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -101,8 +103,9 @@ impl<T: Send + HeapSize + Ordered + 'static> StepOutputs for OrderedBytesSingle<
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_single_queues_ordered_bytes::<T>(specs, ordering)
+        super::handles::build_single_queues_ordered_bytes::<T>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -119,8 +122,9 @@ impl<A: Send + HeapSize + 'static, B: Send + HeapSize + 'static> StepOutputs for
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_tuple2_queues::<A, B>(specs, ordering)
+        super::handles::build_tuple2_queues::<A, B>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -157,8 +161,9 @@ where
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_tuple2_queues_ordered_bytes::<A, B>(specs, ordering)
+        super::handles::build_tuple2_queues_ordered_bytes::<A, B>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -180,8 +185,9 @@ where
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_tuple3_queues::<A, B, C>(specs, ordering)
+        super::handles::build_tuple3_queues::<A, B, C>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -204,8 +210,9 @@ where
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_tuple4_queues::<A, B, C, D>(specs, ordering)
+        super::handles::build_tuple4_queues::<A, B, C, D>(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {
@@ -222,8 +229,9 @@ impl StepOutputs for () {
     fn build_queues(
         specs: &[QueueSpec],
         ordering: &[BranchOrdering],
+        level: crate::builder::InstrumentationLevel,
     ) -> (OutputQueueSet, OutputsViewAny) {
-        super::handles::build_unit_queues(specs, ordering)
+        super::handles::build_unit_queues(specs, ordering, level)
     }
 
     fn mark_all_drained(handles: &super::step::OutputHandles<Self>) {

--- a/crates/fgumi-pipeline-core/src/queues.rs
+++ b/crates/fgumi-pipeline-core/src/queues.rs
@@ -22,9 +22,11 @@
 //!     end-of-stream. Once both are true, no further items will arrive.
 
 use crossbeam_queue::{ArrayQueue, SegQueue};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use super::item::HeapSize;
+use super::runtime::metrics::EdgeMetrics;
 
 /// Transport-layer queue trait. Type-uniform across queue impls: the
 /// `try_push` surface accepts any `T` regardless of whether the impl uses
@@ -83,6 +85,10 @@ pub enum QueueSpec {
 pub struct CountBoundedQueue<T: Send + 'static> {
     inner: ArrayQueue<T>,
     drained: AtomicBool,
+    /// `Some` only on an instrumented edge (`--pipeline-trace`); `None` keeps the
+    /// hot path metric-free. Producer-push counts are recorded here; consumer-pop
+    /// counts are recorded at the `BranchInputHandle` (see `handles.rs`).
+    metrics: Option<Arc<EdgeMetrics>>,
 }
 
 impl<T: Send + 'static> CountBoundedQueue<T> {
@@ -93,8 +99,34 @@ impl<T: Send + 'static> CountBoundedQueue<T> {
     /// Panics if `capacity == 0` (a zero-capacity queue would always reject).
     #[must_use]
     pub fn new(capacity: usize) -> Self {
+        Self::build(capacity, None)
+    }
+
+    /// Like [`new`](Self::new) but recording producer-push metrics into `metrics`
+    /// (an instrumented edge). The non-blocking `try_*` surface is unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity == 0`.
+    #[must_use]
+    pub fn new_instrumented(capacity: usize, metrics: Arc<EdgeMetrics>) -> Self {
+        Self::build(capacity, Some(metrics))
+    }
+
+    /// [`new`](Self::new) when `metrics` is `None`, [`new_instrumented`](Self::new_instrumented)
+    /// when `Some`. Lets branch builders thread an optional metrics handle uniformly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity == 0`.
+    #[must_use]
+    pub fn maybe_instrumented(capacity: usize, metrics: Option<Arc<EdgeMetrics>>) -> Self {
+        Self::build(capacity, metrics)
+    }
+
+    fn build(capacity: usize, metrics: Option<Arc<EdgeMetrics>>) -> Self {
         assert!(capacity > 0, "CountBoundedQueue capacity must be > 0");
-        Self { inner: ArrayQueue::new(capacity), drained: AtomicBool::new(false) }
+        Self { inner: ArrayQueue::new(capacity), drained: AtomicBool::new(false), metrics }
     }
 }
 
@@ -104,11 +136,21 @@ impl<T: Send + 'static> ItemQueue<T> for CountBoundedQueue<T> {
             !self.drained.load(Ordering::Acquire),
             "try_push after mark_drained — producer contract violation"
         );
-        self.inner.push(item)
+        if let Err(item) = self.inner.push(item) {
+            if let Some(m) = &self.metrics {
+                m.record_reject();
+            }
+            return Err(item);
+        }
+        if let Some(m) = &self.metrics {
+            m.record_push(0); // count-bounded: items only, no byte size
+        }
+        Ok(())
     }
 
     fn try_pop(&self) -> Option<T> {
-        self.inner.pop()
+        let item = self.inner.pop()?;
+        Some(item)
     }
 
     fn is_empty(&self) -> bool {
@@ -192,6 +234,10 @@ pub struct ByteBoundedQueue<T: Send + HeapSize + 'static> {
     /// long-lived host / test harness) after the first occurrence. The hot-path
     /// cost is a single relaxed swap after the first hit.
     slot_cap_warned: AtomicBool,
+    /// `Some` only on an instrumented edge; producer-push (items + bytes) and
+    /// rejections are recorded here. Consumer-pop is recorded at the
+    /// `BranchInputHandle` (see `handles.rs`).
+    metrics: Option<Arc<EdgeMetrics>>,
 }
 
 impl<T: Send + HeapSize + 'static> ByteBoundedQueue<T> {
@@ -202,6 +248,32 @@ impl<T: Send + HeapSize + 'static> ByteBoundedQueue<T> {
     /// Panics if `limit_bytes == 0` (a zero-budget queue would always reject).
     #[must_use]
     pub fn new(limit_bytes: u64) -> Self {
+        Self::build(limit_bytes, None)
+    }
+
+    /// Like [`new`](Self::new) but recording producer-push metrics (items + bytes
+    /// + rejections) into `metrics`. Byte-budget semantics unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `limit_bytes == 0`.
+    #[must_use]
+    pub fn new_instrumented(limit_bytes: u64, metrics: Arc<EdgeMetrics>) -> Self {
+        Self::build(limit_bytes, Some(metrics))
+    }
+
+    /// [`new`](Self::new) when `metrics` is `None`, [`new_instrumented`](Self::new_instrumented)
+    /// when `Some`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `limit_bytes == 0`.
+    #[must_use]
+    pub fn maybe_instrumented(limit_bytes: u64, metrics: Option<Arc<EdgeMetrics>>) -> Self {
+        Self::build(limit_bytes, metrics)
+    }
+
+    fn build(limit_bytes: u64, metrics: Option<Arc<EdgeMetrics>>) -> Self {
         assert!(limit_bytes > 0, "ByteBoundedQueue limit_bytes must be > 0");
         Self {
             inner: ArrayQueue::new(BYTE_BOUNDED_QUEUE_SLOT_CAPACITY),
@@ -209,6 +281,7 @@ impl<T: Send + HeapSize + 'static> ByteBoundedQueue<T> {
             limit_bytes: AtomicU64::new(limit_bytes),
             drained: AtomicBool::new(false),
             slot_cap_warned: AtomicBool::new(false),
+            metrics,
         }
     }
 
@@ -286,6 +359,9 @@ impl<T: Send + HeapSize + 'static> ItemQueue<T> for ByteBoundedQueue<T> {
         let cur = self.current_bytes.load(Ordering::Relaxed);
         let limit = self.limit_bytes.load(Ordering::Relaxed);
         if cur >= limit {
+            if let Some(m) = &self.metrics {
+                m.record_reject();
+            }
             return Err(item);
         }
         let size = item.heap_size() as u64;
@@ -298,10 +374,18 @@ impl<T: Send + HeapSize + 'static> ItemQueue<T> for ByteBoundedQueue<T> {
         // the slot cap should never be hit before the byte budget triggers a
         // reject above, but defend against it anyway.)
         match self.inner.push((item, size)) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                if let Some(m) = &self.metrics {
+                    m.record_push(size);
+                }
+                Ok(())
+            }
             Err((item, _size)) => {
                 // Roll back the byte reservation — the item never entered the queue.
                 self.current_bytes.fetch_sub(size, Ordering::Relaxed);
+                if let Some(m) = &self.metrics {
+                    m.record_reject();
+                }
                 // The fixed 1024-slot backing was hit before the byte budget.
                 // This degrades byte-backpressure into a hard count cap for
                 // small items (heap_size ≲ limit/1024) — correctness is
@@ -347,12 +431,31 @@ impl<T: Send + HeapSize + 'static> ItemQueue<T> for ByteBoundedQueue<T> {
 pub struct UnboundedQueue<T: Send + 'static> {
     inner: SegQueue<T>,
     drained: AtomicBool,
+    /// `Some` only on an instrumented edge; producer-push items are recorded
+    /// here (unbounded → never rejects, no byte tracking). Consumer-pop is at the
+    /// `BranchInputHandle`.
+    metrics: Option<Arc<EdgeMetrics>>,
 }
 
 impl<T: Send + 'static> UnboundedQueue<T> {
     #[must_use]
     pub fn new() -> Self {
-        Self { inner: SegQueue::new(), drained: AtomicBool::new(false) }
+        Self { inner: SegQueue::new(), drained: AtomicBool::new(false), metrics: None }
+    }
+
+    /// Like [`new`](Self::new) but recording producer-push item counts into
+    /// `metrics`. Unbounded edges have no byte budget and never reject; depth is
+    /// reported as raw length only.
+    #[must_use]
+    pub fn new_instrumented(metrics: Arc<EdgeMetrics>) -> Self {
+        Self { inner: SegQueue::new(), drained: AtomicBool::new(false), metrics: Some(metrics) }
+    }
+
+    /// [`new`](Self::new) when `metrics` is `None`, [`new_instrumented`](Self::new_instrumented)
+    /// when `Some`.
+    #[must_use]
+    pub fn maybe_instrumented(metrics: Option<Arc<EdgeMetrics>>) -> Self {
+        Self { inner: SegQueue::new(), drained: AtomicBool::new(false), metrics }
     }
 }
 
@@ -369,6 +472,9 @@ impl<T: Send + 'static> ItemQueue<T> for UnboundedQueue<T> {
             "try_push after mark_drained — producer contract violation"
         );
         self.inner.push(item);
+        if let Some(m) = &self.metrics {
+            m.record_push(0);
+        }
         Ok(())
     }
 
@@ -520,5 +626,57 @@ mod tests {
         for i in 0..1024 {
             assert!(q.try_push(i).is_ok());
         }
+    }
+
+    // ── Per-edge metrics (L2-instrumentation Task 2) ─────────────────────────
+
+    #[test]
+    fn instrumented_queue_counts_push_and_reject() {
+        let m = EdgeMetrics::new();
+        let q = CountBoundedQueue::<u32>::new_instrumented(1, Arc::clone(&m));
+        assert!(q.try_push(1).is_ok());
+        assert_eq!(q.try_push(2), Err(2)); // full (cap 1) → reject
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 1, "one successful push");
+        assert_eq!(s.push_rejections, 1, "one rejection");
+        // Producer-push only at this layer; pop is counted at the input handle.
+        assert_eq!(s.popped_items, 0);
+    }
+
+    #[test]
+    fn byte_bounded_instrumented_push_bytes_and_depth() {
+        let m = EdgeMetrics::new();
+        let q = ByteBoundedQueue::<Heavy>::new_instrumented(1000, Arc::clone(&m));
+        q.try_push(Heavy(vec![0; 200])).unwrap();
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 1);
+        assert_eq!(s.pushed_bytes, 200);
+    }
+
+    #[test]
+    fn byte_bounded_instrumented_counts_reject() {
+        // The byte-budget reject path increments push_rejections (distinct from
+        // the CountBounded slot reject above). Fill to budget, then a push rejects.
+        let m = EdgeMetrics::new();
+        let q = ByteBoundedQueue::<Heavy>::new_instrumented(100, Arc::clone(&m));
+        q.try_push(Heavy(vec![0; 200])).unwrap(); // accepted (cur<limit on empty), now over budget
+        assert!(q.try_push(Heavy(vec![0; 1])).is_err(), "at/over budget rejects");
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 1);
+        assert_eq!(s.push_rejections, 1, "byte-budget reject counted");
+    }
+
+    #[test]
+    fn non_instrumented_queue_has_no_metrics() {
+        // Hot-path guard: a plain `new` queue is metric-free (one nullable
+        // branch, no atomics).
+        assert!(CountBoundedQueue::<u32>::new(4).metrics.is_none());
+        assert!(ByteBoundedQueue::<Heavy>::new(100).metrics.is_none());
+        assert!(UnboundedQueue::<u32>::new().metrics.is_none());
+        // And instrumented constructors do attach metrics.
+        assert!(
+            CountBoundedQueue::<u32>::new_instrumented(4, EdgeMetrics::new()).metrics.is_some()
+        );
+        assert!(UnboundedQueue::<u32>::new_instrumented(EdgeMetrics::new()).metrics.is_some());
     }
 }

--- a/crates/fgumi-pipeline-core/src/reorder.rs
+++ b/crates/fgumi-pipeline-core/src/reorder.rs
@@ -166,6 +166,19 @@ pub struct ReorderStage<T: Send + HeapSize + 'static> {
     /// nothing on the lock-free fast path. Mirrors legacy
     /// `ReorderBufferState::can_proceed` (`base.rs:766-781`).
     max_overflow_bytes: AtomicU64,
+    /// Producer-side push metrics for an **ordered** edge, recorded at THIS
+    /// boundary rather than on the transport queue. `try_push` can turn a
+    /// full-transport `Err` into a must-accept stash `Ok`, so recording on the
+    /// transport would miscount a stashed (accepted) item as a rejection. Here we
+    /// record `record_push` on every accepted push (transport OR stash) and
+    /// `record_reject` only on a true `Err`, keeping `pushed_items` /
+    /// `push_rejections` accurate under producer skew. `None` when the edge is
+    /// not instrumented; the pop side is recorded separately by the input handle.
+    push_metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
+    /// Whether `push_metrics` records each push's `heap_size` (byte-bounded edge)
+    /// or `0` (count/unbounded edge) — mirroring the underlying queue's own byte
+    /// accounting. Set from the branch's queue kind at construction.
+    record_item_bytes: bool,
 }
 
 /// Unbounded sentinel for [`ReorderStage::max_overflow_bytes`].
@@ -242,6 +255,8 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
             next_serial_buffered: AtomicBool::new(false),
             drained_observed: AtomicBool::new(false),
             max_overflow_bytes: AtomicU64::new(REORDER_OVERFLOW_UNBOUNDED),
+            push_metrics: None,
+            record_item_bytes: false,
         }
     }
 
@@ -282,7 +297,25 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
             next_serial_buffered: AtomicBool::new(false),
             drained_observed: AtomicBool::new(false),
             max_overflow_bytes: AtomicU64::new(max_bytes),
+            push_metrics: None,
+            record_item_bytes: false,
         }
+    }
+
+    /// Attach producer-side push metrics recorded at the `ReorderStage` boundary
+    /// (see [`push_metrics`](Self::push_metrics)). `record_item_bytes` is `true`
+    /// for a byte-bounded edge (record each push's `heap_size`) and `false` for a
+    /// count/unbounded edge (record `0`), matching the underlying queue's byte
+    /// accounting. Called once by the ordered-branch builder.
+    #[must_use]
+    pub fn with_push_metrics(
+        mut self,
+        push_metrics: Option<Arc<crate::runtime::metrics::EdgeMetrics>>,
+        record_item_bytes: bool,
+    ) -> Self {
+        self.push_metrics = push_metrics;
+        self.record_item_bytes = record_item_bytes;
+        self
     }
 
     /// Producer-side push. The framework allocates `ordinal` from a
@@ -307,6 +340,35 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
     /// were not in must-accept mode (i.e., `next_serial` is already
     /// observable, so the consumer can drain).
     pub fn try_push(&self, ordinal: u64, item: T) -> Result<(), (u64, T)> {
+        // Record push-side metrics at THIS boundary (see `push_metrics`). The
+        // must-accept path turns a full-transport `Err` into a stash `Ok`, so the
+        // transport queue can't tell a stashed (accepted) push from a reject —
+        // only the final `Result` here can. `heap_size()` is read before `item`
+        // moves into the inner push. Every `Ok` (transport OR stash) is a push;
+        // every `Err` (backpressure or stash-cap held) is a reject.
+        //
+        // Gate the `heap_size()` call on metrics being present: on the default
+        // instrumentation-off path (`push_metrics == None`) the byte figure is
+        // never recorded, so computing it would be pure hot-path overhead.
+        let bytes = if self.push_metrics.is_some() && self.record_item_bytes {
+            item.heap_size() as u64
+        } else {
+            0
+        };
+        let result = self.try_push_inner(ordinal, item);
+        if let Some(m) = &self.push_metrics {
+            match &result {
+                Ok(()) => m.record_push(bytes),
+                Err(_) => m.record_reject(),
+            }
+        }
+        result
+    }
+
+    /// Inner push: the transport / must-accept-stash decision, without metrics.
+    /// See [`try_push`](Self::try_push) for the public contract; metrics are
+    /// recorded there so a stashed push is not miscounted as a rejection.
+    fn try_push_inner(&self, ordinal: u64, item: T) -> Result<(), (u64, T)> {
         // Lock-free fast path. If next_serial is in the buffer (consumer
         // can drain), the producer is in pure-backpressure mode: a
         // transport push that succeeds returns Ok; a rejection returns
@@ -401,6 +463,25 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
     /// guard exists only to fail loudly rather than silently wrap and wait
     /// forever for ordinal 0.
     pub fn try_pop_in_order(&self) -> Option<T> {
+        self.try_pop_in_order_reporting_blocked().0
+    }
+
+    /// Like [`try_pop_in_order`](Self::try_pop_in_order), but also reports whether
+    /// a `None` result was *reorder-blocked* — later ordinals are buffered while
+    /// the stage waits for an earlier one — rather than genuinely drained. The
+    /// pop and the reorder-blocked check are computed under the SAME state lock,
+    /// so a shared (`Parallel`) consumer cannot observe a torn `(item, blocked)`
+    /// pair that would skew the `pop_empties` starvation metric. The flag is
+    /// always `false` when an item is returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the in-order ordinal counter would overflow `u64` (i.e.
+    /// `next_serial == u64::MAX`). Branch ordinals start at 0 and increment, so
+    /// this is unreachable on any real workload (~1.8e19 items on one edge); the
+    /// guard exists only to fail loudly rather than silently wrap and wait
+    /// forever for ordinal 0.
+    pub fn try_pop_in_order_reporting_blocked(&self) -> (Option<T>, bool) {
         let mut state = self.state.lock();
         let next = state.next_serial;
 
@@ -437,9 +518,14 @@ impl<T: Send + HeapSize + 'static> ReorderStage<T> {
             // Producers reading post-update see the right state.
             let new_buffered = state.buffer.contains_key(&new_next);
             self.next_serial_buffered.store(new_buffered, Ordering::Release);
-            Some(item)
+            (Some(item), false)
         } else {
-            None
+            // No in-order item. Reorder-blocked (backlog, not starvation) iff the
+            // buffer still holds out-of-order items awaiting an earlier ordinal —
+            // `next` was just confirmed absent, so any remaining entry is a later
+            // ordinal. Computed here under the same lock as the pop above.
+            let reorder_blocked = !state.buffer.is_empty();
+            (None, reorder_blocked)
         }
     }
 
@@ -518,6 +604,93 @@ mod tests {
         assert_eq!(s.try_pop_in_order(), Some(10));
         assert_eq!(s.try_pop_in_order(), Some(20));
         assert_eq!(s.try_pop_in_order(), Some(30));
+    }
+
+    #[test]
+    fn reporting_pop_flags_reorder_blocked_vs_drained() {
+        // The reporting pop returns the reorder-blocked flag from the same locked
+        // path as the pop itself, so a shared consumer sees a consistent pair.
+        let s = make_stage(8);
+        // Buffer a later ordinal while ordinal 0 is absent → reorder-blocked.
+        s.try_push(1, 100).unwrap();
+        assert_eq!(s.try_pop_in_order_reporting_blocked(), (None, true), "blocked, not drained");
+        // Ordinal 0 arrives; the pop yields it and is not blocked.
+        s.try_push(0, 0).unwrap();
+        assert_eq!(s.try_pop_in_order_reporting_blocked(), (Some(0), false));
+        assert_eq!(s.try_pop_in_order_reporting_blocked(), (Some(100), false));
+        // Genuinely drained now → None and NOT reorder-blocked (a true empty pop).
+        assert_eq!(s.try_pop_in_order_reporting_blocked(), (None, false), "drained, not blocked");
+    }
+
+    #[test]
+    fn push_metrics_count_stashed_item_as_push_not_reject() {
+        use crate::runtime::metrics::EdgeMetrics;
+        // Transport capacity 1, next_serial (0) absent → must-accept. The first
+        // push fills the transport; the second must-accept-overflows into the
+        // stash, returning Ok. Recording at the ReorderStage boundary must count
+        // BOTH as pushes and NEITHER as a rejection — the transport's internal
+        // `Err` on the stashed push is not a real backpressure event. (Recording
+        // on the transport, as before, miscounted the stashed item as a reject.)
+        let m = EdgeMetrics::new();
+        let q: Arc<dyn ItemQueue<Sequenced<u32>>> = Arc::new(CountBoundedQueue::new(1));
+        let stage = ReorderStage::new(q).with_push_metrics(Some(Arc::clone(&m)), false);
+        assert!(stage.try_push(1, 10).is_ok(), "ordinal 1 into transport");
+        assert!(stage.try_push(2, 20).is_ok(), "ordinal 2 stashed (transport full)");
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 2, "both accepted pushes counted");
+        assert_eq!(s.push_rejections, 0, "a stashed push is not a rejection");
+        assert_eq!(s.pushed_bytes, 0, "count-bounded edge records 0 push bytes");
+    }
+
+    #[test]
+    fn push_metrics_record_item_bytes_when_byte_bounded() {
+        use crate::runtime::metrics::EdgeMetrics;
+        #[derive(Debug)]
+        struct Heavy;
+        impl HeapSize for Heavy {
+            fn heap_size(&self) -> usize {
+                100
+            }
+        }
+        // With `record_item_bytes = true` (byte-bounded edge), each accepted push
+        // records its `heap_size` — so `pushed_bytes` tracks the bare `T`, the
+        // same size the pop side records.
+        let m = EdgeMetrics::new();
+        let q: Arc<dyn ItemQueue<Sequenced<Heavy>>> = Arc::new(CountBoundedQueue::new(8));
+        let stage = ReorderStage::new(q).with_push_metrics(Some(Arc::clone(&m)), true);
+        assert!(stage.try_push(0, Heavy).is_ok());
+        assert!(stage.try_push(1, Heavy).is_ok());
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 2);
+        assert_eq!(s.pushed_bytes, 200, "byte-bounded edge records heap_size per push");
+    }
+
+    #[test]
+    fn push_without_metrics_skips_heap_size() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        // On the default instrumentation-off path (`push_metrics == None`) the
+        // push wrapper must NOT compute `heap_size` — that byte figure is only
+        // needed to record a push, so computing it would be pure hot-path cost.
+        #[derive(Debug)]
+        struct Counted(Arc<AtomicUsize>);
+        impl HeapSize for Counted {
+            fn heap_size(&self) -> usize {
+                self.0.fetch_add(1, AtomicOrdering::Relaxed);
+                0
+            }
+        }
+        let calls = Arc::new(AtomicUsize::new(0));
+        let q: Arc<dyn ItemQueue<Sequenced<Counted>>> = Arc::new(CountBoundedQueue::new(8));
+        // Byte-bounded edge (`record_item_bytes = true`) but no push metrics.
+        let stage = ReorderStage::new(q).with_push_metrics(None, true);
+        // ordinal 0 == next_serial → transport accepts (no stash), so the only
+        // `heap_size` call would be the wrapper's — which the gate must skip.
+        stage.try_push(0, Counted(Arc::clone(&calls))).unwrap();
+        assert_eq!(
+            calls.load(AtomicOrdering::Relaxed),
+            0,
+            "heap_size must not be computed when push metrics are disabled"
+        );
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/runtime/contexts.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/contexts.rs
@@ -42,6 +42,44 @@ pub struct ChainContexts {
     /// exist (e.g. a chain composed entirely of `CountBounded` /
     /// `Unbounded` steps).
     pub bounded_queues: Vec<RegisteredQueue>,
+    /// Registry of every instrumented edge (`--pipeline-trace`), with its
+    /// `EdgeMetrics` + producer/consumer + (for byte-bounded edges) a depth
+    /// source. Empty when instrumentation is `Off`. Read by the occupancy
+    /// sampler and the end-of-run edge report.
+    pub edges: Vec<RegisteredEdge>,
+}
+
+/// One instrumented edge: its shared [`EdgeMetrics`](crate::runtime::metrics::EdgeMetrics)
+/// (push counts from the transport, pop counts from the input handle), its
+/// producer + consumer steps, and a depth source for occupancy sampling.
+pub struct RegisteredEdge {
+    pub producer_step: StepIdx,
+    pub producer_name: &'static str,
+    /// `None` for a terminal branch with no consumer (e.g. a `--rejects` tail).
+    pub consumer_step: Option<StepIdx>,
+    pub consumer_name: Option<&'static str>,
+    pub branch: BranchIdx,
+    /// On an **ordered** edge, the push-side counters (`pushed_items` /
+    /// `pushed_bytes` / `push_rejections`) are recorded at the `ReorderStage`
+    /// boundary, not on the transport queue: the reorder stage's must-accept path
+    /// turns a full-transport reject into an accepted (stashed) push, so recording
+    /// on the transport would miscount stashed items as backpressure. Recorded at
+    /// the boundary, `pushed_bytes` counts the bare `T` (`heap_size`) and so
+    /// matches `popped_bytes` (the ordinal tag adds no heap).
+    pub metrics: std::sync::Arc<crate::runtime::metrics::EdgeMetrics>,
+    /// `Some` for byte-bounded edges — the transport queue's `current_bytes`
+    /// (plus, for an ordered edge, the `reorder_depth` stash bytes) over
+    /// `limit_bytes` gives the occupancy fraction the sampler records. `None`
+    /// for count/unbounded edges (counters still apply; occupancy histogram is
+    /// skipped).
+    pub depth_source: Option<std::sync::Arc<dyn crate::queues::BoundedQueueHandle>>,
+    /// `Some` for an **ordered** byte-bounded edge — the `ReorderStage`'s
+    /// overflow-stash handle. Its buffered bytes are added to the transport's
+    /// `current_bytes` when sampling depth, so an ordered edge reflects total
+    /// buffered bytes (transport + reorder stash) rather than the transport
+    /// queue alone (which under-reports occupancy when items pile in the reorder
+    /// buffer under producer skew). `None` for direct/count/unbounded edges.
+    pub reorder_depth: Option<std::sync::Arc<dyn crate::reorder::ReorderCapHandle>>,
 }
 
 /// One byte-bounded queue's location in the chain plus the handles for
@@ -72,8 +110,12 @@ pub struct RegisteredQueue {
 /// Panics if `graph.n_steps() != steps.len()` or if any non-source step
 /// has no producer (the builder's all-wired check should prevent this).
 #[must_use]
-pub fn build_chain_contexts(steps: &[Box<dyn ErasedStep>], graph: &ChainGraph) -> ChainContexts {
-    build_chain_contexts_inner(steps, graph, false)
+pub fn build_chain_contexts(
+    steps: &[Box<dyn ErasedStep>],
+    graph: &ChainGraph,
+    level: crate::builder::InstrumentationLevel,
+) -> ChainContexts {
+    build_chain_contexts_inner(steps, graph, false, level)
 }
 
 /// Build the chain's per-step contexts with **direct, unbounded** inter-step
@@ -92,13 +134,48 @@ pub fn build_chain_contexts_fused(
     steps: &[Box<dyn ErasedStep>],
     graph: &ChainGraph,
 ) -> ChainContexts {
-    build_chain_contexts_inner(steps, graph, true)
+    // The fused path uses direct, unbounded transports (no bounded edges), so
+    // there is nothing to instrument — force `Off` regardless of the run's level.
+    build_chain_contexts_inner(steps, graph, true, crate::builder::InstrumentationLevel::Off)
+}
+
+/// Build the producer→consumer edge map (keyed by `(producer_step, branch)`)
+/// used to label registered edges with their consumer. Empty when
+/// instrumentation is off (no edges are registered, so the map is unused).
+fn build_consumer_map(
+    steps: &[Box<dyn ErasedStep>],
+    graph: &ChainGraph,
+    level: crate::builder::InstrumentationLevel,
+) -> std::collections::HashMap<(usize, usize), usize> {
+    let mut m = std::collections::HashMap::new();
+    if !level.is_on() {
+        return m;
+    }
+    for (consumer_idx, step) in steps.iter().enumerate() {
+        if step.is_source() {
+            continue;
+        }
+        match step.input_arity() {
+            1 => {
+                let (p, b) = find_producer(graph, StepIdx(consumer_idx));
+                m.insert((p.0, b.0), consumer_idx);
+            }
+            2 => {
+                for (p, b) in find_all_producers(graph, StepIdx(consumer_idx)) {
+                    m.insert((p.0, b.0), consumer_idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    m
 }
 
 fn build_chain_contexts_inner(
     steps: &[Box<dyn ErasedStep>],
     graph: &ChainGraph,
     direct: bool,
+    level: crate::builder::InstrumentationLevel,
 ) -> ChainContexts {
     assert_eq!(steps.len(), graph.n_steps(), "chain length mismatch");
 
@@ -112,11 +189,15 @@ fn build_chain_contexts_inner(
     // the scheduled path honours each step's profiled queue spec + ordering.
     for step in steps {
         let (set, view) =
-            if direct { step.build_fused_output_set() } else { step.build_output_set() };
+            if direct { step.build_fused_output_set(level) } else { step.build_output_set(level) };
         let outputs_box = step.wrap_outputs_view(view);
         output_sets.push(set);
         outputs.push(outputs_box);
     }
+
+    // Producer→consumer map for edge registration (inverse of `find_producer`,
+    // which Pass 2 uses consumer→producer). Empty when instrumentation is off.
+    let consumer_of = build_consumer_map(steps, graph, level);
 
     // Pass 1.5: collect byte-bounded queue handles into the registry.
     // Must run before Pass 2 because `take_typed_input` (called via
@@ -124,6 +205,7 @@ fn build_chain_contexts_inner(
     // one whose `bounded_queue_handle` is `None` — by then the
     // handles have been moved out of the chain.
     let mut bounded_queues: Vec<RegisteredQueue> = Vec::new();
+    let mut edges: Vec<RegisteredEdge> = Vec::new();
     for (step_idx_usize, set) in output_sets.iter().enumerate() {
         for (branch_idx_usize, entry) in set.branches.iter().enumerate() {
             if let Some(handles) = entry.bounded_queue_handle.as_ref() {
@@ -133,6 +215,28 @@ fn build_chain_contexts_inner(
                     branch: BranchIdx(branch_idx_usize),
                     handle: std::sync::Arc::clone(&handles.transport),
                     reorder_cap: handles.reorder_cap.clone(),
+                });
+            }
+            // Instrumented edge: register its shared metrics + producer/consumer
+            // + (for byte-bounded edges) a depth source for occupancy sampling.
+            if let Some(metrics) = entry.metrics.as_ref() {
+                let consumer_step =
+                    consumer_of.get(&(step_idx_usize, branch_idx_usize)).map(|c| StepIdx(*c));
+                edges.push(RegisteredEdge {
+                    producer_step: StepIdx(step_idx_usize),
+                    producer_name: steps[step_idx_usize].profile().name,
+                    consumer_step,
+                    consumer_name: consumer_step.map(|c| steps[c.0].profile().name),
+                    branch: BranchIdx(branch_idx_usize),
+                    metrics: std::sync::Arc::clone(metrics),
+                    depth_source: entry
+                        .bounded_queue_handle
+                        .as_ref()
+                        .map(|h| std::sync::Arc::clone(&h.transport)),
+                    reorder_depth: entry
+                        .bounded_queue_handle
+                        .as_ref()
+                        .and_then(|h| h.reorder_cap.clone()),
                 });
             }
         }
@@ -188,7 +292,7 @@ fn build_chain_contexts_inner(
     // exactly once via `build_input_handle`, leaving placeholder slots.
     drop(output_sets);
 
-    ChainContexts { inputs, outputs, bounded_queues }
+    ChainContexts { inputs, outputs, bounded_queues, edges }
 }
 
 /// Construct a `BranchInputHandle<()>` that's already drained — for source
@@ -422,8 +526,31 @@ mod tests {
     #[case(4)]
     fn build_chain_contexts_linear(#[case] n: usize) {
         let (steps, graph) = linear_chain(n);
-        let ctx = build_chain_contexts(&steps, &graph);
+        let ctx = build_chain_contexts(&steps, &graph, crate::builder::InstrumentationLevel::Off);
         assert_linear_chain_invariants(&ctx, n);
+    }
+
+    #[test]
+    fn registry_covers_edges_with_producer_and_consumer() {
+        use crate::builder::InstrumentationLevel as L;
+        // Source → Middle → Sink: two producing edges, each with a consumer.
+        let (steps, graph) = linear_chain(3);
+        let ctx = build_chain_contexts(&steps, &graph, L::Summary);
+        assert_eq!(ctx.edges.len(), 2, "every bounded producing edge is registered");
+        for e in &ctx.edges {
+            assert!(
+                e.consumer_step.is_some(),
+                "edge from {} has a resolved consumer",
+                e.producer_name
+            );
+            assert!(e.consumer_name.is_some());
+            // CountBounded edges expose no byte depth source (occupancy via len only).
+            assert!(e.depth_source.is_none(), "count-bounded edge has no byte depth source");
+        }
+        // Off → no edges registered (zero-overhead path).
+        let (steps, graph) = linear_chain(3);
+        let off = build_chain_contexts(&steps, &graph, L::Off);
+        assert!(off.edges.is_empty(), "level Off registers no edges");
     }
 
     proptest! {
@@ -432,7 +559,7 @@ mod tests {
         #[test]
         fn build_chain_contexts_linear_invariants(n in 2usize..=8) {
             let (steps, graph) = linear_chain(n);
-            let ctx = build_chain_contexts(&steps, &graph);
+            let ctx = build_chain_contexts(&steps, &graph, crate::builder::InstrumentationLevel::Off);
             assert_linear_chain_invariants(&ctx, n);
         }
     }

--- a/crates/fgumi-pipeline-core/src/runtime/detached.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/detached.rs
@@ -1,0 +1,731 @@
+//! Detached-step extraction and the dedicated **driver thread** that runs them
+//! off the work-stealing pool.
+//!
+//! A [`StepKind::Detached`](crate::step::StepKind::Detached) step is excluded
+//! from the pool ([`build_worker_storage`](crate::runtime::build_worker_storage)
+//! gives every pool worker a `Skip` entry for it) and instead runs on a dedicated
+//! OS thread spawned at run start alongside the deadlock-monitor /
+//! queue-rebalancer and joined after the workers. This is the legacy sort's
+//! "N + 2" threading: N pool workers do the parallel (compression-bound) work
+//! while off-pool driver threads do the serial coordination + I/O, so neither
+//! steals a pool worker slot.
+//!
+//! ## The driver IS a 1-thread pool ([`run_detached_driver`])
+//!
+//! A driver thread does **not** have a bespoke drive loop. It runs the *same*
+//! [`run_worker_loop`](crate::runtime::run_worker_loop) the pool uses — over a
+//! purpose-built storage row where its group's steps are `Owned` and every other
+//! step is `Skip` ([`build_driver_storage`]) — with a
+//! [`WorkerCore::driver`](crate::runtime::WorkerCore) (Park backoff, off-pool
+//! stats attribution) and the [`DrainFirstScheduler`]. So a driver is literally a
+//! 1-thread (or, for a group, still 1-thread over several `Owned` steps) instance
+//! of the pool loop. Several detached steps sharing a
+//! [`DetachedGroup::Shared`](crate::step::DetachedGroup) label are driven by ONE
+//! thread that round-robins them; [`DetachedGroup::PerStep`] (the default) keeps
+//! one thread per step.
+//!
+//! Because the group's steps and their phases are temporally disjoint (e.g. the
+//! sort's phase-1 admit/sort/frame finish and leave the live set before the
+//! phase-2 merge runs), one driver thread covers a whole phase's coordination
+//! without oversubscription — exactly like main's single main thread.
+//!
+//! ## Lock-ordering acyclicity (non-negotiable, the deadlock proof)
+//!
+//! A driver thread must NEVER hold one queue's internal lock while parking on
+//! another. `run_worker_loop` upholds that by construction:
+//!
+//!   1. Each `try_run_erased` is a single non-blocking call. The step body pops
+//!      from its input transport (a lock-free `crossbeam ArrayQueue` — `try_pop`,
+//!      no lock held across the call) and pushes to its outputs (`try_push`,
+//!      likewise); a full output / empty input is reported back as `NoProgress` /
+//!      `Contention`. It never *blocks* inside `try_run`.
+//!   2. The only blocking a driver does is the loop's `WorkerCore::sleep_backoff`
+//!      (`park_timeout` under the Park policy), which holds NO queue lock.
+//!   3. The loop tries EVERY live step in a pass before it parks (round-robin,
+//!      park only after a full no-progress pass). So when one grouped step is
+//!      blocked, a sibling on the same driver still runs — a park-on-first-idle
+//!      loop would wedge (see `driver_round_robins_all_live_before_parking`).
+//!
+//! So there is no cycle: a driver parks only *between* `try_run` calls, never
+//! while holding a transport lock, so a two-sided step (consuming from the pool
+//! AND producing to it, both bounded) cannot deadlock. The
+//! `detached_two_sided_no_deadlock` test pins this with a wall-clock watchdog.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::erased::{ErasedStep, ErasedStepCtx};
+use crate::runtime::contexts::ChainContexts;
+use crate::runtime::drain::StepDrainCounter;
+use crate::runtime::driver::run_worker_loop;
+use crate::runtime::scheduler::DrainFirstScheduler;
+use crate::runtime::stats::PipelineStats;
+use crate::runtime::storage::WorkerStepEntry;
+use crate::runtime::worker_core::WorkerCore;
+use crate::signal::PipelineSignal;
+use crate::step::{Affinity, DetachedGroup, OutputsViewAny, StepKind, StepOutcome, StepProfile};
+use crate::topology::StepIdx;
+
+/// Sentinel left in the chain's `steps` vec in place of a `Detached` step after
+/// its real instance has been extracted for its dedicated thread (see
+/// [`extract_detached_steps`]). Keeping a same-position placeholder preserves
+/// the `step_idx`-aligned indexing that `build_worker_storage` and
+/// `ChainContexts` rely on. `build_worker_storage` only reads `kind()` (matches
+/// `Detached` → every worker gets `Skip`) and then drops the box, so the
+/// placeholder never has any other method invoked; they panic to catch a
+/// framework bug if one ever is.
+struct DetachedPlaceholder {
+    name: &'static str,
+}
+
+impl ErasedStep for DetachedPlaceholder {
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Detached,
+            sticky: false,
+            output_queues: Vec::new(),
+            branch_ordering: Vec::new(),
+        }
+    }
+    fn name(&self) -> &'static str {
+        self.name
+    }
+    fn kind(&self) -> StepKind {
+        StepKind::Detached
+    }
+    fn sticky(&self) -> bool {
+        false
+    }
+    fn affinity(&self) -> Affinity {
+        Affinity::None
+    }
+    fn detached_group(&self) -> DetachedGroup {
+        // Never consulted: `extract_detached_steps` reads the real step's group
+        // before swapping in this placeholder.
+        DetachedGroup::PerStep
+    }
+    fn try_run_erased(&mut self, _ctx: &mut ErasedStepCtx<'_>) -> std::io::Result<StepOutcome> {
+        panic!("DetachedPlaceholder::try_run_erased invoked — the real instance was extracted");
+    }
+    fn clone_boxed(&self) -> Box<dyn ErasedStep> {
+        panic!("DetachedPlaceholder::clone_boxed invoked — placeholder is never cloned");
+    }
+    fn build_input_handle(
+        &self,
+        _producer_set: &mut crate::handles::OutputQueueSet,
+        _branch_idx: usize,
+    ) -> Box<dyn Any + Send + Sync> {
+        panic!("DetachedPlaceholder::build_input_handle invoked");
+    }
+    fn build_output_set(
+        &self,
+        _level: crate::builder::InstrumentationLevel,
+    ) -> (crate::handles::OutputQueueSet, OutputsViewAny) {
+        panic!("DetachedPlaceholder::build_output_set invoked");
+    }
+    fn build_fused_output_set(
+        &self,
+        _level: crate::builder::InstrumentationLevel,
+    ) -> (crate::handles::OutputQueueSet, OutputsViewAny) {
+        panic!("DetachedPlaceholder::build_fused_output_set invoked");
+    }
+    fn wrap_outputs_view(&self, _view: OutputsViewAny) -> Box<dyn Any + Send + Sync> {
+        panic!("DetachedPlaceholder::wrap_outputs_view invoked");
+    }
+    fn mark_outputs_drained(&self, _outputs: &(dyn Any + Send + Sync)) {
+        panic!("DetachedPlaceholder::mark_outputs_drained invoked");
+    }
+    fn is_source(&self) -> bool {
+        false
+    }
+}
+
+/// One dedicated driver thread's worth of extracted detached steps, in chain
+/// (`StepIdx`) order. The caller spawns one OS thread per group and drives it
+/// with [`run_detached_driver`].
+pub struct DetachedDriverGroup {
+    /// The steps this one driver thread runs, in chain order. Always non-empty
+    /// and all [`StepKind::Detached`]. Private so those invariants — enforced by
+    /// [`Self::new`] — cannot be bypassed by an external caller building the
+    /// struct directly (which could otherwise trigger `steps[0]` panics in
+    /// `primary_step` / `label`, or run non-detached work on an off-pool driver).
+    steps: Vec<(StepIdx, Box<dyn ErasedStep>)>,
+}
+
+impl DetachedDriverGroup {
+    /// Wrap a driver thread's extracted steps, enforcing the invariants every
+    /// consumer relies on: the group is **non-empty** (`primary_step` / `label`
+    /// index `steps[0]`) and **every step is [`StepKind::Detached`]** (a
+    /// non-detached step must not run off-pool on a dedicated driver thread, and
+    /// a `Parallel` step would hang its shared output — see
+    /// [`build_driver_storage`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `steps` is empty or contains a non-`Detached` step.
+    #[must_use]
+    fn new(steps: Vec<(StepIdx, Box<dyn ErasedStep>)>) -> Self {
+        assert!(!steps.is_empty(), "detached driver group must be non-empty");
+        assert!(
+            steps.iter().all(|(_, step)| step.kind() == StepKind::Detached),
+            "detached driver group may only contain Detached steps"
+        );
+        Self { steps }
+    }
+
+    /// The group's representative step (first in chain order). Used as the
+    /// driver thread's off-pool stats key (`WorkerCore::driver`) and as a stable
+    /// label. Non-empty by construction.
+    #[must_use]
+    pub fn primary_step(&self) -> StepIdx {
+        self.steps[0].0
+    }
+
+    /// The name of the group's representative step (first in chain order), used
+    /// to label a `PerStep` driver thread. Non-empty by construction.
+    #[must_use]
+    pub fn primary_name(&self) -> &'static str {
+        self.steps[0].1.name()
+    }
+
+    /// The group label — derived from the steps (every step in the group reports
+    /// the same [`DetachedGroup`]), used to name the driver thread. Non-empty by
+    /// construction.
+    #[must_use]
+    pub fn label(&self) -> DetachedGroup {
+        self.steps[0].1.detached_group()
+    }
+
+    /// Consume the group, yielding its steps for [`build_driver_storage`].
+    #[must_use]
+    fn into_steps(self) -> Vec<(StepIdx, Box<dyn ErasedStep>)> {
+        self.steps
+    }
+}
+
+/// Remove every [`StepKind::Detached`](crate::step::StepKind::Detached) step's
+/// real instance from `steps`, replacing each in place with a
+/// [`DetachedPlaceholder`] so the surviving slots keep their `step_idx`
+/// positions (which `build_worker_storage` and `ChainContexts` index by).
+///
+/// Groups the extracted steps by their [`DetachedGroup`]: every
+/// [`DetachedGroup::Shared`] label collects onto ONE group (one driver thread);
+/// each [`DetachedGroup::PerStep`] step becomes its own singleton group (the
+/// legacy one-thread-per-step behavior — the default, so non-sort chains are
+/// unchanged). Within a group and across groups, order follows chain order
+/// (first appearance). Called by `Pipeline::run` **before** `build_worker_storage`
+/// consumes `steps`, while the (read-only) `ChainContexts` have already been
+/// built from `&steps`.
+#[must_use]
+pub fn extract_detached_steps(steps: &mut [Box<dyn ErasedStep>]) -> Vec<DetachedDriverGroup> {
+    // Accumulate each driver thread's steps as a raw vec, then wrap through
+    // `DetachedDriverGroup::new` so the non-empty / all-Detached invariants are
+    // enforced in one place rather than trusting each construction site.
+    let mut group_steps: Vec<Vec<(StepIdx, Box<dyn ErasedStep>)>> = Vec::new();
+    // Shared(label) -> index into `group_steps`, for O(1) append. PerStep steps
+    // never share, so they are not indexed (each starts its own group).
+    let mut shared_index: HashMap<&'static str, usize> = HashMap::new();
+    for (idx, slot) in steps.iter_mut().enumerate() {
+        if slot.kind() != StepKind::Detached {
+            continue;
+        }
+        let group = slot.detached_group();
+        let placeholder: Box<dyn ErasedStep> = Box::new(DetachedPlaceholder { name: slot.name() });
+        let real = std::mem::replace(slot, placeholder);
+        let entry = (StepIdx(idx), real);
+        match group {
+            DetachedGroup::PerStep => group_steps.push(vec![entry]),
+            DetachedGroup::Shared(label) => {
+                if let Some(&gi) = shared_index.get(label) {
+                    group_steps[gi].push(entry);
+                } else {
+                    shared_index.insert(label, group_steps.len());
+                    group_steps.push(vec![entry]);
+                }
+            }
+        }
+    }
+    group_steps.into_iter().map(DetachedDriverGroup::new).collect()
+}
+
+/// Build a driver thread's storage row: a full-length `Vec<WorkerStepEntry>`
+/// (length `n_total_steps`, indexed by global `step_idx` like every other row)
+/// where each of `group_steps` is `Owned` and every other slot is `Skip`. The
+/// driver thread runs [`run_worker_loop`] over this row exactly as a pool worker
+/// runs over its own row.
+///
+/// # Panics
+///
+/// - if a group step's kind is `Parallel` — a 1-thread driver's
+///   [`StepDrainCounter`] is init 1 (single finisher), which would never close a
+///   `Parallel` step's shared output (that needs init N, all clones finishing),
+///   hanging the downstream consumer;
+/// - if two group steps map to the same `step_idx` (a double registration), or a
+///   step index is out of range.
+#[must_use]
+pub fn build_driver_storage(
+    group_steps: Vec<(StepIdx, Box<dyn ErasedStep>)>,
+    n_total_steps: usize,
+) -> Vec<WorkerStepEntry> {
+    let mut row: Vec<WorkerStepEntry> = (0..n_total_steps).map(|_| WorkerStepEntry::Skip).collect();
+    for (idx, step) in group_steps {
+        assert_ne!(
+            step.kind(),
+            StepKind::Parallel,
+            "driver group step `{}` is Parallel; a 1-thread driver's StepDrainCounter (init 1) \
+             would never close its shared output — group only single-runner steps",
+            step.name()
+        );
+        assert!(
+            matches!(row[idx.0], WorkerStepEntry::Skip),
+            "driver group step index {} registered twice (dual registration)",
+            idx.0
+        );
+        row[idx.0] = WorkerStepEntry::Owned { step };
+    }
+    row
+}
+
+/// Drive one [`DetachedDriverGroup`] to completion on the calling (dedicated)
+/// thread — the unified "1-thread pool". Builds the group's `Owned`/`Skip`
+/// storage row ([`build_driver_storage`]) and runs the *same*
+/// [`run_worker_loop`] the pool uses, with a [`WorkerCore::driver`] (Park
+/// backoff, off-pool stats) and the [`DrainFirstScheduler`] (drain/seal
+/// downstream before producing more — frees the sort's capacity-1 arena fastest).
+///
+/// `drain_counters` is the full per-step slice (init 1 for each detached step, so
+/// the single finisher closes its output edges — the downstream consumer's
+/// end-of-stream signal). On a cancel before `Finished`, outputs are NOT closed
+/// (the run is tearing down; the recorded error/cancel is what propagates) —
+/// `run_worker_loop`'s top-of-loop `is_done` break upholds this.
+pub fn run_detached_driver(
+    group: DetachedDriverGroup,
+    contexts: &Arc<ChainContexts>,
+    drain_counters: &[Arc<StepDrainCounter>],
+    signal: &Arc<PipelineSignal>,
+    stats: Option<&Arc<PipelineStats>>,
+) {
+    let primary = group.primary_step();
+    let mut row = build_driver_storage(group.into_steps(), contexts.inputs.len());
+    let mut worker = WorkerCore::driver(primary);
+    run_worker_loop(
+        &mut worker,
+        &mut row,
+        contexts,
+        drain_counters,
+        signal,
+        stats,
+        &DrainFirstScheduler,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+    use crate::builder::InstrumentationLevel;
+    use crate::erased::TypedStep;
+    use crate::outputs::Single;
+    use crate::queues::QueueSpec;
+    use crate::reorder::BranchOrdering;
+    use crate::step::{InputHandle, OutputHandles, Step, StepCtx, StepKind, StepProfile};
+
+    /// `() -> u32` source stub used only so `build_output_set` constructs the
+    /// transport that becomes the Detached step's input edge. Never run.
+    #[derive(Clone)]
+    struct SrcStub {
+        capacity: usize,
+    }
+    impl Step for SrcStub {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "Src",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: self.capacity }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::NoProgress)
+        }
+    }
+
+    /// `u32 -> u32` pass-through Detached step: pop one item per `try_run`,
+    /// push it on (holding it on output-full backpressure), report `Finished`
+    /// once input drains and nothing is held.
+    #[derive(Clone)]
+    struct PassThroughDetached {
+        held: Option<u32>,
+    }
+    impl Step for PassThroughDetached {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "PassThroughDetached",
+                kind: StepKind::Detached,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(v) = self.held.take() {
+                if ctx.outputs.push(v).is_err() {
+                    self.held = Some(v);
+                    return Ok(StepOutcome::Contention);
+                }
+                return Ok(StepOutcome::Progress);
+            }
+            match ctx.input.pop() {
+                Some(v) => match ctx.outputs.push(v) {
+                    Ok(()) => Ok(StepOutcome::Progress),
+                    Err(unpushed) => {
+                        self.held = Some(unpushed.into_item());
+                        Ok(StepOutcome::Contention)
+                    }
+                },
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+    }
+
+    /// Assemble a `Source -> PassThroughDetached -> Sink` shaped context by
+    /// hand: build the producer's output set (= the Detached input edge), wire
+    /// the Detached step's input from it, build the Detached step's own output
+    /// set (= the downstream consumer's input edge), and return the pieces.
+    #[allow(clippy::type_complexity)]
+    fn build_one_detached(
+        src_capacity: usize,
+    ) -> (
+        Box<dyn ErasedStep>,                       // the detached step
+        Arc<ChainContexts>,                        // contexts for step_idx 1
+        Arc<Box<dyn std::any::Any + Send + Sync>>, // producer outputs (push side)
+        crate::handles::BranchInputHandle<u32>,    // downstream consumer (pop side)
+    ) {
+        let producer: Box<dyn ErasedStep> =
+            Box::new(TypedStep::new(SrcStub { capacity: src_capacity }));
+        let (mut producer_set, producer_view) =
+            producer.build_output_set(InstrumentationLevel::Off);
+        let producer_outputs_any = producer.wrap_outputs_view(producer_view);
+
+        let det: Box<dyn ErasedStep> = Box::new(TypedStep::new(PassThroughDetached { held: None }));
+        let det_input = det.build_input_handle(&mut producer_set, 0);
+        let (mut det_set, det_view) = det.build_output_set(InstrumentationLevel::Off);
+        let det_outputs_any = det.wrap_outputs_view(det_view);
+        let det_output_consumer = det_set.take_typed_input::<u32>(0);
+
+        let contexts = Arc::new(ChainContexts {
+            inputs: vec![Box::new(()), det_input, Box::new(())],
+            outputs: vec![Box::new(()), det_outputs_any, Box::new(())],
+            bounded_queues: vec![],
+            edges: vec![],
+        });
+        (det, contexts, Arc::new(producer_outputs_any), det_output_consumer)
+    }
+
+    /// Drive a single detached `step` at `step_idx` through the unified driver —
+    /// a `PerStep` group of one — on the calling thread, with a full-length
+    /// `drain_counters` slice (init 1 each). Mirrors what `builder.rs` step 4d
+    /// does for a one-step group.
+    fn drive_single(
+        step: Box<dyn ErasedStep>,
+        step_idx: StepIdx,
+        contexts: &Arc<ChainContexts>,
+        signal: &Arc<PipelineSignal>,
+    ) {
+        let drain_counters: Vec<Arc<StepDrainCounter>> =
+            (0..contexts.inputs.len()).map(|_| StepDrainCounter::new(1)).collect();
+        let group = DetachedDriverGroup::new(vec![(step_idx, step)]);
+        run_detached_driver(group, contexts, &drain_counters, signal, None);
+    }
+
+    /// Items pushed onto a Detached step's input flow through to its output;
+    /// the step finishes once its input is drained and closes the output edge.
+    #[test]
+    fn detached_step_flows_items_and_finishes() {
+        let (det, contexts, producer_outputs_any, consumer) = build_one_detached(64);
+        let producer_outputs =
+            producer_outputs_any.downcast_ref::<OutputHandles<Single<u32>>>().unwrap();
+        producer_outputs.push(10).unwrap();
+        producer_outputs.push(20).unwrap();
+        producer_outputs.push(30).unwrap();
+        producer_outputs.mark_all_drained();
+
+        let signal = PipelineSignal::new();
+        drive_single(det, StepIdx(1), &contexts, &signal);
+
+        let mut got = Vec::new();
+        while let Some(v) = consumer.pop() {
+            got.push(v);
+        }
+        assert_eq!(got, vec![10, 20, 30]);
+        assert!(InputHandle::is_drained(&consumer), "output closed on Finished");
+        assert!(!signal.is_done(), "clean completion, no error");
+    }
+
+    /// Zero items in (input drained from the start): the Detached step cleanly
+    /// drains its output and returns.
+    #[test]
+    fn detached_step_zero_items_clean_drain() {
+        let (det, contexts, producer_outputs_any, consumer) = build_one_detached(64);
+        let producer_outputs =
+            producer_outputs_any.downcast_ref::<OutputHandles<Single<u32>>>().unwrap();
+        producer_outputs.mark_all_drained(); // no items
+
+        let signal = PipelineSignal::new();
+        drive_single(det, StepIdx(1), &contexts, &signal);
+
+        assert!(consumer.pop().is_none(), "no items produced");
+        assert!(InputHandle::is_drained(&consumer), "output closed on clean empty drain");
+    }
+
+    /// A two-sided Detached step — consumer of a bounded pool-fed input AND
+    /// producer to a bounded pool-drained output, both tiny — completes without
+    /// deadlock. A wall-clock watchdog aborts (fails the test) if it wedges.
+    /// This is the sort merge's topology.
+    #[test]
+    fn detached_two_sided_no_deadlock() {
+        const N: u32 = 5_000;
+
+        // cap-2 input AND cap-4 output both force interleaved backpressure.
+        let (det, contexts, producer_outputs_any, consumer) = build_one_detached(2);
+        let signal = PipelineSignal::new();
+
+        // Watchdog: a deadlock parks forever; abort so the test FAILS loudly.
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                for _ in 0..200 {
+                    std::thread::sleep(Duration::from_millis(50));
+                    if done.load(Ordering::SeqCst) {
+                        return;
+                    }
+                }
+                eprintln!("detached_two_sided_no_deadlock: WEDGED (deadlock)");
+                std::process::abort();
+            });
+        }
+
+        // Producer thread: push N items into the cap-2 input (backpressure),
+        // then close it so the Detached step's input drains.
+        let pushed = Arc::new(AtomicU32::new(0));
+        let producer_handle = {
+            let producer_outputs_any = Arc::clone(&producer_outputs_any);
+            let pushed = Arc::clone(&pushed);
+            std::thread::spawn(move || {
+                let outputs =
+                    producer_outputs_any.downcast_ref::<OutputHandles<Single<u32>>>().unwrap();
+                let mut held: Option<u32> = None;
+                let mut next = 0u32;
+                loop {
+                    if let Some(v) = held.take() {
+                        match outputs.push(v) {
+                            Ok(()) => {
+                                pushed.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Err(unpushed) => {
+                                held = Some(unpushed.into_item());
+                                std::thread::yield_now();
+                            }
+                        }
+                        continue;
+                    }
+                    if next >= N {
+                        break;
+                    }
+                    match outputs.push(next) {
+                        Ok(()) => {
+                            pushed.fetch_add(1, Ordering::Relaxed);
+                            next += 1;
+                        }
+                        Err(unpushed) => {
+                            // The value at `next` is now held for retry; advance
+                            // `next` so the fresh-push branch doesn't re-emit it
+                            // after `held` flushes (which would double-count).
+                            held = Some(unpushed.into_item());
+                            next += 1;
+                            std::thread::yield_now();
+                        }
+                    }
+                }
+                outputs.mark_all_drained();
+            })
+        };
+
+        // Consumer thread: pop everything the Detached step produces.
+        let received = Arc::new(AtomicU32::new(0));
+        let consumer_handle = {
+            let received = Arc::clone(&received);
+            std::thread::spawn(move || {
+                loop {
+                    if consumer.pop().is_some() {
+                        received.fetch_add(1, Ordering::Relaxed);
+                    } else if InputHandle::is_drained(&consumer) {
+                        break;
+                    } else {
+                        std::thread::yield_now();
+                    }
+                }
+            })
+        };
+
+        // Drive the Detached step (as a one-step group) on this thread to
+        // completion via the unified driver.
+        drive_single(det, StepIdx(1), &contexts, &signal);
+
+        producer_handle.join().unwrap();
+        consumer_handle.join().unwrap();
+        done.store(true, Ordering::SeqCst);
+
+        assert_eq!(pushed.load(Ordering::Relaxed), N, "all items pushed");
+        assert_eq!(
+            received.load(Ordering::Relaxed),
+            N,
+            "all items flowed through the two-sided Detached step"
+        );
+    }
+
+    /// A `Detached` step declaring a `Shared` group label. Used only to exercise
+    /// `extract_detached_steps` grouping — never actually run.
+    #[derive(Clone)]
+    struct SharedDetached {
+        label: &'static str,
+    }
+    impl Step for SharedDetached {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "SharedDetached",
+                kind: StepKind::Detached,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn detached_group(&self) -> crate::step::DetachedGroup {
+            crate::step::DetachedGroup::Shared(self.label)
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::Finished)
+        }
+    }
+
+    /// A `Parallel` step — must never be placed on a 1-thread driver.
+    #[derive(Clone)]
+    struct ParallelStub;
+    impl Step for ParallelStub {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "ParallelStub",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::NoProgress)
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// `extract_detached_steps` collects every `Shared(label)` onto one group,
+    /// keeps each `PerStep` (default) step as its own singleton, preserves chain
+    /// order within and across groups, and leaves non-detached steps in place.
+    #[test]
+    fn extract_groups_shared_together_and_perstep_alone() {
+        use crate::step::DetachedGroup;
+        // idx0 non-detached; idx1/idx3 Shared("coord"); idx2 PerStep; idx4 Shared("io").
+        let mut steps: Vec<Box<dyn ErasedStep>> = vec![
+            Box::new(TypedStep::new(SrcStub { capacity: 4 })),
+            Box::new(TypedStep::new(SharedDetached { label: "coord" })),
+            Box::new(TypedStep::new(PassThroughDetached { held: None })),
+            Box::new(TypedStep::new(SharedDetached { label: "coord" })),
+            Box::new(TypedStep::new(SharedDetached { label: "io" })),
+        ];
+        let groups = extract_detached_steps(&mut steps);
+
+        assert_eq!(groups.len(), 3, "coord{{1,3}}, perstep{{2}}, io{{4}}");
+        // Order is first-appearance in chain order.
+        assert_eq!(groups[0].label(), DetachedGroup::Shared("coord"));
+        assert_eq!(
+            groups[0].steps.iter().map(|(i, _)| i.0).collect::<Vec<_>>(),
+            vec![1, 3],
+            "shared group keeps both steps in chain order"
+        );
+        assert_eq!(groups[0].primary_step(), StepIdx(1));
+        assert_eq!(groups[1].label(), DetachedGroup::PerStep);
+        assert_eq!(groups[1].steps.iter().map(|(i, _)| i.0).collect::<Vec<_>>(), vec![2]);
+        assert_eq!(groups[2].label(), DetachedGroup::Shared("io"));
+
+        // Non-detached step survives; detached slots became placeholders that
+        // still report `Detached` (so `build_worker_storage` Skips them on pool).
+        assert_eq!(steps[0].kind(), StepKind::Exclusive);
+        assert_eq!(steps[1].kind(), StepKind::Detached);
+        assert_eq!(steps[2].kind(), StepKind::Detached);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be non-empty")]
+    fn driver_group_rejects_empty() {
+        // An empty group would panic later in `primary_step`/`label` (`steps[0]`);
+        // the constructor rejects it up front.
+        let _ = DetachedDriverGroup::new(vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "only contain Detached steps")]
+    fn driver_group_rejects_non_detached_step() {
+        // `SrcStub` is Exclusive, not Detached — running it off-pool on a driver
+        // thread is a bug, so the constructor rejects the group.
+        let step: Box<dyn ErasedStep> = Box::new(TypedStep::new(SrcStub { capacity: 1 }));
+        let _ = DetachedDriverGroup::new(vec![(StepIdx(0), step)]);
+    }
+
+    /// `build_driver_storage` makes the group's steps `Owned` and every other
+    /// slot `Skip`, at the correct global indices.
+    #[test]
+    fn build_driver_storage_owns_group_skips_rest() {
+        let det: Box<dyn ErasedStep> = Box::new(TypedStep::new(PassThroughDetached { held: None }));
+        let row = build_driver_storage(vec![(StepIdx(2), det)], 5);
+        assert_eq!(row.len(), 5);
+        assert!(matches!(row[2], WorkerStepEntry::Owned { .. }), "group step is Owned");
+        for i in [0usize, 1, 3, 4] {
+            assert!(matches!(row[i], WorkerStepEntry::Skip), "non-group slot {i} is Skip");
+        }
+    }
+
+    /// G3: a `Parallel` step must never be grouped onto a 1-thread driver (its
+    /// init-1 counter would never close the shared output).
+    #[test]
+    #[should_panic(expected = "is Parallel")]
+    fn build_driver_storage_rejects_parallel_group_step() {
+        let par: Box<dyn ErasedStep> = Box::new(TypedStep::new(ParallelStub));
+        let _ = build_driver_storage(vec![(StepIdx(0), par)], 2);
+    }
+
+    /// G3: two group steps at the same index is a dual registration — rejected.
+    #[test]
+    #[should_panic(expected = "registered twice")]
+    fn build_driver_storage_rejects_dual_registration() {
+        let a: Box<dyn ErasedStep> = Box::new(TypedStep::new(PassThroughDetached { held: None }));
+        let b: Box<dyn ErasedStep> = Box::new(TypedStep::new(PassThroughDetached { held: None }));
+        let _ = build_driver_storage(vec![(StepIdx(1), a), (StepIdx(1), b)], 3);
+    }
+}

--- a/crates/fgumi-pipeline-core/src/runtime/driver.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/driver.rs
@@ -28,9 +28,10 @@ use crate::erased::ErasedStepCtx;
 use crate::runtime::contexts::ChainContexts;
 use crate::runtime::drain::StepDrainCounter;
 use crate::runtime::live::LiveSteps;
+use crate::runtime::scheduler::{Scheduler, WalkDirection};
 use crate::runtime::stats::PipelineStats;
 use crate::runtime::storage::WorkerStepEntry;
-use crate::runtime::worker_core::WorkerCore;
+use crate::runtime::worker_core::{WorkerCore, WorkerRole};
 use crate::signal::{PipelineError, PipelineSignal};
 use crate::step::StepOutcome;
 use crate::topology::StepIdx;
@@ -50,6 +51,7 @@ pub fn run_worker_loop(
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    scheduler: &dyn Scheduler,
 ) {
     // Per-worker worklist of still-dispatchable steps, in chain order. A step
     // is removed when it returns `StepOutcome::Finished`; the worker exits once
@@ -68,6 +70,13 @@ pub fn run_worker_loop(
     // live" so the fast path is skipped entirely.
     let mut sticky_live = worker.sticky_owner.is_some_and(|idx| live.contains(idx));
 
+    // A driver thread attributes busy time PER grouped step on the off-pool
+    // detached line (so a multi-step `Shared` group shows each step's real
+    // busy, not the whole thread's time under one name), recorded inside
+    // `dispatch_one_step`; a pool worker records aggregate busy by `thread_id`
+    // below. Idle/park stay thread-level (keyed to the group's primary step).
+    let is_driver = matches!(worker.role(), WorkerRole::Driver { .. });
+
     loop {
         if signal.is_done() {
             break;
@@ -78,6 +87,11 @@ pub fn run_worker_loop(
         }
 
         let mut did_work = false;
+
+        // Time the dispatch (busy) section vs the backoff sleep (idle) below,
+        // per worker, only when stats are on (`Instant::now()` is otherwise not
+        // called — the no-stats loop stays zero-cost).
+        let work_start = stats.map(|_| Instant::now());
 
         // 1. Sticky re-entry for sticky-owned steps (either an Exclusive
         // sticky step this worker owns, or a Serial+sticky step whose
@@ -102,6 +116,7 @@ pub fn run_worker_loop(
                     &drain_counters[owned_idx.0],
                     signal,
                     stats,
+                    is_driver,
                 ) else {
                     break; // Skip
                 };
@@ -143,6 +158,8 @@ pub fn run_worker_loop(
                 drain_counters,
                 signal,
                 stats,
+                scheduler.walk(),
+                is_driver,
             );
             did_work |= outcome.did_work;
             if outcome.removed_sticky_owner {
@@ -152,14 +169,41 @@ pub fn run_worker_loop(
             }
         }
 
-        // 3. Exponential-backoff sleep on no-progress; reset on progress.
+        // Attribute the dispatch section's wall time to this thread's busy total.
+        // Pool workers sum the whole pass into the N-worker utilisation line (by
+        // thread_id). Driver threads instead record each grouped step's own busy
+        // inside `dispatch_one_step` (on the off-pool detached line, by step) so a
+        // multi-step `Shared` group isn't collapsed onto one name — so nothing to
+        // record here for a driver.
+        if let (Some(stats), Some(ws)) = (stats, work_start) {
+            if let WorkerRole::Pool = worker.role() {
+                let ns = u64::try_from(ws.elapsed().as_nanos()).unwrap_or(u64::MAX);
+                stats.record_worker_busy(worker.thread_id, ns);
+            }
+        }
+
+        // 3. Exponential-backoff sleep on no-progress; reset on progress. The
+        // sleep is the worker's idle/blocked time — attribute it per worker so
+        // pool under-utilisation (cores parked while one worker drives a Serial
+        // step) is visible in `--pipeline-stats`.
         if did_work {
             worker.reset_backoff();
         } else if signal.is_done() {
             break;
         } else {
+            let sleep_start = stats.map(|_| Instant::now());
             worker.sleep_backoff();
             worker.increase_backoff();
+            if let (Some(stats), Some(ss)) = (stats, sleep_start) {
+                let ns = u64::try_from(ss.elapsed().as_nanos()).unwrap_or(u64::MAX);
+                match worker.role() {
+                    WorkerRole::Pool => stats.record_worker_idle(worker.thread_id, ns),
+                    WorkerRole::Driver { primary_step } => {
+                        stats.record_detached_idle(primary_step, ns);
+                        stats.record_detached_park(primary_step);
+                    }
+                }
+            }
         }
     }
 }
@@ -180,6 +224,7 @@ struct RoundRobinOutcome {
 /// [`RoundRobinOutcome::removed_sticky_owner`] when it finishes here, so the
 /// caller can disable the per-iteration sticky fast-path without a linear
 /// `live.contains` scan.
+#[allow(clippy::too_many_arguments)] // shared per-step state + the walk policy; a struct would not clarify
 fn round_robin_dispatch(
     entries: &mut [WorkerStepEntry],
     live: &mut LiveSteps,
@@ -188,6 +233,8 @@ fn round_robin_dispatch(
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    walk: WalkDirection,
+    is_driver: bool,
 ) -> RoundRobinOutcome {
     let mut did_work = false;
     // Steps that finished this pass, removed from `live` after the walk. A
@@ -195,10 +242,20 @@ fn round_robin_dispatch(
     // `break` on `Progress`/error, never revisit), so deferring removal is
     // safe and avoids reorder-under-iteration.
     let mut finished: Vec<StepIdx> = Vec::new();
-    for pos in 0..live.len() {
+    let n = live.len();
+    for i in 0..n {
         if signal.is_done() {
             break;
         }
+        // The Scheduler selects the walk DIRECTION over this worker's live
+        // steps: `Forward` = chain order (upstream-first, favour production);
+        // `Reverse` = downstream-first (favour draining buffered work before
+        // producing more). Everything else — skip-on-contention, the sticky
+        // source/sink fast-path, Finished handling — is direction-agnostic.
+        let pos = match walk {
+            WalkDirection::Forward => i,
+            WalkDirection::Reverse => n - 1 - i,
+        };
         let step_idx = live.order()[pos];
         let entry = &mut entries[step_idx.0];
         let mut mark_skip = false;
@@ -210,6 +267,7 @@ fn round_robin_dispatch(
             &drain_counters[step_idx.0],
             signal,
             stats,
+            is_driver,
         ) else {
             continue; // Skip (build-time placeholder; should not appear in `live`)
         };
@@ -277,6 +335,11 @@ fn dispatch_one_step(
     counter: &StepDrainCounter,
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    // When true (a dedicated driver thread), attribute this dispatch's wall time
+    // to the off-pool detached line keyed by `step_idx` — so each grouped step
+    // reports its own busy. Pool workers pass `false` and record aggregate busy
+    // by `thread_id` in the loop instead.
+    is_driver: bool,
 ) -> Option<DispatchInfo> {
     let outputs_any: &(dyn Any + Send + Sync) = contexts.outputs[step_idx.0].as_ref();
     let mut ctx =
@@ -367,6 +430,11 @@ fn dispatch_one_step(
                 Ok(outcome) => stats.record(step_idx, *outcome, start_ns, elapsed_ns),
                 Err(_) => stats.record_error(step_idx, start_ns, elapsed_ns),
             }
+            // On a driver thread, this step's try_run wall is its own off-pool
+            // busy (excluded from the pool%); each grouped step accrues its own.
+            if is_driver {
+                stats.record_detached_busy(step_idx, elapsed_ns);
+            }
         }
     }
 
@@ -376,7 +444,7 @@ fn dispatch_one_step(
 #[cfg(test)]
 mod tests {
     use std::io;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use super::*;
     use crate::erased::{ErasedStep, TypedStep};
@@ -394,14 +462,26 @@ mod tests {
     fn run_worker_loop_exits_on_signal_done() {
         let signal = PipelineSignal::new();
         let mut entries: Vec<WorkerStepEntry> = vec![];
-        let contexts =
-            Arc::new(ChainContexts { inputs: vec![], outputs: vec![], bounded_queues: vec![] });
+        let contexts = Arc::new(ChainContexts {
+            inputs: vec![],
+            outputs: vec![],
+            bounded_queues: vec![],
+            edges: vec![],
+        });
         let drain_counters: Vec<Arc<StepDrainCounter>> = vec![];
         let _ = ChainGraph::new();
         let mut worker = WorkerCore::new(0, None, None);
 
         signal.cancel();
-        run_worker_loop(&mut worker, &mut entries, &contexts, &drain_counters, &signal, None);
+        run_worker_loop(
+            &mut worker,
+            &mut entries,
+            &contexts,
+            &drain_counters,
+            &signal,
+            None,
+            &crate::runtime::scheduler::ChainOrderScheduler,
+        );
         // If we reach this line, the loop exited cleanly.
     }
 
@@ -576,7 +656,11 @@ mod tests {
     fn parallel_last_finisher_closes_shared_output_exactly_once() {
         const N: usize = 4;
         let (steps, graph, _runs) = three_step_chain(StepKind::Parallel);
-        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
         let mid = StepIdx(1);
         let counter = StepDrainCounter::new(N);
         let signal = PipelineSignal::new();
@@ -592,7 +676,8 @@ mod tests {
                 !InputHandle::is_drained(sink_input),
                 "downstream input drained before the last clone finished (after {i} of {N})"
             );
-            let info = dispatch_one_step(clone, mid, &contexts, &counter, &signal, None).unwrap();
+            let info =
+                dispatch_one_step(clone, mid, &contexts, &counter, &signal, None, false).unwrap();
             assert!(matches!(info.result, Ok(StepOutcome::Finished)));
         }
         assert!(
@@ -607,7 +692,11 @@ mod tests {
     #[test]
     fn serial_drain_gate_short_circuits_second_worker() {
         let (steps, graph, runs) = three_step_chain(StepKind::Serial);
-        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
         let mid = StepIdx(1);
         let counter = StepDrainCounter::new(1);
         let signal = PipelineSignal::new();
@@ -619,7 +708,7 @@ mod tests {
         let mut entry1 =
             WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
         let info1 =
-            dispatch_one_step(&mut entry1, mid, &contexts, &counter, &signal, None).unwrap();
+            dispatch_one_step(&mut entry1, mid, &contexts, &counter, &signal, None, false).unwrap();
         assert!(matches!(info1.result, Ok(StepOutcome::Finished)));
         assert_eq!(runs.load(Ordering::Relaxed), 1, "step ran exactly once on the first worker");
         assert!(drain.is_finished(), "first finisher must set the DrainGate latch");
@@ -628,7 +717,7 @@ mod tests {
         let mut entry2 =
             WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
         let info2 =
-            dispatch_one_step(&mut entry2, mid, &contexts, &counter, &signal, None).unwrap();
+            dispatch_one_step(&mut entry2, mid, &contexts, &counter, &signal, None, false).unwrap();
         assert!(matches!(info2.result, Ok(StepOutcome::Finished)));
         assert_eq!(
             info2.name, "<finished-serial-step>",
@@ -654,7 +743,11 @@ mod tests {
         graph.wire(src, BranchIdx(0), sink);
         let steps: Vec<Box<dyn ErasedStep>> =
             vec![Box::new(TypedStep::new(SrcFinished)), Box::new(TypedStep::new(SinkStep))];
-        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
 
         // Single worker; the source (idx 0) is its Exclusive sticky owner, the
         // sink (idx 1) is Exclusive owned by the same worker for this 1-worker
@@ -669,7 +762,15 @@ mod tests {
 
         // The source finishes immediately; the sink then sees its input drained
         // and finishes too. `run_worker_loop` must return (no hang).
-        run_worker_loop(&mut worker, &mut entries, &contexts, &drain_counters, &signal, None);
+        run_worker_loop(
+            &mut worker,
+            &mut entries,
+            &contexts,
+            &drain_counters,
+            &signal,
+            None,
+            &crate::runtime::scheduler::ChainOrderScheduler,
+        );
     }
 
     /// A sticky owner that returns `NoProgress` on its first call (yielding out
@@ -701,7 +802,11 @@ mod tests {
             Box::new(TypedStep::new(SrcIdleThenFinish { calls: Arc::clone(&calls) })),
             Box::new(TypedStep::new(LingerThenFinish { ticks: 0 })),
         ];
-        let contexts = Arc::new(build_chain_contexts(&steps, &graph));
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
 
         let mut entries: Vec<WorkerStepEntry> = vec![
             WorkerStepEntry::Exclusive { step: steps.into_iter().next().unwrap() },
@@ -718,7 +823,15 @@ mod tests {
         // disable the sticky fast-path so the loop terminates rather than hangs.
         // The `Linger` step stays alive for one more iteration, forcing the
         // post-removal outer iteration that exercises the cleared fast path.
-        run_worker_loop(&mut worker, &mut entries, &contexts, &drain_counters, &signal, None);
+        run_worker_loop(
+            &mut worker,
+            &mut entries,
+            &contexts,
+            &drain_counters,
+            &signal,
+            None,
+            &crate::runtime::scheduler::ChainOrderScheduler,
+        );
 
         // The source must have been called EXACTLY twice: call 1 = idle in the
         // sticky fast-path (`NoProgress`, which does NOT remove it there — that
@@ -736,6 +849,206 @@ mod tests {
             2,
             "source must be called exactly twice (sticky idle, then round-robin finish); \
              a different count means the removed_sticky_owner branch did not gate the fast path",
+        );
+    }
+
+    // ── G1: the load-bearing driver invariant ───────────────────────────────
+    //
+    // A driver thread (`WorkerCore::driver`) is just `run_worker_loop` over a
+    // few `Owned` steps. Its no-deadlock property rests ENTIRELY on the loop
+    // trying EVERY live step in a pass before it parks. A naive "drive the first
+    // live step until it yields, then park" loop would wedge the coordination
+    // driver: it parks on a step whose input isn't ready yet while a *sibling*
+    // step on the same driver holds the work that would unblock it (e.g. park on
+    // `FindBoundariesAndSort` while `SpillGather` holds the chunk that frees the
+    // capacity-1 arena). These two steps pin that the whole-pass discipline holds.
+
+    /// `Owned` step wedged on `NoProgress` until `gate` is flipped by a sibling,
+    /// then `Finished`. Placed FIRST in the walk so a park-on-first-NoProgress
+    /// loop would never let the sibling run — the gate never flips — and hang.
+    #[derive(Clone)]
+    struct WedgedUntilGate {
+        gate: Arc<AtomicBool>,
+    }
+    impl Step for WedgedUntilGate {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "WedgedUntilGate",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if self.gate.load(Ordering::Acquire) {
+                Ok(StepOutcome::Finished)
+            } else {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+    }
+
+    /// `Owned` sibling that flips `gate` and finishes on its first dispatch —
+    /// reached only if the loop tries all live steps in a pass rather than
+    /// parking on the wedged step's `NoProgress`.
+    #[derive(Clone)]
+    struct GateOpener {
+        gate: Arc<AtomicBool>,
+    }
+    impl Step for GateOpener {
+        type Input = u32;
+        type Outputs = ();
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "GateOpener",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            self.gate.store(true, Ordering::Release);
+            Ok(StepOutcome::Finished)
+        }
+    }
+
+    /// A driver (`WorkerCore::driver`, Park backoff) driving `[Wedged, Opener]`
+    /// as two `Owned` steps must drive the sibling that unblocks the wedged step
+    /// and terminate. A watchdog aborts the process on a wedge so the failure is
+    /// loud rather than a silent hang.
+    #[test]
+    fn driver_round_robins_all_live_before_parking() {
+        let mut graph = ChainGraph::new();
+        let wedged = graph.register_step("WedgedUntilGate", 1);
+        let opener = graph.register_step("GateOpener", 0);
+        graph.wire(wedged, BranchIdx(0), opener);
+
+        let gate = Arc::new(AtomicBool::new(false));
+        let steps: Vec<Box<dyn ErasedStep>> = vec![
+            Box::new(TypedStep::new(WedgedUntilGate { gate: Arc::clone(&gate) })),
+            Box::new(TypedStep::new(GateOpener { gate: Arc::clone(&gate) })),
+        ];
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
+
+        // Hand-built driver row: both steps Owned on the one driver thread.
+        let mut entries: Vec<WorkerStepEntry> =
+            steps.into_iter().map(|step| WorkerStepEntry::Owned { step }).collect();
+        let drain_counters = vec![StepDrainCounter::new(1), StepDrainCounter::new(1)];
+        let signal = PipelineSignal::new();
+
+        // Watchdog: a wedge parks forever; abort so the test FAILS loudly.
+        let done = Arc::new(AtomicBool::new(false));
+        {
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                for _ in 0..200 {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                    if done.load(Ordering::SeqCst) {
+                        return;
+                    }
+                }
+                eprintln!("driver_round_robins_all_live_before_parking: WEDGED");
+                std::process::abort();
+            });
+        }
+
+        // Forward walk (ChainOrderScheduler) tries `wedged` (idx 0) first: it
+        // yields NoProgress, and the loop MUST proceed to `opener` in the same
+        // pass, flip the gate, then finish `wedged` on the next pass.
+        let mut worker = WorkerCore::driver(wedged);
+        run_worker_loop(
+            &mut worker,
+            &mut entries,
+            &contexts,
+            &drain_counters,
+            &signal,
+            None,
+            &crate::runtime::scheduler::ChainOrderScheduler,
+        );
+        done.store(true, Ordering::SeqCst);
+
+        assert!(gate.load(Ordering::Acquire), "the sibling opener must have run");
+        assert!(!signal.is_done(), "clean completion, no error");
+    }
+
+    /// A step that spends a measurable, nonzero span inside `try_run` so its
+    /// dispatch busy-time rounds above 0 ns.
+    #[derive(Clone)]
+    struct SlowFinish;
+    impl Step for SlowFinish {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "SlowFinish",
+                kind: StepKind::Exclusive,
+                sticky: false,
+                output_queues: vec![QueueSpec::CountBounded { capacity: 4 }],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            std::thread::sleep(std::time::Duration::from_micros(200));
+            Ok(StepOutcome::Finished)
+        }
+    }
+
+    /// A driver dispatch (`is_driver = true`) records the step's busy on the
+    /// off-pool detached line keyed by THAT step's own index — so a multi-step
+    /// `Shared` group attributes each member's real time, not the whole thread's
+    /// under one name. A pool dispatch (`is_driver = false`) records nothing there.
+    #[test]
+    fn driver_dispatch_records_detached_busy_by_own_step() {
+        let mut graph = ChainGraph::new();
+        let a = graph.register_step("SlowFinish", 1);
+        let sink = graph.register_step("Sink", 0);
+        graph.wire(a, BranchIdx(0), sink);
+        let steps: Vec<Box<dyn ErasedStep>> =
+            vec![Box::new(TypedStep::new(SlowFinish)), Box::new(TypedStep::new(SinkStep))];
+        let contexts = Arc::new(build_chain_contexts(
+            &steps,
+            &graph,
+            crate::builder::InstrumentationLevel::Off,
+        ));
+        let mid = StepIdx(0);
+        let counter = StepDrainCounter::new(1);
+        let signal = PipelineSignal::new();
+
+        // Driver dispatch of step 0 → its busy lands on the detached line keyed
+        // to step 0 (not some group primary).
+        let stats = Arc::new(PipelineStats::new(vec!["SlowFinish", "Sink"]));
+        let mut entry = WorkerStepEntry::Owned { step: Box::new(TypedStep::new(SlowFinish)) };
+        let _ =
+            dispatch_one_step(&mut entry, mid, &contexts, &counter, &signal, Some(&stats), true);
+        let snap = stats.snapshot();
+        assert!(
+            snap.detached.iter().any(|(name, busy, ..)| *name == "SlowFinish" && *busy > 0),
+            "driver dispatch must record detached busy for the dispatched step itself"
+        );
+
+        // Pool dispatch (is_driver=false) records nothing on the detached line.
+        let stats_pool = Arc::new(PipelineStats::new(vec!["SlowFinish", "Sink"]));
+        let mut entry_pool = WorkerStepEntry::Owned { step: Box::new(TypedStep::new(SlowFinish)) };
+        let _ = dispatch_one_step(
+            &mut entry_pool,
+            mid,
+            &contexts,
+            &counter,
+            &signal,
+            Some(&stats_pool),
+            false,
+        );
+        assert!(
+            stats_pool.snapshot().detached.is_empty(),
+            "pool dispatch must not record on the off-pool detached line"
         );
     }
 }

--- a/crates/fgumi-pipeline-core/src/runtime/fused.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/fused.rs
@@ -26,6 +26,7 @@ use std::time::Instant;
 
 use super::contexts::build_chain_contexts_fused;
 use super::stats::PipelineStats;
+use crate::builder::InstrumentationLevel;
 use crate::erased::{ErasedStep, ErasedStepCtx};
 use crate::signal::{PipelineError, PipelineSignal};
 use crate::step::StepOutcome;
@@ -79,6 +80,28 @@ pub fn is_fusible_chain(steps: &[Box<dyn ErasedStep>], graph: &ChainGraph) -> bo
         }
     }
     true
+}
+
+/// Whether `build_chain`'s fused single-thread fast path may be taken for this
+/// chain.
+///
+/// The fast path drives a fusible chain inline over direct buffers, skipping the
+/// scheduler — and with it the per-edge instrumentation the scheduled path sets
+/// up (edge [`EdgeMetrics`](super::metrics::EdgeMetrics), the occupancy sampler,
+/// and the `snapshot_with_edges` bottleneck verdict). An instrumented run
+/// (`InstrumentationLevel != Off`) must therefore NOT fuse, or its
+/// `--pipeline-stats` / `--pipeline-trace` output would silently omit all edge /
+/// occupancy data. When instrumentation is `Off` (the default), fusion is taken
+/// whenever the chain is single-thread and fusible (zero-overhead fast path
+/// preserved).
+#[must_use]
+pub fn should_fuse_single_thread(
+    n_threads: usize,
+    instrumentation: InstrumentationLevel,
+    steps: &[Box<dyn ErasedStep>],
+    graph: &ChainGraph,
+) -> bool {
+    n_threads == 1 && !instrumentation.is_on() && is_fusible_chain(steps, graph)
 }
 
 /// Drive a fusible chain to completion on the calling thread, fused.
@@ -209,6 +232,8 @@ pub fn run_fused_single_thread(
 mod tests {
     use std::io;
     use std::sync::{Arc, Mutex};
+
+    use rstest::rstest;
 
     use super::*;
     use crate::erased::TypedStep;
@@ -409,6 +434,27 @@ mod tests {
         let odd = Arc::new(Mutex::new(Vec::new()));
         let (steps, graph) = fan_out_chain(0, &even, &odd);
         assert!(is_fusible_chain(&steps, &graph));
+    }
+
+    // A fusible chain fuses ONLY when it is single-thread AND uninstrumented: the
+    // fused fast path skips the scheduled path's edge metrics / occupancy sampler
+    // / bottleneck verdict, so any instrumentation level (or ≥2 threads) must fall
+    // through to the scheduled path instead of silently dropping that output.
+    #[rstest]
+    #[case::off_single_thread(1, InstrumentationLevel::Off, true)]
+    #[case::summary_single_thread(1, InstrumentationLevel::Summary, false)]
+    #[case::timeline_single_thread(1, InstrumentationLevel::Timeline, false)]
+    #[case::deep_single_thread(1, InstrumentationLevel::Deep, false)]
+    #[case::off_multi_thread(2, InstrumentationLevel::Off, false)]
+    fn should_fuse_only_when_uninstrumented_single_thread(
+        #[case] n_threads: usize,
+        #[case] level: InstrumentationLevel,
+        #[case] expected: bool,
+    ) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let (steps, graph) = linear_chain(4, &out);
+        assert!(is_fusible_chain(&steps, &graph), "linear chain is fusible");
+        assert_eq!(should_fuse_single_thread(n_threads, level, &steps, &graph), expected);
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/runtime/metrics.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/metrics.rs
@@ -1,0 +1,308 @@
+//! Per-edge instrumentation counters + occupancy histogram.
+//!
+//! An [`EdgeMetrics`] is the edge-side complement of the step-side
+//! [`PipelineStats`](super::stats::PipelineStats): one per instrumented queue
+//! edge, shared (`Arc`) between the producer's transport (push/reject counts)
+//! and the consumer's input handle (pop/empty counts), and sampled periodically
+//! for occupancy. All counters are `Relaxed` atomics — these are statistics, not
+//! synchronization (staleness is fine), mirroring `ByteBoundedQueue::current_bytes`.
+//!
+//! What the histogram alone can classify is [`RawOccupancy`]; the richer
+//! `Empty`-vs-`Starved` / `Full`-vs-`Backpressured` split needs the reject/empty
+//! *rates* and is done by the renderer, not here.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Number of occupancy histogram buckets (depth fraction `0.0..=1.0` split into
+/// `OCCUPANCY_BUCKETS` equal bands; the top band captures exactly-full).
+pub const OCCUPANCY_BUCKETS: usize = 8;
+
+/// Per-edge counters + occupancy histogram. Construct with [`EdgeMetrics::new`]
+/// (returns an `Arc` so the producer transport and consumer input handle share
+/// one instance). All methods are lock-free `Relaxed` atomic updates.
+#[derive(Debug)]
+pub struct EdgeMetrics {
+    /// Items the producer successfully pushed.
+    pushed_items: AtomicU64,
+    /// Bytes pushed (only meaningful for byte-bounded edges; `0` otherwise).
+    pushed_bytes: AtomicU64,
+    /// Items the consumer popped.
+    popped_items: AtomicU64,
+    /// Bytes popped (byte-bounded edges only).
+    popped_bytes: AtomicU64,
+    /// `try_push` rejections — backpressure events (producer wanted to push, the
+    /// edge was full).
+    push_rejections: AtomicU64,
+    /// Consumer `pop` on an empty edge — starvation events.
+    pop_empties: AtomicU64,
+    /// Number of occupancy samples taken (sampler ticks).
+    depth_samples: AtomicU64,
+    /// Histogram of occupancy fraction at sample time.
+    occupancy_buckets: [AtomicU64; OCCUPANCY_BUCKETS],
+    /// Σ of `depth_fraction * 1000` over all samples, for the mean.
+    occupancy_sum_milli: AtomicU64,
+    /// Σ of raw occupied **bytes** over all samples. Kept alongside the fraction
+    /// sum so the mean occupancy can be reported in absolute bytes — which,
+    /// unlike `fraction × final_limit`, stays correct when the byte limit is
+    /// rebalanced at runtime (`queue_memory_total`). For an ordered edge the
+    /// sampled bytes include the `ReorderStage` overflow stash.
+    occupancy_bytes_sum: AtomicU64,
+}
+
+impl EdgeMetrics {
+    /// Construct a fresh metrics instance, shared via `Arc`.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            pushed_items: AtomicU64::new(0),
+            pushed_bytes: AtomicU64::new(0),
+            popped_items: AtomicU64::new(0),
+            popped_bytes: AtomicU64::new(0),
+            push_rejections: AtomicU64::new(0),
+            pop_empties: AtomicU64::new(0),
+            depth_samples: AtomicU64::new(0),
+            occupancy_buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            occupancy_sum_milli: AtomicU64::new(0),
+            occupancy_bytes_sum: AtomicU64::new(0),
+        })
+    }
+
+    /// Record a successful producer push of `bytes` (pass `0` for count-bounded
+    /// / unbounded edges that don't track bytes).
+    pub fn record_push(&self, bytes: u64) {
+        self.pushed_items.fetch_add(1, Ordering::Relaxed);
+        self.pushed_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record a successful consumer pop of `bytes`.
+    pub fn record_pop(&self, bytes: u64) {
+        self.popped_items.fetch_add(1, Ordering::Relaxed);
+        self.popped_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record a `try_push` rejection (backpressure).
+    pub fn record_reject(&self) {
+        self.push_rejections.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a consumer pop that found the edge empty (starvation).
+    pub fn record_empty(&self) {
+        self.pop_empties.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one occupancy sample from the edge's current `occupied_bytes` and
+    /// its byte `limit_bytes`. The histogram bucket and fraction use
+    /// `occupied_bytes / limit_bytes` clamped to `0.0..=1.0`; the **raw**
+    /// `occupied_bytes` (un-clamped — so it stays truthful when an ordered
+    /// edge's reorder stash pushes total buffered bytes past the transport
+    /// limit) is summed for the byte-accurate mean the latency estimate uses. A
+    /// `limit_bytes` of `0` is treated as fraction `0.0` defensively (the
+    /// sampler already skips count/unbounded edges).
+    // Casts are bounded statistics: `f ∈ [0,1]` so `f * BUCKETS` ∈ [0,8] and
+    // `f * 1000` ∈ [0,1000] — no meaningful truncation/sign loss/precision loss.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    pub fn record_depth(&self, occupied_bytes: u64, limit_bytes: u64) {
+        let f = if limit_bytes == 0 {
+            0.0
+        } else {
+            (occupied_bytes as f32 / limit_bytes as f32).clamp(0.0, 1.0)
+        };
+        let bucket = ((f * OCCUPANCY_BUCKETS as f32) as usize).min(OCCUPANCY_BUCKETS - 1);
+        self.occupancy_buckets[bucket].fetch_add(1, Ordering::Relaxed);
+        self.occupancy_sum_milli.fetch_add((f * 1000.0) as u64, Ordering::Relaxed);
+        self.occupancy_bytes_sum.fetch_add(occupied_bytes, Ordering::Relaxed);
+        self.depth_samples.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Take a consistent-enough point-in-time snapshot of the counters.
+    // Mean is a display statistic; u64→f32 precision loss past 2^23 samples is
+    // irrelevant to a 0..1 occupancy mean.
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub fn snapshot(&self) -> EdgeMetricsSnapshot {
+        let buckets: [u64; OCCUPANCY_BUCKETS] =
+            std::array::from_fn(|i| self.occupancy_buckets[i].load(Ordering::Relaxed));
+        let depth_samples = self.depth_samples.load(Ordering::Relaxed);
+        let mean_occupancy = if depth_samples == 0 {
+            0.0
+        } else {
+            (self.occupancy_sum_milli.load(Ordering::Relaxed) as f32 / 1000.0)
+                / depth_samples as f32
+        };
+        let mean_occupancy_bytes = if depth_samples == 0 {
+            0.0
+        } else {
+            self.occupancy_bytes_sum.load(Ordering::Relaxed) as f64 / depth_samples as f64
+        };
+        EdgeMetricsSnapshot {
+            pushed_items: self.pushed_items.load(Ordering::Relaxed),
+            pushed_bytes: self.pushed_bytes.load(Ordering::Relaxed),
+            popped_items: self.popped_items.load(Ordering::Relaxed),
+            popped_bytes: self.popped_bytes.load(Ordering::Relaxed),
+            push_rejections: self.push_rejections.load(Ordering::Relaxed),
+            pop_empties: self.pop_empties.load(Ordering::Relaxed),
+            depth_samples,
+            raw_occupancy: RawOccupancy::from_buckets(&buckets, depth_samples),
+            mean_occupancy,
+            mean_occupancy_bytes,
+        }
+    }
+}
+
+/// A point-in-time read of an [`EdgeMetrics`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeMetricsSnapshot {
+    /// Items successfully pushed onto the edge by the producer.
+    pub pushed_items: u64,
+    /// Bytes successfully pushed onto the edge (0 for count/unbounded edges).
+    pub pushed_bytes: u64,
+    /// Items successfully popped off the edge by the consumer.
+    pub popped_items: u64,
+    /// Bytes successfully popped off the edge (0 for count/unbounded edges).
+    pub popped_bytes: u64,
+    /// Push attempts rejected by backpressure (edge at its limit).
+    pub push_rejections: u64,
+    /// Pop attempts that found the edge empty (starvation signal).
+    pub pop_empties: u64,
+    /// Number of occupancy samples the background sampler took on this edge.
+    pub depth_samples: u64,
+    /// What the occupancy histogram alone says (no rate-based refinement).
+    pub raw_occupancy: RawOccupancy,
+    /// Mean occupancy fraction `0.0..=1.0` over all samples (`0.0` if none).
+    pub mean_occupancy: f32,
+    /// Mean occupied **bytes** over all samples (`0.0` if none). Unlike
+    /// `mean_occupancy` (a fraction that must be multiplied by a limit to
+    /// recover bytes), this is measured directly at sample time, so the
+    /// Little's-Law latency estimate stays correct even when `queue_memory_total`
+    /// rebalances the byte limit mid-run. For an ordered edge it includes the
+    /// `ReorderStage` overflow stash.
+    pub mean_occupancy_bytes: f64,
+}
+
+/// Occupancy classification derivable from the histogram **alone** (no
+/// reject/empty rates). The renderer refines `MostlyEmpty`→`Empty`/`Starved`
+/// and `MostlyFull`→`Full`/`Backpressured` using the rates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawOccupancy {
+    /// Insufficient samples to classify.
+    Unknown,
+    /// ≥80% of samples in the bottom bucket.
+    MostlyEmpty,
+    /// ≥80% of samples in the top bucket.
+    MostlyFull,
+    /// Bottom and top buckets each hold >25% of samples (bursty coupling).
+    Bimodal,
+    /// Spread across the middle — neither side bound.
+    Healthy,
+}
+
+impl RawOccupancy {
+    /// Classify from the bucket histogram and total sample count.
+    // Ratios are display statistics; u64→f64 precision loss is irrelevant to the
+    // 0.25/0.80 thresholds.
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub fn from_buckets(buckets: &[u64; OCCUPANCY_BUCKETS], samples: u64) -> Self {
+        if samples == 0 {
+            return Self::Unknown;
+        }
+        let s = samples as f64;
+        let bottom = buckets[0] as f64 / s;
+        let top = buckets[OCCUPANCY_BUCKETS - 1] as f64 / s;
+        if bottom >= 0.80 {
+            Self::MostlyEmpty
+        } else if top >= 0.80 {
+            Self::MostlyFull
+        } else if bottom > 0.25 && top > 0.25 {
+            Self::Bimodal
+        } else {
+            Self::Healthy
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn edge_metrics_counts_are_exact() {
+        let m = EdgeMetrics::new();
+        for _ in 0..3 {
+            m.record_push(100);
+        }
+        m.record_reject();
+        for _ in 0..2 {
+            m.record_pop(100);
+        }
+        m.record_empty();
+        let s = m.snapshot();
+        assert_eq!(s.pushed_items, 3);
+        assert_eq!(s.pushed_bytes, 300);
+        assert_eq!(s.push_rejections, 1);
+        assert_eq!(s.popped_items, 2);
+        assert_eq!(s.popped_bytes, 200);
+        assert_eq!(s.pop_empties, 1);
+    }
+
+    // Each case records a depth pattern, then asserts the classification (and,
+    // where the pattern pins one, the mean occupancy within a tolerance). The
+    // `mostly_empty` case reuses the `(mean, tol)` form as `(0.0, 0.02)`, i.e.
+    // `mean < 0.02`, since occupancy is non-negative. `fill` is a non-capturing
+    // closure coerced to a `fn` pointer so it can ride as an rstest case value.
+    #[rstest]
+    // Samples are `(occupied_bytes, limit_bytes)`; a 1000-byte limit makes the
+    // occupied byte count read directly as the depth fraction ×1000.
+    #[case::mostly_full(|m: &EdgeMetrics| for _ in 0..100 { m.record_depth(1000, 1000); }, RawOccupancy::MostlyFull, Some((1.0, 0.02)))]
+    #[case::mostly_empty(|m: &EdgeMetrics| for _ in 0..100 { m.record_depth(0, 1000); }, RawOccupancy::MostlyEmpty, Some((0.0, 0.02)))]
+    #[case::bimodal(|m: &EdgeMetrics| for _ in 0..50 { m.record_depth(0, 1000); m.record_depth(1000, 1000); }, RawOccupancy::Bimodal, None)]
+    // Spread uniformly across the middle buckets → mean ≈ 0.45.
+    #[case::healthy(|m: &EdgeMetrics| for i in 0..100u32 { m.record_depth(300 + u64::from(i % 4) * 100, 1000); }, RawOccupancy::Healthy, Some((0.45, 0.05)))]
+    #[case::unknown(|_m: &EdgeMetrics| {}, RawOccupancy::Unknown, None)]
+    fn occupancy_classification(
+        #[case] fill: fn(&EdgeMetrics),
+        #[case] expected: RawOccupancy,
+        #[case] mean_within: Option<(f32, f32)>,
+    ) {
+        let m = EdgeMetrics::new();
+        fill(&m);
+        let s = m.snapshot();
+        assert_eq!(s.raw_occupancy, expected);
+        if let Some((mean, tol)) = mean_within {
+            assert!(
+                (s.mean_occupancy - mean).abs() < tol,
+                "mean_occupancy {} not within {tol} of {mean}",
+                s.mean_occupancy
+            );
+        }
+    }
+
+    #[test]
+    fn mean_occupancy_bytes_tracks_absolute_bytes_independent_of_limit() {
+        // Sampled occupied bytes are averaged in absolute terms, not as a
+        // fraction of the limit — so a later limit change can't distort the mean
+        // (the property the derived-latency estimate relies on). Two 600-byte
+        // samples average to 600 bytes regardless of the 1000-byte limit used.
+        let m = EdgeMetrics::new();
+        m.record_depth(600, 1000);
+        m.record_depth(600, 1000);
+        let s = m.snapshot();
+        assert!((s.mean_occupancy_bytes - 600.0).abs() < 1e-9, "{}", s.mean_occupancy_bytes);
+        assert!((s.mean_occupancy - 0.6).abs() < 0.01, "{}", s.mean_occupancy);
+    }
+
+    #[test]
+    fn mean_occupancy_bytes_keeps_raw_bytes_when_stash_exceeds_limit() {
+        // An ordered edge's reorder stash can push total buffered bytes past the
+        // transport limit; the fraction saturates at 1.0 but the byte mean stays
+        // truthful (1500 bytes), so latency is not under-counted.
+        let m = EdgeMetrics::new();
+        m.record_depth(1500, 1000); // 150% of limit
+        let s = m.snapshot();
+        assert!((s.mean_occupancy - 1.0).abs() < 1e-6, "fraction clamps to 1.0");
+        assert!((s.mean_occupancy_bytes - 1500.0).abs() < 1e-9, "raw bytes preserved");
+    }
+}

--- a/crates/fgumi-pipeline-core/src/runtime/mod.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/mod.rs
@@ -2,21 +2,29 @@
 //! worker pool, worker loop body. Built on top of Phase 1's trait surface.
 
 pub mod contexts;
+pub mod detached;
 pub mod drain;
 pub mod driver;
 pub mod fused;
 pub mod live;
+pub mod metrics;
 pub mod pool;
+pub mod sampler;
+pub mod scheduler;
 pub mod stats;
 pub mod storage;
 pub mod worker_core;
 
 pub use contexts::{ChainContexts, build_chain_contexts, build_chain_contexts_fused};
+pub use detached::{
+    DetachedDriverGroup, build_driver_storage, extract_detached_steps, run_detached_driver,
+};
 pub use drain::StepDrainCounter;
 pub use driver::run_worker_loop;
-pub use fused::{is_fusible_chain, run_fused_single_thread};
+pub use fused::{is_fusible_chain, run_fused_single_thread, should_fuse_single_thread};
 pub use live::LiveSteps;
 pub use pool::{assign_exclusive_owners, assign_sticky_owners};
+pub use scheduler::{ChainOrderScheduler, DrainFirstScheduler, Scheduler, WalkDirection};
 pub use stats::{PipelineStats, StatsSnapshot, StepStatsSnapshot};
 pub use storage::{WorkerStepEntry, build_worker_storage};
-pub use worker_core::WorkerCore;
+pub use worker_core::{BackoffPolicy, WorkerCore, WorkerRole};

--- a/crates/fgumi-pipeline-core/src/runtime/sampler.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/sampler.rs
@@ -1,0 +1,403 @@
+//! Background occupancy sampler for `--pipeline-trace`.
+//!
+//! When instrumentation is on, `Pipeline::run` spawns one
+//! [`run_occupancy_sampler`] thread (same lifecycle slot as the deadlock
+//! monitor / queue rebalancer) that periodically reads each byte-bounded edge's
+//! depth (`current_bytes / limit_bytes`) and feeds it to the edge's
+//! [`EdgeMetrics`](super::metrics::EdgeMetrics) occupancy histogram. It is
+//! read-only over the live queues (one `Relaxed` load per edge per tick), so it
+//! never perturbs the worker hot path; only edges with a `depth_source`
+//! (byte-bounded) are sampled — count/unbounded edges still get their push/pop
+//! counters, just no occupancy histogram.
+
+use std::fmt::Write as _;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use super::contexts::RegisteredEdge;
+
+/// Default sampling interval. Two milliseconds is cheap (one atomic load per
+/// edge) yet fine-grained enough to resolve a chain's phase structure over a
+/// multi-second run.
+pub const DEFAULT_SAMPLE_INTERVAL: Duration = Duration::from_millis(2);
+
+/// Poll each byte-bounded edge's occupancy into its histogram until `stop` is
+/// set. Edges without a `depth_source` (count/unbounded) are skipped. When
+/// `trace_path` is `Some` (the `Timeline` level), also append one TSV row per
+/// tick — `t_ms` plus, per edge, its depth fraction and cumulative
+/// pushed/popped item counts — so the run's phase structure can be plotted.
+pub fn run_occupancy_sampler(
+    stop: &AtomicBool,
+    edges: &[RegisteredEdge],
+    interval: Duration,
+    trace_path: Option<PathBuf>,
+) {
+    let mut trace = trace_path.and_then(|p| TraceWriter::open(&p, edges));
+    let start = Instant::now();
+    let mut sampled_in_loop = false;
+    while !stop.load(Ordering::Relaxed) {
+        sample_once(edges);
+        if let Some(t) = trace.as_mut() {
+            t.write_row(edges, start.elapsed());
+        }
+        sampled_in_loop = true;
+        std::thread::sleep(interval);
+    }
+    // Guard the final sample: only take it when the loop never sampled (a run
+    // so short `stop` was already set before the first iteration). Sampling
+    // unconditionally here would add an extra occupancy point + timeline row
+    // taken AFTER the pipeline already drained, biasing the mean toward the
+    // empty final state.
+    if !sampled_in_loop {
+        sample_once(edges);
+        if let Some(t) = trace.as_mut() {
+            t.write_row(edges, start.elapsed());
+        }
+    }
+    if let Some(mut t) = trace {
+        t.flush();
+    }
+}
+
+/// Bytes buffered in an ordered edge's `ReorderStage` overflow stash (0 for a
+/// direct/count/unbounded edge). Added to the transport queue's `current_bytes`
+/// when sampling depth so an ordered edge reflects total buffered bytes rather
+/// than reading empty while items pile in the reorder buffer awaiting an earlier
+/// ordinal.
+fn reorder_stash_bytes(edge: &RegisteredEdge) -> u64 {
+    edge.reorder_depth.as_ref().map_or(0, |r| r.current_buffer_bytes())
+}
+
+/// Column-name prefix for one edge's timeline columns. Includes the producer
+/// step index and output branch so fan-out edges (one producer, several
+/// branches) and repeated step names produce distinct, collision-free headers —
+/// a bare `producer__consumer` prefix duplicates columns whenever two edges
+/// share both names. `(producer_step, branch)` uniquely identifies an edge.
+fn edge_column_prefix(e: &RegisteredEdge) -> String {
+    format!(
+        "{}__{}#{}b{}",
+        e.producer_name,
+        e.consumer_name.unwrap_or("sink"),
+        e.producer_step.0,
+        e.branch.0,
+    )
+}
+
+/// Per-tick TSV writer for the `Timeline` level. Best-effort: a write error is
+/// logged once and further rows are dropped (instrumentation never aborts a run).
+struct TraceWriter {
+    writer: BufWriter<std::fs::File>,
+    failed: bool,
+}
+
+impl TraceWriter {
+    /// Open `path` and write the header (`t_ms` + three columns per edge).
+    /// Returns `None` (with a warning) if the file can't be created.
+    fn open(path: &std::path::Path, edges: &[RegisteredEdge]) -> Option<Self> {
+        match std::fs::File::create(path) {
+            Ok(file) => {
+                let mut writer = BufWriter::new(file);
+                let mut header = String::from("t_ms");
+                for e in edges {
+                    let edge = edge_column_prefix(e);
+                    let _ = write!(header, "\t{edge}.depth\t{edge}.pushed\t{edge}.popped");
+                }
+                if writeln!(writer, "{header}").is_err() {
+                    log::warn!(
+                        "pipeline-trace: failed to write timeline header to {}",
+                        path.display()
+                    );
+                    return None;
+                }
+                Some(Self { writer, failed: false })
+            }
+            Err(e) => {
+                log::warn!("pipeline-trace: cannot create timeline file {}: {e}", path.display());
+                None
+            }
+        }
+    }
+
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    fn write_row(&mut self, edges: &[RegisteredEdge], elapsed: Duration) {
+        if self.failed {
+            return;
+        }
+        let mut row = format!("{}", elapsed.as_millis());
+        for e in edges {
+            // Count/unbounded edges (no `depth_source`) are unsampled — emit `NA`
+            // rather than `0.000`, which would misread as "empty" instead of
+            // "not measured". Byte-bounded edges report total buffered depth
+            // (transport + reorder stash) as a fraction of the limit.
+            let depth = e
+                .depth_source
+                .as_ref()
+                .and_then(|s| {
+                    let limit = s.limit_bytes();
+                    (limit > 0).then(|| {
+                        let occupied = s.current_bytes().saturating_add(reorder_stash_bytes(e));
+                        format!("{:.3}", occupied as f32 / limit as f32)
+                    })
+                })
+                .unwrap_or_else(|| "NA".to_string());
+            let ms = e.metrics.snapshot();
+            let _ = write!(row, "\t{depth}\t{}\t{}", ms.pushed_items, ms.popped_items);
+        }
+        if writeln!(self.writer, "{row}").is_err() {
+            log::warn!("pipeline-trace: timeline write failed; dropping further rows");
+            self.failed = true;
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.failed {
+            return;
+        }
+        // A dropped flush error can silently lose buffered rows after every
+        // write appeared to succeed — warn and mark the writer failed, matching
+        // `write_row`'s best-effort error handling.
+        if self.writer.flush().is_err() {
+            log::warn!("pipeline-trace: timeline flush failed; buffered rows may be lost");
+            self.failed = true;
+        }
+    }
+}
+
+/// One sampling sweep over all edges. Extracted so tests can drive a single
+/// deterministic tick without the sleep loop.
+#[allow(clippy::cast_precision_loss)]
+pub fn sample_once(edges: &[RegisteredEdge]) {
+    for edge in edges {
+        if let Some(src) = &edge.depth_source {
+            let limit = src.limit_bytes();
+            if limit > 0 {
+                let occupied = src.current_bytes().saturating_add(reorder_stash_bytes(edge));
+                edge.metrics.record_depth(occupied, limit);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use crate::item::HeapSize;
+    use crate::queues::{BoundedQueueHandle, ByteBoundedQueue, ItemQueue};
+    use crate::runtime::metrics::EdgeMetrics;
+    use crate::topology::{BranchIdx, StepIdx};
+
+    #[derive(Debug)]
+    struct Heavy(Vec<u8>);
+    impl HeapSize for Heavy {
+        fn heap_size(&self) -> usize {
+            self.0.len()
+        }
+    }
+
+    fn edge_over(
+        metrics: Arc<EdgeMetrics>,
+        depth_source: Option<Arc<dyn BoundedQueueHandle>>,
+    ) -> RegisteredEdge {
+        RegisteredEdge {
+            producer_step: StepIdx(0),
+            producer_name: "producer",
+            consumer_step: Some(StepIdx(1)),
+            consumer_name: Some("consumer"),
+            branch: BranchIdx(0),
+            metrics,
+            depth_source,
+            reorder_depth: None,
+        }
+    }
+
+    #[test]
+    fn sample_once_records_occupancy_from_depth_source() {
+        let m = EdgeMetrics::new();
+        let q = Arc::new(ByteBoundedQueue::<Heavy>::new(1000));
+        q.try_push(Heavy(vec![0; 500])).unwrap(); // 50% of the 1000-byte budget
+        let edge = edge_over(Arc::clone(&m), Some(Arc::clone(&q) as Arc<dyn BoundedQueueHandle>));
+        for _ in 0..10 {
+            sample_once(std::slice::from_ref(&edge));
+        }
+        let s = m.snapshot();
+        assert_eq!(s.depth_samples, 10);
+        assert!((s.mean_occupancy - 0.5).abs() < 0.05, "mean ≈ 0.5, got {}", s.mean_occupancy);
+    }
+
+    #[test]
+    fn count_edge_without_depth_source_is_skipped() {
+        // An edge with no depth_source (count/unbounded) records no occupancy.
+        let m = EdgeMetrics::new();
+        let edge = edge_over(Arc::clone(&m), None);
+        for _ in 0..5 {
+            sample_once(std::slice::from_ref(&edge));
+        }
+        assert_eq!(m.snapshot().depth_samples, 0, "no depth source → no occupancy samples");
+    }
+
+    #[test]
+    fn run_occupancy_sampler_stops_and_records() {
+        let m = EdgeMetrics::new();
+        let q = Arc::new(ByteBoundedQueue::<Heavy>::new(1000));
+        q.try_push(Heavy(vec![0; 800])).unwrap();
+        let edges =
+            vec![edge_over(Arc::clone(&m), Some(Arc::clone(&q) as Arc<dyn BoundedQueueHandle>))];
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_c = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            run_occupancy_sampler(&stop_c, &edges, Duration::from_millis(1), None);
+        });
+        std::thread::sleep(Duration::from_millis(30));
+        stop.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+        let s = m.snapshot();
+        assert!(s.depth_samples > 0, "sampler recorded at least one tick");
+        assert!((s.mean_occupancy - 0.8).abs() < 0.1, "mean ≈ 0.8, got {}", s.mean_occupancy);
+    }
+
+    #[test]
+    fn edge_columns_are_unique_when_step_names_collide() {
+        // Regression: two edges that share producer AND consumer names (fan-out,
+        // or duplicate step names) must still produce distinct TSV columns — a
+        // bare `producer__consumer` prefix would emit duplicate column headers.
+        let m0 = EdgeMetrics::new();
+        let m1 = EdgeMetrics::new();
+        let e0 = RegisteredEdge {
+            producer_step: StepIdx(0),
+            producer_name: "dup",
+            consumer_step: Some(StepIdx(1)),
+            consumer_name: Some("sink"),
+            branch: BranchIdx(0),
+            metrics: m0,
+            depth_source: None,
+            reorder_depth: None,
+        };
+        // Same names, different (producer_step, branch): a fan-out sibling.
+        let e1 = RegisteredEdge {
+            producer_step: StepIdx(0),
+            producer_name: "dup",
+            consumer_step: Some(StepIdx(2)),
+            consumer_name: Some("sink"),
+            branch: BranchIdx(1),
+            metrics: m1,
+            depth_source: None,
+            reorder_depth: None,
+        };
+        let p0 = edge_column_prefix(&e0);
+        let p1 = edge_column_prefix(&e1);
+        assert_ne!(p0, p1, "colliding names must yield distinct column prefixes");
+        assert_eq!(p0, "dup__sink#0b0");
+        assert_eq!(p1, "dup__sink#0b1");
+    }
+
+    #[test]
+    fn ordered_edge_occupancy_includes_reorder_stash() {
+        use crate::queues::CountBoundedQueue;
+        use crate::reorder::{ReorderCapHandle, ReorderStage, Sequenced};
+        // The transport (occupancy depth source) is empty, but the reorder stash
+        // holds 400 buffered bytes waiting for an earlier ordinal. Sampled
+        // occupancy must reflect the stash (400/1000 = 0.4), not read empty —
+        // otherwise a producer-skewed ordered edge looks idle while backed up.
+        let m = EdgeMetrics::new();
+        let transport = Arc::new(ByteBoundedQueue::<Heavy>::new(1000));
+
+        let reorder_transport: Arc<dyn ItemQueue<Sequenced<Heavy>>> =
+            Arc::new(CountBoundedQueue::<Sequenced<Heavy>>::new(8));
+        let stage = Arc::new(ReorderStage::new(reorder_transport));
+        stage.try_push(1, Heavy(vec![0; 400])).unwrap(); // out-of-order → stashed
+        assert!(stage.try_pop_in_order().is_none(), "ordinal 0 absent → nothing pops");
+        assert!(stage.current_buffer_bytes() >= 400, "stash holds the buffered bytes");
+
+        let edge = RegisteredEdge {
+            producer_step: StepIdx(0),
+            producer_name: "p",
+            consumer_step: Some(StepIdx(1)),
+            consumer_name: Some("c"),
+            branch: BranchIdx(0),
+            metrics: Arc::clone(&m),
+            depth_source: Some(Arc::clone(&transport) as Arc<dyn BoundedQueueHandle>),
+            reorder_depth: Some(Arc::clone(&stage) as Arc<dyn ReorderCapHandle>),
+        };
+        for _ in 0..10 {
+            sample_once(std::slice::from_ref(&edge));
+        }
+        let s = m.snapshot();
+        assert_eq!(s.depth_samples, 10);
+        assert!(
+            (s.mean_occupancy - 0.4).abs() < 0.05,
+            "occupancy reflects the reorder stash, got {}",
+            s.mean_occupancy
+        );
+        assert!(
+            (s.mean_occupancy_bytes - 400.0).abs() < 1.0,
+            "byte mean equals the stashed bytes, got {}",
+            s.mean_occupancy_bytes
+        );
+    }
+
+    #[test]
+    fn timeline_tsv_has_header_and_rows() {
+        let m = EdgeMetrics::new();
+        let q = Arc::new(ByteBoundedQueue::<Heavy>::new(1000));
+        q.try_push(Heavy(vec![0; 400])).unwrap();
+        let edges =
+            vec![edge_over(Arc::clone(&m), Some(Arc::clone(&q) as Arc<dyn BoundedQueueHandle>))];
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("fgumi-trace-test-{}.tsv", std::process::id()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_c = Arc::clone(&stop);
+        let path_c = path.clone();
+        let handle = std::thread::spawn(move || {
+            run_occupancy_sampler(&stop_c, &edges, Duration::from_millis(2), Some(path_c));
+        });
+        std::thread::sleep(Duration::from_millis(30));
+        stop.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        let content = std::fs::read_to_string(&path).expect("trace file written");
+        let _ = std::fs::remove_file(&path);
+        let mut lines = content.lines();
+        let header = lines.next().expect("header row");
+        assert!(header.starts_with("t_ms"), "header begins with t_ms");
+        assert!(header.contains("producer__consumer#0b0.depth"), "per-edge depth column");
+        let rows: Vec<&str> = lines.collect();
+        assert!(!rows.is_empty(), "at least one data row");
+        // First field of a data row is a monotonic t_ms integer.
+        let first_t: u128 = rows[0].split('\t').next().unwrap().parse().expect("t_ms is an int");
+        let last_t: u128 = rows.last().unwrap().split('\t').next().unwrap().parse().unwrap();
+        assert!(last_t >= first_t, "t_ms is monotonic");
+    }
+
+    #[test]
+    fn timeline_tsv_marks_unsampled_edge_na() {
+        // A count/unbounded edge (no depth_source) is unsampled: its depth column
+        // must read `NA`, not `0.000` (which would misread as an empty byte edge).
+        let m = EdgeMetrics::new();
+        let edges = vec![edge_over(Arc::clone(&m), None)];
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("fgumi-trace-na-{}.tsv", std::process::id()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_c = Arc::clone(&stop);
+        let path_c = path.clone();
+        let handle = std::thread::spawn(move || {
+            run_occupancy_sampler(&stop_c, &edges, Duration::from_millis(2), Some(path_c));
+        });
+        std::thread::sleep(Duration::from_millis(30));
+        stop.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        let content = std::fs::read_to_string(&path).expect("trace file written");
+        let _ = std::fs::remove_file(&path);
+        let mut lines = content.lines();
+        let _header = lines.next().expect("header row");
+        let row = lines.next().expect("at least one data row");
+        // Columns: t_ms, <edge>.depth, <edge>.pushed, <edge>.popped.
+        let depth = row.split('\t').nth(1).expect("depth column");
+        assert_eq!(depth, "NA", "unsampled edge's depth column is NA, row: {row}");
+    }
+}

--- a/crates/fgumi-pipeline-core/src/runtime/scheduler.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/scheduler.rs
@@ -1,0 +1,102 @@
+//! Pluggable per-worker dispatch-order policy for the round-robin pool driver.
+//!
+//! The worker loop ([`run_worker_loop`](crate::runtime::run_worker_loop)) walks
+//! each worker's *live* steps once per pass and runs the first that makes
+//! progress. A [`Scheduler`] decides the ORDER of that walk — the only thing it
+//! controls; it never changes which steps exist, the sticky source/sink
+//! fast-path, or the Serial/Exclusive contention rules.
+//!
+//! Two policies ship:
+//!
+//! - [`ChainOrderScheduler`] (the default) — walk **upstream-first** (chain
+//!   order). A worker attempts the earliest-in-chain step with work, favouring
+//!   production. This is the historical behaviour; every command keeps it unless
+//!   it opts out, so existing pipelines are byte-for-byte unaffected.
+//! - [`DrainFirstScheduler`] — walk **downstream-first** (reverse chain order).
+//!   A worker attempts the deepest step with work first, favouring *draining*
+//!   buffered work before producing more. Combined with skip-on-Serial-contention
+//!   this self-balances: for a Serial step fed by an N-way Parallel producer, one
+//!   worker grabs the Serial drain (mutex) while the rest find it contended, skip,
+//!   and fall through to the producer — so the drain overlaps production instead
+//!   of starving behind it on the shared pool. Sources/sinks are unaffected (they
+//!   run on the sticky fast-path, not the round-robin walk).
+//!
+//! This mirrors main's `Scheduler`-trait design (`BalancedChaseDrainScheduler`
+//! among others), but generically over an arbitrary step list rather than a
+//! fixed set of named BAM stages: the only lever exposed here is walk direction,
+//! which is all the generic driver needs to express drain-first scheduling.
+
+/// The order in which a worker attempts its live steps in one round-robin pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalkDirection {
+    /// Chain order (upstream → downstream): favour production.
+    Forward,
+    /// Reverse chain order (downstream → upstream): favour draining.
+    Reverse,
+}
+
+/// A per-worker dispatch-order policy. Selected per pipeline via
+/// [`PipelineConfig::with_scheduler`](crate::builder::PipelineConfig::with_scheduler)
+/// and shared across all workers (the shipped policies are stateless).
+pub trait Scheduler: Send + Sync + std::fmt::Debug {
+    /// Direction to walk this worker's live steps this pass. Called once per
+    /// round-robin pass, so it must be cheap.
+    fn walk(&self) -> WalkDirection;
+
+    /// Human-readable name for diagnostics / `--pipeline-stats`.
+    fn name(&self) -> &'static str;
+}
+
+/// Default upstream-first (chain-order) walk. Preserves the historical dispatch
+/// behaviour for every pipeline that does not opt into a different policy.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ChainOrderScheduler;
+
+impl Scheduler for ChainOrderScheduler {
+    #[inline]
+    fn walk(&self) -> WalkDirection {
+        WalkDirection::Forward
+    }
+    fn name(&self) -> &'static str {
+        "chain-order"
+    }
+}
+
+/// Downstream-first (reverse chain-order) walk — drain buffered work before
+/// producing more. Opt-in per pipeline (e.g. the sort chain, to overlap the
+/// serial boundary/key scan with the parallel inflate instead of starving it on
+/// the shared pool).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DrainFirstScheduler;
+
+impl Scheduler for DrainFirstScheduler {
+    #[inline]
+    fn walk(&self) -> WalkDirection {
+        WalkDirection::Reverse
+    }
+    fn name(&self) -> &'static str {
+        "drain-first"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_forward() {
+        assert_eq!(ChainOrderScheduler.walk(), WalkDirection::Forward);
+        assert_eq!(ChainOrderScheduler.name(), "chain-order");
+    }
+
+    #[test]
+    fn drain_first_is_reverse() {
+        assert_eq!(DrainFirstScheduler.walk(), WalkDirection::Reverse);
+        assert_eq!(DrainFirstScheduler.name(), "drain-first");
+    }
+
+    // The forward/reverse position→step arithmetic these policies drive is
+    // exercised end-to-end against the real dispatcher in driver.rs
+    // (`driver_round_robins_all_live_before_parking`); a standalone test here
+    // would only re-derive the formula, not the driver's actual mapping.
+}

--- a/crates/fgumi-pipeline-core/src/runtime/stats.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/stats.rs
@@ -33,7 +33,6 @@
 //!   work lands.
 
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -43,12 +42,19 @@ use crate::topology::StepIdx;
 /// Atomic counters for a single step.
 #[derive(Debug)]
 pub struct StepStats {
+    /// Total `try_run` dispatches (every outcome, including errors).
     pub try_run_total: AtomicU64,
+    /// Dispatches that returned `StepOutcome::Progress`.
     pub progress_count: AtomicU64,
+    /// Dispatches that returned `StepOutcome::NoProgress`.
     pub no_progress_count: AtomicU64,
+    /// Dispatches that returned `StepOutcome::Contention`.
     pub contention_count: AtomicU64,
+    /// Dispatches that returned `StepOutcome::Finished`.
     pub finished_count: AtomicU64,
+    /// Dispatches that returned an error from `try_run_erased`.
     pub error_count: AtomicU64,
+    /// Cumulative wall-ns spent inside `try_run` across all dispatches.
     pub total_run_ns: AtomicU64,
     /// Wall ns from pipeline start to the start of this step's FIRST
     /// Progress dispatch. `u64::MAX` until set. Lets us see when each
@@ -92,12 +98,41 @@ impl StepStats {
     }
 }
 
+/// Upper bound on per-worker utilization slots. Worker `thread_id`s index the
+/// `worker_busy_ns` / `worker_idle_ns` arrays; ids at or above this are not
+/// tracked (a no-op, never a panic). Sized well above any realistic
+/// `--threads`, so a fixed array avoids threading `num_workers` through every
+/// `PipelineStats::new` call site.
+const MAX_TRACKED_WORKERS: usize = 512;
+
 /// Per-step counter container. Sized to match the pipeline's chain length;
 /// callers obtain one via `Pipeline::stats()`.
 #[derive(Debug)]
 pub struct PipelineStats {
     steps: Box<[StepStats]>,
     step_names: Box<[&'static str]>,
+    /// Per-worker wall-ns spent dispatching (the sticky + round-robin work
+    /// section of `run_worker_loop`), indexed by `WorkerCore::thread_id`.
+    worker_busy_ns: Box<[AtomicU64]>,
+    /// Per-worker wall-ns spent in the no-progress backoff sleep (idle/blocked
+    /// waiting for upstream work), indexed by `thread_id`. Together with
+    /// `worker_busy_ns` this answers "are workers utilised, or blocked".
+    worker_idle_ns: Box<[AtomicU64]>,
+    /// Per-step wall-ns a `StepKind::Detached` step's dedicated thread spent
+    /// inside `try_run` (busy) and parked on its backoff (idle), indexed by
+    /// `step_idx`. Detached threads have no `WorkerCore::thread_id`, so they are
+    /// tracked here separately and are intentionally EXCLUDED from the pool
+    /// utilisation line (which only sums `worker_busy_ns` / `worker_idle_ns`).
+    /// Reported on their own line so the legacy "N + 2" split is visible without
+    /// diluting the N-worker pool%.
+    detached_busy_ns: Box<[AtomicU64]>,
+    detached_idle_ns: Box<[AtomicU64]>,
+    /// Per-step count of backoff-park events on a `StepKind::Detached` step's
+    /// dedicated thread (one per [`backoff_park`](crate::runtime::detached) call),
+    /// indexed by `step_idx`. With `detached_idle_ns` this gives the average park
+    /// duration and the park-to-progress ratio — the signal for whether the
+    /// backoff (vs a precise per-slot condvar) adds latency on the merge's path.
+    detached_park_events: Box<[AtomicU64]>,
     /// Anchor for first/last-progress timestamps. Set at `PipelineStats`
     /// construction; all `first_progress_ns` / `last_progress_ns` values
     /// are wall-ns elapsed from this `Instant`.
@@ -110,10 +145,71 @@ impl PipelineStats {
     #[must_use]
     pub fn new(step_names: Vec<&'static str>) -> Self {
         let steps = (0..step_names.len()).map(|_| StepStats::default()).collect::<Vec<_>>();
+        let worker_busy_ns =
+            (0..MAX_TRACKED_WORKERS).map(|_| AtomicU64::new(0)).collect::<Vec<_>>();
+        let worker_idle_ns =
+            (0..MAX_TRACKED_WORKERS).map(|_| AtomicU64::new(0)).collect::<Vec<_>>();
+        let n_steps = steps.len();
+        let detached_busy_ns = (0..n_steps).map(|_| AtomicU64::new(0)).collect::<Vec<_>>();
+        let detached_idle_ns = (0..n_steps).map(|_| AtomicU64::new(0)).collect::<Vec<_>>();
+        let detached_park_events = (0..n_steps).map(|_| AtomicU64::new(0)).collect::<Vec<_>>();
         Self {
             steps: steps.into_boxed_slice(),
             step_names: step_names.into_boxed_slice(),
+            worker_busy_ns: worker_busy_ns.into_boxed_slice(),
+            worker_idle_ns: worker_idle_ns.into_boxed_slice(),
+            detached_busy_ns: detached_busy_ns.into_boxed_slice(),
+            detached_idle_ns: detached_idle_ns.into_boxed_slice(),
+            detached_park_events: detached_park_events.into_boxed_slice(),
             pipeline_start: Instant::now(),
+        }
+    }
+
+    /// Accumulate `ns` of `try_run` (busy) time for a `StepKind::Detached`
+    /// step's dedicated thread, keyed by `step_idx`. Excluded from pool
+    /// utilisation; reported on the Detached line. Out-of-range steps are a
+    /// silent no-op.
+    #[inline]
+    pub fn record_detached_busy(&self, step: StepIdx, ns: u64) {
+        if let Some(c) = self.detached_busy_ns.get(step.0) {
+            c.fetch_add(ns, Ordering::Relaxed);
+        }
+    }
+
+    /// Accumulate `ns` of backoff-park (idle) time for a `StepKind::Detached`
+    /// step's dedicated thread, keyed by `step_idx`. Excluded from pool
+    /// utilisation; reported on the Detached line.
+    #[inline]
+    pub fn record_detached_idle(&self, step: StepIdx, ns: u64) {
+        if let Some(c) = self.detached_idle_ns.get(step.0) {
+            c.fetch_add(ns, Ordering::Relaxed);
+        }
+    }
+
+    /// Increment the backoff-park event count for a `StepKind::Detached` step's
+    /// dedicated thread (called once per park). Out-of-range steps are a silent
+    /// no-op.
+    #[inline]
+    pub fn record_detached_park(&self, step: StepIdx) {
+        if let Some(c) = self.detached_park_events.get(step.0) {
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Accumulate `ns` of dispatch (busy) time for `worker` (its `thread_id`).
+    /// Ids `>= MAX_TRACKED_WORKERS` are silently dropped.
+    #[inline]
+    pub fn record_worker_busy(&self, worker: usize, ns: u64) {
+        if let Some(c) = self.worker_busy_ns.get(worker) {
+            c.fetch_add(ns, Ordering::Relaxed);
+        }
+    }
+
+    /// Accumulate `ns` of backoff-sleep (idle) time for `worker`.
+    #[inline]
+    pub fn record_worker_idle(&self, worker: usize, ns: u64) {
+        if let Some(c) = self.worker_idle_ns.get(worker) {
+            c.fetch_add(ns, Ordering::Relaxed);
         }
     }
 
@@ -207,7 +303,65 @@ impl PipelineStats {
             .zip(self.step_names.iter())
             .map(|(stats, &name)| (name, stats.snapshot()))
             .collect();
-        StatsSnapshot { steps }
+        // Only workers that recorded any activity (busy or idle) — the array is
+        // sized to MAX_TRACKED_WORKERS but typically few slots are live.
+        let workers = (0..self.worker_busy_ns.len())
+            .map(|w| {
+                (
+                    w,
+                    self.worker_busy_ns[w].load(Ordering::Relaxed),
+                    self.worker_idle_ns[w].load(Ordering::Relaxed),
+                )
+            })
+            .filter(|(_, busy, idle)| *busy != 0 || *idle != 0)
+            .collect();
+        StatsSnapshot { steps, workers, detached: self.detached_snapshot(), edges: Vec::new() }
+    }
+
+    /// Collect `(step_name, busy_ns, idle_ns)` for every step whose Detached
+    /// thread recorded any activity. Shared by both snapshot builders so the
+    /// Detached line renders identically with or without `--pipeline-trace`.
+    fn detached_snapshot(&self) -> Vec<(&'static str, u64, u64, u64)> {
+        (0..self.detached_busy_ns.len())
+            .map(|s| {
+                (
+                    self.step_names[s],
+                    self.detached_busy_ns[s].load(Ordering::Relaxed),
+                    self.detached_idle_ns[s].load(Ordering::Relaxed),
+                    self.detached_park_events[s].load(Ordering::Relaxed),
+                )
+            })
+            .filter(|(_, busy, idle, _)| *busy != 0 || *idle != 0)
+            .collect()
+    }
+
+    /// Like [`snapshot`](Self::snapshot) but also derives per-edge throughput /
+    /// occupancy / latency from the chain's instrumented `edges` over a
+    /// `wall_ns` run. Used by the `--pipeline-trace` end-of-run report.
+    #[must_use]
+    pub fn snapshot_with_edges(
+        &self,
+        edges: &[crate::runtime::contexts::RegisteredEdge],
+        wall_ns: u64,
+    ) -> StatsSnapshot {
+        let mut snap = self.snapshot();
+        snap.edges = edges
+            .iter()
+            .map(|e| {
+                let ms = e.metrics.snapshot();
+                let limit_bytes = e.depth_source.as_ref().map(|s| s.limit_bytes());
+                compute_edge_stats(
+                    e.producer_name,
+                    e.consumer_name,
+                    e.producer_step.0,
+                    e.consumer_step.map(|s| s.0),
+                    &ms,
+                    limit_bytes,
+                    wall_ns,
+                )
+            })
+            .collect();
+        snap
     }
 }
 
@@ -215,16 +369,176 @@ impl PipelineStats {
 #[derive(Debug, Clone)]
 pub struct StatsSnapshot {
     pub steps: Vec<(&'static str, StepStatsSnapshot)>,
+    /// `(thread_id, busy_ns, idle_ns)` for each worker that did anything.
+    pub workers: Vec<(usize, u64, u64)>,
+    /// `(step_name, busy_ns, idle_ns, park_events)` for each `StepKind::Detached`
+    /// step's dedicated thread that did anything. Tracked separately from
+    /// `workers` and EXCLUDED from the pool utilisation line (legacy "N + 2" —
+    /// the merge / writer threads are not pool workers); rendered on their own
+    /// line. `park_events` is the backoff-park count (latency signal).
+    pub detached: Vec<(&'static str, u64, u64, u64)>,
+    /// Per-edge throughput / occupancy / latency. Empty unless the snapshot was
+    /// built via [`PipelineStats::snapshot_with_edges`] (i.e. instrumentation on).
+    pub edges: Vec<EdgeStatsSnapshot>,
+}
+
+/// Occupancy classification refined from the histogram's [`RawOccupancy`] plus
+/// the reject/empty rates: `MostlyEmpty` + high empty-rate → `Starved`,
+/// `MostlyFull` + high reject-rate → `Backpressured`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OccupancyClass {
+    /// No occupancy samples (count/unbounded edge, or run too short).
+    Unknown,
+    /// Mostly empty, low empty-rate — idle, not starved.
+    Empty,
+    /// Mostly empty AND consumer frequently found it empty — producer-starved.
+    Starved,
+    /// Spread across the middle — neither side bound.
+    Healthy,
+    /// Mostly full AND producer frequently rejected — consumer-backpressured.
+    Backpressured,
+    /// Mostly full, low reject-rate — full but not actively rejecting.
+    Full,
+    /// Oscillates empty↔full (bursty / batch coupling).
+    Bimodal,
+}
+
+/// Rate above which a `MostlyEmpty`/`MostlyFull` edge is reclassified as
+/// `Starved`/`Backpressured`. 10% of attempts hitting the wall is a clear signal.
+const RATE_REFINE_THRESHOLD: f64 = 0.10;
+
+/// Per-edge derived statistics for the end-of-run report.
+#[derive(Debug, Clone)]
+pub struct EdgeStatsSnapshot {
+    pub producer: &'static str,
+    pub consumer: Option<&'static str>,
+    /// Producer step index. The bottleneck verdict attributes edges to steps by
+    /// this identity (not by `producer`/`consumer` name), so fan-out, fan-in, or
+    /// duplicate step names are not misattributed to whichever edge matches a
+    /// name first.
+    pub producer_step: usize,
+    /// Consumer step index, `None` for a terminal edge with no consumer.
+    pub consumer_step: Option<usize>,
+    pub items_per_s: f64,
+    /// Consumer throughput in MiB/s (popped bytes / wall time / 2^20).
+    pub mibytes_per_s: f64,
+    pub class: OccupancyClass,
+    pub mean_occupancy: f32,
+    /// Fraction of push attempts rejected (backpressure signal).
+    pub reject_rate: f64,
+    /// Fraction of pop attempts that found the edge empty (starvation signal).
+    pub empty_rate: f64,
+    /// Derived residence time (Little's Law `L/X`), byte-bounded edges only;
+    /// `None` for count/unbounded edges (no occupancy) or zero throughput.
+    pub derived_latency_ms: Option<f64>,
+}
+
+/// Refine the histogram's raw occupancy class using the reject/empty rates.
+#[must_use]
+fn refine_occupancy(
+    raw: crate::runtime::metrics::RawOccupancy,
+    reject_rate: f64,
+    empty_rate: f64,
+) -> OccupancyClass {
+    use crate::runtime::metrics::RawOccupancy;
+    match raw {
+        RawOccupancy::Unknown => OccupancyClass::Unknown,
+        RawOccupancy::Healthy => OccupancyClass::Healthy,
+        RawOccupancy::Bimodal => OccupancyClass::Bimodal,
+        RawOccupancy::MostlyEmpty if empty_rate >= RATE_REFINE_THRESHOLD => OccupancyClass::Starved,
+        RawOccupancy::MostlyEmpty => OccupancyClass::Empty,
+        RawOccupancy::MostlyFull if reject_rate >= RATE_REFINE_THRESHOLD => {
+            OccupancyClass::Backpressured
+        }
+        RawOccupancy::MostlyFull => OccupancyClass::Full,
+    }
+}
+
+/// Little's-Law residence time (`L/X`), byte-bounded edges only. Mean occupancy
+/// in ITEMS = `mean_occupancy_bytes / mean_item_bytes`.
+///
+/// `mean_occupancy_bytes` is sampled directly (absolute bytes at each tick), NOT
+/// reconstructed as `fraction × limit`. That matters because `queue_memory_total`
+/// can rebalance an edge's byte limit at runtime: the limit at teardown may
+/// differ from the limits in force during sampling, so `fraction × final_limit`
+/// would yield a materially wrong byte figure — and hence a wrong latency.
+/// `limit_bytes` is retained only as the byte-bounded gate (`None` for
+/// count/unbounded edges, which have no occupancy and thus no derived latency).
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+fn derived_latency_ms(
+    ms: &crate::runtime::metrics::EdgeMetricsSnapshot,
+    limit_bytes: Option<u64>,
+    items_per_s: f64,
+) -> Option<f64> {
+    if limit_bytes.is_none() || ms.pushed_items == 0 || items_per_s <= 0.0 {
+        return None;
+    }
+    let mean_item_bytes = ms.pushed_bytes as f64 / ms.pushed_items as f64;
+    if mean_item_bytes <= 0.0 {
+        return None;
+    }
+    let mean_items = ms.mean_occupancy_bytes / mean_item_bytes;
+    Some(1000.0 * mean_items / items_per_s)
+}
+
+/// Compute one edge's derived stats from its metrics snapshot + (for a
+/// byte-bounded edge) its byte budget, over a `wall_ns` run. Pure — unit-tested
+/// directly. `limit_bytes` is `None` for count/unbounded edges (no occupancy →
+/// no derived latency).
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn compute_edge_stats(
+    producer: &'static str,
+    consumer: Option<&'static str>,
+    producer_step: usize,
+    consumer_step: Option<usize>,
+    ms: &crate::runtime::metrics::EdgeMetricsSnapshot,
+    limit_bytes: Option<u64>,
+    wall_ns: u64,
+) -> EdgeStatsSnapshot {
+    let wall_secs = (wall_ns as f64) / 1e9;
+    let items_per_s = if wall_secs > 0.0 { ms.popped_items as f64 / wall_secs } else { 0.0 };
+    // Divisor is 1 MiB (2^20), so the field/column is MiB/s, not MB/s.
+    let mibytes_per_s =
+        if wall_secs > 0.0 { (ms.popped_bytes as f64 / wall_secs) / 1_048_576.0 } else { 0.0 };
+    let push_attempts = ms.pushed_items + ms.push_rejections;
+    let reject_rate =
+        if push_attempts > 0 { ms.push_rejections as f64 / push_attempts as f64 } else { 0.0 };
+    let pop_attempts = ms.popped_items + ms.pop_empties;
+    let empty_rate =
+        if pop_attempts > 0 { ms.pop_empties as f64 / pop_attempts as f64 } else { 0.0 };
+
+    EdgeStatsSnapshot {
+        producer,
+        consumer,
+        producer_step,
+        consumer_step,
+        items_per_s,
+        mibytes_per_s,
+        class: refine_occupancy(ms.raw_occupancy, reject_rate, empty_rate),
+        mean_occupancy: ms.mean_occupancy,
+        reject_rate,
+        empty_rate,
+        derived_latency_ms: derived_latency_ms(ms, limit_bytes, items_per_s),
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct StepStatsSnapshot {
+    /// Total `try_run` dispatches (every outcome, including errors).
     pub try_run_total: u64,
+    /// Dispatches that returned `StepOutcome::Progress`.
     pub progress_count: u64,
+    /// Dispatches that returned `StepOutcome::NoProgress`.
     pub no_progress_count: u64,
+    /// Dispatches that returned `StepOutcome::Contention`.
     pub contention_count: u64,
+    /// Dispatches that returned `StepOutcome::Finished`.
     pub finished_count: u64,
+    /// Dispatches that returned an error from `try_run_erased`.
     pub error_count: u64,
+    /// Cumulative wall-ns spent inside `try_run` across all dispatches.
     pub total_run_ns: u64,
     /// Wall ns (from pipeline start) of this step's first Progress
     /// dispatch start. `u64::MAX` if no Progress was ever recorded.
@@ -241,12 +555,162 @@ impl StepStatsSnapshot {
     }
 }
 
+/// Severity of a [`Finding`] from the bottleneck verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Severity {
+    /// The single rate-limiting step (full input edge + empty output edge).
+    Primary,
+    /// A contributing issue (spin, starvation) that is not the prime mover.
+    Secondary,
+    /// Whole-chain observation (e.g. latency-bound, not throughput-bound).
+    Info,
+}
+
+/// One mechanically-derived diagnosis from [`bottleneck_verdict`].
+#[derive(Debug, Clone)]
+pub(crate) struct Finding {
+    /// Triage classification. Set by [`bottleneck_verdict`] and asserted on by
+    /// the crate's tests; the human-readable report renders only `message`, so
+    /// the lib build never reads this field.
+    #[allow(dead_code)]
+    pub severity: Severity,
+    pub message: String,
+}
+
+/// Rate above which a Serial step's `contention/tries` ratio is flagged as spin.
+const SPIN_THRESHOLD: f64 = 0.20;
+
+/// Mechanically locate the chain's bottleneck and contributing issues from a
+/// snapshot's step + edge stats. Rules (all from already-collected numbers):
+/// - **Primary**: a step whose input edge is `Full`/`Backpressured` AND output
+///   edge is `Empty`/`Starved` — work piles into it, it can't fill downstream.
+///   Tagged CPU-bound if it dominates `total_run_ns`, else coordination.
+/// - **Secondary (spin)**: a step with a high `contention/tries` ratio.
+/// - **Secondary (starvation)**: an edge whose consumer frequently finds it
+///   empty — the producer (upstream) can't keep up.
+/// - **Info**: if no primary and no full/empty edge, the chain is
+///   latency/coordination-bound, not throughput-bound.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn bottleneck_verdict(snap: &StatsSnapshot) -> Vec<Finding> {
+    use OccupancyClass::{Backpressured, Empty, Full, Starved};
+    let mut findings = Vec::new();
+    let total_cpu_ns: u64 = snap.steps.iter().map(|(_, s)| s.total_run_ns).sum();
+    // Attribute edges to steps by step IDENTITY (index), not by name. `snap.steps`
+    // is in `StepIdx` order, so a step's index is its id. A step's input is "full"
+    // if ANY input edge (whose consumer is this step) is Full/Backpressured, and
+    // its output is "empty" if ANY output edge (whose producer is this step) is
+    // Empty/Starved — aggregating over all matching edges rather than the first
+    // name match, so fan-out / fan-in / duplicate step names aren't misattributed.
+    let input_full = |step: usize| {
+        snap.edges
+            .iter()
+            .filter(|e| e.consumer_step == Some(step))
+            .any(|e| matches!(e.class, Full | Backpressured))
+    };
+    let output_empty = |step: usize| {
+        snap.edges
+            .iter()
+            .filter(|e| e.producer_step == step)
+            .any(|e| matches!(e.class, Empty | Starved))
+    };
+
+    // Primary bottleneck: full input edge + empty output edge.
+    for (step, (name, s)) in snap.steps.iter().enumerate() {
+        if input_full(step) && output_empty(step) {
+            let cpu_share =
+                if total_cpu_ns > 0 { s.total_run_ns as f64 / total_cpu_ns as f64 } else { 0.0 };
+            let cause = if cpu_share >= 0.30 {
+                format!("CPU-bound ({:.0}% of pipeline try_run time)", cpu_share * 100.0)
+            } else {
+                "coordination-bound (low CPU share — likely a serialization stall)".to_string()
+            };
+            findings.push(Finding {
+                severity: Severity::Primary,
+                message: format!(
+                    "BOTTLENECK: step `{name}` (input edge full, output edge empty) — {cause}"
+                ),
+            });
+        }
+    }
+
+    // Secondary: Serial-step spin (contention thrash). Skip Detached steps —
+    // their dedicated-thread backoff loop records a NoProgress/Contention on
+    // every idle poll, which inflates the contention ratio, and "Detach
+    // candidate" is meaningless for a step that is already Detached.
+    let detached_names: std::collections::HashSet<&str> =
+        snap.detached.iter().map(|(name, ..)| *name).collect();
+    for (name, s) in &snap.steps {
+        if detached_names.contains(name) {
+            continue;
+        }
+        if s.try_run_total > 0 {
+            let spin = s.contention_count as f64 / s.try_run_total as f64;
+            if spin >= SPIN_THRESHOLD {
+                findings.push(Finding {
+                    severity: Severity::Secondary,
+                    message: format!(
+                        "SPIN: step `{name}` contended on {:.0}% of dispatches — affinity / fuse / Detach candidate",
+                        spin * 100.0
+                    ),
+                });
+            }
+        }
+    }
+
+    // Secondary: starvation (consumer of an edge frequently finds it empty).
+    for e in &snap.edges {
+        if matches!(e.class, Starved) {
+            findings.push(Finding {
+                severity: Severity::Secondary,
+                message: format!(
+                    "STARVATION: `{}` is starved by upstream `{}` (empty {:.0}% of pops) — look upstream",
+                    e.consumer.unwrap_or("(sink)"),
+                    e.producer,
+                    e.empty_rate * 100.0
+                ),
+            });
+        }
+    }
+
+    // Info: no clear bottleneck and no full/empty edge → latency-bound.
+    let any_extreme =
+        snap.edges.iter().any(|e| matches!(e.class, Full | Backpressured | Empty | Starved));
+    if findings.is_empty() && !snap.edges.is_empty() && !any_extreme {
+        findings.push(Finding {
+            severity: Severity::Info,
+            message: "No throughput bottleneck — edges have headroom; the chain is \
+                      latency/coordination-bound (look at residence time, not service time)."
+                .to_string(),
+        });
+    }
+    findings
+}
+
 impl fmt::Display for StatsSnapshot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Pipeline stats ({} step{}):", self.steps.len(), pluralize(self.steps.len()))?;
+        // Total dispatch time across steps — the denominator for each step's
+        // `cpu%` share (the Amdahl ranking: which step to optimize first) and
+        // for the headroom line.
+        let total_cpu_ns: u64 = self.steps.iter().map(|(_, s)| s.total_run_ns).sum();
+        self.write_steps(f, total_cpu_ns)?;
+        self.write_utilization(f, total_cpu_ns)?;
+        // Per-edge throughput / occupancy / latency + the bottleneck verdict
+        // (both only when instrumented).
+        self.write_edges(f)?;
+        self.write_verdict(f)
+    }
+}
+
+impl StatsSnapshot {
+    /// Render the per-step counter table, including each step's `cpu%` share of
+    /// total dispatch time (the per-step cost ranking). `total_cpu_ns` is the
+    /// sum of all steps' `total_run_ns`, passed in to avoid recomputing.
+    fn write_steps(&self, f: &mut fmt::Formatter<'_>, total_cpu_ns: u64) -> fmt::Result {
         writeln!(
             f,
-            "  {:<28} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>14} {:>12} {:>12}",
+            "  {:<28} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>14} {:>7} {:>12} {:>12}",
             "step",
             "tries",
             "progress",
@@ -255,6 +719,7 @@ impl fmt::Display for StatsSnapshot {
             "fin",
             "err",
             "total_ms",
+            "cpu%",
             "first_ms",
             "last_ms",
         )?;
@@ -278,9 +743,17 @@ impl fmt::Display for StatsSnapshot {
                 let ms = (s.last_progress_ns as f64) / 1_000_000.0;
                 format!("{ms:.1}")
             };
+            // Share of total dispatch time — the per-step cost ranking. The
+            // chain-order rows stay readable; this column gives the magnitude.
+            #[allow(clippy::cast_precision_loss)]
+            let cpu_pct = if total_cpu_ns == 0 {
+                0.0
+            } else {
+                s.total_run_ns as f64 / total_cpu_ns as f64 * 100.0
+            };
             writeln!(
                 f,
-                "  {:<28} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>14.3} {:>12} {:>12}",
+                "  {:<28} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>14.3} {:>6.1}% {:>12} {:>12}",
                 name,
                 s.try_run_total,
                 s.progress_count,
@@ -289,11 +762,158 @@ impl fmt::Display for StatsSnapshot {
                 s.finished_count,
                 s.error_count,
                 total_ms,
+                cpu_pct,
                 first_str,
                 last_str,
             )?;
         }
         Ok(())
+    }
+
+    /// Render per-worker utilisation, the pool-level utilisation, and the
+    /// squeeze-headroom synthesis. No-op when no worker recorded activity.
+    ///
+    /// Per-worker: busy = dispatch time, idle = backoff-sleep time. A high
+    /// idle% (cores parked while one worker drives a Serial step) is the
+    /// signature of pool under-utilisation. The headroom line reads straight off
+    /// these numbers: the pool idle% is recoverable via better step overlap;
+    /// once the pool saturates (no idle left) the only remaining wins are fewer
+    /// cycles/item or more cores, and the hottest step is the Amdahl target.
+    fn write_utilization(&self, f: &mut fmt::Formatter<'_>, total_cpu_ns: u64) -> fmt::Result {
+        if self.workers.is_empty() {
+            // No pool workers recorded activity, but a Detached thread may still
+            // have run (e.g. a degenerate chain). Render its line if so.
+            self.write_detached(f)?;
+            return Ok(());
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let ms = |ns: u64| (ns as f64) / 1_000_000.0;
+        let (mut sum_busy, mut sum_idle) = (0u64, 0u64);
+        writeln!(f, "  {:<8} {:>14} {:>14} {:>8}", "worker", "busy_ms", "idle_ms", "busy%")?;
+        for &(id, busy, idle) in &self.workers {
+            sum_busy += busy;
+            sum_idle += idle;
+            let pct = if busy + idle == 0 {
+                0.0
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                let p = busy as f64 / (busy + idle) as f64 * 100.0;
+                p
+            };
+            writeln!(f, "  {id:<8} {:>14.3} {:>14.3} {pct:>7.1}%", ms(busy), ms(idle))?;
+        }
+        let pool_pct = if sum_busy + sum_idle == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let p = sum_busy as f64 / (sum_busy + sum_idle) as f64 * 100.0;
+            p
+        };
+        writeln!(
+            f,
+            "  pool utilisation: {pool_pct:.1}% busy across {} worker{} ({:.3} ms busy / {:.3} ms idle)",
+            self.workers.len(),
+            pluralize(self.workers.len()),
+            ms(sum_busy),
+            ms(sum_idle),
+        )?;
+        if let Some((hot_name, hot)) = self.steps.iter().max_by_key(|(_, s)| s.total_run_ns) {
+            #[allow(clippy::cast_precision_loss)]
+            let hot_pct = if total_cpu_ns == 0 {
+                0.0
+            } else {
+                hot.total_run_ns as f64 / total_cpu_ns as f64 * 100.0
+            };
+            writeln!(
+                f,
+                "  headroom: {:.1}% pool idle (recoverable via overlap); hottest step `{hot_name}` = {hot_pct:.1}% of dispatch time (Amdahl target once pool saturates)",
+                100.0 - pool_pct,
+            )?;
+        }
+        self.write_detached(f)
+    }
+
+    /// Render the `StepKind::Detached` threads' busy/idle on their own line(s).
+    /// These threads are NOT pool workers (legacy "N + 2"), so they are reported
+    /// separately and never folded into the pool utilisation %. No-op when no
+    /// Detached thread recorded activity (every non-sort chain).
+    fn write_detached(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.detached.is_empty() {
+            return Ok(());
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let ms = |ns: u64| (ns as f64) / 1_000_000.0;
+        for &(name, busy, idle, parks) in &self.detached {
+            let pct = if busy + idle == 0 {
+                0.0
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                let p = busy as f64 / (busy + idle) as f64 * 100.0;
+                p
+            };
+            // avg park = idle / parks: a few long parks (idle at end) is benign;
+            // many short parks during productive phases is the backoff-latency
+            // signal (the deferred per-slot condvar would eliminate them).
+            #[allow(clippy::cast_precision_loss)]
+            let avg_park_us = if parks == 0 { 0.0 } else { (idle as f64 / parks as f64) / 1000.0 };
+            writeln!(
+                f,
+                "  detached `{name}`: {:.3} ms busy / {:.3} ms idle ({pct:.1}% busy, off pool); {parks} parks (avg {avg_park_us:.1}µs)",
+                ms(busy),
+                ms(idle),
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Render the mechanically-derived bottleneck verdict. No-op when there are
+    /// no instrumented edges (nothing to diagnose).
+    fn write_verdict(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.edges.is_empty() {
+            return Ok(());
+        }
+        let findings = bottleneck_verdict(self);
+        if findings.is_empty() {
+            return Ok(());
+        }
+        writeln!(f, "Bottleneck verdict:")?;
+        for finding in findings {
+            writeln!(f, "  {}", finding.message)?;
+        }
+        Ok(())
+    }
+
+    /// Render the per-edge table (throughput / occupancy class / rates /
+    /// latency). No-op when there are no instrumented edges.
+    fn write_edges(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.edges.is_empty() {
+            return Ok(());
+        }
+        writeln!(f, "Pipeline edges ({}):", self.edges.len())?;
+        writeln!(
+            f,
+            "  {:<40} {:>12} {:>10} {:>14} {:>6} {:>6} {:>10}",
+            "producer→consumer", "items/s", "MiB/s", "class", "rej%", "empt%", "lat_ms",
+        )?;
+        for e in &self.edges {
+            let edge = format!("{}→{}", e.producer, e.consumer.unwrap_or("(none)"));
+            let lat = e.derived_latency_ms.map_or_else(|| "-".to_string(), |l| format!("{l:.2}"));
+            writeln!(
+                f,
+                "  {:<40} {:>12.0} {:>10.1} {:>14} {:>5.1}% {:>5.1}% {:>10}",
+                edge,
+                e.items_per_s,
+                e.mibytes_per_s,
+                format!("{:?}", e.class),
+                e.reject_rate * 100.0,
+                e.empty_rate * 100.0,
+                lat,
+            )?;
+        }
+        writeln!(
+            f,
+            "  (note: throughput is depressed under tracing — confirm wall/RSS with --pipeline-trace off)"
+        )
     }
 }
 
@@ -301,40 +921,10 @@ fn pluralize(n: usize) -> &'static str {
     if n == 1 { "" } else { "s" }
 }
 
-/// Wrapper used by the driver to keep stats access ergonomic. Always pass
-/// the `Option<&StatsRecorder>` shape so the hot path is a single
-/// `if let Some` branch.
-pub struct StatsRecorder<'a> {
-    inner: &'a Arc<PipelineStats>,
-}
-
-impl<'a> StatsRecorder<'a> {
-    #[must_use]
-    pub fn new(stats: &'a Arc<PipelineStats>) -> Self {
-        Self { inner: stats }
-    }
-
-    #[inline]
-    pub fn record(&self, step: StepIdx, outcome: StepOutcome, start_ns: u64, elapsed_ns: u64) {
-        self.inner.record(step, outcome, start_ns, elapsed_ns);
-    }
-
-    #[inline]
-    pub fn record_error(&self, step: StepIdx, start_ns: u64, elapsed_ns: u64) {
-        self.inner.record_error(step, start_ns, elapsed_ns);
-    }
-
-    /// Wall ns elapsed since pipeline start. Used by the driver to stamp
-    /// per-step first/last progress timestamps.
-    #[inline]
-    #[must_use]
-    pub fn elapsed_ns(&self) -> u64 {
-        self.inner.elapsed_ns()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -404,6 +994,288 @@ mod tests {
         assert_eq!(snap2.avg_run_ns(), Some(250));
     }
 
+    #[allow(clippy::too_many_arguments)] // test builder: one arg per snapshot field
+    fn edge_ms(
+        pushed_items: u64,
+        pushed_bytes: u64,
+        popped_items: u64,
+        pop_empties: u64,
+        push_rejections: u64,
+        raw: crate::runtime::metrics::RawOccupancy,
+        mean_occupancy: f32,
+        mean_occupancy_bytes: f64,
+    ) -> crate::runtime::metrics::EdgeMetricsSnapshot {
+        crate::runtime::metrics::EdgeMetricsSnapshot {
+            pushed_items,
+            pushed_bytes,
+            popped_items,
+            popped_bytes: pushed_bytes,
+            push_rejections,
+            pop_empties,
+            depth_samples: 100,
+            raw_occupancy: raw,
+            mean_occupancy,
+            mean_occupancy_bytes,
+        }
+    }
+
+    #[test]
+    fn edge_stats_byte_bounded_latency_is_dimensionally_correct() {
+        use crate::runtime::metrics::RawOccupancy;
+        // 1000 items/s; mean_item_bytes = 100_000/1000 = 100; sampled mean
+        // occupancy 1000 bytes → mean_items 10 → latency = 1000*10/1000 = 10ms.
+        // (The byte figure is sampled directly, so the limit only gates that the
+        // edge is byte-bounded — its value no longer feeds the latency.)
+        let ms = edge_ms(1000, 100_000, 1000, 0, 0, RawOccupancy::Healthy, 0.5, 1000.0);
+        let e = compute_edge_stats("p", Some("c"), 0, Some(1), &ms, Some(2000), 1_000_000_000);
+        assert!((e.items_per_s - 1000.0).abs() < 1.0, "items/s ≈ 1000, got {}", e.items_per_s);
+        let lat = e.derived_latency_ms.expect("byte edge has derived latency");
+        assert!((lat - 10.0).abs() < 0.5, "latency ≈ 10ms, got {lat}");
+    }
+
+    #[test]
+    fn edge_stats_count_edge_has_no_latency() {
+        use crate::runtime::metrics::RawOccupancy;
+        let ms = edge_ms(500, 0, 500, 0, 0, RawOccupancy::Unknown, 0.0, 0.0);
+        let e = compute_edge_stats("p", Some("c"), 0, Some(1), &ms, None, 1_000_000_000);
+        assert!(e.derived_latency_ms.is_none(), "count/unbounded edge → no derived latency");
+        assert!((e.items_per_s - 500.0).abs() < 1.0);
+    }
+
+    // The raw occupancy class is refined by the empty-rate and reject-rate the
+    // edge actually observed; each case pins one (raw class, rates, byte bound)
+    // combination to its refined `OccupancyClass`.
+    #[rstest]
+    // MostlyEmpty + high empty-rate (90/100 pops empty) → Starved.
+    #[case::starved(
+        edge_ms(10, 0, 10, 90, 0, crate::runtime::metrics::RawOccupancy::MostlyEmpty, 0.0, 0.0),
+        None,
+        OccupancyClass::Starved
+    )]
+    // MostlyEmpty + low empty-rate → Empty (idle, not starved).
+    #[case::empty(
+        edge_ms(100, 0, 100, 0, 0, crate::runtime::metrics::RawOccupancy::MostlyEmpty, 0.0, 0.0),
+        None,
+        OccupancyClass::Empty
+    )]
+    // MostlyFull + high reject-rate → Backpressured.
+    #[case::backpressured(
+        edge_ms(10, 0, 10, 0, 90, crate::runtime::metrics::RawOccupancy::MostlyFull, 1.0, 1000.0),
+        Some(1000),
+        OccupancyClass::Backpressured
+    )]
+    fn occupancy_class_refined_by_rates(
+        #[case] ms: crate::runtime::metrics::EdgeMetricsSnapshot,
+        #[case] limit_bytes: Option<u64>,
+        #[case] expected: OccupancyClass,
+    ) {
+        assert_eq!(
+            compute_edge_stats("p", None, 0, None, &ms, limit_bytes, 1_000_000_000).class,
+            expected
+        );
+    }
+
+    fn step_stat(
+        name: &'static str,
+        total_run_ns: u64,
+        contention: u64,
+        tries: u64,
+    ) -> (&'static str, StepStatsSnapshot) {
+        (
+            name,
+            StepStatsSnapshot {
+                try_run_total: tries,
+                progress_count: tries,
+                no_progress_count: 0,
+                contention_count: contention,
+                finished_count: 1,
+                error_count: 0,
+                total_run_ns,
+                first_progress_ns: 0,
+                last_progress_ns: total_run_ns,
+            },
+        )
+    }
+
+    fn edge_stat(
+        producer: &'static str,
+        consumer: Option<&'static str>,
+        producer_step: usize,
+        consumer_step: Option<usize>,
+        class: OccupancyClass,
+        empty_rate: f64,
+    ) -> EdgeStatsSnapshot {
+        EdgeStatsSnapshot {
+            producer,
+            consumer,
+            producer_step,
+            consumer_step,
+            items_per_s: 1000.0,
+            mibytes_per_s: 1.0,
+            class,
+            mean_occupancy: 0.5,
+            reject_rate: 0.0,
+            empty_rate,
+            derived_latency_ms: Some(1.0),
+        }
+    }
+
+    #[test]
+    fn verdict_locates_cpu_bound_bottleneck() {
+        // `Slow`'s input edge is Full and output edge is Empty, and it dominates
+        // CPU → Primary, CPU-bound.
+        let snap = StatsSnapshot {
+            steps: vec![step_stat("Slow", 1000, 0, 10)],
+            workers: vec![],
+            detached: vec![],
+            // `Slow` is step 0. Its input edge (consumer_step 0) is Full; its
+            // output edge (producer_step 0) is Empty. `Up`/`Down` are non-step
+            // ids (1/1) so only `Slow` matches by identity.
+            edges: vec![
+                edge_stat("Up", Some("Slow"), 1, Some(0), OccupancyClass::Full, 0.0),
+                edge_stat("Slow", Some("Down"), 0, Some(1), OccupancyClass::Empty, 0.0),
+            ],
+        };
+        let v = bottleneck_verdict(&snap);
+        let primary: Vec<_> = v.iter().filter(|f| f.severity == Severity::Primary).collect();
+        assert_eq!(primary.len(), 1, "exactly one primary bottleneck");
+        assert!(primary[0].message.contains("Slow"));
+        assert!(primary[0].message.contains("CPU-bound"));
+    }
+
+    #[test]
+    fn verdict_matches_edges_by_step_identity_across_fan_in() {
+        // Regression for name-based misattribution: `Merge` (step 2) has TWO
+        // input edges (fan-in from steps 0 and 1). The first by iteration order
+        // is Healthy; the second is Full. Matching the FIRST edge by consumer
+        // name would see only the Healthy input and report no bottleneck;
+        // matching by step identity aggregates both inputs and correctly flags
+        // `Merge` (input full + output empty).
+        let snap = StatsSnapshot {
+            steps: vec![
+                step_stat("A", 100, 0, 10),
+                step_stat("B", 100, 0, 10),
+                step_stat("Merge", 1000, 0, 10),
+            ],
+            workers: vec![],
+            detached: vec![],
+            edges: vec![
+                edge_stat("A", Some("Merge"), 0, Some(2), OccupancyClass::Healthy, 0.0),
+                edge_stat("B", Some("Merge"), 1, Some(2), OccupancyClass::Full, 0.0),
+                edge_stat("Merge", Some("Sink"), 2, Some(3), OccupancyClass::Empty, 0.0),
+            ],
+        };
+        let v = bottleneck_verdict(&snap);
+        let primary: Vec<_> = v.iter().filter(|f| f.severity == Severity::Primary).collect();
+        assert_eq!(primary.len(), 1, "fan-in bottleneck detected via identity: {v:?}");
+        assert!(primary[0].message.contains("Merge"));
+    }
+
+    #[test]
+    fn verdict_flags_spin_and_starvation() {
+        let snap = StatsSnapshot {
+            // 5/10 dispatches contended → spin.
+            steps: vec![step_stat("Serializer", 100, 5, 10)],
+            workers: vec![],
+            detached: vec![],
+            // A starved edge (steps 1→2, not the `Serializer` step 0): consumer
+            // frequently finds it empty.
+            edges: vec![edge_stat(
+                "Producer",
+                Some("Consumer"),
+                1,
+                Some(2),
+                OccupancyClass::Starved,
+                0.7,
+            )],
+        };
+        let v = bottleneck_verdict(&snap);
+        assert!(
+            v.iter().any(|f| f.severity == Severity::Secondary && f.message.contains("SPIN")),
+            "spin finding present"
+        );
+        assert!(
+            v.iter().any(|f| f.message.contains("STARVATION") && f.message.contains("Consumer")),
+            "starvation finding present"
+        );
+    }
+
+    #[test]
+    fn verdict_skips_spin_for_detached_steps() {
+        // A Detached step's backoff loop records Contention on every idle poll,
+        // so its contention/tries ratio is high — but "SPIN: … Detach candidate"
+        // is nonsensical for an already-Detached step, so it must be skipped.
+        let snap = StatsSnapshot {
+            // 8/10 "contended" — would trip SPIN if it were a pool step.
+            steps: vec![step_stat("SortMerge", 100, 8, 10)],
+            workers: vec![],
+            detached: vec![("SortMerge", 900_000_000, 100_000_000, 4_200)],
+            edges: vec![],
+        };
+        let v = bottleneck_verdict(&snap);
+        assert!(
+            !v.iter().any(|f| f.message.contains("SPIN")),
+            "no SPIN finding for a Detached step: {v:?}"
+        );
+    }
+
+    #[test]
+    fn verdict_reports_latency_bound_when_no_extremes() {
+        let snap = StatsSnapshot {
+            steps: vec![step_stat("A", 100, 0, 10)],
+            workers: vec![],
+            detached: vec![],
+            edges: vec![edge_stat("A", Some("B"), 0, Some(1), OccupancyClass::Healthy, 0.0)],
+        };
+        let v = bottleneck_verdict(&snap);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].severity, Severity::Info);
+        assert!(v[0].message.contains("latency"));
+    }
+
+    #[test]
+    fn snapshot_display_renders_without_edges() {
+        // Back-compat: the edge-less snapshot() still renders (empty edges).
+        let stats = PipelineStats::new(vec!["A"]);
+        let out = format!("{}", stats.snapshot());
+        assert!(out.contains("Pipeline stats"));
+        assert!(!out.contains("Pipeline edges"), "no edge section when edges empty");
+    }
+
+    #[test]
+    fn display_renders_cpu_share_and_headroom() {
+        // Hot owns 750/1000 = 75% of dispatch time; Cool owns the rest. The pool
+        // is 80% busy (800 ms / 1000 ms) → 20% idle headroom.
+        let snap = StatsSnapshot {
+            steps: vec![step_stat("Hot", 750, 0, 10), step_stat("Cool", 250, 0, 10)],
+            workers: vec![(0, 800, 200)],
+            detached: vec![],
+            edges: vec![],
+        };
+        let out = format!("{snap}");
+        assert!(out.contains("cpu%"), "per-step table has a cpu% column: {out}");
+        assert!(out.contains("75.0%"), "Hot step shows its 75% CPU share: {out}");
+        assert!(out.contains("pool utilisation: 80.0%"), "pool utilisation line present: {out}");
+        assert!(
+            out.contains("headroom:") && out.contains("20.0% pool idle") && out.contains("`Hot`"),
+            "headroom line names the hottest step and the idle %: {out}"
+        );
+    }
+
+    #[test]
+    fn utilization_section_absent_without_workers() {
+        // No worker activity → no pool/headroom lines (fused or stats-off runs).
+        let snap = StatsSnapshot {
+            steps: vec![step_stat("Solo", 100, 0, 10)],
+            workers: vec![],
+            detached: vec![],
+            edges: vec![],
+        };
+        let out = format!("{snap}");
+        assert!(!out.contains("pool utilisation"), "no pool line without workers: {out}");
+        assert!(!out.contains("headroom:"), "no headroom line without workers: {out}");
+    }
+
     #[test]
     fn display_renders_header_and_rows() {
         let stats = PipelineStats::new(vec!["StepA", "StepB"]);
@@ -413,5 +1285,46 @@ mod tests {
         assert!(s.contains("StepA"));
         assert!(s.contains("StepB"));
         assert!(s.contains("step"));
+    }
+
+    /// L2.4: a Detached thread's busy/idle is recorded separately, renders on
+    /// its own line, and is EXCLUDED from the pool utilisation % (legacy
+    /// "N + 2"). The snapshot must render without panicking.
+    #[test]
+    fn detached_busy_excluded_from_pool_and_on_own_line() {
+        let stats = PipelineStats::new(vec!["Source", "SortMerge"]);
+        // One pool worker: 800 ms busy / 200 ms idle → pool% = 80%.
+        stats.record_worker_busy(0, 800_000_000);
+        stats.record_worker_idle(0, 200_000_000);
+        // The Detached merge: 900 ms busy / 100 ms idle (off pool).
+        stats.record_detached_busy(StepIdx(1), 900_000_000);
+        stats.record_detached_idle(StepIdx(1), 100_000_000);
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.detached.len(), 1, "one Detached thread recorded");
+        assert_eq!(snap.detached[0].0, "SortMerge");
+
+        let out = format!("{snap}");
+        // Pool% reflects ONLY the worker (80%), NOT the Detached thread (90%).
+        assert!(
+            out.contains("pool utilisation: 80.0%"),
+            "pool% must exclude the Detached thread: {out}"
+        );
+        // The Detached thread is reported on its own line.
+        assert!(
+            out.contains("detached `SortMerge`") && out.contains("90.0% busy, off pool"),
+            "Detached line present with its own busy%: {out}"
+        );
+    }
+
+    /// L2.4: the Detached line renders even when no pool worker recorded
+    /// activity (the `write_utilization` early-return path), without panicking.
+    #[test]
+    fn detached_line_renders_with_no_pool_workers() {
+        let stats = PipelineStats::new(vec!["OnlyDetached"]);
+        stats.record_detached_busy(StepIdx(0), 5_000_000);
+        let out = format!("{}", stats.snapshot());
+        assert!(out.contains("detached `OnlyDetached`"), "Detached line present: {out}");
+        assert!(!out.contains("pool utilisation"), "no pool line without workers: {out}");
     }
 }

--- a/crates/fgumi-pipeline-core/src/runtime/storage.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/storage.rs
@@ -144,6 +144,20 @@ pub fn build_worker_storage(
                 }
                 entries[owner][step_idx] = WorkerStepEntry::Exclusive { step };
             }
+            StepKind::Detached => {
+                // A Detached step never runs on the pool. Every real Detached
+                // instance is extracted by `extract_detached_steps` BEFORE this
+                // function runs (it drives the step on its own dedicated
+                // thread) and is replaced in `steps` by a `DetachedPlaceholder`
+                // whose `kind()` still reports `StepKind::Detached`. So on every
+                // real sort run this arm IS reached — once per placeholder — and
+                // its job is exactly this: give every pool worker a `Skip` entry
+                // and drop the placeholder (it holds no state to run).
+                for entries_for_worker in &mut entries {
+                    entries_for_worker.push(WorkerStepEntry::Skip);
+                }
+                drop(step);
+            }
         }
     }
 
@@ -227,9 +241,40 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct DetachedStep;
+    impl Step for DetachedStep {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            profile_for("Det", StepKind::Detached, false)
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::NoProgress)
+        }
+    }
+
     #[test]
     fn skip_is_not_dispatchable() {
         assert!(!WorkerStepEntry::Skip.is_dispatchable());
+    }
+
+    /// L2.1: a `Detached` step is excluded from every pool worker's dispatch
+    /// list (all workers get `Skip`). The dedicated-thread extraction is L2.3;
+    /// here we only prove the pool never sees it.
+    #[test]
+    fn detached_step_is_skipped_on_all_workers() {
+        let steps: Vec<Box<dyn ErasedStep>> = vec![Box::new(TypedStep::new(DetachedStep))];
+        let owners = vec![None];
+        let entries = build_worker_storage(steps, &owners, 4);
+        assert_eq!(entries.len(), 4);
+        for w in &entries {
+            assert_eq!(w.len(), 1);
+            assert!(
+                matches!(w[0], WorkerStepEntry::Skip),
+                "Detached step must be Skip on every pool worker"
+            );
+        }
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/runtime/worker_core.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/worker_core.rs
@@ -4,11 +4,73 @@ use std::time::Duration;
 
 use crate::topology::StepIdx;
 
-const BACKOFF_INITIAL_US: u64 = 1;
-const BACKOFF_MAX_US: u64 = 50_000; // 50 milliseconds
+// Pool worker idle bounds: a pool worker is never unparked, so it sleeps and can
+// ramp to a coarse cap without hurting wake latency.
+const SLEEP_INITIAL_US: u64 = 1;
+const SLEEP_MAX_US: u64 = 50_000; // 50 milliseconds
+
+// Dedicated-driver idle bounds: a driver drives a small step subset off the pool
+// and must stay responsive to its peers (the pool filling/draining its edges), so
+// it parks with a tight cap. `park_timeout` also lets a producer holding the
+// thread handle unpark it early; the cap is the bounded fallback either way.
+const PARK_INITIAL_US: u64 = 10;
+const PARK_MAX_US: u64 = 500;
+
+/// How a worker idles on a no-progress tick. Selected per thread at construction:
+/// the N-worker pool uses [`Sleep`](BackoffPolicy::Sleep); each dedicated driver
+/// thread (the unified "1-thread pool") uses [`Park`](BackoffPolicy::Park). This
+/// is the *only* behavioral difference between a pool worker and a driver — both
+/// run the same [`run_worker_loop`](crate::runtime::run_worker_loop).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackoffPolicy {
+    /// `thread::sleep`, ramp 1µs→50ms. For pool workers (never unparked).
+    Sleep,
+    /// `thread::park_timeout`, ramp 10µs→500µs. For dedicated driver threads: a
+    /// producer *may* unpark early, and the tight cap bounds wake latency when it
+    /// does not. With no unparker this behaves as a bounded sleep.
+    Park,
+}
+
+impl BackoffPolicy {
+    #[inline]
+    fn initial_us(self) -> u64 {
+        match self {
+            Self::Sleep => SLEEP_INITIAL_US,
+            Self::Park => PARK_INITIAL_US,
+        }
+    }
+
+    #[inline]
+    fn max_us(self) -> u64 {
+        match self {
+            Self::Sleep => SLEEP_MAX_US,
+            Self::Park => PARK_MAX_US,
+        }
+    }
+}
+
+/// Whether a `run_worker_loop` thread is an N-pool worker or a dedicated driver
+/// (the unified "1-thread pool" for a set of off-pool steps). Controls only how
+/// the thread's busy/idle time is attributed in `--pipeline-stats`, always
+/// excluded from the pool% so the "N + 2" split stays visible:
+/// - pool threads sum their whole-pass busy/idle into the N-worker utilisation
+///   line, by `thread_id`;
+/// - driver threads record each grouped step's own busy on the off-pool
+///   "detached" line (by that step's index — so a multi-step `Shared` group
+///   shows each member's real time, not the whole thread's under one name), and
+///   attribute the thread-level idle/park to the group's `primary_step`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerRole {
+    /// N-worker pool thread; busy/idle keyed by `thread_id`.
+    Pool,
+    /// Dedicated driver thread. Per-step busy is recorded by each step's own
+    /// index in `dispatch_one_step`; thread-level idle/park is keyed to
+    /// `primary_step` (the group's representative).
+    Driver { primary_step: StepIdx },
+}
 
 pub struct WorkerCore {
-    /// `0..n_workers`
+    /// `0..n_workers` for pool threads; unused (0) for driver threads.
     pub thread_id: usize,
     /// If this worker owns an `Exclusive` step, that step's index.
     /// Used by the runtime to skip `WorkerStepEntry::Skip` placeholders
@@ -21,30 +83,75 @@ pub struct WorkerCore {
     /// `NoProgress` / `Contention` / `Finished`, then yields to round-
     /// robin. Mirrors the legacy pipeline's sticky read.
     pub sticky_owner: Option<StepIdx>,
+    /// Pool worker vs dedicated driver. Determines both the idle backoff policy
+    /// (`Pool → Sleep`, `Driver → Park`, via [`Self::policy`]) and how the
+    /// thread's aggregate busy/idle time is attributed in `--pipeline-stats`.
+    role: WorkerRole,
     /// Backoff duration in microseconds. Doubled on no-progress; reset on progress.
+    /// Bounds come from `role`'s policy.
     backoff_us: u64,
 }
 
 impl WorkerCore {
+    /// A pool worker (`Sleep` backoff). Existing callers are unchanged.
     #[must_use]
     pub fn new(
         thread_id: usize,
         exclusive_owner: Option<StepIdx>,
         sticky_owner: Option<StepIdx>,
     ) -> Self {
-        Self { thread_id, exclusive_owner, sticky_owner, backoff_us: BACKOFF_INITIAL_US }
+        Self {
+            thread_id,
+            exclusive_owner,
+            sticky_owner,
+            role: WorkerRole::Pool,
+            backoff_us: BackoffPolicy::Sleep.initial_us(),
+        }
+    }
+
+    /// A dedicated driver thread (the unified "1-thread pool"): `Driver` role +
+    /// `Park` backoff (derived from the role). Drives a set of `Owned` steps off
+    /// the pool; its aggregate busy/idle is attributed to `primary_step` on the
+    /// off-pool detached line. `thread_id` is unused for drivers; it never owns
+    /// Exclusive or sticky steps.
+    #[must_use]
+    pub fn driver(primary_step: StepIdx) -> Self {
+        let mut worker = Self::new(0, None, None);
+        worker.role = WorkerRole::Driver { primary_step };
+        worker.backoff_us = worker.policy().initial_us();
+        worker
+    }
+
+    /// This thread's pool/driver role (drives stats attribution in the loop).
+    #[must_use]
+    pub fn role(&self) -> WorkerRole {
+        self.role
+    }
+
+    /// The idle backoff policy implied by this thread's role: pool workers
+    /// `Sleep` (never unparked), driver threads `Park`.
+    #[must_use]
+    pub fn policy(&self) -> BackoffPolicy {
+        match self.role {
+            WorkerRole::Pool => BackoffPolicy::Sleep,
+            WorkerRole::Driver { .. } => BackoffPolicy::Park,
+        }
     }
 
     pub fn reset_backoff(&mut self) {
-        self.backoff_us = BACKOFF_INITIAL_US;
+        self.backoff_us = self.policy().initial_us();
     }
 
     pub fn sleep_backoff(&self) {
-        std::thread::sleep(Duration::from_micros(self.backoff_us));
+        let dur = Duration::from_micros(self.backoff_us);
+        match self.policy() {
+            BackoffPolicy::Sleep => std::thread::sleep(dur),
+            BackoffPolicy::Park => std::thread::park_timeout(dur),
+        }
     }
 
     pub fn increase_backoff(&mut self) {
-        self.backoff_us = self.backoff_us.saturating_mul(2).min(BACKOFF_MAX_US);
+        self.backoff_us = self.backoff_us.saturating_mul(2).min(self.policy().max_us());
     }
 
     #[cfg(test)]
@@ -55,38 +162,50 @@ impl WorkerCore {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
     fn fresh_backoff_is_initial() {
         let w = WorkerCore::new(0, None, None);
-        assert_eq!(w.current_backoff_us(), BACKOFF_INITIAL_US);
+        assert_eq!(w.current_backoff_us(), SLEEP_INITIAL_US);
     }
 
-    #[test]
-    fn backoff_doubles_then_caps() {
-        let mut w = WorkerCore::new(0, None, None);
-        // Pin the doubling sequence before the cap: 1 → 2 → 4 → 8 → … . The
-        // initial value is 1, and each `increase_backoff` doubles it. Asserting
-        // only the final cap would pass a buggy `increase_backoff` that jumped
-        // straight to the cap or incremented by a constant, so check the
-        // sequence too.
-        assert_eq!(w.current_backoff_us(), BACKOFF_INITIAL_US);
-        let mut expected = BACKOFF_INITIAL_US;
-        for _ in 0..10 {
+    // One doubling-then-cap sequence, exercised for both policies: the pool's
+    // `Sleep` bounds and a driver's tight `Park` bounds. Asserting the whole
+    // sequence (not just the final cap) would fail a buggy `increase_backoff`
+    // that jumped straight to the cap or incremented by a constant; the closing
+    // reset confirms it returns to *this* policy's initial, not the other's.
+    #[rstest]
+    #[case::sleep(
+        WorkerCore::new(0, None, None),
+        SLEEP_INITIAL_US,
+        SLEEP_MAX_US,
+        BackoffPolicy::Sleep
+    )]
+    #[case::park(WorkerCore::driver(StepIdx(0)), PARK_INITIAL_US, PARK_MAX_US, BackoffPolicy::Park)]
+    fn backoff_doubles_then_caps(
+        #[case] mut w: WorkerCore,
+        #[case] initial: u64,
+        #[case] max: u64,
+        #[case] policy: BackoffPolicy,
+    ) {
+        assert_eq!(w.policy(), policy);
+        assert_eq!(w.current_backoff_us(), initial);
+        let mut expected = initial;
+        for _ in 0..20 {
             w.increase_backoff();
-            expected = (expected * 2).min(BACKOFF_MAX_US);
+            expected = (expected * 2).min(max);
             assert_eq!(
                 w.current_backoff_us(),
                 expected,
-                "backoff must double each step until it saturates"
+                "backoff must double each step until it saturates at the cap"
             );
         }
-        // Many more doublings saturate at the cap and stay there.
-        for _ in 0..50 {
-            w.increase_backoff();
-        }
-        assert_eq!(w.current_backoff_us(), BACKOFF_MAX_US);
+        assert_eq!(w.current_backoff_us(), max);
+        w.reset_backoff();
+        assert_eq!(w.current_backoff_us(), initial);
     }
 
     #[test]
@@ -96,7 +215,17 @@ mod tests {
             w.increase_backoff();
         }
         w.reset_backoff();
-        assert_eq!(w.current_backoff_us(), BACKOFF_INITIAL_US);
+        assert_eq!(w.current_backoff_us(), SLEEP_INITIAL_US);
+    }
+
+    #[test]
+    fn sleep_and_park_have_distinct_caps() {
+        // Guard against the two policies drifting to the same bound.
+        assert_ne!(SLEEP_MAX_US, PARK_MAX_US);
+        assert_ne!(SLEEP_INITIAL_US, PARK_INITIAL_US);
+        // Policy is derived from role: pool worker → Sleep, driver → Park.
+        assert_eq!(WorkerCore::new(0, None, None).policy(), BackoffPolicy::Sleep);
+        assert_eq!(WorkerCore::driver(StepIdx(0)).policy(), BackoffPolicy::Park);
     }
 
     #[test]

--- a/crates/fgumi-pipeline-core/src/step.rs
+++ b/crates/fgumi-pipeline-core/src/step.rs
@@ -33,6 +33,27 @@ pub enum StepKind {
     /// assigns owners at run start in chain declaration order. Other
     /// workers skip the step entirely.
     Exclusive,
+    /// Runs on a **dedicated OS thread**, spawned at run start alongside the
+    /// deadlock-monitor / queue-rebalancer — never dispatched by the
+    /// work-stealing pool. The dedicated thread drives the step with the
+    /// *same* `run_worker_loop` the pool uses (via
+    /// `runtime::detached::run_detached_driver`): a `WorkerCore::driver` (Park
+    /// backoff) over an `Owned`-for-its-group row. The step body still uses
+    /// non-blocking `try_pop`/`try_push` and never blocks inside `try_run`, so
+    /// it consumes no pool worker slot. A driver is literally a 1-thread pool.
+    ///
+    /// This mirrors the legacy sort's "N + 2" threading: N pool workers do
+    /// the parallel (compression-bound) work while off-pool driver threads do
+    /// the serial coordination + I/O, keeping the pool saturated. Several
+    /// detached steps sharing a [`DetachedGroup::Shared`] label are driven by
+    /// ONE thread; [`DetachedGroup::PerStep`] (the default) keeps one thread
+    /// per step.
+    ///
+    /// **Opt-in.** No existing step declares `Detached` unless the sort chain
+    /// wires it. A single shared instance (like `Serial`/`Exclusive`, never
+    /// `new_worker_copy`'d) runs on the driver thread; every pool worker gets a
+    /// `Skip` entry for it.
+    Detached,
 }
 
 /// Optional scheduling hint for `Serial` steps. Restricts which worker(s)
@@ -80,6 +101,27 @@ impl Affinity {
             Self::Worker(idx) => worker_id == idx,
         }
     }
+}
+
+/// Which dedicated driver thread a [`StepKind::Detached`] step runs on.
+///
+/// Detached steps run off the work-stealing pool on dedicated OS threads. By
+/// default each detached step gets its own thread ([`PerStep`](Self::PerStep))
+/// — the legacy "one dedicated thread per detached step" behavior. Steps that
+/// declare the same [`Shared`](Self::Shared) label instead share ONE dedicated
+/// driver thread that round-robins them through the same `run_worker_loop` the
+/// pool uses (the unified "1-thread pool"). This realizes the true N+2 model:
+/// the sort chain groups its serial coordination steps onto one driver and its
+/// writers onto another, keeping the N pool workers on pure (de)compression.
+///
+/// Ignored for non-`Detached` kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetachedGroup {
+    /// One dedicated thread for this step alone (default; legacy behavior).
+    PerStep,
+    /// Share one dedicated driver thread with every other detached step that
+    /// declares the same label.
+    Shared(&'static str),
 }
 
 /// Static description of how a step is scheduled, plus per-output queue
@@ -243,6 +285,15 @@ pub trait Step: Send + Sized + 'static {
         Affinity::None
     }
 
+    /// Which dedicated driver thread this step runs on, for [`StepKind::Detached`]
+    /// steps. Defaults to [`DetachedGroup::PerStep`] (its own thread — legacy
+    /// behavior). Override to [`DetachedGroup::Shared`] to co-locate several
+    /// detached steps on one driver thread (the true N+2 model). Ignored for
+    /// non-`Detached` kinds.
+    fn detached_group(&self) -> DetachedGroup {
+        DetachedGroup::PerStep
+    }
+
     /// Step body. Pop from `ctx.input`, push to `ctx.outputs`. Returns
     /// `Progress` / `NoProgress` / `Contention` / `Finished`. Errors propagate via `Err`.
     ///
@@ -313,6 +364,12 @@ pub trait Step2: Send + Sized + 'static {
     /// `Affinity::None`.
     fn affinity(&self) -> Affinity {
         Affinity::None
+    }
+
+    /// Same semantics as [`Step::detached_group`]. Defaults to
+    /// [`DetachedGroup::PerStep`].
+    fn detached_group(&self) -> DetachedGroup {
+        DetachedGroup::PerStep
     }
 
     /// Step body. Pop from `ctx.a` (input branch 0) and `ctx.b`

--- a/crates/fgumi-pipeline-core/src/tests.rs
+++ b/crates/fgumi-pipeline-core/src/tests.rs
@@ -74,6 +74,7 @@ fn step2_typed_dispatch_pairs_both_branches() {
     let (a_set, a_view) = <Single<u32> as super::outputs::StepOutputs>::build_queues(
         &[QueueSpec::CountBounded { capacity: 4 }],
         &[BranchOrdering::None],
+        crate::builder::InstrumentationLevel::Off,
     );
     let a_outputs: super::step::OutputHandles<Single<u32>> =
         super::step::OutputHandles::new(a_view);
@@ -82,6 +83,7 @@ fn step2_typed_dispatch_pairs_both_branches() {
     let (b_set, b_view) = <Single<u32> as super::outputs::StepOutputs>::build_queues(
         &[QueueSpec::CountBounded { capacity: 4 }],
         &[BranchOrdering::None],
+        crate::builder::InstrumentationLevel::Off,
     );
     let b_outputs: super::step::OutputHandles<Single<u32>> =
         super::step::OutputHandles::new(b_view);
@@ -96,7 +98,8 @@ fn step2_typed_dispatch_pairs_both_branches() {
     assert_eq!(sum_step.input_arity(), 2);
 
     // Merge step's output set.
-    let (mut merge_outset, merge_view) = sum_step.build_output_set();
+    let (mut merge_outset, merge_view) =
+        sum_step.build_output_set(crate::builder::InstrumentationLevel::Off);
     let merge_outputs_any = sum_step.wrap_outputs_view(merge_view);
     let merge_consumer_input = merge_outset.take_typed_input::<u64>(0);
 
@@ -144,6 +147,7 @@ fn step2_build_two_input_handles_rejects_duplicate_producer() {
     let (a_set, _a_view) = <Single<u32> as super::outputs::StepOutputs>::build_queues(
         &[QueueSpec::CountBounded { capacity: 4 }],
         &[BranchOrdering::None],
+        crate::builder::InstrumentationLevel::Off,
     );
     let mut producer_sets = vec![a_set];
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {


### PR DESCRIPTION
Additive typed-step framework pieces the arena sort engine builds on:
- Pipeline occupancy instrumentation (`--pipeline-stats` / `--pipeline-trace`): per-step/-worker busy-vs-idle, edge-occupancy sampler, bottleneck verdict.
- Detached-step runtime unified with the pool worker loop: a driver thread runs the same `run_worker_loop` over an `Owned` step-set (`WorkerRole`, `BackoffPolicy` Sleep|Park), grouped by `DetachedGroup` so several detached steps share one dedicated thread (the N+2 model).

Additive to `fgumi-pipeline-core`; builds and tests green on its own.

---
### About this stack
This is a 6-PR stack that unifies the fgumi sort engine onto a single arena-based engine for all four sort orders (coordinate, queryname, template-coordinate, natural), retires the legacy sorters, and adds the N+2 threading model (serial coordination on dedicated driver threads, N pool workers on pure de/compression). The work is split one commit per crate to keep each diff small and reviewable.

Merge bottom-up:
1. `nh/sort-1-pipeline-core` → `feat-runall`
2. `nh/sort-2-bgzf-verify` → `nh/sort-1-pipeline-core`
3. `nh/sort-3-arena-engine` → `nh/sort-2-bgzf-verify`
4. `nh/sort-4-pipeline-io` → `nh/sort-3-arena-engine`
5. `nh/sort-5-cli` → `nh/sort-4-pipeline-io`
6. `nh/sort-6-chains-wiring` → `nh/sort-5-cli`

**CI note:** PRs 3–5 are the atomic engine-swap block — removing the legacy sorters leaves the workspace uncompilable until the consumers land in PR 6, so their standalone CI is red by construction. Correctness and the full green build are verified at the stack tip (PR 6): the whole suite passes (2258 tests), and sort output is byte-identical across all four orders (validated against the legacy engine and against `main`). Supersedes the single-squash PR #470.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable instrumentation levels (Off/Summary/Timeline/Deep) with per-edge metrics, optional occupancy sampling, and optional timeline TSV output.
  * Introduced a pluggable per-worker dispatch scheduler (including drain-first traversal).
  * Added dedicated detached-step execution with shared grouping plus expanded end-of-run stats (workers/detached and optional edge throughput/occupancy).
  * Added drain-time `retry_held` for single-output backpressure.
* **Bug Fixes**
  * Corrected ordered-edge “empty vs reorder-blocked” classification and improved metrics/timing accuracy for detached execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->