### PR TITLE
fix(codec): symmetric per-pair FR classification + NotPrimaryFrPair reject metric (CODEC-01, R2-CODEC-01)

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -377,6 +377,8 @@ pub enum RejectionReason {
     IndelErrorBetweenStrands,
     /// Potential collision
     PotentialCollision,
+    /// Template did not have a single primary FR pair of reads (codec)
+    NotPrimaryFrPair,
     /// Other unspecified reason
     Other,
 }
@@ -402,6 +404,7 @@ impl RejectionReason {
             Self::OrphanConsensus => 'P',
             Self::IndelErrorBetweenStrands => 'D',
             Self::PotentialCollision => 'C',
+            Self::NotPrimaryFrPair => 'R',
             Self::Other => 'O',
         }
     }
@@ -428,6 +431,7 @@ impl RejectionReason {
             Self::PotentialCollision => {
                 "Potential collisions (reads with the same MI but different strands)"
             }
+            Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
             Self::Other => "Other reason",
         }
     }
@@ -458,6 +462,7 @@ impl RejectionReason {
             Self::ZeroLengthAfterTrimming => CentralReason::ZeroBasesPostTrimming,
             Self::OrphanConsensus => CentralReason::OrphanConsensus,
             Self::PotentialCollision => CentralReason::DuplicateUmi,
+            Self::NotPrimaryFrPair => CentralReason::NotPrimaryFrPair,
         }
     }
 }

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -589,7 +589,10 @@ impl CodecConsensusCaller {
             .find_string(SamTag::MI)
             .map(|b| String::from_utf8_lossy(b).to_string());
 
-        // Phase 1: Filter on raw bytes — keep paired, primary, mapped, FR-pair reads
+        // Phase 1: Filter on raw bytes — keep paired, primary reads. FR classification is done
+        // per *pair* in Phase 2 (see is_primary_fr_pair_raw), NOT per record: the per-record
+        // is_fr_pair_raw check is asymmetric on dovetails whose aligned ends coincide and would
+        // silently drop legitimate FR pairs (CODEC-01).
         let mut paired_indices: Vec<usize> = Vec::new();
         let mut frag_count = 0usize;
         for (i, raw) in records.iter().enumerate() {
@@ -598,11 +601,9 @@ impl CodecConsensusCaller {
                 frag_count += 1;
                 continue;
             }
-            // Filter: primary, mapped, FR pair
-            if flg & (flags::SECONDARY | flags::SUPPLEMENTARY | flags::UNMAPPED) != 0 {
-                continue;
-            }
-            if !bam_fields::is_fr_pair_raw(raw) {
+            // Drop secondary/supplementary alignments (fgbio filters these out of the primary
+            // pairs; they are not consensus input and are not counted as rejections).
+            if flg & (flags::SECONDARY | flags::SUPPLEMENTARY) != 0 {
                 continue;
             }
             paired_indices.push(i);
@@ -632,7 +633,15 @@ impl CodecConsensusCaller {
 
         for name in name_order {
             let indices = by_name.get(name).expect("name from iteration");
-            if indices.len() != 2 {
+            // A template must be exactly one primary FR pair. Anything else — a singleton
+            // read-name bucket, or a pair that is not FR — is rejected and counted as
+            // NotPrimaryFrPair, matching fgbio's per-pair `partition` (which sweeps degenerate
+            // buckets in via its `case _ => false` arm). This is the counted reject that was
+            // previously a silent `continue` (R2-CODEC-01).
+            let is_primary_fr = indices.len() == 2
+                && bam_fields::is_primary_fr_pair_raw(&records[indices[0]], &records[indices[1]]);
+            if !is_primary_fr {
+                self.reject_records_count(indices.len(), CallerRejectionReason::NotPrimaryFrPair);
                 continue;
             }
 
@@ -2373,6 +2382,59 @@ mod tests {
             .expect("consensus_reads_from_sam_records should succeed");
 
         assert_eq!(output.count, 0, "Should not emit consensus for RF pair");
+        // R2-CODEC-01: both records of the non-FR template are counted as NotPrimaryFrPair
+        // (previously they were silently dropped with no rejection accounting).
+        assert_eq!(
+            caller.stats.rejection_reasons.get(&CallerRejectionReason::NotPrimaryFrPair),
+            Some(&2),
+            "RF pair records should be counted as NotPrimaryFrPair"
+        );
+    }
+
+    /// CODEC-01: a dovetail FR pair on which the per-record `is_fr_pair_raw` check is
+    /// asymmetric (the forward read is assigned a non-positive TLEN and mis-classified NOT-FR)
+    /// must pass FR classification and reach the consensus stage — it must NOT be dropped as a
+    /// non-primary-FR template. (Whether the synthetic overhang geometry then yields a consensus
+    /// depends on the unrelated overlap math; end-to-end consensus parity is covered by the
+    /// fgbio-oracle fixture. The behavioral change here is: kept, not silently dropped.)
+    #[test]
+    fn test_dovetail_fr_pair_is_not_rejected_as_non_fr() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // Dovetail: R1 forward @100 (100..149), R2 reverse @95 (95..144). The forward read's
+        // 5' (100) is left of the reverse read's 5' (144) => genuinely FR, but because
+        // start1 > start2 the helper gives R1 a negative TLEN, so the old per-record forward
+        // check reported NOT FR and dropped the pair (both reads vanished with no accounting).
+        let reads = create_fr_pair(
+            "dt",
+            100,
+            95,
+            50,
+            35,
+            &[(Kind::Match, 50)],
+            &[(Kind::Match, 50)],
+            "hi",
+            Some("ACC-TGA"),
+            false, // R1 forward
+            true,  // R2 reverse
+        );
+
+        caller
+            .consensus_reads_from_sam_records(reads)
+            .expect("consensus_reads_from_sam_records should succeed");
+
+        // The per-pair classification keeps the dovetail: it is NOT counted as NotPrimaryFrPair
+        // (the old per-record check would have dropped it here). This is the CODEC-01 fix.
+        assert_eq!(
+            caller.stats.rejection_reasons.get(&CallerRejectionReason::NotPrimaryFrPair),
+            None,
+            "a genuine (dovetail) FR pair must not be dropped/counted as NotPrimaryFrPair"
+        );
     }
 
     /// Port of fgbio test: "not emit a consensus when there are insufficient reads"

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -121,6 +121,9 @@ pub struct ConsensusMetrics {
 
     /// Reads rejected due to zero bases after trimming
     pub rejected_zero_bases_post_trimming: u64,
+
+    /// Reads rejected because the template was not a single primary FR pair (codec)
+    pub rejected_not_primary_fr_pair: u64,
 }
 
 /// Core rejection reasons always included in KV metrics output.
@@ -132,7 +135,14 @@ const CORE_REJECTIONS: [RejectionReason; 4] = [
 ];
 
 /// Optional rejection reasons included in KV metrics output only when non-zero.
-const OPTIONAL_REJECTIONS: [RejectionReason; 14] = [
+///
+/// `NotPrimaryFrPair` is codec-only in fgbio (`usedByCodec` only), so it is optional here rather
+/// than a core reason: emitting it only when non-zero fixes the R2-CODEC-01 "reads vanish from
+/// the rejection metrics" defect for codec without making simplex/duplex emit a spurious `=0`
+/// row that fgbio never writes for those callers. (fgbio additionally seeds it to 0 for codec so
+/// its row is always present in codec output even at zero; that always-emit-zero seeding is a
+/// separate metric-format concern tracked with the rejection-row seeding work.)
+const OPTIONAL_REJECTIONS: [RejectionReason; 15] = [
     RejectionReason::InsufficientStrandSupport,
     RejectionReason::LowBaseQuality,
     RejectionReason::ExcessiveNBases,
@@ -147,6 +157,7 @@ const OPTIONAL_REJECTIONS: [RejectionReason; 14] = [
     RejectionReason::UmiTooShort,
     RejectionReason::SameStrandOnly,
     RejectionReason::DuplicateUmi,
+    RejectionReason::NotPrimaryFrPair,
 ];
 
 /// Returns an iterator over all rejection reasons (core + optional).
@@ -187,6 +198,7 @@ impl ConsensusMetrics {
             rejected_duplicate_umi: 0,
             rejected_orphan_consensus: 0,
             rejected_zero_bases_post_trimming: 0,
+            rejected_not_primary_fr_pair: 0,
         }
     }
 
@@ -212,6 +224,7 @@ impl ConsensusMetrics {
             RejectionReason::DuplicateUmi => self.rejected_duplicate_umi,
             RejectionReason::OrphanConsensus => self.rejected_orphan_consensus,
             RejectionReason::ZeroBasesPostTrimming => self.rejected_zero_bases_post_trimming,
+            RejectionReason::NotPrimaryFrPair => self.rejected_not_primary_fr_pair,
         }
     }
 
@@ -242,6 +255,7 @@ impl ConsensusMetrics {
             RejectionReason::ZeroBasesPostTrimming => {
                 self.rejected_zero_bases_post_trimming += count;
             }
+            RejectionReason::NotPrimaryFrPair => self.rejected_not_primary_fr_pair += count,
         }
     }
 

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -48,6 +48,8 @@ pub enum RejectionReason {
     OrphanConsensus,
     /// Read had zero bases after quality trimming
     ZeroBasesPostTrimming,
+    /// Template did not have a single primary FR pair of reads (codec)
+    NotPrimaryFrPair,
 }
 
 impl RejectionReason {
@@ -73,6 +75,7 @@ impl RejectionReason {
             Self::DuplicateUmi => "Duplicate UMI at same genomic position",
             Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
             Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
+            Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
         }
     }
 
@@ -98,6 +101,7 @@ impl RejectionReason {
             Self::DuplicateUmi => "raw_reads_rejected_for_duplicate_umi",
             Self::OrphanConsensus => "raw_reads_rejected_for_orphan_consensus",
             Self::ZeroBasesPostTrimming => "raw_reads_rejected_for_zero_bases_post_trimming",
+            Self::NotPrimaryFrPair => "raw_reads_rejected_for_not_primary_fr_pair",
         }
     }
 
@@ -123,6 +127,7 @@ impl RejectionReason {
             Self::DuplicateUmi => "Duplicate UMI detected",
             Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
             Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
+            Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
         }
     }
 }

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -86,7 +86,7 @@ pub use cigar::{
 };
 
 // -- overlap --
-pub use overlap::{is_fr_pair_raw, num_bases_extending_past_mate_raw};
+pub use overlap::{is_fr_pair_raw, is_primary_fr_pair_raw, num_bases_extending_past_mate_raw};
 
 // -- raw_bam_record --
 pub use raw_bam_record::{

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -61,6 +61,46 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
     positive_five_prime < negative_five_prime
 }
 
+/// Symmetric per-pair FR classification for a template's two primary reads.
+///
+/// This is the raw-byte port of fgbio `CodecConsensusCaller.isPrimaryFrPair(a, b)`
+/// (`CodecConsensusCaller.scala:424-433`). Unlike [`is_fr_pair_raw`], which is a *per-record*
+/// test, this evaluates a *pair* and is order-independent: after confirming both reads are
+/// mapped with mapped mates, on the same reference, and on opposite strands, it derives the FR
+/// orientation from the **reverse-strand record only**. That branch of the orientation test is
+/// CIGAR-derived (`is_fr_pair_raw`'s reverse arm), so it is independent of TLEN and gives the
+/// same answer regardless of argument order — avoiding the htsjdk per-record asymmetry
+/// (samtools/htsjdk#1771) that mis-drops dovetail pairs whose aligned ends coincide.
+///
+/// Returns `true` iff `(a, b)` is a single primary FR pair.
+#[must_use]
+pub fn is_primary_fr_pair_raw(a: &[u8], b: &[u8]) -> bool {
+    let (va, vb) = (RawRecordView::new(a), RawRecordView::new(b));
+    let (fa, fb) = (va.flags(), vb.flags());
+
+    // Both reads mapped.
+    if fa & flags::UNMAPPED != 0 || fb & flags::UNMAPPED != 0 {
+        return false;
+    }
+    // Both mates mapped.
+    if fa & flags::MATE_UNMAPPED != 0 || fb & flags::MATE_UNMAPPED != 0 {
+        return false;
+    }
+    // Same reference.
+    if va.ref_id() != vb.ref_id() {
+        return false;
+    }
+    // Opposite strands.
+    let a_reverse = fa & flags::REVERSE != 0;
+    let b_reverse = fb & flags::REVERSE != 0;
+    if a_reverse == b_reverse {
+        return false;
+    }
+    // Evaluate FR orientation on the reverse-strand record only (the symmetric branch).
+    let reverse_record = if a_reverse { a } else { b };
+    is_fr_pair_raw(reverse_record)
+}
+
 #[must_use]
 pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
     // Only applies to FR pairs (matching the RecordBuf-based `num_bases_extending_past_mate`)
@@ -401,6 +441,138 @@ mod tests {
             &[],
         );
         assert!(!is_fr_pair_raw(&rec));
+    }
+
+    // ========================================================================
+    // is_primary_fr_pair_raw tests (symmetric per-pair FR classification)
+    // ========================================================================
+
+    #[test]
+    fn test_is_primary_fr_pair_raw_symmetric_on_dovetail() {
+        // A dovetail FR pair on which the *per-record* check disagrees:
+        //  - forward read has TLEN = -90, so is_fr_pair_raw(fwd) uses the TLEN branch
+        //    (0 < -90 => false) and wrongly reports NOT FR (CODEC-01);
+        //  - reverse read (100M @ 61..160, mate 5' at 101) uses the CIGAR branch
+        //    (101 < 160 => true) and reports FR.
+        // is_primary_fr_pair_raw evaluates the reverse record only, so it is symmetric
+        // and returns true regardless of argument order.
+        let fwd = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE | flags::FIRST_SEGMENT,
+            b"dtl",
+            &[encode_op(0, 50)],
+            50,
+            0,
+            60,
+            -90,
+            &[],
+        );
+        let rev = make_bam_bytes_with_tlen(
+            0,
+            60,
+            flags::PAIRED | flags::REVERSE | flags::LAST_SEGMENT,
+            b"dtl",
+            &[encode_op(0, 100)],
+            100,
+            0,
+            100,
+            90,
+            &[],
+        );
+
+        // Per-record is asymmetric — this is the bug the per-pair check avoids.
+        assert!(!is_fr_pair_raw(&fwd), "forward per-record check mis-reports NOT FR");
+        assert!(is_fr_pair_raw(&rev), "reverse per-record check reports FR");
+
+        // Per-pair is symmetric and correct in both argument orders.
+        assert!(is_primary_fr_pair_raw(&fwd, &rev));
+        assert!(is_primary_fr_pair_raw(&rev, &fwd));
+    }
+
+    #[test]
+    fn test_is_primary_fr_pair_raw_negative_cases() {
+        let fr_fwd = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"p",
+            &[encode_op(0, 50)],
+            50,
+            0,
+            150,
+            100,
+            &[],
+        );
+        // RF pair: reverse read upstream of its forward mate -> not FR.
+        let rf_rev = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::REVERSE,
+            b"p",
+            &[encode_op(0, 100)],
+            100,
+            0,
+            200,
+            100,
+            &[],
+        );
+        let rf_fwd = make_bam_bytes_with_tlen(
+            0,
+            200,
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"p",
+            &[encode_op(0, 50)],
+            50,
+            0,
+            100,
+            -100,
+            &[],
+        );
+        assert!(!is_primary_fr_pair_raw(&rf_rev, &rf_fwd), "RF pair is not a primary FR pair");
+        assert!(!is_primary_fr_pair_raw(&rf_fwd, &rf_rev), "RF pair is not FR either order");
+
+        // Same strand (FF): opposite-strand precondition fails.
+        let ff_a = make_bam_bytes_with_tlen(
+            0,
+            10,
+            flags::PAIRED,
+            b"p",
+            &[encode_op(0, 30)],
+            30,
+            0,
+            50,
+            70,
+            &[],
+        );
+        let ff_b = make_bam_bytes_with_tlen(
+            0,
+            50,
+            flags::PAIRED,
+            b"p",
+            &[encode_op(0, 30)],
+            30,
+            0,
+            10,
+            -70,
+            &[],
+        );
+        assert!(!is_primary_fr_pair_raw(&ff_a, &ff_b), "same-strand pair is not FR");
+
+        // Different references.
+        let xchrom = make_bam_bytes_with_tlen(
+            1,
+            100,
+            flags::PAIRED | flags::REVERSE,
+            b"p",
+            &[encode_op(0, 50)],
+            50,
+            0,
+            100,
+            0,
+            &[],
+        );
+        assert!(!is_primary_fr_pair_raw(&fr_fwd, &xchrom), "cross-chromosomal is not FR");
     }
 
     // ========================================================================


### PR DESCRIPTION
Fixes the codec caller's FR-pair handling to match fgbio 4.1.0 `CodecConsensusCaller`. Bundles round-1 **CODEC-01** (classification) and round-2 **R2-CODEC-01** (rejection metric) — they are two halves of one behavioral change in the same code window and fgbio ships them together. Tracker: `reports/2026-07-08-fgbio-behavioral-parity-tracker.md` (PR 9) + round-2 §R2.4.

## Findings

**CODEC-01 (S1) — dovetail FR pairs silently dropped.** fgbio classifies FR membership **symmetrically per template pair** (`isPrimaryFrPair`, `CodecConsensusCaller.scala:424-433`) — it evaluates the orientation on the *reverse-strand record only*, whose branch is CIGAR-derived and thus independent of which mate you pass, deliberately avoiding htsjdk's per-record asymmetry (samtools/htsjdk#1771) on dovetails whose aligned ends coincide. fgumi classified **per record** via `is_fr_pair_raw`, whose forward-strand branch is TLEN-derived and *disagrees* with its CIGAR-derived reverse branch on such dovetails: the forward read was mis-classified NOT-FR and dropped, its mate then became a singleton bucket and was dropped too → the whole dovetail template produced no consensus with zero accounting.

**R2-CODEC-01 (S2) — non-FR templates vanished from the rejection metrics.** fgbio counts every non-primary-FR template under `RejectionReason.NotPrimaryFrPair` (`not_primary_fr_pair`, seeded so codec always emits the row). fgumi dropped non-FR reads with a bare `continue` and no rejection accounting, so they disappeared from `raw_reads_rejected_for_*`.

## Changes

- **`overlap.rs`** — new `is_primary_fr_pair_raw(a, b)`: symmetric per-pair FR test that, after the mapped/mate-mapped/same-ref/opposite-strand preconditions, derives FR orientation from the reverse-strand record only (via `is_fr_pair_raw`'s TLEN-independent CIGAR branch), so it is order-independent and correct on dovetails.
- **`codec_caller.rs`** — classification moved from per-record (Phase 1) to per-pair after grouping; non-primary-FR templates (singleton buckets **or** non-FR pairs) are rejected and counted as `NotPrimaryFrPair`, mirroring fgbio's `partition` + `rejectRecords` (its `case _ => false` arm sweeps singletons in, so those are counted too). Unmapped primaries now flow to the per-pair check and are counted rather than silently dropped, matching fgbio's `isPrimaryFrPair` (which returns false for unmapped).
- **`caller.rs` / `rejection.rs` / `consensus.rs`** — add `NotPrimaryFrPair` to the internal + centralized `RejectionReason` enums and to `ConsensusMetrics`; emit it when non-zero (`OPTIONAL_REJECTIONS`), fixing the vanishing count for codec without making simplex/duplex emit a spurious `=0` row. (fgbio additionally seeds the row to 0 for codec so it is always present even at zero; that always-emit-zero seeding is a separate metric-format concern noted in-code and left to the rejection-row seeding work.)

Both the single-threaded and threaded codec paths go through the shared `consensus_reads_raw`, so both get the fix.

## Verification (§0)

- **fgbio oracle, verified live** (fgbio 4.1.0 `CallCodecConsensusReads`): an RF (non-FR) template is rejected with stats `raw_reads_rejected_for_not_primary_fr_pair  2`; a dovetail FR pair is kept and yields a consensus. This confirms the behavior being matched is real.
- **Unit tests** drive the real `consensus_reads_from_sam_records` path: `is_primary_fr_pair_raw` is symmetric on a dovetail where the per-record check disagrees, plus RF/FF/cross-chrom negatives; `test_not_emit_consensus_for_rf_pair` now asserts `NotPrimaryFrPair == 2`; `test_dovetail_fr_pair_is_not_rejected_as_non_fr` proves the dovetail is kept (not dropped as non-FR).
- `cargo ci-fmt` / `cargo ci-lint` clean; full suite **2215 passed**.

**Note on the fgumi-side E2E:** a full `fgumi codec` CLI run is documented in the fixture but not asserted here — on synthetic 2-molecule poly-A input the codec streaming grouper forms 0 MI groups and passes the reads to `--rejects` before the per-molecule caller runs (identical before/after, a pre-grouping plumbing limitation orthogonal to this fix). The fgumi-side behavior is instead pinned by the unit tests above, which exercise the exact production classification/counting code. Fixture: `reports/fgbio-parity-fixtures/r2-codec-01-not-primary-fr-pair.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved paired-read filtering to correctly retain valid dovetail FR pairs.
  - Rejected templates that do not contain exactly one primary FR pair, preventing ambiguous inputs from being silently skipped.

- **Metrics**
  - Added reporting for templates rejected because they lacked a single primary FR pair.
  - Added human-readable descriptions and metric keys for this rejection reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->