### PR TITLE
fix(metrics): align TSV metric output with fgbio Metric format (#498)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,8 @@ dependencies = [
  "fgumi-raw-bam",
  "fgumi-sam",
  "noodles",
+ "proptest",
+ "rstest",
  "serde",
  "tempfile",
 ]

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -11,12 +11,15 @@ license.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 fgoxide = "0.6.0"
+tempfile = "3.3.0"
 noodles = { version = "0.111.0", features = ["sam"], optional = true }
 fgumi-raw-bam = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
 fgumi-sam = { workspace = true }
+rstest = "0.26"
+proptest = "1.10"
 
 [features]
 default = ["clip"]

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -57,9 +57,11 @@ pub struct ConsensusMetrics {
     pub umi_groups_failed: u64,
 
     /// Average input reads per consensus read
+    #[serde(with = "crate::float")]
     pub avg_input_reads_per_consensus: f64,
 
     /// Average raw read depth per consensus read
+    #[serde(with = "crate::float")]
     pub avg_raw_read_depth: f64,
 
     /// Minimum raw read depth
@@ -728,5 +730,32 @@ mod tests {
         assert_eq!(kv.key, "test_key");
         assert_eq!(kv.value, "42");
         assert_eq!(kv.description, "A test metric");
+    }
+
+    #[test]
+    fn test_nan_infinity_serialization() -> anyhow::Result<()> {
+        use crate::writer::{read_metrics, write_metrics};
+        use tempfile::NamedTempFile;
+
+        let temp_file = NamedTempFile::new()?;
+        let path = temp_file.path();
+
+        // Both averaged-depth fields serialize through `crate::float`, so non-finite values
+        // (0/0 → NaN, n/0 → Infinity) must round-trip through fgumi's own writer/reader the
+        // same way `correct.rs::test_nan_infinity_serialization` pins them for the sibling
+        // metric type. Plain ryu `inf`/`-inf` tokens would fail fgbio's `Double.parseDouble`.
+        let mut metrics = ConsensusMetrics::new();
+        metrics.avg_input_reads_per_consensus = f64::NAN;
+        metrics.avg_raw_read_depth = f64::INFINITY;
+
+        write_metrics(path, &[metrics], "consensus")?;
+        let read_back: Vec<ConsensusMetrics> = read_metrics(path, "consensus")?;
+
+        assert_eq!(read_back.len(), 1);
+        assert!(read_back[0].avg_input_reads_per_consensus.is_nan());
+        assert!(read_back[0].avg_raw_read_depth.is_infinite());
+        assert!(read_back[0].avg_raw_read_depth > 0.0); // Positive infinity
+
+        Ok(())
     }
 }

--- a/crates/fgumi-metrics/src/correct.rs
+++ b/crates/fgumi-metrics/src/correct.rs
@@ -3,56 +3,10 @@
 //! This module provides metrics for tracking UMI correction operations.
 
 use anyhow::Result;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::Metric;
-
-/// Serializes an f64 as an integer string if it's a whole number.
-///
-/// This matches fgbio's output format where 0.0 is output as "0".
-#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde requires &T signature")]
-fn serialize_f64_as_int<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let value = *value;
-    // Check for NaN and Infinity first
-    if value.is_nan() {
-        return serializer.serialize_str("NaN");
-    }
-    if value.is_infinite() {
-        return serializer.serialize_str(if value > 0.0 { "Infinity" } else { "-Infinity" });
-    }
-
-    // If the value is a whole number, serialize without decimal point
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "i64::MAX boundary check, exact precision not needed"
-    )]
-    let max_safe = i64::MAX as f64;
-    if value.fract() == 0.0 && value.abs() < max_safe {
-        #[expect(clippy::cast_possible_truncation, reason = "guarded by abs check above")]
-        let int_value = value as i64;
-        serializer.serialize_str(&format!("{int_value}"))
-    } else {
-        serializer.serialize_str(&format!("{value}"))
-    }
-}
-
-/// Deserializes an f64 from a string, handling special values like NaN and Infinity.
-fn deserialize_f64_from_str<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: String = String::deserialize(deserializer)?;
-    match s.as_str() {
-        "NaN" => Ok(f64::NAN),
-        "Infinity" => Ok(f64::INFINITY),
-        "-Infinity" => Ok(f64::NEG_INFINITY),
-        _ => s.parse().map_err(serde::de::Error::custom),
-    }
-}
 
 /// Metrics tracking how well observed UMIs match expected UMI sequences.
 ///
@@ -90,17 +44,11 @@ pub struct UmiCorrectionMetrics {
     pub other_matches: u64,
 
     /// The fraction of all UMIs that matched or were corrected to this UMI.
-    #[serde(
-        serialize_with = "serialize_f64_as_int",
-        deserialize_with = "deserialize_f64_from_str"
-    )]
+    #[serde(with = "crate::float")]
     pub fraction_of_matches: f64,
 
     /// The `total_matches` for this UMI divided by the mean `total_matches` for all UMIs.
-    #[serde(
-        serialize_with = "serialize_f64_as_int",
-        deserialize_with = "deserialize_f64_from_str"
-    )]
+    #[serde(with = "crate::float")]
     pub representation: f64,
 }
 

--- a/crates/fgumi-metrics/src/duplex.rs
+++ b/crates/fgumi-metrics/src/duplex.rs
@@ -23,20 +23,26 @@ pub struct FamilySizeMetric {
     /// Count of CS families with this size
     pub cs_count: usize,
     /// Fraction of all CS families with this size
+    #[serde(with = "crate::float")]
     pub cs_fraction: f64,
     /// Fraction of CS families with size >= `family_size`
+    #[serde(with = "crate::float")]
     pub cs_fraction_gt_or_eq_size: f64,
     /// Count of SS families with this size
     pub ss_count: usize,
     /// Fraction of all SS families with this size
+    #[serde(with = "crate::float")]
     pub ss_fraction: f64,
     /// Fraction of SS families with size >= `family_size`
+    #[serde(with = "crate::float")]
     pub ss_fraction_gt_or_eq_size: f64,
     /// Count of DS families with this size
     pub ds_count: usize,
     /// Fraction of all DS families with this size
+    #[serde(with = "crate::float")]
     pub ds_fraction: f64,
     /// Fraction of DS families with size >= `family_size`
+    #[serde(with = "crate::float")]
     pub ds_fraction_gt_or_eq_size: f64,
 }
 
@@ -83,8 +89,10 @@ pub struct DuplexFamilySizeMetric {
     /// Count of families with these AB/BA sizes
     pub count: usize,
     /// Fraction of all duplex families with these sizes
+    #[serde(with = "crate::float")]
     pub fraction: f64,
     /// Fraction of duplex families with AB >= `ab_size` and BA >= `ba_size`
+    #[serde(with = "crate::float")]
     pub fraction_gt_or_eq_size: f64,
 }
 
@@ -132,6 +140,7 @@ impl PartialEq for DuplexFamilySizeMetric {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DuplexYieldMetric {
     /// Approximate fraction of full dataset used
+    #[serde(with = "crate::float")]
     pub fraction: f64,
     /// Number of read pairs upon which metrics are based
     pub read_pairs: usize,
@@ -144,8 +153,10 @@ pub struct DuplexYieldMetric {
     /// Number of DS families that are duplexes (min reads on both strands)
     pub ds_duplexes: usize,
     /// Fraction of DS families that are duplexes
+    #[serde(with = "crate::float")]
     pub ds_fraction_duplexes: f64,
     /// Expected fraction of DS families that should be duplexes under ideal model
+    #[serde(with = "crate::float")]
     pub ds_fraction_duplexes_ideal: f64,
 }
 
@@ -192,10 +203,13 @@ pub struct DuplexUmiMetric {
     /// Number of double-stranded tag families observing this duplex UMI
     pub unique_observations: usize,
     /// Fraction of all raw observations
+    #[serde(with = "crate::float")]
     pub fraction_raw_observations: f64,
     /// Fraction of all unique observations
+    #[serde(with = "crate::float")]
     pub fraction_unique_observations: f64,
     /// Expected fraction based on individual UMI frequencies
+    #[serde(with = "crate::float")]
     pub fraction_unique_observations_expected: f64,
 }
 
@@ -313,30 +327,30 @@ impl DuplexMetricsCollector {
         self.duplex_umi_counts.record(umi, raw_count, error_count, is_unique);
     }
 
-    /// Generates family size metrics
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal array-of-three maximum computation fails, which cannot
-    /// happen since the array is always non-empty.
+    /// Generates family size metrics, one row per observed family size (sparse), sorted
+    /// ascending by `family_size`.
     #[must_use]
     pub fn family_size_metrics(&self) -> Vec<FamilySizeMetric> {
-        // Find max family size across all types
-        let max_size = *[
-            self.cs_family_sizes.keys().max().unwrap_or(&0),
-            self.ss_family_sizes.keys().max().unwrap_or(&0),
-            self.ds_family_sizes.keys().max().unwrap_or(&0),
-        ]
-        .iter()
-        .max()
-        .expect("array of three elements always has a maximum");
-
         let coord_strand_total: usize = self.cs_family_sizes.values().sum();
         let single_strand_total: usize = self.ss_family_sizes.values().sum();
         let double_strand_total: usize = self.ds_family_sizes.values().sum();
 
-        let mut metrics = Vec::new();
-        for size in 1..=*max_size {
+        // fgbio emits one row per *observed* family size (sparse), not a dense
+        // `1..=max` range: `CollectDuplexSeqMetrics.familySizeMetrics` builds a map
+        // keyed only by sizes that occur in the CS/SS/DS counters, then sorts
+        // ascending by `family_size`. Take the sorted union of observed sizes.
+        let mut sizes: Vec<usize> = self
+            .cs_family_sizes
+            .keys()
+            .chain(self.ss_family_sizes.keys())
+            .chain(self.ds_family_sizes.keys())
+            .copied()
+            .collect();
+        sizes.sort_unstable();
+        sizes.dedup();
+
+        let mut metrics = Vec::with_capacity(sizes.len());
+        for size in sizes {
             let mut metric = FamilySizeMetric::new(size);
 
             metric.cs_count = *self.cs_family_sizes.get(&size).unwrap_or(&0);
@@ -469,8 +483,13 @@ impl DuplexMetricsCollector {
             })
             .collect();
 
-        // Sort by unique observations descending (matching Scala's sort order)
-        metrics.sort_by(|a, b| b.unique_observations.cmp(&a.unique_observations));
+        // Sort by unique observations descending (matching fgbio's `sortBy(-unique_observations)`),
+        // with the UMI sequence as a deterministic secondary key. fgbio's own tie order comes from
+        // nondeterministic map iteration; keying ties on `umi` makes fgumi's output stable across
+        // runs and thread counts (an acceptance-criterion requirement) without changing the row set.
+        metrics.sort_by(|a, b| {
+            b.unique_observations.cmp(&a.unique_observations).then_with(|| a.umi.cmp(&b.umi))
+        });
         metrics
     }
 }
@@ -773,6 +792,122 @@ mod tests {
         assert_eq!(duplex_metrics.len(), 1);
         // Expected = 0.5 * 0.5 = 0.25
         assert!((duplex_metrics[0].fraction_unique_observations_expected - 0.25).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_family_size_metrics_are_sparse() {
+        let mut collector = DuplexMetricsCollector::new(false);
+        // Observe only sizes 1 and 5 (a gap at 2, 3, 4). fgbio's `familySizeMetrics`
+        // emits a row per *observed* size; the old dense `1..=max` range emitted
+        // phantom all-zero rows for the unobserved sizes.
+        collector.record_cs_family(1);
+        collector.record_cs_family(5);
+
+        let metrics = collector.family_size_metrics();
+        let sizes: Vec<usize> = metrics.iter().map(|m| m.family_size).collect();
+        assert_eq!(sizes, vec![1, 5], "only observed family sizes should be emitted");
+
+        // The reverse-cumulative `>= size` fraction stays correct across the gap:
+        // each size holds half the CS families, so size 1 → 1.0, size 5 → 0.5.
+        assert!((metrics[0].cs_fraction_gt_or_eq_size - 1.0).abs() < 1e-9);
+        assert!((metrics[1].cs_fraction_gt_or_eq_size - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_family_size_metrics_union_disjoint_cs_ss_ds_keys() {
+        // CS, SS, and DS counters observe *disjoint* sizes (CS=2, SS=4, DS=7). The
+        // emitted rows must be the sorted union of all three key sets — no size may
+        // be dropped just because a given strand type has no families at it, and each
+        // per-type count lands on the right row.
+        let mut collector = DuplexMetricsCollector::new(false);
+        collector.record_cs_family(2);
+        collector.record_ss_family(4);
+        collector.record_ds_family(7);
+
+        let metrics = collector.family_size_metrics();
+        let sizes: Vec<usize> = metrics.iter().map(|m| m.family_size).collect();
+        assert_eq!(sizes, vec![2, 4, 7], "rows must be the sorted union of CS/SS/DS sizes");
+
+        let by_size = |s: usize| metrics.iter().find(|m| m.family_size == s).expect("size present");
+        assert_eq!((by_size(2).cs_count, by_size(2).ss_count, by_size(2).ds_count), (1, 0, 0));
+        assert_eq!((by_size(4).cs_count, by_size(4).ss_count, by_size(4).ds_count), (0, 1, 0));
+        assert_eq!((by_size(7).cs_count, by_size(7).ss_count, by_size(7).ds_count), (0, 0, 1));
+    }
+
+    #[test]
+    fn test_family_size_metrics_match_fgbio_fractions() {
+        // Independent oracle: fgbio `CollectDuplexSeqMetrics.familySizeMetrics` emits one row per
+        // observed CS/SS/DS family size (sparse), each row's per-type fraction = count /
+        // type-total, plus a reverse-cumulative `>= size` fraction. The sparse/union tests above
+        // pin the row *set* and counts; this pins the *fractions* too, computed by hand from that
+        // spec (not re-derived from the implementation). Data is generated programmatically — no
+        // committed fgbio fixture — per the repo's testing conventions.
+        let mut collector = DuplexMetricsCollector::new(false);
+        // CS: 4 families — two of size 1, one of size 2, one of size 4 (total 4).
+        collector.record_cs_family(1);
+        collector.record_cs_family(1);
+        collector.record_cs_family(2);
+        collector.record_cs_family(4);
+        // SS: 2 families — one of size 2, one of size 4 (total 2).
+        collector.record_ss_family(2);
+        collector.record_ss_family(4);
+        // DS: 1 family — one of size 4 (total 1).
+        collector.record_ds_family(4);
+
+        let metrics = collector.family_size_metrics();
+        let sizes: Vec<usize> = metrics.iter().map(|m| m.family_size).collect();
+        assert_eq!(sizes, vec![1, 2, 4], "one row per observed size (sorted union)");
+
+        // Each tuple is `(count, fraction, fraction_gt_or_eq_size)` for the CS/SS/DS column.
+        let check = |m: &FamilySizeMetric,
+                     cs: (usize, f64, f64),
+                     ss: (usize, f64, f64),
+                     ds: (usize, f64, f64)| {
+            assert_eq!(m.cs_count, cs.0, "cs_count size {}", m.family_size);
+            assert!((m.cs_fraction - cs.1).abs() < 1e-9, "cs_fraction size {}", m.family_size);
+            assert!(
+                (m.cs_fraction_gt_or_eq_size - cs.2).abs() < 1e-9,
+                "cs_fraction_gt_or_eq_size size {}",
+                m.family_size
+            );
+            assert_eq!(m.ss_count, ss.0, "ss_count size {}", m.family_size);
+            assert!((m.ss_fraction - ss.1).abs() < 1e-9, "ss_fraction size {}", m.family_size);
+            assert!(
+                (m.ss_fraction_gt_or_eq_size - ss.2).abs() < 1e-9,
+                "ss_fraction_gt_or_eq_size size {}",
+                m.family_size
+            );
+            assert_eq!(m.ds_count, ds.0, "ds_count size {}", m.family_size);
+            assert!((m.ds_fraction - ds.1).abs() < 1e-9, "ds_fraction size {}", m.family_size);
+            assert!(
+                (m.ds_fraction_gt_or_eq_size - ds.2).abs() < 1e-9,
+                "ds_fraction_gt_or_eq_size size {}",
+                m.family_size
+            );
+        };
+
+        // size 1: CS 2/4=0.5 (cum 1.0); SS 0 (cum 1.0); DS 0 (cum 1.0)
+        check(&metrics[0], (2, 0.5, 1.0), (0, 0.0, 1.0), (0, 0.0, 1.0));
+        // size 2: CS 1/4=0.25 (cum 0.5); SS 1/2=0.5 (cum 1.0); DS 0 (cum 1.0)
+        check(&metrics[1], (1, 0.25, 0.5), (1, 0.5, 1.0), (0, 0.0, 1.0));
+        // size 4: CS 1/4=0.25 (cum 0.25); SS 1/2=0.5 (cum 0.5); DS 1/1=1.0 (cum 1.0)
+        check(&metrics[2], (1, 0.25, 0.25), (1, 0.5, 0.5), (1, 1.0, 1.0));
+    }
+
+    #[test]
+    fn test_duplex_umi_metrics_deterministic_tie_order() {
+        // Three duplex UMIs each observed exactly once → equal `unique_observations`
+        // (a tie). Insertion order is reverse-sorted; the output must be ordered by
+        // `umi` ascending (the deterministic secondary sort key) rather than by the
+        // nondeterministic HashMap iteration order the primary key alone would leave.
+        let mut collector = DuplexMetricsCollector::new(true);
+        for umi in ["GGGG-CCCC", "AAAA-TTTT", "CCCC-GGGG"] {
+            collector.record_duplex_umi(umi, 1, 0, true);
+        }
+
+        let metrics = collector.duplex_umi_metrics(&[]);
+        let order: Vec<&str> = metrics.iter().map(|m| m.umi.as_str()).collect();
+        assert_eq!(order, vec!["AAAA-TTTT", "CCCC-GGGG", "GGGG-CCCC"]);
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/float.rs
+++ b/crates/fgumi-metrics/src/float.rs
@@ -1,0 +1,137 @@
+//! Shared serde helpers for writing `f64` metric fields in fgbio's `Metric` TSV format.
+//!
+//! fgbio serializes doubles with `Double.toString`, which renders non-finite values
+//! as `Infinity`, `-Infinity`, and `NaN` — the exact tokens `Double.parseDouble`
+//! accepts on read. Rust's default `f64` serialization (via ryu) instead emits
+//! `inf`/`-inf`/`NaN`, and `inf`/`-inf` are **unparseable** by fgbio's `Metric.read`.
+//!
+//! Every `f64` field in an fgumi metric that is meant to be read back by fgbio must
+//! carry `#[serde(with = "crate::float")]` so non-finite values round-trip through
+//! both tools. Finite whole numbers are written without a trailing `.0` (e.g. `0`
+//! rather than `0.0`), matching fgbio's `DecimalFormat` output for integral values;
+//! other finite values keep full precision (numeric equality — not byte-for-byte
+//! formatting — is the metric contract, see the crate `format_float` docs).
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serializes an `f64` in fgbio's `Metric` TSV format.
+///
+/// Non-finite values become `Infinity`/`-Infinity`/`NaN` (readable by fgbio's
+/// `Double.parseDouble`); finite whole numbers drop the fractional part; all other
+/// finite values keep full precision.
+#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde requires &T signature")]
+pub(crate) fn serialize<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let value = *value;
+    if value.is_nan() {
+        return serializer.serialize_str("NaN");
+    }
+    if value.is_infinite() {
+        return serializer.serialize_str(if value > 0.0 { "Infinity" } else { "-Infinity" });
+    }
+
+    // Render an integral value without a decimal point (fgbio's DecimalFormat does the same).
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "i64::MAX boundary check, exact precision not needed"
+    )]
+    let max_safe = i64::MAX as f64;
+    if value.fract() == 0.0 && value.abs() < max_safe {
+        #[expect(clippy::cast_possible_truncation, reason = "guarded by abs check above")]
+        let int_value = value as i64;
+        serializer.serialize_str(&format!("{int_value}"))
+    } else {
+        serializer.serialize_str(&format!("{value}"))
+    }
+}
+
+/// Deserializes an `f64` written by [`serialize`], accepting the non-finite
+/// tokens `NaN`, `Infinity`, and `-Infinity` in addition to ordinary numbers.
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = String::deserialize(deserializer)?;
+    match s.as_str() {
+        "NaN" => Ok(f64::NAN),
+        "Infinity" => Ok(f64::INFINITY),
+        "-Infinity" => Ok(f64::NEG_INFINITY),
+        _ => s.parse().map_err(serde::de::Error::custom),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fgoxide::io::DelimFile;
+    use proptest::prelude::*;
+    use rstest::rstest;
+    use serde::{Deserialize, Serialize};
+    use tempfile::NamedTempFile;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Row {
+        #[serde(with = "super")]
+        value: f64,
+    }
+
+    /// Writes a one-column TSV via the real `DelimFile` path and returns the value cell
+    /// (the second physical line, after the `value` header).
+    fn to_cell(value: f64) -> String {
+        let file = NamedTempFile::new().expect("temp file");
+        DelimFile::default().write_tsv(file.path(), [Row { value }]).expect("write");
+        let content = std::fs::read_to_string(file.path()).expect("read");
+        content.lines().nth(1).expect("value row").to_string()
+    }
+
+    /// Writes `value` and reads the single row back through the real `DelimFile` path,
+    /// returning the round-tripped `f64`.
+    fn round_trip(value: f64) -> f64 {
+        let file = NamedTempFile::new().expect("temp file");
+        DelimFile::default().write_tsv(file.path(), [Row { value }]).expect("write");
+        let rows: Vec<Row> = DelimFile::default().read_tsv(file.path()).expect("read");
+        assert_eq!(rows.len(), 1);
+        rows[0].value
+    }
+
+    /// Each value serializes to fgbio's exact TSV token: non-finite values become
+    /// `Infinity`/`-Infinity`/`NaN`, integral values drop the decimal point, and
+    /// fractional values keep full precision.
+    #[rstest]
+    #[case::pos_infinity(f64::INFINITY, "Infinity")]
+    #[case::neg_infinity(f64::NEG_INFINITY, "-Infinity")]
+    #[case::nan(f64::NAN, "NaN")]
+    #[case::zero(0.0, "0")]
+    #[case::positive_integral(42.0, "42")]
+    #[case::negative_integral(-7.0, "-7")]
+    #[case::half(0.5, "0.5")]
+    #[case::fractional(1.25, "1.25")]
+    fn writes_fgbio_token(#[case] value: f64, #[case] expected: &str) {
+        assert_eq!(to_cell(value), expected);
+    }
+
+    /// Each signed infinity round-trips back to an infinity of the same sign.
+    #[rstest]
+    #[case::pos_infinity(f64::INFINITY)]
+    #[case::neg_infinity(f64::NEG_INFINITY)]
+    fn round_trips_signed_infinity(#[case] value: f64) {
+        let read = round_trip(value);
+        assert!(read.is_infinite() && read.signum() == value.signum());
+    }
+
+    #[test]
+    fn round_trips_nan() {
+        assert!(round_trip(f64::NAN).is_nan());
+    }
+
+    proptest! {
+        /// Any finite value round-trips through the write/read path to an equal `f64`
+        /// (serialization uses Rust's shortest round-trippable representation).
+        #[test]
+        fn round_trips_finite(value in -1e15_f64..1e15_f64) {
+            let read = round_trip(value);
+            prop_assert!((read - value).abs() < f64::EPSILON, "round-trip {value}");
+        }
+    }
+}

--- a/crates/fgumi-metrics/src/group.rs
+++ b/crates/fgumi-metrics/src/group.rs
@@ -39,14 +39,27 @@ fn build_size_distribution<T>(
 
 /// Metrics for UMI grouping operations.
 ///
-/// These metrics track how reads are grouped by UMI and provide insight into
-/// data quality and molecule representation.
+/// The **serialized** form matches fgbio's `UmiGroupingMetric` exactly — the same
+/// five columns, in the same order, with the same (fgbio-spelled) names:
+/// `accepted_sam_records`, `discarded_non_pf`, `discarded_poor_alignment`,
+/// `discarded_ns_in_umi`, `discarded_umis_to_short`. This keeps the
+/// `.grouping_metrics.txt` output readable by fgbio's `Metric.read`, which hard-fails
+/// on any unexpected column.
+///
+/// The remaining fields are `#[serde(skip)]` — they are computed and retained for
+/// fgumi's own summary logging ([`crate::ProcessingMetrics`] and
+/// `log_umi_grouping_summary`) but are **not** written to the metrics file. They are
+/// all derivable from the accepted count and the family-size distribution, which is
+/// emitted separately in `.family_sizes.txt`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UmiGroupingMetrics {
-    /// Total SAM records processed
+    /// Total SAM records processed (fgumi-internal; not part of fgbio's schema —
+    /// derivable as accepted + discarded).
+    #[serde(skip)]
     pub total_records: u64,
 
-    /// Records accepted for grouping
+    /// Records accepted for grouping (fgbio column `accepted_sam_records`).
+    #[serde(rename = "accepted_sam_records")]
     pub accepted_records: u64,
 
     /// Records discarded (not passing filter)
@@ -58,25 +71,33 @@ pub struct UmiGroupingMetrics {
     /// Records discarded (Ns in UMI)
     pub discarded_ns_in_umi: u64,
 
-    /// Records discarded (UMI too short)
+    /// Records discarded (UMI too short). fgbio spells this column
+    /// `discarded_umis_to_short` (sic); the serialized name matches it exactly.
+    #[serde(rename = "discarded_umis_to_short")]
     pub discarded_umi_too_short: u64,
 
-    /// Number of unique molecule IDs assigned
+    /// Number of unique molecule IDs assigned (fgumi-internal summary only).
+    #[serde(skip)]
     pub unique_molecule_ids: u64,
 
-    /// Total number of UMI families/groups
+    /// Total number of UMI families/groups (fgumi-internal summary only).
+    #[serde(skip)]
     pub total_families: u64,
 
-    /// Average reads per molecule
+    /// Average reads per molecule (fgumi-internal summary only).
+    #[serde(skip)]
     pub avg_reads_per_molecule: f64,
 
-    /// Median reads per molecule
+    /// Median reads per molecule (fgumi-internal summary only).
+    #[serde(skip)]
     pub median_reads_per_molecule: u64,
 
-    /// Minimum reads per molecule
+    /// Minimum reads per molecule (fgumi-internal summary only).
+    #[serde(skip)]
     pub min_reads_per_molecule: u64,
 
-    /// Maximum reads per molecule
+    /// Maximum reads per molecule (fgumi-internal summary only).
+    #[serde(skip)]
     pub max_reads_per_molecule: u64,
 }
 
@@ -123,9 +144,11 @@ pub struct FamilySizeMetrics {
     pub count: u64,
 
     /// Fraction of all families with this size
+    #[serde(with = "crate::float")]
     pub fraction: f64,
 
     /// Cumulative fraction (families with size >= this value)
+    #[serde(with = "crate::float")]
     pub fraction_gt_or_eq_family_size: f64,
 }
 
@@ -176,9 +199,11 @@ pub struct PositionGroupSizeMetrics {
     pub count: u64,
 
     /// Fraction of all position groups with this size
+    #[serde(with = "crate::float")]
     pub fraction: f64,
 
     /// Cumulative fraction (position groups with size >= this value)
+    #[serde(with = "crate::float")]
     pub fraction_gt_or_eq_position_group_size: f64,
 }
 
@@ -231,6 +256,52 @@ mod tests {
         assert_eq!(metrics.total_records, 0);
         assert_eq!(metrics.accepted_records, 0);
         assert_eq!(metrics.unique_molecule_ids, 0);
+    }
+
+    #[test]
+    fn test_umi_grouping_metrics_serializes_fgbio_five_columns() {
+        use fgoxide::io::DelimFile;
+        use tempfile::NamedTempFile;
+
+        let metrics = vec![UmiGroupingMetrics {
+            total_records: 100,
+            accepted_records: 90,
+            discarded_non_pf: 4,
+            discarded_poor_alignment: 3,
+            discarded_ns_in_umi: 2,
+            discarded_umi_too_short: 1,
+            // fgumi-internal fields that must NOT be serialized:
+            unique_molecule_ids: 42,
+            total_families: 42,
+            avg_reads_per_molecule: 2.5,
+            median_reads_per_molecule: 2,
+            min_reads_per_molecule: 1,
+            max_reads_per_molecule: 9,
+        }];
+
+        let file = NamedTempFile::new().expect("temp file");
+        DelimFile::default().write_tsv(file.path(), &metrics).expect("write");
+        let content = std::fs::read_to_string(file.path()).expect("read");
+        let mut lines = content.lines();
+
+        // Header and row must be exactly fgbio's 5-column `UmiGroupingMetric`, in order.
+        assert_eq!(
+            lines.next(),
+            Some(
+                "accepted_sam_records\tdiscarded_non_pf\tdiscarded_poor_alignment\t\
+                 discarded_ns_in_umi\tdiscarded_umis_to_short"
+            )
+        );
+        assert_eq!(lines.next(), Some("90\t4\t3\t2\t1"));
+        assert_eq!(lines.next(), None);
+
+        // And it reads back (fgumi-internal fields default to zero, fgbio columns intact).
+        let read_back: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(file.path()).expect("read back");
+        assert_eq!(read_back.len(), 1);
+        assert_eq!(read_back[0].accepted_records, 90);
+        assert_eq!(read_back[0].discarded_umi_too_short, 1);
+        assert_eq!(read_back[0].total_records, 0);
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -13,6 +13,7 @@ pub mod clip;
 pub mod consensus;
 pub mod correct;
 pub mod duplex;
+pub(crate) mod float;
 pub mod group;
 pub mod rejection;
 pub mod shared;
@@ -21,13 +22,20 @@ pub mod writer;
 
 use serde::{Deserialize, Serialize};
 
-/// Number of decimal places used for float metrics (matches fgbio).
+/// Number of decimal places used by [`format_float`] for fixed-precision float metrics.
 pub const FLOAT_PRECISION: usize = 6;
 
-/// Formats a float value with the standard precision for metrics.
+/// Formats a float with a fixed 6 decimal places (e.g. `0.9` → `"0.900000"`).
 ///
-/// This ensures consistent float formatting across all metrics output,
-/// matching fgbio's 6 decimal place precision.
+/// This does **not** reproduce fgbio's textual format. fgbio uses
+/// `DecimalFormat("0.######")`, which trims trailing zeros (`0.9` → `"0.9"`,
+/// `0.0` → `"0"`) and can switch to scientific notation for very small values. The
+/// metric contract between fgumi and fgbio is *numeric* equality — `fgumi compare
+/// metrics` parses both sides and compares with a tolerance — so this
+/// representation difference is accepted (see the issue's "Accepted (not a bug)"
+/// note). f64 fields that must be *read back* by fgbio instead use the crate's
+/// `float` serde helper (`#[serde(with = "crate::float")]`), which additionally
+/// renders non-finite values as fgbio-parseable `Infinity`/`-Infinity`/`NaN` tokens.
 ///
 /// # Example
 /// ```

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -14,7 +14,7 @@ use std::fmt;
 pub enum RejectionReason {
     /// Insufficient reads to generate a consensus
     InsufficientSupport,
-    /// Read has a different, and minority, set of indels
+    /// Reads has a different, and minority, set of indels
     MinorityAlignment,
     /// Too few reads agreed on the strand orientation
     InsufficientStrandSupport,
@@ -60,7 +60,8 @@ impl RejectionReason {
     pub fn description(&self) -> &'static str {
         match self {
             Self::InsufficientSupport => "Insufficient reads to generate a consensus",
-            Self::MinorityAlignment => "Read has a different, and minority, set of indels",
+            // fgbio spells this "Reads has …" (sic) — matched verbatim for metric parity.
+            Self::MinorityAlignment => "Reads has a different, and minority, set of indels",
             Self::InsufficientStrandSupport => "Too few reads agreed on the strand orientation",
             Self::LowBaseQuality => "Base quality scores were below threshold",
             Self::ExcessiveNBases => "Read group had too many N bases",
@@ -114,7 +115,7 @@ impl RejectionReason {
     pub fn kv_description(&self) -> &'static str {
         match self {
             Self::InsufficientSupport => "Insufficient reads to generate a consensus",
-            Self::MinorityAlignment => "Read has a different, and minority, set of indels",
+            Self::MinorityAlignment => "Reads has a different, and minority, set of indels",
             Self::InsufficientStrandSupport => "Insufficient strand support for consensus",
             Self::LowBaseQuality => "Low base quality",
             Self::ExcessiveNBases => "Excessive N bases in read",
@@ -127,6 +128,7 @@ impl RejectionReason {
             Self::InsufficientMinDepth => "Insufficient minimum read depth",
             Self::ExcessiveErrorRate => "Excessive error rate",
             Self::UmiTooShort => "UMI sequence too short",
+            // fgbio's exact title-cased string for `single_strand_only`, matched for parity.
             Self::SameStrandOnly => "Only Generating One Strand of Duplex Consensus",
             Self::NonPairedReads => "Unpaired/fragment reads not supported by Duplex caller",
             Self::DuplicateUmi => "Potential collision between independent duplex molecules",
@@ -177,9 +179,10 @@ mod tests {
     fn test_rejection_reason_description() {
         assert!(RejectionReason::LowBaseQuality.description().contains("quality"));
         assert!(RejectionReason::InsufficientSupport.description().contains("Insufficient"));
+        // Matches fgbio's exact (grammatically-odd) wording for metric parity.
         assert_eq!(
             RejectionReason::MinorityAlignment.to_string(),
-            "Read has a different, and minority, set of indels"
+            "Reads has a different, and minority, set of indels"
         );
     }
 
@@ -241,6 +244,30 @@ mod tests {
         for reason in &ALL_REASONS {
             assert!(!reason.kv_description().is_empty(), "kv_description for {reason:?} is empty");
         }
+    }
+
+    /// Pin the exact fgbio-parity `tsv_key` + `kv_description` for the two reasons whose strings
+    /// are deliberately matched to fgbio (see the `for parity` comments above). A non-empty check
+    /// would let these silently drift; exact equality is what keeps them aligned with fgbio.
+    #[test]
+    fn test_kv_description_matches_fgbio_verbatim() {
+        assert_eq!(
+            RejectionReason::MinorityAlignment.tsv_key(),
+            "raw_reads_rejected_for_minority_alignment"
+        );
+        assert_eq!(
+            RejectionReason::MinorityAlignment.kv_description(),
+            "Reads has a different, and minority, set of indels"
+        );
+
+        assert_eq!(
+            RejectionReason::SameStrandOnly.tsv_key(),
+            "raw_reads_rejected_for_single_strand_only"
+        );
+        assert_eq!(
+            RejectionReason::SameStrandOnly.kv_description(),
+            "Only Generating One Strand of Duplex Consensus"
+        );
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/shared.rs
+++ b/crates/fgumi-metrics/src/shared.rs
@@ -24,8 +24,10 @@ pub struct UmiMetric {
     /// Number of double-stranded tag families observing this UMI
     pub unique_observations: usize,
     /// Fraction of all raw observations
+    #[serde(with = "crate::float")]
     pub fraction_raw_observations: f64,
     /// Fraction of all unique observations
+    #[serde(with = "crate::float")]
     pub fraction_unique_observations: f64,
 }
 

--- a/crates/fgumi-metrics/src/simplex.rs
+++ b/crates/fgumi-metrics/src/simplex.rs
@@ -22,14 +22,18 @@ pub struct SimplexFamilySizeMetric {
     /// Count of CS families with this size
     pub cs_count: usize,
     /// Fraction of all CS families with this size
+    #[serde(with = "crate::float")]
     pub cs_fraction: f64,
     /// Fraction of CS families with size >= `family_size`
+    #[serde(with = "crate::float")]
     pub cs_fraction_gt_or_eq_size: f64,
     /// Count of SS families with this size
     pub ss_count: usize,
     /// Fraction of all SS families with this size
+    #[serde(with = "crate::float")]
     pub ss_fraction: f64,
     /// Fraction of SS families with size >= `family_size`
+    #[serde(with = "crate::float")]
     pub ss_fraction_gt_or_eq_size: f64,
 }
 
@@ -65,6 +69,7 @@ impl Metric for SimplexFamilySizeMetric {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimplexYieldMetric {
     /// Approximate fraction of full dataset used
+    #[serde(with = "crate::float")]
     pub fraction: f64,
     /// Number of read pairs upon which metrics are based
     pub read_pairs: usize,
@@ -73,10 +78,12 @@ pub struct SimplexYieldMetric {
     /// Number of SS (Single-Strand by UMI) families
     pub ss_families: usize,
     /// Mean SS family size
+    #[serde(with = "crate::float")]
     pub mean_ss_family_size: f64,
     /// Number of SS singleton families (size 1)
     pub ss_singletons: usize,
     /// Fraction of SS families that are singletons
+    #[serde(with = "crate::float")]
     pub ss_singleton_fraction: f64,
     /// Number of SS families with size >= consensus minimum
     pub ss_consensus_families: usize,

--- a/crates/fgumi-metrics/src/writer.rs
+++ b/crates/fgumi-metrics/src/writer.rs
@@ -13,11 +13,19 @@ use crate::Metric;
 /// Write metrics to a TSV file with consistent error handling.
 ///
 /// This is a convenience wrapper around `DelimFile::write_tsv` that provides
-/// consistent error messages across all commands.
+/// consistent error messages across all commands, and — unlike a bare
+/// `DelimFile::write_tsv` — **always writes the column header**, even for an empty
+/// slice.
+///
+/// The underlying csv writer emits headers lazily (on the first record), so writing
+/// a zero-row slice through it produces a 0-byte file. fgbio writes the header
+/// eagerly in its `Metric` writer, so fgbio's `Metric.read` rejects such a file with
+/// "No header found". Emitting a header-only file keeps an empty metrics output
+/// re-readable by both fgbio and fgumi (it parses back to zero rows).
 ///
 /// # Arguments
 /// * `path` - Path to the output TSV file
-/// * `metrics` - The metrics to write (must implement Serialize)
+/// * `metrics` - The metrics to write (must implement `Serialize` and `Default`)
 /// * `description` - Human-readable description of the metrics for error messages
 ///
 /// # Errors
@@ -29,7 +37,7 @@ use crate::Metric;
 /// use serde::Serialize;
 /// use std::path::Path;
 ///
-/// #[derive(Serialize)]
+/// #[derive(Serialize, Default)]
 /// struct MyMetrics {
 ///     count: usize,
 ///     value: f64,
@@ -42,15 +50,51 @@ use crate::Metric;
 ///
 /// write_metrics(Path::new("metrics.txt"), &metrics, "processing").unwrap();
 /// ```
-pub fn write_metrics<P: AsRef<Path>, T: Serialize>(
+pub fn write_metrics<P: AsRef<Path>, T: Serialize + Default>(
     path: P,
     metrics: &[T],
     description: &str,
 ) -> Result<()> {
     let path_ref = path.as_ref();
-    DelimFile::default()
-        .write_tsv(path_ref, metrics)
+    write_metrics_atomic::<_, T>(path_ref, metrics)
         .with_context(|| format!("Failed to write {} metrics: {}", description, path_ref.display()))
+}
+
+/// Serializes `metrics` to `path` atomically, always emitting the column header.
+///
+/// Both the populated and empty cases write to a temporary file in the destination directory
+/// and are then atomically renamed into place. A crash mid-write therefore never leaves the
+/// target holding a partially-written row set — or, for the empty case, the bogus all-default
+/// data row used to materialize the header (which would look like a real collected metric);
+/// the target is either absent or holds the complete, correct content.
+///
+/// An empty slice yields a header-only file: the csv writer emits its header lazily (on the
+/// first record), so a zero-row slice would otherwise produce a 0-byte file, which fgbio's
+/// `Metric.read` rejects with "No header found". We serialize a single `T::default()` row to
+/// materialize the header, then truncate to just that header line (it parses back to zero
+/// rows), so an empty metrics output stays re-readable by both fgbio and fgumi.
+///
+/// The temp file is created via `File::create` (through `Builder::make_in`) rather than the
+/// default `NamedTempFile`, so it inherits the umask-applied `0o666 & !umask` mode. Otherwise
+/// `NamedTempFile`'s hard-coded owner-only `0o600` would make every metrics file owner-only.
+fn write_metrics_atomic<P: AsRef<Path>, T: Serialize + Default>(
+    path: P,
+    metrics: &[T],
+) -> Result<()> {
+    let path_ref = path.as_ref();
+    // Rename is only atomic within a filesystem, so create the temp file next to the target.
+    let dir = path_ref.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = tempfile::Builder::new().make_in(dir, |p| std::fs::File::create(p))?;
+    if metrics.is_empty() {
+        DelimFile::default().write_tsv(tmp.path(), [T::default()])?;
+        let content = std::fs::read_to_string(tmp.path())?;
+        let header = content.lines().next().unwrap_or_default();
+        std::fs::write(tmp.path(), format!("{header}\n"))?;
+    } else {
+        DelimFile::default().write_tsv(tmp.path(), metrics)?;
+    }
+    tmp.persist(path_ref)?;
+    Ok(())
 }
 
 /// Write metrics implementing the Metric trait to a TSV file.
@@ -112,6 +156,7 @@ pub fn read_metrics_auto<P: AsRef<Path>, T: Metric>(path: P) -> Result<Vec<T>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use serde::Deserialize;
     use std::fs;
     use tempfile::NamedTempFile;
@@ -163,14 +208,81 @@ mod tests {
     }
 
     #[test]
-    fn test_write_metrics_empty() -> Result<()> {
+    fn test_write_metrics_empty_is_header_only_and_round_trips() -> Result<()> {
         let temp_file = NamedTempFile::new()?;
         let metrics: Vec<TestMetrics> = vec![];
 
         write_metrics(temp_file.path(), &metrics, "empty")?;
 
-        // Verify the file was created (even if empty/header-only)
-        assert!(temp_file.path().exists());
+        // An empty metrics slice must still produce the column header (fgbio's
+        // Metric.read rejects a 0-byte file with "No header found"), and no data rows.
+        let content = fs::read_to_string(temp_file.path())?;
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "expected header-only file, got: {content:?}");
+        assert_eq!(lines[0], "name\tcount\tvalue");
+
+        // And it round-trips back to zero rows.
+        let read_back: Vec<TestMetrics> = read_metrics(temp_file.path(), "empty")?;
+        assert!(read_back.is_empty());
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::empty(vec![])]
+    #[case::populated(vec![TestMetrics { name: "a".to_string(), count: 1, value: 1.0 }])]
+    fn test_write_metrics_is_atomic_leaves_no_temp_files(
+        #[case] metrics: Vec<TestMetrics>,
+    ) -> Result<()> {
+        // Both the empty (header-only) and populated write paths go through a temp file that
+        // must be atomically renamed into place (and never left behind): after a successful
+        // write the destination directory should hold exactly the target file, with no stray
+        // scratch files. This pins the atomicity of the populated path, not just the empty one.
+        let dir = tempfile::tempdir()?;
+        let target = dir.path().join("metrics.txt");
+
+        write_metrics(&target, &metrics, "atomic")?;
+
+        let entries: Vec<_> = fs::read_dir(dir.path())?.collect::<std::io::Result<_>>()?;
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected only the target file, found: {:?}",
+            entries.iter().map(std::fs::DirEntry::path).collect::<Vec<_>>()
+        );
+        assert_eq!(entries[0].path(), target);
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_write_metrics_empty_matches_populated_file_mode() -> Result<()> {
+        // An empty (header-only) metrics file must not be more restrictive than a populated
+        // one. The populated path writes directly via `File::create` (umask-applied mode),
+        // while the header-only path routes through a temp file; if that temp is left at
+        // `NamedTempFile`'s hard-coded 0600 the two outputs diverge. Assert the modes match.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir()?;
+
+        let populated_path = dir.path().join("populated.txt");
+        write_metrics(
+            &populated_path,
+            &[TestMetrics { name: "x".to_string(), count: 1, value: 1.0 }],
+            "populated",
+        )?;
+        let populated_mode = fs::metadata(&populated_path)?.permissions().mode() & 0o777;
+
+        let empty_path = dir.path().join("empty.txt");
+        let empty: Vec<TestMetrics> = vec![];
+        write_metrics(&empty_path, &empty, "empty")?;
+        let empty_mode = fs::metadata(&empty_path)?.permissions().mode() & 0o777;
+
+        assert_eq!(
+            empty_mode, populated_mode,
+            "empty metrics file mode {empty_mode:o} should match populated {populated_mode:o}"
+        );
 
         Ok(())
     }

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -356,7 +356,7 @@ impl Clip {
             if let Some(mut metrics) = metrics_collection {
                 info!("Writing metrics to {}", metrics_path.display());
                 metrics.finalize();
-                let all_metrics = metrics.all_metrics();
+                let all_metrics = metrics.all_metrics().map(Clone::clone);
                 write_metrics_tsv(metrics_path, &all_metrics, "clipping")?;
                 info!("Metrics written successfully");
             }

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -12,9 +12,8 @@ use crate::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric, FamilySi
 use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
 use crate::umi::extract_mi_base;
 use crate::validation::validate_file_exists;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use fgoxide::io::DelimFile;
 use log::info;
 use statrs::distribution::{Binomial, DiscreteCDF};
 use std::path::PathBuf;
@@ -200,48 +199,39 @@ impl Command for DuplexMetrics {
         // Generate and write metrics
         info!("Writing metrics...");
 
-        // Family size metrics
+        // Family size metrics. Use `write_metrics_auto` (not a bare `DelimFile::write_tsv`)
+        // so an empty distribution still produces a header-only, fgbio-readable file.
         let family_size_metrics = main_collector.family_size_metrics();
         let family_size_path = format!("{}.family_sizes.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&family_size_path, family_size_metrics)
-            .with_context(|| format!("Failed to write family size metrics: {family_size_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&family_size_path, &family_size_metrics)?;
         info!("Wrote family size metrics to {family_size_path}");
 
         // Duplex family size metrics
         let duplex_family_size_metrics = main_collector.duplex_family_size_metrics();
         let duplex_family_size_path = format!("{}.duplex_family_sizes.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&duplex_family_size_path, duplex_family_size_metrics)
-            .with_context(|| {
-                format!("Failed to write duplex family size metrics: {duplex_family_size_path}")
-            })?;
+        crate::metrics::writer::write_metrics_auto(
+            &duplex_family_size_path,
+            &duplex_family_size_metrics,
+        )?;
         info!("Wrote duplex family size metrics to {duplex_family_size_path}");
 
         // UMI metrics
         let umi_metrics = main_collector.umi_metrics();
         let umi_path = format!("{}.umi_counts.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&umi_path, umi_metrics)
-            .with_context(|| format!("Failed to write UMI metrics: {umi_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&umi_path, &umi_metrics)?;
         info!("Wrote UMI metrics to {umi_path}");
 
         // Duplex UMI metrics (if enabled)
         if self.duplex_umi_counts {
-            let duplex_umi_metrics =
-                main_collector.duplex_umi_metrics(&main_collector.umi_metrics());
+            let duplex_umi_metrics = main_collector.duplex_umi_metrics(&umi_metrics);
             let duplex_umi_path = format!("{}.duplex_umi_counts.txt", self.output.display());
-            DelimFile::default().write_tsv(&duplex_umi_path, duplex_umi_metrics).with_context(
-                || format!("Failed to write duplex UMI metrics: {duplex_umi_path}"),
-            )?;
+            crate::metrics::writer::write_metrics_auto(&duplex_umi_path, &duplex_umi_metrics)?;
             info!("Wrote duplex UMI metrics to {duplex_umi_path}");
         }
 
         // Yield metrics
         let yield_path = format!("{}.duplex_yield_metrics.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&yield_path, yield_metrics)
-            .with_context(|| format!("Failed to write yield metrics: {yield_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&yield_path, &yield_metrics)?;
         info!("Wrote yield metrics to {yield_path}");
 
         // Generate PDF plots using R script (optional)

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -2771,12 +2771,17 @@ mod tests {
         );
 
         // ---- Grouping metrics ----
-        // 9 read pairs = 18 records accepted, 6 unique families
+        // 9 read pairs = 18 records accepted, 6 unique families.
+        // The `.grouping_metrics.txt` matches fgbio's 5-column `UmiGroupingMetric`;
+        // `total_records`/`total_families` are fgumi-internal and no longer serialized
+        // (family count is covered by the `.family_sizes.txt` assertions above).
         let grouping: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&grouping_path)?;
         assert_eq!(grouping.len(), 1);
-        assert_eq!(grouping[0].total_records, 18);
         assert_eq!(grouping[0].accepted_records, 18);
-        assert_eq!(grouping[0].total_families, 6);
+        assert_eq!(grouping[0].discarded_non_pf, 0);
+        assert_eq!(grouping[0].discarded_poor_alignment, 0);
+        assert_eq!(grouping[0].discarded_ns_in_umi, 0);
+        assert_eq!(grouping[0].discarded_umi_too_short, 0);
 
         // ---- Position group size histogram ----
         // 3 position groups: one with 1 family, one with 2, one with 3
@@ -2909,11 +2914,11 @@ mod tests {
 
         // Grouping counters: UmiGroupingMetrics has no PartialEq, so compare
         // the integer fields that the per-thread accumulators feed.
+        // The serialized metrics match fgbio's 5-column `UmiGroupingMetric`; the input
+        // total (20 = 18 accepted + 2 discarded) is fgumi-internal and no longer a column.
         let grouping: Vec<UmiGroupingMetrics> = DelimFile::default().read_tsv(&grouping_path)?;
         assert_eq!(grouping.len(), 1);
-        assert_eq!(grouping[0].total_records, 20);
         assert_eq!(grouping[0].accepted_records, 18);
-        assert_eq!(grouping[0].total_families, 6);
         assert_eq!(grouping[0].discarded_non_pf, 0);
         assert_eq!(grouping[0].discarded_poor_alignment, 0);
         assert_eq!(grouping[0].discarded_ns_in_umi, 2);
@@ -2999,9 +3004,22 @@ mod tests {
             DelimFile::default().read_tsv(&prefix_grouping)?;
         assert_eq!(individual_grouping.len(), 1);
         assert_eq!(prefix_grouping.len(), 1);
-        assert_eq!(individual_grouping[0].total_records, prefix_grouping[0].total_records);
+        // Compare the serialized fgbio columns (total_records/total_families are
+        // fgumi-internal and no longer written).
         assert_eq!(individual_grouping[0].accepted_records, prefix_grouping[0].accepted_records);
-        assert_eq!(individual_grouping[0].total_families, prefix_grouping[0].total_families);
+        assert_eq!(individual_grouping[0].discarded_non_pf, prefix_grouping[0].discarded_non_pf);
+        assert_eq!(
+            individual_grouping[0].discarded_poor_alignment,
+            prefix_grouping[0].discarded_poor_alignment
+        );
+        assert_eq!(
+            individual_grouping[0].discarded_ns_in_umi,
+            prefix_grouping[0].discarded_ns_in_umi
+        );
+        assert_eq!(
+            individual_grouping[0].discarded_umi_too_short,
+            prefix_grouping[0].discarded_umi_too_short
+        );
 
         // Position group sizes: only written via --metrics prefix
         let position: Vec<PositionGroupSizeMetrics> =

--- a/src/lib/commands/simplex_metrics.rs
+++ b/src/lib/commands/simplex_metrics.rs
@@ -11,9 +11,8 @@ use crate::logging::OperationTimer;
 use crate::metrics::simplex::{SimplexMetricsCollector, SimplexYieldMetric};
 use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
 use crate::validation::validate_file_exists;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use fgoxide::io::DelimFile;
 use log::info;
 use std::path::PathBuf;
 
@@ -160,27 +159,22 @@ impl Command for SimplexMetrics {
         // Generate and write metrics
         info!("Writing metrics...");
 
-        // Family size metrics
+        // Family size metrics. Use `write_metrics_auto` (not a bare `DelimFile::write_tsv`)
+        // so an empty distribution still produces a header-only, fgbio-readable file.
         let family_size_metrics = main_collector.family_size_metrics();
         let family_size_path = format!("{}.family_sizes.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&family_size_path, family_size_metrics)
-            .with_context(|| format!("Failed to write family size metrics: {family_size_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&family_size_path, &family_size_metrics)?;
         info!("Wrote family size metrics to {family_size_path}");
 
         // UMI metrics
         let umi_metrics = main_collector.umi_metrics();
         let umi_path = format!("{}.umi_counts.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&umi_path, umi_metrics)
-            .with_context(|| format!("Failed to write UMI metrics: {umi_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&umi_path, &umi_metrics)?;
         info!("Wrote UMI metrics to {umi_path}");
 
         // Yield metrics
         let yield_path = format!("{}.simplex_yield_metrics.txt", self.output.display());
-        DelimFile::default()
-            .write_tsv(&yield_path, yield_metrics)
-            .with_context(|| format!("Failed to write yield metrics: {yield_path}"))?;
+        crate::metrics::writer::write_metrics_auto(&yield_path, &yield_metrics)?;
         info!("Wrote yield metrics to {yield_path}");
 
         // Generate PDF plots using R script (optional)

--- a/src/lib/metrics/mod.rs
+++ b/src/lib/metrics/mod.rs
@@ -36,4 +36,4 @@ pub use duplex::{
 };
 pub use group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 pub use shared::UmiMetric;
-pub use writer::{read_metrics, write_metrics};
+pub use writer::{read_metrics, write_metrics, write_metrics_auto};

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -55,17 +55,17 @@ fn test_group_command_writes_new_metrics() {
 
     let metric = &metrics[0];
 
-    // Verify basic fields are populated
-    assert!(metric.total_records > 0, "total_records should be positive");
-    assert!(metric.accepted_records > 0, "accepted_records should be positive");
-    assert!(metric.unique_molecule_ids > 0, "unique_molecule_ids should be positive");
-
-    // Rejection fields are validated by their presence in the struct (no runtime check needed
-    // since they are unsigned integers that are always >= 0)
-    let _ = metric.discarded_non_pf;
-    let _ = metric.discarded_poor_alignment;
-    let _ = metric.discarded_ns_in_umi;
-    let _ = metric.discarded_umi_too_short;
+    // Assert the exact serialized fgbio columns against `create_test_input_bam`'s known
+    // structure: three families of 10 + 5 + 15 single-end reads, all PF, all mapq 60, all
+    // carrying a valid 8bp UMI with no Ns — so every record is accepted and nothing is
+    // discarded. The `.grouping_metrics.txt` matches fgbio's 5-column `UmiGroupingMetric`;
+    // `total_records`/`unique_molecule_ids` are fgumi-internal (`#[serde(skip)]`) and read
+    // back as zero, so they are not asserted here.
+    assert_eq!(metric.accepted_records, 30, "all 30 input records should be accepted");
+    assert_eq!(metric.discarded_non_pf, 0);
+    assert_eq!(metric.discarded_poor_alignment, 0);
+    assert_eq!(metric.discarded_ns_in_umi, 0);
+    assert_eq!(metric.discarded_umi_too_short, 0);
 }
 
 /// Test that the group command handles UMIs with N bases correctly.


### PR DESCRIPTION
Closes #498 (metrics-format items) — makes fgumi's metrics `.txt` outputs readable by fgbio's `Metric.read` and matches fgbio's rows, column names/order, and value tokens on a shared input.

## What changed

| # | Item | Fix |
|---|------|-----|
| MET-02 | Non-finite floats unreadable | New shared `float` serde module writes f64 fields as fgbio's `Infinity`/`-Infinity`/`NaN` tokens (integral values without a trailing `.0`); applied to every serialized f64 field across `correct`/`shared`/`consensus`/`simplex`/`duplex`/`group`. Previously only `correct.rs` was inf-safe; the rest emitted ryu `inf`/`-inf`, which fgbio's `Double.parseDouble` cannot read. |
| MET-03 | Empty metrics file has no header | `write_metrics` now always emits the header, even for a zero-row slice; the duplex-metrics / simplex-metrics per-family/UMI/yield writes route through it. |
| MET-04 | `UmiGroupingMetrics` wrong columns | Serializes exactly fgbio's 5-column `UmiGroupingMetric` (`accepted_sam_records`, `discarded_non_pf`, `discarded_poor_alignment`, `discarded_ns_in_umi`, `discarded_umis_to_short`). The fgumi-internal summary fields stay in memory for logging but are `#[serde(skip)]`-ed (derivable; the family distribution already lives in `.family_sizes.txt`). |
| — | Duplex `family_sizes` dense→sparse | Emits one row per observed family size (matching fgbio `familySizeMetrics`) instead of a dense `1..=max` range. |
| — | `duplex_umi_counts` nondeterministic | Adds `umi` as a deterministic secondary sort key so ties no longer fall back to HashMap iteration order. |
| MET-05 | Consensus KV rejection rows | **Partial:** matches fgbio's exact rejection description text ("Reads has a different, and minority, set of indels"; "Only Generating One Strand of Duplex Consensus"). See "Deferred" below. |
| MET-01 | Float representation (accepted, not a bug) | Doc-only: corrects the `format_float` doc-comment that falsely claimed byte-format parity with fgbio. Numeric equality is the contract. |

`CorrectUmis` zero-count seeding (issue item 5) **already reproduces as fixed on `main`** — both correct execution paths pre-seed a row per expected UMI plus the all-N sentinel — so no change was needed there.

## fgbio-oracle evidence

`reports/fgbio-parity-fixtures/met-02-03-04-fgbio-read.sh` feeds fgumi's exact output bytes (proven by the unit tests) to fgbio 4.1.0's real `Metric.read`:

```
[PASS] MET-04 read UmiGroupingMetric (populated) -> rows=1 accepted_sam_records=90 discarded_umis_to_short=1
[PASS] MET-03 read UmiGroupingMetric (header-only empty) -> rows=0 (header-only parsed cleanly)
[PASS] MET-02 read UmiCorrectionMetrics with representation=Infinity -> representation.isPosInfinity=true fraction=0.5
[FAIL] MET-02 negative-control read representation='inf' (expect FAIL) -> MetricBuilderException
```

The negative control confirms the old ryu `inf` token was genuinely unreadable by fgbio.

## Deferred (out of scope here)

MET-05's caller-type-aware **row-set seeding** — always emitting `raw_reads_rejected_for_non_paired_reads`, `..._potential_umi_collision`, and the codec-specific reasons per fgbio's `usedByVanilla`/`usedByDuplex`/`usedByCodec` model — is deferred to the consensus PR. It requires adding `RejectionReason` variants and wiring them into the duplex/codec callers (this is the same behavioral change as R2-UCC-01, "fgbio rejects fragments as `NonPairedReads`"), which belongs with the consensus work rather than a metrics-format PR. Only the caller-independent description-text parity is done here.

## Testing

- New unit tests: inf/empty-header round-trips, exact 5-column `UmiGroupingMetric` header, sparse family sizes across a gap, deterministic duplex-UMI tie order, rejection-text parity.
- `cargo ci-fmt` / `cargo ci-lint` clean; full suite **2215 passed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * fgbio-compatible float serialization for metric TSVs now applies across exported metrics, including correct round-tripping of `NaN`, `Infinity`, and `-Infinity`.
  * Empty metric distributions now write header-only TSVs (no data rows).

* **Bug Fixes**
  * Family-size histograms now emit only observed sizes (no unobserved zero rows).
  * Duplex UMI metrics use deterministic tie-breaking when values are equal.
  * Rejection-reason text output and grouping-metrics TSV columns align with fgbio.

* **Tests**
  * Updated and extended TSV round-trip, exact header/schema, and non-finite float assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->