### PR TITLE
fix(consensus): require both aD and bD to treat a read as duplex (CONS-02)

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -438,11 +438,14 @@ impl MethylationTags {
 
 /// Detects if a raw BAM record is a duplex consensus.
 ///
-/// Checks for presence of `aD` or `bD` tags in the aux data.
+/// Matches fgbio `Umis.isFgbioDuplexConsensus` (`Umis.scala:144`), which requires **both**
+/// the AB and BA raw-read-count tags (`aD` **and** `bD`). A read carrying only one of the two
+/// is treated as a simplex consensus (fgbio routes it to `filterVanillaConsensusRead`); routing
+/// it through the duplex filter would spuriously reject it on the BA tier (worst-strand depth 0).
 #[must_use]
 pub fn is_duplex_consensus(aux_data: &[u8]) -> bool {
     bam_fields::find_tag_type(aux_data, SamTag::AD).is_some()
-        || bam_fields::find_tag_type(aux_data, SamTag::BD).is_some()
+        && bam_fields::find_tag_type(aux_data, SamTag::BD).is_some()
 }
 
 /// Filters a raw consensus read based on per-read tags (cD depth, cE error rate).
@@ -2203,6 +2206,35 @@ mod tests {
             masked, 5,
             "with_cd={with_cd} with_ce={with_ce}: pb=false, only the 5 low-quality bases masked \
              (depth/error mask skipped unless BOTH per-base tags present)"
+        );
+    }
+
+    // -- CONS-02: duplex detection requires BOTH aD and bD (fgbio Umis.isFgbioDuplexConsensus) --
+
+    // fgbio Umis.isFgbioDuplexConsensus = contains(aD) && contains(bD): only both -> duplex.
+    #[rstest]
+    #[case::neither(false, false, false)]
+    #[case::ad_only(true, false, false)]
+    #[case::bd_only(false, true, false)]
+    #[case::both(true, true, true)]
+    fn test_is_duplex_consensus_requires_both_ad_and_bd(
+        #[case] with_ad: bool,
+        #[case] with_bd: bool,
+        #[case] expected: bool,
+    ) {
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0).pos(0).mapq(60).cigar_ops(&[4 << 4]).sequence(b"ACGT").qualities(&[30; 4]);
+        if with_ad {
+            b.add_int_tag(SamTag::AD, 10);
+        }
+        if with_bd {
+            b.add_int_tag(SamTag::BD, 8);
+        }
+        let rec = b.build();
+        assert_eq!(
+            is_duplex_consensus(fgumi_raw_bam::aux_data_slice(rec.as_ref())),
+            expected,
+            "aD={with_ad} bD={with_bd}: duplex iff both present"
         );
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -1772,19 +1772,29 @@ mod tests {
     fn test_is_duplex_consensus_with_tag() {
         use crate::consensus_filter::is_duplex_consensus;
 
-        // Build a record with the aD tag included directly
-        let mut b = RawSamBuilder::new();
-        b.ref_id(0)
-            .pos(0)
-            .mapq(60)
-            .flags(0)
-            .cigar_ops(&[4 << 4]) // 4M
-            .sequence(b"ACGT")
-            .qualities(&[30, 30, 30, 30]);
-        b.add_int_tag(SamTag::AD, 10);
-        let record = b.build();
+        // A duplex consensus requires BOTH aD and bD (fgbio Umis.isFgbioDuplexConsensus,
+        // CONS-02). A record with only aD is a simplex consensus, not duplex.
+        let build = |with_ad: bool, with_bd: bool| {
+            let mut b = RawSamBuilder::new();
+            b.ref_id(0)
+                .pos(0)
+                .mapq(60)
+                .flags(0)
+                .cigar_ops(&[4 << 4]) // 4M
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30]);
+            if with_ad {
+                b.add_int_tag(SamTag::AD, 10);
+            }
+            if with_bd {
+                b.add_int_tag(SamTag::BD, 8);
+            }
+            b.build()
+        };
 
-        assert!(is_duplex_consensus(aux_data_slice(&record)));
+        assert!(!is_duplex_consensus(aux_data_slice(&build(true, false))), "aD only is not duplex");
+        assert!(!is_duplex_consensus(aux_data_slice(&build(false, true))), "bD only is not duplex");
+        assert!(is_duplex_consensus(aux_data_slice(&build(true, true))), "aD and bD is duplex");
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #494** (which is stacked on #493). Base branch `nh/fix-filter-mask-absent-perbase-tags`. Merge #493 → #494 → this, in order.

## What & why (CONS-02)

fgbio `Umis.isFgbioDuplexConsensus` (`Umis.scala:144`) is `rec.contains(aD) && rec.contains(bD)` — a read carrying only one of the two AB/BA raw-read-count tags is a **simplex** consensus, routed to `filterVanillaConsensusRead`. fgumi's `is_duplex_consensus` used `aD` **OR** `bD`, so a single-strand-tagged read was routed to the **duplex** filter and rejected by the BA tier (worst-strand depth `0 < min-reads`), dropping a read fgbio keeps.

Surfaced while building the FILT-01 fixture (#493).

## Fix

`is_duplex_consensus`: OR → AND, matching fgbio. This also aligns the shared helper with `shared_metrics.rs`, which already computes `has_ad && has_bd` locally (the shared helper was the outlier).

## Blast radius

`is_duplex_consensus` callers: `filter.rs:768` (masking/filter routing) and `tags.rs:189` (`is_simplex_consensus = has_cd && !is_duplex_consensus`). Well-formed consensus reads carry **both** `aD` and `bD`, so their routing is unchanged — only single-strand-tagged (malformed) reads are affected. Full `cargo ci-test` (2215) passes across filter / duplex-metrics / group / review.

## Parity evidence (fgbio 4.1.0 `FilterConsensusReads` vs `fgumi filter`)

Reproducer: `reports/fgbio-parity-fixtures/cons-02-is-duplex-requires-both.sh`. Input: consensus read with per-read `cD/cE` and only `aD` (no `bD`), per-base `cd/ce`, all high-quality, `--min-reads 5`.

| | before | after |
|---|---|---|
| fgbio | keeps (simplex path) | same |
| fgumi | **drops** (duplex BA tier) | keeps |
| `compare bams --mode content` | **DIFFER** | **IDENTICAL** |

## Tests / CI

- New `test_is_duplex_consensus_requires_both_ad_and_bd` (only-aD / only-bD / neither → not duplex; both → duplex).
- A test asserting single-`aD` → duplex is updated to the fgbio semantics.
- `cargo ci-fmt`/`ci-lint`/`ci-test` (2215) all green.

Refs: CONS-02.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplex-consensus detection to require both forward and reverse read-count tags.
  * Records with only one duplex read-count tag are no longer incorrectly classified as duplex.
  * Added coverage for all tag-presence combinations to improve detection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->