### PR TITLE
docs: document MI tag value divergence between fgumi group and fgbio GroupReadsByUmi

### DIFF
--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -85,6 +85,39 @@ fgumi supports the same four UMI assignment strategies as fgbio:
 
 The algorithms are equivalent but fgumi's implementations are optimized for throughput.
 
+### MI Tag Values
+
+`fgumi group` and fgbio's `GroupReadsByUmi` produce **identical UMI groupings** — the same reads
+are assigned to the same molecule — but they generally write **different integer `MI` values** for
+those molecules. This is a known, expected divergence: the grouping is what is biologically
+meaningful, while the `MI` integer is only an arbitrary label for an equivalence class. Verify
+equivalence with `fgumi compare bams --mode grouping`, which compares the partition of reads into
+families rather than the raw integers; it reports 0 mismatches between the two tools' outputs (run
+on the same source reads) even though the integers differ.
+
+The two tools agree on the overall numbering scheme:
+
+- Both emit **consecutive** integer labels `0..N-1` for the `N` distinct molecules (fgumi since
+  [issue #269](https://github.com/fulcrumgenomics/fgumi/issues/269); earlier fgumi versions left
+  gaps).
+- Both number **position groups in template-coordinate order** — the molecule(s) at the earliest
+  coordinate cluster get the lowest integers.
+- For `--strategy paired` (duplex), both use the `{base}/A` · `{base}/B` form, sharing the numeric
+  `{base}` between a molecule's two strands and assigning `/A` to the top strand. See
+  [Tracking Reads](tracking-reads.md).
+
+They diverge only on *which* integer a molecule within a single coordinate cluster receives,
+because the within-cluster numbering order differs (fgumi uses deterministic sorted orders; fgbio
+uses Scala hash-bucket iteration order, which can also shift across Scala/JVM versions). Both are
+deterministic per tool version — fgumi even under `--threads N > 1`. See
+`docs/design/deterministic-mi-numbering.md` for the per-strategy specifics.
+
+Because downstream consensus callers derive read names from the input `MI` base (e.g.
+`<prefix>:<mi_base>`), comparing two pipelines' consensus BAMs by read name or raw `MI` will
+mismatch even when the molecules are identical — verify equivalence at the **grouped** stage with
+`fgumi compare bams --mode grouping`, which preserves the input read names, rather than at the
+consensus stage.
+
 ### Group Metrics
 
 fgumi's `group` command now produces a third metrics file beyond family sizes and grouping

--- a/docs/src/guide/umi-grouping.md
+++ b/docs/src/guide/umi-grouping.md
@@ -71,6 +71,12 @@ The molecular IDs produced have structure: `{base}/{A|B}`. For example, UMI pair
 
 The `edit`, `adjacency`, and `paired` strategies use the `--edits` parameter to control matching of non-identical UMIs.
 
+> **Note:** `fgumi group` and fgbio's `GroupReadsByUmi` produce identical groupings but generally
+> assign different integer `MI` values to the same molecules. This is a known, expected
+> divergence — the `MI` integer is only a label for an equivalence class. See
+> [Migration from fgbio → MI Tag Values](migration-from-fgbio.md#mi-tag-values) for why, and use
+> `fgumi compare bams --mode grouping` (not a raw `MI` diff) to check equivalence.
+
 ## Cell Barcode Support
 
 When processing data with cell barcodes (e.g. single-cell sequencing), reads at the same genomic


### PR DESCRIPTION
## Summary

Documents a known, expected divergence: `fgumi group` and fgbio's `GroupReadsByUmi` produce **identical UMI groupings** but generally write **different integer `MI` values** for the same molecules. The `MI` integer is only an arbitrary label for an equivalence class — the grouping is what's biologically meaningful — so this is a labeling difference, not a correctness difference. `fgumi compare bams --mode grouping` reports 0 mismatches between the two tools on the same input even though the integers differ.

## Why they diverge

Both tools number position groups in template-coordinate order and emit consecutive `0..N-1` labels (fgumi since #269). They diverge on *which* integer a molecule receives, because the order molecules are numbered *within a single coordinate cluster* differs:

- **Pair-orientation subgroups** (non-`paired` strategies): fgumi walks F1R2/F2R1 subgroups in a deterministic sorted order; fgbio walks them in Scala hash-bucket iteration order.
- **`identity` / `edit`:** fgumi mints IDs in lexicographically sorted UMI order; fgbio uses Scala `Set` (hash-bucket) order.
- **`adjacency` / `paired`:** both order by descending family size (so they usually agree), but the equal-count tie-break differs (fgumi: raw first-seen UMI bytes; fgbio: canonicalized UMI), so ties can flip.

Both tools are deterministic per version (fgumi even under `--threads N > 1`), but their orderings were never designed to match, and fgbio's hash-order orderings can also shift across Scala/JVM versions.

Practical consequence: downstream consensus read names inherit the `MI` base (`<prefix>:<mi_base>`), so comparing consensus BAMs across the two pipelines by read name or raw `MI` value will mismatch even when the molecules are identical — use `fgumi compare bams --mode grouping` instead.

## Changes

- `docs/src/guide/migration-from-fgbio.md` — new **"MI Tag Values"** section (authoritative writeup).
- `docs/src/guide/umi-grouping.md` — short note pointing to it.

Docs-only; no code or behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new “MI Tag Values” section explaining that `fgumi group` and fgbio can yield equivalent UMI molecule groupings while assigning different integer `MI` labels within coordinate clusters.
  - Clarified that comparing raw `MI` values or consensus BAMs by read name can be misleading across pipelines.
  - Updated the paired strategy notes to direct users to validate equivalence using `fgumi compare bams --mode grouping`, with a link to the migration guide for deeper reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->