### PR TITLE
fix(zipper): right-size SAM-parsed records to bound pipeline memory

### DIFF
--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -989,24 +989,29 @@ pub(crate) mod merge_step {
         pub output_byte_limit: u64,
     }
 
-    /// One batch in flight on a branch + the cursor into it.
+    /// One batch's templates in flight on a branch + the cursor into them.
+    /// Owns the `Vec<Template>` moved out of the batch (via
+    /// [`BamTemplateBatch::into_parts`]) so the drain cursor can replace
+    /// slots in place — the cached `total_bytes` is dropped with the batch,
+    /// so there is no stale accounting to worry about.
     struct PendingBatch {
-        batch: BamTemplateBatch,
+        templates: Vec<Template>,
         cursor: usize,
     }
 
     impl PendingBatch {
         fn new(batch: BamTemplateBatch) -> Self {
-            Self { batch, cursor: 0 }
+            let (_, templates) = batch.into_parts();
+            Self { templates, cursor: 0 }
         }
 
         fn current(&self) -> Option<&Template> {
-            self.batch.templates.get(self.cursor)
+            self.templates.get(self.cursor)
         }
 
         fn take_current(&mut self) -> Option<Template> {
             let i = self.cursor;
-            if i >= self.batch.templates.len() {
+            if i >= self.templates.len() {
                 return None;
             }
             self.cursor += 1;
@@ -1014,11 +1019,11 @@ pub(crate) mod merge_step {
             // surrounding `Vec` can keep its length without the
             // `Template: Default` bound (Template carries a
             // `MoleculeId` enum that has no canonical default).
-            Some(std::mem::replace(&mut self.batch.templates[i], Template::new(Vec::new())))
+            Some(std::mem::replace(&mut self.templates[i], Template::new(Vec::new())))
         }
 
         fn is_exhausted(&self) -> bool {
-            self.cursor >= self.batch.templates.len()
+            self.cursor >= self.templates.len()
         }
     }
 
@@ -1207,7 +1212,7 @@ pub(crate) mod merge_step {
                                         .map(|t| t.name.clone())
                                         .or_else(|| {
                                             ctx.b.pop().and_then(|batch| {
-                                                batch.templates.first().map(|t| t.name.clone())
+                                                batch.templates().first().map(|t| t.name.clone())
                                             })
                                         });
                                     if let Some(name) = leftover_b {

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -155,7 +155,7 @@ pub(crate) fn build_clip_process_step(
                 RawRecordClipper::new(cap.clipping_mode)
             };
 
-            let BamTemplateBatch { batch_serial, mut templates, .. } = batch;
+            let (batch_serial, mut templates) = batch.into_parts();
             let mut local_templates: u64 = 0;
             let mut local_overlap_clipped: u64 = 0;
             let mut local_extend_clipped: u64 = 0;

--- a/src/lib/pipeline/chains/commands/filter.rs
+++ b/src/lib/pipeline/chains/commands/filter.rs
@@ -168,7 +168,8 @@ pub(crate) fn build_filter_step_single_no_rejects(
         "FilterProcess",
         limit_bytes,
         move |item: DecodedRecordBatch| -> io::Result<DecompressedBlock> {
-            let DecodedRecordBatch { batch_serial, records, .. } = item;
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
             let records_count = records.len() as u64;
             let mut kept_bytes: Vec<u8> = Vec::new();
             let mut passed_count: u64 = 0;
@@ -246,7 +247,8 @@ pub(crate) fn build_filter_step_single_with_rejects(
         limit_bytes,
         move |item: DecodedRecordBatch|
               -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
-            let DecodedRecordBatch { batch_serial, records, .. } = item;
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
             let records_count = records.len() as u64;
             let mut kept_bytes: Vec<u8> = Vec::new();
             let mut rejected_bytes: Vec<u8> = Vec::new();
@@ -316,7 +318,7 @@ pub(crate) fn build_filter_step_template_no_rejects(
         "FilterProcess",
         limit_bytes,
         move |item: BamTemplateBatch| -> io::Result<DecompressedBlock> {
-            let BamTemplateBatch { batch_serial, templates, .. } = item;
+            let (batch_serial, templates) = item.into_parts();
             let mut kept_bytes: Vec<u8> = Vec::new();
             let mut total_records: u64 = 0;
             let mut passed_count: u64 = 0;
@@ -407,7 +409,7 @@ pub(crate) fn build_filter_step_template_with_rejects(
         limit_bytes,
         move |item: BamTemplateBatch|
               -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
-            let BamTemplateBatch { batch_serial, templates, .. } = item;
+            let (batch_serial, templates) = item.into_parts();
             let mut kept_bytes: Vec<u8> = Vec::new();
             let mut rejected_bytes: Vec<u8> = Vec::new();
             let mut total_records: u64 = 0;

--- a/src/lib/pipeline/steps/align_and_merge.rs
+++ b/src/lib/pipeline/steps/align_and_merge.rs
@@ -654,7 +654,7 @@ fn writer_loop(
         // re-aligned BAM by mistake. Error out loudly with the
         // queryname so the misconfiguration is obvious.
         let mut n_templates = 0usize;
-        for template in &batch.templates {
+        for template in batch.templates() {
             let mut wrote_any = false;
             for record in &template.records {
                 let flags = record.flags();
@@ -915,12 +915,12 @@ fn reader_loop_inner(
             // both templates' `name` fields, which both halves
             // already carry.
             debug_assert_eq!(
-                token.unmapped.templates[i].name,
+                token.unmapped.templates()[i].name,
                 mapped.name,
                 "AAM reader: queryname mismatch — unmapped[{i}]='{u}' but mapped='{m}' \
                  (aligner reordered output?)",
                 i = i,
-                u = String::from_utf8_lossy(&token.unmapped.templates[i].name),
+                u = String::from_utf8_lossy(&token.unmapped.templates()[i].name),
                 m = String::from_utf8_lossy(&mapped.name),
             );
 
@@ -988,14 +988,14 @@ fn merge_zipper_batch(zb: ZipperBatch, cfg: &AlignAndMergeConfig) -> io::Result<
     let ZipperBatch { serial, mapped, unmapped } = zb;
     debug_assert_eq!(
         mapped.len(),
-        unmapped.templates.len(),
+        unmapped.templates().len(),
         "ZipperBatch invariant: mapped and unmapped must have equal length",
     );
 
     let mut merged: Vec<Template> = Vec::with_capacity(mapped.len());
     let mut total_records: u64 = 0;
     let mut total_bytes: usize = 0;
-    for (mut mapped_template, unmapped_template) in mapped.into_iter().zip(&unmapped.templates) {
+    for (mut mapped_template, unmapped_template) in mapped.into_iter().zip(unmapped.templates()) {
         merge_one_template(
             unmapped_template,
             &mut mapped_template,

--- a/src/lib/pipeline/steps/correct/mod.rs
+++ b/src/lib/pipeline/steps/correct/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn correct_step_with_rejects(
             // dense serial sequence; pushing nothing (`only_a`) leaves a gap at
             // this serial that wedges the rejects sink. The empty `Vec` does not
             // allocate and produces no physical BGZF block.
-            let batch_serial = kept.batch_serial;
+            let batch_serial = kept.batch_serial();
             Ok(Process2Output::both(kept, DecompressedBlock { batch_serial, bytes: Vec::new() }))
         }
     };
@@ -177,7 +177,7 @@ fn run_batch_with_rejects(
     cfg: &Arc<CorrectStepConfig>,
     batch: BamTemplateBatch,
 ) -> io::Result<(BamTemplateBatch, Option<DecompressedBlock>)> {
-    let BamTemplateBatch { batch_serial, templates, .. } = batch;
+    let (batch_serial, templates) = batch.into_parts();
 
     let mut kept_templates: Vec<Template> = Vec::with_capacity(templates.len());
     let mut rejects_bytes: Vec<u8> = Vec::new();
@@ -261,7 +261,7 @@ fn run_batch_kept_only(
     cfg: &Arc<CorrectStepConfig>,
     batch: BamTemplateBatch,
 ) -> io::Result<(BamTemplateBatch, ())> {
-    let BamTemplateBatch { batch_serial, templates, .. } = batch;
+    let (batch_serial, templates) = batch.into_parts();
 
     let mut kept_templates: Vec<Template> = Vec::with_capacity(templates.len());
     let mut local_metrics = CollectedCorrectMetrics::default();

--- a/src/lib/pipeline/steps/correct/tests.rs
+++ b/src/lib/pipeline/steps/correct/tests.rs
@@ -127,9 +127,9 @@ fn run_batch_with_rejects_splits_kept_and_rejected() {
         run_batch_with_rejects(&mut state, &cfg, batch).expect("run_batch_with_rejects");
 
     // Kept branch keeps the on-whitelist + correctable templates only.
-    assert_eq!(kept.batch_serial, 7);
-    assert_eq!(kept.templates.len(), 2, "exact + correctable kept");
-    let mut kept_umis: Vec<String> = kept.templates.iter().map(template_rx).collect();
+    assert_eq!(kept.batch_serial(), 7);
+    assert_eq!(kept.templates().len(), 2, "exact + correctable kept");
+    let mut kept_umis: Vec<String> = kept.templates().iter().map(template_rx).collect();
     kept_umis.sort();
     // Both kept records carry the corrected/whitelisted UMI "AAAA".
     assert_eq!(kept_umis, vec!["AAAA".to_string(), "AAAA".to_string()]);
@@ -137,7 +137,7 @@ fn run_batch_with_rejects_splits_kept_and_rejected() {
     // templates normalize to "AAAA", so a regression that kept the wrong record
     // (e.g. dropped `correctable` and kept `offlist` rewritten to AAAA) would
     // still satisfy the RX check above.
-    let mut kept_qnames: Vec<String> = kept.templates.iter().map(template_qname).collect();
+    let mut kept_qnames: Vec<String> = kept.templates().iter().map(template_qname).collect();
     kept_qnames.sort();
     assert_eq!(kept_qnames, vec!["correctable".to_string(), "exact".to_string()]);
 
@@ -173,7 +173,7 @@ fn run_batch_with_rejects_no_rejects_when_all_kept() {
     let (kept, rejects) =
         run_batch_with_rejects(&mut state, &cfg, batch).expect("run_batch_with_rejects");
 
-    assert_eq!(kept.templates.len(), 1);
+    assert_eq!(kept.templates().len(), 1);
     assert!(rejects.is_none(), "no rejected records -> no rejects block");
     assert_eq!(cfg.records_emitted.load(Ordering::Relaxed), 1);
 }
@@ -196,14 +196,14 @@ fn run_batch_kept_only_drops_rejected() {
     let (kept, ()) = run_batch_kept_only(&mut state, &cfg, batch).expect("run_batch_kept_only");
 
     // Only the AAAA + correctable templates survive; TTTT is dropped silently.
-    assert_eq!(kept.batch_serial, 11);
-    assert_eq!(kept.templates.len(), 2, "TTTT dropped, no rejects branch");
-    let mut kept_umis: Vec<String> = kept.templates.iter().map(template_rx).collect();
+    assert_eq!(kept.batch_serial(), 11);
+    assert_eq!(kept.templates().len(), 2, "TTTT dropped, no rejects branch");
+    let mut kept_umis: Vec<String> = kept.templates().iter().map(template_rx).collect();
     kept_umis.sort();
     assert_eq!(kept_umis, vec!["AAAA".to_string(), "AAAA".to_string()]);
     // Pin kept identity by QNAME: the on-whitelist `exact` and the `correctable`
     // template survive; `offlist` (TTTT) is the one dropped.
-    let mut kept_qnames: Vec<String> = kept.templates.iter().map(template_qname).collect();
+    let mut kept_qnames: Vec<String> = kept.templates().iter().map(template_qname).collect();
     kept_qnames.sort();
     assert_eq!(kept_qnames, vec!["correctable".to_string(), "exact".to_string()]);
 

--- a/src/lib/pipeline/steps/extract.rs
+++ b/src/lib/pipeline/steps/extract.rs
@@ -324,8 +324,8 @@ mod tests {
         let out = extract_batch(&read_structures, &opts, &emitted, &batch).unwrap();
 
         assert_eq!(out.ordinal(), 7, "output batch_serial must equal the input batch_serial");
-        assert_eq!(out.templates.len(), 3, "all templates converted");
-        let total_records: usize = out.templates.iter().map(Template::read_count).sum();
+        assert_eq!(out.templates().len(), 3, "all templates converted");
+        let total_records: usize = out.templates().iter().map(Template::read_count).sum();
         assert_eq!(total_records, 6, "3 paired templates yield 6 records");
         assert_eq!(
             emitted.load(Ordering::Relaxed),

--- a/src/lib/pipeline/steps/group/bam.rs
+++ b/src/lib/pipeline/steps/group/bam.rs
@@ -100,7 +100,7 @@ impl Step for GroupBam {
         for _ in 0..MAX_BATCHES_PER_LOCK {
             let Some(batch) = ctx.input.pop() else { break };
             did_work = true;
-            let DecodedRecordBatch { records, .. } = batch;
+            let records = batch.into_records();
 
             // Feed pre-decoded records into the wrapped grouper. The
             // grouper returns zero or more completed `TemplateBatch`es

--- a/src/lib/pipeline/steps/group/mi.rs
+++ b/src/lib/pipeline/steps/group/mi.rs
@@ -300,7 +300,7 @@ impl Step for GroupByMi {
         for _ in 0..MAX_BATCHES_PER_LOCK {
             let Some(batch) = ctx.input.pop() else { break };
             did_work = true;
-            let DecodedRecordBatch { records, .. } = batch;
+            let records = batch.into_records();
             for decoded in records {
                 self.process_record(decoded.into_raw_bytes());
             }

--- a/src/lib/pipeline/steps/group/position.rs
+++ b/src/lib/pipeline/steps/group/position.rs
@@ -252,7 +252,7 @@ impl Step for GroupByPosition {
         for _ in 0..MAX_BATCHES_PER_LOCK {
             let Some(batch) = ctx.input.pop() else { break };
             did_work = true;
-            let DecodedRecordBatch { records, .. } = batch;
+            let records = batch.into_records();
             let groups = self.grouper.add_records(records)?;
             self.accumulator.extend(groups);
             if self.accumulator.len() >= self.target_batch_count {

--- a/src/lib/pipeline/steps/group/queryname.rs
+++ b/src/lib/pipeline/steps/group/queryname.rs
@@ -177,7 +177,7 @@ impl Step for GroupByQueryname {
         for _ in 0..MAX_BATCHES_PER_LOCK {
             let Some(batch) = ctx.input.pop() else { break };
             did_work = true;
-            let DecodedRecordBatch { records, .. } = batch;
+            let records = batch.into_records();
             for decoded in records {
                 let name_hash = decoded.key.name_hash;
                 let raw = decoded.into_raw_bytes();

--- a/src/lib/pipeline/steps/parse/sam.rs
+++ b/src/lib/pipeline/steps/parse/sam.rs
@@ -76,19 +76,23 @@ pub fn parse_sam_chunk_into_decoded(
         }
         encoder.get_mut().clear();
         encoder.write_alignment_record(header, &sam_record)?;
-        // `DecodedRecord` takes ownership of the body bytes, so swap the
-        // encoder's inner buffer out (replacing it with a pre-sized fresh one
-        // for the next record) and strip the 4-byte little-endian `block_size`
-        // prefix that `bam::io::Writer` prepends in place. This avoids the extra
-        // full-body memcpy that `get_ref()[4..].to_vec()` performed per record
-        // (this is the hot SAM parse loop). The replacement is sized to the
-        // outgoing buffer's capacity so the encoder keeps room for the next
-        // record instead of re-growing a zero-capacity `Vec` from scratch (which
-        // `std::mem::take` would leave behind).
-        let next_capacity = encoder.get_mut().capacity().max(4096);
-        let mut body_bytes =
-            std::mem::replace(encoder.get_mut(), Vec::with_capacity(next_capacity));
-        body_bytes.drain(..4);
+        // Copy the encoded body into a *right-sized* buffer, stripping the
+        // 4-byte little-endian `block_size` prefix `bam::io::Writer` prepends.
+        // The encoder's scratch buffer is retained and reused (it is cleared at
+        // the top of the next iteration), so it grows once to the largest record
+        // and never reallocates; only this right-sized `to_vec()` allocates per
+        // record.
+        //
+        // A record must NOT inherit the encoder's scratch capacity. A previous
+        // `mem::replace(encoder.get_mut(), Vec::with_capacity(cap.max(4096)))`
+        // handed every `DecodedRecord` a >=4 KiB buffer to hold a ~60-byte body
+        // — a ~20x per-record over-allocation. Because records are held in
+        // flight through the pipeline, that blew `zipper` (and any SAM-input
+        // pipeline) to tens of GiB on large inputs, while the BAM-input path
+        // stayed bounded (its records are right-sized). The single memcpy per
+        // record here is far cheaper than that blowup and matches the BAM path's
+        // right-sized records.
+        let body_bytes = encoder.get_ref()[4..].to_vec();
         // Match the BAM decode path (`DecodeFromRecords`): under
         // `name_hash_only` the key is the name hash alone, so SAM- and
         // BAM-ingested records group identically.
@@ -243,8 +247,35 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         let chunk = sam_chunk_from_records(7);
 
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
-        assert_eq!(batch.batch_serial, 7, "serial propagated from input chunk");
-        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.batch_serial(), 7, "serial propagated from input chunk");
+        assert_eq!(batch.records().len(), 2);
+    }
+
+    #[test]
+    fn parse_sam_chunk_records_are_right_sized_not_encoder_buffer() {
+        // Regression: each SAM record must own a *right-sized* buffer, not the
+        // shared >=4 KiB encoder scratch buffer. Handing every record the
+        // encoder's `Vec::with_capacity(>=4096)` (via `mem::replace`) made a
+        // ~60-byte record carry a 4 KiB allocation — a ~20x per-record blowup
+        // that drove pipeline-mode `zipper` to tens of GiB on large inputs
+        // (fast-path/BAM-input stayed bounded because those records are
+        // right-sized). The BAM decode path is the reference: its records'
+        // capacity tracks their length.
+        use fgumi_bam_io::MemoryEstimate;
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(0);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        for rec in batch.records() {
+            let len = rec.raw_bytes().len();
+            let cap = rec.estimate_heap_size(); // RawRecord::capacity()
+            assert!(
+                cap <= len * 2 + 64,
+                "SAM-parsed record over-allocated: len={len} cap={cap} — each record \
+                 must own a right-sized buffer, not the shared >=4096 B encoder scratch",
+            );
+        }
     }
 
     #[test]
@@ -259,7 +290,7 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
 
         let mut names: Vec<Vec<u8>> = Vec::new();
-        for rec in &batch.records {
+        for rec in batch.records() {
             let body = rec.raw_bytes();
             // BAM record body layout: bytes 0..32 are fixed fields;
             // byte 8 is l_read_name (including NUL); read_name starts at
@@ -291,7 +322,7 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
 
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
-        assert_eq!(batch.records.len(), 1, "empty line should be skipped, not parsed");
+        assert_eq!(batch.records().len(), 1, "empty line should be skipped, not parsed");
     }
 
     #[test]
@@ -301,8 +332,8 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         let chunk = SamChunk { batch_serial: 11, bytes: Vec::new(), line_offsets: Vec::new() };
 
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
-        assert_eq!(batch.batch_serial, 11);
-        assert!(batch.records.is_empty());
+        assert_eq!(batch.batch_serial(), 11);
+        assert!(batch.records().is_empty());
     }
 
     /// Full-field parity: BAM-encode a record via noodles + `DecodeRecords`
@@ -363,8 +394,8 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         }
         let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
-        assert_eq!(batch.records.len(), 1);
-        let sam_decoded = &batch.records[0];
+        assert_eq!(batch.records().len(), 1);
+        let sam_decoded = &batch.records()[0];
 
         // Byte-identical raw record bytes (the SAM and BAM encoder paths
         // both go through `bam::io::Writer::write_alignment_record`).
@@ -388,9 +419,9 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
 
         let chunk = sam_chunk_from_records(0);
         let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
-        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records().len(), 2);
 
-        for rec in &batch.records {
+        for rec in batch.records() {
             let raw = rec.raw_bytes();
             assert_eq!(
                 rec.key,

--- a/src/lib/pipeline/steps/serialize.rs
+++ b/src/lib/pipeline/steps/serialize.rs
@@ -122,7 +122,7 @@ impl Step for SerializeBamRecords {
         // thread-local cache is the goal — see `BgzfDecompress` for the
         // rationale. Per-record framing shared with `SerializeRecordBatch`
         // via [`frame_record_into`].
-        for template in &batch.templates {
+        for template in batch.templates() {
             for record in &template.records {
                 frame_record_into(&mut self.output_scratch, record.as_ref())?;
             }
@@ -132,7 +132,7 @@ impl Step for SerializeBamRecords {
             Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
         );
 
-        let out = DecompressedBlock { batch_serial: batch.batch_serial, bytes };
+        let out = DecompressedBlock { batch_serial: batch.batch_serial(), bytes };
         match ctx.outputs.push(out) {
             Ok(()) => Ok(StepOutcome::Progress),
             Err(unpushed) => {
@@ -222,9 +222,9 @@ mod tests {
 
         // Drive the serializer manually (mirrors the closure path; the
         // step trait integration is exercised by `tests.rs` via `run`).
-        let record_count: usize = input.templates.iter().map(|t| t.records.len()).sum();
-        let mut bytes = Vec::with_capacity(input.total_bytes + 4 * record_count);
-        for template in &input.templates {
+        let record_count: usize = input.templates().iter().map(|t| t.records.len()).sum();
+        let mut bytes = Vec::with_capacity(input.total_bytes() + 4 * record_count);
+        for template in input.templates() {
             for record in &template.records {
                 let block_size = u32::try_from(record.len()).unwrap();
                 bytes.extend_from_slice(&block_size.to_le_bytes());

--- a/src/lib/pipeline/steps/templates_to_records.rs
+++ b/src/lib/pipeline/steps/templates_to_records.rs
@@ -91,22 +91,23 @@ impl Step for TemplatesToRecordBatch {
             return Ok(StepOutcome::NoProgress);
         };
 
-        let serial = batch.batch_serial;
+        let serial = batch.batch_serial();
         // Pre-size the backing buffer from the exact sum of record
-        // body bytes. `batch.total_bytes` over-estimates because
+        // body bytes. `batch.total_bytes()` over-estimates because
         // `Template::heap_size` includes the queryname bytes, but
         // those don't appear in the `RecordBatch.backing` (only the
         // body bytes do). Computing the tight number once is cheap
         // and keeps the builder's allocation in a single mimalloc
         // size class.
         let bytes_cap: usize = batch
-            .templates
+            .templates()
             .iter()
             .flat_map(|t| t.records.iter().map(fgumi_raw_bam::RawRecord::len))
             .sum();
-        let records_cap: usize = batch.templates.iter().map(|t| t.records.len()).sum();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
         let mut builder = RecordBatchBuilder::with_capacity(serial, bytes_cap, records_cap);
-        for template in batch.templates {
+        let (_, templates) = batch.into_parts();
+        for template in templates {
             for record in template.records {
                 builder.push_record_bytes(record.as_ref());
             }
@@ -178,11 +179,12 @@ mod tests {
             42,
             vec![make_paired_template(b"q1"), make_paired_template(b"q2")],
         );
-        let total_bytes = batch.total_bytes;
-        let serial = batch.batch_serial;
-        let records_cap: usize = batch.templates.iter().map(|t| t.records.len()).sum();
+        let total_bytes = batch.total_bytes();
+        let serial = batch.batch_serial();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
         let mut builder = RecordBatchBuilder::with_capacity(serial, total_bytes, records_cap);
-        for template in batch.templates {
+        let (_, templates) = batch.into_parts();
+        for template in templates {
             for record in template.records {
                 builder.push_record_bytes(record.as_ref());
             }

--- a/src/lib/pipeline/steps/tests.rs
+++ b/src/lib/pipeline/steps/tests.rs
@@ -244,18 +244,22 @@ fn full_chain_with_process_mutates_mq() {
     let bump_mq = process_ordered::<DecodedRecordBatch, DecodedRecordBatch, _>(
         "BumpMq",
         bytes_4mb,
-        |mut batch: DecodedRecordBatch| {
+        |batch: DecodedRecordBatch| {
             // BAM record body byte 9 is `mapq` (raw layout: refID(4) +
             // pos(4) + l_read_name(1) + mapq(1) + ...). Mutating mapq
             // doesn't change the record's identity (qname / library /
             // cell barcode), so the pre-computed GroupKey stays valid.
-            for record in &mut batch.records {
+            // Take ownership, edit in place, and rebuild via `new` so the
+            // cached `total_bytes` is recomputed for the edited records.
+            let serial = batch.batch_serial();
+            let mut records = batch.into_records();
+            for record in &mut records {
                 let buf = record.raw_bytes_mut().as_mut_vec();
                 if buf.len() > 9 {
                     buf[9] = 42;
                 }
             }
-            Ok(batch)
+            Ok(DecodedRecordBatch::new(serial, records))
         },
     );
 

--- a/src/lib/pipeline/steps/types.rs
+++ b/src/lib/pipeline/steps/types.rs
@@ -19,7 +19,7 @@
 
 use crate::pipeline::core::item::{HeapSize, Ordered};
 use crate::template::Template;
-use fgumi_bam_io::DecodedRecord;
+use fgumi_bam_io::{DecodedRecord, MemoryEstimate};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Light flowing types (BgzfBlock, DecompressedBlock, RecordBatch,
@@ -43,23 +43,57 @@ pub use fgumi_pipeline_io::types::{BgzfBlock, DecompressedBlock, RecordBatch, Re
 /// A batch of `DecodedRecord`s — raw record bytes paired with a
 /// pre-computed `GroupKey`. Carries `total_bytes` for O(1) `HeapSize`.
 ///
-/// `total_bytes` is cached at construction (`new`) and assumes the
-/// `records` vector is **not** mutated in a size-changing way afterwards.
-/// The fields are `pub` for ergonomics, but in-place edits that change a
-/// record's `raw_bytes().len()` would desync `heap_size()` from reality —
-/// rebuild via [`Self::new`] instead of mutating in place.
+/// `total_bytes` is cached at construction (`new`) and sums each record's
+/// **allocated capacity** ([`MemoryEstimate::estimate_heap_size`]), not its
+/// logical `raw_bytes().len()`. This feeds the pipeline's byte-backpressure
+/// budget, which must track the true heap footprint: accounting by `len`
+/// under-counts an over-allocated record and lets the pipeline buffer far past
+/// its budget.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `records`: the only constructor is [`Self::new`] (which
+/// recomputes the cache), reads go through [`Self::records`] /
+/// [`Self::total_bytes`], and taking ownership of the records consumes the
+/// batch via [`Self::into_records`]. There is no way to mutate `records` in
+/// place, so byte-bounded admission control always sees the true footprint.
 #[derive(Debug)]
 pub struct DecodedRecordBatch {
-    pub batch_serial: u64,
-    pub records: Vec<DecodedRecord>,
-    pub total_bytes: usize,
+    batch_serial: u64,
+    records: Vec<DecodedRecord>,
+    total_bytes: usize,
 }
 
 impl DecodedRecordBatch {
     #[must_use]
     pub fn new(batch_serial: u64, records: Vec<DecodedRecord>) -> Self {
-        let total_bytes = records.iter().map(|d| d.raw_bytes().len()).sum();
+        let total_bytes = records.iter().map(MemoryEstimate::estimate_heap_size).sum();
         Self { batch_serial, records, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's decoded records.
+    #[must_use]
+    pub fn records(&self) -> &[DecodedRecord] {
+        &self.records
+    }
+
+    /// Cached heap footprint (summed allocated capacity) of the records.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return ownership of its records. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the records
+    /// out without any risk of leaving a stale byte count behind.
+    #[must_use]
+    pub fn into_records(self) -> Vec<DecodedRecord> {
+        self.records
     }
 }
 
@@ -82,11 +116,19 @@ impl Ordered for DecodedRecordBatch {
 
 /// A batch of templates (same-queryname record groups), with batch serial
 /// for ordering and `total_bytes` for memory accounting.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `templates`: construct via [`Self::new`] (which recomputes the
+/// cache) or [`Self::from_parts`] (which trusts a caller that already summed
+/// `heap_size`), read through the accessors, and take ownership of the
+/// templates by consuming the batch via [`Self::into_parts`]. There is no way
+/// to mutate `templates` in place, so byte-bounded admission control always
+/// sees the true footprint.
 #[derive(Debug)]
 pub struct BamTemplateBatch {
-    pub batch_serial: u64,
-    pub templates: Vec<Template>,
-    pub total_bytes: usize,
+    batch_serial: u64,
+    templates: Vec<Template>,
+    total_bytes: usize,
 }
 
 impl BamTemplateBatch {
@@ -104,6 +146,32 @@ impl BamTemplateBatch {
     #[must_use]
     pub fn from_parts(batch_serial: u64, templates: Vec<Template>, total_bytes: usize) -> Self {
         Self { batch_serial, templates, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's templates.
+    #[must_use]
+    pub fn templates(&self) -> &[Template] {
+        &self.templates
+    }
+
+    /// Cached heap footprint (summed `Template::heap_size`) of the templates.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return its serial and templates. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the templates
+    /// out (and re-wrap via [`Self::new`]) without risking a stale byte count.
+    #[must_use]
+    pub fn into_parts(self) -> (u64, Vec<Template>) {
+        (self.batch_serial, self.templates)
     }
 }
 
@@ -173,6 +241,63 @@ mod tests {
         let batch = BamTemplateBatch::new(42, vec![]);
         assert_eq!(batch.heap_size(), 0);
         assert_eq!(batch.ordinal(), 42);
+    }
+
+    #[test]
+    fn decoded_record_batch_heap_size_counts_capacity_not_len() {
+        // `heap_size` feeds the pipeline's byte-backpressure budget, so it must
+        // report the records' true heap footprint (allocated capacity), not
+        // their logical length. Accounting by `len` under-counts an
+        // over-allocated record — exactly the failure mode where a SAM-parsed
+        // record with a 4 KiB buffer holding ~60 bytes fooled backpressure and
+        // let the pipeline buffer far past its memory budget.
+        use fgumi_bam_io::{GroupKey, MemoryEstimate};
+        let mut raw = Vec::with_capacity(4096);
+        raw.extend_from_slice(&[0u8; 64]); // len 64, capacity 4096
+        let rec = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        let cap = rec.estimate_heap_size();
+        assert!(cap >= 4096, "sanity: over-allocated record capacity, got {cap}");
+        let batch = DecodedRecordBatch::new(0, vec![rec]);
+        assert_eq!(
+            batch.heap_size(),
+            cap,
+            "heap_size must reflect allocated capacity ({cap}), not logical len — \
+             else byte-backpressure under-counts real memory",
+        );
+    }
+
+    #[test]
+    fn decoded_record_batch_accessors_and_into_records_round_trip() {
+        // The fields are private; callers read via the accessors and take
+        // ownership by consuming the batch. `into_records` must hand back the
+        // exact records `new` was given, and `batch_serial` must round-trip.
+        use fgumi_bam_io::GroupKey;
+        let rec = DecodedRecord::from_raw_bytes(vec![7u8; 32], GroupKey::default());
+        let batch = DecodedRecordBatch::new(3, vec![rec]);
+        assert_eq!(batch.batch_serial(), 3);
+        assert_eq!(batch.records().len(), 1);
+        assert_eq!(batch.total_bytes(), batch.heap_size());
+        let records = batch.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].raw_bytes().len(), 32);
+    }
+
+    #[test]
+    fn bam_template_batch_accessors_and_into_parts_round_trip() {
+        // Mirror of the DecodedRecordBatch contract: private fields, read via
+        // accessors, consume via `into_parts` to move the templates out and
+        // re-wrap through `new` (which recomputes the byte cache).
+        let t1 = crate::template::Template::new(b"read1".to_vec());
+        let expected_bytes = t1.heap_size();
+        let batch = BamTemplateBatch::new(9, vec![t1]);
+        assert_eq!(batch.batch_serial(), 9);
+        assert_eq!(batch.templates().len(), 1);
+        assert_eq!(batch.total_bytes(), expected_bytes);
+        let (serial, templates) = batch.into_parts();
+        assert_eq!(serial, 9);
+        // Re-wrapping the moved-out templates recomputes an identical cache.
+        let rewrapped = BamTemplateBatch::new(serial, templates);
+        assert_eq!(rewrapped.total_bytes(), expected_bytes);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Pipeline-mode `fgumi zipper` reading SAM on stdin — the canonical `bwa mem … | fgumi zipper` — buffered essentially its entire decompressed input, reaching **14–18 GiB** on a vendor WES sample (`agilent-hs2`) while the fast-path and BAM-input paths stayed bounded (~0.1–2 GiB). Root-caused with `dhat` to a per-record over-allocation in the SAM parse step.

## Root cause

`parse_sam_chunk_into_decoded` handed every `DecodedRecord` the encoder's **≥4 KiB scratch buffer** (via `mem::replace(encoder.get_mut(), Vec::with_capacity(cap.max(4096)))`), so a ~60-byte record body carried a 4 KiB allocation — a **~20× per-record over-allocation**. Because records are held in flight through the pipeline, that scaled to tens of GiB. The BAM-input path was unaffected (its records are right-sized). dhat confirmed exactly: `703,413 blocks × 4 KiB` live at the memory peak.

Compounding it, `DecodedRecordBatch::new` summed `raw_bytes().len()` (~200 B) rather than allocated capacity (4 KiB) into `total_bytes`, so the byte-backpressure budget under-counted real memory 20× and couldn't bound the queue.

## Fix

- **`parse/sam.rs`**: copy each encoded body into a right-sized buffer (`to_vec`) and reuse the encoder's scratch buffer across records, instead of donating the oversized buffer per record. The encoder still grows once to the largest record and never reallocates; output is unchanged.
- **`pipeline/steps/types.rs`**: `DecodedRecordBatch::new` sums each record's allocated capacity (`MemoryEstimate::estimate_heap_size`), matching `BamTemplateBatch`'s accounting, so byte-backpressure reflects true heap footprint and can't be fooled by an over-allocated record.

## Verification

- New unit tests (TDD, both fail before the fix): records are right-sized, and `heap_size` reflects capacity not len.
- End-to-end: `agilent-hs2` `zipper --threads 2` drops **18 GiB → 2.7 GiB** with **identical output** (58,971,241 records).
- `ci-fmt` / `ci-lint` clean; full `ci-test` green (2261 passed).

Targets `nh/sort-6-chains-wiring` (#476) because the chains SAM-parse path lives on this stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory handling for decoded records to avoid retaining oversized internal buffers and to keep per-record storage closer to actual data size.
  * Updated decoded record batch memory accounting to use allocated capacity/heap footprint rather than raw byte length, improving consistency and downstream behavior.
* **Tests**
  * Added regression coverage to ensure decoded records don’t keep excessive encoder capacity.
  * Added checks that batch heap/memory estimates match allocated buffer capacity, preventing capacity/length mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->