### PR TITLE
fix(zipper): correct consensus reverse/revcomp tag sets to match fgbio ConsensusTags

### DIFF
--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -193,17 +193,24 @@ impl std::fmt::Display for MoleculeId {
 pub struct TagSets;
 
 impl TagSets {
-    /// Consensus tags that should be reversed.
+    /// Consensus per-base tags that should be **reversed** on negative-strand reads.
     ///
-    /// These are per-base tags from fgbio consensus callers that need to be
-    /// reversed when the read is mapped to the negative strand.
-    pub const CONSENSUS_REVERSE: &[&str] = &["ad", "ae", "bd", "be", "cd"];
+    /// Mirrors fgbio `ConsensusTags.PerBase.TagsToReverse`: the per-base
+    /// depth/error/quality arrays — `cd`,`ce` (consensus), `ad`,`ae` (top strand),
+    /// `bd`,`be` (bottom strand), and `aq`,`bq` (per-strand quals). These are
+    /// position-indexed arrays, so they must be reversed (not reverse-complemented)
+    /// when the read maps to the negative strand.
+    pub const CONSENSUS_REVERSE: &[&str] = &["cd", "ce", "ad", "ae", "bd", "be", "aq", "bq"];
 
-    /// Consensus tags that should be reverse complemented.
+    /// Consensus per-base **base** tags that should be **reverse-complemented** on
+    /// negative-strand reads.
     ///
-    /// These are per-base sequence tags from fgbio consensus callers that need
-    /// to be reverse complemented when the read is mapped to the negative strand.
-    pub const CONSENSUS_REVCOMP: &[&str] = &["aD", "bD", "cD"];
+    /// Mirrors fgbio `ConsensusTags.PerBase.TagsToReverseComplement`: the per-base
+    /// consensus base arrays `ac` (top strand) and `bc` (bottom strand). Being
+    /// sequence bases, they are reverse-complemented (not merely reversed) on the
+    /// negative strand. (Note: `aD`/`bD`/`cD` are per-*read* scalar depths — never
+    /// reversed or revcomped.)
+    pub const CONSENSUS_REVCOMP: &[&str] = &["ac", "bc"];
 }
 
 /// Information about which tags to remove, reverse, or reverse complement
@@ -368,8 +375,62 @@ mod tests {
 
     #[test]
     fn test_consensus_reverse_returns_correct_tags() {
-        assert_eq!(TagSets::CONSENSUS_REVERSE.len(), 5);
-        assert_eq!(TagSets::CONSENSUS_REVERSE, &["ad", "ae", "bd", "be", "cd"]);
+        // fgbio ConsensusTags.PerBase.TagsToReverse = {cd, ce, ad, ae, bd, be, aq, bq}
+        assert_eq!(TagSets::CONSENSUS_REVERSE.len(), 8);
+        assert_eq!(TagSets::CONSENSUS_REVERSE, &["cd", "ce", "ad", "ae", "bd", "be", "aq", "bq"]);
+    }
+
+    /// Programmatic fgbio baseline for the per-base consensus tag sets, so the
+    /// `TagSets::CONSENSUS_*` pins are checked against fgbio's *definition* rather than a
+    /// second hand-copied literal.
+    ///
+    /// This reconstructs fgbio's `ConsensusTags.PerBase` sets from the individually named tag
+    /// symbols, in fgbio's exact `Seq(...)` order (fgbio
+    /// `src/main/scala/com/fulcrumgenomics/umi/ConsensusTags.scala`, `object PerBase`,
+    /// verified against fgbio main). If fgbio adds, removes, or reorders a per-base tag, update
+    /// the named symbols below and this test catches any resulting drift in the production
+    /// constants. The intentional divergence from fgumi's *superset* `per_base` lists — which
+    /// additionally cover the CODEC conversion tags — is asserted separately by
+    /// `test_zipper_consensus_tagset_is_subset_of_canonical_per_base` in `src/lib/tag_reversal.rs`.
+    #[test]
+    fn test_consensus_tag_sets_match_fgbio_perbase_baseline() {
+        // fgbio ConsensusTags.PerBase named symbol -> 2-char SAM tag.
+        let raw_read_count = "cd"; // RawReadCount    (consensus depth)
+        let raw_read_errors = "ce"; // RawReadErrors   (consensus errors)
+        let ab_raw_read_count = "ad"; // AbRawReadCount
+        let ba_raw_read_count = "bd"; // BaRawReadCount
+        let ab_raw_read_errors = "ae"; // AbRawReadErrors
+        let ba_raw_read_errors = "be"; // BaRawReadErrors
+        let ab_consensus_bases = "ac"; // AbConsensusBases
+        let ba_consensus_bases = "bc"; // BaConsensusBases
+        let ab_consensus_quals = "aq"; // AbConsensusQuals
+        let ba_consensus_quals = "bq"; // BaConsensusQuals
+
+        // fgbio: TagsToReverse = Seq(RawReadCount, RawReadErrors, AbRawReadCount, AbRawReadErrors,
+        //                            BaRawReadCount, BaRawReadErrors, AbConsensusQuals, BaConsensusQuals)
+        let fgbio_tags_to_reverse = [
+            raw_read_count,
+            raw_read_errors,
+            ab_raw_read_count,
+            ab_raw_read_errors,
+            ba_raw_read_count,
+            ba_raw_read_errors,
+            ab_consensus_quals,
+            ba_consensus_quals,
+        ];
+        // fgbio: TagsToReverseComplement = Seq(AbConsensusBases, BaConsensusBases)
+        let fgbio_tags_to_reverse_complement = [ab_consensus_bases, ba_consensus_bases];
+
+        assert_eq!(
+            TagSets::CONSENSUS_REVERSE,
+            &fgbio_tags_to_reverse,
+            "CONSENSUS_REVERSE drifted from fgbio ConsensusTags.PerBase.TagsToReverse",
+        );
+        assert_eq!(
+            TagSets::CONSENSUS_REVCOMP,
+            &fgbio_tags_to_reverse_complement,
+            "CONSENSUS_REVCOMP drifted from fgbio ConsensusTags.PerBase.TagsToReverseComplement",
+        );
     }
 
     // ========================================================================
@@ -458,8 +519,9 @@ mod tests {
 
     #[test]
     fn test_consensus_revcomp_returns_correct_tags() {
-        assert_eq!(TagSets::CONSENSUS_REVCOMP.len(), 3);
-        assert_eq!(TagSets::CONSENSUS_REVCOMP, &["aD", "bD", "cD"]);
+        // fgbio ConsensusTags.PerBase.TagsToReverseComplement = {ac, bc} (per-base base arrays)
+        assert_eq!(TagSets::CONSENSUS_REVCOMP.len(), 2);
+        assert_eq!(TagSets::CONSENSUS_REVCOMP, &["ac", "bc"]);
     }
 
     #[test]
@@ -490,21 +552,18 @@ mod tests {
     #[test]
     fn test_taginfo_new_with_consensus_reverse() {
         let tag_info = TagInfo::new(vec![], vec!["Consensus".to_string()], vec![]);
-        assert_eq!(tag_info.reverse.len(), 5);
-        assert!(tag_info.reverse.contains("ad"));
-        assert!(tag_info.reverse.contains("ae"));
-        assert!(tag_info.reverse.contains("bd"));
-        assert!(tag_info.reverse.contains("be"));
-        assert!(tag_info.reverse.contains("cd"));
+        assert_eq!(tag_info.reverse.len(), 8);
+        for t in ["cd", "ce", "ad", "ae", "bd", "be", "aq", "bq"] {
+            assert!(tag_info.reverse.contains(t), "missing reverse tag {t}");
+        }
     }
 
     #[test]
     fn test_taginfo_new_with_consensus_revcomp() {
         let tag_info = TagInfo::new(vec![], vec![], vec!["Consensus".to_string()]);
-        assert_eq!(tag_info.revcomp.len(), 3);
-        assert!(tag_info.revcomp.contains("aD"));
-        assert!(tag_info.revcomp.contains("bD"));
-        assert!(tag_info.revcomp.contains("cD"));
+        assert_eq!(tag_info.revcomp.len(), 2);
+        assert!(tag_info.revcomp.contains("ac"));
+        assert!(tag_info.revcomp.contains("bc"));
     }
 
     #[test]
@@ -517,20 +576,16 @@ mod tests {
         // Remove set
         assert_eq!(tag_info.remove.len(), 1);
         assert!(tag_info.remove.contains("AS"));
-        // Reverse set should have Consensus tags + BQ
-        assert_eq!(tag_info.reverse.len(), 6);
-        assert!(tag_info.reverse.contains("ad"));
-        assert!(tag_info.reverse.contains("ae"));
-        assert!(tag_info.reverse.contains("bd"));
-        assert!(tag_info.reverse.contains("be"));
-        assert!(tag_info.reverse.contains("cd"));
-        assert!(tag_info.reverse.contains("BQ"));
-        // Revcomp set should have Consensus tags + E2
-        assert_eq!(tag_info.revcomp.len(), 4);
-        assert!(tag_info.revcomp.contains("aD"));
-        assert!(tag_info.revcomp.contains("bD"));
-        assert!(tag_info.revcomp.contains("cD"));
-        assert!(tag_info.revcomp.contains("E2"));
+        // Reverse set should have the 8 Consensus tags + BQ
+        assert_eq!(tag_info.reverse.len(), 9);
+        for t in ["cd", "ce", "ad", "ae", "bd", "be", "aq", "bq", "BQ"] {
+            assert!(tag_info.reverse.contains(t), "missing reverse tag {t}");
+        }
+        // Revcomp set should have the 2 Consensus base tags + E2
+        assert_eq!(tag_info.revcomp.len(), 3);
+        for t in ["ac", "bc", "E2"] {
+            assert!(tag_info.revcomp.contains(t), "missing revcomp tag {t}");
+        }
     }
 
     #[test]
@@ -554,8 +609,8 @@ mod tests {
             vec!["Consensus".to_string(), "Consensus".to_string()],
         );
         // Should not duplicate consensus tags
-        assert_eq!(tag_info.reverse.len(), 5);
-        assert_eq!(tag_info.revcomp.len(), 3);
+        assert_eq!(tag_info.reverse.len(), 8);
+        assert_eq!(tag_info.revcomp.len(), 2);
     }
 
     #[test]

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -97,8 +97,11 @@ You can specify which tags to manipulate for reads mapped to the negative strand
 - --tags-to-reverse: Reverses array and string tags (e.g., [1,2,3] becomes [3,2,1])
 - --tags-to-revcomp: Reverse complements sequence tags (e.g., AGAGG becomes CCTCT)
 
-Named tag sets like "Consensus" are automatically expanded to their constituent tags:
-- Consensus: aD bD cD aM bM cM aE bE cE ad bd cd ae be ce ac bc
+Named tag sets like "Consensus" are automatically expanded to their constituent per-base tags
+(matching fgbio's ConsensusTags):
+- --tags-to-reverse Consensus:  cd ce ad ae bd be aq bq  (per-base depth/error/quality arrays; reversed)
+- --tags-to-revcomp Consensus:  ac bc  (per-base consensus base arrays; reverse-complemented)
+Per-read scalar tags (aD bD cD, aM bM cM, aE bE cE) are never reversed or reverse-complemented.
 
 ## Default Behavior
 
@@ -1588,9 +1591,13 @@ mod tests {
         let mut mapped = FgSamBuilder::new_mapped();
 
         let mut attrs = HashMap::new();
-        attrs.insert("aD", BufValue::from("AAAGG".to_string()));
-        attrs.insert("bD", BufValue::from("AAAGC".to_string()));
+        // ac/bc are the per-base consensus BASE arrays -> reverse-complemented on neg strand.
+        attrs.insert("ac", BufValue::from("AAAGG".to_string()));
+        attrs.insert("bc", BufValue::from("AAAGC".to_string()));
+        // ad is a per-base depth array -> reversed on neg strand.
         attrs.insert("ad", BufValue::from(vec![3i16, 3, 4, 4, 2]));
+        // aD is a per-READ scalar depth -> in NO transform set, must be left unchanged.
+        attrs.insert("aD", BufValue::from(42i32));
         unmapped.add_frag_with_attrs("q1", None, true, &attrs);
 
         let mut mapped_attrs1 = HashMap::new();
@@ -1627,12 +1634,12 @@ mod tests {
 
         for rec in &records {
             if rec.flags().is_reverse_complemented() {
-                // Negative strand - should be reversed/revcomped
-                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'a', b'D')) {
+                // Negative strand: ac/bc reverse-complemented, ad reversed, per-read aD unchanged.
+                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'a', b'c')) {
                     assert_eq!(s.to_string(), "CCTTT");
                 }
 
-                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'b', b'D')) {
+                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'b', b'c')) {
                     assert_eq!(s.to_string(), "GCTTT");
                 }
 
@@ -1642,13 +1649,18 @@ mod tests {
                 {
                     assert_eq!(*vals, vec![2i16, 4, 4, 3, 3]);
                 }
+
+                // Per-read scalar aD is in no transform set -> unchanged even on neg strand.
+                if let Some(BufValue::Int32(v)) = rec.data().get(&Tag::new(b'a', b'D')) {
+                    assert_eq!(*v, 42);
+                }
             } else {
                 // Positive strand - no changes
-                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'a', b'D')) {
+                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'a', b'c')) {
                     assert_eq!(s.to_string(), "AAAGG");
                 }
 
-                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'b', b'D')) {
+                if let Some(BufValue::String(s)) = rec.data().get(&Tag::new(b'b', b'c')) {
                     assert_eq!(s.to_string(), "AAAGC");
                 }
 
@@ -1735,16 +1747,18 @@ mod tests {
         let tag_info =
             TagInfo::new(vec![], vec!["Consensus".to_string()], vec!["Consensus".to_string()]);
 
-        // Check that "Consensus" was expanded
-        assert!(tag_info.reverse.contains("ad"));
-        assert!(tag_info.reverse.contains("ae"));
-        assert!(tag_info.reverse.contains("bd"));
-        assert!(tag_info.reverse.contains("be"));
-        assert!(tag_info.reverse.contains("cd"));
-
-        assert!(tag_info.revcomp.contains("aD"));
-        assert!(tag_info.revcomp.contains("bD"));
-        assert!(tag_info.revcomp.contains("cD"));
+        // "Consensus" reverse set = fgbio TagsToReverse {cd, ce, ad, ae, bd, be, aq, bq}
+        for t in ["cd", "ce", "ad", "ae", "bd", "be", "aq", "bq"] {
+            assert!(tag_info.reverse.contains(t), "missing reverse tag {t}");
+        }
+        // "Consensus" revcomp set = fgbio TagsToReverseComplement {ac, bc} (per-base base arrays);
+        // per-read scalars aD/bD/cD must NOT be present.
+        for t in ["ac", "bc"] {
+            assert!(tag_info.revcomp.contains(t), "missing revcomp tag {t}");
+        }
+        for t in ["aD", "bD", "cD"] {
+            assert!(!tag_info.revcomp.contains(t), "per-read scalar {t} must not be revcomped");
+        }
     }
 
     #[test]

--- a/src/lib/tag_reversal.rs
+++ b/src/lib/tag_reversal.rs
@@ -82,6 +82,50 @@ mod tests {
             .expect("raw_record_to_record_buf failed in test")
     }
 
+    /// Cross-path guard for the two per-base tag-transform lists (a drift between them was the
+    /// root cause of ZIP-01/02).
+    ///
+    /// - `fgumi_umi::TagSets::CONSENSUS_*` (used by `zipper`'s `--tags-to-reverse/revcomp
+    ///   Consensus` expansion) mirrors **fgbio's** `ConsensusTags.PerBase` sets exactly — 8
+    ///   reverse (`cd ce ad ae bd be aq bq`), 2 revcomp (`ac bc`) — for fgbio `ZipperBams` parity.
+    /// - `per_base::tags_to_reverse{,_complement}()` (used by this raw reversal path, e.g. from
+    ///   `filter`) is a fgumi **superset**: it additionally reverses the CODEC/bisulfite
+    ///   conversion tags (`cu ct au at bu bt`), which fgbio's `Consensus` set does not include.
+    ///
+    /// So the invariant is a **subset**, not equality: every tag in the zipper Consensus set must
+    /// be a recognized fgumi per-base tag (catches a bogus/typo'd addition), while `per_base` may
+    /// grow. The exact fgbio set is pinned separately by the `fgumi-umi` `TagSets` unit tests.
+    #[test]
+    fn test_zipper_consensus_tagset_is_subset_of_canonical_per_base() {
+        use std::collections::BTreeSet;
+        let canon_rev: BTreeSet<String> =
+            per_base::tags_to_reverse().iter().map(ToString::to_string).collect();
+        for t in fgumi_umi::TagSets::CONSENSUS_REVERSE {
+            assert!(
+                canon_rev.contains(*t),
+                "zipper Consensus reverse tag `{t}` unknown to per_base"
+            );
+        }
+        let canon_rc: BTreeSet<String> =
+            per_base::tags_to_reverse_complement().iter().map(ToString::to_string).collect();
+        for t in fgumi_umi::TagSets::CONSENSUS_REVCOMP {
+            assert!(
+                canon_rc.contains(*t),
+                "zipper Consensus revcomp tag `{t}` unknown to per_base"
+            );
+        }
+
+        // No tag may be in BOTH lists: a per-base tag is either reversed (depth/
+        // error/qual arrays) or reverse-complemented (base arrays), never both.
+        // Guards against a tag being copied into the wrong (or an extra) list.
+        let reverse: BTreeSet<&str> =
+            fgumi_umi::TagSets::CONSENSUS_REVERSE.iter().copied().collect();
+        let revcomp: BTreeSet<&str> =
+            fgumi_umi::TagSets::CONSENSUS_REVCOMP.iter().copied().collect();
+        let both: Vec<&str> = reverse.intersection(&revcomp).copied().collect();
+        assert!(both.is_empty(), "tags in both Consensus reverse and revcomp sets: {both:?}");
+    }
+
     #[rstest]
     #[case(Value::from(vec![1i8, 2, 3]), Value::from(vec![3i8, 2, 1]))]
     #[case(Value::from(vec![1u8, 2, 3]), Value::from(vec![3u8, 2, 1]))]


### PR DESCRIPTION
First PR in the fgbio↔fgumi behavioral-parity burn-down (tracker: ZIP-01, ZIP-02, PIN-02).

## Problem

The named `Consensus` tag set that `zipper` expands for `--tags-to-reverse` / `--tags-to-revcomp` did not match fgbio's `ConsensusTags.PerBase`:

- **revcomp set was `{aD, bD, cD}`** — per-*read* scalar depth tags, on which reverse-complement is a no-op. The per-base consensus **base** arrays `ac`/`bc`, which *must* be reverse-complemented on negative-strand reads, were in **no** set.
- **reverse set was `{ad, ae, bd, be, cd}`** — missing `ce`, `aq`, `bq`.

So a negative-strand consensus read zippered with `--tags Consensus` had its per-base bases left un-reverse-complemented and its per-base errors/quals left in the wrong orientation.

This is **latent in the standard pipeline** — `zipper` runs pre-consensus (`extract → align → zipper → sort → group → consensus`), so these per-base tags don't exist at zipper time and the wrong constants are a no-op (which is exactly why the benchmark never caught it). It bites a **re-zipper-consensus-reads** workflow (remap consensus reads + restore per-base tags on negative-strand alignments).

## Fix

Correct the sets to fgbio's exact `ConsensusTags.PerBase`, **verified against fgbio `main` and the fgbio wiki**:

```
TagsToReverse           = {cd, ce, ad, ae, bd, be, aq, bq}   (per-base depth/error/quality arrays; reversed)
TagsToReverseComplement = {ac, bc}                            (per-base consensus base arrays; reverse-complemented)
```

Per-read scalars (`aD/bD/cD`, …) are correctly in neither set.

## End-to-end verification (fgbio 4.1.0)

Ran `fgbio ZipperBams` (truth) and `fgumi zipper` on a neg-strand consensus read with `--tags-to-reverse/revcomp Consensus`:

| tag | fgbio (truth) | before (unfixed) | after (fixed) |
|-----|---------------|------------------|---------------|
| `ac` | GCTT (revcomp) | AAGC ✗ | GCTT ✓ |
| `bc` | GCAA (revcomp) | TTGC ✗ | GCAA ✓ |
| `cd` | 4,3,2,1 | 4,3,2,1 ✓ | 4,3,2,1 ✓ |
| `ce` | 0,1,0,0 | 0,0,1,0 ✗ | 0,1,0,0 ✓ |
| `aq` | 40,30,20,10 | 10,20,30,40 ✗ | 40,30,20,10 ✓ |
| `bq` | 10,20,30,40 | 40,30,20,10 ✗ | 10,20,30,40 ✓ |

**before vs fgbio: DIFFER (5/6)** → **after vs fgbio: MATCH (all 6).** The repro is committed as an adversarial fixture (`reports/fgbio-parity-fixtures/`, tracked externally) for the compare-hardening capstone.

## Also in this PR

- Fixed **three unit tests** that pinned the wrong sets — including `test_consensus_tag_set`, which fed per-read scalars `aD`/`bD` as if they were revcomp'd sequence tags (PIN-02).
- Corrected the **stale `Consensus` tag list in the `zipper` CLI `long_about`** (it listed per-read scalars, omitted `aq`/`bq`, and didn't distinguish reverse from revcomp).
- Added a **subset guard test**: the zipper `Consensus` set must be a subset of fgumi's canonical `per_base` tag lists. Notably, `per_base` is a **superset** — it also reverses the CODEC/bisulfite conversion tags (`cu ct au at bu bt`) that fgbio's `Consensus` set does not include, so these are two intentionally-different lists (fgbio-parity subset vs fgumi superset), and the guard prevents a bogus/typo'd addition to the zipper set.

CI: `cargo ci-fmt && cargo ci-lint && cargo ci-test` all green (2211 tests). Self-reviewed via `/coderabbitai-review` (both findings — the CLI doc drift and the dual-source-of-truth — addressed above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Consensus” tag set expansion so tag reversal and reverse-complement behavior matches the intended consensus handling.
  * Adjusted the underlying “Consensus” tag groups (including per-base vs per-read distinctions) and ensured per-read scalar depth tags remain unchanged.

* **Documentation**
  * Clarified in command help how `--tags-to-reverse Consensus` vs `--tags-to-revcomp Consensus` expands and transforms tags.

* **Tests**
  * Updated expected expansions and added coverage to verify tag-set consistency and correct strand-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->