### PR TITLE
fix(filter): only mask by base quality when per-base tags are absent (FILT-04)

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -709,6 +709,12 @@ pub fn mask_bases(
     let ce_vals = bam_fields::find_array_tag(&record[aux_off..], SamTag::CE_BASES)
         .map(|r| bam_fields::array_tag_to_vec_u16(&r));
 
+    // Per-base depth/error masking only applies when BOTH per-base tags are present, matching
+    // fgbio's `pb = depths != null && errors != null` guard (FilterConsensusReads.scala:281,
+    // 287-289). When they are absent we must NOT treat depth as 0 and mask everything —
+    // only the base-quality mask applies.
+    let has_per_base = cd_vals.is_some() && ce_vals.is_some();
+
     let mut masked_count = 0;
     for i in 0..len {
         let depth = cd_vals.as_ref().map_or(0u16, |v| v.get(i).copied().unwrap_or(0));
@@ -716,8 +722,9 @@ pub fn mask_bases(
         let qual = bam_fields::get_qual(record, qual_off, i);
 
         let should_mask = min_base_quality.is_some_and(|min_qual| qual < min_qual)
-            || (depth as usize) < thresholds.min_reads
-            || (depth > 0
+            || (has_per_base && (depth as usize) < thresholds.min_reads)
+            || (has_per_base
+                && depth > 0
                 && (f64::from(errors) / f64::from(depth)) > thresholds.max_base_error_rate);
 
         if should_mask {
@@ -2153,5 +2160,49 @@ mod tests {
         assert!((mean_base_quality_full_length(rec.as_ref()) - 21.0).abs() < 1e-9);
         // The non-N mean (what the read-level check must NOT use) is 40.0 — proving they differ.
         assert!((compute_read_stats(rec.as_ref()).1 - 40.0).abs() < 1e-9);
+    }
+
+    // -- FILT-04: when per-base cd/ce tags are absent, mask only by base quality --
+
+    /// Per-base depth/error masking engages only when BOTH the `cd` and `ce` per-base arrays
+    /// are present (`pb = depths != null && errors != null`, fgbio
+    /// FilterConsensusReads.scala:281,287-289). With neither — or only one — present, `pb` is
+    /// false: fgumi must NOT treat an absent array as depth 0 and mask everything; only the
+    /// base-quality mask applies, so exactly the 5 q10 bases (below `--min-base-quality` 30)
+    /// are masked. The one-present-one-absent cases guard the `&&` against a regression to
+    /// `||` / a single `is_some()`: the deliberately low `cd` depths (1 < `min_reads`=5) would
+    /// mask all 10 bases if `pb` were wrongly true.
+    #[rstest]
+    #[case::neither_tag(false, false)]
+    #[case::only_cd_present(true, false)]
+    #[case::only_ce_present(false, true)]
+    fn test_mask_bases_depth_mask_requires_both_per_base_tags(
+        #[case] with_cd: bool,
+        #[case] with_ce: bool,
+    ) {
+        let mut rec = {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .cigar_ops(&[10 << 4])
+                .sequence(b"AAAAAAAAAA")
+                .qualities(&[40, 40, 40, 40, 40, 10, 10, 10, 10, 10]);
+            if with_cd {
+                b.add_array_i16(SamTag::CD_BASES, &[1; 10]);
+            }
+            if with_ce {
+                b.add_array_i16(SamTag::CE_BASES, &[100; 10]);
+            }
+            b.build().into_inner()
+        };
+        let thresholds =
+            FilterThresholds { min_reads: 5, max_read_error_rate: 0.05, max_base_error_rate: 0.1 };
+        let masked = mask_bases(&mut rec, &thresholds, Some(30)).unwrap();
+        assert_eq!(
+            masked, 5,
+            "with_cd={with_cd} with_ce={with_ce}: pb=false, only the 5 low-quality bases masked \
+             (depth/error mask skipped unless BOTH per-base tags present)"
+        );
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -1601,7 +1601,7 @@ mod tests {
             None,
             None,
             Some(vec![1, 10, 4, 10]), // First and third bases have low depth
-            None,
+            Some(vec![0, 0, 0, 0]),   // errors present so per-base masking is active (pb=true)
         );
 
         let thresholds =
@@ -1609,7 +1609,7 @@ mod tests {
 
         mask_bases(&mut record, &thresholds, Some(10)).expect("mask_bases should succeed");
 
-        // Bases with depth < 5 should be masked to N
+        // Bases with depth < 5 should be masked to N (per-base tags present, so depth mask applies)
         let seq = fgumi_raw_bam::RawRecordView::new(&record).sequence_vec();
         assert_eq!(&seq, b"NCNT");
     }


### PR DESCRIPTION
> **Stacked on #493** (base branch `nh/fix-filter-consensus-parity`). Review/merge #493 first; this PR's diff is against that branch.

## What & why (FILT-04)

fgbio's vanilla consensus filter computes `pb = depths != null && errors != null` and guards its per-base **depth** and **error** masks with `pb &&` (`FilterConsensusReads.scala:281,287-289`). When the per-base tags `cd`/`ce` are absent, fgbio masks bases **only** by base quality.

fgumi's `mask_bases` instead read an absent `cd` tag as per-base depth `0`, so `0 < min_reads` masked **every** base — the read became all-N and was dropped on the no-call filter, where fgbio keeps it. This surfaced while building the FILT-01 fixture (#493).

## Fix

Gate the depth and error masks on `has_per_base = cd_vals.is_some() && ce_vals.is_some()`, mirroring fgbio's `pb`. The base-quality mask still applies unconditionally. The duplex path (`mask_duplex_bases`) is intentionally untouched — fgbio *requires* per-base tags there, a separate concern.

## Parity evidence (fgbio 4.1.0 `FilterConsensusReads` vs `fgumi filter`)

Reproducer: `reports/fgbio-parity-fixtures/filt-04-mask-absent-perbase-tags.sh`. Input: unmapped consensus read with per-read `cD/cE` but **no** per-base `cd/ce`, all A, quals 5×q40+5×q10, `--min-base-quality 30 --min-reads 5`.

| | before | after |
|---|---|---|
| fgbio | keeps `AAAAANNNNN` (quality-masked only) | same |
| fgumi | masks all → drops (0 reads) | keeps `AAAAANNNNN` |
| `compare bams --mode content` | **DIFFER** | **IDENTICAL** |

## Tests / CI

- New `test_mask_bases_without_per_base_tags_masks_only_by_quality` (no per-base tags → only the low-quality bases masked, not all).
- A test that exercised depth masking with only the `cd` tag is updated to also carry `ce` (per-base masking requires both).
- `cargo ci-fmt`/`ci-lint`/`ci-test` (2215) all green.

Refs: FILT-04.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed base masking to avoid treating missing per-base consensus tags as zero depth/error.
  * Depth- and error-based masking now runs only when both required per-base tag sets are present, reducing overly aggressive masking.
* **Tests**
  * Strengthened coverage for scenarios where per-base tags are absent or incomplete, ensuring masking is driven only by minimum base quality rather than depth/error logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->