### PR TITLE
fix(dna): IUPAC-aware, case-preserving complement via shared 256-byte LUT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "anyhow",
  "bstr 1.12.1",
  "bytemuck",
+ "fgumi-dna",
  "fgumi-tag",
  "noodles",
  "proptest",

--- a/crates/fgumi-dna/src/dna.rs
+++ b/crates/fgumi-dna/src/dna.rs
@@ -2,49 +2,91 @@
 //!
 //! This module provides common DNA sequence operations like reverse complement.
 
-use crate::{NO_CALL_BASE, NO_CALL_BASE_LOWER};
+/// Lookup table mapping each byte to its Watson–Crick / IUPAC complement.
+///
+/// Single source of truth for base complementation, shared by [`complement_base`]
+/// (and thus every consensus reverse-complement path) and by `fgumi-raw-bam`'s
+/// per-base tag reverse-complement. It mirrors fgbio's `Sequences.complement` /
+/// htsjdk `SequenceUtil`:
+///
+/// - **Full IUPAC**: `A<->T`, `C<->G`, `U->A`, `R<->Y`, `K<->M`, `B<->V`,
+///   `D<->H`, and the self-complements `S`, `W`, `N`.
+/// - **Case-preserving**: lowercase input yields lowercase output (`a->t`),
+///   matching fgbio — e.g. CODEC's lowercase `n` padding survives round trips.
+/// - **Unknown bytes pass through unchanged** (identity default). fgbio *throws*
+///   on invalid bytes; fgumi keeps the non-panicking passthrough because such
+///   bytes are unreachable on real ACGTN(+IUPAC) sequence/tag data and the
+///   `simulate` command relies on passthrough (`fastq_reads.rs`). Strict
+///   validation, if ever needed, belongs at a dedicated entry point, not here.
+///
+/// Indexed by a `u8` into a 256-entry table, so the bounds check is elided:
+/// complementation is a single branch-free load.
+pub const COMPLEMENT: [u8; 256] = {
+    let mut table = [0u8; 256];
+    // Identity default so unknown bytes pass through unchanged. Counter is a `u8`
+    // (widening `as usize` index, no truncating cast) with a break at 255 to
+    // cover the full 0..=255 range without overflowing the increment.
+    let mut b: u8 = 0;
+    loop {
+        table[b as usize] = b;
+        if b == u8::MAX {
+            break;
+        }
+        b += 1;
+    }
+    // Uppercase Watson–Crick + IUPAC.
+    table[b'A' as usize] = b'T';
+    table[b'T' as usize] = b'A';
+    table[b'C' as usize] = b'G';
+    table[b'G' as usize] = b'C';
+    table[b'U' as usize] = b'A';
+    table[b'R' as usize] = b'Y';
+    table[b'Y' as usize] = b'R';
+    table[b'S' as usize] = b'S';
+    table[b'W' as usize] = b'W';
+    table[b'K' as usize] = b'M';
+    table[b'M' as usize] = b'K';
+    table[b'B' as usize] = b'V';
+    table[b'V' as usize] = b'B';
+    table[b'D' as usize] = b'H';
+    table[b'H' as usize] = b'D';
+    table[b'N' as usize] = b'N';
+    // Lowercase (case preserved).
+    table[b'a' as usize] = b't';
+    table[b't' as usize] = b'a';
+    table[b'c' as usize] = b'g';
+    table[b'g' as usize] = b'c';
+    table[b'u' as usize] = b'a';
+    table[b'r' as usize] = b'y';
+    table[b'y' as usize] = b'r';
+    table[b's' as usize] = b's';
+    table[b'w' as usize] = b'w';
+    table[b'k' as usize] = b'm';
+    table[b'm' as usize] = b'k';
+    table[b'b' as usize] = b'v';
+    table[b'v' as usize] = b'b';
+    table[b'd' as usize] = b'h';
+    table[b'h' as usize] = b'd';
+    table[b'n' as usize] = b'n';
+    table
+};
 
-/// Complements a single DNA base, normalizing to uppercase except for N/n.
+/// Complements a single DNA base (IUPAC-aware, case-preserving).
 ///
-/// Returns the Watson-Crick complement: A<->T, C<->G. RNA uracil (`U`/`u`)
-/// complements to `A`, matching fgbio's `Sequences.complement`.
-/// Both uppercase and lowercase A/T/C/G/U input are normalized to uppercase output.
-///
-/// # Case preservation for N/n
-///
-/// Uppercase 'N' and lowercase 'n' are returned unchanged (case preserved).
-/// This is required for fgbio compatibility in CODEC consensus calling:
-///
-/// - **CODEC** uses lowercase 'n' for padding when R1/R2 have different lengths
-///   (see `codec_caller::pad_consensus`). These padded bases are then reverse
-///   complemented for ac/bc tags (see `codec_caller::reverse_complement_ss`).
-///   fgbio preserves lowercase 'n' through this operation.
-///
-/// - **Simplex/Duplex** use only uppercase 'N' for no-call bases in production
-///   (see `vanilla_caller` lines 640, 1024, 1078 and `duplex_caller` `NO_CALL` const).
-///   The `padded_default` function with lowercase 'n' exists but is only used in tests.
-///
-/// - **`Zipper/tag_reversal`** do not create 'n' bases, only reverse complement
-///   existing tag values which come from upstream processing.
+/// Watson–Crick + IUPAC complement via [`COMPLEMENT`]: `A<->T`, `C<->G`,
+/// `R<->Y`, etc. Case is preserved (`a->t`) and unknown bytes pass through
+/// unchanged. See [`COMPLEMENT`] for the exact contract and rationale.
 #[inline]
 #[must_use]
 pub const fn complement_base(base: u8) -> u8 {
-    match base {
-        b'A' | b'a' => b'T',
-        // T and RNA uracil U both complement to A (fgbio Sequences.complement)
-        b'T' | b't' | b'U' | b'u' => b'A',
-        b'C' | b'c' => b'G',
-        b'G' | b'g' => b'C',
-        NO_CALL_BASE => NO_CALL_BASE,             // 'N' stays 'N'
-        NO_CALL_BASE_LOWER => NO_CALL_BASE_LOWER, // 'n' stays 'n' (fgbio compat)
-        _ => base,
-    }
+    COMPLEMENT[base as usize]
 }
 
-/// Reverse complements a DNA sequence.
+/// Reverse complements a DNA sequence (IUPAC-aware, case-preserving).
 ///
-/// Returns the reverse complement of the input sequence, normalizing to uppercase.
-/// A<->T, C<->G, U->A; N and other bases are unchanged.
+/// Reverses the sequence and complements each base via [`complement_base`]:
+/// full IUPAC (`A<->T`, `C<->G`, `R<->Y`, …), case preserved, unknown bytes
+/// unchanged.
 ///
 /// # Examples
 ///
@@ -54,50 +96,19 @@ pub const fn complement_base(base: u8) -> u8 {
 /// assert_eq!(reverse_complement(b"ACGT"), b"ACGT".to_vec());
 /// assert_eq!(reverse_complement(b"AAAA"), b"TTTT".to_vec());
 /// assert_eq!(reverse_complement(b"ACGTN"), b"NACGT".to_vec());
-/// assert_eq!(reverse_complement(b"acgt"), b"ACGT".to_vec());  // normalized to uppercase
+/// assert_eq!(reverse_complement(b"NRG"), b"CYN".to_vec()); // IUPAC-aware
+/// assert_eq!(reverse_complement(b"acgt"), b"acgt".to_vec()); // case preserved
 /// ```
 #[must_use]
 pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
     seq.iter().rev().map(|&base| complement_base(base)).collect()
 }
 
-/// Complements a single DNA base, preserving case.
+/// Reverse complements a DNA string (IUPAC-aware, case-preserving).
 ///
-/// Returns the Watson-Crick complement: A<->T, C<->G. RNA uracil (`U`/`u`)
-/// complements to `A`/`a`, matching fgbio's `Sequences.complement`.
-/// Unlike [`complement_base`], this preserves the case of the input:
-/// uppercase input produces uppercase output, lowercase produces lowercase.
-///
-/// # Examples
-///
-/// ```
-/// use fgumi_dna::dna::complement_base_preserve_case;
-///
-/// assert_eq!(complement_base_preserve_case(b'A'), b'T');
-/// assert_eq!(complement_base_preserve_case(b'a'), b't');
-/// ```
-#[inline]
-#[must_use]
-pub const fn complement_base_preserve_case(base: u8) -> u8 {
-    match base {
-        b'A' => b'T',
-        // T and RNA uracil U both complement to A (fgbio Sequences.complement)
-        b'T' | b'U' => b'A',
-        b'C' => b'G',
-        b'G' => b'C',
-        b'a' => b't',
-        b't' | b'u' => b'a',
-        b'c' => b'g',
-        b'g' => b'c',
-        other => other,
-    }
-}
-
-/// Reverse complements a DNA string, preserving case.
-///
-/// Returns the reverse complement of the input string.
-/// Unlike [`reverse_complement`], this preserves the case of each base.
-/// Non-ASCII characters are passed through unchanged.
+/// Reverses the string and complements each ASCII byte via [`complement_base`]
+/// (case preserved, IUPAC-aware, unknown bytes unchanged). Non-ASCII characters
+/// pass through unchanged.
 ///
 /// # Examples
 ///
@@ -112,15 +123,47 @@ pub const fn complement_base_preserve_case(base: u8) -> u8 {
 pub fn reverse_complement_str(seq: &str) -> String {
     seq.chars()
         .rev()
-        .map(|c| if c.is_ascii() { complement_base_preserve_case(c as u8) as char } else { c })
+        .map(|c| if c.is_ascii() { complement_base(c as u8) as char } else { c })
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::*;
+
+    #[test]
+    fn test_complement_base_iupac_and_case() {
+        // fgbio Sequences.complement: full IUPAC table, case-preserving (R2-SEQ-01/02).
+        assert_eq!(complement_base(b'R'), b'Y');
+        assert_eq!(complement_base(b'Y'), b'R');
+        assert_eq!(complement_base(b'S'), b'S');
+        assert_eq!(complement_base(b'W'), b'W');
+        assert_eq!(complement_base(b'K'), b'M');
+        assert_eq!(complement_base(b'M'), b'K');
+        assert_eq!(complement_base(b'B'), b'V');
+        assert_eq!(complement_base(b'V'), b'B');
+        assert_eq!(complement_base(b'D'), b'H');
+        assert_eq!(complement_base(b'H'), b'D');
+        assert_eq!(complement_base(b'U'), b'A');
+        // Lowercase IUPAC/ACGT preserve case.
+        assert_eq!(complement_base(b'a'), b't');
+        assert_eq!(complement_base(b'u'), b'a'); // RNA uracil, case preserved
+        assert_eq!(complement_base(b'r'), b'y');
+        assert_eq!(complement_base(b'k'), b'm');
+        // Unknown bytes pass through unchanged (R2-SEQ-03: documented passthrough).
+        assert_eq!(complement_base(b'.'), b'.');
+        assert_eq!(complement_base(b'X'), b'X');
+    }
+
+    #[test]
+    fn test_reverse_complement_fgbio_parity() {
+        // fgbio SequencesTest.scala:160,161 — the headline parity cases (R2-SEQ-01/02).
+        assert_eq!(reverse_complement(b"NRG"), b"CYN".to_vec());
+        assert_eq!(reverse_complement(b"acacNNNN"), b"NNNNgtgt".to_vec());
+        // RNA uracil complements to A (matches fgbio revcomp of 'r'-prefixed UMIs).
+        assert_eq!(reverse_complement(b"AAU"), b"ATT".to_vec());
+        assert_eq!(reverse_complement(b"U"), b"A".to_vec());
+    }
 
     #[test]
     fn test_complement_base() {
@@ -130,27 +173,18 @@ mod tests {
         assert_eq!(complement_base(b'C'), b'G');
         assert_eq!(complement_base(b'G'), b'C');
 
-        // Lowercase normalized to uppercase
-        assert_eq!(complement_base(b'a'), b'T');
-        assert_eq!(complement_base(b't'), b'A');
-        assert_eq!(complement_base(b'c'), b'G');
-        assert_eq!(complement_base(b'g'), b'C');
-
-        // RNA uracil complements to A (fgbio Sequences.complement: U/u -> A/a)
-        assert_eq!(complement_base(b'U'), b'A');
-        assert_eq!(complement_base(b'u'), b'A');
+        // Lowercase preserves case (matches fgbio)
+        assert_eq!(complement_base(b'a'), b't');
+        assert_eq!(complement_base(b't'), b'a');
+        assert_eq!(complement_base(b'c'), b'g');
+        assert_eq!(complement_base(b'g'), b'c');
 
         // N bases preserve case (fgbio uses lowercase 'n' for padding)
         assert_eq!(complement_base(b'N'), b'N');
         assert_eq!(complement_base(b'n'), b'n');
 
-        // IUPAC ambiguity codes unchanged
-        for code in [b'R', b'Y', b'S', b'W', b'K', b'M', b'B', b'D', b'H', b'V'] {
-            assert_eq!(complement_base(code), code);
-        }
-
-        // Special characters unchanged
-        for c in [b'.', b'-', b'*', b'0', b'X'] {
+        // Non-base bytes pass through unchanged
+        for c in [b'.', b'-', b'*', b'0'] {
             assert_eq!(complement_base(c), c);
         }
     }
@@ -166,13 +200,9 @@ mod tests {
         assert_eq!(reverse_complement(b"GGGG"), b"CCCC".to_vec());
         assert_eq!(reverse_complement(b"ACGTN"), b"NACGT".to_vec());
 
-        // RNA uracil complements to A (matches fgbio revcomp of 'r'-prefixed UMIs)
-        assert_eq!(reverse_complement(b"AAU"), b"ATT".to_vec());
-        assert_eq!(reverse_complement(b"U"), b"A".to_vec());
-
-        // Lowercase normalized to uppercase
-        assert_eq!(reverse_complement(b"acgt"), b"ACGT".to_vec());
-        assert_eq!(reverse_complement(b"AcGt"), b"ACGT".to_vec());
+        // Case preserved (matches fgbio)
+        assert_eq!(reverse_complement(b"acgt"), b"acgt".to_vec());
+        assert_eq!(reverse_complement(b"AcGt"), b"aCgT".to_vec());
 
         // Palindromic sequences
         assert_eq!(reverse_complement(b"ACGT"), b"ACGT".to_vec());
@@ -181,28 +211,6 @@ mod tests {
         // Double operation returns original (uppercase)
         let seq = b"ACGTACGT";
         assert_eq!(reverse_complement(&reverse_complement(seq)), seq.to_vec());
-    }
-
-    #[rstest]
-    #[case(b'A', b'T')]
-    #[case(b'T', b'A')]
-    #[case(b'C', b'G')]
-    #[case(b'G', b'C')]
-    #[case(b'a', b't')]
-    #[case(b't', b'a')]
-    #[case(b'c', b'g')]
-    #[case(b'g', b'c')]
-    #[case(b'U', b'A')]
-    #[case(b'u', b'a')]
-    #[case(b'N', b'N')]
-    #[case(b'n', b'n')]
-    #[case(b'.', b'.')]
-    #[case(b'-', b'-')]
-    #[case(b'*', b'*')]
-    #[case(b'0', b'0')]
-    #[case(b'X', b'X')]
-    fn test_complement_base_preserve_case(#[case] input: u8, #[case] expected: u8) {
-        assert_eq!(complement_base_preserve_case(input), expected);
     }
 
     #[test]

--- a/crates/fgumi-dna/src/lib.rs
+++ b/crates/fgumi-dna/src/lib.rs
@@ -12,9 +12,7 @@ pub mod dna;
 
 // Re-export submodule contents at crate root for convenience
 pub use bitenc::BitEnc;
-pub use dna::{
-    complement_base, complement_base_preserve_case, reverse_complement, reverse_complement_str,
-};
+pub use dna::{COMPLEMENT, complement_base, reverse_complement, reverse_complement_str};
 
 /// No-call base character (matches fgbio's `NoCallBase`).
 pub const NO_CALL_BASE: u8 = b'N';

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 noodles = { version = "0.111.0", features = ["bam", "bgzf", "core", "csi", "sam"], optional = true }
 anyhow = { version = "1.0.102", optional = true }
 bytemuck = { workspace = true }
+fgumi-dna = { workspace = true }
 fgumi-tag = { workspace = true }
 wide = { workspace = true }
 

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -858,7 +858,11 @@ pub fn reverse_string_tag_in_place(record: &mut [u8], aux_offset: usize, tag: im
     }
 }
 
-/// Reverse-complement a Z-type string tag value in place (A<->T, C<->G).
+/// Reverse-complement a Z-type string tag value in place.
+///
+/// Uses `fgumi_dna::COMPLEMENT`, the shared IUPAC-aware, case-preserving
+/// complement table (unknown bytes pass through), so tag reverse-complement
+/// matches the consensus base paths and fgbio/htsjdk (`R<->Y`, etc.).
 #[inline]
 pub fn reverse_complement_string_tag_in_place(
     record: &mut [u8],
@@ -869,13 +873,7 @@ pub fn reverse_complement_string_tag_in_place(
     if let Some((start, end)) = find_string_tag_range(record, aux_offset, *tag) {
         record[start..end].reverse();
         for b in &mut record[start..end] {
-            *b = match *b {
-                b'A' | b'a' => b'T',
-                b'T' | b't' => b'A',
-                b'C' | b'c' => b'G',
-                b'G' | b'g' => b'C',
-                other => other,
-            };
+            *b = fgumi_dna::COMPLEMENT[*b as usize];
         }
     }
 }
@@ -3369,8 +3367,20 @@ mod tests {
         let aux_offset = aux_data_offset_from_record(&rec)
             .expect("record should have valid header for aux offset");
         reverse_complement_string_tag_in_place(&mut rec, aux_offset, SamTag::RX);
-        // lowercase a->T, c->G, g->C, t->A, reversed: ACGT
-        assert_eq!(find_string_tag(&rec[aux_offset..], SamTag::RX), Some(b"ACGT".as_ref()));
+        // case-preserving: acgt -> reverse tgca -> complement acgt
+        assert_eq!(find_string_tag(&rec[aux_offset..], SamTag::RX), Some(b"acgt".as_ref()));
+    }
+
+    #[test]
+    fn test_reverse_complement_string_tag_in_place_iupac_and_case() {
+        // IUPAC-aware + case-preserving, sharing fgumi-dna's COMPLEMENT table (R2-SEQ-04).
+        // "NRG" -> reverse "GRN" -> complement "CYN"
+        let aux = b"RXZNRG\x00";
+        let mut rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let aux_offset = aux_data_offset_from_record(&rec)
+            .expect("record should have valid header for aux offset");
+        reverse_complement_string_tag_in_place(&mut rec, aux_offset, SamTag::RX);
+        assert_eq!(find_string_tag(&rec[aux_offset..], SamTag::RX), Some(b"CYN".as_ref()));
     }
 
     #[test]

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -32,17 +32,18 @@ static QUAL_TO_ASCII: [u8; 256] = {
 
 /// Lookup table for base complement (A<->T, C<->G, others->N)
 static COMPLEMENT: [u8; 256] = {
+    // Values are shared from `fgumi_dna::COMPLEMENT` (IUPAC-aware, case-preserving),
+    // but this table keeps the FASTQ-validity policy: any byte outside the valid
+    // IUPAC alphabet folds to 'N', since an emitted FASTQ base must be a valid
+    // nucleotide code (unlike the consensus/tag paths, which pass unknowns through).
     let mut table = [b'N'; 256];
-    table[b'A' as usize] = b'T';
-    table[b'a' as usize] = b'T';
-    table[b'T' as usize] = b'A';
-    table[b't' as usize] = b'A';
-    table[b'C' as usize] = b'G';
-    table[b'c' as usize] = b'G';
-    table[b'G' as usize] = b'C';
-    table[b'g' as usize] = b'C';
-    table[b'N' as usize] = b'N';
-    table[b'n' as usize] = b'N';
+    const VALID: &[u8] = b"ACGTURYSWKMBVDHNacgturyswkmbvdhn";
+    let mut i = 0;
+    while i < VALID.len() {
+        let base = VALID[i];
+        table[base as usize] = fgumi_dna::COMPLEMENT[base as usize];
+        i += 1;
+    }
     table
 };
 
@@ -368,16 +369,29 @@ mod tests {
         assert_eq!(COMPLEMENT[b'G' as usize], b'C');
         assert_eq!(COMPLEMENT[b'N' as usize], b'N');
 
-        // Lowercase
-        assert_eq!(COMPLEMENT[b'a' as usize], b'T');
-        assert_eq!(COMPLEMENT[b't' as usize], b'A');
-        assert_eq!(COMPLEMENT[b'c' as usize], b'G');
-        assert_eq!(COMPLEMENT[b'g' as usize], b'C');
-        assert_eq!(COMPLEMENT[b'n' as usize], b'N');
+        // Lowercase (case preserved)
+        assert_eq!(COMPLEMENT[b'a' as usize], b't');
+        assert_eq!(COMPLEMENT[b't' as usize], b'a');
+        assert_eq!(COMPLEMENT[b'c' as usize], b'g');
+        assert_eq!(COMPLEMENT[b'g' as usize], b'c');
+        assert_eq!(COMPLEMENT[b'n' as usize], b'n'); // case preserved (shared table)
 
         // Unknown bases map to N
         assert_eq!(COMPLEMENT[b'X' as usize], b'N');
         assert_eq!(COMPLEMENT[0], b'N');
+    }
+
+    #[test]
+    fn test_complement_lookup_table_iupac_and_case() {
+        // IUPAC-aware (values shared from fgumi_dna::COMPLEMENT), case-preserving,
+        // but keeps the FASTQ-validity policy of folding invalid bytes to N.
+        assert_eq!(COMPLEMENT[b'R' as usize], b'Y');
+        assert_eq!(COMPLEMENT[b'Y' as usize], b'R');
+        assert_eq!(COMPLEMENT[b'K' as usize], b'M');
+        assert_eq!(COMPLEMENT[b'S' as usize], b'S');
+        assert_eq!(COMPLEMENT[b'a' as usize], b't'); // case preserved
+        assert_eq!(COMPLEMENT[b'r' as usize], b'y');
+        assert_eq!(COMPLEMENT[b'.' as usize], b'N'); // invalid -> N (FASTQ validity)
     }
 
     #[test]


### PR DESCRIPTION
## What & why

fgumi's `complement_base` handled only A/C/G/T/N and passed every IUPAC ambiguity code through **un-complemented**, while also uppercasing lowercase bases — diverging from fgbio's `Sequences.complement` / htsjdk `SequenceUtil`. `SequencesTest.scala:161` pins `Sequences.revcomp("NRG") == "CYN"`; fgumi produced `"CRN"`. The same defect lived in two more independently hand-rolled tables: `fgumi-raw-bam`'s per-base tag reverse-complement, and the `fastq` command's BAM→FASTQ complement (the latter folding IUPAC codes to `N`).

This replaces all three with a single shared `const [u8; 256]` table, `fgumi_dna::COMPLEMENT`:

- full IUPAC complement (`R↔Y`, `K↔M`, `B↔V`, `D↔H`, `S`, `W`, `U→A`, `N`)
- case-preserving (`a→t`), matching fgbio (CODEC lowercase-`n` round trips)
- unknown bytes pass through unchanged (identity); the `simulate` command relies on this
- branch-free single load (a `u8` index into a 256-entry table elides the bounds check), replacing the previous branchy `match` — no hot-path regression

### Call sites rewired

- `fgumi-dna` — `complement_base` / `reverse_complement{,_in_place,_str}`
- `fgumi-raw-bam` — `reverse_complement_string_tag_in_place` (gains a `fgumi-dna` dep)
- `fastq` command — its `COMPLEMENT` static derives its values from the shared table but keeps the FASTQ-validity policy of folding invalid bytes to `N` (unlike the consensus/tag paths, which pass unknowns through)

Also removes the now-redundant `complement_base_preserve_case` (`complement_base` is itself case-preserving) and points `reverse_complement_str` at it.

## Tracker findings

Addresses **R2-SEQ-01** (IUPAC complement), **R2-SEQ-02** (case preservation), **R2-SEQ-03** (documented unknown-passthrough), **R2-SEQ-04** (the tag-path copy), and **R2-SEQ-05** (the `fastq` command's table) from the round-2 fgbio behavioral-parity audit.

## Parity evidence

The correct outputs are fgbio's own unit-test vectors: `SequencesTest.scala:160-161` asserts `revcomp("NRG") == "CYN"` and `revcomp("acacNNNN") == "NNNNgtgt"`. The new fgumi tests assert exactly these, written RED-first — before the fix `reverse_complement(b"NRG")` returned `CRN`; after, `CYN`. A synthetic CLI fgbio-vs-fgumi run was deliberately skipped for this item: it is a pure primitive whose ground truth *is* those fgbio vectors, and the CLI trigger (IUPAC bases in read sequence or tags) does not occur in real data, so a run would only exercise a hand-injected fixture. The tool-level round-2 items (clip, codec, group/consensus guards, metrics) will carry the full end-to-end fgbio reproduction.

## Testing

- TDD RED→GREEN for each of the three sites (`dna.rs`, `tags.rs`, `fastq.rs`).
- Full workspace suite: 2223 passed, 0 failed. `cargo ci-fmt` and `cargo ci-lint` clean.
- CodeRabbit self-review (`/coderabbitai-review`) run against the branch diff; its one finding — the third, un-unified `fastq.rs` complement table — is folded into this PR as R2-SEQ-05.

## Stacking

Stacked on #489 (`nh/fix-extract-readname-umi-strict`). Both PRs edit `crates/fgumi-dna/src/dna.rs`: #489 adds `U→A` uracil complement for its `r`-prefix UMI reverse-complement, and this PR's shared LUT subsumes that (the table already maps `U→A`/`u→a`; #489's uracil test coverage is preserved). **Merge #489 first** — this PR will retarget to `main` automatically once #489 lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reverse-complementing now fully supports IUPAC nucleotide codes with case preserved.
  * String reverse-complement leaves non-ASCII characters unchanged.
  * Exposed a public complement lookup for consistent use across components.
* **Bug Fixes**
  * FASTQ and tag reverse-complementing now correctly handles ambiguous bases; invalid/non-alphabet bytes map to a safe default.
* **Breaking Changes**
  * Removed the previously available case-preserving single-base complement helper; switch to the new complement lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->