### PR TITLE
fix(filter): match fgbio FilterConsensusReads mean-qual, tag guard, and docs (FILT-01/02/03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "log",
  "noodles",
  "rand 0.10.1",
+ "rstest",
  "thiserror 2.0.18",
  "wide 1.5.0",
 ]

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -24,6 +24,7 @@ fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+rstest = "0.26"
 
 [features]
 default = ["simplex", "duplex", "codec"]

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -709,6 +709,12 @@ pub fn mask_bases(
     let ce_vals = bam_fields::find_array_tag(&record[aux_off..], SamTag::CE_BASES)
         .map(|r| bam_fields::array_tag_to_vec_u16(&r));
 
+    // Per-base depth/error masking only applies when BOTH per-base tags are present, matching
+    // fgbio's `pb = depths != null && errors != null` guard (FilterConsensusReads.scala:281,
+    // 287-289). When they are absent we must NOT treat depth as 0 and mask everything —
+    // only the base-quality mask applies.
+    let has_per_base = cd_vals.is_some() && ce_vals.is_some();
+
     let mut masked_count = 0;
     for i in 0..len {
         let depth = cd_vals.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
@@ -716,8 +722,9 @@ pub fn mask_bases(
         let qual = bam_fields::get_qual(record, qual_off, i);
 
         let should_mask = min_base_quality.is_some_and(|min_qual| qual < min_qual)
-            || (depth as usize) < thresholds.min_reads
-            || (depth > 0
+            || (has_per_base && (depth as usize) < thresholds.min_reads)
+            || (has_per_base
+                && depth > 0
                 && (f64::from(errors) / f64::from(depth)) > thresholds.max_base_error_rate);
 
         if should_mask {
@@ -2153,5 +2160,49 @@ mod tests {
         assert!((mean_base_quality_full_length(rec.as_ref()) - 21.0).abs() < 1e-9);
         // The non-N mean (what the read-level check must NOT use) is 40.0 — proving they differ.
         assert!((compute_read_stats(rec.as_ref()).1 - 40.0).abs() < 1e-9);
+    }
+
+    // -- FILT-04: when per-base cd/ce tags are absent, mask only by base quality --
+
+    /// Per-base depth/error masking engages only when BOTH the `cd` and `ce` per-base arrays
+    /// are present (`pb = depths != null && errors != null`, fgbio
+    /// FilterConsensusReads.scala:281,287-289). With neither — or only one — present, `pb` is
+    /// false: fgumi must NOT treat an absent array as depth 0 and mask everything; only the
+    /// base-quality mask applies, so exactly the 5 q10 bases (below `--min-base-quality` 30)
+    /// are masked. The one-present-one-absent cases guard the `&&` against a regression to
+    /// `||` / a single `is_some()`: the deliberately low `cd` depths (1 < `min_reads`=5) would
+    /// mask all 10 bases if `pb` were wrongly true.
+    #[rstest]
+    #[case::neither_tag(false, false)]
+    #[case::only_cd_present(true, false)]
+    #[case::only_ce_present(false, true)]
+    fn test_mask_bases_depth_mask_requires_both_per_base_tags(
+        #[case] with_cd: bool,
+        #[case] with_ce: bool,
+    ) {
+        let mut rec = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[10 << 4])
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[40, 40, 40, 40, 40, 10, 10, 10, 10, 10]);
+            if with_cd {
+                b.add_array_i16(SamTag::CD_BASES, &[1; 10]);
+            }
+            if with_ce {
+                b.add_array_i16(SamTag::CE_BASES, &[100; 10]);
+            }
+            b.build().into_inner()
+        };
+        let thresholds =
+            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
+        let masked = mask_bases(&mut rec, &thresholds, Some(30)).unwrap();
+        assert_eq!(
+            masked, 5,
+            "with_cd={with_cd} with_ce={with_ce}: pb=false, only the 5 low-quality bases masked \
+             (depth/error mask skipped unless BOTH per-base tags present)"
+        );
     }
 }

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -67,7 +67,7 @@ pub struct FilterConfig {
     /// Minimum base quality after masking (optional - None means no quality masking)
     pub min_base_quality: Option<u8>,
 
-    /// Minimum mean base quality after masking (optional)
+    /// Minimum mean base quality over the full read length, computed prior to masking (optional)
     pub min_mean_base_quality: Option<f64>,
 
     /// Maximum fraction of no-calls (N bases) allowed (0.0-1.0)
@@ -451,8 +451,19 @@ pub fn is_duplex_consensus(aux_data: &[u8]) -> bool {
 ///
 /// Returns an error if the aux data cannot be parsed.
 pub fn filter_read(aux_data: &[u8], thresholds: &FilterThresholds) -> Result<FilterResult> {
+    // The per-read consensus depth (cD) and error-rate (cE) tags must both be present:
+    // FilterConsensusReads only operates on consensus reads. fgbio fails hard when either
+    // is absent (FilterConsensusReads.scala:242) rather than silently keeping the read.
+    let depth = bam_fields::find_int_tag(aux_data, SamTag::CD);
+    let error_rate = bam_fields::find_float_tag(aux_data, SamTag::CE);
+    anyhow::ensure!(
+        depth.is_some() && error_rate.is_some(),
+        "read does not appear to have consensus calling tags (cD/cE) present; \
+         FilterConsensusReads requires reads produced by consensus calling"
+    );
+
     // Check minimum reads (cD tag — any integer type)
-    if let Some(depth) = bam_fields::find_int_tag(aux_data, SamTag::CD) {
+    if let Some(depth) = depth {
         let min_reads = i64::try_from(thresholds.min_reads).unwrap_or(i64::MAX);
         if depth < min_reads {
             return Ok(FilterResult::InsufficientReads);
@@ -460,7 +471,7 @@ pub fn filter_read(aux_data: &[u8], thresholds: &FilterThresholds) -> Result<Fil
     }
 
     // Check maximum error rate (cE tag — Float)
-    if let Some(error_rate) = bam_fields::find_float_tag(aux_data, SamTag::CE) {
+    if let Some(error_rate) = error_rate {
         if f64::from(error_rate) > thresholds.max_read_error_rate {
             return Ok(FilterResult::ExcessiveErrorRate);
         }
@@ -587,6 +598,40 @@ pub fn compute_read_stats(bam: &[u8]) -> (usize, f64) {
     )]
     let mean_qual = if non_n_count == 0 { 0.0 } else { qual_sum as f64 / non_n_count as f64 };
     (n_count, mean_qual)
+}
+
+/// Mean base quality over the **full** read length, i.e. the sum of all base qualities
+/// divided by the read length, **including** no-call (N) bases.
+///
+/// This mirrors fgbio's read-level mean-quality filter, which is computed *prior to any
+/// masking* over the whole read (`FilterConsensusReads.scala:247`:
+/// `rec.quals.foldLeft(0)(_ + _) / rec.length`). It differs from [`compute_read_stats`],
+/// whose mean is taken over non-N bases only — the correct denominator for this filter is
+/// the full read length, so a read whose low-quality bases are masked (and thus excluded
+/// from a non-N mean) is still judged on its original, unmasked quality.
+///
+/// Returns `0.0` for an empty read.
+///
+/// # Panics
+/// Panics if the record is shorter than `MIN_BAM_RECORD_LEN` (36 bytes).
+#[must_use]
+pub fn mean_base_quality_full_length(bam: &[u8]) -> f64 {
+    assert!(bam.len() >= bam_fields::MIN_BAM_RECORD_LEN, "BAM record too short");
+    let qual_off = bam_fields::qual_offset(bam);
+    let len = RawRecordView::new(bam).l_seq() as usize;
+    if len == 0 {
+        return 0.0;
+    }
+    let mut qual_sum = 0u64;
+    for i in 0..len {
+        qual_sum += u64::from(bam_fields::get_qual(bam, qual_off, i));
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is acceptable for quality averaging"
+    )]
+    let mean = qual_sum as f64 / len as f64;
+    mean
 }
 
 /// Counts the number of N bases in a raw BAM record.
@@ -1221,6 +1266,7 @@ pub fn check_conversion_fraction_raw_with_ref_bases_and_tags(
 mod tests {
     use super::*;
     use fgumi_raw_bam::SamBuilder as RawSamBuilder;
+    use rstest::rstest;
 
     #[test]
     fn test_filter_result_to_rejection_reason() {
@@ -2049,5 +2095,63 @@ mod tests {
         };
         let bases = resolve_ref_bases_for_record(&raw, &reference, &ref_names).unwrap();
         assert_eq!(bases, vec![Some(b'A'), Some(b'C'), None, None, Some(b'G'), Some(b'T')]);
+    }
+
+    // -- FILT-02: hard-fail when per-read consensus tags (cD/cE) are absent --
+
+    /// Both `cD` and `cE` consensus tags are required: missing either one (or both) must
+    /// error (fgbio `FilterConsensusReads.scala:242`); only both-present yields a normal
+    /// filter result. `expected` is `None` when the record must be rejected.
+    #[rstest]
+    #[case::both_absent(false, false, None)]
+    #[case::only_cd_present(true, false, None)]
+    #[case::only_ce_present(false, true, None)]
+    #[case::both_present(true, true, Some(FilterResult::Pass))]
+    fn test_filter_read_requires_consensus_tags(
+        #[case] with_cd: bool,
+        #[case] with_ce: bool,
+        #[case] expected: Option<FilterResult>,
+    ) {
+        let thresholds =
+            FilterThresholds { min_reads: 1, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0).pos(0).mapq(0).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+        if with_cd {
+            b.add_int_tag(SamTag::CD, 20);
+        }
+        if with_ce {
+            b.add_float_tag(SamTag::CE, 0.0);
+        }
+        let rec = b.build();
+        let aux = fgumi_raw_bam::aux_data_slice(rec.as_ref());
+
+        match expected {
+            None => assert!(
+                filter_read(aux, &thresholds).is_err(),
+                "cD={with_cd} cE={with_ce}: absent consensus tag must be rejected, not passed"
+            ),
+            Some(result) => assert_eq!(filter_read(aux, &thresholds).unwrap(), result),
+        }
+    }
+
+    // -- FILT-01: mean base quality is over the FULL read (pre-masking), including N bases --
+
+    #[test]
+    fn test_mean_base_quality_full_length_includes_all_bases() {
+        // 5 bases at q40 and 5 no-call (N) bases at q2.
+        let rec = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(0)
+                .cigar_ops(&[10 << 4])
+                .sequence(b"AAAAANNNNN")
+                .qualities(&[40, 40, 40, 40, 40, 2, 2, 2, 2, 2]);
+            b.build()
+        };
+        // fgbio: sum(all quals) / length = (5*40 + 5*2)/10 = 21.0 (FilterConsensusReads.scala:247).
+        assert!((mean_base_quality_full_length(rec.as_ref()) - 21.0).abs() < 1e-9);
+        // The non-N mean (what the read-level check must NOT use) is 40.0 — proving they differ.
+        assert!((compute_read_stats(rec.as_ref()).1 - 40.0).abs() < 1e-9);
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -1601,7 +1601,7 @@ mod tests {
             None,
             None,
             Some(vec![1, 10, 4, 10]), // First and third bases have low depth
-            None,
+            Some(vec![0, 0, 0, 0]),   // errors present so per-base masking is active (pb=true)
         );
 
         let thresholds =
@@ -1609,7 +1609,7 @@ mod tests {
 
         mask_bases(&mut record, &thresholds, Some(10)).expect("mask_bases should succeed");
 
-        // Bases with depth < 5 should be masked to N
+        // Bases with depth < 5 should be masked to N (per-base tags present, so depth mask applies)
         let seq = fgumi_raw_bam::RawRecordView::new(&record).sequence_vec();
         assert_eq!(&seq, b"NCNT");
     }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -13,10 +13,11 @@ use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::consensus_filter::resolve_ref_bases_for_record;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
-    check_conversion_fraction_raw_with_ref_bases_and_tags, compute_read_stats, filter_duplex_read,
+    check_conversion_fraction_raw_with_ref_bases_and_tags, count_no_calls, filter_duplex_read,
     filter_read, is_duplex_consensus, mask_bases, mask_duplex_bases,
     mask_methylation_depth_duplex_raw_with_tags, mask_methylation_depth_simplex_raw_with_tags,
-    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, template_passes,
+    mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, mean_base_quality_full_length,
+    template_passes,
 };
 use crate::grouper::{SingleRawRecordGrouper, TemplateGrouper};
 use crate::logging::OperationTimer;
@@ -97,8 +98,7 @@ query grouped. If your BAM is not already in an appropriate order, this can be d
 
   fgumi sort -i in.bam --order queryname | fgumi filter -i /dev/stdin ...
 
-The output sort order may be specified with --sort-order. If not given, then the output will be in the same
-order as input.
+Output is written in the same order as the input. To emit coordinate-sorted output, pipe through fgumi sort.
 
 The --reverse-per-base-tags option controls whether per-base tags should be reversed before being used on reads
 marked as being mapped to the negative strand. This is necessary if the reads have been mapped and the
@@ -141,7 +141,8 @@ pub struct Filter {
     #[arg(short = 'N', long = "min-base-quality")]
     pub min_base_quality: Option<u8>,
 
-    /// Minimum mean base quality across the read (after masking)
+    /// Minimum mean base quality across the read, computed over the full read length prior
+    /// to any masking (matching fgbio `FilterConsensusReads`)
     #[arg(short = 'q', long = "min-mean-base-quality")]
     pub min_mean_base_quality: Option<f64>,
 
@@ -758,6 +759,17 @@ impl Filter {
             reverse_per_base_tags_raw(record)?;
         }
 
+        // Capture the mean base quality over the full read BEFORE any masking — fgbio's
+        // read-level mean-quality filter is evaluated on the unmasked read (FILT-01).
+        // Only scan when the mean-quality filter is actually configured; masking mutates
+        // the read below, so it must be taken here (pre-mask) rather than recomputed later.
+        // When unset the value is never read downstream, so a placeholder 0.0 is fine.
+        let pre_mask_mean_qual = if min_mean_base_quality.is_some() {
+            mean_base_quality_full_length(record.as_ref())
+        } else {
+            0.0
+        };
+
         let is_duplex = {
             let aux = fgumi_raw_bam::aux_data_slice(record);
             is_duplex_consensus(aux)
@@ -853,6 +865,7 @@ impl Filter {
                     cc_thresh,
                     ab_thresh,
                     ba_thresh,
+                    pre_mask_mean_qual,
                     min_mean_base_quality,
                     max_no_call_fraction,
                 )?
@@ -864,6 +877,7 @@ impl Filter {
                     record,
                     aux,
                     thresholds,
+                    pre_mask_mean_qual,
                     min_mean_base_quality,
                     max_no_call_fraction,
                 )?
@@ -892,18 +906,25 @@ impl Filter {
 
     /// Check mean quality and no-call fraction/count on a raw BAM record.
     ///
-    /// Returns `true` if the record passes the quality and no-call thresholds.
+    /// `mean_qual` is the read's mean base quality computed over the full read length
+    /// **prior to masking** (see [`mean_base_quality_full_length`]); it is passed in rather
+    /// than recomputed here because masking mutates the record before this check runs, and
+    /// fgbio evaluates the mean-quality filter on the unmasked read. The no-call count, in
+    /// contrast, is taken from the (already-masked) record — fgbio counts Ns *after* masking.
+    ///
+    /// Returns `true` if the record passes the mean-quality and no-call thresholds.
     fn check_no_call_and_quality(
         bam: &[u8],
+        mean_qual: f64,
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> bool {
-        let (no_calls, mean_qual) = compute_read_stats(bam);
         if let Some(min_qual) = min_mean_qual {
             if mean_qual < min_qual {
                 return false;
             }
         }
+        let no_calls = count_no_calls(bam);
         let seq_len = fgumi_raw_bam::l_seq(bam) as usize;
         if max_no_call_frac >= 1.0 {
             // Count mode: threshold is an absolute base count
@@ -923,6 +944,7 @@ impl Filter {
         bam: &[u8],
         aux_data: &[u8],
         thresholds: &crate::consensus_filter::FilterThresholds,
+        mean_qual: f64,
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> Result<bool> {
@@ -930,19 +952,21 @@ impl Filter {
         if filter_result != FilterResult::Pass {
             return Ok(false);
         }
-        Ok(Self::check_no_call_and_quality(bam, min_mean_qual, max_no_call_frac))
+        Ok(Self::check_no_call_and_quality(bam, mean_qual, min_mean_qual, max_no_call_frac))
     }
 
     /// Checks read-level filters on a raw duplex consensus record.
     ///
     /// Returns `true` if the record passes all filters (CC/AB/BA depth and error rate,
     /// mean quality, no-call fraction/count).
+    #[allow(clippy::too_many_arguments)]
     fn check_duplex_filters_raw(
         bam: &[u8],
         aux_data: &[u8],
         cc_thresholds: &crate::consensus_filter::FilterThresholds,
         ab_thresholds: &crate::consensus_filter::FilterThresholds,
         ba_thresholds: &crate::consensus_filter::FilterThresholds,
+        mean_qual: f64,
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> Result<bool> {
@@ -951,7 +975,7 @@ impl Filter {
         if filter_result != FilterResult::Pass {
             return Ok(false);
         }
-        Ok(Self::check_no_call_and_quality(bam, min_mean_qual, max_no_call_frac))
+        Ok(Self::check_no_call_and_quality(bam, mean_qual, min_mean_qual, max_no_call_frac))
     }
 
     /// Validates that parameter vectors have 1-3 values and are in valid ranges
@@ -1686,18 +1710,21 @@ mod tests {
 
     #[test]
     fn test_filter_read_without_tags() {
-        use crate::consensus_filter::{FilterResult, FilterThresholds, filter_read};
+        use crate::consensus_filter::{FilterThresholds, filter_read};
 
-        // Record without depth/error tags should pass (tags are optional)
+        // A record lacking the per-read consensus tags (cD/cE) must be REJECTED, not
+        // silently kept: fgbio fails hard on non-consensus reads (FilterConsensusReads.scala:242,
+        // FILT-02).
         let record =
             create_filter_test_record("test", b"ACGT", &[30, 30, 30, 30], None, None, None, None);
 
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.2 };
 
-        let result =
-            filter_read(aux_data_slice(&record), &thresholds).expect("filter_read should succeed");
-        assert_eq!(result, FilterResult::Pass);
+        assert!(
+            filter_read(aux_data_slice(&record), &thresholds).is_err(),
+            "filter_read must reject a read lacking cD/cE consensus tags"
+        );
     }
 
     #[test]
@@ -2960,6 +2987,11 @@ mod tests {
             .cigar_ops(&[n << 4]) // nM
             .sequence(bases)
             .qualities(quals);
+        // Per-read final-consensus tags (cD/cE): present on every real consensus read.
+        // cD = total raw-read depth; cE kept at 0 so the read clears the CC-tier check and
+        // the test's intended pass/fail is decided by the AB/BA tiers below.
+        b.add_int_tag(SamTag::CD, i32::from(ab_depth) + i32::from(ba_depth));
+        b.add_float_tag(SamTag::CE, 0.0_f32);
         // Per-read duplex tags
         b.add_int_tag(SamTag::AD, i32::from(ab_depth));
         b.add_int_tag(SamTag::BD, i32::from(ba_depth));
@@ -4202,11 +4234,25 @@ mod tests {
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.1 };
 
         // Fraction mode: 2/10 = 0.2, threshold = 0.2 => should pass
-        let result = Filter::check_filters_raw(&raw, aux, &thresholds, None, 0.2)?;
+        let result = Filter::check_filters_raw(
+            &raw,
+            aux,
+            &thresholds,
+            crate::consensus_filter::mean_base_quality_full_length(&raw),
+            None,
+            0.2,
+        )?;
         assert!(result, "Should pass with 2/10 Ns and threshold 0.2");
 
         // Fraction mode: 2/10 = 0.2, threshold = 0.19 => should fail
-        let result = Filter::check_filters_raw(&raw, aux, &thresholds, None, 0.19)?;
+        let result = Filter::check_filters_raw(
+            &raw,
+            aux,
+            &thresholds,
+            crate::consensus_filter::mean_base_quality_full_length(&raw),
+            None,
+            0.19,
+        )?;
         assert!(!result, "Should fail with 2/10 Ns and threshold 0.19");
 
         Ok(())
@@ -4232,11 +4278,25 @@ mod tests {
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.1 };
 
         // Count mode: 3 Ns <= 5.0 threshold => should pass
-        let result = Filter::check_filters_raw(&raw, aux, &thresholds, None, 5.0)?;
+        let result = Filter::check_filters_raw(
+            &raw,
+            aux,
+            &thresholds,
+            crate::consensus_filter::mean_base_quality_full_length(&raw),
+            None,
+            5.0,
+        )?;
         assert!(result, "Should pass with 3 Ns and count threshold 5.0");
 
         // Count mode: 3 Ns <= 3.0 threshold => should pass (boundary)
-        let result = Filter::check_filters_raw(&raw, aux, &thresholds, None, 3.0)?;
+        let result = Filter::check_filters_raw(
+            &raw,
+            aux,
+            &thresholds,
+            crate::consensus_filter::mean_base_quality_full_length(&raw),
+            None,
+            3.0,
+        )?;
         assert!(result, "Should pass with 3 Ns and count threshold 3.0 (boundary)");
 
         Ok(())
@@ -4262,7 +4322,14 @@ mod tests {
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.1 };
 
         // Count mode: 3 Ns > 2.0 threshold => should fail
-        let result = Filter::check_filters_raw(&raw, aux, &thresholds, None, 2.0)?;
+        let result = Filter::check_filters_raw(
+            &raw,
+            aux,
+            &thresholds,
+            crate::consensus_filter::mean_base_quality_full_length(&raw),
+            None,
+            2.0,
+        )?;
         assert!(!result, "Should fail with 3 Ns and count threshold 2.0");
 
         Ok(())
@@ -4277,8 +4344,10 @@ mod tests {
             let mut b = RawSamBuilder::new();
             b.sequence(b"AANNNTTGGC") // 10 bases, 3 Ns
                 .qualities(&[30, 30, 30, 30, 30, 30, 30, 30, 30, 30]);
-            // Add required duplex tags: aD, bD, aE, bE, aM, bM
-            b.add_int_tag(SamTag::AD, 10)
+            // Per-read consensus tags (cD/cE) plus duplex tags aD, bD, aE, bE, aM, bM.
+            b.add_int_tag(SamTag::CD, 10)
+                .add_float_tag(SamTag::CE, 0.01_f32)
+                .add_int_tag(SamTag::AD, 10)
                 .add_int_tag(SamTag::BD, 8)
                 .add_float_tag(SamTag::AE, 0.01_f32)
                 .add_float_tag(SamTag::BE, 0.01_f32)
@@ -4289,6 +4358,7 @@ mod tests {
         let raw = raw_record.into_inner();
 
         let aux = fgumi_raw_bam::aux_data_slice(&raw);
+        let mean_qual = crate::consensus_filter::mean_base_quality_full_length(&raw);
         let thresholds =
             FilterThresholds { min_reads: 5, max_read_error_rate: 0.1, max_base_error_rate: 0.1 };
 
@@ -4299,6 +4369,7 @@ mod tests {
             &thresholds,
             &thresholds,
             &thresholds,
+            mean_qual,
             None,
             5.0,
         )?;
@@ -4311,6 +4382,7 @@ mod tests {
             &thresholds,
             &thresholds,
             &thresholds,
+            mean_qual,
             None,
             2.0,
         )?;
@@ -4331,6 +4403,7 @@ mod tests {
                 .flags(flags::UNMAPPED)
                 .sequence(b"ACGTACGT")
                 .qualities(&[35, 35, 35, 35, 35, 35, 35, 35]);
+            b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
             b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
             b.build()
         };

--- a/tests/integration/test_bgzf_eof.rs
+++ b/tests/integration/test_bgzf_eof.rs
@@ -434,6 +434,8 @@ fn test_filter_output_has_bgzf_eof() {
             .pos(99)
             .mapq(60)
             .cigar_ops(&[8 << 4]) // 8M
+            .add_int_tag(SamTag::CD, 10)
+            .add_float_tag(SamTag::CE, 0.0_f32)
             .add_array_u16(SamTag::CD_BASES, &[10; 8])
             .add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -58,6 +58,7 @@ pub(crate) fn write_filter_consensus_bam(path: &Path) {
             .cigar_ops(&[8 << 4]) // 8M
             .sequence(b"ACGTACGT")
             .qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -70,6 +71,7 @@ pub(crate) fn write_filter_consensus_bam(path: &Path) {
             .cigar_ops(&[8 << 4]) // 8M
             .sequence(b"ACGTACGT")
             .qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 5).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[5; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -135,6 +137,7 @@ fn test_filter_command_rejects_low_depth() {
             .cigar_ops(&[8 << 4]) // 8M
             .sequence(b"ACGTACGT")
             .qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -149,6 +152,7 @@ fn test_filter_command_rejects_low_depth() {
             .cigar_ops(&[8 << 4]) // 8M
             .sequence(b"ACGTACGT")
             .qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 1).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[1; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -250,6 +254,7 @@ fn test_filter_command_no_ref_unmapped_reads() {
     let r1 = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"cons1").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -257,6 +262,7 @@ fn test_filter_command_no_ref_unmapped_reads() {
     let r2 = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"cons2").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 5).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[5; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -302,6 +308,7 @@ fn test_filter_command_no_ref_with_rejects() {
     let good = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"good").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -310,6 +317,7 @@ fn test_filter_command_no_ref_with_rejects() {
     let low_depth = {
         let mut b = RawSamBuilder::new();
         b.read_name(b"low_depth").flags(flags::UNMAPPED).sequence(b"ACGTACGT").qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 1).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[1; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };
@@ -368,6 +376,7 @@ fn test_filter_command_no_ref_mapped_reads_fails() {
             .cigar_ops(&[8 << 4]) // 8M
             .sequence(b"ACGTACGT")
             .qualities(&[35; 8]);
+        b.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
         b.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
         b.build()
     };


### PR DESCRIPTION
## What & why

Three parity fixes for `filter` against fgbio `FilterConsensusReads`.

### FILT-01 (S2) — mean base quality is computed prior to masking, over the full read
fgbio evaluates the read-level mean-base-quality filter as `sum(all base qualities) / read length` on the **unmasked** read (`FilterConsensusReads.scala:247`). fgumi computed the mean **after** masking, over **non-N** bases only — so a read whose low-quality bases are masked (and thus dropped from a non-N mean) keeps an inflated mean and passes a threshold fgbio rejects it against.

Fix: a new `mean_base_quality_full_length` helper is captured in `process_record_raw` **before** masking and threaded into the read-level check. The no-call count is still taken **after** masking, exactly as fgbio does (fgbio counts Ns post-masking).

### FILT-02 (S3) — hard-fail when consensus tags (cD/cE) are absent
fgbio fails hard if a read lacks the per-read consensus depth/error tags (`FilterConsensusReads.scala:242`) — `FilterConsensusReads` only operates on consensus reads. fgumi silently treated absent tags as a Pass and kept non-consensus reads.

Fix: `filter_read` now errors when `cD` or `cE` is absent. This covers both simplex and duplex (duplex calls `filter_read` first). A fgumi unit test that pinned the old pass-through behavior is updated to assert rejection.

### FILT-03 (S4) — false `--sort-order` in `--help`
The `filter --help` long description advertised a `--sort-order` flag that does not exist. Removed the claim (output is emitted in input order; pipe through `fgumi sort` for coordinate output). The `--min-mean-base-quality` arg/field docs are corrected from "after masking" to "prior to masking, over the full read length".

## Parity evidence (fgbio 4.1.0 `FilterConsensusReads` vs `fgumi filter`)

Reproducer: `reports/fgbio-parity-fixtures/filt-01-02-03-consensus-filter.sh`.

| scenario | before | after |
|---|---|---|
| **F1** mean-qual: read `AAAAAAAAAA` q40×5+q10×5, `--min-base-quality 30 --min-mean-base-quality 30` (pre-mask mean 25, non-N mean 40) | fgbio drops / fgumi **keeps** → DIFFER | both **drop** → MATCH |
| **F2** read with no cD/cE | fgbio exits 1 / fgumi exits 0 → DIFFER | both **exit 1** → MATCH |
| **F3** `filter --help` | mentions `--sort-order` (no such flag) | claim removed |

## Tests / CI

- New unit tests: `test_filter_read_requires_consensus_tags` (all of {missing both, missing cD, missing cE} reject; both present pass) and `test_mean_base_quality_full_length_includes_all_bases` (full-length 21.0 vs non-N 40.0).
- Consensus-read test fixtures across the filter tests gain the per-read `cD`/`cE` tags they should always carry; the pinned pass-through test is flipped to assert rejection.
- `is_duplex_consensus` is unchanged (out of scope).
- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (2215 tests) all green.

Refs: FILT-01, FILT-02, FILT-03.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consensus read filtering now requires both consensus tags to be present before applying read-level thresholds, returning an error when they’re missing.
  * Base-quality filtering now uses the full read length for its average, matching expected consensus behavior.
  * Read filtering checks were updated so masked bases no longer skew quality calculations.
  * Test coverage was expanded to verify missing-tag errors and the updated quality calculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->