### PR TITLE
fix(group,dedup): pair duplex strands sharing an unclipped 5' coordinate

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -889,6 +889,36 @@ pub(crate) fn serialize_raw_bam_records<R: AsRef<[u8]>>(
     Ok(records.len() as u64)
 }
 
+/// Checks whether R1 is genomically earlier than R2 from their raw BAM bytes.
+///
+/// Shared by `group` and `dedup` so their paired-UMI assignment can't drift.
+/// Uses zero-allocation CIGAR iteration; unmapped reads return position 0
+/// (matching noodles `unwrap_or(0)` behavior). Ordering is by reference id,
+/// then unclipped 5' coordinate, then strand.
+///
+/// The strand tie-break mirrors fgbio `GroupReadsByUmi.umiForRead`'s
+/// `pos1 == pos2 && r1.positiveStrand`: when both mates share an unclipped 5'
+/// coordinate (fully-overlapping / short-insert pairs), R1 is "earlier" iff it
+/// is on the forward strand. A bare `r1_pos <= r2_pos` returns `true`
+/// unconditionally on a tie, which assigns the lower/higher paired-UMI prefix
+/// inconsistently between the two duplex strands — so the strands fail to
+/// reverse-match and one duplex molecule is incorrectly split into two.
+pub(crate) fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
+    use fgumi_raw_bam::RawRecordView;
+
+    let ref1 = fgumi_raw_bam::ref_id(r1);
+    let ref2 = fgumi_raw_bam::ref_id(r2);
+    if ref1 != ref2 {
+        return ref1 < ref2;
+    }
+    let r1_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r1);
+    let r2_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r2);
+    if r1_pos != r2_pos {
+        return r1_pos < r2_pos;
+    }
+    (RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::REVERSE) == 0
+}
+
 /// Parses a boolean value from a string, accepting: true/false, yes/no, y/n, t/f
 /// (case-insensitive). Matches sopt/fgbio behavior.
 pub(crate) fn parse_bool(s: &str) -> Result<bool, String> {

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -516,6 +516,24 @@ enum MiKey {
     Strand { base: i64, strand: u8 },
 }
 
+impl MiKey {
+    /// The molecule-level id, ignoring any duplex strand suffix.
+    ///
+    /// For duplex output the two strands of one molecule share a `base` but
+    /// differ in `strand` (`/A` vs `/B`). Grouping-equivalence checks that key
+    /// on the full [`MiKey`] treat the strands as independent groups, so they
+    /// cannot detect a *strand-pairing* difference — one file bundling `X/A` +
+    /// `X/B` into a single molecule while another splits them into `X/A` +
+    /// `Y/A`. Comparing at the `base` level catches that: reads that share a
+    /// molecule in one file must share a molecule in the other.
+    fn base(&self) -> i64 {
+        match self {
+            MiKey::Int(v) => *v,
+            MiKey::Strand { base, .. } => *base,
+        }
+    }
+}
+
 impl std::fmt::Display for MiKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -523,6 +541,45 @@ impl std::fmt::Display for MiKey {
             MiKey::Strand { base, strand } => write!(f, "{base}/{}", *strand as char),
         }
     }
+}
+
+/// Count molecule-level (strand-suffix-stripped) grouping mismatches in both
+/// directions: the number of `base` groups in either file whose reads map to
+/// more than one `base` in the other file.
+///
+/// This complements the full-[`MiKey`] grouping check (which keeps `/A`/`/B`
+/// distinct to catch strand *disagreements*) by catching strand-*pairing*
+/// differences the full-key check is structurally blind to: if BAM1 pairs
+/// `X/A` + `X/B` into molecule `X` and BAM2 splits those same reads into
+/// `X/A` + `Y/A`, the full-key mapping is still a consistent bijection
+/// (`X/A↔X/A`, `X/B↔Y/A`) with zero mismatches, yet the duplex molecules
+/// genuinely differ. For single-strand (`Int`) MIs `base()` is the id itself,
+/// so this reduces to the same partition check and never adds false mismatches.
+fn count_base_pairing_mismatches(
+    mi_map1: &AHashMap<ReadKeyHash, MiKey>,
+    mi_map2: &AHashMap<ReadKeyHash, MiKey>,
+) -> u64 {
+    fn count_one_direction(
+        from: &AHashMap<ReadKeyHash, MiKey>,
+        to: &AHashMap<ReadKeyHash, MiKey>,
+    ) -> u64 {
+        let mut base_to_base: AHashMap<i64, (i64, bool)> = AHashMap::new();
+        for (key_hash, mi_from) in from {
+            if let Some(mi_to) = to.get(key_hash) {
+                base_to_base
+                    .entry(mi_from.base())
+                    .and_modify(|(first, has_mismatch)| {
+                        if *first != mi_to.base() {
+                            *has_mismatch = true;
+                        }
+                    })
+                    .or_insert((mi_to.base(), false));
+            }
+        }
+        base_to_base.values().filter(|(_, has_mismatch)| *has_mismatch).count() as u64
+    }
+
+    count_one_direction(mi_map1, mi_map2) + count_one_direction(mi_map2, mi_map1)
 }
 
 /// Build a map from MI value to set of read key hashes.
@@ -1832,6 +1889,21 @@ impl CompareBams {
             }
         }
 
+        // Verify molecule-level (duplex strand-pairing) equivalence — the
+        // per-MiKey checks above keep `/A`/`/B` distinct and so cannot detect a
+        // strand-pairing split (see `count_base_pairing_mismatches`). Fold any
+        // base-level mismatches into the total so a split makes groupings DIFFER.
+        let base_pairing_mismatches = count_base_pairing_mismatches(&mi_map1, &mi_map2);
+        if base_pairing_mismatches > 0 {
+            stats.grouping_mismatches += base_pairing_mismatches;
+            if grouping_errors.len() < self.max_diffs {
+                grouping_errors.push(format!(
+                    "{base_pairing_mismatches} molecule(s) differ in duplex strand pairing \
+                     (reads sharing a molecule in one BAM are split across molecules in the other)"
+                ));
+            }
+        }
+
         // Determine result
         let is_equivalent = !stats.count_mismatch
             && stats.order_mismatches == 0
@@ -2030,6 +2102,22 @@ impl CompareBams {
                 mismatches2.into_iter().take(max_diffs.saturating_sub(grouping_errors.len())),
             );
 
+            // Phase 5: Verify molecule-level (duplex strand-pairing) equivalence.
+            // Phase 4 keys on the full MiKey, so it cannot see a strand-pairing
+            // split (see `count_base_pairing_mismatches`). Fold any base-level
+            // mismatches into the grouping-mismatch total so such a split makes
+            // the groupings DIFFER instead of silently passing as EQUIVALENT.
+            let base_pairing_mismatches = count_base_pairing_mismatches(&mi_map1, &mi_map2);
+            if base_pairing_mismatches > 0 {
+                stats.grouping_mismatches += base_pairing_mismatches;
+                if grouping_errors.len() < max_diffs {
+                    grouping_errors.push(format!(
+                        "{base_pairing_mismatches} molecule(s) differ in duplex strand pairing \
+                         (reads sharing a molecule in one BAM are split across molecules in the other)"
+                    ));
+                }
+            }
+
             Ok(())
         });
 
@@ -2108,6 +2196,66 @@ mod tests {
         let h1 = hash_read_key_raw(b"read_one", true);
         let h2 = hash_read_key_raw(b"read_one", true);
         assert_eq!(h1, h2, "same input must yield same hash");
+    }
+
+    // ---- count_base_pairing_mismatches (duplex strand-pairing check) --------
+
+    /// A strand-pairing split must be flagged: BAM1 pairs both strands into
+    /// molecule `0` (`0/A` + `0/B`); BAM2 splits those same reads into two
+    /// molecules (`0/A` + `1/A`). The full-MiKey check sees a consistent
+    /// bijection (0 mismatches), so this base-level check is what catches it.
+    #[test]
+    fn count_base_pairing_mismatches_flags_strand_split() {
+        let mut m1: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m1.insert(1, MiKey::Strand { base: 0, strand: b'A' });
+        m1.insert(2, MiKey::Strand { base: 0, strand: b'B' });
+        let mut m2: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m2.insert(1, MiKey::Strand { base: 0, strand: b'A' });
+        m2.insert(2, MiKey::Strand { base: 1, strand: b'A' });
+        assert!(
+            count_base_pairing_mismatches(&m1, &m2) > 0,
+            "a duplex molecule split across two bases must be flagged"
+        );
+    }
+
+    /// Pure molecule renumbering (same pairing, different base id) is
+    /// equivalent and must not be flagged.
+    #[test]
+    fn count_base_pairing_mismatches_zero_for_molecule_relabel() {
+        let mut m1: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m1.insert(1, MiKey::Strand { base: 0, strand: b'A' });
+        m1.insert(2, MiKey::Strand { base: 0, strand: b'B' });
+        let mut m2: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m2.insert(1, MiKey::Strand { base: 9, strand: b'A' });
+        m2.insert(2, MiKey::Strand { base: 9, strand: b'B' });
+        assert_eq!(count_base_pairing_mismatches(&m1, &m2), 0);
+    }
+
+    /// Swapping the `/A` and `/B` labels of a molecule is a naming difference,
+    /// not a pairing difference — equivalent at the base level.
+    #[test]
+    fn count_base_pairing_mismatches_zero_for_ab_strand_swap() {
+        let mut m1: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m1.insert(1, MiKey::Strand { base: 0, strand: b'A' });
+        m1.insert(2, MiKey::Strand { base: 0, strand: b'B' });
+        let mut m2: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m2.insert(1, MiKey::Strand { base: 0, strand: b'B' });
+        m2.insert(2, MiKey::Strand { base: 0, strand: b'A' });
+        assert_eq!(count_base_pairing_mismatches(&m1, &m2), 0);
+    }
+
+    /// For single-strand (`Int`) MIs `base()` is the id itself, so a consistent
+    /// relabel reduces to the ordinary partition check and adds no false
+    /// mismatches.
+    #[test]
+    fn count_base_pairing_mismatches_zero_for_simplex_relabel() {
+        let mut m1: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m1.insert(1, MiKey::Int(5));
+        m1.insert(2, MiKey::Int(5));
+        let mut m2: AHashMap<ReadKeyHash, MiKey> = AHashMap::new();
+        m2.insert(1, MiKey::Int(7));
+        m2.insert(2, MiKey::Int(7));
+        assert_eq!(count_base_pairing_mismatches(&m1, &m2), 0);
     }
 
     #[test]

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool,
+    build_pipeline_config, is_r1_genomically_earlier_raw, parse_bool,
 };
 use crate::sam::TC_TAG;
 use fgumi_raw_bam;
@@ -463,18 +463,6 @@ fn get_pair_orientation(template: &Template) -> (bool, bool) {
         .r2()
         .is_none_or(|r| (RawRecordView::new(r).flags() & fgumi_raw_bam::flags::REVERSE) == 0);
     (r1_positive, r2_positive)
-}
-
-/// Check if R1 is genomically earlier than R2.
-fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
-    let ref1 = fgumi_raw_bam::ref_id(r1);
-    let ref2 = fgumi_raw_bam::ref_id(r2);
-    if ref1 != ref2 {
-        return ref1 < ref2;
-    }
-    let r1_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r1);
-    let r2_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r2);
-    r1_pos <= r2_pos
 }
 
 /// Truncate UMIs to minimum length if specified.
@@ -2111,30 +2099,34 @@ mod tests {
 
     #[test]
     fn test_is_r1_earlier_equal_position() {
-        // Both at position 100 -> true (<=)
-        let r1 = {
+        // Both mates share an unclipped 5' coordinate, so the tie breaks on
+        // strand (mirroring fgbio): R1 is "earlier" iff it is on the forward
+        // strand. A forward-strand R1 => true; a reverse-strand R1 => false.
+        // Assert both halves so the strand-dependent tie-break stays pinned.
+        let build_mate = |first_segment: bool, r1_reverse: bool| {
             let mut b = RawSamBuilder::new();
+            let strand = if r1_reverse { flags::REVERSE } else { 0 };
+            let segment = if first_segment { flags::FIRST_SEGMENT } else { flags::LAST_SEGMENT };
             b.read_name(b"q1")
                 .sequence(b"ACGT")
                 .qualities(&[30, 30, 30, 30])
                 .ref_id(0)
                 .pos(99)
                 .cigar_ops(&[encode_op(0, 4)])
-                .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+                .flags(flags::PAIRED | segment | strand);
             b.build()
         };
-        let r2 = {
-            let mut b = RawSamBuilder::new();
-            b.read_name(b"q1")
-                .sequence(b"TGCA")
-                .qualities(&[30, 30, 30, 30])
-                .ref_id(0)
-                .pos(99)
-                .cigar_ops(&[encode_op(0, 4)])
-                .flags(flags::PAIRED | flags::LAST_SEGMENT);
-            b.build()
-        };
-        assert!(is_r1_genomically_earlier_raw(&r1, &r2));
+
+        // Forward-strand R1 at the tie => R1 is earlier.
+        let r1_fwd = build_mate(true, false);
+        let r2_fwd = build_mate(false, false);
+        assert!(is_r1_genomically_earlier_raw(&r1_fwd, &r2_fwd));
+
+        // Reverse-strand R1 at the same tie => R1 is NOT earlier. This is the
+        // half the old `r1_pos <= r2_pos` tie-break got wrong.
+        let r1_rev = build_mate(true, true);
+        let r2_rev = build_mate(false, false);
+        assert!(!is_r1_genomically_earlier_raw(&r1_rev, &r2_rev));
     }
 
     // ========================================================================

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -4,7 +4,7 @@ use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool,
+    build_pipeline_config, is_r1_genomically_earlier_raw, parse_bool,
 };
 use crate::grouper::{
     FilterMetrics, ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper,
@@ -271,23 +271,6 @@ fn filter_template_raw(
 
     metrics.accepted_templates += num_primary_reads;
     true
-}
-
-/// Check if R1 is genomically earlier than R2 using raw bytes.
-///
-/// Uses zero-allocation CIGAR iteration. Unmapped reads return position 0
-/// (matching noodles `unwrap_or(0)` behavior).
-fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
-    use fgumi_raw_bam;
-
-    let ref1 = fgumi_raw_bam::ref_id(r1);
-    let ref2 = fgumi_raw_bam::ref_id(r2);
-    if ref1 != ref2 {
-        return ref1 < ref2;
-    }
-    let r1_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r1);
-    let r2_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(r2);
-    r1_pos <= r2_pos
 }
 
 /// Get pair orientation from raw-byte template.
@@ -4228,58 +4211,200 @@ mod tests {
         Ok(())
     }
 
+    /// Build a paired template for the duplex `paired` strategy with an
+    /// explicit R1 strand, so both strands of one duplex molecule can be
+    /// constructed (unlike `build_test_pair`, which is FR-only).
+    ///
+    /// * `r1_reverse = false` — top strand: R1 forward at `r1_pos`, R2 reverse
+    ///   at `r2_pos`.
+    /// * `r1_reverse = true` — bottom strand: R1 reverse at `r1_pos`, R2 forward
+    ///   at `r2_pos`.
+    ///
+    /// Both reads are 100M and carry `umi` in `RX` plus the mate's cigar in
+    /// `MC` (required for the paired `GroupKey`'s mate-position computation).
+    fn build_duplex_pair(
+        name: &str,
+        ref_id: usize,
+        r1_pos: i32,
+        r2_pos: i32,
+        umi: &str,
+        r1_reverse: bool,
+    ) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+        let seq = vec![b'A'; 100];
+        let quals = vec![30u8; 100];
+        let cigar = encode_op(0, 100); // 100M
+
+        // R1 strand is `r1_reverse`; R2 is always the opposite strand. Each
+        // read's MATE_REVERSE bit reflects the other read's strand.
+        let r1_flags = flags::PAIRED
+            | flags::FIRST_SEGMENT
+            | if r1_reverse { flags::REVERSE } else { flags::MATE_REVERSE };
+        let r2_flags = flags::PAIRED
+            | flags::LAST_SEGMENT
+            | if r1_reverse { flags::MATE_REVERSE } else { flags::REVERSE };
+
+        let mut b1 = RawSamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .flags(r1_flags)
+            .ref_id(ref_id as i32)
+            .pos(r1_pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(r2_pos - 1);
+        b1.add_string_tag(SamTag::RX, umi.as_bytes());
+        b1.add_string_tag(SamTag::MC, b"100M");
+        let r1 = b1.build();
+
+        let mut b2 = RawSamBuilder::new();
+        b2.read_name(name.as_bytes())
+            .flags(r2_flags)
+            .ref_id(ref_id as i32)
+            .pos(r2_pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(&seq)
+            .qualities(&quals)
+            .mate_ref_id(ref_id as i32)
+            .mate_pos(r1_pos - 1);
+        b2.add_string_tag(SamTag::RX, umi.as_bytes());
+        b2.add_string_tag(SamTag::MC, b"100M");
+        let r2 = b2.build();
+
+        (r1, r2)
+    }
+
+    /// Distinct molecule bases (the `MI` value before the `/A`|`/B` suffix).
+    fn distinct_mi_bases(
+        records: &[sam::alignment::RecordBuf],
+    ) -> std::collections::HashSet<String> {
+        get_mi_tags(records)
+            .into_iter()
+            .map(|t| t.split('/').next().unwrap_or(&t).to_string())
+            .collect()
+    }
+
     #[test]
     fn test_paired_assigner_explicit_ab_ba_symmetry() -> Result<()> {
-        // Test that paired assigner correctly handles A-B and B-A pairs
-        // They should be grouped separately as different orientations
+        // Ported from fgbio GroupReadsByUmiTest "correctly group reads with the
+        // paired assigner when the two UMIs are the same". The two strands of
+        // ONE duplex molecule — the top strand (R1 forward) and the bottom
+        // strand (R1 reverse), whose paired UMIs are reverses of each other —
+        // must group into a SINGLE molecule with `/A` and `/B` suffixes, NOT
+        // two separate molecules.
+        //
+        // The prior version of this test used the FR-only `build_test_pair`
+        // helper (so it could not build the reverse-strand bottom read) and
+        // asserted 2 groups, inverting fgbio's contract.
         let mut records = Vec::new();
 
-        // Create pairs with A-B orientation
-        let (r1_ab, r2_ab) = build_test_pair("read_ab_1", 0, 100, 300, 60, 60, "AAAA-TTTT");
-        records.push(r1_ab);
-        records.push(r2_ab);
+        // Top strand: R1 forward @100, R2 reverse @300; UMI AAAA-TTTT.
+        let (r1, r2) = build_duplex_pair("read_ab_1", 0, 100, 300, "AAAA-TTTT", false);
+        records.push(r1);
+        records.push(r2);
+        let (r1, r2) = build_duplex_pair("read_ab_2", 0, 100, 300, "AAAA-TTTT", false);
+        records.push(r1);
+        records.push(r2);
 
-        // Create another pair with same A-B orientation
-        let (r1_ab2, r2_ab2) = build_test_pair("read_ab_2", 0, 100, 300, 60, 60, "AAAA-TTTT");
-        records.push(r1_ab2);
-        records.push(r2_ab2);
-
-        // Create pairs with B-A orientation (swapped UMIs)
-        let (r1_ba, r2_ba) = build_test_pair("read_ba_1", 0, 100, 300, 60, 60, "TTTT-AAAA");
-        records.push(r1_ba);
-        records.push(r2_ba);
+        // Bottom strand: R1 reverse @300, R2 forward @100; UMI reversed to
+        // TTTT-AAAA — the opposite strand of the SAME molecule.
+        let (r1, r2) = build_duplex_pair("read_ba_1", 0, 300, 100, "TTTT-AAAA", true);
+        records.push(r1);
+        records.push(r2);
 
         let input = create_test_bam(records)?;
         let paths = TestPaths::new()?;
-
         let cmd = GroupReadsByUmi {
             io: BamIoOptions {
                 input: input.path().to_path_buf(),
                 output: paths.output.clone(),
                 async_reader: false,
             },
-            ..test_group_cmd(Strategy::Paired, 0)
+            ..test_group_cmd(Strategy::Paired, 1)
         };
-
         cmd.execute("test")?;
 
         let output_records = read_bam_records(&paths.output)?;
-
-        // Should have 6 records (3 pairs)
         assert_eq!(output_records.len(), 6, "Should have all 6 records");
+        let mi_tags = get_mi_tags(&output_records);
+        assert!(
+            mi_tags.iter().all(|t| t.ends_with("/A") || t.ends_with("/B")),
+            "All MI tags should have /A or /B suffix. Tags: {mi_tags:?}"
+        );
 
-        // Get the MI tags
+        // Both strands are ONE molecule: exactly one base, and exactly two
+        // full MI values (`<base>/A` and `<base>/B`).
+        let bases = distinct_mi_bases(&output_records);
+        assert_eq!(
+            bases.len(),
+            1,
+            "top and bottom strands must share one molecule base; got MIs {mi_tags:?}"
+        );
+        assert_eq!(
+            count_unique_mi_tags(&output_records),
+            2,
+            "the one molecule must have exactly two strands /A and /B; got MIs {mi_tags:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_paired_assigner_pairs_overlapping_duplex_strands() -> Result<()> {
+        // Regression test for the paired-strategy strand-pairing bug on
+        // fully-overlapping / short-insert fragments.
+        //
+        // When a template's two mates share an unclipped 5' coordinate, the
+        // `is_r1_genomically_earlier_raw` tie-break decides which half of the
+        // paired UMI gets the lower-vs-higher-read prefix. A tie-break of
+        // `r1_pos <= r2_pos` returns `true` for BOTH strands (R1 forward and R1
+        // reverse), so the two strands' prefixed UMIs are no longer reverses of
+        // each other and fail to pair — splitting one duplex molecule into two.
+        // fgbio breaks the tie on `r1.positiveStrand`, keeping the strands
+        // paired; this test pins that behavior.
+        //
+        // Geometry (100M reads): top strand R1 forward @199 / R2 reverse @100
+        // and bottom strand R1 reverse @100 / R2 forward @199. Both mates'
+        // unclipped 5' ends land on 199 (100 + 100 - 1), so the tie-break fires.
+        let mut records = Vec::new();
+        let (r1, r2) = build_duplex_pair("top", 0, 199, 100, "AAAA-TTTT", false);
+        records.push(r1);
+        records.push(r2);
+        let (r1, r2) = build_duplex_pair("bottom", 0, 100, 199, "TTTT-AAAA", true);
+        records.push(r1);
+        records.push(r2);
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
+            ..test_group_cmd(Strategy::Paired, 1)
+        };
+        cmd.execute("test")?;
+
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 4, "Should have all 4 records");
         let mi_tags = get_mi_tags(&output_records);
 
-        // With paired strategy, A-B and B-A should form separate groups
-        // but both should get /A or /B suffixes
-        let unique_groups = count_unique_mi_tags(&output_records);
-        assert_eq!(unique_groups, 2, "Should have 2 groups (A-B vs B-A orientation)");
-
-        // All tags should have the /A or /B suffix
-        assert!(
-            mi_tags.iter().all(|t| t.contains("/A") || t.contains("/B")),
-            "All MI tags should have /A or /B suffix. Tags: {mi_tags:?}"
+        // The two strands must be ONE molecule: a single base, with both /A and
+        // /B present. Before the fix this produced two distinct bases (a split).
+        let bases = distinct_mi_bases(&output_records);
+        assert_eq!(
+            bases.len(),
+            1,
+            "overlapping-fragment duplex strands must share one molecule base, \
+             not be split; got MIs {mi_tags:?}"
+        );
+        assert_eq!(
+            count_unique_mi_tags(&output_records),
+            2,
+            "the one molecule must have exactly two strands /A and /B; got MIs {mi_tags:?}"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

fgumi's `paired` grouping strategy can split a single duplex molecule into two when a template's two mates share an unclipped 5' coordinate — i.e. fully-overlapping / short-insert fragments. This diverges from fgbio `GroupReadsByUmi`, which pairs the two strands into one molecule.

## Root cause

Duplex strand pairing prefixes each half of the paired UMI with a lower- vs higher-coordinate-read marker (`lowerReadUmiPrefix` / `higherReadUmiPrefix`) so the top strand's prefixed UMI is the exact reverse of the bottom strand's. That prefix is chosen by `is_r1_genomically_earlier_raw`, which broke the position tie with `r1_pos <= r2_pos`. On a tie (`r1_pos == r2_pos`) that returns `true` for **both** strands (top = R1 forward, bottom = R1 reverse), so both get the lower prefix on R1's half, their prefixed UMIs are no longer reverses of each other, they fail to reverse-match in the assigner, and the molecule is split in two.

fgbio breaks the same tie on strand (`GroupReadsByUmi.umiForRead`): `pos1 < pos2 || (pos1 == pos2 && r1.positiveStrand)`. This PR mirrors that — on a tie, R1 is "earlier" iff it is on the forward strand. The buggy helper was shared by `group` and `dedup`; both are fixed.

## `compare bams` was blind to it

The grouping-mode comparison keyed only on the full MI (`base` + `/A`|`/B`), treating the two strands as independent groups. A strand-pairing split keeps the per-MiKey mapping a consistent bijection (`X/A↔X/A`, `X/B↔Y/A`), so it reported the split as `EQUIVALENT` with zero mismatches — which is why the benchmark's own `group.paired` equivalence check never flagged this. This PR adds a base-level (strand-suffix-stripped) molecule-membership check: reads that share a molecule in one BAM must share a molecule in the other. A genuine strand-pairing split now makes the groupings `DIFFER`; a molecule relabel or an `/A`↔`/B` swap stays `EQUIVALENT`.

## Tests

- New regression test `test_paired_assigner_pairs_overlapping_duplex_strands`: builds the two strands of one duplex molecule at equal unclipped 5' positions and asserts they group into one molecule. Verified RED on the pre-fix code (`["0/A","0/A","1/A","1/A"]`, two bases), GREEN after.
- Repaired `test_paired_assigner_explicit_ab_ba_symmetry`: the port of fgbio's "correctly group reads with the paired assigner when the two UMIs are the same" used an FR-only builder (so it never built the reverse-strand bottom read) and asserted two separate groups, inverting fgbio's contract. It now builds a real reverse-strand bottom read and asserts one molecule with `/A` + `/B`, matching fgbio.
- Unit tests for the compare base-level check (split flagged; molecule relabel, `/A`↔`/B` swap, and single-strand relabel not flagged).

Full suite green (2215 tests); fmt and clippy (pedantic) clean.

## Validation on real data

Reproduced end-to-end on the agilent-hs2 vendor sample (SRR30485713): fgumi's own `group → duplex → filter` produced 1,025,610 filtered records vs fgbio's 1,025,612 — a single degenerate duplex molecule (chr11:119116712; 8 top-strand + 3 bottom-strand templates of a fully-overlapping fragment) that fgumi split and fgbio kept. After the fix fgumi produces 1,025,612, byte-identical to fgbio. The behavior is present on `main` (0.4.0), so it is not a recent regression. The fixed `compare bams` flags exactly that one molecule out of 10,220,662 (`Grouping mismatches: 1`, `DIFFER`) where the old tool reported `EQUIVALENT`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BAM grouping consistency checks with an additional molecule-level duplex strand-pairing validation to catch split/merge discrepancies.
  * Fixed strand-aware tie-breaking for paired-read processing when mates share identical unclipped 5’ coordinates.
  * Updated pairing/UMI grouping behavior so duplex strands from the same molecule remain together and aren’t split.
* **Tests**
  * Added unit tests for duplex pairing mismatch detection, and expanded regression coverage for label swapping, relabeling, single-strand cases, and fully overlapping short-insert templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->