### PR TITLE
fix(clip): unmap fully-clipped reads and match fgbio unmap/mate fidelity (CLIP-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "fgumi-tag",
  "log",
  "noodles",
+ "rstest",
  "tempfile",
 ]
 

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -20,6 +20,7 @@ tempfile = "3.3.0"
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+rstest = "0.26"
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -45,6 +45,45 @@ macro_rules! slice_array {
     };
 }
 
+/// Base-oriented aux tags that are reverse-complemented (with `SEQ`) when a read is
+/// reverse-complemented, mirroring htsjdk `SAMRecord.TAGS_TO_REVERSE_COMPLEMENT`.
+const TAGS_TO_REVERSE_COMPLEMENT: [fgumi_raw_bam::SamTag; 2] =
+    [fgumi_raw_bam::SamTag::E2, fgumi_raw_bam::SamTag::SQ];
+
+/// Quality-oriented aux tags that are reversed (with `QUAL`) when a read is
+/// reverse-complemented, mirroring htsjdk `SAMRecord.TAGS_TO_REVERSE`.
+const TAGS_TO_REVERSE: [fgumi_raw_bam::SamTag; 2] =
+    [fgumi_raw_bam::SamTag::OQ, fgumi_raw_bam::SamTag::U2];
+
+/// Reorients the strand-sensitive aux tags of a `RecordBuf` the way htsjdk
+/// `SAMRecord.reverseComplement` does when unmapping a reverse-strand read:
+/// reverse-complement the base-oriented tags ([`TAGS_TO_REVERSE_COMPLEMENT`]) and
+/// reverse the quality-oriented tags ([`TAGS_TO_REVERSE`]).
+///
+/// Only the `Z`-string encoding is handled — the sole form these tags take in practice.
+/// htsjdk additionally reverses array-encoded (`B:...`) values, but none of these tags
+/// is emitted as an array by real tooling, and skipping them keeps this in lockstep with
+/// the raw path (`RawTagsMut::reverse_string` / `reverse_complement_string`).
+fn reorient_strand_tags(record: &mut RecordBuf) {
+    for tag in TAGS_TO_REVERSE_COMPLEMENT {
+        if let Some(Value::String(s)) = record.data_mut().get_mut(&tag.to_noodles_tag()) {
+            let mut bytes = s.to_vec();
+            bytes.reverse();
+            for b in &mut bytes {
+                *b = fgumi_dna::complement_base(*b);
+            }
+            *s = bytes.into();
+        }
+    }
+    for tag in TAGS_TO_REVERSE {
+        if let Some(Value::String(s)) = record.data_mut().get_mut(&tag.to_noodles_tag()) {
+            let mut bytes = s.to_vec();
+            bytes.reverse();
+            *s = bytes.into();
+        }
+    }
+}
+
 /// Modes of clipping that can be applied to reads
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ClippingMode {
@@ -155,6 +194,69 @@ impl SamRecordClipper {
         }
     }
 
+    /// Number of bases available to be clipped from the alignment.
+    ///
+    /// The sum of the alignment (`M`/`=`/`X`) and insertion (`I`) CIGAR op lengths,
+    /// i.e. the read bases that are aligned. Mirrors fgbio `numberOfClippableBases`.
+    fn number_of_clippable_bases(record: &RecordBuf) -> usize {
+        record
+            .cigar()
+            .iter()
+            .filter_map(Result::ok)
+            .filter(|op| {
+                matches!(
+                    op.kind(),
+                    Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch | Kind::Insertion
+                )
+            })
+            .map(CigarOp::len)
+            .sum()
+    }
+
+    /// Unmaps a read the way htsjdk `SAMUtils.makeReadUnmapped` does.
+    ///
+    /// Clears the reference, position, mapping quality, CIGAR, and template length, and
+    /// clears the duplicate, secondary, supplementary, and proper-pair flags while setting
+    /// the unmapped flag. For reverse-strand reads the (reference-forward) bases are
+    /// reverse-complemented, the qualities reversed, and the strand-sensitive aux tags
+    /// reoriented (see [`reorient_strand_tags`]) — returning them to original read
+    /// orientation — before the reverse-strand flag is cleared. Bases and qualities are
+    /// otherwise preserved (they are *not* dropped).
+    fn make_read_unmapped(record: &mut RecordBuf) {
+        use noodles::sam::alignment::record::Flags;
+
+        if record.flags().is_reverse_complemented() {
+            let rc = fgumi_dna::reverse_complement(record.sequence().as_ref());
+            let mut quals: Vec<u8> = record.quality_scores().as_ref().to_vec();
+            quals.reverse();
+            *record.sequence_mut() = Sequence::from(rc);
+            *record.quality_scores_mut() = QualityScores::from(quals);
+            reorient_strand_tags(record);
+        }
+
+        let flags = record.flags_mut();
+        flags.remove(
+            Flags::REVERSE_COMPLEMENTED
+                | Flags::DUPLICATE
+                | Flags::SECONDARY
+                | Flags::SUPPLEMENTARY
+                | Flags::PROPERLY_SEGMENTED,
+        );
+        flags.insert(Flags::UNMAPPED);
+
+        *record.reference_sequence_id_mut() = None;
+        *record.alignment_start_mut() = None;
+        // htsjdk makeReadUnmapped sets NO_MAPPING_QUALITY (0), not the "unavailable"
+        // sentinel: a typed `None` here would serialize to BAM MAPQ 255, diverging from
+        // both htsjdk and the raw path (`make_read_unmapped_raw` sets 0).
+        *record.mapping_quality_mut() = Some(
+            noodles::sam::alignment::record::MappingQuality::try_from(0u8)
+                .expect("0 is a valid mapping quality"),
+        );
+        *record.template_length_mut() = 0;
+        *record.cigar_mut() = CigarBuf::default();
+    }
+
     /// Clips a specified number of bases from the start (left side) of the alignment
     ///
     /// Returns the number of bases actually clipped
@@ -181,6 +283,14 @@ impl SamRecordClipper {
         let sequence_len = record.sequence();
         if sequence_len.is_empty() {
             return 0;
+        }
+
+        // If the read has no more clippable (aligned/inserted) bases than requested, it
+        // cannot retain an alignment; unmap it (fgbio SamRecordClipper.scala:111-114).
+        let num_clippable = Self::number_of_clippable_bases(record);
+        if num_clippable <= bases_to_clip {
+            Self::make_read_unmapped(record);
+            return num_clippable;
         }
 
         // Collect existing CIGAR ops
@@ -357,6 +467,14 @@ impl SamRecordClipper {
         let sequence_len = record.sequence();
         if sequence_len.is_empty() {
             return 0;
+        }
+
+        // If the read has no more clippable (aligned/inserted) bases than requested, it
+        // cannot retain an alignment; unmap it (fgbio SamRecordClipper.scala:157-160).
+        let num_clippable = Self::number_of_clippable_bases(record);
+        if num_clippable <= bases_to_clip {
+            Self::make_read_unmapped(record);
+            return num_clippable;
         }
 
         // Collect existing CIGAR ops
@@ -1392,6 +1510,60 @@ impl RawRecordClipper {
         }
     }
 
+    /// Number of bases available to be clipped from the alignment.
+    ///
+    /// The sum of the alignment (`M`/`=`/`X`) and insertion (`I`) CIGAR op lengths.
+    /// Raw-byte equivalent of [`SamRecordClipper::number_of_clippable_bases`].
+    fn number_of_clippable_bases_raw(ops: &[u32]) -> usize {
+        ops.iter()
+            .filter(|&&op| matches!(op & 0xF, 0 | 1 | 7 | 8)) // M, I, =, X
+            .map(|&op| (op >> 4) as usize)
+            .sum()
+    }
+
+    /// Unmaps a read the way htsjdk `SAMUtils.makeReadUnmapped` does.
+    ///
+    /// Raw-byte equivalent of [`SamRecordClipper::make_read_unmapped`]: clears the
+    /// reference, position, mapping quality, CIGAR, and template length, clears the
+    /// duplicate/secondary/supplementary/proper-pair flags, and sets the unmapped flag.
+    /// Reverse-strand reads have their bases reverse-complemented, qualities reversed, and
+    /// strand-sensitive aux tags reoriented (see [`reorient_strand_tags`]) before the
+    /// reverse flag is cleared. Bases and qualities are otherwise preserved.
+    fn make_read_unmapped_raw(record: &mut fgumi_raw_bam::RawRecord) {
+        use fgumi_raw_bam::flags as rflags;
+
+        let flags = record.flags();
+        if flags & rflags::REVERSE != 0 {
+            let rc = fgumi_dna::reverse_complement(&record.sequence_vec());
+            let mut quals = record.quality_scores().to_vec();
+            quals.reverse();
+            record.set_sequence_and_qualities(&rc, &quals);
+            // Reorient the strand-sensitive aux tags alongside SEQ/QUAL, matching htsjdk
+            // `SAMRecord.reverseComplement` (see `reorient_strand_tags` for the Z-only note).
+            let mut tags = record.tags_mut();
+            for tag in TAGS_TO_REVERSE_COMPLEMENT {
+                tags.reverse_complement_string(tag);
+            }
+            for tag in TAGS_TO_REVERSE {
+                tags.reverse_string(tag);
+            }
+        }
+
+        let new_flags = (flags
+            & !(rflags::REVERSE
+                | rflags::DUPLICATE
+                | rflags::SECONDARY
+                | rflags::SUPPLEMENTARY
+                | rflags::PROPER_PAIR))
+            | rflags::UNMAPPED;
+        record.set_flags(new_flags);
+        record.set_ref_id(-1);
+        record.set_pos(-1);
+        record.set_mapq(0);
+        record.set_template_length(0);
+        record.set_cigar_ops(&[]);
+    }
+
     /// Clips a specified number of bases from the start (left side) of the alignment.
     ///
     /// Returns the number of bases actually clipped.
@@ -1429,6 +1601,14 @@ impl RawRecordClipper {
         }
 
         let old_ops: Vec<u32> = record.cigar_ops_vec();
+
+        // If the read has no more clippable (aligned/inserted) bases than requested, it
+        // cannot retain an alignment; unmap it (fgbio SamRecordClipper.scala:111-114).
+        let num_clippable = Self::number_of_clippable_bases_raw(&old_ops);
+        if num_clippable <= bases_to_clip {
+            Self::make_read_unmapped_raw(record);
+            return num_clippable;
+        }
 
         // Extract existing hard and soft clips from the start
         let existing_hard_clip: usize = old_ops
@@ -1568,6 +1748,10 @@ impl RawRecordClipper {
         clippy::cast_possible_truncation,
         reason = "CIGAR lengths are bounded by BAM read length which fits in u32"
     )]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "mirrors clip_start_of_alignment with symmetric end-clipping logic"
+    )]
     pub fn clip_end_of_alignment(
         &self,
         record: &mut fgumi_raw_bam::RawRecord,
@@ -1586,6 +1770,14 @@ impl RawRecordClipper {
         }
 
         let old_ops: Vec<u32> = record.cigar_ops_vec();
+
+        // If the read has no more clippable (aligned/inserted) bases than requested, it
+        // cannot retain an alignment; unmap it (fgbio SamRecordClipper.scala:157-160).
+        let num_clippable = Self::number_of_clippable_bases_raw(&old_ops);
+        if num_clippable <= bases_to_clip {
+            Self::make_read_unmapped_raw(record);
+            return num_clippable;
+        }
 
         // Extract existing hard and soft clips from the end (reverse order)
         let existing_hard_clip: usize = old_ops
@@ -2725,17 +2917,20 @@ mod tests {
         let seq = "ACGTACGTACGTACGTACGT"; // 20 bases
         let mut record = create_test_record("10S10M", seq, 10);
 
+        // Only 10 clippable (aligned) bases; requesting 10 consumes the whole alignment,
+        // so fgbio unmaps the read (SamRecordClipper.scala:111-114) rather than masking.
         let clipped = clipper.clip_start_of_alignment(&mut record, 10);
         assert_eq!(clipped, 10);
 
-        let cigar_str = format_cigar(&record.cigar());
-        assert_eq!(cigar_str, "20S"); // All bases now soft-clipped (0M operations are removed)
+        assert!(record.flags().is_unmapped(), "read should be unmapped");
+        assert_eq!(record.cigar().iter().count(), 0, "CIGAR should be empty");
 
-        // Check all 20 bases are masked to N
-        let bases = record.sequence();
-        for i in 0..20 {
-            assert_eq!(bases.as_ref()[i], b'N');
-        }
+        // Bases are preserved (NOT masked) on unmap — makeReadUnmapped keeps seq/qual.
+        assert_eq!(
+            record.sequence().as_ref(),
+            seq.as_bytes(),
+            "bases should be preserved, not masked"
+        );
     }
 
     #[test]
@@ -4700,11 +4895,13 @@ mod tests {
         let clipper = SamRecordClipper::new(ClippingMode::Soft);
         let mut record = create_test_record("10M", &"A".repeat(10), 1000);
 
+        // Clipping all 10 aligned bases leaves no alignment, so fgbio unmaps the read
+        // (SamRecordClipper.scala:157-160) instead of emitting an all-soft-clip CIGAR.
         let clipped = clipper.clip_end_of_alignment(&mut record, 10);
         assert_eq!(clipped, 10);
 
-        let cigar = format_cigar(&record.cigar());
-        assert_eq!(cigar, "10S");
+        assert!(record.flags().is_unmapped(), "read should be unmapped");
+        assert_eq!(record.cigar().iter().count(), 0, "CIGAR should be empty");
     }
 
     #[test]
@@ -5285,6 +5482,7 @@ mod crosscheck_tests {
     use noodles::sam::alignment::RecordBuf;
     use noodles::sam::alignment::record::Sequence as SequenceTrait;
     use noodles::sam::alignment::record::cigar::op::Kind;
+    use rstest::rstest;
 
     /// Build a SAM header with a single reference sequence of length 100 000.
     fn test_header() -> noodles::sam::Header {
@@ -5757,6 +5955,274 @@ mod crosscheck_tests {
 
             assert_eq!(buf_c, raw_c, "3' positive mode={mode:?}");
             assert_raw_matches_buf(&raw, &buf, &format!("clip_3prime pos mode={mode:?}"));
+        }
+    }
+
+    // =========================================================================
+    // Unmap-when-fully-clipped cross-checks (CLIP-01)
+    //
+    // fgbio `SamRecordClipper.clip{Start,End}OfAlignment` unmaps the read (via
+    // htsjdk `SAMUtils.makeReadUnmapped`) when the requested clip is >= the number
+    // of clippable (alignment + insertion) bases, keeping bases/quals intact.
+    // Refs: SamRecordClipper.scala:106-128,152-173; SamRecordClipperTest.scala:168,311.
+    // =========================================================================
+
+    /// Assert both clippers put the record into the fgbio `makeReadUnmapped` state
+    /// and that the raw and typed records agree on sequence and qualities.
+    fn assert_both_unmapped(raw: &RawRecord, buf: &RecordBuf, context: &str) {
+        use fgumi_raw_bam::flags as rflags;
+
+        // --- RecordBuf (typed) ---
+        assert!(buf.flags().is_unmapped(), "{context}: buf not unmapped");
+        assert!(!buf.flags().is_reverse_complemented(), "{context}: buf reverse not cleared");
+        assert!(!buf.flags().is_duplicate(), "{context}: buf duplicate not cleared");
+        assert!(!buf.flags().is_secondary(), "{context}: buf secondary not cleared");
+        assert!(!buf.flags().is_supplementary(), "{context}: buf supplementary not cleared");
+        assert!(!buf.flags().is_properly_segmented(), "{context}: buf proper-pair not cleared");
+        assert_eq!(buf.reference_sequence_id(), None, "{context}: buf ref id");
+        assert_eq!(buf.alignment_start(), None, "{context}: buf alignment start");
+        // MAPQ must be 0 (htsjdk NO_MAPPING_QUALITY), NOT the "unavailable" sentinel
+        // that a typed `None` serializes to (255). This must equal the raw path's 0
+        // below — the two clippers agree on the same on-wire MAPQ.
+        assert_eq!(
+            buf.mapping_quality().map(u8::from),
+            Some(0u8),
+            "{context}: buf mapq should be 0 (htsjdk makeReadUnmapped), matching raw path"
+        );
+        assert_eq!(buf.template_length(), 0, "{context}: buf tlen");
+        assert_eq!(buf.cigar().iter().count(), 0, "{context}: buf cigar not empty");
+
+        // --- RawRecord ---
+        assert!(raw.flags() & rflags::UNMAPPED != 0, "{context}: raw not unmapped");
+        assert!(raw.flags() & rflags::REVERSE == 0, "{context}: raw reverse not cleared");
+        assert!(raw.flags() & rflags::DUPLICATE == 0, "{context}: raw duplicate not cleared");
+        assert!(raw.flags() & rflags::SECONDARY == 0, "{context}: raw secondary not cleared");
+        assert!(
+            raw.flags() & rflags::SUPPLEMENTARY == 0,
+            "{context}: raw supplementary not cleared"
+        );
+        assert!(raw.flags() & rflags::PROPER_PAIR == 0, "{context}: raw proper-pair not cleared");
+        assert_eq!(raw.ref_id(), -1, "{context}: raw ref id");
+        assert_eq!(raw.pos(), -1, "{context}: raw pos");
+        assert_eq!(raw.mapq(), 0, "{context}: raw mapq");
+        assert_eq!(raw.template_length(), 0, "{context}: raw tlen");
+        assert!(raw.cigar_ops_vec().is_empty(), "{context}: raw cigar not empty");
+
+        // --- Cross-check seq & qual (bases/quals are preserved on unmap) ---
+        let buf_seq: Vec<u8> = buf.sequence().iter().collect();
+        assert_eq!(raw.sequence_vec(), buf_seq, "{context}: seq mismatch");
+        assert_eq!(
+            raw.quality_scores().to_vec(),
+            buf.quality_scores().as_ref().to_vec(),
+            "{context}: qual mismatch"
+        );
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_clip_start_exceeds_alignment(
+        #[values(ClippingMode::Soft, ClippingMode::SoftWithMask, ClippingMode::Hard)]
+        mode: ClippingMode,
+    ) {
+        // fgbio SamRecordClipperTest.scala:168 — 10S40M, clip 50 from the start.
+        // Only 40 clippable bases (the 40M); 40 <= 50 => unmap, return 40.
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("10S40M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+        let mut raw = to_raw(&buf);
+
+        let buf_c = SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 50);
+        let raw_c = RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 50);
+
+        assert_eq!(buf_c, 40, "buf return count mode={mode:?}");
+        assert_eq!(raw_c, 40, "raw return count mode={mode:?}");
+        assert_eq!(buf.sequence().iter().count(), 50, "buf seq len preserved mode={mode:?}");
+        assert_eq!(raw.l_seq(), 50, "raw seq len preserved mode={mode:?}");
+        assert_both_unmapped(&raw, &buf, &format!("clip_start 10S40M clip=50 mode={mode:?}"));
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_clip_end_exceeds_alignment(
+        #[values(ClippingMode::Soft, ClippingMode::SoftWithMask, ClippingMode::Hard)]
+        mode: ClippingMode,
+    ) {
+        // fgbio SamRecordClipperTest.scala:311 — 40M10S, clip 50 from the end.
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("40M10S")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+        let mut raw = to_raw(&buf);
+
+        let buf_c = SamRecordClipper::new(mode).clip_end_of_alignment(&mut buf, 50);
+        let raw_c = RawRecordClipper::new(mode).clip_end_of_alignment(&mut raw, 50);
+
+        assert_eq!(buf_c, 40, "buf return count mode={mode:?}");
+        assert_eq!(raw_c, 40, "raw return count mode={mode:?}");
+        assert_both_unmapped(&raw, &buf, &format!("clip_end 40M10S clip=50 mode={mode:?}"));
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_boundary_clip_equals_clippable(
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        // Boundary: requesting exactly the clippable-base count also unmaps
+        // (fgbio uses `numClippable <= numberOfBasesToClip`).
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("50M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+        let mut raw = to_raw(&buf);
+
+        let buf_c = SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 50);
+        let raw_c = RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 50);
+
+        assert_eq!(buf_c, 50, "buf return count mode={mode:?}");
+        assert_eq!(raw_c, 50, "raw return count mode={mode:?}");
+        assert_both_unmapped(&raw, &buf, &format!("clip_start 50M clip=50 mode={mode:?}"));
+    }
+
+    #[rstest]
+    fn crosscheck_no_unmap_when_clip_below_clippable(
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        // Regression guard: clipping fewer than the clippable bases must NOT unmap.
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("50M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .build();
+        let mut raw = to_raw(&buf);
+
+        let buf_c = SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 49);
+        let raw_c = RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 49);
+
+        assert_eq!(buf_c, 49, "buf return count mode={mode:?}");
+        assert_eq!(raw_c, 49, "raw return count mode={mode:?}");
+        assert!(!buf.flags().is_unmapped(), "buf must stay mapped mode={mode:?}");
+        assert!(raw.flags() & fgumi_raw_bam::flags::UNMAPPED == 0, "raw must stay mapped");
+        assert_raw_matches_buf(&raw, &buf, &format!("clip_start 50M clip=49 mode={mode:?}"));
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_negative_strand_revcomps_bases(
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        // A negative-strand read that gets fully clipped is unmapped with its stored
+        // (reference-forward) SEQ reverse-complemented and QUAL reversed, mirroring
+        // htsjdk `SAMUtils.makeReadUnmapped` (reverseComplement + clear reverse flag).
+        let seq = format!("{}{}", "A".repeat(25), "C".repeat(25));
+        let expected_rc = fgumi_dna::reverse_complement(seq.as_bytes());
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&seq)
+            .cigar("50M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .reverse_complement(true)
+            .build();
+        let mut raw = to_raw(&buf);
+
+        SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 60);
+        RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 60);
+
+        assert_both_unmapped(&raw, &buf, &format!("neg-strand unmap mode={mode:?}"));
+        assert_eq!(raw.sequence_vec(), expected_rc, "neg-strand seq revcomp mode={mode:?}");
+    }
+
+    /// Reads a `Z`-type string tag back from a typed [`RecordBuf`].
+    fn typed_string_tag(buf: &RecordBuf, tag: [u8; 2]) -> Vec<u8> {
+        use noodles::sam::alignment::record::data::field::Tag;
+        use noodles::sam::alignment::record_buf::data::field::Value;
+        match buf.data().get(&Tag::new(tag[0], tag[1])) {
+            Some(Value::String(s)) => s.to_vec(),
+            other => {
+                panic!("expected string tag {:?}, got {other:?}", String::from_utf8_lossy(&tag))
+            }
+        }
+    }
+
+    /// Reads a `Z`-type string tag back from a [`RawRecord`].
+    fn raw_string_tag(raw: &RawRecord, tag: [u8; 2]) -> Vec<u8> {
+        fgumi_raw_bam::find_string_tag(fgumi_raw_bam::aux_data_slice(raw.as_ref()), tag)
+            .unwrap_or_else(|| panic!("expected string tag {:?}", String::from_utf8_lossy(&tag)))
+            .to_vec()
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_negative_strand_reorients_tags(
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        use fgumi_raw_bam::SamTag;
+        // htsjdk `SAMUtils.makeReadUnmapped` calls `reverseComplement(true)`, which — for
+        // reverse-strand reads — also reverse-complements the base-oriented tags
+        // (E2, SQ) and reverses the quality-oriented tags (OQ, U2), matching
+        // `SAMRecord.TAGS_TO_REVERSE_COMPLEMENT` / `TAGS_TO_REVERSE`.
+        let oq = format!("{}{}", "5".repeat(25), "F".repeat(25)); // reversed -> F*25 5*25
+        let u2 = format!("{}{}", "#".repeat(25), "2".repeat(25)); // reversed -> 2*25 #*25
+        let e2 = format!("{}{}", "A".repeat(25), "C".repeat(25)); // revcomp  -> G*25 T*25
+        let expected_oq = format!("{}{}", "F".repeat(25), "5".repeat(25));
+        let expected_u2 = format!("{}{}", "2".repeat(25), "#".repeat(25));
+        let expected_e2 = format!("{}{}", "G".repeat(25), "T".repeat(25));
+
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("50M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .reverse_complement(true)
+            .tag("OQ", oq.as_str())
+            .tag("U2", u2.as_str())
+            .tag("E2", e2.as_str())
+            .build();
+        let mut raw = to_raw(&buf);
+
+        SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 60);
+        RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 60);
+
+        assert_both_unmapped(&raw, &buf, &format!("neg-strand tag reorient mode={mode:?}"));
+        for (tag, want) in
+            [(*SamTag::OQ, &expected_oq), (*SamTag::U2, &expected_u2), (*SamTag::E2, &expected_e2)]
+        {
+            let label = String::from_utf8_lossy(&tag).into_owned();
+            assert_eq!(typed_string_tag(&buf, tag), want.as_bytes(), "typed {label} mode={mode:?}");
+            assert_eq!(raw_string_tag(&raw, tag), want.as_bytes(), "raw {label} mode={mode:?}");
+        }
+    }
+
+    #[rstest]
+    fn crosscheck_unmap_positive_strand_leaves_tags_untouched(
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        use fgumi_raw_bam::SamTag;
+        // For forward-strand reads, htsjdk `makeReadUnmapped` does NOT call
+        // `reverseComplement`, so the base/quality-oriented tags are left as-is.
+        let oq = format!("{}{}", "5".repeat(25), "F".repeat(25));
+        let e2 = format!("{}{}", "A".repeat(25), "C".repeat(25));
+
+        let mut buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(50))
+            .cigar("50M")
+            .alignment_start(100)
+            .mapping_quality(60)
+            .tag("OQ", oq.as_str())
+            .tag("E2", e2.as_str())
+            .build();
+        let mut raw = to_raw(&buf);
+
+        SamRecordClipper::new(mode).clip_start_of_alignment(&mut buf, 60);
+        RawRecordClipper::new(mode).clip_start_of_alignment(&mut raw, 60);
+
+        assert_both_unmapped(&raw, &buf, &format!("fwd-strand unmap mode={mode:?}"));
+        for (tag, want) in [(*SamTag::OQ, &oq), (*SamTag::E2, &e2)] {
+            let label = String::from_utf8_lossy(&tag).into_owned();
+            assert_eq!(typed_string_tag(&buf, tag), want.as_bytes(), "typed {label} unchanged");
+            assert_eq!(raw_string_tag(&raw, tag), want.as_bytes(), "raw {label} unchanged");
         }
     }
 }

--- a/crates/fgumi-tag/src/tag.rs
+++ b/crates/fgumi-tag/src/tag.rs
@@ -128,6 +128,23 @@ impl SamTag {
     pub const UQ: SamTag = SamTag::new(b'U', b'Q');
     /// Original base quality scores, before recalibration (SAM spec).
     pub const OQ: SamTag = SamTag::new(b'O', b'Q');
+    /// The 2nd-most-likely base calls, a base-oriented `Z` string (SAM spec).
+    ///
+    /// Reverse-complemented alongside `SEQ` when a read is reverse-complemented
+    /// (htsjdk `SAMRecord.TAGS_TO_REVERSE_COMPLEMENT`).
+    pub const E2: SamTag = SamTag::new(b'E', b'2');
+    /// Phred quality of the 2nd-most-likely base calls, a quality-oriented `Z`
+    /// string (SAM spec).
+    ///
+    /// Reversed alongside `QUAL` when a read is reverse-complemented (htsjdk
+    /// `SAMRecord.TAGS_TO_REVERSE`).
+    pub const U2: SamTag = SamTag::new(b'U', b'2');
+    /// Deprecated per-base substitution/quality string, a base-oriented tag
+    /// (SAM spec).
+    ///
+    /// Reverse-complemented alongside `SEQ` when a read is reverse-complemented
+    /// (htsjdk `SAMRecord.TAGS_TO_REVERSE_COMPLEMENT`).
+    pub const SQ: SamTag = SamTag::new(b'S', b'Q');
     /// Per-base offset to base alignment quality (BAQ), `B:C` array (SAM spec).
     ///
     /// Note: the Rust identifier uses a descriptive suffix to avoid a name

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -338,9 +338,9 @@ impl Clip {
                     total_clipped_mate_extension += 1;
                 }
 
-                // Update mate info (MC and MQ tags) using raw tag API
-                update_mate_info_raw(r1, r2);
-                update_mate_info_raw(r2, r1);
+                // Fix full mate-pair info (mate coords/strand, mate-unmapped flag, MQ/MC,
+                // TLEN), matching fgbio ClipBam's SamPairUtil.setMateInfo call.
+                set_mate_info_raw(r1, r2);
             }
 
             // Regenerate alignment tags (always done to match Scala fgbio behavior)
@@ -754,9 +754,9 @@ impl Clip {
                         }
                     }
 
-                    // Update mate info (MC and MQ tags) using raw tag API
-                    update_mate_info_raw(r1, r2);
-                    update_mate_info_raw(r2, r1);
+                    // Fix full mate-pair info (mate coords/strand, mate-unmapped flag,
+                    // MQ/MC, TLEN), matching fgbio ClipBam's SamPairUtil.setMateInfo call.
+                    set_mate_info_raw(r1, r2);
                 }
 
                 // Regenerate alignment tags (always done to match fgbio behavior)
@@ -841,29 +841,147 @@ impl Clip {
     }
 }
 
-/// Updates mate information tags (MC and MQ) for a read based on its mate.
-///
-/// After clipping operations, mate information tags need to be updated to reflect
-/// the new state of the mate read. This function updates:
-/// - MC tag: Mate CIGAR string
-/// - MQ tag: Mate mapping quality
-///
-/// These tags are standard SAM optional tags that store information about the mate
-/// to enable single-ended processing.
-///
-/// # Arguments
-///
-/// * `record` - The record to update (mutable)
-/// * `mate` - The mate record to read information from
-fn update_mate_info_raw(record: &mut RawRecord, mate: &RawRecord) {
-    // Update MC tag: build CIGAR string from raw bytes
-    let cigar_str = mate.cigar_to_string();
-    let mut editor = record.tags_editor();
-    editor.update_string(SamTag::MC, cigar_str.as_bytes());
+/// Snapshot of the mate-relevant fields of a read, taken before any mutation.
+struct MateSnap {
+    ref_id: i32,
+    pos: i32,
+    neg: bool,
+    unmapped: bool,
+    mapq: u8,
+    cigar: String,
+    aln_start: Option<usize>,
+    aln_end: Option<usize>,
+}
 
-    // Update MQ tag: mate mapping quality
-    let mapq = mate.mapq();
-    editor.update_int(SamTag::MQ, i32::from(mapq));
+impl MateSnap {
+    fn of(rec: &RawRecord) -> Self {
+        use fgumi_raw_bam::flags as rflags;
+        Self {
+            ref_id: rec.ref_id(),
+            pos: rec.pos(),
+            neg: rec.flags() & rflags::REVERSE != 0,
+            unmapped: rec.flags() & rflags::UNMAPPED != 0,
+            mapq: rec.mapq(),
+            cigar: rec.cigar_to_string(),
+            aln_start: rec.alignment_start_1based(),
+            aln_end: rec.alignment_end_1based(),
+        }
+    }
+}
+
+/// Sets or clears the `MATE_REVERSE` and `MATE_UNMAPPED` flags on a record.
+fn set_mate_flags_raw(rec: &mut RawRecord, mate_neg: bool, mate_unmapped: bool) {
+    use fgumi_raw_bam::flags as rflags;
+    let mut f = rec.flags();
+    if mate_neg {
+        f |= rflags::MATE_REVERSE;
+    } else {
+        f &= !rflags::MATE_REVERSE;
+    }
+    if mate_unmapped {
+        f |= rflags::MATE_UNMAPPED;
+    } else {
+        f &= !rflags::MATE_UNMAPPED;
+    }
+    rec.set_flags(f);
+}
+
+/// Writes the MQ (mate mapping quality) and MC (mate CIGAR) tags for a read.
+fn set_mate_mq_mc_raw(rec: &mut RawRecord, mate_mapq: u8, mate_cigar: &str) {
+    let mut editor = rec.tags_editor();
+    editor.update_int(SamTag::MQ, i32::from(mate_mapq));
+    editor.update_string(SamTag::MC, mate_cigar.as_bytes());
+}
+
+/// Removes the MQ and MC tags from a read (used when the mate is unmapped).
+fn clear_mate_mq_mc_raw(rec: &mut RawRecord) {
+    let mut editor = rec.tags_editor();
+    editor.remove(SamTag::MQ);
+    editor.remove(SamTag::MC);
+}
+
+/// Computes the TLEN (inferred insert size) for the first read of a pair, mirroring
+/// htsjdk `SamPairUtil.computeInsertSize`. Returns 0 unless both reads are mapped to
+/// the same reference; the second read's TLEN is the negation of this value.
+fn compute_insert_size_raw(s1: &MateSnap, s2: &MateSnap) -> i32 {
+    if s1.unmapped || s2.unmapped || s1.ref_id != s2.ref_id {
+        return 0;
+    }
+    let five_prime = |s: &MateSnap| if s.neg { s.aln_end } else { s.aln_start };
+    let (Some(p1), Some(p2)) = (five_prime(s1), five_prime(s2)) else {
+        return 0;
+    };
+    let (p1, p2) = (p1 as i64, p2 as i64);
+    let adjustment = if p2 >= p1 { 1 } else { -1 };
+    i32::try_from(p2 - p1 + adjustment).unwrap_or(0)
+}
+
+/// Sets full mate-pair information on a read pair, mirroring htsjdk
+/// `SamPairUtil.setMateInfo(rec1, rec2, setMateCigar=true)`.
+///
+/// fgbio `ClipBam` calls `SamPairUtil.setMateInfo` on every pair after clipping so that
+/// mate reference/position/strand, the mate-unmapped flag, the MQ/MC tags, and TLEN all
+/// reflect the post-clip state — including reads that clipping unmapped (see CLIP-01). The
+/// three branches (both mapped, both unmapped, one of each) match htsjdk exactly; an
+/// unmapped read is relocated to its mapped mate's coordinate.
+fn set_mate_info_raw(r1: &mut RawRecord, r2: &mut RawRecord) {
+    // Snapshot both reads up front so mutating one never reads stale/updated fields of the other.
+    let s1 = MateSnap::of(r1);
+    let s2 = MateSnap::of(r2);
+
+    if !s1.unmapped && !s2.unmapped {
+        // Both mapped: copy each read's coordinates into the other's mate fields.
+        r1.set_mate_ref_id(s2.ref_id);
+        r1.set_mate_pos(s2.pos);
+        set_mate_flags_raw(r1, s2.neg, false);
+        set_mate_mq_mc_raw(r1, s2.mapq, &s2.cigar);
+
+        r2.set_mate_ref_id(s1.ref_id);
+        r2.set_mate_pos(s1.pos);
+        set_mate_flags_raw(r2, s1.neg, false);
+        set_mate_mq_mc_raw(r2, s1.mapq, &s1.cigar);
+
+        let insert_size = compute_insert_size_raw(&s1, &s2);
+        r1.set_template_length(insert_size);
+        r2.set_template_length(-insert_size);
+    } else if s1.unmapped && s2.unmapped {
+        // Both unmapped: clear coordinates and mate coordinates, flag each mate unmapped.
+        for (rec, mate_neg) in [(&mut *r1, s2.neg), (&mut *r2, s1.neg)] {
+            rec.set_ref_id(-1);
+            rec.set_pos(-1);
+            rec.set_mate_ref_id(-1);
+            rec.set_mate_pos(-1);
+            set_mate_flags_raw(rec, mate_neg, true);
+            clear_mate_mq_mc_raw(rec);
+            rec.set_template_length(0);
+        }
+    } else {
+        // Exactly one is unmapped: relocate it to the mapped mate's coordinate.
+        let (mapped, unmapped, mapped_snap, unmapped_snap) = if s1.unmapped {
+            (&mut *r2, &mut *r1, &s2, &s1)
+        } else {
+            (&mut *r1, &mut *r2, &s1, &s2)
+        };
+
+        // The unmapped read is placed at the mapped read's coordinate.
+        unmapped.set_ref_id(mapped_snap.ref_id);
+        unmapped.set_pos(mapped_snap.pos);
+        unmapped.set_mate_ref_id(mapped_snap.ref_id);
+        unmapped.set_mate_pos(mapped_snap.pos);
+        set_mate_flags_raw(unmapped, mapped_snap.neg, false);
+        set_mate_mq_mc_raw(unmapped, mapped_snap.mapq, &mapped_snap.cigar);
+        unmapped.set_template_length(0);
+
+        // The mapped read points its mate fields at the (now co-located) unmapped read.
+        // Its mate-reverse flag reflects the unmapped read's *actual* strand (htsjdk
+        // `SamPairUtil.java:267`): the clipper's own unmap clears REVERSE, but a read that
+        // arrived unmapped-on-input may still carry it, and this runs on every pair.
+        mapped.set_mate_ref_id(mapped_snap.ref_id);
+        mapped.set_mate_pos(mapped_snap.pos);
+        set_mate_flags_raw(mapped, unmapped_snap.neg, true);
+        clear_mate_mq_mc_raw(mapped);
+        mapped.set_template_length(0);
+    }
 }
 
 /// Returns the number of clipped bases (soft + hard) in a raw record's CIGAR.
@@ -2593,5 +2711,156 @@ mod tests {
         assert_eq!(metrics.read_one.reads, 1);
         assert_eq!(metrics.read_one.bases_clipped_five_prime, 2);
         assert_eq!(metrics.read_one.bases_clipped_three_prime, 1);
+    }
+
+    /// `set_mate_info_raw` mirrors htsjdk `SamPairUtil.setMateInfo` across all three
+    /// branches (both mapped, one unmapped, both unmapped) so `fgumi clip` matches fgbio
+    /// `ClipBam` when clipping unmaps a read (CLIP-01).
+    #[test]
+    fn test_set_mate_info_raw_all_branches() {
+        use fgumi_raw_bam::flags as raw_flags;
+
+        let has_flag = |rec: &RawRecord, f: u16| rec.flags() & f != 0;
+        let has_tag = |rec: &RawRecord, tag: [u8; 2]| {
+            fgumi_raw_bam::find_tag_type(fgumi_raw_bam::aux_data_slice(rec.as_ref()), tag).is_some()
+        };
+        // Forward, mapped read: 20M at 0-based pos 99 (alignment start 100).
+        let mapped_fwd = || {
+            fgumi_raw_bam::SamBuilder::new()
+                .read_name(b"t")
+                .sequence(b"ACGTACGTACGTACGTACGT")
+                .qualities(&[30; 20])
+                .cigar_ops(&[20u32 << 4])
+                .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .build()
+        };
+        // Reverse, mapped read: 20M at 0-based pos 199 (alignment start 200).
+        let mapped_rev = || {
+            fgumi_raw_bam::SamBuilder::new()
+                .read_name(b"t")
+                .sequence(b"ACGTACGTACGTACGTACGT")
+                .qualities(&[30; 20])
+                .cigar_ops(&[20u32 << 4])
+                .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(40)
+                .build()
+        };
+        // Unmapped read as produced by makeReadUnmapped: no ref/pos, no strand, no CIGAR.
+        let unmapped = |last: bool| {
+            let seg = if last { raw_flags::LAST_SEGMENT } else { raw_flags::FIRST_SEGMENT };
+            fgumi_raw_bam::SamBuilder::new()
+                .read_name(b"t")
+                .sequence(b"ACGTACGTACGTACGTACGT")
+                .qualities(&[30; 20])
+                .cigar_ops(&[])
+                .flags(raw_flags::PAIRED | seg | raw_flags::UNMAPPED)
+                .ref_id(-1)
+                .pos(-1)
+                .mapq(0)
+                .build()
+        };
+
+        // --- Branch 1: both mapped ---
+        let (mut r1, mut r2) = (mapped_fwd(), mapped_rev());
+        set_mate_info_raw(&mut r1, &mut r2);
+        assert_eq!((r1.mate_ref_id(), r1.mate_pos()), (0, 199), "r1 mate coords <- r2");
+        assert!(has_flag(&r1, raw_flags::MATE_REVERSE), "r1 mate-reverse (r2 is reverse)");
+        assert!(!has_flag(&r1, raw_flags::MATE_UNMAPPED), "r1 mate mapped");
+        assert_eq!((r2.mate_ref_id(), r2.mate_pos()), (0, 99), "r2 mate coords <- r1");
+        assert!(!has_flag(&r2, raw_flags::MATE_REVERSE), "r2 mate not reverse (r1 forward)");
+        // TLEN: fwd 5' = 100, rev 5' = alignmentEnd 219 -> 219 - 100 + 1 = 120.
+        assert_eq!(r1.template_length(), 120, "r1 TLEN");
+        assert_eq!(r2.template_length(), -120, "r2 TLEN");
+        assert!(has_tag(&r1, *SamTag::MQ) && has_tag(&r1, *SamTag::MC), "r1 MQ/MC set");
+        assert!(has_tag(&r2, *SamTag::MQ) && has_tag(&r2, *SamTag::MC), "r2 MQ/MC set");
+
+        // --- Branch 2: one mapped (r1), one unmapped (r2) ---
+        let (mut r1, mut r2) = (mapped_fwd(), unmapped(true));
+        set_mate_info_raw(&mut r1, &mut r2);
+        // Unmapped r2 is relocated to r1's coordinate.
+        assert_eq!((r2.ref_id(), r2.pos()), (0, 99), "unmapped r2 placed at mate coord");
+        assert_eq!((r2.mate_ref_id(), r2.mate_pos()), (0, 99), "r2 mate coords <- r1");
+        assert!(!has_flag(&r2, raw_flags::MATE_UNMAPPED), "r2's mate (r1) is mapped");
+        assert!(
+            has_tag(&r2, *SamTag::MQ) && has_tag(&r2, *SamTag::MC),
+            "r2 MQ/MC from mapped mate"
+        );
+        // Mapped r1 points at the co-located unmapped mate.
+        assert_eq!((r1.mate_ref_id(), r1.mate_pos()), (0, 99), "r1 mate coords <- unmapped r2");
+        assert!(has_flag(&r1, raw_flags::MATE_UNMAPPED), "r1 mate unmapped");
+        assert!(!has_flag(&r1, raw_flags::MATE_REVERSE), "r1 mate-reverse cleared (unmapped)");
+        assert!(!has_tag(&r1, *SamTag::MQ) && !has_tag(&r1, *SamTag::MC), "r1 MQ/MC removed");
+        assert_eq!(
+            (r1.template_length(), r2.template_length()),
+            (0, 0),
+            "TLEN 0 when a mate unmapped"
+        );
+
+        // --- Branch 3: both unmapped ---
+        let (mut r1, mut r2) = (unmapped(false), unmapped(true));
+        set_mate_info_raw(&mut r1, &mut r2);
+        for rec in [&r1, &r2] {
+            assert_eq!((rec.ref_id(), rec.pos()), (-1, -1), "unmapped coords cleared");
+            assert_eq!(
+                (rec.mate_ref_id(), rec.mate_pos()),
+                (-1, -1),
+                "unmapped mate coords cleared"
+            );
+            assert!(has_flag(rec, raw_flags::MATE_UNMAPPED), "mate-unmapped set");
+            assert!(!has_flag(rec, raw_flags::MATE_REVERSE), "mate-reverse cleared");
+            assert!(!has_tag(rec, *SamTag::MQ) && !has_tag(rec, *SamTag::MC), "MQ/MC removed");
+            assert_eq!(rec.template_length(), 0, "TLEN 0");
+        }
+    }
+
+    /// htsjdk's one-mapped branch sets the mapped read's mate-reverse flag from the
+    /// unmapped read's *actual current* strand (`SamPairUtil.java:267`), not an assumed
+    /// `false`. This only diverges for a read that was already unmapped on input while
+    /// still carrying the REVERSE flag — the clipper's own unmap clears it, but
+    /// `set_mate_info_raw` runs on every pair, so such a read reaches this branch.
+    #[test]
+    fn test_set_mate_info_raw_one_mapped_uses_unmapped_reads_strand() {
+        use fgumi_raw_bam::flags as raw_flags;
+        let has_flag = |rec: &RawRecord, f: u16| rec.flags() & f != 0;
+
+        // Mapped forward r1.
+        let mut r1 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"t")
+            .sequence(b"ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar_ops(&[20u32 << 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .build();
+        // Unmapped r2 that still carries the REVERSE flag (already unmapped on input).
+        let mut r2 = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"t")
+            .sequence(b"ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar_ops(&[])
+            .flags(
+                raw_flags::PAIRED
+                    | raw_flags::LAST_SEGMENT
+                    | raw_flags::UNMAPPED
+                    | raw_flags::REVERSE,
+            )
+            .ref_id(-1)
+            .pos(-1)
+            .mapq(0)
+            .build();
+
+        set_mate_info_raw(&mut r1, &mut r2);
+
+        assert!(
+            has_flag(&r1, raw_flags::MATE_REVERSE),
+            "mapped r1 mate-reverse must reflect unmapped r2's actual REVERSE flag"
+        );
     }
 }


### PR DESCRIPTION
## What & why

`clip` (and every internal caller of `SamRecordClipper` / `RawRecordClipper`) diverged from fgbio when clipping removes all of a read's aligned bases. This PR closes the gap and, in doing so, ports the full fgbio/htsjdk fidelity for the unmap and mate-info paths.

fgbio `SamRecordClipper.clip{Start,End}OfAlignment` computes `numberOfClippableBases` (the sum of alignment `M`/`=`/`X` and insertion `I` CIGAR op lengths) and, when the requested clip is `>=` that count, calls htsjdk `SAMUtils.makeReadUnmapped` and returns — the read becomes **unmapped** with an **empty CIGAR**, keeping its bases/qualities. fgumi instead clipped every aligned base, leaving the read **mapped** at a stale `POS` with an all-clip CIGAR (e.g. `50H`) and an empty sequence — silent corruption. This is tracker finding **CLIP-01**.

## Fix

**1. Unmap when the whole alignment is clipped (CLIP-01).**

- Add the `numberOfClippableBases` guard to **both** `SamRecordClipper` and `RawRecordClipper`, in `clip_start_of_alignment` and `clip_end_of_alignment`: when `clippable <= requested`, unmap the read and return the clippable count, rather than proceeding to clip.
- `make_read_unmapped[_raw]` mirrors htsjdk `SAMUtils.makeReadUnmapped`: clear reference / pos / mapq / CIGAR / TLEN and the duplicate, secondary, supplementary, and proper-pair flags; set `UNMAPPED`; reverse-complement bases + reverse quals (then clear the reverse flag) for reverse-strand reads; bases/quals are otherwise preserved.
- Two fgumi unit tests that pinned the old all-soft-clip behavior (`10S10M` clip 10, `10M` clip 10) are updated to assert the unmap.

**2. Reorient strand-sensitive aux tags on unmap (htsjdk `reverseComplement(true)` fidelity).**

htsjdk `makeReadUnmapped` reverse-complements a reverse-strand read via `reverseComplement(true)`, which does more than `SEQ`/`QUAL`: it also reverse-complements the base-oriented tags in `SAMRecord.TAGS_TO_REVERSE_COMPLEMENT` (`E2`, `SQ`) and reverses the quality-oriented tags in `TAGS_TO_REVERSE` (`OQ`, `U2`). fgumi's `make_read_unmapped[_raw]` previously left these forward-oriented, so a reverse-strand read carrying e.g. `OQ` that clipping unmapped diverged from fgbio — squarely in the CLIP-01 path.

- `make_read_unmapped` (typed) and `make_read_unmapped_raw` now reorient these tags for reverse-strand reads, driven by shared `TAGS_TO_REVERSE_COMPLEMENT` / `TAGS_TO_REVERSE` constants so the two paths stay in lockstep.
- Only the `Z`-string encoding is handled (the sole form these tags take in practice); htsjdk additionally reverses array-encoded forms, but none of these tags is emitted as an array by real tooling. Documented inline.
- Adds `E2` / `U2` / `SQ` to the `SamTag` catalog.

**3. Full mate-info parity, including the one-mapped mate-reverse flag.**

Because fgbio `ClipBam` then calls `SamPairUtil.setMateInfo(r1, r2, true)` on every pair, the clipper unmap surfaced a paired-read gap: fgumi's `clip` only refreshed the MC/MQ tags. This PR replaces that with `set_mate_info_raw`, a faithful port of htsjdk `setMateInfo` (all three branches — both mapped, both unmapped, one of each) covering mate ref/pos/strand, the mate-unmapped flag, MQ/MC tags, and TLEN. This makes paired output match fgbio when a mate unmaps, and also fixes stale mate-pos/TLEN in the ordinary both-mapped case (previously never updated after a clip shifted a start).

- In the one-mapped branch, the mapped read's mate-reverse flag now reflects the unmapped read's **actual** strand (`SamPairUtil.java:267`) rather than an assumed `false`. The clipper's own unmap clears `REVERSE`, but a read that arrived unmapped-on-input may still carry it, and `set_mate_info_raw` runs on every pair, so such a read reaches this branch.

## Parity evidence (fgbio 4.1.0 `ClipBam` vs `fgumi clip`, `compare bams --mode content`)

Reproducer: `reports/fgbio-parity-fixtures/clip-01-unmap-fully-clipped.sh`.

**Scenario A — mapped fragment, `50M`@chr1:100, `--read-one-five-prime 60`:**

| | before | after |
|---|---|---|
| fgumi | `FLAG=0 POS=150 CIGAR=50H` (mapped, corrupt) | `FLAG=4 POS=0 CIGAR=*` (unmapped) |
| vs fgbio | **DIFFER** | **IDENTICAL** |

**Scenario B — FR pair, both clipped past alignment (`--read-one-five-prime 101 --read-two-five-prime 101`, ClipBamTest.scala:621):**

| | before | after |
|---|---|---|
| fgumi | mate-flags stale (`MATE_REVERSE` set, `RNEXT=chr1`) | `FLAG=77/141`, `RNEXT=* PNEXT=0 TLEN=0` |
| vs fgbio | **DIFFER** | **IDENTICAL** |

Also verified **IDENTICAL** to fgbio for normal paired clipping that does *not* unmap (overlap clip, fixed 3′ clip, clip-past-mate), confirming the `setMateInfo` change is safe on the common path.

## Tests / CI

- Clipper unmap cross-checks (`crosscheck_unmap_*`): start/end, boundary (`clip == clippable`), no-unmap regression guard, and negative-strand revcomp — on both `SamRecordClipper` and `RawRecordClipper`.
- New tag-reorientation cross-checks: negative-strand reorients `OQ`/`U2` (reversed) and `E2` (reverse-complemented) identically on the typed and raw paths; positive-strand leaves them untouched.
- `test_set_mate_info_raw_all_branches` (all three htsjdk branches) plus a new one-mapped case asserting the mate-reverse flag follows the unmapped read's actual strand.
- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (2217 tests) all green.

Refs: CLIP-01.
