### PR TITLE
feat(sort): unified arena sort engine for all four sort orders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,44 @@ of records) and a safe rewrite measurably regresses sort throughput.
   `RawQuerynameKey::new`).
 - **`crates/fgumi-sort/src/radix.rs`** — internal radix-sort helpers; see file
   comments for the `SAFETY:` invariants.
+- **`crates/fgumi-sort/src/ref_sort.rs`** — one `#[allow(unsafe_code)]` site in
+  `sort_coordinate_refs`: a pointer cast reinterpreting `&mut [RecordRef]` as
+  `&mut [CoordSortRef]` to feed the parallel `voracious_mt_sort` radix on the
+  large-input / multi-thread coordinate path. SAFETY: `CoordSortRef` is
+  `#[repr(transparent)]` over `RecordRef`, so the two have identical size,
+  alignment, and layout; the pointer cast (clippy rejects a ref-to-ref
+  `transmute`) is sound. This is approved for the same reason as the other sort
+  hot paths — it runs once per coordinate sort over millions of record refs, and
+  the parallel radix is measurably (~4×) faster than the safe single-threaded
+  fallback; both produce byte-identical output (verified by the ref-sort oracle
+  proptests).
+- **`crates/fgumi-sort/src/segmented_buf.rs`** — two `#[allow(unsafe_code)]`
+  sites backing the arena record buffer (a segmented, append-only `Vec<u8>` the
+  sort engine decompresses/frames records into without per-record allocation):
+  - `grow_uninit` (≈line 207) — grows a segment's live `len` over
+    reserved-but-uninitialized bytes via `Vec::set_len` (after `reserve`), to skip
+    zero-filling the slot on the ingest hot path. SAFETY: after `reserve(additional)`,
+    `capacity() >= new_len`, so `set_len(new_len)` only extends `len` over
+    already-allocated bytes; `u8` has no drop glue and no validity invariant, so
+    growing `len` over uninitialized bytes is not itself UB — the documented contract
+    requires the caller to fully write the grown `[old_len, new_len)` region (via
+    `slice_mut`) before any read, and a read-before-write is the only UB, which the
+    contract forbids. Pointer stability is a *separate* invariant: this `reserve`
+    MAY reallocate and move the segment, so no `slice_mut` borrow may be live across
+    a `grow_uninit` — the borrow checker enforces this in the single-threaded case
+    (`&mut self`), and the concurrent-inflate path first calls
+    `reserve_full_capacity` once per fresh segment so the per-slot `reserve` is a
+    no-op (it does NOT rely on `reserve` alone for stability).
+  - `slice_mut` (≈line 267) — synthesizes a `&mut [u8]` slot from a shared `&self`
+    (so disjoint slots can be written concurrently by different workers). SAFETY:
+    the asserted `seg_offset + len <= seg.len()` keeps the range inside the
+    segment's live region (in-bounds pointer + length); the `&mut` is sound only
+    under the caller's disjointness contract — each call's range must not overlap
+    any other concurrently-borrowed range — so the produced `&mut` aliases no
+    other `&`/`&mut`. Approved for the same reason as the other sort hot paths:
+    ingest runs once per record over millions-to-billions of records, and a safe
+    rewrite (zero-fill on grow, or an owning `Vec` per slot) measurably regresses
+    sort throughput.
 
 ### Approved natural-order comparator (fgumi-raw-bam)
 

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -13,6 +13,12 @@ keywords = ["bioinformatics", "bam", "sort", "sequencing", "ngs"]
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 
+[lints.rust]
+# `loom` is a config flag set only for the model-checking test target
+# (`tests/loom_merge_slots.rs`, run via `RUSTFLAGS="--cfg loom"`). Declare it so
+# the unexpected-cfg lint stays quiet under the normal `-D warnings` build.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
 [dependencies]
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
@@ -30,6 +36,7 @@ arc-swap = "1"
 tempfile = "3.4"
 bytemuck = { workspace = true }
 ahash = "0.8"
+smallvec = "1.15"
 anyhow = "1.0.102"
 bstr = "1.12.1"
 bytes = "1"
@@ -37,6 +44,7 @@ bytesize = "2.3"
 fs4 = { version = "1.1", default-features = false, features = ["sync"] }
 log = "0"
 zstd = "0.13"
+voracious_radix_sort = { version = "1", features = ["voracious_multithread"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.6"
@@ -47,6 +55,7 @@ nix = { version = "0.31", default-features = false, features = ["fs"] }
 [features]
 default = []
 memory-debug = []
+test-utils = []
 
 [dev-dependencies]
 fgumi-bam-io = { workspace = true }
@@ -56,3 +65,20 @@ rstest = "0"
 proptest = "1.10"
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3.4"
+
+# loom is only compiled under `--cfg loom`. It is a *regular* (not dev)
+# dependency so `merge_slots.rs` itself can swap `std::sync` -> `loom::sync`
+# under `#[cfg(loom)]` and have its REAL atomics/locks model-checked by
+# `tests/loom_merge_slots.rs` (which drives the real `SortMergeSlot`). The test
+# is `#![cfg(loom)]` (empty under a normal build).
+# Run with:  RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
+[[bench]]
+name = "chunk_sorter"
+harness = false
+
+[[bench]]
+name = "queryname_keys"
+harness = false

--- a/crates/fgumi-sort/benches/chunk_sorter.rs
+++ b/crates/fgumi-sort/benches/chunk_sorter.rs
@@ -1,0 +1,76 @@
+//! Microbenchmark for the P6 `SortBuffer` chunk sorters' sort + materialize
+//! step (`take_sorted_chunk`).
+//!
+//! This isolates the cost the A/B smoke campaign flagged: `take_sorted_chunk`
+//! materialized a full owned `Vec<(K, RawRecord)>` (one heap copy + malloc per
+//! record) while the source `RecordBuffer` arena was still alive — doubling
+//! peak memory and paying a full per-record copy. The fix routes coordinate /
+//! template through the zero-copy `InMemoryChunk` (arena-move). Run before and
+//! after to confirm the materialize step gets cheaper:
+//!
+//!     cargo bench -p fgumi-sort --bench chunk_sorter
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{RawExternalSorter, SortOrder};
+use noodles::sam::Header;
+
+/// Build `n` aligned records at scattered positions on tid 0 so the sort does
+/// real reordering work; ~100 bp reads ≈ a realistic per-record size.
+fn synth_records(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            let pos = (i as u64).wrapping_mul(2_654_435_761) % 5_000_000;
+            let name = format!("r{i:08}");
+            make_bam_bytes(0, pos as i32, 0, name.as_bytes(), &[], 100, -1, -1, &[])
+        })
+        .collect()
+}
+
+fn bench_materialize(c: &mut Criterion) {
+    const N: usize = 500_000;
+    let records = synth_records(N);
+
+    let mut group = c.benchmark_group("chunk_sorter_materialize");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    group.bench_function("coordinate_500k", |b| {
+        b.iter_batched(
+            || {
+                let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+                    .threads(4)
+                    .into_coordinate_chunk_sorter(&Header::default())
+                    .expect("build coordinate chunk sorter");
+                for r in &records {
+                    sorter.push(r).expect("push");
+                }
+                sorter
+            },
+            |mut sorter| std::hint::black_box(sorter.take_sorted_chunk()),
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("template_coordinate_500k", |b| {
+        b.iter_batched(
+            || {
+                let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                    .threads(4)
+                    .into_template_chunk_sorter(&Header::default())
+                    .expect("build template chunk sorter");
+                for r in &records {
+                    sorter.push(r).expect("push");
+                }
+                sorter
+            },
+            |mut sorter| std::hint::black_box(sorter.take_sorted_chunk()),
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_materialize);
+criterion_main!(benches);

--- a/crates/fgumi-sort/benches/queryname_keys.rs
+++ b/crates/fgumi-sort/benches/queryname_keys.rs
@@ -1,0 +1,197 @@
+//! Microbenchmarks isolating the queryname sort's per-record key cost, to
+//! decide two things before touching the production queryname path:
+//!
+//!   1. **Prefix key (solution C)** — does packing the first 8 name bytes into a
+//!      `u64` for a cheap first-pass compare actually help? The answer depends
+//!      entirely on the name distribution: Illumina read names share a long
+//!      common prefix (`instrument:run:flowcell:lane:` is identical for every
+//!      read in a lane) and only vary in the `tile:x:y` suffix — so a *front*
+//!      prefix key may discriminate nothing and add pure overhead. We therefore
+//!      bench with REALISTIC Illumina-style names, not random ones.
+//!
+//!   2. **Null-key ceilings** — the wall-time floor if the key were free:
+//!      - `*_ingest`: owned-name extraction (alloc + memcpy per record) vs a
+//!        cheap `u64` extraction (no alloc). The delta is the ceiling on what
+//!        solution A (borrow the name from the arena, drop the per-record Vec)
+//!        can recover on the ingest side.
+//!      - `*_sort`: full-name comparator vs a cheap `u64` comparator. The delta
+//!        is the ceiling on what a cheaper comparator (C, or radix on a packed
+//!        key) can recover on the sort side.
+//!
+//!     cargo bench -p fgumi-sort --bench queryname_keys
+
+use std::cmp::Ordering;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{RawQuerynameKey, RawQuerynameLexKey, RawSortKey};
+
+/// Number of records per bench iteration.
+const N: usize = 1_000_000;
+
+/// Build `n` realistic Illumina-style read names: a fixed
+/// `instrument:run:flowcell:lane:` prefix shared by every read (22 bytes), then
+/// a varying `tile:x:y` suffix. This is the adversarial case for a front-prefix
+/// key — the first ~22 bytes are identical across all records.
+fn illumina_names(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            // Vary tile (1101..1112), x (0..) and y (0..) like a real lane.
+            let tile = 1101 + (i % 12);
+            let x = (i.wrapping_mul(2_654_435_761)) % 30_000;
+            let y = (i.wrapping_mul(40_503)) % 30_000;
+            format!("A00123:45:HGVWXDSXY:1:{tile}:{x}:{y}").into_bytes()
+        })
+        .collect()
+}
+
+/// Pack the first 8 bytes of `name` into a big-endian `u64` so numeric ordering
+/// of the u64 matches lexicographic ordering of the first 8 bytes (short names
+/// zero-pad on the right).
+#[inline]
+fn prefix8(name: &[u8]) -> u64 {
+    let mut buf = [0u8; 8];
+    let take = name.len().min(8);
+    buf[..take].copy_from_slice(&name[..take]);
+    u64::from_be_bytes(buf)
+}
+
+/// Build BAM records carrying `names` (paired R1 flag), so key extraction walks
+/// a real record body exactly as production does.
+fn bam_records(names: &[Vec<u8>]) -> Vec<Vec<u8>> {
+    names.iter().map(|name| make_bam_bytes(0, 0, 0, name, &[], 100, -1, -1, &[])).collect()
+}
+
+fn bench_ingest(c: &mut Criterion) {
+    let names = illumina_names(N);
+    let records = bam_records(&names);
+
+    let mut group = c.benchmark_group("queryname_ingest_1M");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    // Owned natural key: alloc + memcpy of the name per record (current path).
+    group.bench_function("natural_owned_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<RawQuerynameKey> =
+                records.iter().map(|r| RawQuerynameKey::extract_from_record(r)).collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    // Owned lex key: same alloc + memcpy.
+    group.bench_function("lex_owned_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<RawQuerynameLexKey> =
+                records.iter().map(|r| RawQuerynameLexKey::extract_from_record(r)).collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    // Null key: a cheap u64 prefix, NO allocation. The delta vs the owned
+    // extracts is the ceiling on solution A (borrow, drop the per-record Vec).
+    group.bench_function("null_u64_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<u64> = records
+                .iter()
+                .map(|r| {
+                    // True no-alloc floor: walk the raw name bytes directly
+                    // (`l_read_name` at byte 8, name at offset 32) with no
+                    // `RawQuerynameLexKey`/`NameBuf` allocation, then take the u64
+                    // prefix. `fields::read_name` yields the same name bytes
+                    // `RawQuerynameLexKey::name()` does, so the only delta vs
+                    // `lex_owned_extract` is the alloc + memcpy this path skips —
+                    // a valid lower bound for solution A.
+                    prefix8(fgumi_raw_bam::fields::read_name(r))
+                })
+                .collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_sort(c: &mut Criterion) {
+    let names = illumina_names(N);
+    let records = bam_records(&names);
+
+    // Pre-build the three key representations once, outside the timed loop.
+    let nat_keys: Vec<RawQuerynameKey> =
+        records.iter().map(|r| RawQuerynameKey::extract_from_record(r)).collect();
+    let lex_keys: Vec<RawQuerynameLexKey> =
+        records.iter().map(|r| RawQuerynameLexKey::extract_from_record(r)).collect();
+    // Prefix + full: (u64 prefix, full lex key). Prefix compared first, full
+    // name only on prefix ties.
+    let prefix_keys: Vec<(u64, RawQuerynameLexKey)> = records
+        .iter()
+        .map(|r| {
+            let k = RawQuerynameLexKey::extract_from_record(r);
+            (prefix8(k.name()), k)
+        })
+        .collect();
+    let u64_keys: Vec<u64> = prefix_keys.iter().map(|(p, _)| *p).collect();
+
+    let mut group = c.benchmark_group("queryname_sort_1M");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    // Full natural comparator (samtools strnum_cmp) — current path.
+    group.bench_function("natural_full_cmp", |b| {
+        b.iter_batched(
+            || nat_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Full lex comparator (Vec<u8>::cmp) — current lex path.
+    group.bench_function("lex_full_cmp", |b| {
+        b.iter_batched(
+            || lex_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Prefix-then-full: cheap u64 compare first, full name only on prefix ties.
+    // On Illumina names the shared front prefix means this almost always falls
+    // through to the full compare — the bench proves whether it helps or hurts.
+    group.bench_function("lex_prefix_then_full_cmp", |b| {
+        b.iter_batched(
+            || prefix_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable_by(|a, b| match a.0.cmp(&b.0) {
+                    Ordering::Equal => a.1.cmp(&b.1),
+                    other => other,
+                });
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Null key: sort the u64 prefix alone. The comparator ceiling — no full
+    // name ever compared.
+    group.bench_function("null_u64_cmp", |b| {
+        b.iter_batched(
+            || u64_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ingest, bench_sort);
+criterion_main!(benches);

--- a/crates/fgumi-sort/examples/arena_bench.rs
+++ b/crates/fgumi-sort/examples/arena_bench.rs
@@ -1,0 +1,240 @@
+//! Arena-lifetime microbenchmark — settles N_arena (in-flight sort arenas) and
+//! the gather/compress release point, isolated from the typed-step pipeline.
+// Throwaway diagnostic bench (not production): relax pedantic lints.
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::map_unwrap_or,
+    clippy::cast_possible_truncation
+)]
+//!
+//! Models the proposed Phase-1 dataflow with a **reused arena pool** (no
+//! mem-take-and-mint): a producer fills + par-sorts one `RecordBuffer` to a
+//! memory limit, hands ownership to a consumer that gathers (frames sorted
+//! records into ≤64 KiB blocks) + compresses, then returns the buffer to the
+//! pool. The pool depth is `N_arena`; the release point is `split`
+//! (return the buffer right after gather, before compress) or `fused`
+//! (return only after compress).
+//!
+//! Uses the REAL kernels: `RecordBuffer` (fill/par_sort/refs/get_record),
+//! `frame_keyed_record_into`, `SpillBlockCompressor::compress_block`.
+//!
+//! Run one config per process (clean peak RSS):
+//!   cargo run --release -p fgumi-sort --example arena_bench -- <mode> <N_arena> <chunk_mib> <n_chunks> <workers>
+//! e.g. cargo run --release -p fgumi-sort --example arena_bench -- split 1 512 6 4
+//!
+//! Output (stdout, one TSV line): mode N_arena chunk_mib n_chunks workers wall_s fill_s sort_s gather_s compress_s
+//! Peak RSS is sampled externally by the runner wrapper (this process prints its PID first).
+
+use std::sync::mpsc::sync_channel;
+use std::time::{Duration, Instant};
+
+use fgumi_sort::{
+    RawCoordinateKey, RawSortKey, RecordBuffer, SpillBlockCompressor, SpillCodec,
+    frame_keyed_record_into,
+};
+
+const BLOCK_SIZE: usize = 65280; // BGZF_MAX_BLOCK_SIZE
+const RECORD_BODY: usize = 200; // ~realistic BAM record body bytes
+
+/// Per-record framing overhead `frame_keyed_record_into` adds: a 4-byte `u32`
+/// record-length prefix, plus the serialized key ONLY when the key is not
+/// already embedded in the record. Derived from `RawCoordinateKey`'s own trait
+/// constants so it tracks the framing (and key size) instead of hardcoding `12`,
+/// which would silently mis-size blocks if the key encoding ever changed.
+const FRAME_OVERHEAD: usize = 4 // u32 record-length prefix
+    + if RawCoordinateKey::EMBEDDED_IN_RECORD {
+        0
+    } else {
+        // The coordinate key is fixed-size; a variable-length key (`None`) can't
+        // be statically bounded, but this bench only frames `RawCoordinateKey`.
+        match RawCoordinateKey::SERIALIZED_SIZE {
+            Some(n) => n,
+            None => 0,
+        }
+    };
+
+/// Synthesize one ~200-byte BAM-ish record into `out`: tid (bytes 0-3), pos
+/// (4-7), then a semi-compressible payload so zstd does realistic work. `n` is
+/// the record ordinal (varies tid/pos so keys differ).
+fn synth_record(out: &mut Vec<u8>, n: u64) {
+    out.clear();
+    let tid: i32 = (n % 25) as i32; // 25 contigs
+    let pos: i32 = ((n.wrapping_mul(2_654_435_761) >> 8) % 250_000_000) as i32;
+    out.extend_from_slice(&tid.to_le_bytes());
+    out.extend_from_slice(&pos.to_le_bytes());
+    // bytes 8..16 — remaining fixed BAM header fields (arbitrary)
+    out.extend_from_slice(&[0u8; 8]);
+    // payload: semi-compressible (a few repeating motifs keyed off n)
+    let motif = [(n & 0xFF) as u8, b'A', b'C', b'G', b'T', ((n >> 3) & 0xFF) as u8];
+    while out.len() < RECORD_BODY {
+        out.extend_from_slice(&motif);
+    }
+    out.truncate(RECORD_BODY);
+}
+
+/// Frame the sorted records of `buf` into ≤64 KiB raw blocks, cut-before-overflow.
+/// Reads `buf.refs()` (sorted) + `buf.get_record()` — the real gather access pattern.
+fn gather_range(buf: &RecordBuffer, start: usize, end: usize) -> Vec<Vec<u8>> {
+    let refs = buf.refs();
+    let mut blocks = Vec::new();
+    let mut cur = Vec::with_capacity(BLOCK_SIZE + 1024);
+    for r in &refs[start..end] {
+        let key = RawCoordinateKey { sort_key: r.sort_key };
+        let body = buf.get_record(r);
+        // would this record overflow a non-empty block? cut first.
+        if !cur.is_empty() && cur.len() + FRAME_OVERHEAD + body.len() > BLOCK_SIZE {
+            blocks.push(std::mem::replace(&mut cur, Vec::with_capacity(BLOCK_SIZE + 1024)));
+        }
+        frame_keyed_record_into(&mut cur, &key, body).expect("frame");
+    }
+    if !cur.is_empty() {
+        blocks.push(cur);
+    }
+    blocks
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args.get(1).map(String::as_str).unwrap_or("split").to_string();
+    let n_arena: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1);
+    let chunk_mib: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n_chunks: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(6);
+    let workers: usize = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(4);
+    let codec = SpillCodec::Zstd;
+    let level = 1u32;
+    let mem_limit = chunk_mib * 1024 * 1024;
+
+    eprintln!("PID {}", std::process::id());
+    eprintln!(
+        "config: mode={mode} N_arena={n_arena} chunk_mib={chunk_mib} n_chunks={n_chunks} workers={workers} codec=zstd{level}"
+    );
+
+    // Per-phase timing accumulators (nanos).
+    let fill_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let sort_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let gather_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let compress_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    // Arena pool: a free-list channel seeded with N_arena empty buffers, and a
+    // work channel of filled+sorted buffers. Bounded so the producer blocks when
+    // no arena is free (this IS the N_arena bound).
+    let (free_tx, free_rx) = sync_channel::<RecordBuffer>(n_arena);
+    let (work_tx, work_rx) = sync_channel::<RecordBuffer>(n_arena);
+    // Estimate records/arena for with_capacity pre-sizing.
+    let est_records = mem_limit / (RECORD_BODY + 8 + 16);
+    for _ in 0..n_arena {
+        free_tx.send(RecordBuffer::with_capacity(est_records, mem_limit, 25)).expect("seed pool");
+    }
+
+    let wall = Instant::now();
+
+    // Producer: fill + par_sort each chunk, hand the owned buffer to the consumer.
+    let prod_fill = fill_ns.clone();
+    let prod_sort = sort_ns.clone();
+    let producer = std::thread::spawn(move || {
+        let mut scratch = Vec::with_capacity(RECORD_BODY + 8);
+        let mut ordinal: u64 = 0;
+        for _ in 0..n_chunks {
+            let mut buf = free_rx.recv().expect("acquire arena");
+            let t = Instant::now();
+            while buf.memory_usage() < mem_limit {
+                synth_record(&mut scratch, ordinal);
+                ordinal += 1;
+                buf.push_coordinate(&scratch).expect("push");
+            }
+            prod_fill
+                .fetch_add(t.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            let t = Instant::now();
+            buf.par_sort();
+            prod_sort
+                .fetch_add(t.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            work_tx.send(buf).expect("hand to consumer");
+        }
+        // drop work_tx → consumer loop ends
+    });
+
+    // Consumer: gather + compress each chunk; release the arena per `mode`.
+    let split = mode == "split";
+    while let Ok(mut buf) = work_rx.recv() {
+        let n = buf.len();
+        // contiguous index ranges, one per worker
+        let per = n.div_ceil(workers.max(1));
+        let ranges: Vec<(usize, usize)> = (0..workers)
+            .map(|w| (w * per, ((w + 1) * per).min(n)))
+            .filter(|(s, e)| s < e)
+            .collect();
+
+        if split {
+            // GATHER (parallel) → owned raw blocks; then RELEASE arena; then COMPRESS (parallel).
+            let tg = Instant::now();
+            let raw: Vec<Vec<u8>> = std::thread::scope(|sc| {
+                let bref = &buf;
+                let handles: Vec<_> = ranges
+                    .iter()
+                    .map(|&(s, e)| sc.spawn(move || gather_range(bref, s, e)))
+                    .collect();
+                handles.into_iter().flat_map(|h| h.join().expect("gather join")).collect()
+            });
+            gather_ns
+                .fetch_add(tg.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            // RELEASE the arena BEFORE compress (the whole point of "split").
+            buf.clear();
+            let _ = free_tx.send(buf);
+            // COMPRESS the owned raw blocks in parallel (arena already free).
+            let tc = Instant::now();
+            let chunks: Vec<&[Vec<u8>]> =
+                raw.chunks(raw.len().div_ceil(workers.max(1)).max(1)).collect();
+            std::thread::scope(|sc| {
+                for ch in &chunks {
+                    sc.spawn(move || {
+                        let mut comp = SpillBlockCompressor::new(codec, level).expect("compressor");
+                        for blk in *ch {
+                            let out = comp.compress_block(blk).expect("compress");
+                            std::hint::black_box(&out);
+                        }
+                    });
+                }
+            });
+            compress_ns
+                .fetch_add(tc.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            // FUSED: each worker gathers+compresses its range from the arena;
+            // the arena is released only after ALL workers finish.
+            let tf = Instant::now();
+            std::thread::scope(|sc| {
+                for &(s, e) in &ranges {
+                    let bref = &buf;
+                    sc.spawn(move || {
+                        let mut comp = SpillBlockCompressor::new(codec, level).expect("compressor");
+                        for blk in gather_range(bref, s, e) {
+                            let out = comp.compress_block(&blk).expect("compress");
+                            std::hint::black_box(&out);
+                        }
+                    });
+                }
+            });
+            // fused gather+compress are interleaved; attribute the whole span to compress.
+            compress_ns
+                .fetch_add(tf.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            buf.clear();
+            let _ = free_tx.send(buf);
+        }
+        let _ = n;
+    }
+    producer.join().expect("producer join");
+    let wall_s = wall.elapsed().as_secs_f64();
+
+    let g = |a: &std::sync::atomic::AtomicU64| {
+        Duration::from_nanos(a.load(std::sync::atomic::Ordering::Relaxed)).as_secs_f64()
+    };
+    // headline TSV
+    println!(
+        "{mode}\t{n_arena}\t{chunk_mib}\t{n_chunks}\t{workers}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{:.2}",
+        wall_s,
+        g(&fill_ns),
+        g(&sort_ns),
+        g(&gather_ns),
+        g(&compress_ns)
+    );
+}

--- a/crates/fgumi-sort/src/arena_pool.rs
+++ b/crates/fgumi-sort/src/arena_pool.rs
@@ -1,0 +1,182 @@
+#![deny(unsafe_code)]
+//! Bounded, reusable pool of [`SegmentedBuf`] sort arenas (lever-1 RSS fix).
+//!
+//! The Phase-1 spill path fills a multi-GB `SegmentedBuf`, hands it downstream
+//! as an `Arc`, and (pre-pool) minted a *fresh* buffer for the next fill via
+//! `mem::take`. Combined with the block-parallel spill running async, two full
+//! arenas were live at the Phase-1→Phase-2 boundary (the in-flight chunk —
+//! pinned by slow compression through `SpillGather`'s bounded `pending` — plus
+//! the next fill), inflating peak RSS to ~2× base.
+//!
+//! This pool **bounds** the live arenas to `capacity` (default 1, matching
+//! legacy's one-arena-at-a-time `drain_pending_spill` model) and **reuses**
+//! their storage: [`try_acquire`](ArenaPool::try_acquire) hands out a
+//! reset-for-reuse buffer or `None` when all `capacity` arenas are in flight
+//! (the caller backpressures with `NoProgress` until an in-flight chunk's `Arc`
+//! drops and returns its arena via [`PooledSegmentedBuf`]'s `Drop`). Capping at
+//! 1 means the next fill cannot start until the prior chunk is spilled and its
+//! arena freed — exactly legacy's behaviour, and the RSS-gate-safe footprint.
+
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
+
+use crate::segmented_buf::SegmentedBuf;
+
+/// A bounded free-list of reusable [`SegmentedBuf`] arenas. At most `capacity`
+/// buffers ever exist; `try_acquire` returns `None` when all are in flight.
+pub struct ArenaPool {
+    inner: Mutex<PoolInner>,
+    /// Maximum number of live arenas (`N_arena`); clamped to ≥ 1.
+    capacity: usize,
+    /// Segment size for freshly-allocated arenas.
+    segment_size: usize,
+}
+
+struct PoolInner {
+    /// Returned, reset-for-reuse buffers ready to hand out.
+    free: Vec<SegmentedBuf>,
+    /// Total arenas ever allocated (never decremented; bounds at `capacity`).
+    made: usize,
+}
+
+impl ArenaPool {
+    /// Create a pool bounded to `capacity` (≥1) arenas, each `segment_size`.
+    #[must_use]
+    pub fn new(capacity: usize, segment_size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(PoolInner { free: Vec::new(), made: 0 }),
+            capacity: capacity.max(1),
+            segment_size,
+        })
+    }
+
+    /// Acquire a reset-for-reuse arena, or `None` if all `capacity` arenas are
+    /// in flight (the caller must backpressure and retry once one returns).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned (another thread panicked while
+    /// holding it, which indicates an unrecoverable state).
+    #[must_use]
+    pub fn try_acquire(&self) -> Option<SegmentedBuf> {
+        let mut g = self.inner.lock().expect("arena pool mutex poisoned");
+        if let Some(buf) = g.free.pop() {
+            return Some(buf);
+        }
+        if g.made < self.capacity {
+            g.made += 1;
+            return Some(SegmentedBuf::with_capacity(0, self.segment_size));
+        }
+        None
+    }
+
+    /// Return an arena to the free-list, reset for reuse (capacity retained).
+    fn release(&self, mut buf: SegmentedBuf) {
+        // Catch a buffer that never came from this pool's `try_acquire` (wrong
+        // `segment_size`): reusing it would silently defeat the `capacity`-based
+        // RSS bound this pool exists to enforce. Debug-only — the check is a
+        // developer guard, not a production cost.
+        debug_assert_eq!(
+            buf.segment_size(),
+            self.segment_size,
+            "released arena's segment_size doesn't match this pool's configured size"
+        );
+        buf.reset_for_reuse();
+        self.inner.lock().expect("arena pool mutex poisoned").free.push(buf);
+    }
+
+    /// Number of arenas currently available in the free-list (test/diagnostic).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    #[cfg(test)]
+    #[must_use]
+    pub fn free_len(&self) -> usize {
+        self.inner.lock().expect("arena pool mutex poisoned").free.len()
+    }
+}
+
+/// A [`SegmentedBuf`] that returns to its [`ArenaPool`] on drop (when `pool`
+/// is `Some`). Used as the `Arc`-shared backing store of an in-memory sort
+/// chunk: the arena is reclaimed once the last `Arc` clone drops (after the
+/// gather has framed a spilled chunk). The residual chunk and the
+/// `from_owned_records`/`empty` test constructors use `pool == None` so they
+/// drop normally and never return to the pool.
+pub struct PooledSegmentedBuf {
+    /// `Some` until `Drop`. `Option` only so `Drop` can move the buffer out.
+    buf: Option<SegmentedBuf>,
+    /// `Some` → return to the pool on drop; `None` → drop normally.
+    pool: Option<Arc<ArenaPool>>,
+}
+
+impl PooledSegmentedBuf {
+    /// Wrap a buffer that should return to `pool` on drop.
+    #[must_use]
+    pub fn pooled(buf: SegmentedBuf, pool: Arc<ArenaPool>) -> Self {
+        Self { buf: Some(buf), pool: Some(pool) }
+    }
+
+    /// Wrap a buffer that is NOT pool-managed (drops normally).
+    #[must_use]
+    pub fn unpooled(buf: SegmentedBuf) -> Self {
+        Self { buf: Some(buf), pool: None }
+    }
+}
+
+impl Deref for PooledSegmentedBuf {
+    type Target = SegmentedBuf;
+    fn deref(&self) -> &SegmentedBuf {
+        self.buf.as_ref().expect("PooledSegmentedBuf used after drop")
+    }
+}
+
+impl Drop for PooledSegmentedBuf {
+    fn drop(&mut self) {
+        if let Some(buf) = self.buf.take() {
+            if let Some(pool) = &self.pool {
+                pool.release(buf);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_to_capacity_and_reuses() {
+        let pool = ArenaPool::new(1, 1024);
+        let a = pool.try_acquire().expect("first acquire");
+        assert!(pool.try_acquire().is_none(), "capacity 1 → second acquire blocked");
+        // Return it via the Pooled wrapper's Drop.
+        drop(PooledSegmentedBuf::pooled(a, Arc::clone(&pool)));
+        assert_eq!(pool.free_len(), 1, "released arena back in the free-list");
+        let _b = pool.try_acquire().expect("acquire after release reuses the arena");
+        assert!(pool.try_acquire().is_none(), "still capacity-bound");
+    }
+
+    #[test]
+    fn unpooled_does_not_return() {
+        let pool = ArenaPool::new(1, 1024);
+        drop(PooledSegmentedBuf::unpooled(SegmentedBuf::with_capacity(0, 1024)));
+        assert_eq!(pool.free_len(), 0, "unpooled buffer never reaches the pool");
+    }
+
+    #[test]
+    fn reused_arena_retains_capacity() {
+        let pool = ArenaPool::new(1, 16);
+        let mut buf = pool.try_acquire().unwrap();
+        for i in 0..4u8 {
+            buf.extend_from_slice(&[i; 10]);
+        }
+        let (segs, cap) = (buf.num_segments(), buf.allocated_capacity());
+        assert!(segs >= 2, "grew multiple segments");
+        pool.release(buf);
+        let reused = pool.try_acquire().unwrap();
+        assert!(reused.is_empty(), "reset for reuse");
+        assert_eq!(reused.num_segments(), segs, "retained segments");
+        assert_eq!(reused.allocated_capacity(), cap, "no realloc");
+    }
+}

--- a/crates/fgumi-sort/src/block_offsets.rs
+++ b/crates/fgumi-sort/src/block_offsets.rs
@@ -1,0 +1,259 @@
+#![allow(dead_code)] // Wired into the sort ingest in increment 3; until then exercised only by tests.
+
+//! Arena layout planner for the parallel-inflate sort ingest.
+//!
+//! Given the ISIZE (uncompressed size) of each incoming BGZF block, [`ArenaLayout`]
+//! computes the gap-aware byte offset at which that block's decompressed bytes will
+//! land in a [`crate::segmented_buf::SegmentedBuf`] arena, and decides when to seal
+//! the current arena so no arena exceeds the `--max-memory` budget. It is a pure
+//! arithmetic planner: it owns no arena and performs no I/O. The offsets it predicts
+//! are byte-identical to [`crate::segmented_buf::SegmentedBuf::reserve_contiguous`]
+//! (and therefore to `grow_uninit`), so increment 3 can drive a real arena from these
+//! placements. Seal points mirror the existing spill trigger
+//! (`memory_usage() >= memory_limit`).
+
+/// Where one BGZF block's decompressed bytes land in the arena sequence, plus
+/// whether placing it seals the current arena (it reached the memory budget).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BlockPlacement {
+    /// Which arena (monotonically increasing run index, == spill `file_id` order).
+    pub(crate) arena_id: u64,
+    /// Gap-aware byte offset of the block's first byte within `arena_id`.
+    pub(crate) start: usize,
+    /// Length of the block's slot in bytes (== the block's ISIZE).
+    pub(crate) len: usize,
+    /// True iff this block is the last in `arena_id` (the arena reached the budget);
+    /// the next `plan` call begins a fresh arena at offset 0.
+    pub(crate) seals_arena: bool,
+}
+
+/// Plans gap-aware arena offsets and seal points for a stream of BGZF blocks.
+///
+/// Pure arithmetic — owns no arena. `segment_size` and `budget` are bytes. The
+/// offsets reproduce [`SegmentedBuf::reserve_contiguous`](crate::segmented_buf::SegmentedBuf::reserve_contiguous);
+/// seal points reproduce the existing `memory_usage() >= memory_limit` spill trigger.
+pub(crate) struct ArenaLayout {
+    segment_size: usize,
+    budget: usize,
+    arena_id: u64,
+    /// Gap-inclusive bytes placed in the current arena so far (== what
+    /// `SegmentedBuf::len()` would report for this arena).
+    arena_len: usize,
+}
+
+impl ArenaLayout {
+    /// Create a planner for the given `segment_size` and byte `budget`.
+    ///
+    /// # Note
+    ///
+    /// `budget` should be `> 0`. With `budget == 0`, [`plan`](Self::plan) seals
+    /// every block into its own single-block arena (even a zero-length one, since
+    /// `0 >= 0`) — safe and bounded, but degenerate. Production always resolves
+    /// `--max-memory` to a positive budget; callers that subdivide it (the
+    /// `budget / N` arena pool) must keep each share positive.
+    pub(crate) fn new(segment_size: usize, budget: usize) -> Self {
+        Self { segment_size: segment_size.max(1), budget, arena_id: 0, arena_len: 0 }
+    }
+
+    /// Place a block of `isize` uncompressed bytes; return its [`BlockPlacement`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `isize > segment_size` (a slot must fit within one segment).
+    pub(crate) fn plan(&mut self, isize: usize) -> BlockPlacement {
+        assert!(
+            isize <= self.segment_size,
+            "block of {} bytes exceeds segment size {}",
+            isize,
+            self.segment_size,
+        );
+
+        // Gap-pad to the next segment boundary, mirroring SegmentedBuf::reserve_contiguous.
+        let seg_used = self.arena_len % self.segment_size;
+        if seg_used + isize > self.segment_size && seg_used > 0 {
+            self.arena_len += self.segment_size - seg_used;
+        }
+
+        let start = self.arena_len;
+        self.arena_len += isize;
+
+        // Seal AFTER the block that reaches the budget (inclusive >=), matching the
+        // existing spill trigger. The exact seal point is parity-neutral.
+        let seals_arena = self.arena_len >= self.budget;
+        let placement = BlockPlacement { arena_id: self.arena_id, start, len: isize, seals_arena };
+        if seals_arena {
+            self.arena_id += 1;
+            self.arena_len = 0;
+        }
+        placement
+    }
+
+    /// The arena id the next [`plan`](Self::plan) call will place into.
+    pub(crate) fn current_arena_id(&self) -> u64 {
+        self.arena_id
+    }
+
+    /// True when the current arena holds at least one unsealed block — the EOF
+    /// "seal the residual run" signal.
+    pub(crate) fn has_open_arena(&self) -> bool {
+        self.arena_len > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::segmented_buf::SegmentedBuf;
+    use proptest::prelude::*;
+
+    proptest! {
+        // For any sequence of block sizes (incl. zero-length), with a budget that
+        // never seals, the planner's offsets equal reserve_contiguous's offsets.
+        #[test]
+        fn prop_offsets_match_reserve_contiguous(isizes in prop::collection::vec(0usize..=100, 0..50)) {
+            let seg = 100usize;
+            let mut layout = ArenaLayout::new(seg, usize::MAX);
+            let mut oracle = SegmentedBuf::with_capacity(0, seg);
+            for &n in &isizes {
+                let p = layout.plan(n);
+                let want = oracle.reserve_contiguous(n);
+                oracle.extend_in_place(&vec![0u8; n]);
+                prop_assert_eq!(p.start, want);
+                prop_assert_eq!(p.len, n);
+                prop_assert!(!p.seals_arena);
+                prop_assert_eq!(p.arena_id, 0);
+            }
+        }
+
+        // For any block sizes and any positive budget: arena_id increments by exactly
+        // one and only right after a seal; within an arena offsets are the prefix sum;
+        // a sealed arena's cumulative reached the budget while its predecessor did not.
+        #[test]
+        fn prop_seal_invariants(
+            isizes in prop::collection::vec(1usize..=50, 1..40),
+            budget in 1usize..=300,
+        ) {
+            let mut layout = ArenaLayout::new(1_000_000, budget); // no intra-arena gaps for ≤50B blocks
+            let mut prev_arena: u64 = 0;
+            let mut running: usize = 0;     // cumulative within the current arena
+            let mut prev_sealed = false;    // did the previous block seal?
+            for &n in &isizes {
+                let p = layout.plan(n);
+                if prev_sealed {
+                    prop_assert_eq!(p.arena_id, prev_arena + 1, "arena_id must increment by 1 after a seal");
+                    running = 0;
+                } else {
+                    prop_assert_eq!(p.arena_id, prev_arena, "arena_id must not change without a seal");
+                }
+                prop_assert_eq!(p.start, running, "offset must be the within-arena prefix sum");
+                running += n;
+                prop_assert_eq!(p.seals_arena, running >= budget, "seal iff cumulative reached budget");
+                prev_arena = p.arena_id;
+                prev_sealed = p.seals_arena;
+            }
+        }
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn planned_offsets_drive_grow_uninit_round_trip() {
+        // End-to-end bridge to increment 1: the planner predicts exactly where
+        // grow_uninit lands each block in a real arena (single arena, MAX budget),
+        // and the bytes round-trip through slice_mut/slice.
+        let seg = 100usize;
+        // Includes a zero-length block (index 2) so the unsafe path exercises
+        // grow_uninit(0): its predicted offset must still match grow_uninit's.
+        let isizes = [60usize, 60, 0, 30, 40, 50];
+        let mut layout = ArenaLayout::new(seg, usize::MAX);
+        let mut buf = SegmentedBuf::with_capacity(0, seg);
+
+        for (i, &n) in isizes.iter().enumerate() {
+            let p = layout.plan(n);
+            // SAFETY: the slot is fully written via slice_mut before any read.
+            let off = unsafe { buf.grow_uninit(n) };
+            assert_eq!(off, p.start, "grow_uninit landed where the planner predicted");
+            unsafe { buf.slice_mut(off, n) }.fill(u8::try_from(i).unwrap());
+        }
+
+        let mut replay = ArenaLayout::new(seg, usize::MAX);
+        for (i, &n) in isizes.iter().enumerate() {
+            let p = replay.plan(n);
+            assert_eq!(buf.slice(p.start, n), &vec![u8::try_from(i).unwrap(); n][..]);
+        }
+    }
+
+    #[test]
+    fn plan_offsets_match_reserve_contiguous_across_segment_gaps() {
+        // segment_size 100 forces gaps; budget MAX so nothing seals (single arena).
+        let seg = 100usize;
+        let isizes = [60usize, 60, 30, 40, 50];
+        let mut layout = ArenaLayout::new(seg, usize::MAX);
+        let mut oracle = SegmentedBuf::with_capacity(0, seg);
+
+        for &n in &isizes {
+            let p = layout.plan(n);
+            let want = oracle.reserve_contiguous(n);
+            oracle.extend_in_place(&vec![0u8; n]); // advance the oracle like a real write
+            assert_eq!(
+                p.start, want,
+                "planner offset diverged from reserve_contiguous for isize={n}"
+            );
+            assert_eq!(p.len, n);
+            assert_eq!(p.arena_id, 0);
+            assert!(!p.seals_arena, "MAX budget must never seal");
+        }
+        // Explicit expected offsets: 0, gap→100, 160, gap→200, 240.
+        let mut l2 = ArenaLayout::new(seg, usize::MAX);
+        let starts: Vec<usize> = isizes.iter().map(|&n| l2.plan(n).start).collect();
+        assert_eq!(starts, vec![0, 100, 160, 200, 240]);
+    }
+
+    #[test]
+    fn seal_fires_after_block_that_reaches_budget_then_resets() {
+        // segment_size huge so no intra-arena gaps; budget 100; 40-byte blocks.
+        let mut layout = ArenaLayout::new(1_000_000, 100);
+        let p0 = layout.plan(40); // arena_len 40
+        let p1 = layout.plan(40); // arena_len 80
+        let p2 = layout.plan(40); // arena_len 120 >= 100 → seals
+        let p3 = layout.plan(40); // fresh arena
+
+        assert_eq!((p0.arena_id, p0.start, p0.seals_arena), (0, 0, false));
+        assert_eq!((p1.arena_id, p1.start, p1.seals_arena), (0, 40, false));
+        assert_eq!((p2.arena_id, p2.start, p2.seals_arena), (0, 80, true));
+        assert_eq!((p3.arena_id, p3.start, p3.seals_arena), (1, 0, false));
+        assert!(layout.has_open_arena(), "arena 1 holds an unsealed 40-byte block");
+        assert_eq!(layout.current_arena_id(), 1);
+    }
+
+    #[test]
+    fn single_block_at_or_over_budget_seals_immediately() {
+        let mut layout = ArenaLayout::new(1_000_000, 30);
+        let p = layout.plan(50); // 50 >= 30
+        assert_eq!((p.arena_id, p.start, p.len, p.seals_arena), (0, 0, 50, true));
+        assert!(!layout.has_open_arena(), "the sealing block left no open arena");
+    }
+
+    #[test]
+    fn has_open_arena_false_before_any_block_and_after_clean_seal() {
+        let mut layout = ArenaLayout::new(1_000_000, 100);
+        assert!(!layout.has_open_arena(), "no blocks placed yet");
+        layout.plan(100); // exactly reaches budget → seals, arena_len resets to 0
+        assert!(!layout.has_open_arena(), "exact-budget block sealed cleanly");
+    }
+
+    #[test]
+    fn zero_length_block_is_placed_without_advancing() {
+        let mut layout = ArenaLayout::new(100, usize::MAX);
+        let p0 = layout.plan(0);
+        let p1 = layout.plan(10);
+        assert_eq!((p0.start, p0.len), (0, 0));
+        assert_eq!((p1.start, p1.len), (0, 10)); // zero-length block did not move the cursor
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds segment size")]
+    fn plan_isize_over_segment_size_panics() {
+        let mut layout = ArenaLayout::new(100, usize::MAX);
+        let _ = layout.plan(101);
+    }
+}

--- a/crates/fgumi-sort/src/chunk_sorter.rs
+++ b/crates/fgumi-sort/src/chunk_sorter.rs
@@ -1,0 +1,982 @@
+//! Lean in-memory buffering sorter for the P6 `SortBuffer` step.
+//!
+//! [`CoordinateChunkSorter`] is the buffer-management slice of the former
+//! `CoordinateSortStream` (the streaming sort engine retired in P7) with **all
+//! the disk and pool machinery removed**: it ingests records into a
+//! [`RecordBuffer`], and on
+//! demand par-sorts the buffer and materializes it into an owned sorted chunk
+//! (`Vec<(RawCoordinateKey, RawRecord)>`). It never writes to disk, owns no
+//! `SortWorkerPool`, no temp dirs, and no spill files — compressing and writing
+//! a chunk is the `CompressSpill` step's job (P6 Phase-1 split).
+//!
+//! The driver (`SortBuffer`) calls [`push`](CoordinateChunkSorter::push) per
+//! record; when it returns `true` (buffer at the memory limit), the driver takes
+//! a sorted chunk via [`take_sorted_chunk`](CoordinateChunkSorter::take_sorted_chunk)
+//! and emits it as a spill chunk. At end of input the driver takes one final
+//! residual chunk the same way.
+//!
+//! # Parity
+//!
+//! `take_sorted_chunk` uses the global stable [`RecordBuffer::par_sort`] plus a
+//! parallel `par_iter` materialization — exactly the no-spill residual path in
+//! `CoordinateSortStream::into_slot_setup`. The legacy with-spill multi-thread
+//! path used `par_sort_into_chunks` to emit *k* sub-runs; emitting one
+//! globally-sorted chunk instead is record-order identical (the sub-runs are
+//! merged back by key with a lower-source-index tie-break, which for a stable
+//! global sort is the same original-insertion order), and it keeps the residual
+//! a single merge source so a `Parallel` `CompressSpill` reordering chunks can
+//! never perturb the tie-break.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+#[cfg(test)]
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::SamTag;
+use rayon::ThreadPool;
+
+use crate::arena_pool::ArenaPool;
+use crate::external::{
+    KeyTypesSpec, LibraryLookup, TemplateKeyVariant, dropped_lane_error,
+    extract_template_key_inline, select_template_variant, verify_dropped_lanes,
+};
+use crate::inline::{
+    CbKey32, InMemoryChunk, RecordBuffer, TemplateKey, TemplateKey24, TemplateKey40,
+    TemplateLaneKey, TemplateRecordBuffer, TertKey32,
+};
+use crate::keys::RawCoordinateKey;
+use crate::memory_probe::force_mi_collect;
+
+/// In-memory coordinate buffering sorter that emits owned sorted chunks.
+pub struct CoordinateChunkSorter {
+    buffer: RecordBuffer,
+    /// Private rayon pool sized to `--threads`, used for `par_sort` and the
+    /// parallel chunk materialization.
+    rayon_pool: ThreadPool,
+    /// Memory-usage threshold (bytes) at which `push` signals a chunk is due.
+    memory_limit: usize,
+    total_records: u64,
+    /// Bounded pool of reusable sort arenas (lever-1 RSS fix). The buffer's
+    /// backing `SegmentedBuf` is acquired here and returns (reset-for-reuse)
+    /// when the emitted chunk's `Arc` drops, so at most `N_arena` arenas are
+    /// ever live. Capacity 1 (default) matches legacy's one-arena-at-a-time
+    /// `drain_pending_spill` model.
+    arena_pool: Arc<ArenaPool>,
+    /// `true` once an arena is installed in `buffer` and not yet drained.
+    has_arena: bool,
+}
+
+impl CoordinateChunkSorter {
+    /// Construct from a pre-sized buffer + rayon pool + arena pool. Built via
+    /// [`RawExternalSorter::into_coordinate_chunk_sorter`](crate::RawExternalSorter::into_coordinate_chunk_sorter).
+    /// `buffer` starts drained; the first [`ensure_arena`](Self::ensure_arena)
+    /// installs one from `arena_pool`.
+    pub(crate) fn new(
+        buffer: RecordBuffer,
+        rayon_pool: ThreadPool,
+        memory_limit: usize,
+        arena_pool: Arc<ArenaPool>,
+    ) -> Self {
+        Self { buffer, rayon_pool, memory_limit, total_records: 0, arena_pool, has_arena: false }
+    }
+
+    /// Ensure the buffer has a backing arena before a fill. Returns `false`
+    /// when all `N_arena` pool arenas are in flight — the caller (`SortBuffer`)
+    /// must backpressure (`NoProgress`) and retry once an in-flight chunk is
+    /// spilled and its arena returns to the pool. Idempotent while installed.
+    #[must_use]
+    pub fn ensure_arena(&mut self) -> bool {
+        if self.has_arena {
+            return true;
+        }
+        // Only acquire at the START of a fill (drained buffer). Never swap a
+        // partially-filled (default) buffer for a pool arena mid-fill — the
+        // arena install replaces the backing store, which would orphan the
+        // records already buffered. A caller that began filling the default
+        // (because the bounded pool was momentarily empty) finishes into it and
+        // drains it unpooled.
+        if !self.buffer.is_empty() {
+            return false;
+        }
+        if let Some(arena) = self.arena_pool.try_acquire() {
+            self.buffer.install_arena(arena);
+            self.has_arena = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Push one raw BAM record into the buffer.
+    ///
+    /// Returns `true` when the buffer's memory usage has reached the configured
+    /// limit and the caller should take a sorted (spill) chunk via
+    /// [`Self::take_sorted_chunk`] before pushing more. The caller must have
+    /// called [`ensure_arena`](Self::ensure_arena) (returning `true`) first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be parsed for its coordinate key
+    /// (e.g. truncated record).
+    pub fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        // Best-effort: acquire a pool arena if one is free. A bounded, RSS-
+        // critical driver would call `ensure_arena` explicitly first and
+        // backpressure on `false`, so on that path the arena is always installed
+        // here. Callers (the `SortBuffer` RecordBatch path, unit tests) that
+        // don't pre-check simply fill the buffer's current (possibly pool,
+        // possibly default) storage — `take_sorted_chunk` returns it to the pool
+        // only when it is a pool arena (`has_arena`).
+        let _ = self.ensure_arena();
+        // Count only after the record is successfully buffered, so a truncated
+        // record (push_coordinate error) never bumps `total_records` for a
+        // record that was never stored.
+        self.buffer.push_coordinate(bam_bytes)?;
+        self.total_records += 1;
+        Ok(self.buffer.memory_usage() >= self.memory_limit)
+    }
+
+    /// Par-sort the current buffer, materialize it into an owned sorted chunk
+    /// (parallel `par_iter`), and clear the buffer for reuse.
+    ///
+    /// Returns an empty chunk if the buffer is empty (so the caller can skip
+    /// emitting an empty chunk).
+    ///
+    /// **Zero-copy materialisation.** The sorted buffer is drained into an
+    /// [`InMemoryChunk`] that *moves* the arena (`Arc<SegmentedBuf>`) and keeps
+    /// per-record `(key, offset, len)` references into it — no per-record byte
+    /// copy or allocation. (The pre-fix path materialised an owned
+    /// `Vec<(K, RawRecord)>`, copying + `malloc`-ing every record and doubling
+    /// peak RSS; the A/B smoke campaign flagged that regression vs the legacy
+    /// path, which already used this primitive.)
+    #[must_use]
+    pub fn take_sorted_chunk(&mut self) -> InMemoryChunk<RawCoordinateKey> {
+        if self.buffer.is_empty() {
+            return InMemoryChunk::empty();
+        }
+        {
+            let buffer = &mut self.buffer;
+            let rayon_pool = &self.rayon_pool;
+            rayon_pool.install(|| buffer.par_sort());
+        }
+        // If the buffer is a pool arena, drain into a POOL-MANAGED chunk so the
+        // arena returns (reset-for-reuse) when the chunk's last `Arc` drops
+        // (after the gather frames it) — this is the reuse + cap-1 bound on the
+        // standalone coordinate path. If it is the default storage (a caller
+        // that bypassed the pool because it was momentarily empty), drain
+        // unpooled so a non-pool buffer never enters the pool. `has_arena` is
+        // cleared either way so the next fill re-acquires.
+        let chunk = if self.has_arena {
+            self.buffer.drain_into_pooled_chunk(&self.arena_pool)
+        } else {
+            self.buffer.drain_into_single_chunk()
+        };
+        self.has_arena = false;
+        chunk
+    }
+
+    /// Total records pushed so far.
+    #[must_use]
+    pub fn total_records(&self) -> u64 {
+        self.total_records
+    }
+
+    /// `true` iff the buffer currently holds no records.
+    #[must_use]
+    pub fn buffer_is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Construct a minimal `CoordinateChunkSorter` for unit tests.
+    ///
+    /// Mirrors the construction in
+    /// [`RawExternalSorter::into_coordinate_chunk_sorter`](crate::external::RawExternalSorter::into_coordinate_chunk_sorter):
+    /// a zero-capacity `RecordBuffer` (the pool hands out the first arena on the
+    /// initial `ensure_arena`/`push`), a single-thread rayon pool, and a
+    /// capacity-1 `ArenaPool` with the standard segment size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if rayon cannot build a single-thread pool (which never occurs in
+    /// practice but is the contract of `ThreadPoolBuilder::build`).
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    pub fn for_test(memory_limit: usize, n_ref: u32) -> Self {
+        let buffer = crate::inline::RecordBuffer::with_capacity(0, 0, n_ref);
+        let rayon_pool =
+            rayon::ThreadPoolBuilder::new().num_threads(1).build().expect("rayon pool for test");
+        let arena_pool = crate::arena_pool::ArenaPool::new(1, crate::inline::SORT_SEGMENT_SIZE);
+        Self::new(buffer, rayon_pool, memory_limit, arena_pool)
+    }
+}
+
+// ============================================================================
+// TemplateChunkSorter — template-coordinate (stable radix, like coordinate)
+// ============================================================================
+
+/// The narrowed lane-key buffer the [`TemplateChunkSorter`] sorts on. The
+/// variant is chosen on the first `push` from `--key-types` (via
+/// [`select_template_variant`]) and matches the batch `RawExternalSorter::sort`
+/// dispatch one-for-one: `(cb, tertiary)` → `(false,false)`=`TemplateKey24`
+/// (3 lanes), `(true,false)`=`CbKey32`, `(false,true)`=`TertKey32` (4 lanes),
+/// `(true,true)`=`TemplateKey40` (5 lanes, the full key). The radix sort runs
+/// on the narrower key for speed; the emitted chunk re-widens to the full
+/// [`TemplateKey`] (see [`TemplateChunkSorter::take_sorted_chunk`]).
+enum TemplateBuffer {
+    K24(TemplateRecordBuffer<TemplateKey24>),
+    Cb32(TemplateRecordBuffer<CbKey32>),
+    Tert32(TemplateRecordBuffer<TertKey32>),
+    K40(TemplateRecordBuffer<TemplateKey40>),
+}
+
+/// Run `$body` against the inner `TemplateRecordBuffer<K>` of whichever variant
+/// `$self` holds, with the buffer bound to `$buf`. `$body` is monomorphized per
+/// arm, so type inference resolves `K` (e.g. `TemplateLaneKey::from_full`,
+/// `b.push`) from the matched buffer type.
+macro_rules! with_template_buffer {
+    ($self:expr, $buf:ident => $body:expr) => {
+        match $self {
+            TemplateBuffer::K24($buf) => $body,
+            TemplateBuffer::Cb32($buf) => $body,
+            TemplateBuffer::Tert32($buf) => $body,
+            TemplateBuffer::K40($buf) => $body,
+        }
+    };
+}
+
+impl TemplateBuffer {
+    /// Build the buffer for the chosen `variant`, sized from the shared
+    /// (key-width-agnostic) capacity hints. The slight per-`K` ref-size
+    /// difference is immaterial for a capacity hint — the buffer grows as
+    /// needed — so a single estimate is used across variants.
+    fn from_variant(
+        variant: TemplateKeyVariant,
+        estimated_records: usize,
+        estimated_data_bytes: usize,
+    ) -> Self {
+        match (variant.cb, variant.tertiary) {
+            (false, false) => Self::K24(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (true, false) => Self::Cb32(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (false, true) => Self::Tert32(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (true, true) => Self::K40(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+        }
+    }
+
+    /// Push a record under the narrowed key derived from its full key.
+    fn push_full(&mut self, bam_bytes: &[u8], full: &TemplateKey) -> Result<()> {
+        with_template_buffer!(self, b => b.push(bam_bytes, TemplateLaneKey::from_full(full)))
+    }
+
+    fn memory_usage(&self) -> usize {
+        with_template_buffer!(self, b => b.memory_usage())
+    }
+
+    fn is_empty(&self) -> bool {
+        with_template_buffer!(self, b => b.is_empty())
+    }
+
+    fn par_sort(&mut self) {
+        with_template_buffer!(self, b => b.par_sort());
+    }
+
+    // Test-only: only the owned oracle path (`take_sorted_chunk_owned`) clears
+    // the buffer explicitly; the production arena drain empties it in place.
+    #[cfg(test)]
+    fn clear(&mut self) {
+        with_template_buffer!(self, b => b.clear());
+    }
+
+    /// Materialize the (already narrow-key-sorted) buffer into an owned chunk
+    /// keyed by the **full** [`TemplateKey`], re-extracted per record. Narrow-K
+    /// order equals full-key order because every dropped lane is verified
+    /// constant, so the chunk is correctly ordered for the downstream merge.
+    /// Must be invoked inside the sorter's `rayon_pool.install`.
+    ///
+    /// Test-only: the owned materialisation is retained purely as the byte-parity
+    /// oracle for [`drain_into_full_key_chunk`](Self::drain_into_full_key_chunk),
+    /// which is the production path.
+    #[cfg(test)]
+    fn materialize_full(
+        &self,
+        lib_lookup: &LibraryLookup,
+        cell_tag: Option<SamTag>,
+        cb_hasher: &ahash::RandomState,
+    ) -> Vec<(TemplateKey, RawRecord)> {
+        use rayon::prelude::*;
+        with_template_buffer!(self, b => b
+            .refs()
+            .par_iter()
+            .map(|r| {
+                let bam_bytes = b.get_record(r);
+                let full = extract_template_key_inline(bam_bytes, lib_lookup, cell_tag, cb_hasher);
+                (full, RawRecord::from(bam_bytes.to_vec()))
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Zero-copy analogue of [`materialize_full`](Self::materialize_full): drain
+    /// the (already narrow-key-sorted) buffer into an arena-backed
+    /// `InMemoryChunk<TemplateKey>` keyed by the re-extracted full key, WITHOUT
+    /// copying record bodies (the arena is moved into the chunk). Produces the
+    /// same sorted order, keys, and body bytes as `materialize_full` — the only
+    /// difference is the records reference the moved arena instead of owned
+    /// `RawRecord`s. Must be invoked inside the sorter's `rayon_pool.install`.
+    fn drain_into_full_key_chunk(
+        &mut self,
+        lib_lookup: &LibraryLookup,
+        cell_tag: Option<SamTag>,
+        cb_hasher: &ahash::RandomState,
+    ) -> InMemoryChunk<TemplateKey> {
+        with_template_buffer!(self, b => b.drain_into_full_key_chunk(|body| {
+            extract_template_key_inline(body, lib_lookup, cell_tag, cb_hasher)
+        }))
+    }
+}
+
+/// State that exists only once the first record has been seen: the chosen
+/// narrowed-key variant, the full key of the first record (the dropped-lane
+/// verify baseline), and the matching buffer. Bundling the three behind one
+/// `Option` captures their shared "set together on the first push" invariant in
+/// the type, so the hot path never unwraps.
+struct Provisioned {
+    /// Full key of the first record; later records' dropped lanes are verified
+    /// against it.
+    first_key: TemplateKey,
+    /// The chosen narrowed-key variant (`--key-types` + first record).
+    variant: TemplateKeyVariant,
+    /// The narrowed-key buffer matching `variant`.
+    buffer: TemplateBuffer,
+}
+
+/// In-memory template-coordinate buffering sorter that emits owned sorted
+/// chunks. The template analogue of [`CoordinateChunkSorter`]: a
+/// [`TemplateRecordBuffer`] + private rayon pool, with the library / cell-barcode
+/// / MI key-extraction state the template key needs. Uses the same global stable
+/// radix [`TemplateRecordBuffer::par_sort`], so the single-residual-chunk parity
+/// argument is identical to coordinate's.
+///
+/// **Narrowed radix key (`--key-types`).** Like the batch `RawExternalSorter::sort`
+/// path, the in-memory radix sort runs on the `KeyTypesSpec`-narrowed key
+/// (`TemplateBuffer` — `TemplateKey24`/`CbKey32`/`TertKey32`/`TemplateKey40`),
+/// chosen lazily on the first `push` once the first record is available to seed
+/// `select_template_variant`. The narrower key is a **speed** optimization
+/// (fewer radix passes). The emitted chunk re-widens to the full [`TemplateKey`]
+/// in [`take_sorted_chunk`](Self::take_sorted_chunk) so the buffer-chain protocol
+/// (`CompressSpill`/`SortMerge`) stays on the full key.
+///
+/// Narrowing is order-preserving and validated: `--key-types` may only drop a
+/// lane the [dropped-lane validation](verify_dropped_lanes) proves constant, so
+/// the narrow-key sort yields the identical order to a full-key sort. This path
+/// therefore produces byte-for-byte the same output as the batch path AND rejects
+/// the same dropped-lane violations. (The pre-P6 streaming path skipped this
+/// validation entirely; restoring it makes `--key-types` actually function in
+/// production.)
+pub struct TemplateChunkSorter {
+    /// Variant + first-key + buffer, provisioned on the first `push` (`None`
+    /// until then; an empty stream leaves it `None`).
+    state: Option<Provisioned>,
+    rayon_pool: ThreadPool,
+    memory_limit: usize,
+    /// Capacity hints for the lazily-built `TemplateBuffer` (key-width-agnostic).
+    estimated_records: usize,
+    estimated_data_bytes: usize,
+    lib_lookup: LibraryLookup,
+    cb_hasher: ahash::RandomState,
+    cell_tag: Option<SamTag>,
+    /// `--key-types` spec; selects which optional lanes may be dropped.
+    key_types: KeyTypesSpec,
+    /// Whether the header realizes >1 library ordinal (informs `Auto` selection).
+    header_library_varies: bool,
+    total_records: u64,
+}
+
+impl TemplateChunkSorter {
+    /// Built via
+    /// [`RawExternalSorter::into_template_chunk_sorter`](crate::RawExternalSorter::into_template_chunk_sorter).
+    /// The narrowed-key buffer is deferred to the first `push` (the variant is
+    /// chosen from the first record), so this takes capacity hints rather than a
+    /// pre-built buffer.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        rayon_pool: ThreadPool,
+        memory_limit: usize,
+        estimated_records: usize,
+        estimated_data_bytes: usize,
+        lib_lookup: LibraryLookup,
+        cb_hasher: ahash::RandomState,
+        cell_tag: Option<SamTag>,
+        key_types: KeyTypesSpec,
+        header_library_varies: bool,
+    ) -> Self {
+        Self {
+            state: None,
+            rayon_pool,
+            memory_limit,
+            estimated_records,
+            estimated_data_bytes,
+            lib_lookup,
+            cb_hasher,
+            cell_tag,
+            key_types,
+            header_library_varies,
+            total_records: 0,
+        }
+    }
+
+    /// Push one record (extracting the template key); returns `true` when the
+    /// buffer has reached the memory limit.
+    ///
+    /// On the first record the dropped-lane variant is provisioned from
+    /// `--key-types`; every record then has its dropped lanes verified against
+    /// the first record's, matching the batch `RawExternalSorter::sort` path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be buffered (e.g. truncated), or if
+    /// a record carries a dropped-lane value (CB / MI / library) absent from the
+    /// input's first record.
+    pub fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        let key = extract_template_key_inline(
+            bam_bytes,
+            &self.lib_lookup,
+            self.cell_tag,
+            &self.cb_hasher,
+        );
+
+        let memory_usage = if let Some(state) = self.state.as_mut() {
+            // Subsequent records: verify the lanes the chosen variant drops are
+            // constant relative to the first record, then buffer.
+            if let Some(violation) = verify_dropped_lanes(&state.first_key, &key, state.variant) {
+                let name = fgumi_raw_bam::RawRecordView::new(bam_bytes).read_name();
+                return Err(dropped_lane_error(&String::from_utf8_lossy(name), violation));
+            }
+            state.buffer.push_full(bam_bytes, &key)?;
+            state.buffer.memory_usage()
+        } else {
+            // First record: provision the variant from --key-types and build the
+            // matching narrowed-key buffer. Buffer the record BEFORE committing
+            // `self.state`, so a `push_full` error leaves the sorter unprovisioned
+            // rather than holding a first_key/variant from a never-buffered record.
+            let variant =
+                select_template_variant(Some(&key), self.key_types, self.header_library_varies);
+            let mut buffer = TemplateBuffer::from_variant(
+                variant,
+                self.estimated_records,
+                self.estimated_data_bytes,
+            );
+            buffer.push_full(bam_bytes, &key)?;
+            let memory_usage = buffer.memory_usage();
+            self.state = Some(Provisioned { first_key: key, variant, buffer });
+            memory_usage
+        };
+
+        // Count only after the record is successfully buffered (past the
+        // dropped-lane check and push_full), so an error never bumps
+        // `total_records` for a record that was never stored.
+        self.total_records += 1;
+        Ok(memory_usage >= self.memory_limit)
+    }
+
+    /// Par-sort (on the narrowed key) + drain the buffer into one **arena-backed**
+    /// `InMemoryChunk<TemplateKey>` keyed by the full [`TemplateKey`] — zero body
+    /// copies (the sort arena is moved into the chunk, the full key re-extracted
+    /// per record). Symmetric with [`CoordinateChunkSorter::take_sorted_chunk`].
+    /// Both `data` and `refs` are cleared by the drain.
+    #[must_use]
+    pub fn take_sorted_chunk(&mut self) -> InMemoryChunk<TemplateKey> {
+        let Some(state) = self.state.as_mut() else {
+            return InMemoryChunk::default();
+        };
+        if state.buffer.is_empty() {
+            return InMemoryChunk::default();
+        }
+        self.rayon_pool.install(|| state.buffer.par_sort());
+        let lib_lookup = &self.lib_lookup;
+        let cell_tag = self.cell_tag;
+        let cb_hasher = &self.cb_hasher;
+        let chunk = self
+            .rayon_pool
+            .install(|| state.buffer.drain_into_full_key_chunk(lib_lookup, cell_tag, cb_hasher));
+        force_mi_collect();
+        chunk
+    }
+
+    /// Test-only owned materialisation — the byte-parity oracle reference for
+    /// [`take_sorted_chunk`](Self::take_sorted_chunk). Par-sorts then copies each
+    /// record into an owned `Vec<(TemplateKey, RawRecord)>` via `materialize_full`
+    /// (the pre-arena behaviour), so a test can assert the arena chunk is
+    /// byte-identical to what the owned path produced.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn take_sorted_chunk_owned(&mut self) -> Vec<(TemplateKey, RawRecord)> {
+        let Some(state) = self.state.as_mut() else {
+            return Vec::new();
+        };
+        if state.buffer.is_empty() {
+            return Vec::new();
+        }
+        self.rayon_pool.install(|| state.buffer.par_sort());
+        let buffer_ref = &state.buffer;
+        let lib_lookup = &self.lib_lookup;
+        let cell_tag = self.cell_tag;
+        let cb_hasher = &self.cb_hasher;
+        let chunk = self
+            .rayon_pool
+            .install(|| buffer_ref.materialize_full(lib_lookup, cell_tag, cb_hasher));
+        state.buffer.clear();
+        force_mi_collect();
+        chunk
+    }
+
+    /// Total records pushed so far.
+    #[must_use]
+    pub fn total_records(&self) -> u64 {
+        self.total_records
+    }
+
+    /// The narrowed-key variant chosen on the first push (`None` before any
+    /// push). Exposed for tests asserting `--key-types` narrowing selects the
+    /// expected lane width.
+    #[cfg(test)]
+    pub(crate) fn chosen_variant(&self) -> Option<TemplateKeyVariant> {
+        self.state.as_ref().map(|s| s.variant)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::RawExternalSorter;
+    use crate::inline::InMemoryChunk;
+    use crate::keys::{RawCoordinateKey, SortOrder};
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    /// Build `n` coordinate records at descending positions on tid 0, so a
+    /// correct sort must reorder them to ascending position.
+    fn descending_pos_records(n: usize) -> Vec<Vec<u8>> {
+        (0..n)
+            .map(|i| {
+                let pos = i32::try_from(n - 1 - i).expect("pos fits i32");
+                let name = format!("r{i:05}");
+                make_bam_bytes(0, pos, 0, name.as_bytes(), &[], 80, -1, -1, &[])
+            })
+            .collect()
+    }
+
+    /// Assert a chunk's keys are non-decreasing (each chunk is a sorted run).
+    fn assert_chunk_sorted(chunk: &InMemoryChunk<RawCoordinateKey>) {
+        for i in 1..chunk.len() {
+            assert!(
+                chunk.key_at(i - 1).cmp(chunk.key_at(i)).is_le(),
+                "chunk not sorted by coordinate key"
+            );
+        }
+    }
+
+    /// A generous memory limit keeps everything in one residual chunk; `push`
+    /// never signals full, and the single chunk is fully sorted.
+    #[test]
+    fn no_spill_single_sorted_residual_chunk() {
+        let records = descending_pos_records(500);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+
+        for r in &records {
+            assert!(!sorter.push(r).expect("push"), "no spill expected under a large memory limit");
+        }
+        let residual = sorter.take_sorted_chunk();
+        assert_eq!(residual.len(), records.len(), "residual must hold every record");
+        assert_chunk_sorted(&residual);
+        assert_eq!(sorter.total_records(), records.len() as u64);
+        assert!(sorter.buffer_is_empty(), "buffer cleared after take");
+    }
+
+    /// A tiny memory limit forces mid-stream spill chunks; every chunk is a
+    /// sorted run and the union covers all records exactly once.
+    #[test]
+    fn tiny_limit_emits_multiple_sorted_chunks_covering_all_records() {
+        let records = descending_pos_records(2_000);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(16 * 1024) // tiny → frequent spills
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+
+        let mut chunks = Vec::new();
+        for r in &records {
+            if sorter.push(r).expect("push") {
+                let chunk = sorter.take_sorted_chunk();
+                assert!(!chunk.is_empty());
+                assert_chunk_sorted(&chunk);
+                chunks.push(chunk);
+            }
+        }
+        let residual = sorter.take_sorted_chunk();
+        if !residual.is_empty() {
+            assert_chunk_sorted(&residual);
+            chunks.push(residual);
+        }
+
+        assert!(chunks.len() >= 2, "tiny limit should force at least one spill plus residual");
+        // Assert identity, not just count: a spill path that drops record A and
+        // duplicates B keeps the total unchanged, so compare the multiset of
+        // record bytes across all chunks against the input.
+        let mut seen: Vec<Vec<u8>> = chunks
+            .iter()
+            .flat_map(|c| (0..c.len()).map(move |i| c.record_bytes(i).to_vec()))
+            .collect();
+        seen.sort();
+        let mut expected: Vec<Vec<u8>> = records.clone();
+        expected.sort();
+        assert_eq!(seen, expected, "chunk union must equal the input set (no drops/dups)");
+    }
+
+    /// Equal-key stability: when every record shares one coordinate, the global
+    /// stable `par_sort` must emit them in input order. This is the
+    /// output-identity-critical tie-break the single-residual design relies on
+    /// (vs samtools sort), so pin it directly — not just sortedness.
+    #[test]
+    fn equal_keys_preserve_input_order_within_chunk() {
+        // All at tid 0, pos 0 → identical coordinate key; distinct names make
+        // each record's bytes unique so input order is observable.
+        let records: Vec<Vec<u8>> = (0..400)
+            .map(|i| {
+                let name = format!("r{i:05}");
+                make_bam_bytes(0, 0, 0, name.as_bytes(), &[], 60, -1, -1, &[])
+            })
+            .collect();
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        for r in &records {
+            assert!(!sorter.push(r).expect("push"));
+        }
+        let chunk = sorter.take_sorted_chunk();
+        assert_eq!(chunk.len(), records.len());
+        for (i, rec) in records.iter().enumerate() {
+            assert_eq!(
+                chunk.record_bytes(i),
+                rec.as_slice(),
+                "equal-key record {i} emerged out of input order"
+            );
+        }
+    }
+
+    /// `--key-types` is honored in the buffer path: dropping the tertiary (MI)
+    /// lane and then feeding a record whose MI differs from the first record's is
+    /// rejected with the same actionable error the batch `sort()` path produces.
+    /// (Pre-P6 the streaming production path skipped this validation entirely.)
+    #[test]
+    fn template_chunk_sorter_rejects_dropped_lane_violation() {
+        use crate::external::KeyTypesSpec;
+
+        // Raw BAM aux for `MI:i:<v>` (tag bytes + 'i' type + i32 LE value).
+        fn mi_aux(v: i32) -> Vec<u8> {
+            let mut a = vec![b'M', b'I', b'i'];
+            a.extend_from_slice(&v.to_le_bytes());
+            a
+        }
+
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::None) // drop all optional lanes incl. tertiary/MI
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+
+        let r1 = make_bam_bytes(0, 10, 0, b"r1", &[], 40, -1, -1, &mi_aux(1));
+        let r2 = make_bam_bytes(0, 10, 0, b"r2", &[], 40, -1, -1, &mi_aux(2));
+        assert!(!sorter.push(&r1).expect("first push provisions the variant"));
+        let err =
+            sorter.push(&r2).expect_err("a differing MI under --key-types none must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MI") && msg.contains("--key-types mi"),
+            "unexpected dropped-lane error: {msg}"
+        );
+    }
+
+    /// With a consistent input (the dropped lanes are constant), `--key-types`
+    /// validation passes and the sort proceeds — the common case.
+    #[test]
+    fn template_chunk_sorter_accepts_constant_dropped_lanes() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::None)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build");
+        // No optional lanes present at all → nothing to violate.
+        for i in 0..200i32 {
+            let pos = 200 - i;
+            let rec = make_bam_bytes(0, pos, 0, format!("r{i}").as_bytes(), &[], 40, -1, -1, &[]);
+            sorter.push(&rec).expect("constant (absent) dropped lanes accepted");
+        }
+        assert_eq!(sorter.take_sorted_chunk().len(), 200);
+    }
+
+    /// Plain template records (no cell barcode, no MI, single library) under
+    /// `Auto` select the narrowest 3-lane [`TemplateKey24`] variant — confirming
+    /// the radix sort runs on the narrowed key, not the full key — while still
+    /// producing a correctly ordered chunk keyed by the full [`TemplateKey`].
+    #[test]
+    fn template_chunk_sorter_selects_narrow_variant_without_cb_or_mi() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .key_types(KeyTypesSpec::Auto)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+        assert!(sorter.chosen_variant().is_none(), "no variant before the first push");
+
+        // Descending positions on tid 0 → a correct sort reorders to ascending.
+        for i in 0..300i32 {
+            let pos = 300 - i;
+            let rec =
+                make_bam_bytes(0, pos, 0, format!("r{i:05}").as_bytes(), &[], 40, -1, -1, &[]);
+            sorter.push(&rec).expect("plain record accepted");
+        }
+
+        let variant = sorter.chosen_variant().expect("variant provisioned on first push");
+        assert_eq!(
+            variant.lanes(),
+            3,
+            "no cb / no MI / single library must narrow to the 3-lane TemplateKey24"
+        );
+
+        let chunk = sorter.take_sorted_chunk_owned();
+        assert_eq!(chunk.len(), 300, "every record retained");
+        for w in chunk.windows(2) {
+            assert!(
+                w[0].0.cmp(&w[1].0).is_le(),
+                "narrow-key sort must yield a full-key-ordered chunk"
+            );
+        }
+    }
+
+    /// Output-identity: the narrowed-key (3-lane `TemplateKey24`) sort must emit
+    /// byte-identical record order to the full-key (5-lane `TemplateKey40`) sort,
+    /// **including equal-key ties** — template-coordinate order is
+    /// output-identity-critical, so pin identity, not just sortedness. The input
+    /// deliberately contains records sharing a full template key (same tid / pos /
+    /// name) but differing in a non-key field (mapq), so a stable sort must keep
+    /// each tie group in input order under both key widths.
+    #[test]
+    fn template_chunk_sorter_narrow_matches_full_key_order() {
+        use crate::external::KeyTypesSpec;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1; // 8 distinct positions → coordinate-level ties
+            let name = format!("t{:03}", i % 30); // 30 names → full-key ties within a pos
+            for seq_len in [20usize, 40usize] {
+                // Same (tid, pos, name) but distinct seq length → identical
+                // template key, distinct bytes: an observable equal-key tie.
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        let sort_with = |key_types: KeyTypesSpec| -> (usize, Vec<Vec<u8>>) {
+            let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build template chunk sorter");
+            for r in &records {
+                sorter.push(r).expect("push");
+            }
+            let lanes = sorter.chosen_variant().expect("variant provisioned").lanes();
+            let out = sorter
+                .take_sorted_chunk_owned()
+                .into_iter()
+                .map(|(_, rec)| rec.as_ref().to_vec())
+                .collect();
+            (lanes, out)
+        };
+
+        let (narrow_lanes, narrow) = sort_with(KeyTypesSpec::Auto);
+        let (full_lanes, full) = sort_with(KeyTypesSpec::Full);
+        assert_eq!(narrow_lanes, 3, "Auto over cb/MI-free data must narrow to TemplateKey24");
+        assert_eq!(full_lanes, 5, "Full must force the 5-lane TemplateKey40");
+        assert_eq!(narrow.len(), records.len(), "every record retained");
+        assert_eq!(
+            narrow, full,
+            "narrowed-key sort must emit byte-identical record order (incl. equal-key ties) \
+             to the full-key sort"
+        );
+    }
+
+    /// Byte-parity oracle: the arena-backed production drain
+    /// (`take_sorted_chunk`, zero body copies) must produce byte-for-byte the
+    /// same sorted (full-key, body) sequence as the owned `materialize_full`
+    /// path (`take_sorted_chunk_owned`). Same records + the same deterministic stable
+    /// radix on two identical sorters ⇒ identical output, so any divergence in
+    /// the arena offset math, full-key re-extraction, or ordering fails here.
+    /// Exercises equal-key ties (same tid/pos/name, distinct seq length) under
+    /// both the narrowed (`Auto` → `TemplateKey24`) and full (`Full` →
+    /// `TemplateKey40`) key widths.
+    #[test]
+    fn template_arena_drain_matches_owned_materialize() {
+        use crate::external::KeyTypesSpec;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1;
+            let name = format!("t{:03}", i % 30);
+            for seq_len in [20usize, 40usize] {
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        let build = |key_types: KeyTypesSpec| {
+            RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build template chunk sorter")
+        };
+
+        for key_types in [KeyTypesSpec::Auto, KeyTypesSpec::Full] {
+            let mut owned_sorter = build(key_types);
+            let mut arena_sorter = build(key_types);
+            for r in &records {
+                owned_sorter.push(r).expect("push owned");
+                arena_sorter.push(r).expect("push arena");
+            }
+            let owned = owned_sorter.take_sorted_chunk_owned();
+            let arena = arena_sorter.take_sorted_chunk();
+
+            assert_eq!(arena.len(), owned.len(), "record count must match ({key_types:?})");
+            assert_eq!(owned.len(), records.len(), "every record retained ({key_types:?})");
+            for (i, (key, rec)) in owned.iter().enumerate() {
+                assert_eq!(
+                    arena.key_at(i),
+                    key,
+                    "full key at {i} must match owned path ({key_types:?})"
+                );
+                assert_eq!(
+                    arena.record_bytes(i),
+                    rec.as_ref(),
+                    "record bytes at {i} must be byte-identical to owned path ({key_types:?})"
+                );
+            }
+        }
+    }
+
+    /// Byte-parity: the arena-front `TemplateArenaAccumulator` must produce the
+    /// same sorted (full-key, body) sequence as the owned `TemplateChunkSorter`
+    /// — same library/CB provisioning, same `--key-types` narrowed-lane radix,
+    /// same full-key re-extraction — for a mix of tied and distinct keys, under
+    /// both the narrowed (`Auto` → `TemplateKey24`) and full (`Full` →
+    /// `TemplateKey40`) widths. This pins the arena front (Inc 3) to the legacy
+    /// path before it is wired into the pipeline.
+    #[test]
+    #[allow(unsafe_code)]
+    fn template_arena_accumulator_matches_owned_sorter() {
+        use crate::arena_pool::PooledSegmentedBuf;
+        use crate::external::KeyTypesSpec;
+        use crate::segmented_buf::SegmentedBuf;
+        use crate::template_arena::TemplateArenaAccumulator;
+        use std::sync::Arc;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1;
+            let name = format!("t{:03}", i % 30);
+            for seq_len in [20usize, 40usize] {
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        for key_types in [KeyTypesSpec::Auto, KeyTypesSpec::Full] {
+            // ---- Owned oracle ----
+            let mut owned = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build owned template sorter");
+            for r in &records {
+                owned.push(r).expect("owned push");
+            }
+            let owned_chunk = owned.take_sorted_chunk_owned();
+
+            // ---- Arena accumulator (bodies resident in a shared arena) ----
+            let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+            arena.reserve_full_capacity();
+            let mut acc =
+                TemplateArenaAccumulator::from_header(&Header::default(), None, key_types);
+            for r in &records {
+                // SAFETY: each slot is fully written (copy_from_slice) before any read.
+                let off = unsafe { arena.grow_uninit(r.len()) };
+                unsafe { arena.slice_mut(off, r.len()) }.copy_from_slice(r);
+                acc.push(r, off as u64, u32::try_from(r.len()).unwrap()).expect("arena push");
+            }
+            let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+            let arena_chunk = acc.seal(arena_arc, 2);
+
+            assert_eq!(arena_chunk.len(), owned_chunk.len(), "record count ({key_types:?})");
+            assert_eq!(owned_chunk.len(), records.len(), "every record retained ({key_types:?})");
+            // Byte-parity is the invariant: the arena chunk's records, in sorted
+            // order, must be byte-identical to the owned oracle's. The arena chunk
+            // now carries the chosen narrow lane key (variant-agnostic here), and
+            // narrow-lane order equals full-key order, so record order matches the
+            // owned full-key sort exactly.
+            for (i, (_key, rec)) in owned_chunk.iter().enumerate() {
+                assert_eq!(
+                    arena_chunk.record_bytes(i),
+                    rec.as_ref(),
+                    "record body at {i} must be byte-identical to owned path ({key_types:?})"
+                );
+            }
+        }
+    }
+
+    /// An empty template stream never builds a buffer and yields an empty
+    /// residual (the lazy `Option<TemplateBuffer>` stays `None`).
+    #[test]
+    fn template_chunk_sorter_empty_stream_yields_empty_residual() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::Auto)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+        assert!(sorter.take_sorted_chunk().is_empty());
+        assert_eq!(sorter.total_records(), 0);
+        assert!(sorter.chosen_variant().is_none(), "no push → no variant");
+    }
+
+    /// An empty stream yields an empty residual (the caller emits no chunk).
+    #[test]
+    fn empty_stream_yields_empty_residual() {
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        assert!(sorter.take_sorted_chunk().is_empty());
+        assert_eq!(sorter.total_records(), 0);
+    }
+}

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -233,6 +233,7 @@ pub fn cb_hasher() -> ahash::RandomState {
 ///
 /// Pre-computes ordinals by sorting library names alphabetically.
 /// Empty/unknown library sorts first (ordinal 0).
+#[derive(Clone)]
 pub struct LibraryLookup {
     /// RG ID -> library ordinal
     rg_to_ordinal: HashMap<Vec<u8>, u32>,
@@ -795,8 +796,11 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 /// individual `RawRecord`s and produces `Owned` chunks — the
 /// per-record allocation is sunk cost, so we preserve the original
 /// zero-copy `mem::swap` merge bridge.
-pub(crate) enum MemorySources<K: RawSortKey + Default + 'static> {
+pub enum MemorySources<K: RawSortKey + Default + 'static> {
+    /// Inline-buffer (coordinate / template) residual chunks sharing an
+    /// `Arc<SegmentedBuf>` — zero per-record allocation.
     Shared(Vec<InMemoryChunk<K>>),
+    /// Queryname-style residual chunks (each record an owned `RawRecord`).
     Owned(Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>),
 }
 
@@ -1402,185 +1406,117 @@ impl RawExternalSorter {
         self.sort_order
     }
 
-    /// Convert this configured sorter into a streaming coordinate-sort handle.
+    /// The configured cell-barcode tag (template-coordinate CB hashing), if any.
+    /// Read when building a record-input arena strategy so it matches the
+    /// block-input template strategy exactly.
+    #[must_use]
+    pub fn cell_tag_value(&self) -> Option<SamTag> {
+        self.cell_tag
+    }
+
+    /// The configured `--key-types` narrowing spec (template-coordinate only).
+    #[must_use]
+    pub fn key_types_spec(&self) -> KeyTypesSpec {
+        self.key_types
+    }
+
+    /// The configured in-memory sort budget in bytes (per-run seal threshold).
+    #[must_use]
+    pub fn memory_limit_bytes(&self) -> usize {
+        self.memory_limit
+    }
+
+    /// The configured sort thread count (per-chunk parallel sort width).
+    #[must_use]
+    pub fn num_threads(&self) -> usize {
+        self.threads
+    }
+
+    /// Convert this configured sorter into a lean coordinate buffering sorter
+    /// for the P6 `SortBuffer` step.
     ///
-    /// The returned [`CoordinateSortStream`] ingests records via `push_record`
-    /// / `push_records`, spilling internally as the buffer crosses
-    /// `memory_limit`, and is finalized by the typed-step pipeline via
-    /// `into_slot_setup`. Gated on `SortOrder::Coordinate`; see
-    /// [`Self::into_queryname_stream`] / [`Self::into_template_coordinate_stream`]
-    /// for the other orders.
+    /// Same buffer sizing / rayon pool as the retired `into_coordinate_stream`,
+    /// but with **no** `SortWorkerPool`, temp dirs, or spill files — the
+    /// `SortBuffer` step only ingests + par-sorts + materializes chunks; the
+    /// `CompressSpill` step owns compression and disk I/O.
     ///
     /// # Errors
     ///
-    /// Returns an error if `self.sort_order` is not `Coordinate`, if the temp
-    /// directories cannot be created, or if the rayon sort pool cannot be built.
-    pub fn into_coordinate_stream(self, header: &Header) -> Result<CoordinateSortStream> {
+    /// Returns an error if `self.sort_order` is not `Coordinate`, the reference
+    /// count exceeds `u32::MAX`, or the rayon sort pool cannot be built.
+    pub fn into_coordinate_chunk_sorter(
+        self,
+        header: &Header,
+    ) -> Result<crate::chunk_sorter::CoordinateChunkSorter> {
         anyhow::ensure!(
             matches!(self.sort_order, SortOrder::Coordinate),
-            "into_coordinate_stream requires SortOrder::Coordinate (got {:?}); \
-             queryname / template-coordinate streaming entry points are forthcoming",
+            "into_coordinate_chunk_sorter requires SortOrder::Coordinate (got {:?})",
             self.sort_order,
         );
-        self.ensure_spill_codec_compat()?;
-
-        // Spill codec from config (zstd by default, the same fast codec
-        // standalone sort uses). `SortSpillDecompress` is codec-aware — it
-        // detects each spill chunk's codec from its file magic (see
-        // `slots_for_chunk_files`) and dispatches accordingly — so the streaming
-        // path no longer has to pin BGZF.
-        // Phase 1 (streaming) is capped by --sort-threads; this pool is Phase-1-only (dropped at finalize).
-        let pool = Arc::new(SortWorkerPool::new(
-            self.phase1_threads(),
-            self.temp_compression,
-            self.output_compression,
-            self.spill_codec,
-        ));
-        // Phase 1 is the steady-state ingest mode for incoming records.
-        pool.set_phase(crate::worker_pool::phase::PHASE1);
-
-        let (temp_dirs, alloc) = self.create_temp_dirs()?;
         let rayon_pool = self.build_sort_rayon_pool()?;
-
-        // The output header is owned by the chain builder (it injects @PG and the
-        // sort order onto the sink header); this stream's copy is used only to size
-        // the record buffer (nref), so it is not @PG-augmented here.
-        let header = header.clone();
-
-        // Estimate buffer capacity from initial_capacity (matching sort_coordinate_optimized).
         let nref = u32::try_from(header.reference_sequences().len())
             .context("reference sequence count exceeds u32::MAX")?;
         let init_cap = self.effective_initial_capacity();
-        // Per-record footprint: ~200 bytes BAM + 16 header + 24 ref = ~240 bytes
+        // Per-record footprint estimate matches `into_coordinate_stream`.
         let estimated_records = init_cap / 240;
-        let estimated_data_bytes = init_cap.saturating_sub(estimated_records * 24);
-        let buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
-
-        Ok(CoordinateSortStream {
-            sorter: self,
-            pool,
-            _temp_dirs: temp_dirs,
-            alloc,
-            namer_chunk_count: 0,
-            namer_merge_count: 0,
-            chunk_files: Vec::new(),
+        // The data arena comes from the `ArenaPool` (acquired on the first
+        // `ensure_arena`), so the buffer starts with NO pre-allocated data
+        // segment (0 bytes) — only the refs Vec is pre-sized.
+        let buffer = RecordBuffer::with_capacity(estimated_records, 0, nref);
+        // Bounded reusable-arena pool (lever-1 RSS fix). Capacity 1 = legacy's
+        // one-arena-at-a-time footprint: the next chunk cannot fill until the
+        // prior chunk is spilled and its arena returns, bounding peak RSS to
+        // ~one arena ≈ base. (Tunable via `--sort-arenas` in a later increment.)
+        let arena_pool = crate::arena_pool::ArenaPool::new(1, crate::inline::SORT_SEGMENT_SIZE);
+        Ok(crate::chunk_sorter::CoordinateChunkSorter::new(
             buffer,
-            pending_spill: None,
             rayon_pool,
-            header,
-            stats: RawSortStats::default(),
-            timer: SortPhaseTimer::new(),
-            progress: ProgressTracker::new("Read records").with_interval(1_000_000),
-            probe: SpillProbe::new("phase1"),
-            finalized: false,
-        })
+            self.memory_limit,
+            arena_pool,
+        ))
     }
 
-    /// Convert this configured sorter into a streaming
-    /// template-coordinate-sort handle.
-    ///
-    /// Same shape as [`Self::into_coordinate_stream`] but uses
-    /// `TemplateRecordBuffer` and the template key (which incorporates
-    /// library, cell barcode, and MI in addition to coordinates).
+    /// Convert this configured sorter into a lean template-coordinate buffering
+    /// sorter for the P6 `SortBuffer` step (the template analogue of
+    /// [`Self::into_coordinate_chunk_sorter`] — same sizing as the retired
+    /// `into_template_coordinate_stream`, minus the pool/temp-dirs).
     ///
     /// # Errors
     ///
-    /// Returns an error if `self.sort_order` is not `TemplateCoordinate`,
-    /// if the temp directories cannot be created, or if the rayon sort
-    /// pool cannot be built.
-    pub fn into_template_coordinate_stream(
+    /// Returns an error if `self.sort_order` is not `TemplateCoordinate` or the
+    /// rayon sort pool cannot be built.
+    pub fn into_template_chunk_sorter(
         self,
         header: &Header,
-    ) -> Result<TemplateCoordinateSortStream> {
+    ) -> Result<crate::chunk_sorter::TemplateChunkSorter> {
         anyhow::ensure!(
             matches!(self.sort_order, SortOrder::TemplateCoordinate),
-            "into_template_coordinate_stream requires SortOrder::TemplateCoordinate (got {:?})",
+            "into_template_chunk_sorter requires SortOrder::TemplateCoordinate (got {:?})",
             self.sort_order,
         );
-        self.ensure_spill_codec_compat()?;
-
-        // Spill codec from config (see `into_coordinate_stream`): the streaming
-        // decoder is codec-aware, so honor `self.spill_codec` (zstd default).
-        // Phase 1 (streaming) is capped by --sort-threads; this pool is Phase-1-only (dropped at finalize).
-        let pool = Arc::new(SortWorkerPool::new(
-            self.phase1_threads(),
-            self.temp_compression,
-            self.output_compression,
-            self.spill_codec,
-        ));
-        pool.set_phase(crate::worker_pool::phase::PHASE1);
-
-        let (temp_dirs, alloc) = self.create_temp_dirs()?;
         let rayon_pool = self.build_sort_rayon_pool()?;
-
-        // Output header owned by the chain builder; stream copy used only for nref.
-        let header = header.clone();
-
-        let lib_lookup = LibraryLookup::from_header(&header);
+        let lib_lookup = LibraryLookup::from_header(header);
+        let header_library_varies = lib_lookup.distinct_header_ordinals() > 1;
         let cb_hasher = cb_hasher();
-
+        // Capacity hints for the lazily-built narrowed-key buffer. The variant
+        // (and thus the exact key width) is not known until the first record, so
+        // a key-width-agnostic estimate is used (the per-K ref-size difference is
+        // immaterial for a capacity hint).
         let init_cap = self.effective_initial_capacity();
         let bytes_per_record = 354;
         let estimated_records = init_cap / bytes_per_record;
         let estimated_data_bytes = init_cap * 86 / 100;
-        let buffer = TemplateRecordBuffer::with_capacity(estimated_records, estimated_data_bytes);
-
-        Ok(TemplateCoordinateSortStream {
-            sorter: self,
-            pool,
-            _temp_dirs: temp_dirs,
-            alloc,
-            namer_chunk_count: 0,
-            namer_merge_count: 0,
-            chunk_files: Vec::new(),
-            buffer,
-            pending_spill: None,
+        Ok(crate::chunk_sorter::TemplateChunkSorter::new(
             rayon_pool,
-            header,
+            self.memory_limit,
+            estimated_records,
+            estimated_data_bytes,
             lib_lookup,
             cb_hasher,
-            stats: RawSortStats::default(),
-            timer: SortPhaseTimer::new(),
-            progress: ProgressTracker::new("Read records").with_interval(1_000_000),
-            probe: SpillProbe::new("phase1"),
-            finalized: false,
-        })
-    }
-
-    /// Convert this configured sorter into a streaming queryname-sort handle.
-    ///
-    /// Same shape as [`Self::into_coordinate_stream`] but for queryname-order
-    /// sorts. The returned [`QuerynameSortStream`] is an enum dispatching to
-    /// the lex / natural variants based on `self.sort_order`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `self.sort_order` is not `Queryname(_)`, if the
-    /// temp directories cannot be created, or if the rayon sort pool cannot
-    /// be built.
-    pub fn into_queryname_stream(self, header: &Header) -> Result<QuerynameSortStream> {
-        use crate::keys::{QuerynameComparator, RawQuerynameKey, RawQuerynameLexKey};
-
-        let comparator = match self.sort_order {
-            SortOrder::Queryname(c) => c,
-            other => {
-                anyhow::bail!("into_queryname_stream requires SortOrder::Queryname (got {other:?})")
-            }
-        };
-
-        match comparator {
-            QuerynameComparator::Lexicographic => {
-                let inner = QuerynameSortStreamGeneric::<RawQuerynameLexKey>::new_from_sorter(
-                    self, header,
-                )?;
-                Ok(QuerynameSortStream::Lex(inner))
-            }
-            QuerynameComparator::Natural => {
-                let inner =
-                    QuerynameSortStreamGeneric::<RawQuerynameKey>::new_from_sorter(self, header)?;
-                Ok(QuerynameSortStream::Natural(inner))
-            }
-        }
+            self.cell_tag,
+            self.key_types,
+            header_library_varies,
+        ))
     }
 
     /// Create a new raw external sorter with the given sort order.
@@ -1667,7 +1603,12 @@ impl RawExternalSorter {
     }
 
     /// Effective Phase-1 worker count: `sort_threads` if set, else `threads`.
-    fn phase1_threads(&self) -> usize {
+    ///
+    /// Public so the streaming arena front (`SortBuffer::from_sorter`) sizes its
+    /// per-chunk sort with the resolved `--sort-threads` override rather than the
+    /// raw base `--threads` (`num_threads`), which silently ignores the override.
+    #[must_use]
+    pub fn phase1_threads(&self) -> usize {
         self.sort_threads.unwrap_or(self.threads).max(1)
     }
 
@@ -1701,8 +1642,8 @@ impl RawExternalSorter {
 
     /// Set the codec used for temporary chunk files.
     ///
-    /// Defaults to [`SpillCodec::Zstd`] which is significantly faster than
-    /// BGZF at comparable ratios for BAM-record data.
+    /// Defaults to [`SpillCodec::Zstd`](crate::codec::SpillCodec::Zstd) which is
+    /// significantly faster than BGZF at comparable ratios for BAM-record data.
     #[must_use]
     pub fn spill_codec(mut self, codec: crate::codec::SpillCodec) -> Self {
         self.spill_codec = codec;
@@ -3131,6 +3072,22 @@ impl RawExternalSorter {
         super::create_output_header(self.sort_order, header)
     }
 
+    /// Create the spill temp dirs + allocator for the P6 `CompressSpill` step.
+    ///
+    /// Public wrapper over [`Self::create_temp_dirs`]: honors `--temp-dir` /
+    /// `FGUMI_TMP_DIRS` (the configured `temp_dirs`) exactly as the legacy
+    /// streaming path does. The caller hands the [`Vec<TempDir>`] RAII handles to
+    /// `CompressSpill` (held for the step's lifetime) and the [`TmpDirAllocator`]
+    /// behind a shared mutex for per-file base-dir allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a temp directory cannot be created or has insufficient
+    /// free space.
+    pub fn create_spill_dirs(&self) -> Result<(Vec<TempDir>, TmpDirAllocator)> {
+        self.create_temp_dirs()
+    }
+
     /// Create per-base temp directories and an allocator over their subdirs.
     ///
     /// For each user-supplied base directory, a fresh sort-run subdirectory is
@@ -3554,7 +3511,7 @@ pub fn verify_dropped_lanes(
 }
 
 /// Build the actionable error message for a dropped-lane violation.
-fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
+pub(crate) fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
     let field = match v {
         DroppedLaneViolation::Cb => "CB",
         DroppedLaneViolation::Mi => "MI",
@@ -3567,963 +3524,55 @@ fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
     )
 }
 
-/// Output of `*SortStream::into_slot_setup` — the raw materials a typed
-/// pipeline `SortMerge` step needs to build a slot-backed `MergeDriver`.
+/// Open `path` as a single [`SortMergeSlot`] with the given `file_id`.
 ///
-/// Produced by [`CoordinateSortStream::into_slot_setup`],
-/// [`TemplateCoordinateSortStream::into_slot_setup`], and
-/// [`QuerynameSortStreamGeneric::into_slot_setup`]. The caller (the
-/// unified-pipeline `SortAndSpill` step) decomposes this into
-/// `SortPhase1Event::SpillReady` events (one per slot) and
-/// `SortPhase1Event::MemoryChunk` events (one per memory chunk).
-pub struct SlotSetup<K: RawSortKey + Default + Send + 'static> {
-    /// One per spill file. Each slot owns a fresh `BufReader<File>`
-    /// positioned at byte 0 of the spill chunk.
-    pub slots: Vec<Arc<SortMergeSlot>>,
-    /// Already-sorted in-memory residual chunks (the par-sorted residual
-    /// buffer; one chunk for the in-memory fast path, multiple sub-chunks
-    /// for `par_sort_into_chunks` at multi-thread external-merge).
-    pub memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
-    /// RAII tempdir handles. Must outlive the slots' readers (the spill
-    /// files live inside these directories). The caller stashes them
-    /// somewhere with a lifetime that exceeds the merge phase.
-    pub temp_dirs: Vec<TempDir>,
-    /// `RawSortStats::total_records` at the moment ingestion completed.
-    /// Carried so the `SortAndSpill` step can stamp it on emitted events.
-    pub total_records: u64,
-}
-
-/// Helper: open the spill `chunk_files` as `Arc<SortMergeSlot>`s with
-/// sequential `file_id`s. Returns an error if any file fails to open.
-fn slots_for_chunk_files(chunk_files: &[std::path::PathBuf]) -> Result<Vec<Arc<SortMergeSlot>>> {
-    chunk_files
-        .iter()
-        .enumerate()
-        .map(|(idx, path)| {
-            let mut file = std::fs::File::open(path)
-                .with_context(|| format!("failed to open spill chunk {}", path.display()))?;
-            // Detect the spill codec from the file magic. For zstd ("ZSP1") the
-            // 4-byte magic is consumed here, leaving the reader at the first
-            // `[len][frame]` record; for BGZF the `1f 8b` is part of the first
-            // block, so rewind to byte 0. `SortSpillDecompress` reads
-            // `slot.codec` to decompress accordingly.
-            let mut magic = [0u8; 4];
-            let filled = read_exact_or_eof(&mut file, &mut magic)
-                .with_context(|| format!("failed to read spill chunk magic {}", path.display()))?;
-            let codec = if filled {
-                crate::codec::SpillCodec::from_magic(&magic)
-                    .unwrap_or(crate::codec::SpillCodec::Bgzf)
-            } else {
-                crate::codec::SpillCodec::Bgzf
-            };
-            if matches!(codec, crate::codec::SpillCodec::Bgzf) {
-                use std::io::Seek;
-                file.seek(std::io::SeekFrom::Start(0))
-                    .with_context(|| format!("failed to rewind spill chunk {}", path.display()))?;
-            }
-            let reader = std::io::BufReader::new(file);
-            let file_id = u32::try_from(idx)
-                .with_context(|| format!("spill file_id {idx} exceeds u32::MAX"))?;
-            Ok(Arc::new(SortMergeSlot::new(file_id, reader, codec)))
-        })
-        .collect()
-}
-
-/// Materialize main's `Vec<InMemoryChunk<K>>` (the `par_sort_into_chunks`
-/// output, whose records borrow a shared `SegmentedBuf`) into the
-/// `Vec<Vec<(K, RawRecord)>>` shape the typed-step merge protocol carries.
+/// The spill codec is auto-detected from the file magic: for zstd (`ZSP1`) the
+/// 4-byte magic is consumed here, leaving the reader at the first `[len][frame]`
+/// record; for BGZF the `1f 8b` is part of the first block, so the reader is
+/// rewound to byte 0. `SortSpillDecompress` reads `slot.codec` to decompress
+/// accordingly.
 ///
-/// The streaming pipeline path needs owned per-record `RawRecord`s because the
-/// memory chunks flow across `SortPhase1Event`/`SortPhase2Event` to a separate
-/// `SortMerge` step (the `SegmentedBuf` Arc would otherwise pin the whole sort
-/// buffer in the merge step). This matches the #330 representation; the
-/// `InMemoryChunk` sharing optimization stays on main's standalone-sort path.
-fn inmem_chunks_to_keyed<K: Default>(
-    chunks: Vec<crate::inline::InMemoryChunk<K>>,
-) -> Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> {
-    chunks
-        .into_iter()
-        .map(|mut chunk| {
-            (0..chunk.len())
-                .map(|i| {
-                    let bytes = chunk.record_bytes(i).to_vec();
-                    let key = chunk.take_key(i);
-                    (key, fgumi_raw_bam::RawRecord::from(bytes))
-                })
-                .collect()
-        })
-        .collect()
+/// `file_id` is the slot's stable merge-order identifier — `SortMerge` orders
+/// sources by it so the `LoserTree` tie-break for equal sort keys matches the
+/// legacy chunk-files order. The P6 `CompressSpill` step passes a chunk's
+/// **logical spill index** here so the tie-break is independent of which worker
+/// happened to write the file.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened, its magic cannot be read, or
+/// (for BGZF) the rewind fails.
+pub fn open_spill_slot(path: &std::path::Path, file_id: u32) -> Result<Arc<SortMergeSlot>> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open spill chunk {}", path.display()))?;
+    let mut magic = [0u8; 4];
+    let filled = read_exact_or_eof(&mut file, &mut magic)
+        .with_context(|| format!("failed to read spill chunk magic {}", path.display()))?;
+    let codec = if filled {
+        crate::codec::SpillCodec::from_magic(&magic).unwrap_or(crate::codec::SpillCodec::Bgzf)
+    } else {
+        crate::codec::SpillCodec::Bgzf
+    };
+    if matches!(codec, crate::codec::SpillCodec::Bgzf) {
+        use std::io::Seek;
+        file.seek(std::io::SeekFrom::Start(0))
+            .with_context(|| format!("failed to rewind spill chunk {}", path.display()))?;
+    }
+    let reader = std::io::BufReader::new(file);
+    Ok(Arc::new(SortMergeSlot::new(file_id, reader, codec)))
 }
 
 // ============================================================================
 // CoordinateSortStream — streaming coordinate-sort handle
 // ============================================================================
 
-/// Streaming coordinate-sort handle. Constructed via
-/// [`RawExternalSorter::into_coordinate_stream`].
-///
-/// Push raw BAM records via [`Self::push_record`] one at a time; each push
-/// may opportunistically trigger an internal spill if the in-memory buffer
-/// crosses `memory_limit`. When input is drained, finalize via
-/// [`Self::into_slot_setup`], which returns the `SortMergeSlot`s + residual
-/// memory chunks for the typed-step `SortMerge` to drive.
-///
-/// Owns the per-sort `SortWorkerPool`, the temp-dir RAII handles (so spill
-/// files are cleaned up on drop), and all the per-sort buffer / progress
-/// state previously local to `sort_coordinate_optimized`. The
-/// `RawExternalSorter` itself is moved in for read-only access to its
-/// configuration.
-pub struct CoordinateSortStream {
-    /// Configuration source (`memory_limit`, `threads`, `max_temp_files`, etc.).
-    sorter: RawExternalSorter,
-    /// Shared worker pool for parallel spill compress/decompress.
-    pool: Arc<SortWorkerPool>,
-    /// RAII tempdir handles; kept alive until the stream is dropped so spill
-    /// files are cleaned up automatically.
-    _temp_dirs: Vec<TempDir>,
-    /// Allocates spill-file paths across one-or-more temp dirs.
-    alloc: TmpDirAllocator,
-    /// Persisted `ChunkNamer.chunk_count`. Re-attached to a fresh
-    /// `ChunkNamer` whenever we need to call `drain_pending_spill`.
-    namer_chunk_count: usize,
-    /// Persisted `ChunkNamer.merge_count`. Same role for consolidation paths.
-    namer_merge_count: usize,
-    chunk_files: Vec<PathBuf>,
-    buffer: RecordBuffer,
-    pending_spill: Option<PendingSpill>,
-    rayon_pool: rayon::ThreadPool,
-    /// Output BAM header (already augmented with `@PG` if `pg_info` was set).
-    header: Header,
-    stats: RawSortStats,
-    timer: SortPhaseTimer,
-    progress: ProgressTracker,
-    probe: SpillProbe,
-    /// Set after `into_slot_setup` runs; subsequent calls panic.
-    finalized: bool,
-}
-
-impl CoordinateSortStream {
-    /// Push one raw BAM record into the sort buffer. May trigger an
-    /// internal spill (buffer sort + write-to-disk) if the buffer crosses
-    /// `memory_limit`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the record cannot be parsed for the coordinate
-    /// key, if a spill write fails, or if a previous pending-spill drain
-    /// reports an error.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called after [`Self::into_slot_setup`] has consumed `self`.
-    pub fn push_record(&mut self, bam_bytes: &[u8]) -> Result<()> {
-        use crate::keys::RawCoordinateKey;
-
-        assert!(!self.finalized, "push_record called after into_slot_setup");
-
-        self.stats.total_records += 1;
-        self.progress.log_if_needed(1);
-
-        self.buffer.push_coordinate(bam_bytes)?;
-
-        if self.probe.should_sample_read(self.stats.total_records) {
-            self.probe
-                .log_mid_read(probe_stats(&self.buffer), Some(self.pool.phase1_queue_depths()));
-        }
-
-        if self.buffer.memory_usage() < self.sorter.memory_limit {
-            return Ok(());
-        }
-
-        // Spill threshold reached: drain previous pending spill, sort the
-        // current buffer, write a new spill chunk, and start a fresh buffer.
-        // This mirrors `sort_coordinate_optimized` line-for-line so the
-        // spill-pipeline behavior (start_finish + pending_spill overlap)
-        // is identical.
-        self.timer.end_read_span();
-        let bstats = probe_stats(&self.buffer);
-        let depths = Some(self.pool.phase1_queue_depths());
-        self.probe.pre_spill(bstats, depths);
-
-        // Borrow alloc + counters into a fresh ChunkNamer for the
-        // drain_pending_spill call (which may consolidate temp files).
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<RawCoordinateKey>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        let chunk_path = namer.next_chunk_path()?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-        // namer (which holds `&mut self.alloc`) goes out of scope at end of
-        // block, releasing the borrow before we touch self.buffer below.
-
-        self.probe.post_drain(probe_stats(&self.buffer), Some(self.pool.phase1_queue_depths()));
-
-        let buffer = &mut self.buffer;
-        let rayon_pool = &self.rayon_pool;
-        self.timer.time_sort(|| {
-            rayon_pool.install(|| buffer.par_sort());
-        });
-
-        let pool = &self.pool;
-        let buffer_ref = &self.buffer;
-        let chunk_path_clone = chunk_path.clone();
-        let handle = self.timer.time_spill_write(|| {
-            let mut writer = PooledChunkWriter::<RawCoordinateKey>::new(
-                Arc::clone(pool),
-                &chunk_path_clone,
-                pool.spill_codec(),
-            )?;
-            for r in buffer_ref.refs() {
-                let key = RawCoordinateKey { sort_key: r.sort_key };
-                let record_bytes = buffer_ref.get_record(r);
-                writer.write_record(&key, record_bytes)?;
-            }
-            writer.start_finish()
-        })?;
-
-        self.pending_spill = Some(PendingSpill { handle, chunk_path });
-
-        self.buffer.clear();
-        force_mi_collect();
-        self.probe.post_spill(Some(self.pool.phase1_queue_depths()));
-        self.timer.begin_read_span();
-
-        Ok(())
-    }
-
-    /// Push a batch of records via [`Self::push_record`] in one call.
-    ///
-    /// Identical semantics to invoking `push_record` per record — the
-    /// per-record work (sort-key extraction + buffer copy + memory-limit
-    /// check + opportunistic spill) still runs per record. The win is
-    /// the call-boundary savings at the typed-step caller (one
-    /// `SortInner` enum dispatch per batch instead of per record).
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::push_record`].
-    ///
-    /// # Panics
-    ///
-    /// Same as [`Self::push_record`].
-    pub fn push_records<'a, I: IntoIterator<Item = &'a [u8]>>(&mut self, iter: I) -> Result<()> {
-        for bytes in iter {
-            self.push_record(bytes)?;
-        }
-        Ok(())
-    }
-
-    /// Finalize the stream for the typed-step pipeline: return raw
-    /// `SortMergeSlot`s and memory chunks for a typed-step `SortMerge` to
-    /// drive. See [`SlotSetup`] for the output shape.
-    ///
-    /// Performs the same prologue (drain pending spill, par-sort residual
-    /// buffer matching legacy tie-break), but opens fresh `BufReader`s
-    /// for each spill chunk file inside the returned slots and skips
-    /// pool Phase 2 activation (slots are independent of the pool —
-    /// `SortSpillDecompress` will drive disk I/O via the slots' own
-    /// readers).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a pending-spill drain fails, the residual-buffer
-    /// sort fails, or a spill chunk file cannot be opened for its slot reader.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called twice on the same stream.
-    pub fn into_slot_setup(mut self) -> Result<SlotSetup<crate::keys::RawCoordinateKey>> {
-        use crate::keys::RawCoordinateKey;
-
-        assert!(!self.finalized, "into_slot_setup called twice");
-        self.finalized = true;
-
-        self.pool.set_main_thread(std::thread::current());
-        self.timer.end_read_span();
-
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<RawCoordinateKey>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-
-        self.probe.phase1_end(self.buffer.memory_usage() as u64);
-
-        // No-spill path uses `par_sort` (global sort) + parallel
-        // `par_iter` collect, producing ONE memory chunk. This keeps
-        // the downstream `MergeDriver::from_slots` LoserTree at a
-        // single source (no per-record heap comparisons in the merge
-        // hot path) while still parallelizing the per-record
-        // `RawRecord::from(...to_vec())` allocations across rayon
-        // threads (the dominant cost at 5M+ records). With-spill
-        // path keeps `par_sort_into_chunks` since merge is unavoidable
-        // there anyway (one source per spill file + memory chunks).
-        let memory_chunks: Vec<Vec<(RawCoordinateKey, fgumi_raw_bam::RawRecord)>> =
-            if self.buffer.is_empty() {
-                Vec::new()
-            } else if self.chunk_files.is_empty() {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                self.timer.time_sort(|| {
-                    rayon_pool.install(|| buffer.par_sort());
-                });
-                let chunk = rayon_pool.install(|| {
-                    use rayon::prelude::*;
-                    self.buffer
-                        .refs()
-                        .par_iter()
-                        .map(|r| {
-                            let key = RawCoordinateKey { sort_key: r.sort_key };
-                            let bytes = self.buffer.get_record(r);
-                            (key, fgumi_raw_bam::RawRecord::from(bytes.to_vec()))
-                        })
-                        .collect::<Vec<_>>()
-                });
-                vec![chunk]
-            } else if self.sorter.phase1_threads() > 1 {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                let threads = self.sorter.phase1_threads();
-                inmem_chunks_to_keyed(
-                    self.timer
-                        .time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(threads))),
-                )
-            } else {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                self.timer.time_sort(|| {
-                    rayon_pool.install(|| buffer.par_sort());
-                });
-                let chunk = self
-                    .buffer
-                    .refs()
-                    .iter()
-                    .map(|r| {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        (key, fgumi_raw_bam::RawRecord::from(self.buffer.get_record(r).to_vec()))
-                    })
-                    .collect();
-                vec![chunk]
-            };
-
-        let chunk_files = std::mem::take(&mut self.chunk_files);
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "_temp_dirs is RAII-only on the *SortStream; into_slot_setup hands ownership to the caller for the lifetime of the merge"
-        )]
-        let temp_dirs = std::mem::take(&mut self._temp_dirs);
-        let total_records = self.stats.total_records;
-        let slots = slots_for_chunk_files(&chunk_files)?;
-
-        Ok(SlotSetup { slots, memory_chunks, temp_dirs, total_records })
-    }
-}
-
 // ============================================================================
 // QuerynameSortStream — streaming queryname-sort handle (lex or natural)
 // ============================================================================
 
-/// Streaming queryname-sort handle. Constructed via
-/// [`RawExternalSorter::into_queryname_stream`].
-///
-/// Wraps the per-comparator generic [`QuerynameSortStreamGeneric`] so callers
-/// can hold a single concrete type regardless of the sub-order
-/// (lexicographic vs natural). Operations on the stream dispatch to the
-/// underlying generic via the inner enum variant.
-pub enum QuerynameSortStream {
-    /// Lexicographic comparator (default for `--order queryname`).
-    Lex(QuerynameSortStreamGeneric<crate::keys::RawQuerynameLexKey>),
-    /// Natural comparator (samtools-compatible).
-    Natural(QuerynameSortStreamGeneric<crate::keys::RawQuerynameKey>),
-}
-
-impl QuerynameSortStream {
-    /// Push one raw BAM record into the sort buffer. May trigger an
-    /// internal spill if the in-memory buffer crosses `memory_limit`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a spill write fails or a previous pending-spill
-    /// drain reports an error.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called after [`Self::into_slot_setup`] has consumed `self`.
-    pub fn push_record(&mut self, bam_bytes: &[u8]) -> Result<()> {
-        match self {
-            Self::Lex(s) => s.push_record(bam_bytes),
-            Self::Natural(s) => s.push_record(bam_bytes),
-        }
-    }
-
-    /// Push a batch of records via [`Self::push_record`] in one call.
-    /// See [`CoordinateSortStream::push_records`] for the rationale.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::push_record`].
-    ///
-    /// # Panics
-    ///
-    /// Same as [`Self::push_record`].
-    pub fn push_records<'a, I: IntoIterator<Item = &'a [u8]>>(&mut self, iter: I) -> Result<()> {
-        match self {
-            Self::Lex(s) => s.push_records(iter),
-            Self::Natural(s) => s.push_records(iter),
-        }
-    }
-}
-
-/// Generic queryname-sort stream over the comparator key type
-/// (`RawQuerynameLexKey` or `RawQuerynameKey`). Mirrors
-/// [`CoordinateSortStream`] but stores entries as `Vec<(K, RawRecord)>`
-/// instead of an inline arena, matching today's `sort_queryname_keyed`.
-pub struct QuerynameSortStreamGeneric<K: RawSortKey + Default + 'static> {
-    sorter: RawExternalSorter,
-    pool: Arc<SortWorkerPool>,
-    _temp_dirs: Vec<TempDir>,
-    alloc: TmpDirAllocator,
-    namer_chunk_count: usize,
-    namer_merge_count: usize,
-    chunk_files: Vec<PathBuf>,
-    entries: Vec<(K, fgumi_raw_bam::RawRecord)>,
-    memory_used: usize,
-    pending_spill: Option<PendingSpill>,
-    rayon_pool: rayon::ThreadPool,
-    header: Header,
-    ctx: crate::keys::SortContext,
-    stats: RawSortStats,
-    timer: SortPhaseTimer,
-    progress: ProgressTracker,
-    probe: SpillProbe,
-    finalized: bool,
-}
-
-impl<K: RawSortKey + Default + 'static> QuerynameSortStreamGeneric<K> {
-    /// Construct from a `RawExternalSorter` config. Caller (via
-    /// [`RawExternalSorter::into_queryname_stream`]) is responsible for
-    /// matching the `sort_order` to `K`.
-    fn new_from_sorter(sorter: RawExternalSorter, header: &Header) -> Result<Self> {
-        use crate::keys::SortContext;
-
-        sorter.ensure_spill_codec_compat()?;
-
-        // Spill codec from config (see `into_coordinate_stream`): the streaming
-        // decoder is codec-aware, so honor `sorter.spill_codec` (zstd default).
-        // Phase 1 (streaming) is capped by --sort-threads; this pool is Phase-1-only (dropped at finalize).
-        let pool = Arc::new(SortWorkerPool::new(
-            sorter.phase1_threads(),
-            sorter.temp_compression,
-            sorter.output_compression,
-            sorter.spill_codec,
-        ));
-        pool.set_phase(crate::worker_pool::phase::PHASE1);
-
-        let (temp_dirs, alloc) = sorter.create_temp_dirs()?;
-        let rayon_pool = sorter.build_sort_rayon_pool()?;
-
-        // Output header owned by the chain builder; stream copy used only for nref/ctx.
-        let header = header.clone();
-
-        let ctx = SortContext::from_header(&header);
-        let init_cap = sorter.effective_initial_capacity();
-        let estimated_records = init_cap / 300;
-
-        Ok(Self {
-            sorter,
-            pool,
-            _temp_dirs: temp_dirs,
-            alloc,
-            namer_chunk_count: 0,
-            namer_merge_count: 0,
-            chunk_files: Vec::new(),
-            entries: Vec::with_capacity(estimated_records),
-            memory_used: 0,
-            pending_spill: None,
-            rayon_pool,
-            header,
-            ctx,
-            stats: RawSortStats::default(),
-            timer: SortPhaseTimer::new(),
-            progress: ProgressTracker::new("Read records").with_interval(1_000_000),
-            probe: SpillProbe::new("phase1"),
-            finalized: false,
-        })
-    }
-
-    /// Push one raw BAM record. See [`QuerynameSortStream::push_record`].
-    ///
-    /// # Errors
-    ///
-    /// Propagates any spill-compression or I/O error that fires when the
-    /// in-memory buffer hits `memory_limit` and the chunk must be flushed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called after [`Self::into_slot_setup`] has finalized
-    /// the stream.
-    pub fn push_record(&mut self, bam_bytes: &[u8]) -> Result<()> {
-        assert!(!self.finalized, "push_record called after into_slot_setup");
-
-        self.stats.total_records += 1;
-        self.progress.log_if_needed(1);
-
-        let key = K::extract(bam_bytes, &self.ctx);
-        let record_size = bam_bytes.len() + 50; // approximate key overhead
-        self.memory_used += record_size;
-        self.entries.push((key, fgumi_raw_bam::RawRecord::from(bam_bytes.to_vec())));
-
-        if self.probe.should_sample_read(self.stats.total_records) {
-            let bstats =
-                BufferProbeStats::simple(self.memory_used as u64, self.entries.len() as u64);
-            self.probe.log_mid_read(bstats, Some(self.pool.phase1_queue_depths()));
-        }
-
-        if self.memory_used < self.sorter.memory_limit {
-            return Ok(());
-        }
-
-        // Spill threshold reached — same shape as sort_queryname_keyed.
-        self.timer.end_read_span();
-        let bstats = BufferProbeStats::simple(self.memory_used as u64, self.entries.len() as u64);
-        let depths = Some(self.pool.phase1_queue_depths());
-        self.probe.pre_spill(bstats, depths);
-
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<K>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        let chunk_path = namer.next_chunk_path()?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-
-        self.probe.post_drain(bstats, Some(self.pool.phase1_queue_depths()));
-
-        let entries = &mut self.entries;
-        let rayon_pool = &self.rayon_pool;
-        self.timer.time_sort(|| {
-            use rayon::prelude::*;
-            rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
-        });
-
-        let pool = &self.pool;
-        let entries_drain = &mut self.entries;
-        let chunk_path_clone = chunk_path.clone();
-        let handle = self.timer.time_spill_write(|| {
-            let mut writer = PooledChunkWriter::<K>::new(
-                Arc::clone(pool),
-                &chunk_path_clone,
-                pool.spill_codec(),
-            )?;
-            for (key, record) in entries_drain.drain(..) {
-                writer.write_record(&key, record.as_ref())?;
-            }
-            writer.start_finish()
-        })?;
-
-        self.pending_spill = Some(PendingSpill { handle, chunk_path });
-
-        self.memory_used = 0;
-        force_mi_collect();
-        self.probe.post_spill(Some(self.pool.phase1_queue_depths()));
-        self.timer.begin_read_span();
-
-        Ok(())
-    }
-
-    /// Push a batch of records via [`Self::push_record`] in one call.
-    /// See [`CoordinateSortStream::push_records`] for the rationale.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::push_record`].
-    ///
-    /// # Panics
-    ///
-    /// Same as [`Self::push_record`].
-    pub fn push_records<'a, I: IntoIterator<Item = &'a [u8]>>(&mut self, iter: I) -> Result<()> {
-        for bytes in iter {
-            self.push_record(bytes)?;
-        }
-        Ok(())
-    }
-
-    /// Finalize the stream for the typed-step pipeline: drain pending spill,
-    /// par-sort the residual buffer, and return `SortMergeSlot`s + memory
-    /// chunks. See [`CoordinateSortStream::into_slot_setup`] for the contract.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a pending-spill drain fails, the residual-buffer
-    /// sort fails, or a spill chunk file cannot be opened for its slot reader.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called twice on the same stream.
-    pub fn into_slot_setup(mut self) -> Result<SlotSetup<K>>
-    where
-        K: Send,
-    {
-        assert!(!self.finalized, "into_slot_setup called twice");
-        self.finalized = true;
-
-        self.pool.set_main_thread(std::thread::current());
-        self.timer.end_read_span();
-
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<K>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-
-        self.probe.phase1_end(self.memory_used as u64);
-
-        let memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if self.entries.is_empty() {
-            Vec::new()
-        } else if self.chunk_files.is_empty() {
-            let entries = &mut self.entries;
-            let rayon_pool = &self.rayon_pool;
-            if self.sorter.phase1_threads() > 1 {
-                self.timer.time_sort(|| {
-                    use rayon::prelude::*;
-                    rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
-                });
-            } else {
-                self.timer.time_sort(|| {
-                    entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                });
-            }
-            vec![std::mem::take(&mut self.entries)]
-        } else if self.sorter.phase1_threads() > 1 {
-            let entries = &mut self.entries;
-            let rayon_pool = &self.rayon_pool;
-            let threads = self.sorter.phase1_threads();
-            self.timer.time_sort(|| {
-                use rayon::prelude::*;
-                let chunk_size = entries.len().div_ceil(threads.max(1));
-                rayon_pool.install(|| {
-                    entries.par_chunks_mut(chunk_size).for_each(|chunk| {
-                        chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                    });
-                });
-                let mut remaining = std::mem::take(entries);
-                let num_chunks = remaining.len().div_ceil(chunk_size);
-                let mut chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> =
-                    Vec::with_capacity(num_chunks);
-                let tail_len = remaining.len() % chunk_size;
-                if tail_len != 0 {
-                    let split_at = remaining.len() - tail_len;
-                    chunks.push(remaining.split_off(split_at));
-                }
-                while !remaining.is_empty() {
-                    let split_at = remaining.len().saturating_sub(chunk_size);
-                    chunks.push(remaining.split_off(split_at));
-                }
-                chunks.reverse();
-                chunks
-            })
-        } else {
-            let entries = &mut self.entries;
-            self.timer.time_sort(|| {
-                entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-            });
-            vec![std::mem::take(&mut self.entries)]
-        };
-
-        let chunk_files = std::mem::take(&mut self.chunk_files);
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "_temp_dirs is RAII-only on the *SortStream; into_slot_setup hands ownership to the caller"
-        )]
-        let temp_dirs = std::mem::take(&mut self._temp_dirs);
-        let total_records = self.stats.total_records;
-        let slots = slots_for_chunk_files(&chunk_files)?;
-
-        Ok(SlotSetup { slots, memory_chunks, temp_dirs, total_records })
-    }
-}
-
 // ============================================================================
 // TemplateCoordinateSortStream — streaming template-coordinate-sort handle
 // ============================================================================
-
-/// Streaming template-coordinate-sort handle. Constructed via
-/// [`RawExternalSorter::into_template_coordinate_stream`].
-///
-/// Same shape as [`CoordinateSortStream`] but uses [`TemplateRecordBuffer`]
-/// and the packed [`TemplateKey`] (which incorporates library, cell
-/// barcode, and MI in addition to coordinates). Mirrors
-/// `sort_template_coordinate` line-for-line so spill / merge / fast-path
-/// semantics match.
-pub struct TemplateCoordinateSortStream {
-    sorter: RawExternalSorter,
-    pool: Arc<SortWorkerPool>,
-    _temp_dirs: Vec<TempDir>,
-    alloc: TmpDirAllocator,
-    namer_chunk_count: usize,
-    namer_merge_count: usize,
-    chunk_files: Vec<PathBuf>,
-    buffer: TemplateRecordBuffer<TemplateKey>,
-    pending_spill: Option<PendingSpill>,
-    rayon_pool: rayon::ThreadPool,
-    header: Header,
-    lib_lookup: LibraryLookup,
-    cb_hasher: ahash::RandomState,
-    stats: RawSortStats,
-    timer: SortPhaseTimer,
-    progress: ProgressTracker,
-    probe: SpillProbe,
-    finalized: bool,
-}
-
-impl TemplateCoordinateSortStream {
-    /// Push one raw BAM record. May trigger an internal spill.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a spill write fails, the buffer push fails, or
-    /// a previous pending-spill drain reports an error.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called after [`Self::into_slot_setup`] has consumed `self`.
-    pub fn push_record(&mut self, bam_bytes: &[u8]) -> Result<()> {
-        assert!(!self.finalized, "push_record called after into_slot_setup");
-
-        self.stats.total_records += 1;
-        self.progress.log_if_needed(1);
-
-        let key = extract_template_key_inline(
-            bam_bytes,
-            &self.lib_lookup,
-            self.sorter.cell_tag,
-            &self.cb_hasher,
-        );
-        self.buffer.push(bam_bytes, key)?;
-
-        if self.probe.should_sample_read(self.stats.total_records) {
-            self.probe
-                .log_mid_read(probe_stats(&self.buffer), Some(self.pool.phase1_queue_depths()));
-        }
-
-        if self.buffer.memory_usage() < self.sorter.memory_limit {
-            return Ok(());
-        }
-
-        // Spill threshold reached.
-        self.timer.end_read_span();
-        let bstats = probe_stats(&self.buffer);
-        let depths = Some(self.pool.phase1_queue_depths());
-        self.probe.pre_spill(bstats, depths);
-
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<TemplateKey>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        let chunk_path = namer.next_chunk_path()?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-
-        self.probe.post_drain(probe_stats(&self.buffer), Some(self.pool.phase1_queue_depths()));
-
-        let buffer = &mut self.buffer;
-        let rayon_pool = &self.rayon_pool;
-        self.timer.time_sort(|| {
-            rayon_pool.install(|| buffer.par_sort());
-        });
-
-        let pool = &self.pool;
-        let buffer_ref = &self.buffer;
-        let chunk_path_clone = chunk_path.clone();
-        let handle = self.timer.time_spill_write(|| {
-            let mut writer = PooledChunkWriter::<TemplateKey>::new(
-                Arc::clone(pool),
-                &chunk_path_clone,
-                pool.spill_codec(),
-            )?;
-            for (key, record) in buffer_ref.iter_sorted_keyed() {
-                writer.write_record(&key, record)?;
-            }
-            writer.start_finish()
-        })?;
-
-        self.pending_spill = Some(PendingSpill { handle, chunk_path });
-
-        self.buffer.clear();
-        force_mi_collect();
-        self.probe.post_spill(Some(self.pool.phase1_queue_depths()));
-        self.timer.begin_read_span();
-
-        Ok(())
-    }
-
-    /// Push a batch of records via [`Self::push_record`] in one call.
-    /// See [`CoordinateSortStream::push_records`] for the rationale.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::push_record`].
-    ///
-    /// # Panics
-    ///
-    /// Same as [`Self::push_record`].
-    pub fn push_records<'a, I: IntoIterator<Item = &'a [u8]>>(&mut self, iter: I) -> Result<()> {
-        for bytes in iter {
-            self.push_record(bytes)?;
-        }
-        Ok(())
-    }
-
-    /// Finalize the stream for the typed-step pipeline: drain pending spill,
-    /// par-sort the residual buffer, and return `SortMergeSlot`s + memory
-    /// chunks. See [`CoordinateSortStream::into_slot_setup`] for the contract.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a pending-spill drain fails, the residual-buffer
-    /// sort fails, or a spill chunk file cannot be opened for its slot reader.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called twice on the same stream.
-    pub fn into_slot_setup(mut self) -> Result<SlotSetup<TemplateKey>> {
-        assert!(!self.finalized, "into_slot_setup called twice");
-        self.finalized = true;
-
-        self.pool.set_main_thread(std::thread::current());
-        self.timer.end_read_span();
-
-        let mut namer = ChunkNamer {
-            alloc: &mut self.alloc,
-            chunk_count: self.namer_chunk_count,
-            merge_count: self.namer_merge_count,
-        };
-        self.sorter.drain_pending_spill::<TemplateKey>(
-            &mut self.pending_spill,
-            &mut self.chunk_files,
-            &mut self.stats,
-            &mut self.timer,
-            &mut namer,
-            &self.pool,
-        )?;
-        self.namer_chunk_count = namer.chunk_count;
-        self.namer_merge_count = namer.merge_count;
-
-        self.probe.phase1_end(self.buffer.memory_usage() as u64);
-
-        // No-spill path uses `par_sort` (global sort) + parallel
-        // `par_iter` collect, producing ONE memory chunk. This keeps
-        // the downstream `MergeDriver::from_slots` LoserTree at a
-        // single source (no per-record heap comparisons in the merge
-        // hot path) while still parallelizing the per-record
-        // `RawRecord::from(...to_vec())` allocations across rayon
-        // threads (the dominant cost at 5M+ records). With-spill
-        // path keeps `par_sort_into_chunks` since merge is unavoidable
-        // there anyway (one source per spill file + memory chunks).
-        let memory_chunks: Vec<Vec<(TemplateKey, fgumi_raw_bam::RawRecord)>> =
-            if self.buffer.is_empty() {
-                Vec::new()
-            } else if self.chunk_files.is_empty() {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                self.timer.time_sort(|| {
-                    rayon_pool.install(|| buffer.par_sort());
-                });
-                let chunk = rayon_pool.install(|| {
-                    use rayon::prelude::*;
-                    self.buffer
-                        .refs()
-                        .par_iter()
-                        .map(|r| {
-                            let key = self.buffer.get_key(r);
-                            let bytes = self.buffer.get_record(r);
-                            (key, fgumi_raw_bam::RawRecord::from(bytes.to_vec()))
-                        })
-                        .collect::<Vec<_>>()
-                });
-                vec![chunk]
-            } else if self.sorter.phase1_threads() > 1 {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                let threads = self.sorter.phase1_threads();
-                inmem_chunks_to_keyed(
-                    self.timer
-                        .time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(threads))),
-                )
-            } else {
-                let buffer = &mut self.buffer;
-                let rayon_pool = &self.rayon_pool;
-                self.timer.time_sort(|| {
-                    rayon_pool.install(|| buffer.par_sort());
-                });
-                let chunk = self
-                    .buffer
-                    .iter_sorted_keyed()
-                    .map(|(k, r)| (k, fgumi_raw_bam::RawRecord::from(r.to_vec())))
-                    .collect();
-                vec![chunk]
-            };
-
-        let chunk_files = std::mem::take(&mut self.chunk_files);
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "_temp_dirs is RAII-only on the *SortStream; into_slot_setup hands ownership to the caller"
-        )]
-        let temp_dirs = std::mem::take(&mut self._temp_dirs);
-        let total_records = self.stats.total_records;
-        let slots = slots_for_chunk_files(&chunk_files)?;
-
-        Ok(SlotSetup { slots, memory_chunks, temp_dirs, total_records })
-    }
-}
 
 // ============================================================================
 // Streaming-sort merge path (unified pipeline `SortMerge` step)
@@ -4825,8 +3874,13 @@ enum SlotMergeSource<K: RawSortKey + Default + 'static> {
     /// `slot.decompressed` with decompressed blocks; this driver reads them
     /// in-order via the per-source [`SlotParserState`].
     Slot { slot: Arc<crate::merge_slots::SortMergeSlot>, parser: SlotParserState },
-    /// In-memory sorted residual records from the inline buffer.
+    /// In-memory sorted residual records from a queryname-style sort (each
+    /// record an owned `RawRecord`). Read via a zero-copy `mem::swap` bridge.
     Memory { records: Vec<(K, fgumi_raw_bam::RawRecord)>, idx: usize },
+    /// In-memory sorted residual from an inline-buffer (coordinate / template)
+    /// sort, sharing an `Arc<SegmentedBuf>` — zero per-record allocation. Read
+    /// copies each record's bytes into the caller's reused `buf`.
+    MemoryShared { chunk: InMemoryChunk<K>, idx: usize },
 }
 
 impl<K: RawSortKey + Default + 'static> SlotMergeSource<K> {
@@ -4842,6 +3896,20 @@ impl<K: RawSortKey + Default + 'static> SlotMergeSource<K> {
                     // avoid re-allocating. The caller's buf is a plain Vec<u8>.
                     std::mem::swap(buf, data.as_mut_vec());
                     let key = std::mem::take(key);
+                    *idx += 1;
+                    Ok(TryRead::Ready(Some(key)))
+                } else {
+                    Ok(TryRead::Ready(None))
+                }
+            }
+            SlotMergeSource::MemoryShared { chunk, idx } => {
+                if *idx < chunk.len() {
+                    // Bytes are borrowed from the shared `Arc<SegmentedBuf>`, so
+                    // copy them into the caller's reused `buf` (one memcpy, no
+                    // per-record allocation — the materialise-time copy is gone).
+                    buf.clear();
+                    buf.extend_from_slice(chunk.record_bytes(*idx));
+                    let key = chunk.take_key(*idx);
                     *idx += 1;
                     Ok(TryRead::Ready(Some(key)))
                 } else {
@@ -4939,11 +4007,11 @@ impl<K: RawSortKey + Default + Send + 'static> MergeDriver<K> {
     #[must_use]
     pub fn from_slots(
         slots: Vec<Arc<crate::merge_slots::SortMergeSlot>>,
-        memory_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>,
+        memory: MemorySources<K>,
         total_records: u64,
     ) -> Self {
         let num_slots = slots.len();
-        let num_memory = memory_chunks.iter().filter(|c| !c.is_empty()).count();
+        let num_memory = memory.num_non_empty();
         let num_sources = num_slots + num_memory;
 
         if num_slots > 0 {
@@ -4956,9 +4024,20 @@ impl<K: RawSortKey + Default + Send + 'static> MergeDriver<K> {
         for slot in slots {
             sources.push(SlotMergeSource::Slot { slot, parser: SlotParserState::new() });
         }
-        for chunk in memory_chunks {
-            if !chunk.is_empty() {
-                sources.push(SlotMergeSource::Memory { records: chunk, idx: 0 });
+        match memory {
+            MemorySources::Owned(chunks) => {
+                for chunk in chunks {
+                    if !chunk.is_empty() {
+                        sources.push(SlotMergeSource::Memory { records: chunk, idx: 0 });
+                    }
+                }
+            }
+            MemorySources::Shared(chunks) => {
+                for chunk in chunks {
+                    if !chunk.is_empty() {
+                        sources.push(SlotMergeSource::MemoryShared { chunk, idx: 0 });
+                    }
+                }
             }
         }
 
@@ -5264,6 +4343,12 @@ mod tests {
         // sort_threads overrides only Phase 1.
         let sort_only = new().sort_threads(2);
         assert_eq!((sort_only.phase1_threads(), sort_only.phase2_threads()), (2, 8));
+        // The public `num_threads()` accessor returns the BASE count, unaffected
+        // by the Phase-1 override — so the streaming front must read
+        // `phase1_threads()`, not `num_threads()`, to honor `--sort-threads`
+        // (the D1.1 regression was reading the base here). Pin the distinction.
+        assert_eq!(sort_only.num_threads(), 8);
+        assert_eq!(sort_only.phase1_threads(), 2);
         // merge_threads overrides only Phase 2.
         let merge_only = new().merge_threads(3);
         assert_eq!((merge_only.phase1_threads(), merge_only.phase2_threads()), (8, 3));
@@ -5405,69 +4490,6 @@ mod tests {
         );
     }
 
-    /// Build a streaming sorter for `order` with `threads(4)` and the optional
-    /// `sort_threads` cap, returning its Phase-1 `SortWorkerPool` worker count.
-    /// Centralizes the per-order stream-constructor dispatch so the pool-sizing
-    /// assertion can be parameterized.
-    fn streaming_phase1_pool_workers(order: SortOrder, sort_threads: Option<usize>) -> usize {
-        use noodles::sam::Header;
-
-        let header = Header::default();
-        let mut sorter = RawExternalSorter::new(order).threads(4);
-        if let Some(j) = sort_threads {
-            sorter = sorter.sort_threads(j);
-        }
-        match order {
-            SortOrder::Coordinate => sorter
-                .into_coordinate_stream(&header)
-                .expect("coordinate stream")
-                .pool
-                .num_workers(),
-            SortOrder::TemplateCoordinate => sorter
-                .into_template_coordinate_stream(&header)
-                .expect("template-coordinate stream")
-                .pool
-                .num_workers(),
-            SortOrder::Queryname(_) => {
-                match sorter.into_queryname_stream(&header).expect("queryname stream") {
-                    QuerynameSortStream::Lex(s) => s.pool.num_workers(),
-                    QuerynameSortStream::Natural(s) => s.pool.num_workers(),
-                }
-            }
-        }
-    }
-
-    /// The streaming Phase-1 `SortWorkerPool` must be sized to `phase1_threads()`,
-    /// not `threads`. When `sort_threads` is set, the pool must reflect the cap;
-    /// when it is unset, the pool has the full `threads` count. One case per
-    /// (order, split-state) so a failure names the exact combination.
-    #[rstest::rstest]
-    #[case::coordinate_split(SortOrder::Coordinate, Some(1), 1)]
-    #[case::coordinate_nosplit(SortOrder::Coordinate, None, 4)]
-    #[case::template_coordinate_split(SortOrder::TemplateCoordinate, Some(1), 1)]
-    #[case::template_coordinate_nosplit(SortOrder::TemplateCoordinate, None, 4)]
-    #[case::queryname_split(
-        SortOrder::Queryname(crate::keys::QuerynameComparator::Lexicographic),
-        Some(1),
-        1
-    )]
-    #[case::queryname_nosplit(
-        SortOrder::Queryname(crate::keys::QuerynameComparator::Lexicographic),
-        None,
-        4
-    )]
-    fn streaming_pool_is_capped_to_phase1_threads(
-        #[case] order: SortOrder,
-        #[case] sort_threads: Option<usize>,
-        #[case] expected_workers: usize,
-    ) {
-        assert_eq!(
-            streaming_phase1_pool_workers(order, sort_threads),
-            expected_workers,
-            "order {order:?} sort_threads {sort_threads:?}: stream pool must size to phase1_threads"
-        );
-    }
-
     #[test]
     fn test_raw_sorter_memory_limit() {
         let sorter = RawExternalSorter::new(SortOrder::Coordinate).memory_limit(256 * 1024 * 1024);
@@ -5507,43 +4529,6 @@ mod tests {
             "unexpected error: {msg}"
         );
         assert!(!output.exists(), "no output should be produced on validation failure");
-    }
-
-    /// The streaming entry points must reject `temp_compression=0` + zstd too,
-    /// not just `sort()` — otherwise the fused pipeline path (which builds the
-    /// sorter then calls `into_*_stream`) could reach a misconfigured pool that
-    /// `sort()` would have refused. Header is irrelevant: the guard fires before
-    /// any pool/temp-dir work.
-    #[test]
-    fn test_streaming_entry_points_reject_temp_compression_zero_with_zstd() {
-        use noodles::sam::Header;
-
-        let header = Header::default();
-
-        for sort_order in [
-            SortOrder::Coordinate,
-            SortOrder::TemplateCoordinate,
-            SortOrder::Queryname(crate::keys::QuerynameComparator::Lexicographic),
-        ] {
-            let sorter = RawExternalSorter::new(sort_order)
-                .spill_codec(crate::codec::SpillCodec::Zstd)
-                .temp_compression(0);
-            let err = match sort_order {
-                SortOrder::Coordinate => sorter.into_coordinate_stream(&header).err(),
-                SortOrder::TemplateCoordinate => {
-                    sorter.into_template_coordinate_stream(&header).err()
-                }
-                SortOrder::Queryname(_) => sorter.into_queryname_stream(&header).err(),
-            }
-            .unwrap_or_else(|| {
-                panic!("{sort_order:?} stream should reject temp_compression=0 + zstd")
-            });
-            assert!(
-                err.to_string()
-                    .contains("temp_compression=0 is only supported with SpillCodec::Bgzf"),
-                "unexpected error for {sort_order:?}: {err}"
-            );
-        }
     }
 
     #[test]
@@ -6253,6 +5238,31 @@ mod tests {
 
         assert_eq!(count, 40);
         assert_eq!(count_bam_records(&merged), 40);
+
+        // Verify template-coordinate order/identity via an independent oracle
+        // (mirrors `narrow_sort_output_passes_full_width_verify`): re-extract the
+        // template key from every merged record and assert non-decreasing core
+        // order. A count-only check would pass even if the merge reordered or
+        // duplicated records.
+        let (_, hdr) = create_raw_bam_reader(&merged, 1).expect("header");
+        let lib = LibraryLookup::from_header(&hdr);
+        let hasher = cb_hasher();
+        let file = std::fs::File::open(&merged).expect("open merged");
+        let mut raw_reader = crate::reader::RawBamRecordReader::new(file).expect("reader");
+        raw_reader.skip_header().expect("skip header");
+        let (total, violations, first) = crate::verify::verify_sort_order(
+            raw_reader,
+            |bam| extract_template_key_inline(bam, &lib, None, &hasher),
+            |cur: &TemplateKey40, prev: &TemplateKey40| {
+                cur.core_cmp(prev) == std::cmp::Ordering::Less
+            },
+        )
+        .expect("verify runs");
+        assert_eq!(total, 40, "verify must see every merged record");
+        assert_eq!(
+            violations, 0,
+            "template-coordinate order violated after merge (first={first:?}, total={total})"
+        );
     }
 
     #[test]
@@ -7720,7 +6730,7 @@ mod from_slots_merge_tests {
             populated_slot(2, &file2, 1),
         ];
 
-        let driver = MergeDriver::<TestKey>::from_slots(slots, Vec::new(), 9);
+        let driver = MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 9);
         let emitted_bytes = drain_merge_driver_bytes(driver);
         let expected: Vec<Vec<u8>> = vec![
             b"AAA-1".to_vec(),
@@ -7747,7 +6757,8 @@ mod from_slots_merge_tests {
             .collect();
 
         let slots = vec![populated_slot(0, &records, 4)];
-        let driver = MergeDriver::<TestKey>::from_slots(slots, Vec::new(), 20);
+        let driver =
+            MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 20);
         let emitted_bytes = drain_merge_driver_bytes(driver);
         let expected: Vec<Vec<u8>> = records.into_iter().map(|(_, b)| b).collect();
         assert_eq!(emitted_bytes, expected, "cross-block parse corrupted record sequence");
@@ -7764,7 +6775,11 @@ mod from_slots_merge_tests {
         empty_slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
         // Lazy priming: `from_slots` always yields a driver; the empty
         // determination happens on the first `try_step`, which returns `Done`.
-        let driver = MergeDriver::<TestKey>::from_slots(vec![empty_slot], Vec::new(), 0);
+        let driver = MergeDriver::<TestKey>::from_slots(
+            vec![empty_slot],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
         let emitted = drain_merge_driver_bytes(driver);
         assert!(emitted.is_empty(), "all-empty merge must emit zero records");
     }
@@ -7782,8 +6797,11 @@ mod from_slots_merge_tests {
             crate::codec::SpillCodec::Bgzf,
         ));
         // Empty queue, NOT eof — the producer is "still feeding".
-        let mut driver =
-            MergeDriver::<TestKey>::from_slots(vec![StdArc::clone(&slot)], Vec::new(), 0);
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
 
         // Priming cannot read the slot's first record → Stalled, not a hang.
         assert!(
@@ -7825,8 +6843,11 @@ mod from_slots_merge_tests {
             let bytes = serialize_records(&[(TestKey(1), b"rec-A".to_vec())]);
             slot.decompressed.lock().unwrap().push_back(bytes);
         }
-        let mut driver =
-            MergeDriver::<TestKey>::from_slots(vec![StdArc::clone(&slot)], Vec::new(), 0);
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
 
         // Prime + emit the first record.
         match driver.try_step().expect("try_step") {
@@ -7873,8 +6894,11 @@ mod from_slots_merge_tests {
         ));
         slot.decompressed.lock().unwrap().push_back(vec![serialized[0]]);
 
-        let mut driver =
-            MergeDriver::<TestKey>::from_slots(vec![StdArc::clone(&slot)], Vec::new(), 1);
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            1,
+        );
 
         // Each step before the last byte consumes one byte into the pending
         // record and stalls (queue empty, not EOF).
@@ -7918,8 +6942,11 @@ mod from_slots_merge_tests {
         ));
         slot.decompressed.lock().unwrap().push_back(head.to_vec());
 
-        let mut driver =
-            MergeDriver::<TestEmbeddedKey>::from_slots(vec![StdArc::clone(&slot)], Vec::new(), 1);
+        let mut driver = MergeDriver::<TestEmbeddedKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            1,
+        );
 
         // Body incomplete in the first block → Stalled mid-record.
         assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Stalled));
@@ -7951,7 +6978,11 @@ mod from_slots_merge_tests {
         ];
 
         let slots = vec![populated_slot(0, &slot_records, 2)];
-        let driver = MergeDriver::<TestKey>::from_slots(slots, vec![memory_records], 6);
+        let driver = MergeDriver::<TestKey>::from_slots(
+            slots,
+            MemorySources::Owned(vec![memory_records]),
+            6,
+        );
         let emitted_bytes = drain_merge_driver_bytes(driver);
         let expected: Vec<Vec<u8>> = vec![
             b"slot-1".to_vec(),
@@ -8070,7 +7101,8 @@ mod from_slots_merge_tests {
             embedded_populated_slot(2, &file2, 1),
         ];
 
-        let driver = MergeDriver::<TestEmbeddedKey>::from_slots(slots, Vec::new(), 9);
+        let driver =
+            MergeDriver::<TestEmbeddedKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 9);
         let emitted = drain_merge_driver_bytes(driver);
 
         // Verify keys are emitted in sorted order. Tail bytes prove the
@@ -8111,7 +7143,7 @@ mod from_slots_merge_tests {
         // populated slot.
         let slots = vec![empty_slot, populated_slot(0, &populated, 1)];
 
-        let driver = MergeDriver::<TestKey>::from_slots(slots, Vec::new(), 3);
+        let driver = MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 3);
         let emitted = drain_merge_driver_bytes(driver);
         assert_eq!(emitted, vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()]);
     }
@@ -8127,7 +7159,8 @@ mod from_slots_merge_tests {
         let total = (f0.len() + f1.len()) as u64;
 
         let slots = vec![populated_slot(0, &f0, 3), populated_slot(1, &f1, 2)];
-        let mut driver = MergeDriver::<TestKey>::from_slots(slots, Vec::new(), total);
+        let mut driver =
+            MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), total);
 
         let mut emitted = 0u64;
         loop {

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -14,6 +14,7 @@
 
 #![allow(dead_code)]
 
+use crate::arena_pool::{ArenaPool, PooledSegmentedBuf};
 use crate::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::radix::bytes_needed_u64;
 use crate::segmented_buf::SegmentedBuf;
@@ -44,7 +45,7 @@ use std::sync::Arc;
 /// In exchange, materialization is allocation-free and the peak
 /// memory of the sort drops by ~1× (the materialization no longer
 /// transiently doubles the buffer).
-pub(crate) struct InMemoryChunk<K> {
+pub struct InMemoryChunk<K> {
     /// Shared backing store for record bytes (the original sort
     /// buffer's `SegmentedBuf`). All sibling chunks from one
     /// `par_sort_into_chunks` call share this Arc, so the segments
@@ -55,7 +56,11 @@ pub(crate) struct InMemoryChunk<K> {
     /// merge is slightly higher, but the materialization-peak
     /// memory drops by ~1× (pre-PR transiently held both the buffer
     /// and a full copy in per-record `Vec<u8>`s).
-    data: Arc<SegmentedBuf>,
+    /// Wrapped in [`PooledSegmentedBuf`] so a chunk drained from a pooled
+    /// coordinate arena returns its storage to the
+    /// [`ArenaPool`](crate::arena_pool::ArenaPool) when the last `Arc` clone
+    /// drops. Non-pooled constructors use `PooledSegmentedBuf::unpooled`.
+    data: Arc<PooledSegmentedBuf>,
     /// `(sort_key, byte_offset_in_data, len)` per record, in sorted
     /// order. `offset` is `u64` because a single `SegmentedBuf` can
     /// exceed 4 GiB at high `--max-memory` × `--threads`; `len` is
@@ -67,39 +72,79 @@ impl<K> InMemoryChunk<K> {
     /// Construct an empty chunk backed by an empty shared buffer.
     #[must_use]
     pub(crate) fn empty() -> Self {
-        Self { data: Arc::new(SegmentedBuf::default()), records: Vec::new() }
+        Self {
+            data: Arc::new(PooledSegmentedBuf::unpooled(SegmentedBuf::default())),
+            records: Vec::new(),
+        }
     }
 
     /// Construct a chunk holding the given records, all referencing
-    /// the same shared data buffer.
+    /// the same shared (possibly pooled) data buffer.
     #[must_use]
-    pub(crate) fn from_parts(data: Arc<SegmentedBuf>, records: Vec<(K, u64, u32)>) -> Self {
+    pub(crate) fn from_parts(data: Arc<PooledSegmentedBuf>, records: Vec<(K, u64, u32)>) -> Self {
         Self { data, records }
+    }
+
+    /// Build a chunk from owned `(key, bytes)` records by packing the bytes into
+    /// a fresh `SegmentedBuf`. This **copies** every record, so it is for callers
+    /// that already hold owned records (tests, or future owned→shared bridging) —
+    /// the production sort path uses [`RecordBuffer::drain_into_single_chunk`],
+    /// which moves the arena without copying.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any record's length exceeds `u32::MAX`. BAM records are always
+    /// < 4 GiB, so this cannot happen for real records.
+    #[must_use]
+    pub fn from_owned_records(records: Vec<(K, Vec<u8>)>) -> Self {
+        let mut data = SegmentedBuf::new();
+        let records = records
+            .into_iter()
+            .map(|(key, bytes)| {
+                let offset = data.extend_from_slice(&bytes) as u64;
+                let len = u32::try_from(bytes.len())
+                    .expect("InMemoryChunk record length exceeds u32 (BAM records are < 4 GiB)");
+                (key, offset, len)
+            })
+            .collect();
+        Self { data: Arc::new(PooledSegmentedBuf::unpooled(data)), records }
     }
 
     /// Number of records in the chunk.
     #[must_use]
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.records.len()
     }
 
     /// Whether the chunk is empty.
     #[must_use]
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.records.is_empty()
     }
 
+    /// Total record-payload bytes (the sum of record lengths; excludes keys and
+    /// index overhead). Used for byte-budget accounting at the chunk boundary.
+    #[must_use]
+    pub fn payload_bytes(&self) -> usize {
+        self.records.iter().map(|(_, _, len)| *len as usize).sum()
+    }
+
     /// Borrow the `i`th record's bytes from the shared data buffer.
+    ///
+    /// `pub` so out-of-crate consumers (e.g. the block-parallel spill serializer
+    /// in `fgumi-pipeline-io`) can iterate a chunk's records zero-copy.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)] // offset/len fit in usize on all supported targets
-    pub(crate) fn record_bytes(&self, i: usize) -> &[u8] {
+    pub fn record_bytes(&self, i: usize) -> &[u8] {
         let (_, offset, len) = &self.records[i];
         self.data.slice(*offset as usize, *len as usize)
     }
 
     /// Borrow the `i`th record's sort key.
+    ///
+    /// `pub` for the same reason as [`record_bytes`](Self::record_bytes).
     #[must_use]
-    pub(crate) fn key_at(&self, i: usize) -> &K {
+    pub fn key_at(&self, i: usize) -> &K {
         &self.records[i].0
     }
 
@@ -309,7 +354,7 @@ pub struct RecordBuffer {
 ///
 /// Both `RecordBuffer` and `TemplateRecordBuffer` use this segment size so that
 /// a single BAM record (≤128 MiB in practice) always fits within one segment.
-const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
+pub const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
 /// Shared implementation for `par_sort_into_chunks` on both buffer types.
 ///
@@ -333,7 +378,7 @@ macro_rules! par_sort_into_chunks_impl {
 
         if $threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
             $sort_fn(&mut $self.refs);
-            let data = Arc::new(std::mem::take(&mut $self.data));
+            let data = Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut $self.data)));
             let records: Vec<_> =
                 $self.refs.iter().map(|r| ($key_fn(r), r.offset + header_size, r.len)).collect();
             // Clear refs to leave the buffer in a consistent drained
@@ -351,7 +396,7 @@ macro_rules! par_sort_into_chunks_impl {
             $sort_fn(chunk);
         });
 
-        let data = Arc::new(std::mem::take(&mut $self.data));
+        let data = Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut $self.data)));
 
         let chunks: Vec<_> = $self
             .refs
@@ -536,7 +581,7 @@ impl RecordBuffer {
     /// index-panic against the empty `SegmentedBuf`.
     #[must_use]
     pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<RawCoordinateKey> {
-        let data = Arc::new(std::mem::take(&mut self.data));
+        let data = Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut self.data)));
         let records: Vec<_> = self
             .refs
             .iter()
@@ -548,6 +593,44 @@ impl RecordBuffer {
         self.refs.clear();
         self.max_sort_key = 0;
         InMemoryChunk::from_parts(data, records)
+    }
+
+    /// Drain the (already-sorted) buffer into a single chunk whose backing
+    /// `SegmentedBuf` is **pool-managed**: the arena returns to `pool`
+    /// (reset-for-reuse) when the chunk's last `Arc` clone drops. `self.data`
+    /// is left an empty default; the caller must
+    /// [`install_arena`](Self::install_arena) a fresh pool arena before the
+    /// next fill.
+    #[must_use]
+    pub(crate) fn drain_into_pooled_chunk(
+        &mut self,
+        pool: &Arc<ArenaPool>,
+    ) -> InMemoryChunk<RawCoordinateKey> {
+        let data =
+            Arc::new(PooledSegmentedBuf::pooled(std::mem::take(&mut self.data), Arc::clone(pool)));
+        let records: Vec<_> = self
+            .refs
+            .iter()
+            .map(|r| {
+                (RawCoordinateKey { sort_key: r.sort_key }, r.offset + HEADER_SIZE as u64, r.len)
+            })
+            .collect();
+        self.refs.clear();
+        self.max_sort_key = 0;
+        InMemoryChunk::from_parts(data, records)
+    }
+
+    /// Install a (pool-acquired) arena as this buffer's backing store, replacing
+    /// the empty placeholder left by [`drain_into_pooled_chunk`]. Requires the
+    /// buffer to be drained (no refs).
+    pub(crate) fn install_arena(&mut self, arena: SegmentedBuf) {
+        // Unconditional (not `debug_assert!`): replacing `self.data` while stale
+        // `refs` still index the old arena is a silent data-corruption path for a
+        // bit-identical sort engine. This is a state-transition guard, not a
+        // hot-path bounds check — the `is_empty()` cost is negligible next to
+        // record processing.
+        assert!(self.refs.is_empty(), "install_arena over a non-drained buffer");
+        self.data = arena;
     }
 
     /// Get record bytes by reference.
@@ -1632,11 +1715,53 @@ impl<K: TemplateLaneKey> TemplateRecordBuffer<K> {
     /// index-panic against the empty `SegmentedBuf`.
     #[must_use]
     pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<K> {
-        let data = Arc::new(std::mem::take(&mut self.data));
+        let data = Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut self.data)));
         let records: Vec<_> = self
             .refs
             .iter()
             .map(|r| (r.key, r.offset + TEMPLATE_HEADER_SIZE as u64, r.len))
+            .collect();
+        self.refs.clear();
+        InMemoryChunk::from_parts(data, records)
+    }
+
+    /// Drain the (already-sorted) buffer into a single in-memory chunk keyed by
+    /// the **full** [`TemplateKey`] (re-extracted per record via `extract`),
+    /// whose records share an `Arc<SegmentedBuf>` backing store — NO record
+    /// bytes are copied (the arena is moved, not the bodies).
+    ///
+    /// This is the zero-copy analogue of the owned materialisation the legacy
+    /// `TemplateChunkSorter` performs: the narrow lane key `K` drove the sort,
+    /// and the full key is re-widened here for the downstream merge (whose
+    /// `MergeDriver<TemplateKey>` orders on the full key), but the record bodies
+    /// stay resident in the moved arena instead of being copied into owned
+    /// `RawRecord`s. `extract` receives each record's body bytes (the inline
+    /// header already skipped, exactly what [`get_record`](Self::get_record)
+    /// returns) and returns its full `TemplateKey`; it MUST be the same
+    /// extraction the owned path uses, so the produced chunk is byte-for-byte
+    /// identical to the owned `Vec<(TemplateKey, RawRecord)>` (same sorted order,
+    /// same keys, same bodies).
+    ///
+    /// Runs the per-record extraction in parallel (like the owned path's
+    /// `par_iter`), so call it inside the sorter's `rayon_pool.install`. Both
+    /// `data` and `refs` are cleared after this call (the arena is moved into the
+    /// returned chunk); see [`drain_into_single_chunk`](Self::drain_into_single_chunk).
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)] // body_off/len fit usize on all supported targets (BAM < 4 GiB, arena < address space)
+    pub(crate) fn drain_into_full_key_chunk(
+        &mut self,
+        extract: impl Fn(&[u8]) -> TemplateKey + Sync,
+    ) -> InMemoryChunk<TemplateKey> {
+        use rayon::prelude::*;
+        let data = Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut self.data)));
+        let records: Vec<(TemplateKey, u64, u32)> = self
+            .refs
+            .par_iter()
+            .map(|r| {
+                let body_off = r.offset + TEMPLATE_HEADER_SIZE as u64;
+                let body = data.slice(body_off as usize, r.len as usize);
+                (extract(body), body_off, r.len)
+            })
             .collect();
         self.refs.clear();
         InMemoryChunk::from_parts(data, records)
@@ -2582,6 +2707,49 @@ mod tests {
         }
     }
 
+    /// Parallel/serial parity at the arena dispatch cutoff. The arena front
+    /// (`template_chunk_from_arena_refs`) routes to `parallel_radix_sort_template_refs`
+    /// only when `refs.len() >= PARALLEL_SORT_THRESHOLD`; the arena-vs-owned parity
+    /// test runs far below that, so the parallel branch is never compared against a
+    /// reference there. Mirror `parallel_coordinate_sort_matches_serial_radix_at_threshold`:
+    /// build a threshold-sized input with deliberate key ties and pin the parallel
+    /// radix's ordering against the single-threaded stable radix. Since the
+    /// arena-vs-owned test already proves `radix_sort_template_refs` matches the
+    /// owned sorter, parallel-matches-serial here pins parallel-matches-owned at
+    /// threshold by transitivity.
+    #[test]
+    fn parallel_template_radix_matches_serial_at_threshold() {
+        let n = crate::ref_sort::PARALLEL_SORT_THRESHOLD; // crosses the arena cutoff
+        // Vary the library-name hash (a full-key radix lane) over a small modulus
+        // → ~260 ties per value across the input, so a stability or lane-ordering
+        // bug in the parallel path would reorder equal-key records relative to the
+        // serial radix. `offset` ascends with input order to witness stability.
+        let refs: Vec<TemplateRecordRef<TemplateKey>> = (0..n)
+            .map(|i| {
+                let hash = (i as u64).wrapping_mul(2_654_435_761) % 1009;
+                let key =
+                    TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), hash, false);
+                TemplateRecordRef { key, offset: i as u64, len: 10, padding: 0 }
+            })
+            .collect();
+
+        let mut parallel = refs.clone();
+        let mut serial = refs;
+        parallel_radix_sort_template_refs(&mut parallel); // n > 10_000 → real parallel path
+        radix_sort_template_refs(&mut serial); // single-threaded stable reference
+
+        assert_eq!(parallel.len(), serial.len());
+        for (i, (p, s)) in parallel.iter().zip(&serial).enumerate() {
+            assert!(
+                p.key == s.key && p.offset == s.offset,
+                "parallel template radix diverged from serial radix at index {i} \
+                 (parallel offset {}, serial offset {})",
+                p.offset,
+                s.offset,
+            );
+        }
+    }
+
     #[test]
     fn test_template_record_buffer_sort_stability() {
         // Test that TemplateRecordBuffer::sort() is stable
@@ -3023,7 +3191,7 @@ mod tests {
     fn test_in_memory_chunk_from_parts_reads_records() {
         let (buf, offsets) =
             build_segmented_buf_with_records(&[b"first", b"second-record", b"third"]);
-        let data = Arc::new(buf);
+        let data = Arc::new(PooledSegmentedBuf::unpooled(buf));
         let records = vec![
             (10u32, offsets[0].0, offsets[0].1),
             (20u32, offsets[1].0, offsets[1].1),
@@ -3045,7 +3213,7 @@ mod tests {
     fn test_in_memory_chunk_take_key_replaces_with_default() {
         let (buf, offsets) = build_segmented_buf_with_records(&[b"payload"]);
         let chunk = InMemoryChunk::<u32>::from_parts(
-            Arc::new(buf),
+            Arc::new(PooledSegmentedBuf::unpooled(buf)),
             vec![(42u32, offsets[0].0, offsets[0].1)],
         );
         let mut chunk = chunk;
@@ -3063,7 +3231,7 @@ mod tests {
         // Arc<SegmentedBuf>, so the data isn't duplicated and is freed
         // only when the last chunk drops.
         let (buf, offsets) = build_segmented_buf_with_records(&[b"alpha", b"beta", b"gamma"]);
-        let data = Arc::new(buf);
+        let data = Arc::new(PooledSegmentedBuf::unpooled(buf));
         let chunk_a = InMemoryChunk::<u32>::from_parts(
             Arc::clone(&data),
             vec![(1, offsets[0].0, offsets[0].1)],

--- a/crates/fgumi-sort/src/keys.rs
+++ b/crates/fgumi-sort/src/keys.rs
@@ -23,10 +23,20 @@
 //! - samtools' `bam1_tag` union (C)
 
 use noodles::sam::Header;
+use smallvec::SmallVec;
 use std::cmp::Ordering;
 
 use fgumi_raw_bam::RawRecordView;
 use std::io::{Read, Write};
+
+/// Inline-capacity buffer for queryname key name bytes. Illumina/SRA read names
+/// are short (typically ≤ ~24 bytes incl. the NUL), so an inline `SmallVec`
+/// keeps the name **contiguous inside the sort ref array** instead of a
+/// per-record heap allocation. During the comparison sort this eliminates the
+/// pointer-chase to scattered heap that dominates on memory-latency-bound cores
+/// (e.g. Graviton), where the queryname sort regressed vs the owned-`Vec` key.
+/// Names longer than the inline capacity spill to the heap transparently.
+type NameBuf = SmallVec<[u8; 24]>;
 
 // ============================================================================
 // Generic Sorting Abstraction (Trait-based, inspired by fgbio/samtools)
@@ -477,13 +487,18 @@ fn write_queryname_key<W: Write>(name: &[u8], flags: u16, writer: &mut W) -> std
 }
 
 /// Deserialize a queryname key from `[name_len: u16][name: bytes][flags: u16]`.
+///
+/// Reads the name straight into an inline [`NameBuf`] so the spill-merge read
+/// path allocates no per-record heap for short names — the merge-side analogue
+/// of the SSO key change on the ingest path.
 #[inline]
-fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(Vec<u8>, u16)> {
+fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(NameBuf, u16)> {
     let mut len_buf = [0u8; 2];
     reader.read_exact(&mut len_buf)?;
     let name_len = u16::from_le_bytes(len_buf) as usize;
 
-    let mut name = vec![0u8; name_len];
+    let mut name: NameBuf = SmallVec::new();
+    name.resize(name_len, 0);
     reader.read_exact(&mut name)?;
 
     let mut flags_buf = [0u8; 2];
@@ -501,12 +516,27 @@ fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(Vec<u8>, u16)
 /// Unlike fixed-size keys, serialization size depends on name length.
 ///
 /// Serialization format: `[name_len: u16][name: bytes][flags: u16]`
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct RawQuerynameKey {
-    /// Read name bytes, null-terminated for `natural_compare_nul`.
-    name: Vec<u8>,
+    /// Read name bytes, null-terminated for `natural_compare_nul`. Inline for
+    /// short names (see [`NameBuf`]) so the comparison sort stays cache-local.
+    name: NameBuf,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
+}
+
+impl Default for RawQuerynameKey {
+    /// A default key must still satisfy the null-terminated invariant that
+    /// `cmp`'s `natural_compare_nul` relies on — a derived `Default` would leave
+    /// `name` empty (no terminator), so a default-constructed key would feed a
+    /// non-terminated pointer into the comparator (out-of-bounds read). This is
+    /// required because generic merge code bounds `K: RawSortKey + Default`
+    /// (e.g. `MergeDriver<K>`, `MemorySources<K>`). The default is the empty
+    /// name `"\0"` — it orders before any non-empty name and terminates
+    /// immediately.
+    fn default() -> Self {
+        Self { name: SmallVec::from_slice(&[0]), flags: 0 }
+    }
 }
 
 impl PartialEq for RawQuerynameKey {
@@ -526,7 +556,7 @@ impl RawQuerynameKey {
         if name.last() != Some(&0) {
             name.push(0);
         }
-        Self { name, flags }
+        Self { name: SmallVec::from_vec(name), flags }
     }
 
     /// Returns the read name bytes (including the null terminator).
@@ -543,8 +573,8 @@ impl RawQuerynameKey {
         let flags = queryname_flag_order(u16::from_le_bytes([bam[14], bam[15]]));
         match raw_name_with_nul(bam) {
             // BAM stores the name NUL-terminated, so copy those bytes directly
-            // instead of stripping the NUL and re-appending it.
-            Some(name) => Self { name: name.to_vec(), flags },
+            // (inline when short) instead of stripping the NUL and re-appending.
+            Some(name) => Self { name: SmallVec::from_slice(name), flags },
             // Truncated record: fall back to the stripped-name path (`new`
             // re-adds the terminator), preserving the prior bytes exactly.
             None => Self::new(extract_raw_name_and_flags(bam).0.to_vec(), flags),
@@ -556,7 +586,8 @@ impl Ord for RawQuerynameKey {
     #[inline]
     #[allow(unsafe_code)]
     fn cmp(&self, other: &Self) -> Ordering {
-        // SAFETY: `name` is always null-terminated (see `extract_queryname_key` and `new`).
+        // SAFETY: `name` is always null-terminated by every constructor
+        // (`extract_queryname_key`, `new`, and `read_from`).
         unsafe { natural_compare_nul(self.name.as_ptr(), other.name.as_ptr()) }
             .then_with(|| self.flags.cmp(&other.flags))
     }
@@ -590,8 +621,18 @@ impl RawSortKey for RawQuerynameKey {
 
     #[inline]
     fn read_from<R: Read>(reader: &mut R) -> std::io::Result<Self> {
-        let (name, flags) = read_queryname_key(reader)?;
-        Ok(Self::new(name, flags))
+        // A well-formed frame (written by `write_to`) already carries the
+        // trailing NUL that `cmp`'s `natural_compare_nul` unsafe relies on, so
+        // the common path constructs directly rather than via `new`. But
+        // `read_from` is a public entry point that could be handed a truncated
+        // or malformed frame; re-append the terminator if it is missing so the
+        // NUL-termination invariant holds unconditionally and the comparator can
+        // never walk off the end.
+        let (mut name, flags) = read_queryname_key(reader)?;
+        if name.last() != Some(&0) {
+            name.push(0);
+        }
+        Ok(Self { name, flags })
     }
 }
 
@@ -607,8 +648,9 @@ impl RawSortKey for RawQuerynameKey {
 /// Serialization format: `[name_len: u16][name: bytes][flags: u16]`
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub struct RawQuerynameLexKey {
-    /// Read name bytes.
-    name: Vec<u8>,
+    /// Read name bytes. Inline for short names (see [`NameBuf`]) so the
+    /// comparison sort stays cache-local.
+    name: NameBuf,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
 }
@@ -617,7 +659,7 @@ impl RawQuerynameLexKey {
     /// Create a new lexicographic queryname key.
     #[must_use]
     pub fn new(name: Vec<u8>, flags: u16) -> Self {
-        Self { name, flags }
+        Self { name: SmallVec::from_vec(name), flags }
     }
 
     /// Returns the read name bytes.
@@ -631,7 +673,7 @@ impl RawQuerynameLexKey {
     #[must_use]
     fn extract_queryname_key(bam: &[u8]) -> Self {
         let (raw_name, flags) = extract_raw_name_and_flags(bam);
-        Self { name: raw_name.to_vec(), flags }
+        Self { name: SmallVec::from_slice(raw_name), flags }
     }
 }
 
@@ -682,6 +724,21 @@ impl RawSortKey for RawQuerynameLexKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `RawQuerynameKey::default()` must produce a null-terminated `name` so the
+    /// `unsafe` `natural_compare_nul` in `cmp` never walks off the end of an
+    /// unterminated buffer (a derived `Default` would leave `name` empty). The
+    /// default orders before any non-empty name.
+    #[test]
+    fn default_queryname_key_is_null_terminated() {
+        let def = RawQuerynameKey::default();
+        assert_eq!(def.name(), &[0u8], "default name must be a single NUL terminator");
+        // cmp against a real key must not read out of bounds and must order the
+        // empty default first.
+        let real = RawQuerynameKey::new(b"read1".to_vec(), 0);
+        assert_eq!(def.cmp(&real), Ordering::Less);
+        assert_eq!(def.cmp(&RawQuerynameKey::default()), Ordering::Equal);
+    }
 
     // ========================================================================
     // queryname_flag_order tests
@@ -1630,5 +1687,96 @@ mod tests {
         const { assert!(RawQuerynameLexKey::EMBEDDED_IN_RECORD) };
         const { assert!(RawQuerynameKey::EMBEDDED_IN_RECORD) };
         const { assert!(RawCoordinateKey::EMBEDDED_IN_RECORD) };
+    }
+
+    // ========================================================================
+    // NameBuf heap-fallback (SSO spill) tests
+    //
+    // `NameBuf` inlines names up to 24 bytes and spills longer ones to the
+    // heap. Read names in real data are almost always short, so the common
+    // unit tests above only exercise the inline path. These tests explicitly
+    // drive names past the inline capacity for BOTH key kinds (lexicographic
+    // and natural) across every surface that touches a `NameBuf`: `new`,
+    // `extract_from_record`, the `write_to`/`read_from` serialization
+    // roundtrip, and ordering — so the heap-backed path can never silently
+    // regress.
+    // ========================================================================
+
+    /// A read name comfortably longer than `NameBuf`'s 24-byte inline capacity,
+    /// so the backing `SmallVec` is forced onto the heap. The trailing `9` /
+    /// `10` lets a paired name below expose the lex-vs-natural ordering split.
+    const HEAP_NAME_PREFIX: &[u8] = b"A00123:45:HGVWXDSXY:1:1101:12345:";
+
+    #[test]
+    fn test_natural_key_heap_name_serialization_roundtrip() {
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > 24, "test name must exceed NameBuf inline capacity");
+
+        let key = RawQuerynameKey::new(name.clone(), 42);
+        // `new` appends the NUL terminator that `natural_compare_nul` relies on.
+        assert_eq!(key.name(), [name.as_slice(), b"\0"].concat().as_slice());
+
+        let mut buf = Vec::new();
+        key.write_to(&mut buf).expect("write_to should succeed");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let restored = RawQuerynameKey::read_from(&mut cursor).expect("read_from should succeed");
+
+        assert_eq!(key, restored);
+        assert_eq!(restored.name(), key.name(), "heap name (incl. NUL) must survive roundtrip");
+    }
+
+    #[test]
+    fn test_lex_key_heap_name_serialization_roundtrip() {
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > 24, "test name must exceed NameBuf inline capacity");
+
+        let key = RawQuerynameLexKey::new(name.clone(), 42);
+        assert_eq!(key.name(), name.as_slice());
+
+        let mut buf = Vec::new();
+        key.write_to(&mut buf).expect("write_to should succeed");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let restored =
+            RawQuerynameLexKey::read_from(&mut cursor).expect("read_from should succeed");
+
+        assert_eq!(key, restored);
+        assert_eq!(restored.name(), key.name(), "heap name must survive roundtrip");
+    }
+
+    #[test]
+    fn test_queryname_keys_extract_from_record_heap_name() {
+        use fgumi_raw_bam::testutil::make_bam_bytes;
+
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > 24, "test name must exceed NameBuf inline capacity");
+        let bam = make_bam_bytes(0, 0, 0, &name, &[], 100, -1, -1, &[]);
+
+        // Lexicographic: the extracted name is the raw name, no NUL.
+        let lex = RawQuerynameLexKey::extract_from_record(&bam);
+        assert_eq!(lex.name(), name.as_slice());
+
+        // Natural: the extracted name is NUL-terminated for `natural_compare_nul`.
+        let nat = RawQuerynameKey::extract_from_record(&bam);
+        assert_eq!(nat.name(), [name.as_slice(), b"\0"].concat().as_slice());
+    }
+
+    #[test]
+    fn test_heap_name_lex_vs_natural_ordering_difference() {
+        // Both names spill to the heap; they differ only in the numeric suffix
+        // `9` vs `10`, so the two comparators disagree exactly as they do for
+        // short names — proving the split is preserved on the heap-backed path.
+        let name_9 = [HEAP_NAME_PREFIX, b"9"].concat();
+        let name_10 = [HEAP_NAME_PREFIX, b"10"].concat();
+        assert!(name_9.len() > 24 && name_10.len() > 24, "names must exceed inline capacity");
+
+        // Lexicographic: '1' < '9', so `...:10` sorts before `...:9`.
+        let lex_9 = RawQuerynameLexKey::new(name_9.clone(), 0);
+        let lex_10 = RawQuerynameLexKey::new(name_10.clone(), 0);
+        assert!(lex_10 < lex_9, "lexicographic: '...:10' should be < '...:9'");
+
+        // Natural: 9 < 10 numerically, so `...:9` sorts before `...:10`.
+        let nat_9 = RawQuerynameKey::new(name_9, 0);
+        let nat_10 = RawQuerynameKey::new(name_10, 0);
+        assert!(nat_9 < nat_10, "natural: '...:9' should be < '...:10'");
     }
 }

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -41,7 +41,10 @@ use tempfile::TempDir;
 
 // All sub-modules are crate-private. Items intended for external consumers are
 // re-exported at the crate root below.
+pub mod arena_pool;
 pub(crate) mod bgzf_io;
+pub(crate) mod block_offsets;
+pub(crate) mod chunk_sorter;
 pub mod codec;
 pub(crate) mod external;
 pub(crate) mod inline;
@@ -55,8 +58,17 @@ pub(crate) mod pooled_chunk_writer;
 pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;
-pub(crate) mod segmented_buf;
+pub mod ref_sort;
+pub mod segmented_buf;
+pub mod template_arena;
+// Block-granular spill compression kernel for the block-parallel spill steps
+// (`SpillGather`/`SpillCompress`/`SpillWrite`). Surfaced via the re-exports
+// below.
+pub(crate) mod spill_block;
 pub(crate) mod spill_block_reader;
+// Synchronous inline spill compress for the P6 `CompressSpill` step (retires the
+// `SortWorkerPool` compress path). Surfaced via `write_sorted_chunk` below.
+pub(crate) mod sync_spill_writer;
 pub(crate) mod tmp_dir_alloc;
 pub(crate) mod verify;
 pub(crate) mod worker_pool;
@@ -165,15 +177,18 @@ fn create_temp_dir(base: Option<&Path>) -> Result<TempDir> {
     }
 }
 
+pub use arena_pool::{ArenaPool, PooledSegmentedBuf};
+pub use chunk_sorter::{CoordinateChunkSorter, TemplateChunkSorter};
 pub use codec::SpillCodec;
+pub use external::MemorySources;
 pub use external::{
-    CoordinateSortStream, KeyTypesSpec, LibraryLookup, MergeDriver, MergeDriverDyn, MergeStep,
-    QuerynameSortStream, QuerynameSortStreamGeneric, RawExternalSorter, SlotSetup,
-    TemplateCoordinateSortStream, cb_hasher, extract_template_key_inline,
+    KeyTypesSpec, LibraryLookup, MergeDriver, MergeDriverDyn, MergeStep, RawExternalSorter,
+    cb_hasher, extract_template_key_inline, open_spill_slot,
 };
 pub use inline::{
-    PackedCoordinateKey, RecordRef, TemplateKey, extract_coordinate_key_inline,
-    radix_sort_record_refs, radix_sort_record_refs_with_max,
+    CbKey32, InMemoryChunk, PackedCoordinateKey, RecordBuffer, RecordRef, SORT_SEGMENT_SIZE,
+    TemplateKey, TemplateKey24, TertKey32, extract_coordinate_key_inline, radix_sort_record_refs,
+    radix_sort_record_refs_with_max,
 };
 pub use keys::{
     QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
@@ -181,7 +196,17 @@ pub use keys::{
 };
 pub use merge_slots::{PHASE2_DECOMP_CAP, SortMergeSlot};
 pub use reader::RawBamRecordReader;
+pub use ref_sort::{
+    coordinate_chunk_from_arena_refs, coordinate_chunk_from_refs, queryname_chunk_from_arena_refs,
+};
+pub use segmented_buf::SegmentedBuf;
+pub use spill_block::{SpillBlockCompressor, frame_keyed_record_into, spill_magic, spill_trailer};
 pub use spill_block_reader::SpillBlockDecompressor;
+pub use sync_spill_writer::{write_sorted_chunk, write_sorted_chunk_inmem};
+pub use template_arena::{
+    TemplateArenaAccumulator, TemplateMemChunk, template_chunk_from_arena_refs,
+};
+pub use tmp_dir_alloc::TmpDirAllocator;
 pub use verify::{VerifySummary, verify_sort_order};
 
 #[cfg(test)]

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -65,37 +65,55 @@
 //! ## The OTHER Phase-2 implementation (`worker_pool.rs`) still has all of
 //! this — by design.
 //!
-//! Standalone file-to-file `fgumi sort` uses `worker_pool::Phase2FileState`
-//! plus the gap-filler this module dropped. That path is NOT broken: its merge
-//! consumer is a parked OS thread (no framework Skip), so the v4 deadlock
-//! cannot occur there, and its single-reader/**multi-decompressor** topology
-//! genuinely needs the reorder buffer + in-flight counter (a plain FIFO
-//! suffices HERE only because read-and-decompress is one inline op, so blocks
-//! decompress strictly in read order). Unifying the two drivers is a deferred
-//! goal — see commit `9d6d7e9` / PR #395 and
-//! `docs/design/sort-phase2-unification-deferral.md` — gated on this streaming
-//! path gaining file-to-file drive + `--write-index` + `--verify` + a
-//! deadlock-safe consumer.
-// TODO(#395): unify the two Phase-2 sort drivers — see docs/design/sort-phase2-unification-deferral.md
+//! Since the P6/P7 unification (#395) THIS module is the production Phase-2 for
+//! both standalone `fgumi sort` and the fused `runall` sort. `worker_pool::
+//! Phase2FileState` (plus the gap-filler this module dropped) no longer drives
+//! a production sort; it is retained as the `RawExternalSorter::sort` library
+//! path and the `#[cfg(test)]` parity oracle. It keeps the reorder buffer +
+//! in-flight counter because its single-reader/**multi-decompressor** topology
+//! genuinely needs them (a plain FIFO suffices HERE only because read-and-
+//! decompress is one inline op, so blocks decompress strictly in read order).
+//! (History: commit `9d6d7e9` / PR #395 and
+//! `docs/design/sort-phase2-unification-deferral.md`.)
 
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::BufReader;
+
+// Concurrency primitives are sourced from `loom` under `--cfg loom` so the
+// model-checking test (`tests/loom_merge_slots.rs`) exercises the REAL
+// `SortMergeSlot` atomics/mutexes — every interleaving and memory reordering of
+// the block-parallel EOF/in-flight/finalize protocol — instead of a hand-copied
+// re-implementation. Under a normal build these are the `std` types verbatim.
+#[cfg(loom)]
+use loom::sync::Mutex;
+#[cfg(loom)]
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+#[cfg(not(loom))]
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(loom))]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use fgumi_bam_io::reorder::ReorderBuffer;
 
 use crate::codec::SpillCodec;
 
 /// Per-slot decompressed-block queue cap. Bounds in-flight
 /// decompressed memory: `num_slots × PHASE2_DECOMP_CAP ×` per-entry size,
 /// where each entry is a decompressed BGZF block or zstd frame ranging from
-/// ~64 KB (BGZF) up to 256 KB (zstd worst case). Matches
-/// `worker_pool::PHASE2_DECOMP_CAP` numerically.
+/// ~64 KB (BGZF) up to 256 KB (zstd worst case).
+///
+/// Raised from 8 to 32 (increment 1a) to give the work-stealing decompressor
+/// more runway ahead of the `Detached` merge, which was input-starved
+/// (`MergeDiag stalls`) at the spill-heavy operating point. The `worker_pool.rs`
+/// copy (the `cfg(test)`/library oracle path) is intentionally left at 8 — these
+/// two are no longer equal.
 ///
 /// Hard cap — there is no admission escape. Producers skip a slot
 /// when its queue is at this cap, returning to it on a later
-/// `try_run` after the consumer has drained.
-pub const PHASE2_DECOMP_CAP: usize = 8;
+/// `try_run` after the consumer has drained. It stays a per-slot, independent
+/// bound (deadlock-safety is unchanged — see the module header).
+pub const PHASE2_DECOMP_CAP: usize = 32;
 
 /// Disk reader state for a single spill file. Mutex'd separately
 /// from `decompressed` so the producer can hold the reader during
@@ -103,6 +121,15 @@ pub const PHASE2_DECOMP_CAP: usize = 8;
 pub struct SortMergeReader {
     /// Buffered file handle.
     pub inner: BufReader<File>,
+    /// Next per-slot sequence number to assign to a raw block read from this
+    /// file. Used ONLY by the block-parallel `SortSpillDecompress` path: each
+    /// raw block read under the reader lock is stamped with a monotonically
+    /// increasing sequence number so the out-of-order decompression results can
+    /// be reassembled in read order by the slot's [`SortMergeSlot::reorder`]
+    /// buffer. Because every read is serialized under the reader lock, the
+    /// sequence numbers are dense and assigned in strict read order. Unused by
+    /// the inline (file-granularity) path, which never reorders.
+    pub next_seq: u64,
 }
 
 /// Per-spill-file shared state.
@@ -151,6 +178,36 @@ pub struct SortMergeSlot {
     /// stores while holding `decompressed`; consumer reads under
     /// the same lock.
     pub decomp_error: AtomicBool,
+
+    // ── Block-parallel decompression state (file_granularity == false) ───────
+    //
+    // These three fields are inert in the inline (file-granularity) path. In
+    // the block-parallel path multiple workers decompress one file's blocks
+    // concurrently: the READ is serialized under `reader` (sequence-tagged via
+    // `SortMergeReader::next_seq`), but the decompression happens outside the
+    // lock, so results complete out of order and are reassembled here.
+    /// Number of raw blocks that have been READ (under the reader lock) but not
+    /// yet inserted into `reorder`. Incremented under the reader lock when a
+    /// batch is read; decremented after the worker inserts that batch into
+    /// `reorder`. The slot may declare EOF only once this reaches zero — a
+    /// worker that observes reader-EOF must not truncate the merge while another
+    /// worker still holds an in-flight (read-but-undelivered) block.
+    pub in_flight: AtomicUsize,
+    /// Set true once a read returns fewer raw blocks than requested, i.e. the
+    /// disk reader reached a clean EOF. Distinct from `queue_eof`: `reader_eof`
+    /// means "no more blocks will be read", whereas `queue_eof` means "every
+    /// block has been read, decompressed, reassembled, and delivered to the
+    /// FIFO". `queue_eof` is set only when `reader_eof && in_flight == 0 &&
+    /// reorder.is_empty()`. Stored under the reader lock (Release), read in the
+    /// finalize path (Acquire); being an atomic it does not participate in lock
+    /// ordering.
+    pub reader_eof: AtomicBool,
+    /// Per-slot reorder buffer that reassembles out-of-order decompression
+    /// results back into read (sequence) order before they are drained into the
+    /// FIFO. Lock order: acquire `reorder` BEFORE `decompressed` (never the
+    /// reverse); the reader lock, when held, is outermost. The consumer never
+    /// touches this — it only pops the in-order FIFO.
+    pub reorder: Mutex<ReorderBuffer<Vec<u8>>>,
 }
 
 impl SortMergeSlot {
@@ -161,10 +218,13 @@ impl SortMergeSlot {
         Self {
             file_id,
             codec,
-            reader: Mutex::new(SortMergeReader { inner: reader }),
+            reader: Mutex::new(SortMergeReader { inner: reader, next_seq: 0 }),
             decompressed: Mutex::new(VecDeque::with_capacity(PHASE2_DECOMP_CAP)),
             queue_eof: AtomicBool::new(false),
             decomp_error: AtomicBool::new(false),
+            in_flight: AtomicUsize::new(0),
+            reader_eof: AtomicBool::new(false),
+            reorder: Mutex::new(ReorderBuffer::new()),
         }
     }
 
@@ -242,9 +302,203 @@ impl SortMergeSlot {
         let active = !self.queue_eof.load(Ordering::Acquire);
         (pending_blocks, pending_bytes, active)
     }
+
+    /// Current number of decompressed blocks resident in the FIFO. Locks
+    /// `decompressed` for an O(1) `len()` read — used by the decompressor's
+    /// emptiest-first refill order (most-starved slot first). Cheaper than
+    /// [`Self::probe_stats`], which also sums per-block byte lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn fifo_len(&self) -> usize {
+        self.decompressed.lock().expect("SortMergeSlot decompressed mutex poisoned").len()
+    }
+
+    // ── Block-parallel decompression helpers (file_granularity == false) ─────
+
+    /// Block-parallel admission control: may a worker read another batch of raw
+    /// blocks (whose first block would be tagged `next_seq`) into this slot's
+    /// reorder window?
+    ///
+    /// Combines [`ReorderBuffer::would_accept`] (the deadlock-free predicate the
+    /// pipeline uses elsewhere) with a hard `heap_bytes < window_budget`
+    /// backstop. The backstop is what actually bounds memory: `would_accept`
+    /// alone returns `true` (accept-all) while the buffer is *stuck* (the front
+    /// sequence not yet decompressed), which would let a slow straggler balloon
+    /// the window. The backstop is deadlock-safe **in this topology** because
+    /// reads are serialized and densely sequenced, so the front gap is ALWAYS an
+    /// already-read in-flight block (some worker is decompressing it) — never an
+    /// unread block that a new read would be required to fetch. Refusing new
+    /// reads therefore cannot wedge progress.
+    ///
+    /// `window_budget == 0` means unlimited.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` mutex is poisoned.
+    #[must_use]
+    pub fn bp_reorder_admits(&self, next_seq: u64, window_budget: u64) -> bool {
+        let rb = self.reorder.lock().expect("reorder mutex poisoned");
+        if !rb.would_accept(next_seq, window_budget) {
+            return false;
+        }
+        window_budget == 0 || rb.heap_bytes() < window_budget
+    }
+
+    /// Reserve `count` in-flight blocks just read under the reader lock.
+    ///
+    /// **Ordering requirement:** the caller MUST call this BEFORE
+    /// [`Self::bp_set_reader_eof`] for the EOF-carrying batch. Both stores are
+    /// `Release`; the lock-free finalizer in [`Self::drain_locked_and_finalize`]
+    /// reads `reader_eof` (Acquire) then `in_flight` (Acquire) WITHOUT the
+    /// reader lock, so only this publish order guarantees that observing
+    /// `reader_eof == true` also makes this batch's `in_flight` increment
+    /// visible — otherwise the finalizer can declare a clean EOF that truncates
+    /// the EOF read's own still-in-flight block (loom-verified; see
+    /// `tests/loom_merge_slots.rs`).
+    pub fn bp_add_in_flight(&self, count: usize) {
+        self.in_flight.fetch_add(count, Ordering::Release);
+    }
+
+    /// Mark the disk reader as having reached a clean EOF (called under the
+    /// reader lock when a read returns fewer blocks than requested).
+    ///
+    /// **Ordering requirement:** call this AFTER [`Self::bp_add_in_flight`] has
+    /// reserved the current batch — see that method's note. Publishing
+    /// `reader_eof` before the in-flight reservation reopens a truncation race.
+    pub fn bp_set_reader_eof(&self) {
+        self.reader_eof.store(true, Ordering::Release);
+    }
+
+    /// Publish the accounting for a batch of `count` raw blocks just read under
+    /// the reader lock, in the one order that is correct: reserve the in-flight
+    /// blocks FIRST, then (on a short read) set `reader_eof`.
+    ///
+    /// This is the single source of truth for the publish order — both the
+    /// production worker (`SortSpillDecompress::try_fill_block_parallel_slot`)
+    /// and the loom model (`tests/loom_merge_slots.rs`) call it, so the ordering
+    /// is model-checked against the real code and the two cannot drift.
+    ///
+    /// **Why this order (loom-verified).** The lock-free finalizer in
+    /// [`Self::drain_locked_and_finalize`] reads `reader_eof` (Acquire) then
+    /// `in_flight` (Acquire) WITHOUT the reader lock, so the reader lock does not
+    /// order this batch's accounting against it. Both stores are `Release`; a
+    /// finalizer that observes `reader_eof == true` therefore also observes this
+    /// (possibly EOF-carrying) batch's `in_flight` increment, and so cannot
+    /// finalize `queue_eof` while the batch is still in flight. Setting
+    /// `reader_eof` first would let a finalizer see `reader_eof == true` with
+    /// `in_flight == 0` after earlier blocks drained, finalizing a clean EOF that
+    /// silently truncates this batch's own block. Swapping the two lines makes
+    /// `tests/loom_merge_slots.rs` fail (as it did before the fix in `ac0a2ad`).
+    pub fn bp_commit_read(&self, count: usize, hit_eof: bool) {
+        self.bp_add_in_flight(count);
+        if hit_eof {
+            self.bp_set_reader_eof();
+        }
+    }
+
+    /// Number of additional decompressed blocks the FIFO can accept before it
+    /// hits [`PHASE2_DECOMP_CAP`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn bp_fifo_room(&self) -> usize {
+        let dec = self.decompressed.lock().expect("decompressed mutex poisoned");
+        PHASE2_DECOMP_CAP.saturating_sub(dec.len())
+    }
+
+    /// Tracked reorder-window heap bytes (for tests / diagnostics).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` mutex is poisoned.
+    #[must_use]
+    pub fn bp_reorder_heap_bytes(&self) -> u64 {
+        self.reorder.lock().expect("reorder mutex poisoned").heap_bytes()
+    }
+
+    /// Insert a freshly-decompressed batch `[start_seq, start_seq + count)` into
+    /// the reorder buffer, release the in-flight reservation, drain any now-ready
+    /// (in-order) blocks into the FIFO (bounded by [`PHASE2_DECOMP_CAP`]), and
+    /// finalize `queue_eof` if the slot is fully delivered.
+    ///
+    /// `blocks.len()` need not equal `count`: an empty final read (`count == 0`)
+    /// still calls through here so the EOF can be finalized once the last
+    /// in-flight block drains. Returns `true` if it made progress (drained at
+    /// least one block or finalized EOF).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` or `decompressed` mutex is poisoned.
+    pub fn bp_insert_drain_finalize(
+        &self,
+        start_seq: u64,
+        blocks: Vec<Vec<u8>>,
+        count: usize,
+    ) -> bool {
+        let mut rb = self.reorder.lock().expect("reorder mutex poisoned");
+        for (i, block) in blocks.into_iter().enumerate() {
+            let size = block.len();
+            // `start_seq + i` cannot exceed the number of blocks read from one
+            // spill file, which is far below u64::MAX.
+            rb.insert_with_size(start_seq + i as u64, block, size);
+        }
+        // The reservation now lives in `reorder`, so release it. AcqRel so the
+        // finalize load below sees a consistent count.
+        self.in_flight.fetch_sub(count, Ordering::AcqRel);
+        self.drain_locked_and_finalize(&mut rb)
+    }
+
+    /// Drain-only block-parallel pass: move any in-order ready blocks from the
+    /// reorder buffer into the FIFO (used when the FIFO had no room earlier, or
+    /// post-reader-EOF to flush stragglers other workers inserted) and finalize
+    /// `queue_eof`. Returns `true` if it made progress.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` or `decompressed` mutex is poisoned.
+    pub fn bp_drain_and_finalize(&self) -> bool {
+        let mut rb = self.reorder.lock().expect("reorder mutex poisoned");
+        self.drain_locked_and_finalize(&mut rb)
+    }
+
+    /// Shared drain + finalize, called with the `reorder` lock held. Acquires
+    /// `decompressed` (lock order: reorder → decompressed) so `queue_eof` is
+    /// stored under the same mutex the consumer reads it under.
+    fn drain_locked_and_finalize(&self, rb: &mut ReorderBuffer<Vec<u8>>) -> bool {
+        let mut dec = self.decompressed.lock().expect("decompressed mutex poisoned");
+        let mut room = PHASE2_DECOMP_CAP.saturating_sub(dec.len());
+        let mut drained = 0usize;
+        while room > 0 {
+            let Some(block) = rb.try_pop_next() else { break };
+            dec.push_back(block);
+            room -= 1;
+            drained += 1;
+        }
+        // Finalize EOF: reader is exhausted, every read block has been inserted
+        // (in_flight == 0), and the reorder buffer is fully drained. Stored
+        // under `decompressed` so the consumer's release-acquire chain sees it.
+        let mut finalized = false;
+        if !self.queue_eof.load(Ordering::Acquire)
+            && self.reader_eof.load(Ordering::Acquire)
+            && self.in_flight.load(Ordering::Acquire) == 0
+            && rb.is_empty()
+        {
+            self.queue_eof.store(true, Ordering::Release);
+            finalized = true;
+        }
+        drained > 0 || finalized
+    }
 }
 
-#[cfg(test)]
+// These exercise `SortMergeSlot` outside `loom::model`, which is illegal once
+// the primitives are loom's, so they compile only in a normal (non-loom) build.
+// The `--cfg loom` invocation runs `tests/loom_merge_slots.rs` exclusively.
+#[cfg(all(test, not(loom)))]
 mod tests {
     use super::*;
 
@@ -276,6 +530,15 @@ mod tests {
         let popped = slot.decompressed.lock().unwrap().pop_front();
         assert_eq!(popped, Some(vec![0xAB, 0xCD]));
         assert!(slot.is_drained(), "drained once queue empty AND queue_eof");
+    }
+
+    #[test]
+    fn fifo_len_reports_block_count() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        assert_eq!(slot.fifo_len(), 0);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 10]);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 20]);
+        assert_eq!(slot.fifo_len(), 2, "counts blocks, not bytes");
     }
 
     #[test]
@@ -334,5 +597,94 @@ mod tests {
         slot.queue_eof.store(true, Ordering::Release);
         assert!(slot.is_drained(), "clean empty + queue_eof is drained");
         assert!(!slot.has_error(), "clean drain has no error");
+    }
+
+    // ── Block-parallel helper tests ─────────────────────────────────────────
+
+    /// A single in-order batch drains straight into the FIFO and (because the
+    /// reader is at EOF with no other in-flight blocks) finalizes `queue_eof`.
+    #[test]
+    fn bp_single_batch_drains_and_finalizes() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.bp_add_in_flight(2);
+        slot.bp_set_reader_eof();
+        let progressed = slot.bp_insert_drain_finalize(0, vec![vec![1u8], vec![2u8]], 2);
+        assert!(progressed);
+        assert!(slot.queue_eof.load(Ordering::Acquire), "reader_eof + drained ⇒ queue_eof");
+        let mut dec = slot.decompressed.lock().unwrap();
+        assert_eq!(dec.pop_front(), Some(vec![1u8]));
+        assert_eq!(dec.pop_front(), Some(vec![2u8]));
+    }
+
+    /// EOF-with-stragglers: a worker reads the FINAL (short) batch and hits
+    /// reader-EOF while another worker still holds an earlier in-flight batch.
+    /// The EOF-observing worker must NOT finalize `queue_eof` (which would
+    /// truncate the merge); only after the straggler is delivered, in order,
+    /// does the slot finalize. No block is dropped or reordered.
+    #[test]
+    fn bp_eof_with_straggler_does_not_truncate() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Worker A reserved seqs 0,1; worker B reserved seqs 2,3 on the final
+        // (short) read and set reader_eof.
+        slot.bp_add_in_flight(2); // A: seq 0,1
+        slot.bp_add_in_flight(2); // B: seq 2,3 (final batch)
+        slot.bp_set_reader_eof();
+
+        // Worker B finishes decompressing FIRST and delivers seqs 2,3. Gap at
+        // 0,1 ⇒ nothing drains, and in_flight (A's 2) is non-zero ⇒ no EOF.
+        let b_progress = slot.bp_insert_drain_finalize(2, vec![vec![2u8], vec![3u8]], 2);
+        assert!(!b_progress, "straggler ahead-of-gap insert drains nothing and can't finalize");
+        assert!(!slot.queue_eof.load(Ordering::Acquire), "must NOT declare EOF with A in flight");
+        assert!(slot.decompressed.lock().unwrap().is_empty(), "nothing delivered yet");
+
+        // Worker A finishes and delivers seqs 0,1 ⇒ all four drain in order and
+        // EOF finalizes.
+        let a_progress = slot.bp_insert_drain_finalize(0, vec![vec![0u8], vec![1u8]], 2);
+        assert!(a_progress);
+        assert!(slot.queue_eof.load(Ordering::Acquire), "EOF finalizes once straggler delivered");
+
+        let mut dec = slot.decompressed.lock().unwrap();
+        let order: Vec<u8> = std::iter::from_fn(|| dec.pop_front()).map(|b| b[0]).collect();
+        assert_eq!(order, vec![0, 1, 2, 3], "blocks delivered in read order, none truncated");
+    }
+
+    /// The reorder window stays bounded when the front sequence straggles: a
+    /// worker keeps decompressing ahead-of-gap blocks, but `bp_reorder_admits`
+    /// refuses new reads once `heap_bytes` reaches the window budget, so the
+    /// buffer never balloons past `budget + one batch`.
+    #[test]
+    fn bp_reorder_window_is_bounded_under_straggler() {
+        const BLOCK: usize = 1024;
+        const BUDGET: u64 = 4 * BLOCK as u64; // 4 blocks
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Seq 0 is the straggler — it is reserved but never decompressed/inserted,
+        // so the buffer can never pop and keeps a permanent front gap.
+        slot.bp_add_in_flight(1); // seq 0 in flight forever (the straggler)
+
+        // Workers race ahead delivering seqs 1,2,3,… as long as admission allows.
+        let mut next = 1u64;
+        let mut admitted = 0;
+        while slot.bp_reorder_admits(next, BUDGET) {
+            slot.bp_add_in_flight(1);
+            slot.bp_insert_drain_finalize(next, vec![vec![0u8; BLOCK]], 1);
+            // Front gap at seq 0 ⇒ nothing drains.
+            assert!(slot.decompressed.lock().unwrap().is_empty());
+            assert!(!slot.queue_eof.load(Ordering::Acquire), "never EOF while seq 0 in flight");
+            assert!(
+                slot.bp_reorder_heap_bytes() <= BUDGET,
+                "reorder window must stay within budget, got {} > {BUDGET}",
+                slot.bp_reorder_heap_bytes(),
+            );
+            next += 1;
+            admitted += 1;
+            assert!(admitted < 1000, "admission must eventually backpressure, not loop forever");
+        }
+        assert!(admitted > 0, "should admit at least some ahead-of-gap blocks");
+        assert!(
+            slot.bp_reorder_heap_bytes() >= BUDGET.saturating_sub(BLOCK as u64),
+            "should have filled the window before backpressuring",
+        );
     }
 }

--- a/crates/fgumi-sort/src/ref_sort.rs
+++ b/crates/fgumi-sort/src/ref_sort.rs
@@ -1,0 +1,381 @@
+//! Build a sorted coordinate [`InMemoryChunk`] from record bodies already resident
+//! in a shared arena, WITHOUT copying record bytes — the core of the parallel-inflate
+//! ingest. The chunk's `(offset, len)` point at record bodies in the supplied arena;
+//! the existing Phase-2 merge consumes it unchanged.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use voracious_radix_sort::{RadixSort, Radixable};
+
+use crate::arena_pool::PooledSegmentedBuf;
+use crate::inline::{
+    InMemoryChunk, RecordRef, extract_coordinate_key_inline, radix_sort_record_refs,
+};
+use crate::keys::{RawCoordinateKey, RawSortKey};
+
+/// Arrays smaller than this sort faster single-threaded (the parallel radix's
+/// partition + thread-coordination overhead exceeds its benefit on small inputs;
+/// microbench-tuned). Shared with the template arena builder
+/// (`template_arena::template_chunk_from_arena_refs`) so both order-specific
+/// radix fronts fall back to the serial path at the same input size.
+pub(crate) const PARALLEL_SORT_THRESHOLD: usize = 256 * 1024;
+
+/// `repr(transparent)` view of a [`RecordRef`] that orders by the
+/// `(sort_key, offset)` **composite** rather than by `sort_key` alone.  This lets
+/// `voracious`'s (unstable) parallel radix produce a STABLE-equivalent coordinate
+/// order: within one chunk every record has a distinct `offset` that increases in
+/// input order, so `(sort_key, offset)` is a total order whose ties resolve to
+/// input order — byte-identical to the stable single-threaded radix.  Wrapping
+/// (instead of changing `RecordRef`'s own `PartialEq`) keeps `RecordRef`'s
+/// existing key-only equality untouched for the rest of the engine.
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct CoordSortRef(RecordRef);
+
+impl CoordSortRef {
+    #[inline]
+    fn composite(self) -> u128 {
+        (u128::from(self.0.sort_key) << 64) | u128::from(self.0.offset)
+    }
+}
+
+impl PartialOrd for CoordSortRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.composite().cmp(&other.composite()))
+    }
+}
+
+impl PartialEq for CoordSortRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.composite() == other.composite()
+    }
+}
+
+impl Radixable<u128> for CoordSortRef {
+    type Key = u128;
+    #[inline]
+    fn key(&self) -> u128 {
+        self.composite()
+    }
+}
+
+/// Sort coordinate `RecordRef`s in place, stably by `sort_key`.
+///
+/// For large inputs with `sort_threads > 1`, uses `voracious`'s parallel radix
+/// over the `(sort_key, offset)` composite (see [`CoordSortRef`]) — measured ~4×
+/// faster than the single-threaded radix at realistic coordinate-key widths.  For
+/// small inputs or a single thread it falls back to the single-threaded stable LSD
+/// radix (the parallel path's overhead does not pay off there).  Both produce
+/// byte-identical output (verified by the ref-sort oracle tests).
+fn sort_coordinate_refs(refs: &mut [RecordRef], sort_threads: usize) {
+    if sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD {
+        // SAFETY: `CoordSortRef` is `#[repr(transparent)]` over `RecordRef`, so the
+        // two have identical size, alignment, and layout; reinterpreting the slice
+        // (via a pointer cast — clippy rejects a ref-to-ref `transmute`) is sound.
+        // This is the only `unsafe` in this module's production path.
+        #[allow(unsafe_code)]
+        let view: &mut [CoordSortRef] =
+            unsafe { &mut *(std::ptr::from_mut::<[RecordRef]>(refs) as *mut [CoordSortRef]) };
+        view.voracious_mt_sort(sort_threads);
+    } else {
+        radix_sort_record_refs(refs);
+    }
+}
+
+/// Build a sorted coordinate chunk from record bodies already resident in `arena`.
+///
+/// `bodies[i] = (body_offset, body_len)` locate each record's BAM body (the 4-byte
+/// `block_size` prefix already excluded) within `arena`. The coordinate key is
+/// extracted from each body exactly as `RecordBuffer::push_coordinate` does, the
+/// refs are radix-sorted, and the same `arena` is wrapped into the returned chunk
+/// (no record bytes are copied). The chunk's `(offset, len)` therefore point at the
+/// bodies in `arena`, byte-identical to what the copy-based sorter materializes.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)] // offset/len fit in usize on all supported targets (BAM is < 4 GiB; arenas < address space)
+pub fn coordinate_chunk_from_arena_refs(
+    arena: Arc<PooledSegmentedBuf>,
+    bodies: &[(u64, u32)],
+    n_ref: u32,
+    sort_threads: usize,
+) -> InMemoryChunk<RawCoordinateKey> {
+    let mut refs: Vec<RecordRef> = Vec::with_capacity(bodies.len());
+    for &(offset, len) in bodies {
+        let body = arena.slice(offset as usize, len as usize);
+        let sort_key = extract_coordinate_key_inline(body, n_ref);
+        refs.push(RecordRef::new(sort_key, offset, len));
+    }
+    coordinate_chunk_from_refs(arena, refs, sort_threads)
+}
+
+/// Build a sorted coordinate chunk from already-extracted `RecordRef`s (each
+/// carries its coordinate `sort_key` and the `(offset, len)` of its body in
+/// `arena`).  Radix-sorts the refs and wraps `arena` into the returned chunk —
+/// NO walk of the arena and NO record-byte copies.
+///
+/// This is the fused entry point: the caller (`FindBoundariesAndSort`) extracts
+/// the key during its single boundary scan and hands the refs here, so the arena
+/// is walked exactly once for the whole run (the previous two-step
+/// [`coordinate_chunk_from_arena_refs`] re-walked it to re-derive each key).
+#[must_use]
+pub fn coordinate_chunk_from_refs(
+    arena: Arc<PooledSegmentedBuf>,
+    mut refs: Vec<RecordRef>,
+    sort_threads: usize,
+) -> InMemoryChunk<RawCoordinateKey> {
+    sort_coordinate_refs(&mut refs, sort_threads);
+    let records: Vec<(RawCoordinateKey, u64, u32)> =
+        refs.iter().map(|r| (RawCoordinateKey { sort_key: r.sort_key }, r.offset, r.len)).collect();
+    InMemoryChunk::from_parts(arena, records)
+}
+
+/// Build a sorted queryname chunk from already-extracted `(key, offset, len)`
+/// refs pointing into `arena`. Unlike the coordinate/template builders, the
+/// queryname key is a variable-length read name (not radix-able), so this sorts
+/// by the key comparator with `par_sort_unstable_by` — matching the legacy
+/// queryname path's unstable comparator sort. No record bytes are copied: the
+/// returned chunk references its bodies in `arena`.
+///
+/// **Threading contract (differs from the coordinate/template radix builders on
+/// purpose).** Those take an explicit `sort_threads` and gate the parallel radix
+/// on both `sort_threads > 1` and [`PARALLEL_SORT_THRESHOLD`]. This builder takes
+/// no `sort_threads`: the caller (`QuerynameStrategy::seal`, in `fgumi-pipeline-io`)
+/// runs it inside a rayon pool already sized to `sort_threads`, so parallelism is
+/// bounded there,
+/// and `rayon::par_sort_unstable_by` has its own internal sequential cutoff for
+/// small slices — so a tiny run does not pay a partition/coordination cost even
+/// without an explicit size threshold here.
+#[must_use]
+pub fn queryname_chunk_from_arena_refs<K: RawSortKey>(
+    arena: Arc<PooledSegmentedBuf>,
+    mut records: Vec<(K, u64, u32)>,
+) -> InMemoryChunk<K> {
+    use rayon::prelude::*;
+    // `par_sort_unstable_by` gives no order guarantee for records whose keys
+    // compare equal (exact name+flag-class ties). samtools resolves those
+    // remaining ties by input order; the arena assigns offsets in ingest order,
+    // so break exact ties by ascending offset to preserve that (and keep output
+    // byte-identical run to run).
+    records.par_sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    InMemoryChunk::from_parts(arena, records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The parallel `voracious_mt_sort` coordinate path only fires at
+    /// `sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD`; the oracle
+    /// tests use small, single-thread inputs and never reach it. Build a
+    /// threshold-sized input with deliberate key ties and pin the parallel path's
+    /// ordering against the single-threaded stable radix (`radix_sort_record_refs`,
+    /// which the oracle already proves matches the copy sorter). Both order by
+    /// `sort_key`, breaking ties by input order (== ascending `offset` here), so
+    /// they must agree on `(sort_key, offset)` for every record — a divergence
+    /// would mean the parallel composite mis-sorts or loses stability.
+    #[test]
+    fn parallel_coordinate_sort_matches_serial_radix_at_threshold() {
+        let n = PARALLEL_SORT_THRESHOLD; // exactly at the parallel cutoff
+        // Keys in a small range → ~260 ties per key across the input, so a
+        // stability bug in the parallel path would reorder equal-key records.
+        let refs: Vec<RecordRef> = (0..n)
+            .map(|i| {
+                let i = i as u64;
+                RecordRef::new(i.wrapping_mul(2_654_435_761) % 997, i, 1)
+            })
+            .collect();
+        let mut parallel = refs.clone();
+        let mut serial = refs;
+        sort_coordinate_refs(&mut parallel, 4); // threads > 1 + len >= threshold → parallel path
+        radix_sort_record_refs(&mut serial); // single-threaded stable reference
+        assert_eq!(parallel.len(), serial.len());
+        for (p, s) in parallel.iter().zip(&serial) {
+            assert_eq!(
+                (p.sort_key, p.offset),
+                (s.sort_key, s.offset),
+                "parallel voracious path diverged from the serial radix"
+            );
+        }
+    }
+    use crate::arena_pool::PooledSegmentedBuf;
+    use crate::chunk_sorter::CoordinateChunkSorter;
+    use crate::segmented_buf::SegmentedBuf;
+    use std::sync::Arc;
+
+    // Build a minimal valid BAM record body (no block_size prefix) with the given
+    // refId/pos and a one-character read name `name`. The read name is NOT part of
+    // the coordinate sort key (which reads only refId/pos/flags at bytes 0-15), so
+    // two records with the same (refId,pos) but different `name` are a coordinate
+    // TIE whose relative order is observable in the output bytes — that is what lets
+    // these tests actually witness a stable-vs-unstable sort difference. Returns the
+    // body bytes.
+    fn coord_body(ref_id: i32, pos: i32, name: u8) -> Vec<u8> {
+        // Minimal BAM record body: refID(4) pos(4) l_read_name(1) mapq(1) bin(2)
+        // n_cigar_op(2) flag(2) l_seq(4) next_refID(4) next_pos(4) tlen(4) + read_name.
+        let mut b = Vec::new();
+        b.extend_from_slice(&ref_id.to_le_bytes());
+        b.extend_from_slice(&pos.to_le_bytes());
+        b.push(2); // l_read_name (incl NUL): "<name>\0"
+        b.push(0); // mapq
+        b.extend_from_slice(&0u16.to_le_bytes()); // bin
+        b.extend_from_slice(&0u16.to_le_bytes()); // n_cigar_op
+        b.extend_from_slice(&0u16.to_le_bytes()); // flag (forward)
+        b.extend_from_slice(&0u32.to_le_bytes()); // l_seq
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_refID
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_pos
+        b.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        b.push(name); // read_name char (distinguishes tied records)
+        b.push(0); // read_name NUL terminator
+        b
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn ref_sort_matches_copy_based_sorter_byte_for_byte() {
+        // Records deliberately out of coordinate order.
+        let n_ref = 4u32;
+        // Distinct read-name bytes make every record byte-unique, so a stability
+        // divergence (reordering the (0,50) tie at indices 1 and 3) would change the
+        // output byte sequence and fail the assertion below.
+        let recs = vec![
+            coord_body(2, 100, b'a'),
+            coord_body(0, 50, b'b'),
+            coord_body(2, 10, b'c'),
+            coord_body(0, 50, b'd'), // coordinate tie with index 1 → stable sort must keep b before d
+            coord_body(1, 999, b'e'),
+        ];
+
+        // ---- Path A: the existing copy-based sorter (the ORACLE) ----
+        let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref); // see note below
+        for r in &recs {
+            let _ = oracle.push(r).unwrap();
+        }
+        let oracle_chunk = oracle.take_sorted_chunk();
+        let oracle_bytes: Vec<Vec<u8>> =
+            (0..oracle_chunk.len()).map(|i| oracle_chunk.record_bytes(i).to_vec()).collect();
+
+        // ---- Path B: the ref-sort over an arena holding verbatim [block_size][body] ----
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        let mut bodies = Vec::new();
+        for r in &recs {
+            // store verbatim record: 4-byte block_size (= body len) then body.
+            let block_size = u32::try_from(r.len()).unwrap();
+            // SAFETY: each slot fully written before any read.
+            let prefix_off = unsafe { arena.grow_uninit(4) };
+            unsafe { arena.slice_mut(prefix_off, 4) }.copy_from_slice(&block_size.to_le_bytes());
+            let body_off = unsafe { arena.grow_uninit(r.len()) };
+            unsafe { arena.slice_mut(body_off, r.len()) }.copy_from_slice(r);
+            bodies.push((body_off as u64, block_size)); // ref points at the BODY, len = block_size
+        }
+        let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        let ref_chunk = coordinate_chunk_from_arena_refs(arena_arc, &bodies, n_ref, 1);
+        let ref_bytes: Vec<Vec<u8>> =
+            (0..ref_chunk.len()).map(|i| ref_chunk.record_bytes(i).to_vec()).collect();
+
+        assert_eq!(
+            ref_bytes, oracle_bytes,
+            "ref-sort output must be byte-identical to the copy-based sorter"
+        );
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        // For any multiset of (refId, pos) records — including ties and unmapped —
+        // the ref-sort produces the same sorted body sequence as the copy sorter.
+        #[test]
+        #[allow(unsafe_code)]
+        fn prop_ref_sort_matches_copy_sorter(
+            // `-1` tids exercise the unmapped → `nref` sentinel (`u64::MAX`)
+            // ordering path, which `0..5` alone never reaches despite the header.
+            coords in prop::collection::vec((-1i32..5, 0i32..2000), 0..60),
+        ) {
+            let n_ref = 5u32;
+            // A unique read-name per record (by input index) makes every record
+            // byte-distinct, so any reordering of equal-key (tied) records would
+            // change the output and fail the assertion — witnessing stability.
+            let recs: Vec<Vec<u8>> = coords
+                .iter()
+                .enumerate()
+                .map(|(i, &(t, p))| coord_body(t, p, u8::try_from(i).unwrap()))
+                .collect();
+
+            let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref);
+            for r in &recs { let _ = oracle.push(r).unwrap(); }
+            let oracle_chunk = oracle.take_sorted_chunk();
+            let oracle_bytes: Vec<Vec<u8>> =
+                (0..oracle_chunk.len()).map(|i| oracle_chunk.record_bytes(i).to_vec()).collect();
+
+            let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+            arena.reserve_full_capacity();
+            let mut bodies = Vec::new();
+            for r in &recs {
+                let bs = u32::try_from(r.len()).unwrap();
+                // SAFETY: each slot is fully written (via `slice_mut`) before any
+                // read — the 4-byte prefix and the body are copied in immediately
+                // after each `grow_uninit`, satisfying the write-before-read contract.
+                let po = unsafe { arena.grow_uninit(4) };
+                unsafe { arena.slice_mut(po, 4) }.copy_from_slice(&bs.to_le_bytes());
+                // SAFETY: as above — the body slot is fully written before any read.
+                let bo = unsafe { arena.grow_uninit(r.len()) };
+                unsafe { arena.slice_mut(bo, r.len()) }.copy_from_slice(r);
+                bodies.push((bo as u64, bs));
+            }
+            let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+            let ref_chunk = coordinate_chunk_from_arena_refs(arena_arc, &bodies, n_ref, 1);
+            let ref_bytes: Vec<Vec<u8>> =
+                (0..ref_chunk.len()).map(|i| ref_chunk.record_bytes(i).to_vec()).collect();
+
+            prop_assert_eq!(ref_bytes, oracle_bytes);
+        }
+    }
+
+    /// Exact queryname ties (identical name + flag class) must emerge in ingest
+    /// order — samtools' final tie-break — which the arena encodes as ascending
+    /// offset. `par_sort_unstable_by` on the key alone gives no such guarantee,
+    /// so feed equal-key refs in scrambled order and assert the sort restores
+    /// ascending-offset (== ingest) order.
+    #[test]
+    #[allow(unsafe_code)]
+    fn queryname_arena_sort_breaks_exact_ties_by_offset() {
+        use crate::keys::RawQuerynameKey;
+
+        let n = 2_000usize;
+        let key = RawQuerynameKey::new(b"dup/name".to_vec(), 0); // one shared key → all ties
+
+        // Each body encodes its ingest index; offsets ascend with the index, so a
+        // correct sort must decode 0,1,2,… in order.
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        let mut by_index: Vec<(u64, u32)> = Vec::with_capacity(n);
+        for i in 0..n {
+            let body = (i as u64).to_le_bytes();
+            // SAFETY: each slot is fully written (copy_from_slice) before any read.
+            let off = unsafe { arena.grow_uninit(body.len()) };
+            unsafe { arena.slice_mut(off, body.len()) }.copy_from_slice(&body);
+            by_index.push((off as u64, u32::try_from(body.len()).unwrap()));
+        }
+
+        // Feed refs in a scrambled order (odds then evens) so an unstable sort with
+        // no offset tie-break would not reliably yield ascending offsets.
+        let mut refs: Vec<(RawQuerynameKey, u64, u32)> = Vec::with_capacity(n);
+        for i in (0..n).filter(|i| i % 2 == 1).chain((0..n).filter(|i| i % 2 == 0)) {
+            let (off, len) = by_index[i];
+            refs.push((key.clone(), off, len));
+        }
+
+        let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        let chunk = queryname_chunk_from_arena_refs(arena_arc, refs);
+        assert_eq!(chunk.len(), n);
+
+        let mut prev: Option<u64> = None;
+        for i in 0..chunk.len() {
+            let v = u64::from_le_bytes(chunk.record_bytes(i).try_into().unwrap());
+            if let Some(p) = prev {
+                assert!(v > p, "exact-tie records not in ascending ingest order: {p} then {v}");
+            }
+            prev = Some(v);
+        }
+    }
+}

--- a/crates/fgumi-sort/src/segmented_buf.rs
+++ b/crates/fgumi-sort/src/segmented_buf.rs
@@ -27,6 +27,14 @@ pub struct SegmentedBuf {
     segments: Vec<Vec<u8>>,
     /// Total bytes stored across all segments.
     total_len: usize,
+    /// Index of the segment currently being filled (the write cursor). Writes
+    /// land in `segments[cur]`; on overflow the cursor advances and **reuses**
+    /// `segments[cur+1]` if it already exists (retained by `reset_for_reuse`),
+    /// else a new segment is pushed. `cur == total_len / segment_size` always
+    /// holds (the overflow path pads `total_len` to the segment boundary), which
+    /// keeps `locate()` exact. For an actively-growing buffer `cur` is the last
+    /// index, so behaviour is identical to the pre-cursor `segments.last()` path.
+    cur: usize,
 }
 
 #[allow(dead_code)] // Some methods are only exercised from tests for now.
@@ -45,13 +53,39 @@ impl SegmentedBuf {
         let estimated_segments = (capacity / segment_size).max(1);
         let mut segments = Vec::with_capacity(estimated_segments);
         segments.push(Vec::with_capacity(first_cap));
-        Self { segment_size, segments, total_len: 0 }
+        Self { segment_size, segments, total_len: 0, cur: 0 }
     }
 
     /// Create a new buffer with a default segment size of 256 MiB.
     #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(0, DEFAULT_SEGMENT_SIZE)
+    }
+
+    /// Ensure `needed` bytes fit contiguously in the current segment, starting a
+    /// fresh (gap-padded) segment if they don't.
+    ///
+    /// This is the single source of truth for the "pad `total_len` to the next
+    /// segment boundary, then [`advance_segment`](Self::advance_segment)" offset
+    /// arithmetic shared by [`extend_from_slice`](Self::extend_from_slice),
+    /// [`reserve_contiguous`](Self::reserve_contiguous), and
+    /// [`grow_uninit`](Self::grow_uninit). Keeping it in one place is a
+    /// correctness requirement, not just DRY: `ArenaLayout::plan`
+    /// (`block_offsets.rs`) must reproduce these offsets byte-for-byte, so a
+    /// divergence between the three call sites would silently corrupt sort output
+    /// identity. Callers read `self.total_len` as the write offset *after* this
+    /// returns.
+    #[inline]
+    fn make_room(&mut self, needed: usize) {
+        let seg = &self.segments[self.cur];
+        if seg.len() + needed > self.segment_size {
+            // Pad total_len to the next segment boundary so locate() works.
+            let remainder = self.total_len % self.segment_size;
+            if remainder > 0 {
+                self.total_len += self.segment_size - remainder;
+            }
+            self.advance_segment();
+        }
     }
 
     /// Append bytes to the buffer, returning the global offset of the write.
@@ -76,20 +110,44 @@ impl SegmentedBuf {
             self.segment_size,
         );
 
-        let seg = self.segments.last().expect("segments is never empty");
-        if seg.len() + data.len() > self.segment_size {
-            // Pad total_len to the next segment boundary so locate() works.
-            let remainder = self.total_len % self.segment_size;
-            if remainder > 0 {
-                self.total_len += self.segment_size - remainder;
-            }
-            self.segments.push(Vec::with_capacity(self.segment_size));
-        }
+        self.make_room(data.len());
 
         let offset = self.total_len;
-        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.segments[self.cur].extend_from_slice(data);
         self.total_len += data.len();
         offset
+    }
+
+    /// Advance the write cursor to the next segment, **reusing** a retained
+    /// (already-cleared) segment if one exists, else allocating a fresh one.
+    /// Reuse is what makes `reset_for_reuse` + refill allocation-free.
+    #[inline]
+    fn advance_segment(&mut self) {
+        self.cur += 1;
+        if self.cur == self.segments.len() {
+            self.segments.push(Vec::with_capacity(self.segment_size));
+        }
+        debug_assert!(
+            self.segments[self.cur].is_empty(),
+            "advance_segment landed on a non-empty segment (reset_for_reuse must clear all)"
+        );
+    }
+
+    /// Ensure the current segment's backing `Vec` has capacity == `segment_size`.
+    ///
+    /// After this, any sequence of [`grow_uninit`](Self::grow_uninit) /
+    /// [`extend_from_slice`](Self::extend_from_slice) calls that stay within this
+    /// segment never reallocate it — so a `&mut [u8]` previously handed out by
+    /// [`slice_mut`](Self::slice_mut) for an earlier slot cannot be invalidated by
+    /// a later grow. This is what makes the parallel-inflate arena sound: the
+    /// serial admit path calls this once per fresh segment before handing any slot
+    /// to an inflate worker. No-op if the segment already holds `segment_size`.
+    pub fn reserve_full_capacity(&mut self) {
+        let seg = &mut self.segments[self.cur];
+        let have = seg.capacity();
+        if have < self.segment_size {
+            seg.reserve_exact(self.segment_size - seg.len());
+        }
     }
 
     /// Ensure at least `additional` bytes fit in the current segment.
@@ -112,14 +170,7 @@ impl SegmentedBuf {
             self.segment_size,
         );
 
-        let seg = self.segments.last().expect("segments is never empty");
-        if seg.len() + additional > self.segment_size {
-            let remainder = self.total_len % self.segment_size;
-            if remainder > 0 {
-                self.total_len += self.segment_size - remainder;
-            }
-            self.segments.push(Vec::with_capacity(self.segment_size));
-        }
+        self.make_room(additional);
         self.total_len
     }
 
@@ -134,11 +185,136 @@ impl SegmentedBuf {
     #[inline]
     pub fn extend_in_place(&mut self, data: &[u8]) {
         debug_assert!(
-            self.segments.last().is_some_and(|s| s.len() + data.len() <= self.segment_size),
+            self.segments[self.cur].len() + data.len() <= self.segment_size,
             "extend_in_place exceeds segment capacity; use reserve_contiguous first"
         );
-        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.segments[self.cur].extend_from_slice(data);
         self.total_len += data.len();
+    }
+
+    /// Reserve a contiguous slot of `additional` **uninitialized-but-live** bytes,
+    /// returning the global offset of its first byte. The slot is guaranteed to lie
+    /// within a single segment (gap-padding is applied exactly as
+    /// [`reserve_contiguous`](Self::reserve_contiguous)), so it can later be written
+    /// through [`slice_mut`](Self::slice_mut) and read through [`slice`](Self::slice).
+    ///
+    /// Unlike `reserve_contiguous` + `extend_in_place`, this grows the segment's
+    /// length WITHOUT copying or zero-filling — it is the admit-path primitive for
+    /// the parallel-inflate arena, where an inflate worker writes every byte of the
+    /// slot exactly once. The returned offsets reproduce `reserve_contiguous`'s
+    /// accounting byte-for-byte.
+    ///
+    /// # Safety
+    ///
+    /// On return the `additional` bytes at the returned offset are LIVE but
+    /// UNINITIALIZED. The caller MUST fully initialize the entire slot (e.g. via
+    /// [`slice_mut`](Self::slice_mut)) before reading any of those bytes through
+    /// [`slice`](Self::slice) or [`slice_mut`]. Reading the slot before it is
+    /// fully written is undefined behavior.
+    ///
+    /// **Pointer stability:** `grow_uninit` calls `Vec::reserve`, which *can*
+    /// reallocate and move a segment's storage — invalidating any `&mut [u8]`
+    /// previously handed out by [`slice_mut`](Self::slice_mut) for an earlier
+    /// slot in the same segment. So before exposing any `slice_mut` slot that
+    /// will be held across a later `grow_uninit` on the same segment (the
+    /// concurrent-inflate use case), the caller MUST first call
+    /// [`reserve_full_capacity`](Self::reserve_full_capacity) once for that fresh
+    /// segment: it fixes the segment at `segment_size` capacity so no subsequent
+    /// `grow_uninit` within it reallocates. (In the single-threaded case the
+    /// borrow checker already forbids holding a `slice_mut` borrow across a
+    /// `&mut self` `grow_uninit` call.)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `additional > segment_size`.
+    #[allow(unsafe_code)]
+    #[allow(clippy::uninit_vec)] // intentional: slot is live-but-uninitialized; contract requires caller to fully write it
+    pub unsafe fn grow_uninit(&mut self, additional: usize) -> usize {
+        assert!(
+            additional <= self.segment_size,
+            "grow of {} bytes exceeds segment size {}",
+            additional,
+            self.segment_size,
+        );
+
+        self.make_room(additional);
+
+        let offset = self.total_len;
+        let seg = &mut self.segments[self.cur];
+        let new_len = seg.len() + additional;
+        seg.reserve(additional);
+        // SAFETY: after `reserve(additional)`, `capacity() >= new_len`, so
+        // `set_len(new_len)` only extends `len` over already-allocated bytes. The
+        // grown region `old_len..new_len` is intentionally left uninitialized; the
+        // documented `# Safety` contract requires the caller to fully write it via
+        // `slice_mut` before any read. `u8` has no drop glue and no validity
+        // invariant, so growing `len` over uninitialized bytes is not itself UB —
+        // only a read-before-write would be, which the contract forbids.
+        //
+        // NB: this `reserve` MAY reallocate and move the segment's storage; that
+        // is safe here only because no `slice_mut` borrow is live across this call
+        // — either the borrow checker forbids it (`&mut self`), or the caller
+        // pre-sized the segment via `reserve_full_capacity` so this `reserve` is a
+        // no-op (see the `# Safety` "Pointer stability" note).
+        unsafe {
+            seg.set_len(new_len);
+        }
+        self.total_len += additional;
+        offset
+    }
+
+    /// Obtain a mutable view of a previously-reserved slot by global `(offset, len)`.
+    ///
+    /// Takes `&self` (not `&mut self`) so that multiple **disjoint** slots can be
+    /// written concurrently from different threads, each holding its own
+    /// `&mut [u8]` into the shared buffer — the parallel-inflate use case.
+    ///
+    /// # Safety
+    ///
+    /// The caller MUST guarantee that:
+    /// 1. `(offset, len)` was produced by [`grow_uninit`](Self::grow_uninit) (or
+    ///    `reserve_contiguous` + a matching in-place fill), so it lies within a
+    ///    single segment's live region and is in bounds; and
+    /// 2. no other `slice`/`slice_mut` borrow of ANY overlapping range is live for
+    ///    the duration of the returned reference — callers partition the buffer
+    ///    into non-overlapping slots and write each exactly once.
+    ///
+    /// Violating either is undefined behavior (an aliasing `&mut`, or an
+    /// out-of-bounds reference).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range spans a segment boundary or exceeds the segment's
+    /// live length.
+    #[must_use]
+    #[allow(unsafe_code)]
+    #[allow(clippy::mut_from_ref)] // intentional: &self lets disjoint slots be written concurrently; caller's disjointness contract is the safety invariant
+    pub unsafe fn slice_mut(&self, offset: usize, len: usize) -> &mut [u8] {
+        // A zero-length slot never needs to be located: `offset` may legitimately
+        // sit on a segment boundary (e.g. after `grow_uninit(0)` when the current
+        // segment is exactly full), where `locate` would index past the last
+        // segment and panic. Return an empty slice instead.
+        if len == 0 {
+            return &mut [];
+        }
+        let (seg_idx, seg_offset) = self.locate(offset);
+        let seg = &self.segments[seg_idx];
+        assert!(
+            seg_offset + len <= seg.len(),
+            "slice_mut ({offset}..{}) spans segment boundary (seg {seg_idx}, seg_offset {seg_offset}, seg_len {})",
+            offset + len,
+            seg.len(),
+        );
+        // SAFETY: `seg_offset + len <= seg.len()` (asserted) keeps the range inside
+        // the segment's live region, so the pointer + length are in bounds. The
+        // `&mut [u8]` synthesized from a shared `&self` is sound only under the
+        // caller's contract (point 2) that this range is disjoint from every other
+        // concurrently-borrowed range, so the produced `&mut` aliases no other
+        // `&`/`&mut`. The bytes are live (slot reserved via grow_uninit).
+        unsafe {
+            let base = seg.as_ptr().add(seg_offset).cast_mut();
+            std::slice::from_raw_parts_mut(base, len)
+        }
     }
 
     /// Total bytes stored (including gap padding at segment boundaries).
@@ -167,6 +343,13 @@ impl SegmentedBuf {
     #[inline]
     #[must_use]
     pub fn slice(&self, offset: usize, len: usize) -> &[u8] {
+        // A zero-length range never needs to be located: `offset` may legitimately
+        // sit on a segment boundary (e.g. after a zero-length reservation when the
+        // current segment is exactly full), where `locate` would index past the
+        // last segment and panic. Return an empty slice instead.
+        if len == 0 {
+            return &[];
+        }
         let (seg_idx, seg_offset) = self.locate(offset);
         let seg = &self.segments[seg_idx];
         assert!(
@@ -190,11 +373,29 @@ impl SegmentedBuf {
         self.segments.len()
     }
 
-    /// Clear all data, retaining the first segment's allocation.
+    /// Clear all data, retaining only the first segment's allocation (drops
+    /// segments `1..`). Used by callers that want memory released between
+    /// unrelated sorts (legacy `.sort()`, the streaming path). For
+    /// allocation-free arena reuse across spill chunks use
+    /// [`reset_for_reuse`](Self::reset_for_reuse) instead.
     pub fn clear(&mut self) {
         self.segments.truncate(1);
         self.segments[0].clear();
         self.total_len = 0;
+        self.cur = 0;
+    }
+
+    /// Reset for reuse **retaining every segment allocation** (capacity kept).
+    /// The next fill reuses the retained segments via the write cursor, so a
+    /// pooled arena cycles through fill→spill→reset without reallocating its
+    /// segments. Unlike [`clear`](Self::clear), `num_segments()` and
+    /// `allocated_capacity()` are unchanged (they hold the peak across reuses).
+    pub fn reset_for_reuse(&mut self) {
+        for seg in &mut self.segments {
+            seg.clear();
+        }
+        self.total_len = 0;
+        self.cur = 0;
     }
 
     /// Translate a global byte offset to `(segment_index, offset_within_segment)`.
@@ -240,6 +441,41 @@ mod tests {
         assert!(buf.is_empty());
         assert_eq!(buf.len(), 0);
         assert_eq!(buf.num_segments(), 1); // one pre-allocated segment
+    }
+
+    #[test]
+    fn reset_for_reuse_retains_segments_and_reuses_storage() {
+        // segment_size 16; ten-byte writes each start a fresh segment (10+10 > 16).
+        let mut buf = SegmentedBuf::with_capacity(0, 16);
+        let mut offs = Vec::new();
+        for i in 0..4u8 {
+            offs.push(buf.extend_from_slice(&[i; 10]));
+        }
+        assert_eq!(buf.num_segments(), 4, "four 10B writes into 16B segments → 4 segments");
+        for (i, &o) in offs.iter().enumerate() {
+            assert_eq!(buf.slice(o, 10), &[u8::try_from(i).unwrap(); 10][..]);
+        }
+        let cap_before = buf.allocated_capacity();
+
+        // Reset for reuse: data cleared, but the 4 segment allocations are RETAINED.
+        buf.reset_for_reuse();
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.num_segments(), 4, "reset retains the segment allocations");
+        assert_eq!(buf.allocated_capacity(), cap_before, "no realloc on reset");
+
+        // Refill: must REUSE the retained segments (count stays 4, capacity unchanged),
+        // and locate()/slice() must remain correct over the reused segments.
+        let mut offs2 = Vec::new();
+        for i in 0..4u8 {
+            offs2.push(buf.extend_from_slice(&[100 + i; 10]));
+        }
+        assert_eq!(buf.num_segments(), 4, "refill reuses retained segments (no growth)");
+        assert_eq!(buf.allocated_capacity(), cap_before, "refill reused storage (no new alloc)");
+        assert_eq!(offs2, offs, "offsets reproduce identically after reuse");
+        for (i, &o) in offs2.iter().enumerate() {
+            assert_eq!(buf.slice(o, 10), &[100 + u8::try_from(i).unwrap(); 10][..]);
+        }
     }
 
     #[test]
@@ -348,6 +584,88 @@ mod tests {
         assert_eq!(buf.num_segments(), 1);
     }
 
+    #[allow(unsafe_code)]
+    #[test]
+    fn grow_uninit_then_slice_mut_round_trips() {
+        // segment_size 100; first slot fits, second forces a gap to a new segment.
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+
+        // SAFETY: each slot is fully written via slice_mut before any slice() read.
+        let o0 = unsafe { buf.grow_uninit(60) };
+        assert_eq!(o0, 0);
+        assert_eq!(buf.len(), 60);
+        assert_eq!(buf.num_segments(), 1);
+        unsafe { buf.slice_mut(o0, 60) }.fill(0xAB);
+
+        // 60 used, a 60-byte slot won't fit in the remaining 40 → gap to seg 1.
+        let o1 = unsafe { buf.grow_uninit(60) };
+        assert_eq!(o1, 100, "gap-padded to the segment boundary (matches reserve_contiguous)");
+        assert_eq!(buf.num_segments(), 2);
+        assert_eq!(buf.len(), 160);
+        unsafe { buf.slice_mut(o1, 60) }.fill(0xCD);
+
+        // Both slots read back exactly through the safe slice() path.
+        assert_eq!(buf.slice(o0, 60), &[0xAB; 60][..]);
+        assert_eq!(buf.slice(o1, 60), &[0xCD; 60][..]);
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn grow_uninit_offsets_match_reserve_contiguous() {
+        // grow_uninit must reproduce reserve_contiguous's offset/gap accounting so
+        // the ISIZE prefix-sum (increment 2) and the existing reserve path agree.
+        let sizes = [3usize, 3, 5, 90, 7];
+        let mut a = SegmentedBuf::with_capacity(0, 100);
+        let mut b = SegmentedBuf::with_capacity(0, 100);
+        for &n in &sizes {
+            let ra = a.reserve_contiguous(n);
+            a.extend_in_place(&vec![0u8; n]);
+            // SAFETY: slot fully written immediately below.
+            let rb = unsafe { b.grow_uninit(n) };
+            unsafe { b.slice_mut(rb, n) }.fill(0);
+            assert_eq!(ra, rb, "grow_uninit offset diverged from reserve_contiguous for n={n}");
+        }
+        assert_eq!(a.len(), b.len());
+        assert_eq!(a.num_segments(), b.num_segments());
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    #[should_panic(expected = "exceeds segment size")]
+    fn grow_uninit_oversize_panics() {
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        // SAFETY: call panics before any slot is reserved.
+        let _ = unsafe { buf.grow_uninit(11) };
+    }
+
+    /// Regression: a zero-length reservation whose offset lands exactly on a
+    /// segment boundary (the current segment is full) must not make `slice` /
+    /// `slice_mut` index past the last segment and panic. Both accessors return
+    /// an empty slice for a zero-length range.
+    #[allow(unsafe_code)]
+    #[test]
+    fn zero_length_slice_at_full_segment_boundary_does_not_panic() {
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+
+        // Fill the (only) segment exactly full.
+        buf.extend_from_slice(b"0123456789");
+        assert_eq!(buf.num_segments(), 1);
+        assert_eq!(buf.len(), 10);
+
+        // A zero-length grow returns an offset on the boundary (== total_len),
+        // which `locate` would map to a not-yet-allocated segment.
+        // SAFETY: the returned slot has length 0, so no byte is ever read or
+        // written through it.
+        let off = unsafe { buf.grow_uninit(0) };
+        assert_eq!(off, 10, "zero-length grow lands on the segment boundary");
+        assert_eq!(buf.num_segments(), 1, "zero-length grow allocates nothing");
+
+        // Neither accessor may panic; both yield an empty slice.
+        assert!(buf.slice(off, 0).is_empty());
+        // SAFETY: zero-length slot — no bytes are aliased, read, or written.
+        assert!(unsafe { buf.slice_mut(off, 0) }.is_empty());
+    }
+
     #[test]
     fn test_many_segments() {
         let mut buf = SegmentedBuf::with_capacity(0, 100);
@@ -443,5 +761,140 @@ mod tests {
 
         // Can read the entire contiguous range
         assert_eq!(buf.slice(0, 12), b"aaaabbbbcccc");
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn slice_mut_concurrent_disjoint_writes_are_sound() {
+        use std::thread;
+
+        // Reserve N disjoint slots on the serial admit path, then write them all
+        // concurrently — each thread owns exactly one slot. This is the
+        // parallel-inflate access pattern; under `miri` it is checked for data races.
+        let n_slots = 8usize;
+        let slot_len = 40usize; // 40-byte slots in a 100-byte segment → 2 slots/segment
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+        let mut slots = Vec::with_capacity(n_slots);
+        for _ in 0..n_slots {
+            // SAFETY: every reserved slot is fully written exactly once below before
+            // any read; offsets are distinct so the ranges are non-overlapping.
+            slots.push(unsafe { buf.grow_uninit(slot_len) });
+        }
+
+        let buf_ref = &buf;
+        thread::scope(|scope| {
+            for (i, &offset) in slots.iter().enumerate() {
+                let byte = u8::try_from(i).unwrap();
+                scope.spawn(move || {
+                    // SAFETY: each thread writes a distinct slot (distinct offset,
+                    // fixed len); the ISIZE-prefix-sum analogue here is the distinct
+                    // grow_uninit offsets, so the ranges are pairwise disjoint and no
+                    // two &mut alias.
+                    let dst = unsafe { buf_ref.slice_mut(offset, slot_len) };
+                    dst.fill(byte);
+                });
+            }
+        });
+
+        // After the scope joins (write→read happens-before), every slot reads back
+        // its writer's byte through the safe slice() path.
+        for (i, &offset) in slots.iter().enumerate() {
+            let byte = u8::try_from(i).unwrap();
+            assert_eq!(buf.slice(offset, slot_len), &vec![byte; slot_len][..]);
+        }
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn slice_mut_spanning_segment_boundary_panics() {
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+        // SAFETY: slot fully written before the (panicking) over-read attempt.
+        let o = unsafe { buf.grow_uninit(40) };
+        unsafe { buf.slice_mut(o, 40) }.fill(0);
+        // A 40-byte slot at offset 0 has only 40 live bytes; asking for 80 must panic.
+        let result = std::panic::catch_unwind(|| {
+            // SAFETY: the call asserts and panics before producing a reference.
+            let _ = unsafe { buf.slice_mut(o, 80) };
+        });
+        assert!(result.is_err(), "slice_mut past the live region must panic");
+    }
+
+    #[test]
+    fn reserve_full_capacity_makes_segment_zero_full() {
+        // A pool-fresh arena has a capacity-0 segment 0; reserve_full_capacity must
+        // bring it to segment_size so the first grow_uninit cannot reallocate it.
+        let seg = 4096usize;
+        let mut buf = SegmentedBuf::with_capacity(0, seg);
+        buf.reserve_full_capacity();
+        assert!(buf.num_segments() == 1);
+        assert!(buf.allocated_capacity() >= seg, "segment 0 must hold >= segment_size capacity");
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn grow_uninit_is_realloc_free_after_reserve_full_capacity() {
+        // After reserve_full_capacity, growing many blocks that sum to <= segment_size
+        // must (a) stay in ONE segment (no gap/advance) and (b) never move the segment's
+        // backing buffer — so a slice_mut handed out for an early block stays valid.
+        let seg = 4096usize;
+        let mut buf = SegmentedBuf::with_capacity(0, seg);
+        buf.reserve_full_capacity();
+
+        // SAFETY: each slot is fully written before any read; offsets are distinct.
+        let off0 = unsafe { buf.grow_uninit(100) };
+        let ptr0 = unsafe { buf.slice_mut(off0, 100) }.as_ptr() as usize;
+        unsafe { buf.slice_mut(off0, 100) }.fill(0xA1);
+
+        // Grow several more blocks; total stays under segment_size → one segment.
+        let mut prev_end = off0 + 100;
+        for i in 0..20u8 {
+            let n = 100usize;
+            let off = unsafe { buf.grow_uninit(n) };
+            assert_eq!(off, prev_end, "no gap: offsets are contiguous within one segment");
+            unsafe { buf.slice_mut(off, n) }.fill(0xB0 + i);
+            prev_end = off + n;
+        }
+        assert_eq!(buf.num_segments(), 1, "all growth stayed in the pre-sized segment 0");
+
+        // The early block's backing pointer is unchanged → no realloc moved it.
+        let ptr0_after = buf.slice(off0, 100).as_ptr() as usize;
+        assert_eq!(ptr0, ptr0_after, "segment 0 buffer must not have been reallocated");
+        assert_eq!(buf.slice(off0, 100), &[0xA1; 100][..]);
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn grow_uninit_reuses_arena_after_reset_without_stale_reads() {
+        // Increment-5 pattern: a pooled arena is filled, reset_for_reuse'd (len → 0,
+        // segment capacity RETAINED), then refilled. The post-reset grow_uninit takes
+        // the seg.reserve path on an already-grown segment; confirm offsets reproduce
+        // and reads return the fresh bytes, never the retained bytes from the first fill.
+        let mut buf = SegmentedBuf::with_capacity(0, 100);
+
+        // First fill: two 40-byte slots (both in segment 0; 40 + 40 <= 100).
+        // SAFETY: each slot is fully written via slice_mut before any read.
+        let a0 = unsafe { buf.grow_uninit(40) };
+        unsafe { buf.slice_mut(a0, 40) }.fill(0x11);
+        let a1 = unsafe { buf.grow_uninit(40) };
+        unsafe { buf.slice_mut(a1, 40) }.fill(0x22);
+        assert_eq!(buf.slice(a0, 40), &[0x11; 40][..]);
+        assert_eq!(buf.slice(a1, 40), &[0x22; 40][..]);
+
+        // Reset for reuse: data cleared, segment allocations retained.
+        buf.reset_for_reuse();
+        assert!(buf.is_empty());
+
+        // Refill: offsets must reproduce the first fill, and reads must return the
+        // freshly-written bytes — never the retained 0x11/0x22 still physically present
+        // in the reused segment's capacity.
+        // SAFETY: each slot is fully written before any read.
+        let b0 = unsafe { buf.grow_uninit(40) };
+        unsafe { buf.slice_mut(b0, 40) }.fill(0x33);
+        let b1 = unsafe { buf.grow_uninit(40) };
+        unsafe { buf.slice_mut(b1, 40) }.fill(0x44);
+        assert_eq!(b0, a0, "post-reset grow_uninit reproduces the first-fill offset");
+        assert_eq!(b1, a1, "post-reset grow_uninit reproduces the first-fill offset");
+        assert_eq!(buf.slice(b0, 40), &[0x33; 40][..]);
+        assert_eq!(buf.slice(b1, 40), &[0x44; 40][..]);
     }
 }

--- a/crates/fgumi-sort/src/spill_block.rs
+++ b/crates/fgumi-sort/src/spill_block.rs
@@ -1,0 +1,311 @@
+//! Block-granular spill compression kernel shared by the Phase-1 spill steps
+//! (`SpillGather` → `SpillCompress` → `SpillWrite`).
+//!
+//! The legacy [`SyncSpillWriter`](crate::sync_spill_writer) streams a whole
+//! sorted chunk through one stateful compressor on a single worker. To compress
+//! a spill across the framework pool instead, the chunk is cut into raw blocks by
+//! the (Serial) serialize step, each block is compressed **independently** by a
+//! (Parallel) compress worker, and the writer concatenates the results per file.
+//! This module holds the three pieces that keep that byte-compatible with the
+//! existing spill readers:
+//!
+//! - [`frame_keyed_record_into`] — append one `[key?][u32 LE len][record]` record
+//!   to a raw block buffer (the identical on-disk record layout
+//!   `SyncSpillWriter::write_record` produces).
+//! - [`SpillBlockCompressor`] — a per-worker, codec-fixed compressor whose
+//!   [`compress_block`](SpillBlockCompressor::compress_block) turns one raw block
+//!   into a self-contained, independently-decodable unit: framed BGZF block(s)
+//!   for bgzf, or a `[u32 LE len][zstd frame]` for zstd.
+//! - [`spill_magic`] / [`spill_trailer`] — the per-codec file prologue/epilogue
+//!   the writer brackets the compressed blocks with.
+//!
+//! Because a BGZF/zstd spill stream is just independent blocks concatenated and
+//! the readers stream across boundaries, **any** blocking of the same raw
+//! `[key?][len][record]…` byte stream reads back to the identical records (see
+//! the round-trip + re-blocking-independence tests below and the format notes in
+//! [`sync_spill_writer`](crate::sync_spill_writer)). Block boundaries are
+//! therefore the serialize step's free choice, and compression is a pure function
+//! of each block — so the result is byte-for-byte independent of how many workers
+//! compress concurrently.
+
+use std::io;
+
+use fgumi_bgzf::BGZF_EOF;
+use fgumi_bgzf::writer::InlineBgzfCompressor;
+use zstd::bulk::Compressor as ZstdCompressor;
+
+use crate::codec::{SpillCodec, ZSPILL_MAGIC};
+use crate::keys::RawSortKey;
+
+/// Append one keyed record to `block` in the spill record framing:
+/// `[key bytes if !K::EMBEDDED_IN_RECORD][u32 LE record-len][record body]`.
+///
+/// This is the exact layout `SyncSpillWriter::write_record` writes; the
+/// serialize step accumulates records into a raw block with this helper, and the
+/// merge / Phase-2 readers parse it back unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the record is longer than `u32::MAX` (cannot fit the
+/// length prefix) or key serialization fails.
+pub fn frame_keyed_record_into<K: RawSortKey>(
+    block: &mut Vec<u8>,
+    key: &K,
+    record: &[u8],
+) -> io::Result<()> {
+    // Validate the length BEFORE writing the key, so an oversized record fails
+    // loud without leaving partial (key) bytes in the block.
+    let record_len = u32::try_from(record.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("BAM record too large ({} bytes) for a u32 length prefix", record.len()),
+        )
+    })?;
+    if !K::EMBEDDED_IN_RECORD {
+        // `Vec<u8>: Write`, so the key serializes straight into the block buffer.
+        key.write_to(block)?;
+    }
+    block.extend_from_slice(&record_len.to_le_bytes());
+    block.extend_from_slice(record);
+    Ok(())
+}
+
+/// Per-worker, codec-fixed block compressor. Constructed once per compress
+/// worker (like `BgzfCompress`'s `InlineBgzfCompressor`) and reused across the
+/// blocks that worker handles.
+pub enum SpillBlockCompressor {
+    /// bgzf: each block becomes one or more framed BGZF blocks (header + deflate
+    /// + footer). No EOF marker — that is the file trailer (see [`spill_trailer`]).
+    Bgzf(InlineBgzfCompressor),
+    /// zstd: each block becomes one `[u32 LE frame-len][zstd frame]` unit.
+    Zstd(ZstdCompressor<'static>),
+}
+
+impl SpillBlockCompressor {
+    /// Build a compressor for `codec` at `compression` (bgzf level — `0` writes
+    /// framed *stored* blocks; or zstd level, which must be ≥ 1).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the zstd compressor cannot be initialized.
+    pub fn new(codec: SpillCodec, compression: u32) -> io::Result<Self> {
+        match codec {
+            SpillCodec::Bgzf => Ok(Self::Bgzf(InlineBgzfCompressor::new(compression))),
+            SpillCodec::Zstd => {
+                #[allow(clippy::cast_possible_wrap)]
+                let compressor = ZstdCompressor::new(compression as i32).map_err(|e| {
+                    io::Error::other(format!("zstd compressor init (level {compression}): {e}"))
+                })?;
+                Ok(Self::Zstd(compressor))
+            }
+        }
+    }
+
+    /// Compress one raw block into a self-contained, independently-decodable
+    /// unit. Concatenating these units (bracketed by [`spill_magic`] /
+    /// [`spill_trailer`]) reproduces the same decompressed stream as the
+    /// streaming `SyncSpillWriter`, regardless of where the block boundaries fall.
+    ///
+    /// An empty block yields an empty `Vec` (no empty BGZF block / zstd frame is
+    /// emitted), matching the streaming writer's "no empty frames" invariant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if compression fails or a zstd frame exceeds `u32::MAX`.
+    pub fn compress_block(&mut self, raw: &[u8]) -> io::Result<Vec<u8>> {
+        if raw.is_empty() {
+            return Ok(Vec::new());
+        }
+        match self {
+            Self::Bgzf(compressor) => {
+                compressor.write_all(raw)?;
+                // Flush forces a block boundary at the end of this raw block, so
+                // the unit is independently decodable.
+                compressor.flush()?;
+                let mut out = Vec::new();
+                for block in compressor.take_blocks() {
+                    out.extend_from_slice(&block.data);
+                }
+                Ok(out)
+            }
+            Self::Zstd(compressor) => {
+                let frame = compressor
+                    .compress(raw)
+                    .map_err(|e| io::Error::other(format!("zstd compress: {e}")))?;
+                let frame_len = u32::try_from(frame.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "zstd frame larger than 4 GiB cannot fit a u32 length prefix",
+                    )
+                })?;
+                let mut out = Vec::with_capacity(4 + frame.len());
+                out.extend_from_slice(&frame_len.to_le_bytes());
+                out.extend_from_slice(&frame);
+                Ok(out)
+            }
+        }
+    }
+}
+
+/// File prologue for `codec`: `ZSPILL_MAGIC` for zstd, empty for bgzf (a BGZF
+/// stream needs no prologue — each block self-identifies via the gzip magic).
+#[must_use]
+pub fn spill_magic(codec: SpillCodec) -> &'static [u8] {
+    match codec {
+        SpillCodec::Bgzf => &[],
+        SpillCodec::Zstd => &ZSPILL_MAGIC,
+    }
+}
+
+/// File epilogue for `codec`: the `BGZF_EOF` empty-block terminator for bgzf,
+/// empty for zstd (the zstd spill format has no trailing marker).
+#[must_use]
+pub fn spill_trailer(codec: SpillCodec) -> &'static [u8] {
+    match codec {
+        SpillCodec::Bgzf => &BGZF_EOF,
+        SpillCodec::Zstd => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::GenericKeyedChunkReader;
+    use crate::inline::TemplateKey;
+    use std::fs::File;
+    use std::io::{BufWriter, Write as _};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_key(i: u64) -> TemplateKey {
+        TemplateKey::new(
+            i as i32,
+            i as i32,
+            false,
+            i32::MAX,
+            i32::MAX,
+            false,
+            0,
+            0,
+            (0, false),
+            i,
+            false,
+        )
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn sample_records(n: u64) -> Vec<(TemplateKey, Vec<u8>)> {
+        (0..n).map(|i| (make_key(i), vec![(i % 256) as u8; 200 + (i as usize % 50)])).collect()
+    }
+
+    /// An embedded key (`RawCoordinateKey`, `EMBEDDED_IN_RECORD == true`) writes
+    /// no key prefix — the framed block is exactly `[u32 LE len][record]`. Locks
+    /// the embedded layout at the kernel boundary (the streaming-writer tests use
+    /// the non-embedded `TemplateKey`, which exercises the key-prefix branch).
+    #[test]
+    fn frame_omits_key_prefix_for_embedded_keys() {
+        let mut block = Vec::new();
+        let key = crate::keys::RawCoordinateKey { sort_key: 0x0102_0304_0506_0708 };
+        frame_keyed_record_into(&mut block, &key, &[0xAB, 0xCD]).unwrap();
+        // Just the u32 LE length (2) + the 2 record bytes — no key prefix.
+        assert_eq!(block, [2, 0, 0, 0, 0xAB, 0xCD]);
+    }
+
+    /// Write a spill file via the block kernel: frame records into raw blocks
+    /// (cutting a new block every `records_per_block` records, to force many
+    /// independent compressed units), compress each block, and bracket with the
+    /// codec magic/trailer.
+    fn write_via_kernel(
+        path: &Path,
+        codec: SpillCodec,
+        compression: u32,
+        records: &[(TemplateKey, Vec<u8>)],
+        records_per_block: usize,
+    ) {
+        let mut comp = SpillBlockCompressor::new(codec, compression).unwrap();
+        let mut out = BufWriter::with_capacity(256 * 1024, File::create(path).unwrap());
+        out.write_all(spill_magic(codec)).unwrap();
+        let mut block = Vec::new();
+        let mut in_block = 0usize;
+        let flush =
+            |block: &mut Vec<u8>, comp: &mut SpillBlockCompressor, out: &mut BufWriter<File>| {
+                out.write_all(&comp.compress_block(block).unwrap()).unwrap();
+                block.clear();
+            };
+        for (k, r) in records {
+            frame_keyed_record_into(&mut block, k, r).unwrap();
+            in_block += 1;
+            if in_block >= records_per_block {
+                flush(&mut block, &mut comp, &mut out);
+                in_block = 0;
+            }
+        }
+        flush(&mut block, &mut comp, &mut out);
+        out.write_all(spill_trailer(codec)).unwrap();
+        out.flush().unwrap();
+    }
+
+    fn read_back(path: &Path) -> Vec<(TemplateKey, Vec<u8>)> {
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(path, None).expect("open reader");
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            out.push((key, buf.clone()));
+        }
+        out
+    }
+
+    /// Kernel-built files read back to the original records for every codec/level
+    /// — including a small block size that forces many independent compressed
+    /// units, proving block-independent compression is reader-compatible.
+    #[test]
+    fn kernel_blocks_read_back_records() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(400);
+        for (codec, level, name) in
+            [(SpillCodec::Zstd, 3, "z3"), (SpillCodec::Bgzf, 1, "b1"), (SpillCodec::Bgzf, 0, "b0")]
+        {
+            let path = dir.path().join(format!("kernel_{name}.keyed"));
+            write_via_kernel(&path, codec, level, &records, 7);
+            assert_eq!(read_back(&path), records, "kernel round-trip mismatch for {name}");
+        }
+    }
+
+    /// Kernel output matches the streaming `write_sorted_chunk` oracle, read back
+    /// through the production reader — locks block-granular ≡ streaming.
+    #[test]
+    fn kernel_matches_streaming_oracle_read_back() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(500);
+        let keyed: Vec<(TemplateKey, fgumi_raw_bam::RawRecord)> =
+            records.iter().map(|(k, r)| (*k, fgumi_raw_bam::RawRecord::from(r.clone()))).collect();
+        for (codec, level) in [(SpillCodec::Zstd, 3), (SpillCodec::Bgzf, 1)] {
+            let kernel_path = dir.path().join("kernel.keyed");
+            let oracle_path = dir.path().join("oracle.keyed");
+            write_via_kernel(&kernel_path, codec, level, &records, 11);
+            crate::write_sorted_chunk(&oracle_path, codec, level, &keyed).unwrap();
+            assert_eq!(
+                read_back(&kernel_path),
+                read_back(&oracle_path),
+                "kernel vs streaming-oracle read-back differ ({codec:?})"
+            );
+        }
+    }
+
+    /// Different block boundaries produce files that read back identically — the
+    /// invariant that lets the (Serial) serialize step choose boundaries freely.
+    #[test]
+    fn reblocking_is_boundary_independent() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(300);
+        for codec in [SpillCodec::Zstd, SpillCodec::Bgzf] {
+            let a = dir.path().join("a.keyed");
+            let b = dir.path().join("b.keyed");
+            write_via_kernel(&a, codec, 1, &records, 3);
+            write_via_kernel(&b, codec, 1, &records, 64);
+            assert_eq!(read_back(&a), read_back(&b), "re-blocking changed readback ({codec:?})");
+        }
+    }
+}

--- a/crates/fgumi-sort/src/spill_block_reader.rs
+++ b/crates/fgumi-sort/src/spill_block_reader.rs
@@ -132,6 +132,89 @@ impl SpillBlockDecompressor {
         }
         Ok(out)
     }
+
+    /// Read up to `max` *raw* (still-compressed) blocks from `reader` using
+    /// `codec`, returning the compressed payloads **without** decompressing them.
+    ///
+    /// This is the read half of the block-parallel `SortSpillDecompress` path:
+    /// the caller acquires the per-slot reader lock, calls `read_raw` to pull a
+    /// batch of compressed blocks (which it sequence-tags), releases the lock,
+    /// and then decompresses each block via [`Self::decompress_one`] *outside*
+    /// the lock so multiple workers decompress one file's blocks concurrently.
+    /// The read and the decompression of a given block still happen within a
+    /// single `try_run` of a single worker — only the lock is released between
+    /// them — which preserves the read-and-decompress-together invariant that
+    /// the FIFO inline path also upholds.
+    ///
+    /// For BGZF each returned `Vec<u8>` is one complete raw block (header +
+    /// compressed data + footer), exactly what [`Self::decompress_one`] expects;
+    /// EOF-marker blocks are skipped. For zstd each is one raw frame body (the
+    /// `[u32 LE len]` prefix is consumed here). A result shorter than `max`
+    /// (including empty) signals a clean EOF, matching [`Self::read_blocks`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O errors and truncation (a partial BGZF block, or a partial
+    /// zstd length prefix / frame body at EOF).
+    pub fn read_raw<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        codec: SpillCodec,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        match codec {
+            SpillCodec::Bgzf => {
+                let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(reader, max)?;
+                Ok(raw_blocks.into_iter().map(|b| b.data).collect())
+            }
+            SpillCodec::Zstd => {
+                let mut out = Vec::with_capacity(max);
+                for _ in 0..max {
+                    let Some(frame_len) = read_length_prefix(reader)? else {
+                        break;
+                    };
+                    let mut frame = vec![0u8; frame_len];
+                    reader.read_exact(&mut frame)?;
+                    out.push(frame);
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    /// Decompress a single raw block/frame previously read by [`Self::read_raw`].
+    ///
+    /// `raw` is one BGZF raw block (header + compressed data + footer) or one
+    /// zstd frame body, per `codec`. Returns the decompressed bytes. Uses the
+    /// worker's reusable scratch buffers, so this is cheap to call in a loop over
+    /// a freshly-read batch.
+    ///
+    /// # Errors
+    ///
+    /// Propagates BGZF/zstd decompression failures (bad CRC, size mismatch, or a
+    /// malformed frame).
+    pub fn decompress_one(&mut self, codec: SpillCodec, raw: &[u8]) -> io::Result<Vec<u8>> {
+        match codec {
+            SpillCodec::Bgzf => {
+                fgumi_bgzf::reader::decompress_block_slice_into(
+                    raw,
+                    &mut self.bgzf,
+                    &mut self.bgzf_scratch,
+                )?;
+                Ok(std::mem::replace(&mut self.bgzf_scratch, Vec::with_capacity(SCRATCH_CAP)))
+            }
+            SpillCodec::Zstd => {
+                if self.zstd_buf.len() < SCRATCH_CAP {
+                    self.zstd_buf.resize(SCRATCH_CAP, 0);
+                }
+                let n = self
+                    .zstd
+                    .decompress_to_buffer(raw, &mut self.zstd_buf)
+                    .map_err(|e| io::Error::other(format!("zstd spill frame decompress: {e}")))?;
+                Ok(self.zstd_buf[..n].to_vec())
+            }
+        }
+    }
 }
 
 impl Default for SpillBlockDecompressor {
@@ -237,5 +320,97 @@ mod tests {
     #[test]
     fn roundtrip_zstd() {
         roundtrip(SpillCodec::Zstd);
+    }
+
+    /// The split `read_raw` + `decompress_one` path (used by the block-parallel
+    /// `SortSpillDecompress`) must yield the exact same per-block bytes as the
+    /// inline `read_blocks` path. We read the same chunk twice and compare.
+    fn read_raw_matches_read_blocks(codec: SpillCodec) {
+        use crate::keys::{RawCoordinateKey, RawSortKey};
+
+        let records: Vec<Vec<u8>> = (0usize..80)
+            .map(|i| {
+                let size = 3000 + (i % 13) * 500;
+                let mut r = vec![0u8; size];
+                let stamp = u8::try_from(i % 251).expect("i % 251 fits u8");
+                r[0] = stamp;
+                let last = r.len() - 1;
+                r[last] = stamp;
+                r
+            })
+            .collect();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chunk.spill");
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6, codec));
+        {
+            let mut w = PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &path, codec)
+                .expect("writer");
+            for rec in &records {
+                let key = RawCoordinateKey::extract_from_record(rec);
+                w.write_record(&key, rec).expect("write");
+            }
+            w.start_finish().expect("start_finish").wait().expect("finish");
+        }
+
+        // Helper: open the chunk positioned past any codec magic.
+        let open = || {
+            let mut file = std::fs::File::open(&path).expect("open");
+            let mut magic = [0u8; 4];
+            let filled = crate::external::read_exact_or_eof(&mut file, &mut magic).expect("magic");
+            let detected = if filled {
+                SpillCodec::from_magic(&magic).unwrap_or(SpillCodec::Bgzf)
+            } else {
+                SpillCodec::Bgzf
+            };
+            if matches!(detected, SpillCodec::Bgzf) {
+                use std::io::Seek;
+                file.seek(std::io::SeekFrom::Start(0)).expect("seek");
+            }
+            (std::io::BufReader::new(file), detected)
+        };
+
+        // Path A: inline read_blocks.
+        let (mut reader_a, detected) = open();
+        let mut dec_a = SpillBlockDecompressor::new();
+        let mut blocks_a: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let blocks = dec_a.read_blocks(&mut reader_a, detected, 4).expect("read_blocks");
+            let got = blocks.len();
+            blocks_a.extend(blocks);
+            if got < 4 {
+                break;
+            }
+        }
+
+        // Path B: read_raw + decompress_one.
+        let (mut reader_b, _) = open();
+        let mut dec_b = SpillBlockDecompressor::new();
+        let mut blocks_b: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let raws = dec_b.read_raw(&mut reader_b, detected, 4).expect("read_raw");
+            let got = raws.len();
+            for raw in &raws {
+                blocks_b.push(dec_b.decompress_one(detected, raw).expect("decompress_one"));
+            }
+            if got < 4 {
+                break;
+            }
+        }
+
+        assert_eq!(
+            blocks_a, blocks_b,
+            "split read_raw path must match inline read_blocks ({codec:?})"
+        );
+    }
+
+    #[test]
+    fn read_raw_matches_read_blocks_bgzf() {
+        read_raw_matches_read_blocks(SpillCodec::Bgzf);
+    }
+
+    #[test]
+    fn read_raw_matches_read_blocks_zstd() {
+        read_raw_matches_read_blocks(SpillCodec::Zstd);
     }
 }

--- a/crates/fgumi-sort/src/sync_spill_writer.rs
+++ b/crates/fgumi-sort/src/sync_spill_writer.rs
@@ -1,0 +1,512 @@
+//! Synchronous keyed-chunk spill writer (inline compression, no worker pool).
+//!
+//! The P6 Phase-1 decomposition runs the spill **compress** as a `Parallel`
+//! `CompressSpill` step on the framework work-stealing pool, replacing the async
+//! [`PooledChunkWriter`] → `SortWorkerPool` path so the sort no longer needs a
+//! second, private thread pool. Each `CompressSpill` `try_run` already executes
+//! on a framework worker, so the per-chunk write compresses **inline** on that
+//! thread.
+//!
+//! The on-disk format is byte-compatible with [`PooledChunkWriter`], so
+//! `SortSpillDecompress` (the Phase-2 streaming reader) and
+//! `GenericKeyedChunkReader` (the merge reader) read these files unchanged:
+//!
+//! - **bgzf** (any `compression`, including `0`): framed BGZF blocks (header +
+//!   deflate + footer) via [`InlineBgzfCompressor`] then a trailing `BGZF_EOF`,
+//!   exactly like `PooledChunkWriter`'s bgzf path. Level 0 still produces *framed*
+//!   (stored) BGZF blocks — NOT raw bytes — because the bgzf reader requires the
+//!   `0x1f 0x8b` block magic; an unframed raw spill would fail the reader's
+//!   magic check.
+//! - **zstd** (the production default): [`ZSPILL_MAGIC`] then
+//!   `[u32 LE frame-len][zstd frame]` per ≤`BGZF_MAX_BLOCK_SIZE` raw block, with
+//!   no trailing marker — mirroring `PooledChunkWriter`'s zstd path and the
+//!   `ZspillStreamReader` format.
+//!
+//! In both cases block/frame *boundaries* may differ from the pooled writer, but
+//! the decompressed byte stream (and therefore every record read back) is
+//! identical, because the reader streams across boundaries.
+//!
+//! [`PooledChunkWriter`]: crate::pooled_chunk_writer::PooledChunkWriter
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::marker::PhantomData;
+use std::path::Path;
+
+use anyhow::Result;
+use fgumi_bgzf::writer::InlineBgzfCompressor;
+use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
+use fgumi_raw_bam::RawRecord;
+use zstd::bulk::Compressor as ZstdCompressor;
+
+use crate::codec::{SpillCodec, ZSPILL_MAGIC};
+use crate::keys::RawSortKey;
+
+/// Compress and write a fully-sorted in-memory chunk to `path` as a keyed spill
+/// file, inline on the calling thread (no `SortWorkerPool`).
+///
+/// This is the single-chunk entry point the P6 `CompressSpill` step calls per
+/// sorted chunk: it creates a [`SyncSpillWriter`] for `codec`/`compression`,
+/// writes every `(key, record)` pair in `records` order, and closes the file.
+/// The on-disk format is byte-compatible with `PooledChunkWriter`, so
+/// [`open_spill_slot`](crate::open_spill_slot) → `SortSpillDecompress` / the
+/// merge reader consume it unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created, the zstd compressor cannot be
+/// initialized, or any record write/flush fails.
+pub fn write_sorted_chunk<K: RawSortKey>(
+    path: &Path,
+    codec: SpillCodec,
+    compression: u32,
+    records: &[(K, RawRecord)],
+) -> Result<()> {
+    let mut writer = SyncSpillWriter::<K>::create(path, codec, compression)?;
+    for (key, record) in records {
+        writer.write_record(key, record.as_ref())?;
+    }
+    writer.finish()
+}
+
+/// Write an already-sorted [`InMemoryChunk`](crate::InMemoryChunk) to a spill
+/// file — the zero-copy analogue of [`write_sorted_chunk`]. The chunk's records
+/// share an `Arc<SegmentedBuf>` backing store, so this iterates by index and
+/// writes each record's bytes directly (no owned `RawRecord`s), avoiding the
+/// per-record copy the buffer chain previously paid to materialise
+/// `Vec<(K, RawRecord)>`.
+///
+/// # Errors
+///
+/// Propagates I/O / compression errors from the underlying writer.
+pub fn write_sorted_chunk_inmem<K: RawSortKey>(
+    path: &Path,
+    codec: SpillCodec,
+    compression: u32,
+    chunk: &crate::InMemoryChunk<K>,
+) -> Result<()> {
+    let mut writer = SyncSpillWriter::<K>::create(path, codec, compression)?;
+    for i in 0..chunk.len() {
+        writer.write_record(chunk.key_at(i), chunk.record_bytes(i))?;
+    }
+    writer.finish()
+}
+
+/// Synchronous keyed-chunk spill writer that compresses inline on the calling
+/// (framework-worker) thread — no `SortWorkerPool`.
+pub(crate) enum SyncSpillWriter<K: RawSortKey> {
+    /// bgzf: framed BGZF blocks (any level, including a stored level-0 block) +
+    /// trailing `BGZF_EOF`.
+    Bgzf(BgzfSpillWriter<K>),
+    /// zstd: inline-compressed `[u32 len][frame]` blocks after `ZSPILL_MAGIC`.
+    Zstd(ZstdSpillWriter<K>),
+}
+
+impl<K: RawSortKey> SyncSpillWriter<K> {
+    /// Create a writer for `path` using `codec` at `compression` level.
+    ///
+    /// For zstd, `compression` is the zstd level (must be ≥ 1 — level 0 is
+    /// rejected up front by `SortOptions::validate`, since zstd has no
+    /// uncompressed mode). For bgzf, `compression == 0` writes *framed* stored
+    /// (uncompressed) BGZF blocks and `> 0` writes deflate-compressed BGZF blocks
+    /// at that level — in both cases valid, reader-consumable BGZF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created or the zstd
+    /// compressor cannot be initialized.
+    pub(crate) fn create(path: &Path, codec: SpillCodec, compression: u32) -> Result<Self> {
+        match codec {
+            SpillCodec::Bgzf => Ok(Self::Bgzf(BgzfSpillWriter::create(path, compression)?)),
+            SpillCodec::Zstd => Ok(Self::Zstd(ZstdSpillWriter::create(path, compression)?)),
+        }
+    }
+
+    /// Write one keyed record in the spill frame format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key serialization or the underlying write fails.
+    pub(crate) fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        match self {
+            Self::Bgzf(w) => w.write_record(key, record),
+            Self::Zstd(w) => w.write_record(key, record),
+        }
+    }
+
+    /// Flush and close the chunk file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a final flush/compress fails.
+    pub(crate) fn finish(self) -> Result<()> {
+        match self {
+            Self::Bgzf(w) => w.finish(),
+            Self::Zstd(w) => w.finish(),
+        }
+    }
+}
+
+/// Inline BGZF spill writer: framed BGZF blocks (via [`InlineBgzfCompressor`])
+/// followed by a trailing `BGZF_EOF`, matching `PooledChunkWriter`'s bgzf output.
+/// Records are framed `[key.write_to() if !EMBEDDED][u32 LE record-len][record]`
+/// into the compressor's byte stream, identical to the zstd arm.
+pub(crate) struct BgzfSpillWriter<K: RawSortKey> {
+    writer: BufWriter<File>,
+    compressor: InlineBgzfCompressor,
+    _marker: PhantomData<K>,
+}
+
+impl<K: RawSortKey> BgzfSpillWriter<K> {
+    fn create(path: &Path, level: u32) -> Result<Self> {
+        let file = File::create(path)?;
+        let writer = BufWriter::with_capacity(256 * 1024, file);
+        Ok(Self { writer, compressor: InlineBgzfCompressor::new(level), _marker: PhantomData })
+    }
+
+    /// Drain any completed (full-block) compressed output to disk, bounding the
+    /// compressor's retained-block memory during a large chunk write.
+    fn drain_blocks(&mut self) -> Result<()> {
+        for block in self.compressor.take_blocks() {
+            self.writer.write_all(&block.data)?;
+        }
+        Ok(())
+    }
+
+    fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        // Validate the record length BEFORE any compressor write, so an oversized
+        // record fails loud without leaving partial (key) bytes in the stream.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
+        if !K::EMBEDDED_IN_RECORD {
+            let mut key_bytes = Vec::new();
+            key.write_to(&mut key_bytes)?;
+            self.compressor.write_all(&key_bytes)?;
+        }
+        self.compressor.write_all(&record_len.to_le_bytes())?;
+        // Drain between block-sized chunks so retained compressed-block memory
+        // stays bounded even for a very large (long-read) record, rather than
+        // scaling with the record size.
+        for chunk in record.chunks(BGZF_MAX_BLOCK_SIZE) {
+            self.compressor.write_all(chunk)?;
+            self.drain_blocks()?;
+        }
+        // Catch the key/length bytes when `record` is empty (the loop is a no-op).
+        self.drain_blocks()
+    }
+
+    fn finish(mut self) -> Result<()> {
+        self.compressor.flush()?;
+        self.drain_blocks()?;
+        // BGZF stream terminator (the empty-block EOF marker), as the pooled
+        // writer and noodles bgzf writer both emit.
+        self.writer.write_all(&BGZF_EOF)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+/// Inline zstd spill writer: `ZSPILL_MAGIC` then length-prefixed zstd frames,
+/// one frame per ≤`BGZF_MAX_BLOCK_SIZE` raw block.
+pub(crate) struct ZstdSpillWriter<K: RawSortKey> {
+    writer: BufWriter<File>,
+    compressor: ZstdCompressor<'static>,
+    /// Raw (uncompressed) staging block; flushed as a zstd frame at
+    /// `BGZF_MAX_BLOCK_SIZE`.
+    block: Vec<u8>,
+    _marker: PhantomData<K>,
+}
+
+impl<K: RawSortKey> ZstdSpillWriter<K> {
+    fn create(path: &Path, level: u32) -> Result<Self> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::with_capacity(256 * 1024, file);
+        writer.write_all(&ZSPILL_MAGIC)?;
+        #[allow(clippy::cast_possible_wrap)]
+        let compressor = ZstdCompressor::new(level as i32)
+            .map_err(|e| anyhow::anyhow!("zstd compressor init (level {level}): {e}"))?;
+        Ok(Self {
+            writer,
+            compressor,
+            block: Vec::with_capacity(BGZF_MAX_BLOCK_SIZE + 1024),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Compress the staged block as one zstd frame and write `[u32 len][frame]`.
+    /// No-op when the block is empty (no empty frames in the stream).
+    fn flush_block(&mut self) -> Result<()> {
+        if self.block.is_empty() {
+            return Ok(());
+        }
+        let frame = self
+            .compressor
+            .compress(&self.block)
+            .map_err(|e| anyhow::anyhow!("zstd compress: {e}"))?;
+        let frame_len = u32::try_from(frame.len())
+            .map_err(|_| anyhow::anyhow!("zstd frame larger than 4 GiB cannot fit a u32 prefix"))?;
+        self.writer.write_all(&frame_len.to_le_bytes())?;
+        self.writer.write_all(&frame)?;
+        self.block.clear();
+        Ok(())
+    }
+
+    /// Append `data` to the staging block, flushing a frame whenever the block
+    /// fills. A record (or key) larger than one block therefore spans frames —
+    /// safe because the reader streams across frame boundaries.
+    fn append(&mut self, mut data: &[u8]) -> Result<()> {
+        while !data.is_empty() {
+            let space = BGZF_MAX_BLOCK_SIZE.saturating_sub(self.block.len());
+            let n = data.len().min(space);
+            self.block.extend_from_slice(&data[..n]);
+            data = &data[n..];
+            if self.block.len() >= BGZF_MAX_BLOCK_SIZE {
+                self.flush_block()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        // Validate the record length BEFORE any append, so an oversized record
+        // fails loud without leaving partial (key) bytes in the staging block.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
+        if !K::EMBEDDED_IN_RECORD {
+            // Keys are small and fixed-size; a transient buffer keeps the
+            // borrow simple. The record path below dominates the spill cost.
+            let mut key_bytes = Vec::new();
+            key.write_to(&mut key_bytes)?;
+            self.append(&key_bytes)?;
+        }
+        self.append(&record_len.to_le_bytes())?;
+        self.append(record)?;
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<()> {
+        self.flush_block()?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::GenericKeyedChunkReader;
+    use crate::inline::TemplateKey;
+    use crate::pooled_chunk_writer::PooledChunkWriter;
+    use crate::worker_pool::SortWorkerPool;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_key(i: u64) -> TemplateKey {
+        TemplateKey::new(
+            i as i32,
+            i as i32,
+            false,
+            i32::MAX,
+            i32::MAX,
+            false,
+            0,
+            0,
+            (0, false),
+            i,
+            false,
+        )
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn sample_records(n: u64) -> Vec<(TemplateKey, Vec<u8>)> {
+        (0..n).map(|i| (make_key(i), vec![(i % 256) as u8; 200 + (i as usize % 50)])).collect()
+    }
+
+    fn read_back(path: &Path) -> Vec<(TemplateKey, Vec<u8>)> {
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(path, None).expect("open reader");
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            out.push((key, buf.clone()));
+        }
+        out
+    }
+
+    /// The sync zstd writer round-trips every record back through the same reader
+    /// the production merge/Phase-2 path uses, and the file carries `ZSPILL_MAGIC`.
+    #[test]
+    fn sync_zstd_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sync_zstd.keyed");
+        let records = sample_records(300);
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, SpillCodec::Zstd, 3).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[..ZSPILL_MAGIC.len()], &ZSPILL_MAGIC[..], "missing ZSPILL_MAGIC");
+        assert_eq!(read_back(&path), records, "sync zstd round-trip mismatch");
+    }
+
+    /// Cross-check: the sync zstd writer and the pooled (async) zstd writer
+    /// produce files that read back to the *same* records — proving the formats
+    /// are interchangeable for `SortSpillDecompress` / the merge reader.
+    #[test]
+    fn sync_zstd_matches_pooled_zstd_read_back() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(500);
+
+        let sync_path = dir.path().join("sync.keyed");
+        let mut w =
+            SyncSpillWriter::<TemplateKey>::create(&sync_path, SpillCodec::Zstd, 3).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let pooled_path = dir.path().join("pooled.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 3, 6, SpillCodec::Zstd));
+        {
+            let mut pw = PooledChunkWriter::<TemplateKey>::new(
+                Arc::clone(&pool),
+                &pooled_path,
+                SpillCodec::Zstd,
+            )
+            .unwrap();
+            for (k, r) in &records {
+                pw.write_record(k, r).unwrap();
+            }
+            pw.finish().unwrap();
+        }
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+
+        assert_eq!(
+            read_back(&sync_path),
+            read_back(&pooled_path),
+            "sync vs pooled read-back differ"
+        );
+    }
+
+    /// Records larger than one block must span frames and still round-trip.
+    #[test]
+    fn sync_zstd_spans_frames_for_large_records() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("large.keyed");
+        // Two records each ~3x the block size — forces multi-frame spanning.
+        let big = vec![0xABu8; BGZF_MAX_BLOCK_SIZE * 3 + 17];
+        let records = vec![(make_key(1), big.clone()), (make_key(2), big)];
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, SpillCodec::Zstd, 1).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(read_back(&path), records, "large-record frame spanning round-trip mismatch");
+    }
+
+    /// Uncompressed bgzf (level 0) must write *framed* (stored) BGZF blocks —
+    /// starting with the `0x1f 0x8b` gzip magic — NOT raw bytes, or the bgzf
+    /// reader's magic check rejects the spill. Regression for the
+    /// `--temp-compression 0 --temp-codec bgzf` path. Also cross-checks that the
+    /// records read back match the pooled writer at level 0.
+    #[test]
+    fn sync_bgzf_level0_is_framed_and_matches_pooled() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(300);
+
+        let sync_path = dir.path().join("sync_l0.keyed");
+        let mut w =
+            SyncSpillWriter::<TemplateKey>::create(&sync_path, SpillCodec::Bgzf, 0).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let bytes = std::fs::read(&sync_path).unwrap();
+        assert_eq!(
+            &bytes[..2],
+            &[0x1f, 0x8b],
+            "level-0 bgzf spill must be framed BGZF (gzip magic), not raw"
+        );
+        assert_eq!(read_back(&sync_path), records, "level-0 bgzf round-trip mismatch");
+
+        // Cross-check vs the pooled writer at level 0 (its pool is built with
+        // temp_compression = 0).
+        let pooled_path = dir.path().join("pooled_l0.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 0, 6, SpillCodec::Bgzf));
+        {
+            let mut pw = PooledChunkWriter::<TemplateKey>::new(
+                Arc::clone(&pool),
+                &pooled_path,
+                SpillCodec::Bgzf,
+            )
+            .unwrap();
+            for (k, r) in &records {
+                pw.write_record(k, r).unwrap();
+            }
+            pw.finish().unwrap();
+        }
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+        assert_eq!(
+            read_back(&sync_path),
+            read_back(&pooled_path),
+            "level-0 bgzf: sync vs pooled read-back differ"
+        );
+    }
+
+    /// `write_sorted_chunk` (the per-chunk entry the `CompressSpill` step calls)
+    /// round-trips every record through the merge reader, and `open_spill_slot`
+    /// opens the result with the requested `file_id` and the detected codec.
+    #[test]
+    fn write_sorted_chunk_round_trips_and_open_spill_slot_sets_file_id() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("chunk_0007.keyed");
+        let records = sample_records(400);
+        // `write_sorted_chunk` takes `(K, RawRecord)`; `read_back` yields
+        // `(K, Vec<u8>)`. Build the keyed form once and compare read-back vs the
+        // original `Vec<u8>` payloads.
+        let keyed: Vec<(TemplateKey, RawRecord)> =
+            records.iter().map(|(k, r)| (*k, RawRecord::from(r.clone()))).collect();
+
+        crate::write_sorted_chunk(&path, SpillCodec::Zstd, 3, &keyed).unwrap();
+        assert_eq!(read_back(&path), records, "write_sorted_chunk round-trip mismatch");
+
+        let slot = crate::open_spill_slot(&path, 7).expect("open spill slot");
+        assert_eq!(slot.file_id, 7, "open_spill_slot must honor the requested file_id");
+        assert_eq!(slot.codec, SpillCodec::Zstd, "codec must be detected from the file magic");
+
+        // The bgzf arm: codec detection must fall back to Bgzf (no ZSPILL magic).
+        let bgzf_path = dir.path().join("chunk_0008.keyed");
+        crate::write_sorted_chunk(&bgzf_path, SpillCodec::Bgzf, 1, &keyed).unwrap();
+        let bgzf_slot = crate::open_spill_slot(&bgzf_path, 8).expect("open bgzf spill slot");
+        assert_eq!(bgzf_slot.file_id, 8);
+        assert_eq!(bgzf_slot.codec, SpillCodec::Bgzf);
+    }
+
+    /// The bgzf arm delegates to the proven `GenericKeyedChunkWriter`; confirm
+    /// the unified type round-trips there too.
+    #[test]
+    fn sync_bgzf_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sync_bgzf.keyed");
+        let records = sample_records(200);
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, SpillCodec::Bgzf, 1).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(read_back(&path), records, "sync bgzf round-trip mismatch");
+    }
+}

--- a/crates/fgumi-sort/src/template_arena.rs
+++ b/crates/fgumi-sort/src/template_arena.rs
@@ -1,0 +1,418 @@
+//! Template-coordinate arena-front sort: build a sorted
+//! [`InMemoryChunk<TemplateKey>`] from record bodies already resident in a shared
+//! arena, WITHOUT copying record bytes — the template analogue of the coordinate
+//! [`coordinate_chunk_from_refs`](crate::ref_sort::coordinate_chunk_from_refs).
+//!
+//! [`TemplateArenaAccumulator`] encapsulates everything the template key needs
+//! that the arena-front pipeline step (`FindBoundariesAndSort` in
+//! `fgumi-pipeline-io`) does not have: the [`LibraryLookup`], cell-barcode tag +
+//! hasher, the `--key-types` narrowed-lane selection, and the per-record
+//! dropped-lane verification. The pipeline step calls [`push`](TemplateArenaAccumulator::push)
+//! per record (arena offset + len) and [`seal`](TemplateArenaAccumulator::seal)
+//! per run, exactly mirroring the owned [`TemplateChunkSorter`](crate::TemplateChunkSorter)
+//! so the output is byte-for-byte identical — only the record bodies stay in the
+//! shared arena instead of being copied into owned `RawRecord`s.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use noodles::sam::Header;
+
+use crate::arena_pool::PooledSegmentedBuf;
+use crate::external::{
+    KeyTypesSpec, LibraryLookup, TemplateKeyVariant, cb_hasher, dropped_lane_error,
+    extract_template_key_inline, select_template_variant, verify_dropped_lanes,
+};
+use crate::inline::{
+    CbKey32, InMemoryChunk, TemplateKey, TemplateKey24, TemplateKey40, TemplateLaneKey,
+    TemplateRecordRef, TertKey32, parallel_radix_sort_template_refs, radix_sort_template_refs,
+};
+use crate::ref_sort::PARALLEL_SORT_THRESHOLD;
+use crate::{SpillCodec, frame_keyed_record_into, write_sorted_chunk_inmem};
+use fgumi_raw_bam::{RawRecordView, SamTag};
+
+/// Variant-carrying erased template residual chunk: one arm per `--key-types`
+/// narrowed lane. Lets `MemoryChunkErased::TemplateCoordinate` hold whichever
+/// lane variant the sort chose, so template-coordinate rides its natural narrow
+/// key end-to-end through merge and spill — exactly like every other sort order
+/// rides its own `K` — instead of being pinned to the full 40-byte
+/// [`TemplateKey`]. Narrow-lane order equals full-key order (every dropped lane
+/// is verified constant on the ingest path), so merging and spilling the narrow
+/// key is byte-identical to the full key. The [`K40`](Self::K40) arm is the full
+/// key (all lanes), used by the legacy owned path and the full variant.
+pub enum TemplateMemChunk {
+    /// 24-byte core-only lane (neither cb nor tertiary optional word present).
+    K24(InMemoryChunk<TemplateKey24>),
+    /// 32-byte lane whose optional word carries `cb_hash`.
+    Cb32(InMemoryChunk<CbKey32>),
+    /// 32-byte lane whose optional word carries the tertiary (library<<48 | mi).
+    Tert32(InMemoryChunk<TertKey32>),
+    /// Full 40-byte key (all lanes) — the legacy owned path and full variant.
+    K40(InMemoryChunk<TemplateKey>),
+}
+
+impl TemplateMemChunk {
+    /// Number of records in the chunk.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::K24(c) => c.len(),
+            Self::Cb32(c) => c.len(),
+            Self::Tert32(c) => c.len(),
+            Self::K40(c) => c.len(),
+        }
+    }
+
+    /// `true` iff the chunk holds zero records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Total record-payload bytes (sum of record lengths; excludes keys and
+    /// index overhead). Used for byte-budget accounting at the chunk boundary.
+    #[must_use]
+    pub fn payload_bytes(&self) -> usize {
+        match self {
+            Self::K24(c) => c.payload_bytes(),
+            Self::Cb32(c) => c.payload_bytes(),
+            Self::Tert32(c) => c.payload_bytes(),
+            Self::K40(c) => c.payload_bytes(),
+        }
+    }
+
+    /// Borrow the `i`th record's raw BAM body bytes, in this chunk's sorted order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`.
+    #[must_use]
+    pub fn record_bytes(&self, i: usize) -> &[u8] {
+        match self {
+            Self::K24(c) => c.record_bytes(i),
+            Self::Cb32(c) => c.record_bytes(i),
+            Self::Tert32(c) => c.record_bytes(i),
+            Self::K40(c) => c.record_bytes(i),
+        }
+    }
+
+    /// Frame the `i`th record into `out` in the spill layout
+    /// `[key][u32 LE len][record]`, using this chunk's narrow-lane key.
+    ///
+    /// Encapsulates the per-variant key dispatch so the pipeline-io spill
+    /// serializer stays variant-agnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to `out` fails.
+    pub fn frame_record_into(&self, i: usize, out: &mut Vec<u8>) -> io::Result<()> {
+        match self {
+            Self::K24(c) => frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i)),
+            Self::Cb32(c) => frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i)),
+            Self::Tert32(c) => frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i)),
+            Self::K40(c) => frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i)),
+        }
+    }
+
+    /// Write the whole chunk to a spill file at `path` via
+    /// [`write_sorted_chunk_inmem`], keyed by this chunk's narrow lane.
+    ///
+    /// Encapsulates the per-variant key dispatch so the pipeline-io compress
+    /// step stays variant-agnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the spill write fails.
+    pub fn write_spill(&self, path: &Path, codec: SpillCodec, compression: u32) -> Result<()> {
+        match self {
+            Self::K24(c) => write_sorted_chunk_inmem(path, codec, compression, c),
+            Self::Cb32(c) => write_sorted_chunk_inmem(path, codec, compression, c),
+            Self::Tert32(c) => write_sorted_chunk_inmem(path, codec, compression, c),
+            Self::K40(c) => write_sorted_chunk_inmem(path, codec, compression, c),
+        }
+    }
+}
+
+/// Build a sorted template chunk from narrow-lane refs pointing into `arena`.
+///
+/// Featherweight seal (the template analogue of the coordinate
+/// [`coordinate_chunk_from_refs`](crate::ref_sort::coordinate_chunk_from_refs)):
+/// sorts `refs` on their cached narrow lane key (stable radix — parallel for
+/// large multi-threaded runs, matching the owned path's `par_sort`) and copies
+/// that narrow key straight into the returned [`InMemoryChunk<K>`]. NO full-key
+/// re-extraction, NO arena body access — the key is already resident in each
+/// ref (computed once at `push`). No record bytes are copied: the records
+/// reference their bodies in `arena` at `(offset, len)`. Narrow-lane order
+/// equals full-key order (every dropped lane is verified constant on the ingest
+/// path), so the chunk is correctly ordered for the downstream `MergeDriver<K>`,
+/// and spilling/merging the narrow key is byte-identical to the full key.
+///
+/// The parallel-vs-serial decision mirrors the coordinate front
+/// ([`sort_coordinate_refs`](crate::ref_sort)): it uses the parallel radix only
+/// when `sort_threads > 1` AND the run exceeds the shared
+/// [`PARALLEL_SORT_THRESHOLD`], so a small run does not pay the parallel radix's
+/// partition/coordination overhead. Both paths produce byte-identical output
+/// (the parallel template radix is stability-tested against the serial one).
+#[must_use]
+pub fn template_chunk_from_arena_refs<K: TemplateLaneKey>(
+    arena: Arc<PooledSegmentedBuf>,
+    mut refs: Vec<TemplateRecordRef<K>>,
+    sort_threads: usize,
+) -> InMemoryChunk<K> {
+    if sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD {
+        parallel_radix_sort_template_refs(&mut refs);
+    } else {
+        radix_sort_template_refs(&mut refs);
+    }
+    let records: Vec<(K, u64, u32)> = refs.into_iter().map(|r| (r.key, r.offset, r.len)).collect();
+    InMemoryChunk::from_parts(arena, records)
+}
+
+/// Narrow-lane ref accumulator, one arm per `--key-types` variant (mirrors the
+/// owned `TemplateBuffer`'s variant set). Each holds `TemplateRecordRef<K>`s
+/// pointing at record bodies in the shared inflate arena — no owned byte storage.
+enum ArenaRefs {
+    K24(Vec<TemplateRecordRef<TemplateKey24>>),
+    Cb32(Vec<TemplateRecordRef<CbKey32>>),
+    Tert32(Vec<TemplateRecordRef<TertKey32>>),
+    K40(Vec<TemplateRecordRef<TemplateKey40>>),
+}
+
+impl ArenaRefs {
+    fn for_variant(v: TemplateKeyVariant) -> Self {
+        match (v.cb, v.tertiary) {
+            (false, false) => Self::K24(Vec::new()),
+            (true, false) => Self::Cb32(Vec::new()),
+            (false, true) => Self::Tert32(Vec::new()),
+            (true, true) => Self::K40(Vec::new()),
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, full: &TemplateKey, offset: u64, len: u32) {
+        // The `key` field type resolves `K` per arm, so `from_full` narrows to the
+        // matching lane width (identical to the owned `TemplateRecordBuffer::push`).
+        match self {
+            Self::K24(v) => {
+                v.push(TemplateRecordRef {
+                    key: TemplateLaneKey::from_full(full),
+                    offset,
+                    len,
+                    padding: 0,
+                });
+            }
+            Self::Cb32(v) => {
+                v.push(TemplateRecordRef {
+                    key: TemplateLaneKey::from_full(full),
+                    offset,
+                    len,
+                    padding: 0,
+                });
+            }
+            Self::Tert32(v) => {
+                v.push(TemplateRecordRef {
+                    key: TemplateLaneKey::from_full(full),
+                    offset,
+                    len,
+                    padding: 0,
+                });
+            }
+            Self::K40(v) => {
+                v.push(TemplateRecordRef {
+                    key: TemplateLaneKey::from_full(full),
+                    offset,
+                    len,
+                    padding: 0,
+                });
+            }
+        }
+    }
+
+    fn reserve(&mut self, n: usize) {
+        match self {
+            Self::K24(v) => v.reserve(n),
+            Self::Cb32(v) => v.reserve(n),
+            Self::Tert32(v) => v.reserve(n),
+            Self::K40(v) => v.reserve(n),
+        }
+    }
+}
+
+/// State that exists only once the first record has been seen: the chosen
+/// narrowed-key variant, the first record's full key (the dropped-lane verify
+/// baseline), and the accumulated refs. Set together on the first push and
+/// persisted across runs (spills) — matching the owned `TemplateChunkSorter`,
+/// whose variant/baseline are chosen once and never re-selected.
+struct AccState {
+    first_key: TemplateKey,
+    variant: TemplateKeyVariant,
+    refs: ArenaRefs,
+}
+
+/// Arena-front template-coordinate accumulator: the template analogue of the
+/// owned [`TemplateChunkSorter`](crate::TemplateChunkSorter), accumulating
+/// arena-pointing refs instead of copying records. Produces byte-identical
+/// output (same provisioning, same dropped-lane rejection, same sorted order).
+pub struct TemplateArenaAccumulator {
+    lib_lookup: LibraryLookup,
+    cell_tag: Option<SamTag>,
+    cb_hasher: ahash::RandomState,
+    key_types: KeyTypesSpec,
+    header_library_varies: bool,
+    /// Variant + baseline + refs; `None` until the first record provisions it.
+    state: Option<AccState>,
+    /// Reserve hint received before the first record (variant unknown), applied
+    /// when the ref buffer is provisioned.
+    pending_reserve: usize,
+    /// Bounded rayon pool (sized to `sort_threads`) that [`seal`](Self::seal)
+    /// installs the per-run radix + full-key gather into, so they run on exactly
+    /// `sort_threads` threads instead of the GLOBAL rayon pool. Without this the
+    /// parallel radix and `par_iter` gather fan out over every core and
+    /// oversubscribe the pipeline's own worker pool during a spill (the pipeline
+    /// runs the sort on one worker while the others inflate/compress). Built once
+    /// on the first seal (`sort_threads` is only known then) and reused; `None`
+    /// on a fresh worker copy. Mirrors the owned `TemplateChunkSorter`'s
+    /// `rayon_pool.install(...)`.
+    sort_pool: Option<rayon::ThreadPool>,
+}
+
+impl TemplateArenaAccumulator {
+    /// Build an accumulator from the BAM `header`, the sort's cell-barcode tag,
+    /// and the `--key-types` spec, deriving the library lookup and CB hasher
+    /// exactly as
+    /// [`RawExternalSorter::into_template_chunk_sorter`](crate::RawExternalSorter::into_template_chunk_sorter).
+    #[must_use]
+    pub fn from_header(header: &Header, cell_tag: Option<SamTag>, key_types: KeyTypesSpec) -> Self {
+        let lib_lookup = LibraryLookup::from_header(header);
+        let header_library_varies = lib_lookup.distinct_header_ordinals() > 1;
+        Self {
+            lib_lookup,
+            cell_tag,
+            cb_hasher: cb_hasher(),
+            key_types,
+            header_library_varies,
+            state: None,
+            pending_reserve: 0,
+            sort_pool: None,
+        }
+    }
+
+    /// Reserve capacity for approximately `est_records` refs for the current run.
+    pub fn reserve(&mut self, est_records: usize) {
+        if let Some(state) = self.state.as_mut() {
+            state.refs.reserve(est_records);
+        } else {
+            self.pending_reserve = self.pending_reserve.max(est_records);
+        }
+    }
+
+    /// Extract the template key from `body` (the record's BAM body, `block_size`
+    /// prefix excluded, at arena offset `body_off`, length `len`), provision the
+    /// narrowed-lane variant on the first record, verify the dropped lanes on
+    /// every subsequent record, and accumulate a ref into the arena.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a record carries a dropped-lane value (CB / MI /
+    /// library) absent from the first record — the same rejection the owned
+    /// `TemplateChunkSorter::push` performs.
+    pub fn push(&mut self, body: &[u8], body_off: u64, len: u32) -> Result<()> {
+        let key =
+            extract_template_key_inline(body, &self.lib_lookup, self.cell_tag, &self.cb_hasher);
+        if let Some(state) = self.state.as_mut() {
+            if let Some(violation) = verify_dropped_lanes(&state.first_key, &key, state.variant) {
+                let name = RawRecordView::new(body).read_name();
+                return Err(dropped_lane_error(&String::from_utf8_lossy(name), violation));
+            }
+            state.refs.push(&key, body_off, len);
+        } else {
+            let variant =
+                select_template_variant(Some(&key), self.key_types, self.header_library_varies);
+            let mut refs = ArenaRefs::for_variant(variant);
+            if self.pending_reserve > 0 {
+                refs.reserve(self.pending_reserve);
+            }
+            refs.push(&key, body_off, len);
+            self.state = Some(AccState { first_key: key, variant, refs });
+        }
+        Ok(())
+    }
+
+    /// Sort the refs accumulated for the current run and drain them into an
+    /// arena-backed [`TemplateMemChunk`] (zero body copies). The chosen variant +
+    /// baseline are RETAINED for subsequent runs (spills), matching the owned
+    /// sorter. Empty if nothing was pushed.
+    ///
+    /// Featherweight seal: each arm emits the variant-matching narrow
+    /// [`TemplateMemChunk`] lane using the key already resident in the ref — no
+    /// per-record re-extraction and no body access — so the downstream
+    /// merge/spill ride the narrow key lane chosen for this run.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bounded sort rayon pool cannot be built (an infrastructure
+    /// failure, e.g. the OS refuses the `sort_threads` worker threads).
+    #[must_use]
+    pub fn seal(
+        &mut self,
+        arena: Arc<PooledSegmentedBuf>,
+        sort_threads: usize,
+    ) -> TemplateMemChunk {
+        // Drain this run's refs, leaving a fresh empty accumulator of the SAME
+        // variant so the next run re-uses the once-chosen variant + baseline.
+        // (Scoped so the `self.state` borrow ends before we touch `sort_pool`.)
+        let refs = {
+            let Some(state) = self.state.as_mut() else {
+                return TemplateMemChunk::K40(InMemoryChunk::default());
+            };
+            std::mem::replace(&mut state.refs, ArenaRefs::for_variant(state.variant))
+        };
+        // Bounded pool sized to `sort_threads`, built once and reused. Running the
+        // radix + gather inside `pool.install` bounds BOTH to `sort_threads` (via
+        // the pool's `current_num_threads`), so they no longer oversubscribe the
+        // pipeline's worker pool on a spill.
+        let pool = self.sort_pool.get_or_insert_with(|| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(sort_threads.max(1))
+                .thread_name(|i| format!("tmpl-sort-{i}"))
+                .build()
+                .expect("build bounded template-sort rayon pool")
+        });
+        // Featherweight seal: each arm produces the variant-matching narrow chunk
+        // (the key is already in the ref — no re-extraction, no body access), and
+        // tags it with the chosen variant so the downstream merge/spill ride the
+        // narrow lane. The variant is global, so every run's chunk shares one arm.
+        pool.install(move || match refs {
+            ArenaRefs::K24(r) => {
+                TemplateMemChunk::K24(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::Cb32(r) => {
+                TemplateMemChunk::Cb32(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::Tert32(r) => {
+                TemplateMemChunk::Tert32(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::K40(r) => {
+                TemplateMemChunk::K40(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+        })
+    }
+
+    /// A fresh accumulator with the same configuration and empty state — used to
+    /// build a worker copy of the arena-front step.
+    #[must_use]
+    pub fn fresh(&self) -> Self {
+        Self {
+            lib_lookup: self.lib_lookup.clone(),
+            cell_tag: self.cell_tag,
+            cb_hasher: self.cb_hasher.clone(),
+            key_types: self.key_types,
+            header_library_varies: self.header_library_varies,
+            state: None,
+            pending_reserve: 0,
+            sort_pool: None,
+        }
+    }
+}

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -568,27 +568,28 @@ pub(crate) struct Phase2Reader {
 /// be reading, decompressing, and the main thread can be popping records all
 /// concurrently as long as they touch different sub-states.
 ///
-/// # Two Phase-2 merge implementations (deliberate split — see commit `9d6d7e9` / PR #395)
+/// # Two Phase-2 merge implementations (production vs. the retained oracle)
 ///
-/// This pool path drives standalone file-to-file `fgumi sort` (it keeps the
-/// engine, zstd spill, `--write-index`, and `--verify`). A SECOND, slimmer
-/// Phase-2 lives in `merge_slots.rs` (`SortMergeSlot`) for the fused in-pipeline
-/// `runall` sort. That path REMOVED the `raw_blocks` FIFO, `decomp_in_flight`,
-/// the reorder buffer, and the gap-filler because its cooperative-step consumer
-/// deadlocked at production scale (see its module header).
+/// Since the P6/P7 sort unification (#395), the `fgumi` production sort — both
+/// standalone `fgumi sort` and the fused `runall` sort — runs entirely on the
+/// buffer chain, whose Phase-2 is `merge_slots.rs` (`SortMergeSlot`). THIS pool
+/// path no longer drives any production sort; it is retained as the
+/// `RawExternalSorter::sort` library entry point and the `#[cfg(test)]` parity
+/// oracle (the byte-for-byte cross-check the buffer chain is verified against),
+/// keeping the engine, zstd spill, `--write-index`, and `--verify`.
 ///
-/// This pool path is IMMUNE to that v4 deadlock: its merge consumer is a parked
-/// OS thread (`external.rs::advance_to_next_block`), not a framework step the
-/// engine can Skip; and its single-reader gapless-FIFO serials guarantee the
-/// stuck serial is always either at the `raw_blocks` head (so the gap-filler
-/// fires) or in-flight in a worker's decompressor. Do NOT delete the gap-filler
-/// or the reorder buffer to "match" `merge_slots` — single-*reader* is not
-/// single-*decompressor* here (workers decompress in parallel, so completion
-/// order ≠ pop order), and removing them reintroduces a real deadlock and/or
-/// out-of-order merge output. The split is intentional and deferred-for-now
-/// (see commit `9c39dea` / PR #389 and
-/// `docs/design/sort-phase2-unification-deferral.md`).
-// TODO(#395): unify the two Phase-2 sort drivers — see docs/design/sort-phase2-unification-deferral.md
+/// The two implementations differ deliberately, and that difference is
+/// load-bearing for the oracle. This path keeps the `raw_blocks` FIFO,
+/// `decomp_in_flight`, the reorder buffer, and the gap-filler because its merge
+/// consumer is a parked OS thread (`external.rs::advance_to_next_block`, immune
+/// to the v4 framework-Skip deadlock) and its single-*reader* /
+/// multi-*decompressor* topology means completion order ≠ pop order. The
+/// slimmer `merge_slots.rs` dropped all four because its consumer reads AND
+/// decompresses in one inline op (blocks decompress strictly in read order, so
+/// a plain FIFO suffices). Do NOT delete the gap-filler or the reorder buffer
+/// here to "match" `merge_slots` — it would reintroduce a real deadlock and/or
+/// out-of-order merge output. (History: commits `9d6d7e9` / `9c39dea`, PRs
+/// #389 / #395, `docs/design/sort-phase2-unification-deferral.md`.)
 pub(crate) struct Phase2FileState {
     /// Disk reader. Held only while popping bytes from disk.
     pub(crate) reader: Mutex<Phase2Reader>,
@@ -1919,6 +1920,11 @@ impl SortWorkerPool {
     /// early misdirected wake is
     /// harmless as long as a later `unpark` arrives — which it always does
     /// (every subsequent block publish + the terminal drain/EOF unpark).
+    ///
+    /// Now exercised only by this module's unit tests: its production caller was
+    /// the streaming `*SortStream::into_slot_setup`, retired in P7. Retained as a
+    /// tested pool primitive (the `.sort()` oracle never needed to re-target).
+    #[allow(dead_code)]
     pub fn set_main_thread(&self, handle: std::thread::Thread) {
         self.shared.main_thread_handle.store(std::sync::Arc::new(handle));
     }

--- a/crates/fgumi-sort/tests/loom_merge_slots.rs
+++ b/crates/fgumi-sort/tests/loom_merge_slots.rs
@@ -1,0 +1,326 @@
+//! Loom model-check of the block-parallel Phase-2 decompress protocol
+//! (`file_granularity == false`), driving the **real** `SortMergeSlot`.
+//!
+//! # What this verifies (and what it does NOT)
+//!
+//! Under `--cfg loom`, `merge_slots.rs` swaps `std::sync` -> `loom::sync`, so
+//! the `SortMergeSlot` constructed here uses loom's atomics and mutexes. loom
+//! explores the thread interleavings and the memory reorderings the C11 model
+//! permits (preemption-bounded — see "Preemption-bounded exploration" below),
+//! running the REAL slot methods each time:
+//!
+//!   * [`SortMergeSlot::bp_commit_read`] — the publish order (reserve
+//!     `in_flight` before setting `reader_eof`) that the original silent-
+//!     truncation bug lived in. Production
+//!     (`SortSpillDecompress::try_fill_block_parallel_slot`) calls the SAME
+//!     method, so the model and the code cannot drift.
+//!   * [`SortMergeSlot::bp_insert_drain_finalize`] /
+//!     [`SortMergeSlot::bp_drain_and_finalize`] and the private
+//!     `drain_locked_and_finalize` (the finalize predicate `!queue_eof &&
+//!     reader_eof && in_flight == 0 && reorder.is_empty()`, the lock order
+//!     reorder -> decompressed, and the real `in_flight.fetch_sub(AcqRel)`).
+//!   * The slot's REAL `reader` mutex serializes reads, and its REAL `reorder`
+//!     buffer ([`fgumi_bam_io::reorder::ReorderBuffer`]) reassembles them.
+//!
+//! Only two things are *not* the production code, both sound and documented:
+//!
+//!   * **The "read" is simulated.** loom cannot model real file I/O, so a
+//!     worker computes `(start_seq, got, hit_eof)` from a test-held total under
+//!     the real `reader` lock instead of calling `read_raw`; "decompression"
+//!     yields the seq number as the payload. The slot's accounting/finalize
+//!     methods that run on the result are 100% production code.
+//!   * **Blocking `reader.lock()` instead of production's `try_lock()`.** The
+//!     property under test depends only on reads being *serialized* (so
+//!     `reader_eof` can never become visible while an unreserved block still
+//!     exists); a blocking lock preserves exactly that while collapsing the
+//!     `try_lock`-miss-retry fan-out that would otherwise explode loom's state
+//!     space (and a spin-retry is a loom anti-pattern). It is a sound
+//!     over-approximation of the serialization invariant.
+//!
+//! ## Modeling choices (documented for honesty)
+//!
+//!   * **Window/FIFO admission disabled.** `bp_reorder_admits` backpressure is a
+//!     *bounded-memory* property, separately covered by the `merge_slots` unit
+//!     test `bp_reorder_window_is_bounded_under_straggler`. Workers here always
+//!     admit, keeping the model focused on the EOF/truncation invariants.
+//!   * **Tiny sizes (2-4 blocks, 2-3 workers).** loom's state space is
+//!     super-exponential; these sizes still exercise every out-of-order
+//!     insert/finalize interleaving the per-slot protocol can hit (more blocks
+//!     add only more of the same kind, not a new kind).
+//!   * **One pass per producer, no spin.** `n_workers == reads_needed(N,
+//!     batch)`, so every block is read by exactly one producer and the model
+//!     always terminates; a protocol that failed to finalize surfaces as the
+//!     `queue_eof` assertion below, not as a hang.
+//!   * **A concurrent merge consumer** ([`consume_until_drained`]) polls the
+//!     FIFO and STOPS at `is_drained()`, mirroring `SortMerge`. This is what
+//!     makes a *premature* `queue_eof` observable as truncation (without it the
+//!     straggler is appended after the join and the bug hides — verified: the
+//!     `bp_commit_read` order swap is caught only with the consumer present).
+//!   * **Preemption-bounded exploration.** The consumer's poll loop adds a
+//!     scheduling point per iteration; combined with 2-3 producers the fully
+//!     exhaustive state space is minutes-long. Every model is therefore explored
+//!     under a preemption bound (`Some(k)`) — a recognized technique: essentially
+//!     all real concurrency bugs (including the truncation race this guards)
+//!     manifest with ≤2-3 preemptions. The bound is verified to still catch the
+//!     `bp_commit_read` order swap.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
+//! ```
+//!
+//! # Complementary coverage and its residual
+//!
+//! This model is one leg of the block-parallel hardening; the others are the
+//! `merge_slots` unit tests (bounded-memory window), the
+//! `fgumi-pipeline-io` granularity/proptest/soak-matrix tests (the real
+//! end-to-end pipeline over real spill files), and a `ThreadSanitizer` pass.
+//!
+//! **Sanitizer residual (recorded for honesty):** the `ThreadSanitizer` run
+//! exercised the real pipeline on **arm64 only**, and the C decompression codecs
+//! (`zstd` via the `zstd` crate, `libdeflate` via `libdeflater`) are
+//! **uninstrumented** — the sanitizer only sees the Rust side, so a data race
+//! *inside* a C codec would be missed. This is acceptable because the codecs are
+//! pure per-block transforms with no shared mutable state across threads (each
+//! worker decompresses its own block into its own buffer); the cross-thread
+//! protocol the sanitizer and loom actually need to clear is the Rust-side slot
+//! accounting, which is fully instrumented here.
+
+#![cfg(loom)]
+#![deny(unsafe_code)]
+// Block counts/seqs in this model are tiny (≤ a handful) and always fit a
+// usize; the casts below are between u64 model seqs and usize counts.
+#![allow(clippy::cast_possible_truncation)]
+
+use std::fs::File;
+use std::io::BufReader;
+
+use fgumi_sort::{SortMergeSlot, SpillCodec};
+use loom::sync::Arc;
+use loom::sync::atomic::Ordering;
+
+/// A throwaway reader for the slot. The block-parallel slot methods never touch
+/// `reader.inner`; the model serializes reads on the `reader` mutex and computes
+/// the read result arithmetically, so an empty file is all the struct needs.
+fn empty_reader() -> BufReader<File> {
+    BufReader::new(tempfile::tempfile().expect("create tempfile"))
+}
+
+/// One worker's body: mirrors a single `try_run` of
+/// `SortSpillDecompress::try_fill_block_parallel_slot`, but with the file read
+/// simulated (see module docs). Reads up to `block_batch` blocks under the REAL
+/// `reader` lock, publishes the accounting via the REAL
+/// [`SortMergeSlot::bp_commit_read`], "decompresses" outside the lock, then
+/// inserts/drains/finalizes via the REAL [`SortMergeSlot::bp_insert_drain_finalize`].
+/// A worker that finds the reader already at EOF falls through to the REAL
+/// Phase-B drain-only [`SortMergeSlot::bp_drain_and_finalize`].
+fn worker_one_pass(slot: &SortMergeSlot, block_batch: u64, total_blocks: u64) {
+    if slot.queue_eof.load(Ordering::Acquire) {
+        return;
+    }
+    let mut did_phase_a = false;
+    if !slot.reader_eof.load(Ordering::Acquire) {
+        // Blocking lock (sound over-approximation of production's `try_lock`;
+        // see module docs) — serializes reads on the REAL reader mutex.
+        let mut reader = slot.reader.lock().unwrap();
+        // Re-check under the lock: another worker may have hit EOF.
+        if !slot.reader_eof.load(Ordering::Acquire) {
+            let start_seq = reader.next_seq;
+            let remaining = total_blocks - start_seq;
+            let got = block_batch.min(remaining);
+            let hit_eof = got < block_batch;
+            // Stamp the read range and commit the accounting BEFORE releasing
+            // the lock, via the real publish-order method.
+            reader.next_seq += got;
+            slot.bp_commit_read(got as usize, hit_eof);
+            drop(reader);
+
+            // "Decompress" outside the reader lock: the payload is the seq as
+            // 8 little-endian bytes, so the drained FIFO can be checked for
+            // in-order, no-loss delivery.
+            let blocks: Vec<Vec<u8>> =
+                (start_seq..start_seq + got).map(|s| s.to_le_bytes().to_vec()).collect();
+            slot.bp_insert_drain_finalize(start_seq, blocks, got as usize);
+            did_phase_a = true;
+        }
+    }
+    if !did_phase_a {
+        slot.bp_drain_and_finalize();
+    }
+}
+
+/// Number of reader-lock acquisitions (= worker passes) needed to read every
+/// block and then observe the clean EOF: `ceil((N + 1) / batch)`. The `+ 1`
+/// accounts for the read that returns fewer than `batch` blocks (possibly
+/// empty), which is what sets `reader_eof`.
+fn reads_needed(total_blocks: u64, block_batch: u64) -> usize {
+    ((total_blocks + 1).div_ceil(block_batch)) as usize
+}
+
+/// Decode an 8-byte little-endian seq payload back to its sequence number.
+fn seq_of(block: &[u8]) -> u64 {
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&block[..8]);
+    u64::from_le_bytes(buf)
+}
+
+/// The merge consumer, mirroring `SortMerge`/`slot_try_load_block`: pop every
+/// available block, then STOP the instant the slot looks cleanly drained
+/// (`is_drained()` == `queue_eof && FIFO empty && !error`). Returns the seqs it
+/// collected, in pop (delivery) order.
+///
+/// This stop condition is what makes a *premature* `queue_eof` observable: if
+/// the slot finalizes EOF while a block is still outstanding (the truncation the
+/// publish-order protocol prevents), the consumer sees an empty FIFO + EOF and
+/// quits early, so `run_model`'s completeness check fails. Without a consumer
+/// the straggler would still be appended after the join and the bug would hide.
+///
+/// `yield_now` between polls is the loom scheduling point; the model is finite
+/// (every producer runs exactly one pass), so the wait always terminates.
+fn consume_until_drained(slot: &SortMergeSlot) -> Vec<u64> {
+    let mut collected = Vec::new();
+    loop {
+        loop {
+            let popped = slot.decompressed.lock().unwrap().pop_front();
+            match popped {
+                Some(b) => collected.push(seq_of(&b)),
+                None => break,
+            }
+        }
+        if slot.is_drained() {
+            break;
+        }
+        loom::thread::yield_now();
+    }
+    collected
+}
+
+/// Drive one worker pass per required read over `total_blocks` blocks with
+/// `block_batch` blocks per read PLUS a concurrent merge consumer, under loom,
+/// and assert the no-loss / in-order / clean-EOF invariants for every
+/// interleaving against the REAL slot state.
+fn run_model(total_blocks: u64, block_batch: u64) {
+    let slot = Arc::new(SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf));
+    let n_workers = reads_needed(total_blocks, block_batch);
+
+    let mut handles: Vec<_> = (0..n_workers)
+        .map(|_| {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || worker_one_pass(&slot, block_batch, total_blocks))
+        })
+        .collect();
+    let consumer = {
+        let slot = Arc::clone(&slot);
+        loom::thread::spawn(move || consume_until_drained(&slot))
+    };
+    for h in handles.drain(..) {
+        h.join().unwrap();
+    }
+    let delivered = consumer.join().unwrap();
+
+    // Post-conditions: clean EOF reached, no error, nothing left in flight or
+    // buffered, and the consumer collected every block exactly once, in read
+    // order, BEFORE it observed the clean EOF (a premature `queue_eof` truncates
+    // `delivered`).
+    assert!(slot.queue_eof.load(Ordering::Acquire), "slot never reached queue_eof");
+    assert!(!slot.has_error(), "spurious decomp_error");
+    assert_eq!(slot.in_flight.load(Ordering::Acquire), 0, "blocks left in flight at EOF");
+    assert!(slot.reorder.lock().unwrap().is_empty(), "reorder buffer not drained at EOF");
+    assert!(slot.decompressed.lock().unwrap().is_empty(), "FIFO not fully consumed at EOF");
+
+    let expected: Vec<u64> = (0..total_blocks).collect();
+    assert_eq!(
+        delivered, expected,
+        "blocks lost, duplicated, reordered, or truncated by early EOF"
+    );
+}
+
+/// Run `f` under loom with at most `preemption_bound` preemptions. See the
+/// module-level "Preemption-bounded exploration" note for why every model is
+/// bounded rather than exhaustive.
+fn check_model<F: Fn() + Sync + Send + 'static>(preemption_bound: usize, f: F) {
+    let mut builder = loom::model::Builder::new();
+    builder.preemption_bound = Some(preemption_bound);
+    builder.check(f);
+}
+
+/// Three blocks, batch 2 ⇒ 2 producer passes: the second read is SHORT (carries
+/// seq 2 AND sets `reader_eof`) while the first read's blocks (seq 0,1) may
+/// still be in flight — the exact `bp_eof_with_straggler` shape.
+#[test]
+fn loom_three_blocks_batch2() {
+    check_model(3, || run_model(3, 2));
+}
+
+/// Two blocks, batch 2 ⇒ 2 producer passes: the second read is the EMPTY
+/// EOF-detecting read (got == 0) that sets `reader_eof` while the first read's
+/// blocks (seq 0,1) may still be in flight. Exercises the `count == 0` finalize
+/// path of `bp_insert_drain_finalize`.
+#[test]
+fn loom_two_blocks_batch2_empty_eof_read() {
+    check_model(3, || run_model(2, 2));
+}
+
+/// Four blocks, batch 3 ⇒ 2 producer passes (read seq 0,1,2; short read seq 3
+/// sets EOF). A larger in-flight batch straggling behind the EOF read.
+#[test]
+fn loom_four_blocks_batch3() {
+    check_model(3, || run_model(4, 3));
+}
+
+/// Two blocks, batch 1 ⇒ 3 producer passes (read seq 0, read seq 1, empty EOF
+/// read) plus the consumer — four concurrent threads. Covers the three-way race
+/// between two in-flight blocks and the EOF-setter. Bounded tighter (the
+/// four-thread × nested-mutex state space is the largest here).
+#[test]
+fn loom_two_blocks_batch1_three_workers_bounded() {
+    check_model(2, || run_model(2, 1));
+}
+
+// ── decomp-error-beats-clean-EOF (#399) ──────────────────────────────────────
+
+/// The consumer that observes `queue_eof` under the `decompressed` mutex
+/// (`is_drained`) must also observe `decomp_error` whenever the producer took
+/// the error path — i.e. a failed slot can never be mistaken for a clean EOF.
+///
+/// This drives the REAL slot: the producer mirrors
+/// `SortSpillDecompress::mark_slot_failed` (store `decomp_error` then
+/// `queue_eof`, both under the `decompressed` mutex), and the consumer is the
+/// real [`SortMergeSlot::is_drained`] / [`SortMergeSlot::has_error`] pair. The
+/// mutex release-acquire makes the two flags jointly visible regardless of which
+/// the consumer reads first.
+#[test]
+fn loom_decomp_error_beats_clean_eof() {
+    loom::model(|| {
+        let slot = Arc::new(SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf));
+
+        // Producer: error path. Mirrors `mark_slot_failed` — set decomp_error
+        // THEN queue_eof, both under the `decompressed` mutex.
+        let producer = {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || {
+                let _g = slot.decompressed.lock().unwrap();
+                slot.decomp_error.store(true, Ordering::Release);
+                slot.queue_eof.store(true, Ordering::Release);
+            })
+        };
+
+        // Consumer: the real `is_drained()` / `has_error()`. The invariant: if
+        // the slot looks drained (clean EOF), it must NOT have an error — but
+        // because the producer's only path is the error path, any observation of
+        // `queue_eof == true` must come with `decomp_error == true`, so
+        // `is_drained()` must return false and `has_error()` true.
+        let consumer = {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || {
+                let drained = slot.is_drained();
+                let errored = slot.has_error();
+                // A clean drain that hid the error is the bug this guards.
+                assert!(!(drained && !errored), "observed clean EOF that hid a decomp error");
+            })
+        };
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+    });
+}


### PR DESCRIPTION
Replaces the legacy per-order sorters (`SortBamFile` / `*SortStream`) with one arena-based engine for coordinate, queryname, template-coordinate, and natural orders: capacity-1 arena pool with deferred-seal runs, LSD radix sort over record refs, queryname SSO keys with heap fallback, segmented spill buffers, and the k-way merge-slot machinery. Large net code deletion.

**Intermediate PR (red CI expected):** removing the legacy sorters leaves the consumers (pipeline-io, cli, root) referencing removed types until PR 6. See the stack note below.

---
### About this stack
This is a 6-PR stack that unifies the fgumi sort engine onto a single arena-based engine for all four sort orders (coordinate, queryname, template-coordinate, natural), retires the legacy sorters, and adds the N+2 threading model (serial coordination on dedicated driver threads, N pool workers on pure de/compression). The work is split one commit per crate to keep each diff small and reviewable.

Merge bottom-up:
1. `nh/sort-1-pipeline-core` → `feat-runall`
2. `nh/sort-2-bgzf-verify` → `nh/sort-1-pipeline-core`
3. `nh/sort-3-arena-engine` → `nh/sort-2-bgzf-verify`
4. `nh/sort-4-pipeline-io` → `nh/sort-3-arena-engine`
5. `nh/sort-5-cli` → `nh/sort-4-pipeline-io`
6. `nh/sort-6-chains-wiring` → `nh/sort-5-cli`

**CI note:** PRs 3–5 are the atomic engine-swap block — removing the legacy sorters leaves the workspace uncompilable until the consumers land in PR 6, so their standalone CI is red by construction. Correctness and the full green build are verified at the stack tip (PR 6): the whole suite passes (2258 tests), and sort output is byte-identical across all four orders (validated against the legacy engine and against `main`). Supersedes the single-squash PR #470.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added arena-backed in-memory coordinate/template chunk sorters, reference-based sorting utilities, and a template arena accumulator.
  * Added a synchronous spill writer with BGZF and zstd-compatible block framing.
* **Bug Fixes**
  * Strengthened block-parallel merge-slot finalization and corrected EOF/error race handling.
  * Improved template key validation and ordering stability for in-memory reuse.
* **Performance**
  * Reduced allocations using pooled arenas and inline queryname key storage.
  * Added microbenchmarks for chunk sorting and queryname key extraction/sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->