### PR TITLE
feat(simd-fastq): validate record structure and surface errors instead of panicking

### DIFF
--- a/crates/fgumi-simd-fastq/src/lib.rs
+++ b/crates/fgumi-simd-fastq/src/lib.rs
@@ -33,5 +33,5 @@ mod reader;
 
 pub use bitmask::FastqBitmask;
 pub use lexer::lex_block_full;
-pub use parser::{FastqRecord, find_record_offsets, parse_records};
+pub use parser::{FastqParseError, FastqRecord, find_record_offsets, parse_records};
 pub use reader::SimdFastqReader;

--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -1,5 +1,7 @@
 //! FASTQ parser: uses SIMD-produced newline bitmasks to find record boundaries.
 
+use std::fmt;
+
 use crate::lexer;
 
 /// A borrowed FASTQ record with zero-copy slices into the input buffer.
@@ -12,6 +14,45 @@ pub struct FastqRecord<'a> {
     /// Quality scores (Phred-encoded ASCII).
     pub quality: &'a [u8],
 }
+
+/// A structural error encountered while parsing a single FASTQ record.
+///
+/// These mirror the malformed-input cases that fgbio's `FastqSource` rejects:
+/// a header not starting with `@`, a record without the expected four lines, a
+/// quality header not starting with `+`, and a sequence/quality length mismatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FastqParseError {
+    /// The header line did not start with `@`.
+    MissingAtPrefix,
+    /// The record did not contain the four expected newline-delimited lines.
+    TooFewLines,
+    /// The quality header line did not start with `+`.
+    MissingPlusPrefix,
+    /// The sequence and quality lines had different lengths.
+    LengthMismatch {
+        /// Number of sequence bases.
+        seq_len: usize,
+        /// Number of quality scores.
+        qual_len: usize,
+    },
+}
+
+impl fmt::Display for FastqParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingAtPrefix => write!(f, "FASTQ record must start with @"),
+            Self::TooFewLines => write!(f, "FASTQ record must have four newline-delimited lines"),
+            Self::MissingPlusPrefix => write!(f, "FASTQ quality header must start with +"),
+            Self::LengthMismatch { seq_len, qual_len } => write!(
+                f,
+                "FASTQ sequence and quality lengths differ ({seq_len} bases vs {qual_len} quals)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FastqParseError {}
 
 /// Find FASTQ record boundary offsets in a byte buffer.
 ///
@@ -143,16 +184,21 @@ impl<'a> Iterator for RecordIter<'a> {
     }
 }
 
-/// Parse a single FASTQ record from a byte slice.
+/// Parse a single FASTQ record from a byte slice, validating its structure.
 ///
-/// Expects format: `@name\nsequence\n+\nquality\n`
+/// Expects format: `@name\nsequence\n+\nquality\n`. Validates, in order, that
+/// the record starts with `@`, has the four expected lines, has a quality header
+/// starting with `+`, and has equal-length sequence and quality lines. These are
+/// the same structural checks fgbio's `FastqSource` enforces. All checks are
+/// `O(1)` beyond the newline scan already required for framing.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the record does not contain exactly 4 newline-delimited lines
-/// or does not start with `@`.
-pub(crate) fn parse_single_record(record: &[u8]) -> FastqRecord<'_> {
-    assert!(!record.is_empty() && record[0] == b'@', "FASTQ record must start with @");
+/// Returns a [`FastqParseError`] describing the first structural violation.
+pub(crate) fn try_parse_single_record(record: &[u8]) -> Result<FastqRecord<'_>, FastqParseError> {
+    if record.is_empty() || record[0] != b'@' {
+        return Err(FastqParseError::MissingAtPrefix);
+    }
 
     // Find the 3 internal newlines (the 4th newline is the last byte)
     let mut newline_positions = [0usize; 3];
@@ -170,11 +216,18 @@ pub(crate) fn parse_single_record(record: &[u8]) -> FastqRecord<'_> {
         }
     }
 
-    assert_eq!(count, 3, "FASTQ record must have at least 3 internal newlines");
+    if count != 3 {
+        return Err(FastqParseError::TooFewLines);
+    }
 
     let name_end = newline_positions[0];
     let seq_end = newline_positions[1];
     let plus_end = newline_positions[2];
+
+    // The quality header (third line, between seq_end and plus_end) must start with '+'.
+    if record.get(seq_end + 1) != Some(&b'+') {
+        return Err(FastqParseError::MissingPlusPrefix);
+    }
 
     // name: skip '@', up to first newline
     let name = &record[1..name_end];
@@ -183,14 +236,56 @@ pub(crate) fn parse_single_record(record: &[u8]) -> FastqRecord<'_> {
     // quality: after third newline, up to end (excluding trailing newline if present)
     let qual_start = plus_end + 1;
     let qual_end = if record.last() == Some(&b'\n') { record.len() - 1 } else { record.len() };
+    // When the record ends right after the '+' line (its third newline is the
+    // final byte) there is no quality line at all: qual_start would exceed
+    // qual_end and the slice below would panic. Treat this as a missing fourth
+    // line rather than indexing an inverted range.
+    if qual_start > qual_end {
+        return Err(FastqParseError::TooFewLines);
+    }
     let quality = &record[qual_start..qual_end];
 
-    FastqRecord { name, sequence, quality }
+    if sequence.len() != quality.len() {
+        return Err(FastqParseError::LengthMismatch {
+            seq_len: sequence.len(),
+            qual_len: quality.len(),
+        });
+    }
+
+    Ok(FastqRecord { name, sequence, quality })
+}
+
+/// Parse a single FASTQ record from a byte slice, panicking on malformed input.
+///
+/// Convenience wrapper over [`try_parse_single_record`] for the infallible
+/// zero-copy [`parse_records`] scan, which assumes well-formed input. The
+/// streaming [`SimdFastqReader`](crate::SimdFastqReader) uses the fallible form
+/// so real files surface a clean error instead of a panic.
+///
+/// # Panics
+///
+/// Panics if the record is structurally invalid; see [`FastqParseError`].
+pub(crate) fn parse_single_record(record: &[u8]) -> FastqRecord<'_> {
+    try_parse_single_record(record).unwrap_or_else(|e| panic!("{e}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+    use rstest::rstest;
+
+    proptest! {
+        // `try_parse_single_record` is the fallible core the streaming reader
+        // routes real input through, so it must never panic on malformed bytes —
+        // it may only return `Ok` or a typed `FastqParseError`. Arbitrary byte
+        // slices exercise the record-slicing logic (e.g. a record ending right
+        // after the '+' line) and guard against slice-panic regressions.
+        #[test]
+        fn test_try_parse_single_record_never_panics(record in proptest::collection::vec(any::<u8>(), 0..64)) {
+            let _ = try_parse_single_record(&record);
+        }
+    }
 
     #[test]
     fn test_empty_input() {
@@ -236,6 +331,46 @@ mod tests {
         assert_eq!(records[0].name, b"read1");
         assert_eq!(records[0].sequence, b"ACGT");
         assert_eq!(records[0].quality, b"IIII");
+    }
+
+    #[test]
+    fn test_try_parse_single_record_ok() {
+        let rec = try_parse_single_record(b"@read1\nACGT\n+\nIIII\n")
+            .expect("well-formed record should parse");
+        assert_eq!(rec.name, b"read1");
+        assert_eq!(rec.sequence, b"ACGT");
+        assert_eq!(rec.quality, b"IIII");
+    }
+
+    #[test]
+    fn test_try_parse_single_record_ok_zero_length_read() {
+        // Empty sequence and quality lines are valid (0 == 0) and must be preserved;
+        // fgumi supports zero-length reads and this must not regress.
+        let rec =
+            try_parse_single_record(b"@read1\n\n+\n\n").expect("zero-length read should parse");
+        assert_eq!(rec.name, b"read1");
+        assert_eq!(rec.sequence, b"");
+        assert_eq!(rec.quality, b"");
+    }
+
+    #[rstest]
+    #[case::missing_at_prefix(b"read1\nACGT\n+\nIIII\n", FastqParseError::MissingAtPrefix)]
+    // Only two newline-delimited lines.
+    #[case::too_few_lines(b"@read1\nACGT\n", FastqParseError::TooFewLines)]
+    #[case::missing_plus_prefix(b"@read1\nACGT\n?\nIIII\n", FastqParseError::MissingPlusPrefix)]
+    #[case::length_mismatch(
+        b"@read1\nACGT\n+\nII\n",
+        FastqParseError::LengthMismatch { seq_len: 4, qual_len: 2 }
+    )]
+    // Record ends right after the '+' line (three newlines, no quality line):
+    // the quality range would be empty-but-inverted (qual_start > qual_end), so
+    // this must return TooFewLines rather than panic on the slice.
+    #[case::plus_line_but_no_quality(b"@r\nA\n+\n", FastqParseError::TooFewLines)]
+    fn test_try_parse_single_record_rejects_malformed(
+        #[case] input: &[u8],
+        #[case] expected: FastqParseError,
+    ) {
+        assert_eq!(try_parse_single_record(input), Err(expected));
     }
 
     #[test]

--- a/crates/fgumi-simd-fastq/src/reader.rs
+++ b/crates/fgumi-simd-fastq/src/reader.rs
@@ -5,7 +5,7 @@
 
 use std::io::{self, BufRead};
 
-use crate::parser::{self, parse_single_record};
+use crate::parser::{self, try_parse_single_record};
 
 /// Default internal buffer size (1 MiB), matching `seq_io`'s default.
 const DEFAULT_BUFFER_SIZE: usize = 1 << 20;
@@ -139,7 +139,14 @@ impl<R: BufRead> Iterator for SimdFastqReader<R> {
                 let end = self.offsets[self.next_record_idx + 1];
                 self.next_record_idx += 1;
 
-                let borrowed = parse_single_record(&self.buffer[start..end]);
+                let borrowed = match try_parse_single_record(&self.buffer[start..end]) {
+                    Ok(rec) => rec,
+                    Err(e) => {
+                        // Preserve the typed `FastqParseError` as the io::Error's inner error
+                        // so downstream callers can inspect or downcast it via `get_ref()`.
+                        return Some(Err(io::Error::new(io::ErrorKind::InvalidData, e)));
+                    }
+                };
                 return Some(Ok(OwnedFastqRecord {
                     name: borrowed.name.to_vec(),
                     sequence: borrowed.sequence.to_vec(),
@@ -174,6 +181,7 @@ impl<R: BufRead> Iterator for SimdFastqReader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::io::Cursor;
 
     #[test]
@@ -240,6 +248,50 @@ mod tests {
         let data = b"";
         let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
         assert!(reader.next().is_none());
+    }
+
+    // ── Malformed-record validation (mirrors fgbio's FastqSource throwing
+    // behavior in FastqIoTest, adapted to fgumi's fallible `io::Result` item
+    // contract: the streaming reader surfaces an `InvalidData` error rather than
+    // panicking or silently yielding a corrupt record). ──
+
+    fn assert_next_is_invalid_data<R: BufRead>(reader: &mut SimdFastqReader<R>) {
+        let err = reader
+            .next()
+            .expect("reader should yield an item")
+            .expect_err("malformed record should be an error, not Ok");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "unexpected error: {err}");
+    }
+
+    #[rstest]
+    // Header line does not start with '@'.
+    #[case::missing_at_prefix(b"r1\nACGT\n+\nIIII\n")]
+    // Third line (quality header) does not start with '+'.
+    #[case::missing_plus_line(b"@r1\nACGT\n?\nIIII\n")]
+    // Sequence has 4 bases but quality has 2 scores.
+    #[case::seq_qual_length_mismatch(b"@r1\nACGT\n+\nII\n")]
+    fn test_reader_rejects_malformed_record(#[case] data: &[u8]) {
+        let mut reader = SimdFastqReader::new(Cursor::new(data));
+        assert_next_is_invalid_data(&mut reader);
+    }
+
+    #[test]
+    fn test_reader_error_preserves_parse_error_source() {
+        // Sequence has 4 bases but quality has 2 scores.
+        let data = b"@r1\nACGT\n+\nII\n";
+        let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+        let err = reader
+            .next()
+            .expect("reader should yield an item")
+            .expect_err("malformed record should be an error, not Ok");
+
+        // The typed FastqParseError must survive as the io::Error's inner error so callers
+        // can downcast it, rather than being flattened into a string.
+        let inner = err.get_ref().expect("io::Error should carry an inner error");
+        let parse_err = inner
+            .downcast_ref::<parser::FastqParseError>()
+            .expect("inner error should downcast to FastqParseError");
+        assert_eq!(*parse_err, parser::FastqParseError::LengthMismatch { seq_len: 4, qual_len: 2 });
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #486. This closes the FASTQ-reader validation gaps that the #486 investigation surfaced: fgumi reimplemented its FASTQ reader from scratch (`fgumi-simd-fastq`) rather than porting fgbio's `FastqSource`, and its parsing contract diverged from what fgbio enforces (and tests in `FastqIoTest`).

> **Reviewer note:** please review after #486 — the base of this PR is `nh/feat-extract-strip-read-number-suffix`, not `main`. GitHub will retarget it to `main` automatically once #486 merges.

## Problem

`SimdFastqReader` only enforced one of the four structural invariants fgbio's `FastqSource` checks, and did so by panicking:

| fgbio `FastqSource` rejects… | fgumi reader (before) |
|---|---|
| header not starting with `@` | ✅ enforced — but via `assert!` (**panic**) |
| quality header not starting with `+` | ❌ **silently accepted** |
| `seq.len != qual.len` | ❌ **silently produced a corrupt record** |
| not the four expected lines | ⚠️ `assert!` (panic) / dropped as leftover |

The length-mismatch case is the worst: it emitted a record with mismatched sequence and quality with no error at all.

## Change

- Add a fallible parse core, `try_parse_single_record`, returning a typed `FastqParseError` (`MissingAtPrefix`, `TooFewLines`, `MissingPlusPrefix`, `LengthMismatch { seq_len, qual_len }`). It validates all four invariants.
- The streaming `SimdFastqReader` (the production path, used by `extract` via `ReadSetIterator`) now routes failures through its **existing** `io::Result` item channel as an `InvalidData` error instead of panicking. `extract` surfaces a clean message and a non-zero exit.
- The infallible zero-copy `parse_records` scan keeps its panic-on-malformed contract via a thin documented wrapper (it assumes well-formed/trusted input, e.g. benchmarks).

The new checks are **O(1)** beyond the newline scan already required for record framing (a single-byte compare for `+`, a length compare for seq/qual) — negligible against the per-record allocations already on the path, so no hot-path regression.

### End-to-end behavior

Before: a length-mismatched record was written silently. After:

```
$ fgumi extract --inputs bad.fq --output out.bam --sample s --library l --read-structures +T
Error: FASTQ sequence and quality lengths differ (4 bases vs 2 quals)
```

## Tests (TDD)

Written test-first (watched each fail before implementing):

- **Reader-level** (`reader.rs`), mirroring fgbio's `FastqIoTest` throwing cases adapted to fgumi's `io::Result` contract: missing `@`, missing `+`, and seq/qual length mismatch each yield an `InvalidData` error rather than panicking or silently succeeding.
- **Parser-level** (`parser.rs`) for `try_parse_single_record`: the `Ok` case, a **zero-length-read** `Ok` guard (empty seq/qual, `0 == 0`, must not regress), and one case per error variant.

Full suite green (2219 passed); fmt and clippy clean.

## Why this wasn't caught before

The `/1`/`/2` and validation behaviors are all properties of fgbio's `FastqSource` (the reader), tested in `FastqIoTest` — not `FastqToBam`/`FastqToBamTest`. The fgumi port targeted `FastqToBam` → `extract` and wrote a fresh SIMD reader, so neither the reader behaviors nor their tests came across. #486 fixed the `/1`/`/2` half; this PR fixes the validation half.

## Audit of the other FASTQ path (done)

The unified-pipeline FASTQ parser (`src/lib/unified_pipeline/fastq.rs` + `src/lib/fastq_parse.rs::FastqRecord::from_slice`) was audited and is **already clean** — no changes needed:

- `FastqRecord::from_slice` independently validates all four invariants (`@`, four lines, `+`, equal seq/qual lengths) and returns `io::Result` `InvalidData`, with unit tests per error case. Its boundary scanners (`detect_prefix_end` and the reverse scan) re-validate all four per 4-line window, so malformed records can't be mis-framed.
- The `/1`/`/2` QNAME strip from #486 already covers this path: extract's unified route (`run_fastq_pipeline` → `make_raw_records_static`) converges on the same `extract_read_name_and_umi` that #486 fixed. The broad `strip_read_suffix` in `fastq_parse.rs` is only used by `grouper.rs` for name *comparison*, never to write a QNAME, so it does not over-strip output names.

The only real gap was the `fgumi-simd-fastq` reader, which this PR fixes. (Minor: the 4-invariant check now lives in three spots — this reader, `from_slice`, and the boundary scanners — a possible future consolidation, but each has a distinct borrowed/owned/scan context.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed `FastqParseError` in the public API for structured, fallible FASTQ parsing.
* **Bug Fixes**
  * Improved FASTQ parsing validation to report specific structural issues (missing prefixes, incomplete records, and sequence/quality length mismatches).
  * While iterating FASTQ input, malformed records now surface as clear invalid-data errors and preserve the original parse error details for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->