### PR TITLE
fix(consensus): sort-order + error-rate guards and duplex rejection rows (CONS-01, DUP-01, R2-MET-05, R2-UCC-01)

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -452,9 +452,9 @@ impl RejectionReason {
             Self::QualityTooLow | Self::QualityTrimmed => CentralReason::LowBaseQuality,
             Self::FailedQC => CentralReason::NotPassingFilter,
             Self::MissingUmi => CentralReason::MissingUmi,
-            // For reasons that don't have a direct centralized equivalent,
-            // we use the closest semantic match
-            Self::FragmentRead => CentralReason::SameStrandOnly,
+            // A fragment/unpaired read supplied to the duplex/codec caller maps to
+            // fgbio's NonPairedReads reason (UmiConsensusCaller.scala:81).
+            Self::FragmentRead => CentralReason::NonPairedReads,
             Self::Unmapped
             | Self::Mapped
             | Self::SecondaryOrSupplementary
@@ -1072,7 +1072,7 @@ mod tests {
 
         // Test every variant maps to a centralized reason
         let mappings = [
-            (RejectionReason::FragmentRead, CentralReason::SameStrandOnly),
+            (RejectionReason::FragmentRead, CentralReason::NonPairedReads),
             (RejectionReason::InsufficientReads, CentralReason::InsufficientSupport),
             (RejectionReason::QualityTooLow, CentralReason::LowBaseQuality),
             (RejectionReason::Unmapped, CentralReason::NoValidAlignment),

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -706,6 +706,11 @@ impl DuplexConsensusCaller {
         }
     }
 
+    /// Returns true if the record is a paired read (fgbio's `_.paired`).
+    fn is_paired(record: &RawRecord) -> bool {
+        RawRecordView::new(record).flags() & flags::PAIRED != 0
+    }
+
     /// Returns true if the record is a paired first-of-pair read.
     ///
     /// An unpaired/fragment read is never treated as R1.
@@ -2206,8 +2211,22 @@ impl ConsensusCaller for DuplexConsensusCaller {
     fn consensus_reads(&mut self, records: Vec<RawRecord>) -> Result<ConsensusOutput> {
         self.stats.record_input(records.len());
 
+        // Partition out unpaired/fragment reads and reject them as NonPairedReads,
+        // matching fgbio's DuplexConsensusCaller
+        // (`val (pairs, frags) = recs.partition(_.paired); rejectRecords(frags, NonPairedReads)`).
+        // fgumi previously folded fragments into the strand groups where they were
+        // ignored but mis-accounted (R2-UCC-01).
+        let (paired, fragments): (Vec<RawRecord>, Vec<RawRecord>) =
+            records.into_iter().partition(Self::is_paired);
+        if !fragments.is_empty() {
+            self.stats.record_rejection(RejectionReason::FragmentRead, fragments.len());
+            if self.track_rejects {
+                self.rejected_reads.extend(fragments.into_iter().map(RawRecord::into_inner));
+            }
+        }
+
         // Partition records by strand using raw byte-level operations.
-        let (base_mi_opt, a_records, b_records) = Self::partition_records_by_strand(records)?;
+        let (base_mi_opt, a_records, b_records) = Self::partition_records_by_strand(paired)?;
 
         let Some(base_mi) = base_mi_opt else {
             return Ok(ConsensusOutput::default());
@@ -2344,6 +2363,73 @@ mod tests {
             raw_with_mi(b"read4", b"UMI1/B"),
         ];
         assert!(DuplexConsensusCaller::has_both_strands(&many_a_one_b));
+    }
+
+    #[test]
+    fn test_consensus_reads_rejects_fragments_as_non_paired() -> Result<()> {
+        // R2-UCC-01: unpaired/fragment reads are rejected as NonPairedReads — matching
+        // fgbio's `partition(_.paired); rejectRecords(frags, NonPairedReads)` — instead of
+        // being silently folded into the strand groups where they were mis-accounted.
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            vec![1],
+            20,
+            false,
+            false,
+            None,
+            None,
+            false,
+            45,
+            40,
+        )?;
+
+        // raw_with_mi builds an unpaired read (PAIRED flag clear) => a fragment.
+        let _ = caller.consensus_reads(vec![raw_with_mi(b"frag", b"UMI1/A")])?;
+
+        let non_paired = caller
+            .stats
+            .rejection_reasons
+            .get(&RejectionReason::FragmentRead)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(non_paired, 1, "fragment reads must be rejected as non-paired");
+
+        // ...and that reason maps to the central NonPairedReads metric row.
+        assert_eq!(
+            RejectionReason::FragmentRead.to_centralized(),
+            fgumi_metrics::rejection::RejectionReason::NonPairedReads
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_consensus_reads_retains_rejected_fragments_when_tracking() -> Result<()> {
+        // R2-UCC-01: with `track_rejects` enabled, the rejected unpaired/fragment read is not
+        // just counted but retained in `rejected_reads` so `fgumi duplex --rejects` can emit it.
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            vec![1],
+            20,
+            false,
+            false,
+            None,
+            None,
+            true, // track_rejects
+            45,
+            40,
+        )?;
+
+        let _ = caller.consensus_reads(vec![raw_with_mi(b"frag", b"UMI1/A")])?;
+
+        assert_eq!(caller.rejected_reads.len(), 1, "the fragment must be retained for --rejects");
+        assert_eq!(
+            fgumi_raw_bam::read_name(&caller.rejected_reads[0]),
+            b"frag",
+            "the retained rejected read is the fragment"
+        );
+        Ok(())
     }
 
     #[test]
@@ -3398,6 +3484,83 @@ mod tests {
             result.count, 2,
             "Should produce 2 duplex consensus reads (R1 and R2), got {}",
             result.count
+        );
+
+        Ok(())
+    }
+
+    /// R2-UCC-01: a single MI group with *mixed* family composition — paired AB/BA
+    /// reads plus stray unpaired fragments carrying the same MI. fgbio partitions
+    /// the fragments out (`partition(_.paired)`) and rejects them as `NonPairedReads`
+    /// while the paired reads still form a duplex consensus. This exercises the
+    /// mixed-family edge case rather than the fragment-only groups the other two
+    /// tests cover.
+    #[test]
+    fn test_consensus_reads_mixed_paired_and_fragments() -> Result<()> {
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            vec![1],
+            10,
+            false,
+            false,
+            None,
+            None,
+            false,
+            45,
+            40,
+        )?;
+
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+
+        // Two stray fragments (unpaired) sharing the group's MI base `foo`.
+        let frag = |b: &mut SamBuilder, name: &[u8], mi: &[u8]| -> RawRecord {
+            b.clear();
+            b.ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .flags(0) // unpaired => fragment
+                .read_name(name)
+                .cigar_ops(cigar_10m)
+                .sequence(b"AAAAAAAAAA")
+                .qualities(quals);
+            b.add_string_tag(SamTag::MI, mi);
+            b.build()
+        };
+
+        let reads = vec![
+            // Paired AB/BA reads that form a duplex consensus.
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", &[]),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", &[]),
+            ba_r1(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", &[]),
+            ba_r2(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", &[]),
+            // Stray fragments in the same MI group.
+            frag(&mut b, b"frag1", b"foo/A"),
+            frag(&mut b, b"frag2", b"foo/B"),
+        ];
+
+        let result = caller.consensus_reads(reads)?;
+
+        // The paired reads still produce the R1/R2 duplex consensus...
+        assert_eq!(
+            result.count, 2,
+            "paired reads should still produce 2 duplex consensus reads despite the stray fragments, got {}",
+            result.count
+        );
+
+        // ...and both fragments are counted under NonPairedReads (via FragmentRead).
+        let non_paired = caller
+            .stats
+            .rejection_reasons
+            .get(&RejectionReason::FragmentRead)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(non_paired, 2, "both stray fragments must be rejected as non-paired");
+        assert_eq!(
+            RejectionReason::FragmentRead.to_centralized(),
+            fgumi_metrics::rejection::RejectionReason::NonPairedReads
         );
 
         Ok(())

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -113,6 +113,9 @@ pub struct ConsensusMetrics {
     /// Reads rejected due to same strand only
     pub rejected_same_strand_only: u64,
 
+    /// Reads rejected because they were unpaired/fragment reads (duplex/codec)
+    pub rejected_non_paired_reads: u64,
+
     /// Reads rejected due to duplicate UMI
     pub rejected_duplicate_umi: u64,
 
@@ -126,23 +129,69 @@ pub struct ConsensusMetrics {
     pub rejected_not_primary_fr_pair: u64,
 }
 
-/// Core rejection reasons always included in KV metrics output.
-const CORE_REJECTIONS: [RejectionReason; 4] = [
+/// The consensus caller whose statistics are being rendered.
+///
+/// Used to seed the always-emitted KV rejection rows to match fgbio's per-caller
+/// `initializeRejectCounts` (`UmiConsensusCaller.scala:223-224`): the vanilla
+/// caller seeds `usedByVanilla` reasons, duplex additionally seeds `usedByDuplex`,
+/// and codec additionally seeds `usedByCodec`. Seeded rows are emitted even when
+/// their count is zero, exactly as fgbio does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsensusCallerKind {
+    /// Vanilla / simplex (`CallMolecularConsensusReads`).
+    Vanilla,
+    /// Duplex (`CallDuplexConsensusReads`).
+    Duplex,
+    /// Codec (`CallCodecConsensusReads`).
+    Codec,
+}
+
+/// Reasons fgbio always emits for every caller (`usedByVanilla`), in fgbio order.
+const VANILLA_SEEDED: [RejectionReason; 4] = [
     RejectionReason::InsufficientSupport,
     RejectionReason::MinorityAlignment,
     RejectionReason::OrphanConsensus,
     RejectionReason::ZeroBasesPostTrimming,
 ];
 
-/// Optional rejection reasons included in KV metrics output only when non-zero.
+/// Additional reasons the duplex/codec callers always emit (`usedByDuplex`), in fgbio order.
+const DUPLEX_EXTRA_SEEDED: [RejectionReason; 3] = [
+    RejectionReason::NonPairedReads,
+    RejectionReason::SameStrandOnly,
+    RejectionReason::DuplicateUmi,
+];
+
+/// Additional reason the codec caller always emits (`usedByCodec`).
+const CODEC_EXTRA_SEEDED: [RejectionReason; 1] = [RejectionReason::NotPrimaryFrPair];
+
+impl ConsensusCallerKind {
+    /// The rejection reasons this caller seeds (always emits), in fgbio's order.
+    fn seeded_reasons(self) -> Vec<RejectionReason> {
+        let mut reasons = VANILLA_SEEDED.to_vec();
+        if matches!(self, Self::Duplex | Self::Codec) {
+            reasons.extend(DUPLEX_EXTRA_SEEDED);
+        }
+        if matches!(self, Self::Codec) {
+            reasons.extend(CODEC_EXTRA_SEEDED);
+        }
+        reasons
+    }
+}
+
+/// All rejection reasons fgumi tracks, in a stable order (seeded reasons first).
 ///
-/// `NotPrimaryFrPair` is codec-only in fgbio (`usedByCodec` only), so it is optional here rather
-/// than a core reason: emitting it only when non-zero fixes the R2-CODEC-01 "reads vanish from
-/// the rejection metrics" defect for codec without making simplex/duplex emit a spurious `=0`
-/// row that fgbio never writes for those callers. (fgbio additionally seeds it to 0 for codec so
-/// its row is always present in codec output even at zero; that always-emit-zero seeding is a
-/// separate metric-format concern tracked with the rejection-row seeding work.)
-const OPTIONAL_REJECTIONS: [RejectionReason; 15] = [
+/// fgumi's taxonomy is finer-grained than fgbio's; the reasons not in any caller's
+/// seeded set (e.g. `LowBaseQuality`) are fgumi-specific and are emitted only when
+/// non-zero.
+const ALL_REJECTIONS: [RejectionReason; 20] = [
+    RejectionReason::InsufficientSupport,
+    RejectionReason::MinorityAlignment,
+    RejectionReason::OrphanConsensus,
+    RejectionReason::ZeroBasesPostTrimming,
+    RejectionReason::NonPairedReads,
+    RejectionReason::SameStrandOnly,
+    RejectionReason::DuplicateUmi,
+    RejectionReason::NotPrimaryFrPair,
     RejectionReason::InsufficientStrandSupport,
     RejectionReason::LowBaseQuality,
     RejectionReason::ExcessiveNBases,
@@ -155,14 +204,11 @@ const OPTIONAL_REJECTIONS: [RejectionReason; 15] = [
     RejectionReason::InsufficientMinDepth,
     RejectionReason::ExcessiveErrorRate,
     RejectionReason::UmiTooShort,
-    RejectionReason::SameStrandOnly,
-    RejectionReason::DuplicateUmi,
-    RejectionReason::NotPrimaryFrPair,
 ];
 
-/// Returns an iterator over all rejection reasons (core + optional).
+/// Returns an iterator over all rejection reasons fgumi tracks.
 fn all_rejections() -> impl Iterator<Item = RejectionReason> {
-    CORE_REJECTIONS.into_iter().chain(OPTIONAL_REJECTIONS)
+    ALL_REJECTIONS.into_iter()
 }
 
 impl ConsensusMetrics {
@@ -195,6 +241,7 @@ impl ConsensusMetrics {
             rejected_excessive_error_rate: 0,
             rejected_umi_too_short: 0,
             rejected_same_strand_only: 0,
+            rejected_non_paired_reads: 0,
             rejected_duplicate_umi: 0,
             rejected_orphan_consensus: 0,
             rejected_zero_bases_post_trimming: 0,
@@ -221,6 +268,7 @@ impl ConsensusMetrics {
             RejectionReason::ExcessiveErrorRate => self.rejected_excessive_error_rate,
             RejectionReason::UmiTooShort => self.rejected_umi_too_short,
             RejectionReason::SameStrandOnly => self.rejected_same_strand_only,
+            RejectionReason::NonPairedReads => self.rejected_non_paired_reads,
             RejectionReason::DuplicateUmi => self.rejected_duplicate_umi,
             RejectionReason::OrphanConsensus => self.rejected_orphan_consensus,
             RejectionReason::ZeroBasesPostTrimming => self.rejected_zero_bases_post_trimming,
@@ -250,6 +298,7 @@ impl ConsensusMetrics {
             RejectionReason::ExcessiveErrorRate => self.rejected_excessive_error_rate += count,
             RejectionReason::UmiTooShort => self.rejected_umi_too_short += count,
             RejectionReason::SameStrandOnly => self.rejected_same_strand_only += count,
+            RejectionReason::NonPairedReads => self.rejected_non_paired_reads += count,
             RejectionReason::DuplicateUmi => self.rejected_duplicate_umi += count,
             RejectionReason::OrphanConsensus => self.rejected_orphan_consensus += count,
             RejectionReason::ZeroBasesPostTrimming => {
@@ -281,9 +330,14 @@ impl ConsensusMetrics {
     /// Converts metrics to fgbio-compatible key-value-description format.
     ///
     /// Returns a vector of `ConsensusKvMetric` rows matching fgbio's vertical
-    /// metrics output format used by `CallMolecularConsensusReads`.
+    /// metrics output format (`UmiConsensusCaller.statistics`). The `kind`
+    /// selects which rejection rows are seeded (always emitted, even at zero),
+    /// matching fgbio's per-caller `initializeRejectCounts`: vanilla emits four
+    /// rows, duplex additionally emits `non_paired_reads`, `single_strand_only`,
+    /// and `potential_umi_collision`, and codec additionally `not_primary_fr_pair`.
+    /// fgumi-specific finer-grained reasons are emitted only when non-zero.
     #[must_use]
-    pub fn to_kv_metrics(&self) -> Vec<ConsensusKvMetric> {
+    pub fn to_kv_metrics(&self, kind: ConsensusCallerKind) -> Vec<ConsensusKvMetric> {
         let mut metrics = Vec::new();
 
         let raw_reads_used = self.total_input_reads.saturating_sub(self.filtered_reads);
@@ -311,8 +365,9 @@ impl ConsensusMetrics {
             "Fraction of raw reads used in consensus reads",
         ));
 
-        // Core rejection reasons (always included)
-        for reason in &CORE_REJECTIONS {
+        // Seeded rejection reasons for this caller: always emitted, in fgbio order.
+        let seeded = kind.seeded_reasons();
+        for reason in &seeded {
             metrics.push(ConsensusKvMetric::new(
                 reason.tsv_key(),
                 self.rejection_count(*reason).to_string(),
@@ -320,8 +375,19 @@ impl ConsensusMetrics {
             ));
         }
 
-        // Optional rejection reasons (only included when non-zero)
-        self.push_optional_rejections(&mut metrics);
+        // fgumi-specific reasons not in the seeded set: emit only when non-zero.
+        for reason in all_rejections() {
+            if !seeded.contains(&reason) {
+                let count = self.rejection_count(reason);
+                if count > 0 {
+                    metrics.push(ConsensusKvMetric::new(
+                        reason.tsv_key(),
+                        count.to_string(),
+                        reason.kv_description(),
+                    ));
+                }
+            }
+        }
 
         // Final output metric
         metrics.push(ConsensusKvMetric::new(
@@ -331,20 +397,6 @@ impl ConsensusMetrics {
         ));
 
         metrics
-    }
-
-    /// Appends fgumi-specific rejection metrics with non-zero counts.
-    fn push_optional_rejections(&self, metrics: &mut Vec<ConsensusKvMetric>) {
-        for reason in &OPTIONAL_REJECTIONS {
-            let count = self.rejection_count(*reason);
-            if count > 0 {
-                metrics.push(ConsensusKvMetric::new(
-                    reason.tsv_key(),
-                    count.to_string(),
-                    reason.kv_description(),
-                ));
-            }
-        }
     }
 }
 
@@ -500,7 +552,7 @@ mod tests {
         metrics.rejected_insufficient_support = 50;
         metrics.rejected_minority_alignment = 50;
 
-        let kv_metrics = metrics.to_kv_metrics();
+        let kv_metrics = metrics.to_kv_metrics(ConsensusCallerKind::Vanilla);
 
         // Should have core metrics
         let raw_reads = kv_metrics.iter().find(|m| m.key == "raw_reads_considered");
@@ -551,7 +603,7 @@ mod tests {
     #[test]
     fn test_to_kv_metrics_zero_reads() {
         let metrics = ConsensusMetrics::new();
-        let kv_metrics = metrics.to_kv_metrics();
+        let kv_metrics = metrics.to_kv_metrics(ConsensusCallerKind::Vanilla);
 
         // frac_raw_reads_used should be 0.0 when total_input_reads is 0
         let frac = kv_metrics.iter().find(|m| m.key == "frac_raw_reads_used");
@@ -565,7 +617,7 @@ mod tests {
         metrics.total_input_reads = 100;
         metrics.rejected_low_base_quality = 5; // This is an optional rejection
 
-        let kv_metrics = metrics.to_kv_metrics();
+        let kv_metrics = metrics.to_kv_metrics(ConsensusCallerKind::Vanilla);
 
         // Should have low_base_quality since it's non-zero
         let lbq = kv_metrics.iter().find(|m| m.key == "raw_reads_rejected_for_low_base_quality");
@@ -575,6 +627,99 @@ mod tests {
         // Should NOT have excessive_n_bases since it's zero
         let en = kv_metrics.iter().find(|m| m.key == "raw_reads_rejected_for_excessive_n_bases");
         assert!(en.is_none());
+    }
+
+    /// R2-MET-05: the duplex caller seeds (always emits) `non_paired_reads`,
+    /// `single_strand_only`, and `potential_umi_collision` even at zero, matching
+    /// fgbio's `initializeRejectCounts(usedByVanilla || usedByDuplex)`. The vanilla
+    /// caller emits none of them at zero.
+    ///
+    /// Assert the *complete ordered* key sequence for both callers (not just presence), so
+    /// row-order drift is caught. The two expected sequences also encode the semantics
+    /// checked before: the duplex-only rows appear (in fgbio order) for Duplex and are absent
+    /// for Vanilla.
+    #[test]
+    fn test_to_kv_metrics_duplex_seeds_duplex_rows() {
+        // Vanilla: four core metrics, the four seeded vanilla rejections in fgbio order, then
+        // the final emitted count. No duplex-only rows.
+        const EXPECTED_VANILLA: &[&str] = &[
+            "raw_reads_considered",
+            "raw_reads_rejected",
+            "raw_reads_used",
+            "frac_raw_reads_used",
+            "raw_reads_rejected_for_insufficient_support",
+            "raw_reads_rejected_for_minority_alignment",
+            "raw_reads_rejected_for_orphan_consensus",
+            "raw_reads_rejected_for_zero_bases_post_trimming",
+            "consensus_reads_emitted",
+        ];
+        // Duplex: the same sequence plus the three duplex-only rows seeded (in fgbio order)
+        // immediately after the vanilla rejections and before the final emitted count.
+        const EXPECTED_DUPLEX: &[&str] = &[
+            "raw_reads_considered",
+            "raw_reads_rejected",
+            "raw_reads_used",
+            "frac_raw_reads_used",
+            "raw_reads_rejected_for_insufficient_support",
+            "raw_reads_rejected_for_minority_alignment",
+            "raw_reads_rejected_for_orphan_consensus",
+            "raw_reads_rejected_for_zero_bases_post_trimming",
+            "raw_reads_rejected_for_non_paired_reads",
+            "raw_reads_rejected_for_single_strand_only",
+            "raw_reads_rejected_for_potential_umi_collision",
+            "consensus_reads_emitted",
+        ];
+
+        let metrics = ConsensusMetrics::new();
+
+        let vanilla = metrics.to_kv_metrics(ConsensusCallerKind::Vanilla);
+        let vanilla_keys: Vec<&str> = vanilla.iter().map(|m| m.key.as_str()).collect();
+        assert_eq!(vanilla_keys.as_slice(), EXPECTED_VANILLA, "vanilla KV row order drifted");
+
+        let duplex = metrics.to_kv_metrics(ConsensusCallerKind::Duplex);
+        let duplex_keys: Vec<&str> = duplex.iter().map(|m| m.key.as_str()).collect();
+        assert_eq!(duplex_keys.as_slice(), EXPECTED_DUPLEX, "duplex KV row order drifted");
+    }
+
+    /// R2-MET-05: the codec caller additionally seeds `not_primary_fr_pair`
+    /// (`usedByCodec`) on top of the duplex rows.
+    #[test]
+    fn test_to_kv_metrics_codec_seeds_codec_row() {
+        let metrics = ConsensusMetrics::new();
+        let codec = metrics.to_kv_metrics(ConsensusCallerKind::Codec);
+        let has_key = |key: &str| codec.iter().any(|m| m.key == key);
+        assert!(
+            has_key("raw_reads_rejected_for_not_primary_fr_pair"),
+            "codec KV metrics must always emit not_primary_fr_pair"
+        );
+        // ...and it still seeds the duplex rows.
+        assert!(has_key("raw_reads_rejected_for_non_paired_reads"));
+        // Duplex must NOT seed the codec-only row.
+        let duplex = metrics.to_kv_metrics(ConsensusCallerKind::Duplex);
+        assert!(
+            !duplex.iter().any(|m| m.key == "raw_reads_rejected_for_not_primary_fr_pair"),
+            "duplex KV metrics must not seed the codec-only row at zero"
+        );
+    }
+
+    /// R2-MET-05: seeded duplex rows carry fgbio's exact keys and descriptions.
+    #[test]
+    fn test_duplex_seeded_row_descriptions_match_fgbio() {
+        let metrics = ConsensusMetrics::new();
+        let kv = metrics.to_kv_metrics(ConsensusCallerKind::Duplex);
+        let find = |key: &str| kv.iter().find(|m| m.key == key).map(|m| m.description.clone());
+        assert_eq!(
+            find("raw_reads_rejected_for_non_paired_reads").as_deref(),
+            Some("Unpaired/fragment reads not supported by Duplex caller")
+        );
+        assert_eq!(
+            find("raw_reads_rejected_for_single_strand_only").as_deref(),
+            Some("Only Generating One Strand of Duplex Consensus")
+        );
+        assert_eq!(
+            find("raw_reads_rejected_for_potential_umi_collision").as_deref(),
+            Some("Potential collision between independent duplex molecules")
+        );
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -88,7 +88,7 @@ pub trait ProcessingMetrics {
 // Re-export commonly used types
 #[cfg(feature = "clip")]
 pub use clip::{ClipCounts, ClippingMetrics, ClippingMetricsCollection, ReadType};
-pub use consensus::{ConsensusKvMetric, ConsensusMetrics};
+pub use consensus::{ConsensusCallerKind, ConsensusKvMetric, ConsensusMetrics};
 pub use correct::UmiCorrectionMetrics;
 pub use duplex::{
     DuplexFamilySizeMetric, DuplexMetricsCollector, DuplexUmiMetric, DuplexYieldMetric,

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -42,7 +42,9 @@ pub enum RejectionReason {
     UmiTooShort,
     /// Template had reads on same strand only (no proper pair)
     SameStrandOnly,
-    /// Duplicate UMI at same genomic position
+    /// Unpaired/fragment reads supplied to the duplex/codec caller
+    NonPairedReads,
+    /// Potential collision between independent duplex molecules sharing an MI
     DuplicateUmi,
     /// Only one of R1 or R2 consensus was generated (orphan)
     OrphanConsensus,
@@ -72,7 +74,8 @@ impl RejectionReason {
             Self::ExcessiveErrorRate => "Consensus read had excessive error rate",
             Self::UmiTooShort => "UMI was too short",
             Self::SameStrandOnly => "Template had reads on same strand only",
-            Self::DuplicateUmi => "Duplicate UMI at same genomic position",
+            Self::NonPairedReads => "Unpaired/fragment reads not supported by Duplex caller",
+            Self::DuplicateUmi => "Potential collision between independent duplex molecules",
             Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
             Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
             Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
@@ -98,7 +101,8 @@ impl RejectionReason {
             Self::ExcessiveErrorRate => "raw_reads_rejected_for_excessive_error_rate",
             Self::UmiTooShort => "raw_reads_rejected_for_umi_too_short",
             Self::SameStrandOnly => "raw_reads_rejected_for_single_strand_only",
-            Self::DuplicateUmi => "raw_reads_rejected_for_duplicate_umi",
+            Self::NonPairedReads => "raw_reads_rejected_for_non_paired_reads",
+            Self::DuplicateUmi => "raw_reads_rejected_for_potential_umi_collision",
             Self::OrphanConsensus => "raw_reads_rejected_for_orphan_consensus",
             Self::ZeroBasesPostTrimming => "raw_reads_rejected_for_zero_bases_post_trimming",
             Self::NotPrimaryFrPair => "raw_reads_rejected_for_not_primary_fr_pair",
@@ -123,8 +127,9 @@ impl RejectionReason {
             Self::InsufficientMinDepth => "Insufficient minimum read depth",
             Self::ExcessiveErrorRate => "Excessive error rate",
             Self::UmiTooShort => "UMI sequence too short",
-            Self::SameStrandOnly => "Only generating one strand of duplex consensus",
-            Self::DuplicateUmi => "Duplicate UMI detected",
+            Self::SameStrandOnly => "Only Generating One Strand of Duplex Consensus",
+            Self::NonPairedReads => "Unpaired/fragment reads not supported by Duplex caller",
+            Self::DuplicateUmi => "Potential collision between independent duplex molecules",
             Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
             Self::ZeroBasesPostTrimming => "Read or mate had zero bases post trimming",
             Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
@@ -178,29 +183,33 @@ mod tests {
         );
     }
 
+    /// Every rejection reason fgumi tracks, for coverage assertions.
+    const ALL_REASONS: [RejectionReason; 20] = [
+        RejectionReason::InsufficientSupport,
+        RejectionReason::MinorityAlignment,
+        RejectionReason::InsufficientStrandSupport,
+        RejectionReason::LowBaseQuality,
+        RejectionReason::ExcessiveNBases,
+        RejectionReason::NoValidAlignment,
+        RejectionReason::LowMappingQuality,
+        RejectionReason::NBasesInUmi,
+        RejectionReason::MissingUmi,
+        RejectionReason::NotPassingFilter,
+        RejectionReason::LowMeanQuality,
+        RejectionReason::InsufficientMinDepth,
+        RejectionReason::ExcessiveErrorRate,
+        RejectionReason::UmiTooShort,
+        RejectionReason::SameStrandOnly,
+        RejectionReason::NonPairedReads,
+        RejectionReason::DuplicateUmi,
+        RejectionReason::OrphanConsensus,
+        RejectionReason::ZeroBasesPostTrimming,
+        RejectionReason::NotPrimaryFrPair,
+    ];
+
     #[test]
     fn test_tsv_key_prefix() {
-        let all_reasons = [
-            RejectionReason::InsufficientSupport,
-            RejectionReason::MinorityAlignment,
-            RejectionReason::InsufficientStrandSupport,
-            RejectionReason::LowBaseQuality,
-            RejectionReason::ExcessiveNBases,
-            RejectionReason::NoValidAlignment,
-            RejectionReason::LowMappingQuality,
-            RejectionReason::NBasesInUmi,
-            RejectionReason::MissingUmi,
-            RejectionReason::NotPassingFilter,
-            RejectionReason::LowMeanQuality,
-            RejectionReason::InsufficientMinDepth,
-            RejectionReason::ExcessiveErrorRate,
-            RejectionReason::UmiTooShort,
-            RejectionReason::SameStrandOnly,
-            RejectionReason::DuplicateUmi,
-            RejectionReason::OrphanConsensus,
-            RejectionReason::ZeroBasesPostTrimming,
-        ];
-        for reason in &all_reasons {
+        for reason in &ALL_REASONS {
             assert!(
                 reason.tsv_key().starts_with("raw_reads_rejected_for_"),
                 "tsv_key for {:?} does not have expected prefix: {}",
@@ -211,28 +220,25 @@ mod tests {
     }
 
     #[test]
+    fn test_duplex_row_keys_match_fgbio() {
+        // R2-MET-05 / R2-UCC-01: the duplex/codec rejection rows carry fgbio's exact keys.
+        assert_eq!(
+            RejectionReason::NonPairedReads.tsv_key(),
+            "raw_reads_rejected_for_non_paired_reads"
+        );
+        assert_eq!(
+            RejectionReason::SameStrandOnly.tsv_key(),
+            "raw_reads_rejected_for_single_strand_only"
+        );
+        assert_eq!(
+            RejectionReason::DuplicateUmi.tsv_key(),
+            "raw_reads_rejected_for_potential_umi_collision"
+        );
+    }
+
+    #[test]
     fn test_kv_description_non_empty() {
-        let all_reasons = [
-            RejectionReason::InsufficientSupport,
-            RejectionReason::MinorityAlignment,
-            RejectionReason::InsufficientStrandSupport,
-            RejectionReason::LowBaseQuality,
-            RejectionReason::ExcessiveNBases,
-            RejectionReason::NoValidAlignment,
-            RejectionReason::LowMappingQuality,
-            RejectionReason::NBasesInUmi,
-            RejectionReason::MissingUmi,
-            RejectionReason::NotPassingFilter,
-            RejectionReason::LowMeanQuality,
-            RejectionReason::InsufficientMinDepth,
-            RejectionReason::ExcessiveErrorRate,
-            RejectionReason::UmiTooShort,
-            RejectionReason::SameStrandOnly,
-            RejectionReason::DuplicateUmi,
-            RejectionReason::OrphanConsensus,
-            RejectionReason::ZeroBasesPostTrimming,
-        ];
-        for reason in &all_reasons {
+        for reason in &ALL_REASONS {
             assert!(!reason.kv_description().is_empty(), "kv_description for {reason:?} is empty");
         }
     }

--- a/crates/fgumi-sam/src/builder.rs
+++ b/crates/fgumi-sam/src/builder.rs
@@ -244,6 +244,18 @@ impl SamBuilder {
         }
     }
 
+    /// Stamps template-coordinate sort order (`SO:unsorted`, `GO:query`,
+    /// `SS:template-coordinate`) onto the header.
+    ///
+    /// Consensus callers require template-coordinate-sorted input, so tests that
+    /// exercise `simplex`/`duplex`/`codec` end-to-end should call this before
+    /// writing the input BAM (the records must already be grouped by molecule,
+    /// which the builder's per-group insertion order satisfies).
+    pub fn set_template_coordinate_sort_order(&mut self) -> &mut Self {
+        self.header = crate::header_as_template_coordinate(&self.header);
+        self
+    }
+
     /// Returns the next sequential name.
     fn next_name(&self) -> String {
         format!("{:04}", self.counter.fetch_add(1, Ordering::SeqCst))

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -213,6 +213,44 @@ pub fn is_template_coordinate_sorted(header: &Header) -> bool {
     }
 }
 
+/// Checks if a header advertises `SO:unsorted` and `GO:query` (query-grouped but
+/// *without* a template-coordinate sub-sort).
+///
+/// This is the input order that fgbio's `UmiConsensusCaller.checkSortOrder`
+/// tolerates with a warning (rather than an error) for consensus calling: the
+/// reads are grouped by query name so molecules are contiguous, but the header
+/// does not assert full template-coordinate ordering. Following htsjdk (where an
+/// absent `SO` defaults to `unsorted`), a missing `SO` tag is treated as
+/// unsorted; `GO` must be explicitly `query`.
+///
+/// # Arguments
+///
+/// * `header` - SAM header to check
+///
+/// # Returns
+///
+/// `true` if the header is query-grouped and (explicitly or by default) unsorted,
+/// `false` otherwise.
+#[must_use]
+pub fn is_query_grouped_unsorted(header: &Header) -> bool {
+    if let Some(hdr_map) = header.header() {
+        let other_fields = hdr_map.other_fields();
+
+        // Absent SO defaults to "unsorted" (matches htsjdk `getSortOrder`); a
+        // present SO must equal "unsorted" (coordinate/queryname disqualify it).
+        let is_unsorted =
+            other_fields.get(b"SO").is_none_or(|so| <_ as AsRef<[u8]>>::as_ref(so) == UNSORTED);
+
+        // GO must be explicitly "query".
+        let is_query_grouped =
+            other_fields.get(b"GO").is_some_and(|go| <_ as AsRef<[u8]>>::as_ref(go) == b"query");
+
+        is_unsorted && is_query_grouped
+    } else {
+        false
+    }
+}
+
 /// Checks if a BAM file is queryname sorted and logs a warning if not.
 ///
 /// This function validates that the input file has the correct sort order for
@@ -266,6 +304,45 @@ pub fn header_as_unsorted(header: &Header) -> Header {
     other_fields.insert(SORT_ORDER, BString::from(UNSORTED));
     other_fields.shift_remove(b"GO");
     other_fields.shift_remove(b"SS");
+
+    let mut builder = Header::builder();
+    for (name, rg) in header.read_groups() {
+        builder = builder.add_read_group(name.clone(), rg.clone());
+    }
+    for (name, reference) in header.reference_sequences() {
+        builder = builder.add_reference_sequence(name.clone(), reference.clone());
+    }
+    for (id, pg) in header.programs().as_ref() {
+        builder = builder.add_program(id.clone(), pg.clone());
+    }
+    for comment in header.comments() {
+        builder = builder.add_comment(comment.clone());
+    }
+    builder.set_header(header_map).build()
+}
+
+/// Returns a copy of `header` advertising template-coordinate sort order.
+///
+/// Sets `SO:unsorted`, `GO:query`, and `SS:template-coordinate` — the order
+/// `is_template_coordinate_sorted` accepts and that `fgumi group`/`sort` emit.
+/// Primarily useful for constructing consensus-calling inputs (real or test).
+#[must_use]
+pub fn header_as_template_coordinate(header: &Header) -> Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::header::tag::{
+        GROUP_ORDER, SORT_ORDER, SUBSORT_ORDER,
+    };
+
+    let mut header_map = header
+        .header()
+        .cloned()
+        .unwrap_or_else(Map::<noodles::sam::header::record::value::map::Header>::default);
+
+    let other_fields = header_map.other_fields_mut();
+    other_fields.insert(SORT_ORDER, BString::from(UNSORTED));
+    other_fields.insert(GROUP_ORDER, BString::from("query"));
+    other_fields.insert(SUBSORT_ORDER, BString::from("template-coordinate"));
 
     let mut builder = Header::builder();
     for (name, rg) in header.read_groups() {
@@ -876,6 +953,73 @@ mod tests {
     fn test_is_template_coordinate_sorted_empty_header() {
         let header = create_empty_header();
         assert!(!is_template_coordinate_sorted(&header));
+    }
+
+    // =========================================================================
+    // Tests for is_query_grouped_unsorted()
+    // =========================================================================
+
+    #[test]
+    fn test_is_query_grouped_unsorted_true_for_unsorted_query() {
+        // SO:unsorted + GO:query (no SS) is the fgbio-tolerated "warn" order.
+        let header = create_template_coord_header("unsorted", Some("query"), None);
+        assert!(is_query_grouped_unsorted(&header));
+    }
+
+    #[test]
+    fn test_is_query_grouped_unsorted_true_for_template_coordinate() {
+        // Full template-coordinate order is also query-grouped and unsorted.
+        let header =
+            create_template_coord_header("unsorted", Some("query"), Some("template-coordinate"));
+        assert!(is_query_grouped_unsorted(&header));
+    }
+
+    #[test]
+    fn test_is_query_grouped_unsorted_false_for_coordinate() {
+        // SO:coordinate disqualifies it even when GO:query is present.
+        let header = create_template_coord_header("coordinate", Some("query"), None);
+        assert!(!is_query_grouped_unsorted(&header));
+    }
+
+    #[test]
+    fn test_is_query_grouped_unsorted_false_without_group_order() {
+        // GO must be explicitly "query".
+        let header = create_template_coord_header("unsorted", None, None);
+        assert!(!is_query_grouped_unsorted(&header));
+    }
+
+    #[test]
+    fn test_is_query_grouped_unsorted_true_when_so_absent_but_go_query() {
+        // Matches htsjdk: an absent SO defaults to unsorted, so GO:query alone qualifies.
+        let header: Header =
+            "@HD\tVN:1.6\tGO:query\n".parse().expect("failed to parse header with GO but no SO");
+        assert!(is_query_grouped_unsorted(&header));
+    }
+
+    // =========================================================================
+    // Tests for header_as_template_coordinate()
+    // =========================================================================
+
+    #[test]
+    fn test_header_as_template_coordinate_is_recognized() {
+        let header = create_template_coord_header("coordinate", None, None);
+        let stamped = header_as_template_coordinate(&header);
+        assert!(is_template_coordinate_sorted(&stamped));
+        assert!(!is_template_coordinate_sorted(&header));
+    }
+
+    #[test]
+    fn test_header_as_template_coordinate_preserves_read_groups_and_refs() {
+        let header_str = "@HD\tVN:1.6\tSO:coordinate\n\
+                          @SQ\tSN:chr1\tLN:1000\n\
+                          @RG\tID:rg1\tSM:sample1\n\
+                          @PG\tID:prog1\tPN:tool\n";
+        let header: Header = header_str.parse().expect("parse header");
+        let stamped = header_as_template_coordinate(&header);
+        assert!(is_template_coordinate_sorted(&stamped));
+        assert!(stamped.reference_sequences().contains_key(b"chr1".as_slice()));
+        assert!(stamped.read_groups().contains_key(b"rg1".as_slice()));
+        assert_eq!(stamped.programs().as_ref().len(), 1);
     }
 
     // =========================================================================

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -312,6 +312,10 @@ impl Command for Codec {
                 &self.io.input,
                 self.io.pipeline_reader_opts(),
             )?;
+            crate::commands::common::check_consensus_sort_order(
+                &header,
+                &self.io.input.display().to_string(),
+            )?;
             let output_header = create_unmapped_consensus_header(
                 &header,
                 &self.read_group.read_group_id,
@@ -335,6 +339,10 @@ impl Command for Codec {
         // Single-threaded fast path: open the raw reader once and derive the header from it.
         let (mut raw_reader, header) =
             create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        crate::commands::common::check_consensus_sort_order(
+            &header,
+            &self.io.input.display().to_string(),
+        )?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,
@@ -933,6 +941,9 @@ mod tests {
         let rg = Map::<noodles::sam::header::record::value::map::ReadGroup>::default();
         header.read_groups_mut().insert(bstr::BString::from("A"), rg);
 
+        // Consensus callers require template-coordinate-sorted input (CONS-01).
+        let header = fgumi_sam::header_as_template_coordinate(&header);
+
         let mut writer = noodles::bam::io::writer::Builder.build_from_path(path)?;
         writer.write_header(&header)?;
 
@@ -975,6 +986,50 @@ mod tests {
 
         // Output file should be created
         assert!(output_path.exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_codec_execute_rejects_non_template_coordinate_input() -> Result<()> {
+        // CONS-01: codec requires template-coordinate-sorted input. An ungrouped header must be
+        // rejected by execute() (via check_consensus_sort_order) rather than silently
+        // mis-grouping molecules; the accept branch is covered by the other execute tests.
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::{ReferenceSequence, header::Version};
+        use std::num::NonZeroUsize;
+
+        let dir = TempDir::new()?;
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+
+        // Plain header — deliberately NOT stamped template-coordinate (unlike write_codec_bam).
+        let mut header = Header::builder()
+            .set_header(Map::<noodles::sam::header::record::value::map::Header>::new(Version::new(
+                1, 6,
+            )))
+            .build();
+        header.reference_sequences_mut().insert(
+            bstr::BString::from("chr1"),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(1000).expect("non-zero length")),
+        );
+        header.read_groups_mut().insert(
+            bstr::BString::from("A"),
+            Map::<noodles::sam::header::record::value::map::ReadGroup>::default(),
+        );
+        let (r1, r2) = create_codec_fr_pair_overlapping("UMI001", 100, 105, 20, &[30; 20]);
+        let mut writer = noodles::bam::io::writer::Builder.build_from_path(&input_path)?;
+        writer.write_header(&header)?;
+        writer.write_alignment_record(&header, &r1)?;
+        writer.write_alignment_record(&header, &r2)?;
+        drop(writer);
+
+        let cmd = create_codec_with_paths(input_path, output_path);
+        let err = cmd.execute("test").expect_err("codec must reject non-template-coordinate input");
+        assert!(
+            err.to_string().contains("template-coordinate"),
+            "error must suggest template-coordinate sorting: {err}"
+        );
 
         Ok(())
     }

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -17,7 +17,7 @@ use fgumi_bam_io::is_stdin_path;
 #[cfg(feature = "simplex")]
 use fgumi_consensus::methylation::RefBaseProvider;
 #[cfg(feature = "simplex")]
-use log::info;
+use log::{info, warn};
 use noodles::sam::Header;
 
 /// CLI argument value for `--methylation-mode`.
@@ -120,6 +120,56 @@ pub fn add_pg_to_builder(
     command_line: &str,
 ) -> anyhow::Result<noodles::sam::header::Builder> {
     fgumi_bam_io::header::add_pg_to_builder(builder, crate::version::VERSION.as_str(), command_line)
+}
+
+/// Verifies that a consensus-calling input BAM is sorted appropriately.
+///
+/// Mirrors fgbio's `UmiConsensusCaller.checkSortOrder`
+/// (`UmiConsensusCaller.scala:165-173`), which the `CallMolecularConsensusReads`,
+/// `CallDuplexConsensusReads`, and `CallCodecConsensusReads` tools all invoke on
+/// their input header. Consensus calling groups reads by molecule as they stream,
+/// so it requires template-coordinate order; coordinate-sorted (or otherwise
+/// mis-ordered) input silently interleaves molecules and every molecule is split,
+/// corrupting the entire output.
+///
+/// Behavior, matching fgbio exactly:
+/// - Template-coordinate (`SO:unsorted`, `GO:query`, `SS:template-coordinate`):
+///   accepted silently.
+/// - Query-grouped but unsorted without the `SS` sub-sort (`SO:unsorted`,
+///   `GO:query`): accepted with a warning (probably compatible, e.g. an fgbio
+///   `GroupReadsByUmi` output that omits the sub-sort).
+/// - Anything else (coordinate, queryname, ungrouped, …): rejected with an error.
+///
+/// This reads only the header and never touches or re-opens the record stream, so
+/// it is safe to call on a stdin-backed reader after the header has been read.
+///
+/// # Arguments
+///
+/// * `header` - the already-read input BAM header
+/// * `source` - a human-readable description of the input (path or `<stdin>`)
+///
+/// # Errors
+///
+/// Returns an error if the header advertises an order that is definitely
+/// incompatible with consensus calling.
+pub fn check_consensus_sort_order(header: &Header, source: &str) -> anyhow::Result<()> {
+    if fgumi_sam::is_template_coordinate_sorted(header) {
+        return Ok(());
+    }
+    if fgumi_sam::is_query_grouped_unsorted(header) {
+        warn!(
+            "File {source} may not be sorted correctly for consensus read generation \
+             (query-grouped but missing the template-coordinate sub-sort). Continuing, \
+             but sort with `fgumi sort --order template-coordinate` if the output looks wrong."
+        );
+        return Ok(());
+    }
+    anyhow::bail!(
+        "File {source} is not sorted correctly for consensus calling. The input must be \
+         template-coordinate sorted (header must advertise SO:unsorted, GO:query, and \
+         SS:template-coordinate).\n\nSort it first, e.g.:\n  \
+         fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
+    );
 }
 
 /// EM-Seq methylation-aware consensus calling options.
@@ -973,6 +1023,35 @@ mod tests {
     fn enable_logging() {
         let _ =
             env_logger::builder().is_test(true).filter_level(log::LevelFilter::Trace).try_init();
+    }
+
+    /// CONS-01: `check_consensus_sort_order` mirrors fgbio's `UmiConsensusCaller.checkSortOrder`
+    /// (the cases pinned by `UmiConsensusCallerTest.scala:34-60`): template-coordinate is
+    /// accepted silently; query-grouped-unsorted (no `SS`) is accepted with a warning;
+    /// coordinate-sorted (silently splits every molecule) and ungrouped headers both error
+    /// with a message naming the source and suggesting template-coordinate.
+    #[rstest]
+    #[case::template_coordinate(
+        "@HD\tVN:1.6\tSO:unsorted\tGO:query\tSS:template-coordinate\n",
+        true
+    )]
+    #[case::unsorted_query_warns("@HD\tVN:1.6\tSO:unsorted\tGO:query\n", true)]
+    #[case::coordinate("@HD\tVN:1.6\tSO:coordinate\n", false)]
+    #[case::ungrouped("@HD\tVN:1.6\n", false)]
+    fn test_check_consensus_sort_order(#[case] header_str: &str, #[case] should_accept: bool) {
+        enable_logging();
+        let header: Header = header_str.parse().expect("parse");
+        let result = check_consensus_sort_order(&header, "foo.bam");
+        if should_accept {
+            assert!(result.is_ok(), "header must be accepted: {header_str:?}");
+        } else {
+            let err = result.expect_err("header must be rejected");
+            assert!(err.to_string().contains("foo.bam"), "error must name the source: {err}");
+            assert!(
+                err.to_string().contains("template-coordinate"),
+                "error must suggest template-coordinate: {err}"
+            );
+        }
     }
 
     #[test]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -541,9 +541,13 @@ impl Command for Duplex {
         metrics.consensus_reads = consensus_count as u64;
         log_consensus_summary(&metrics);
 
-        // Write statistics file if requested
+        // Write statistics file if requested. Emit the same fgbio seeded key-value format as
+        // the multi-threaded path (`execute_threads_mode`) so duplex metrics output is
+        // thread-independent — the single-threaded path previously wrote the wide format,
+        // omitting the always-seeded `usedByDuplex` rejection rows (R2-MET-05).
         if let Some(stats_path) = &self.stats_opts.stats {
-            DelimFile::default().write_tsv(stats_path, [metrics]).map_err(|e| {
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Duplex);
+            DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
                 anyhow::anyhow!("Failed to write statistics to {}: {}", stats_path.display(), e)
             })?;
             info!("Statistics written to: {}", stats_path.display());
@@ -850,7 +854,7 @@ impl Duplex {
 
         // Write statistics file if requested
         if let Some(stats_path) = &self.stats_opts.stats {
-            let kv_metrics = metrics.to_kv_metrics();
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Duplex);
             DelimFile::default()
                 .write_tsv(stats_path, kv_metrics)
                 .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -291,6 +291,9 @@ impl Command for Duplex {
         // streams them in a single pass).
         self.io.validate()?;
 
+        // Validate consensus arguments (e.g. error rates must be > 0).
+        self.validate()?;
+
         // Get threading configuration (duplex is worker-heavy with consensus calling)
         let reader_threads = self.threading.num_threads();
         let worker_threads = self.threading.num_threads();
@@ -343,6 +346,10 @@ impl Command for Duplex {
                 &self.io.input,
                 self.io.pipeline_reader_opts(),
             )?;
+            crate::commands::common::check_consensus_sort_order(
+                &header,
+                &self.io.input.display().to_string(),
+            )?;
             let header = crate::commands::common::add_pg_record(header, command_line)?;
             let read_name_prefix = self.read_group.prefix_or_from_header(&header);
             let methylation_ref: MethylationRef =
@@ -365,6 +372,10 @@ impl Command for Duplex {
         // Single-threaded fast path: open the raw reader once and derive the header from it.
         let (mut raw_reader, header) =
             create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        crate::commands::common::check_consensus_sort_order(
+            &header,
+            &self.io.input.display().to_string(),
+        )?;
         let header = crate::commands::common::add_pg_record(header, command_line)?;
         let read_name_prefix = self.read_group.prefix_or_from_header(&header);
         let methylation_ref: MethylationRef =
@@ -547,6 +558,23 @@ impl Command for Duplex {
 }
 
 impl Duplex {
+    /// Validates command-line arguments prior to execution.
+    ///
+    /// Mirrors fgbio's `CallDuplexConsensusReads` argument validation: both the
+    /// pre- and post-UMI Phred-scaled error rates must be strictly greater than
+    /// zero. A rate of Q0 corresponds to `P(error) = 1`, which is nonsensical as
+    /// a prior and would corrupt the duplex consensus quality model, so fgbio
+    /// rejects it (`CallDuplexConsensusReads.scala:131-132`).
+    fn validate(&self) -> Result<()> {
+        if self.consensus.error_rate_pre_umi == 0 {
+            bail!("error-rate-pre-umi must be > 0");
+        }
+        if self.consensus.error_rate_post_umi == 0 {
+            bail!("error-rate-post-umi must be > 0");
+        }
+        Ok(())
+    }
+
     /// Execute using 7-step unified pipeline with --threads.
     ///
     /// This method is called when `--threads N` is specified with N > 1.
@@ -963,7 +991,8 @@ mod tests {
                 ),
             );
 
-        builder.build()
+        // Consensus callers require template-coordinate-sorted input (CONS-01).
+        fgumi_sam::header_as_template_coordinate(&builder.build())
     }
 
     fn to_record_buf(raw: fgumi_raw_bam::RawRecord) -> sam::alignment::RecordBuf {
@@ -1128,6 +1157,24 @@ mod tests {
     // ========================================================================
     // Unit Tests for Duplex Configuration
     // ========================================================================
+
+    /// DUP-01: fgbio's `CallDuplexConsensusReads` requires both Phred error rates > 0
+    /// (`CallDuplexConsensusReads.scala:131-132`); Q0 => P(err)=1, which fgbio rejects.
+    #[rstest]
+    #[case::defaults_valid(45, 40, true)]
+    #[case::zero_pre_umi_rejected(0, 40, false)]
+    #[case::zero_post_umi_rejected(45, 0, false)]
+    fn test_error_rate_validation(
+        #[case] pre_umi: u8,
+        #[case] post_umi: u8,
+        #[case] expect_ok: bool,
+    ) {
+        let mut duplex =
+            create_duplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("output.bam"));
+        duplex.consensus.error_rate_pre_umi = pre_umi;
+        duplex.consensus.error_rate_post_umi = post_umi;
+        assert_eq!(duplex.validate().is_ok(), expect_ok);
+    }
 
     #[test]
     fn test_default_parameters() {

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -288,6 +288,10 @@ impl Command for Simplex {
                 &self.io.input,
                 self.io.pipeline_reader_opts(),
             )?;
+            crate::commands::common::check_consensus_sort_order(
+                &header,
+                &self.io.input.display().to_string(),
+            )?;
             let output_header = create_unmapped_consensus_header(
                 &header,
                 &self.read_group.read_group_id,
@@ -315,6 +319,10 @@ impl Command for Simplex {
         // Single-threaded fast path: open the raw reader once and derive the header from it.
         let (mut raw_reader, header) =
             create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
+        crate::commands::common::check_consensus_sort_order(
+            &header,
+            &self.io.input.display().to_string(),
+        )?;
         let output_header = create_unmapped_consensus_header(
             &header,
             &self.read_group.read_group_id,
@@ -832,6 +840,28 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
+    #[test]
+    fn test_rejects_non_template_coordinate_input() -> Result<()> {
+        // CONS-01: consensus calling groups reads by molecule as they stream, so it
+        // requires template-coordinate-sorted input. A bare (ungrouped) header must be
+        // rejected — proceeding would silently split every molecule and corrupt output.
+        let mut builder = SamBuilder::new_unmapped();
+        let mut attrs = HashMap::new();
+        attrs.insert("MI", BufValue::from("GATTACA:0"));
+        attrs.insert("RX", BufValue::from("ACGT-TGCA"));
+        builder.add_pair_with_attrs("READ:0", None, None, true, true, &attrs);
+
+        let paths = TestPaths::new()?;
+        // Deliberately NOT stamped with template-coordinate order.
+        builder.write(&paths.input)?;
+
+        let cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
+        let result = cmd.execute("test");
+        assert!(result.is_err(), "simplex must reject non-template-coordinate input");
+        assert!(result.unwrap_err().to_string().contains("template-coordinate"));
+        Ok(())
+    }
+
     // ========================================================================
     // Integration Tests
     // ========================================================================
@@ -940,7 +970,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.read_group.read_group_id = "ABC".to_string();
@@ -1013,7 +1043,7 @@ mod tests {
         builder.add_frag_with_attrs("b2", None, true, &attrs_b);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.read_group.read_group_id = "ABC".to_string();
@@ -1078,7 +1108,7 @@ mod tests {
         builder.add_frag_with_attrs("c1", None, true, &attrs3);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.min_reads = 3;
@@ -1116,7 +1146,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.consensus.output_per_base_tags = true;
@@ -1165,7 +1195,7 @@ mod tests {
 
         let paths = TestPaths::new()?;
         let output_multi_path = paths.dir.path().join("output_multi.bam");
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         // Run with single thread
         let cmd_single = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
@@ -1205,7 +1235,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.max_reads = Some(10);
@@ -1230,9 +1260,12 @@ mod tests {
     #[test]
     fn test_max_reads_less_than_min_reads_fails() {
         // Create a dummy BAM file so validation gets to tag check
-        let builder = SamBuilder::new_unmapped();
+        let mut builder = SamBuilder::new_unmapped();
         let paths = TestPaths::new().expect("failed to create test paths");
-        builder.write(&paths.input).expect("failed to write test BAM");
+        builder
+            .set_template_coordinate_sort_order()
+            .write(&paths.input)
+            .expect("failed to write test BAM");
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), PathBuf::from("out.bam"));
         cmd.min_reads = 5;
@@ -1262,7 +1295,7 @@ mod tests {
         builder.add_frag_with_attrs("f1", None, true, &attrs2);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.stats_opts.stats = Some(paths.stats.clone());
@@ -1307,7 +1340,7 @@ mod tests {
         builder.add_frag_with_attrs("read2", None, true, &attrs);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.read_group.read_name_prefix = Some("MYCONSENSUS".to_string());
@@ -1342,7 +1375,7 @@ mod tests {
         builder.add_frag_with_attrs("f1", None, true, &attrs2);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.rejects_opts.rejects = Some(paths.rejects.clone());
@@ -1384,7 +1417,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.rejects_opts.rejects = Some(paths.rejects.clone());
@@ -1419,7 +1452,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.stats_opts.stats = Some(paths.stats.clone());
@@ -1469,7 +1502,7 @@ mod tests {
         builder.add_pair_with_attrs("pair2", None, None, true, true, &attrs);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.overlapping.consensus_call_overlapping_bases = true;
@@ -1497,7 +1530,7 @@ mod tests {
         builder.add_frag_with_attrs("frag3", None, true, &attrs);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.overlapping.consensus_call_overlapping_bases = true;
@@ -1522,7 +1555,7 @@ mod tests {
         builder.add_frag_with_attrs("read2", None, true, &attrs);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.consensus.trim = true;
@@ -1547,7 +1580,7 @@ mod tests {
         builder.add_frag_with_attrs("read2", None, true, &attrs);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.consensus.min_consensus_base_quality = 30;
@@ -1577,7 +1610,7 @@ mod tests {
         builder.add_frag_with_attrs("no_umi2", None, true, &attrs_no_umi);
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
 
@@ -1610,7 +1643,7 @@ mod tests {
         builder.add_frag_with_attrs("read1", None, true, &attrs);
         builder.add_frag_with_attrs("read2", None, true, &attrs);
         builder.add_frag_with_attrs("read3", None, true, &attrs);
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.threading = threading;
@@ -1696,7 +1729,7 @@ mod tests {
         }
 
         let paths = TestPaths::new()?;
-        builder.write(&paths.input)?;
+        builder.set_template_coordinate_sort_order().write(&paths.input)?;
 
         let mut cmd = create_simplex_with_paths(paths.input.clone(), paths.output.clone());
         cmd.methylation_mode = Some(crate::commands::common::MethylationModeArg::EmSeq);

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -470,7 +470,7 @@ impl Command for Simplex {
 
         if let Some(stats_path) = &self.stats_opts.stats {
             // Convert to fgbio-compatible vertical key-value-description format
-            let kv_metrics = metrics.to_kv_metrics();
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Vanilla);
             DelimFile::default()
                 .write_tsv(stats_path, kv_metrics)
                 .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
@@ -746,7 +746,7 @@ impl Simplex {
 
         if let Some(stats_path) = &self.stats_opts.stats {
             // Convert to fgbio-compatible vertical key-value-description format
-            let kv_metrics = metrics.to_kv_metrics();
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Vanilla);
             DelimFile::default()
                 .write_tsv(stats_path, kv_metrics)
                 .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -360,4 +360,20 @@ fn test_duplex_command_with_stats() {
     .expect("failed to parse duplex args");
     cmd.execute("fgumi duplex").expect("Duplex command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
+
+    // Single-threaded duplex must emit the same fgbio seeded key-value format as the
+    // multi-threaded path (thread-independent metrics): the always-seeded `usedByDuplex`
+    // rejection rows must be present even at zero. The wide (per-field) format the
+    // single-threaded path previously wrote would not contain these KV keys.
+    let stats = std::fs::read_to_string(&stats_path).expect("read stats");
+    for key in [
+        "raw_reads_rejected_for_non_paired_reads",
+        "raw_reads_rejected_for_single_strand_only",
+        "raw_reads_rejected_for_potential_umi_collision",
+    ] {
+        assert!(
+            stats.contains(key),
+            "single-threaded duplex stats must emit the seeded KV row {key}:\n{stats}"
+        );
+    }
 }


### PR DESCRIPTION
Burn-down PR #10 of the fgbio↔fgumi behavioral-parity tracker. Four findings, all verified end-to-end against fgbio 4.1.0. Stacked on #505 (`nh/fix-codec-fr-pair-rejection`) because the rejection-machinery findings touch the same files (`caller.rs`, `codec_caller.rs`, `consensus.rs`, `rejection.rs`); retarget to `main` once #505 merges.

## CONS-01 (S3) — consensus sort-order guard

fgbio's `UmiConsensusCaller.checkSortOrder` errors unless the input is template-coordinate sorted; `simplex`/`duplex`/`codec` had no such guard (only `group`/`dedup` did), so coordinate-sorted standalone input silently interleaved molecules and split every one of them — corrupting the entire output. Added `check_consensus_sort_order` (mirroring fgbio's three cases exactly: template-coordinate → accept, `SO:unsorted`+`GO:query` → warn, else → error), wired into the already-read header of both the threaded and single-threaded paths of all three callers (stdin-safe; no re-open).

## DUP-01 (S3) — duplex error-rate validation

fgbio's `CallDuplexConsensusReads` requires `errorRate{Pre,Post}Umi > 0` (Q0 ⇒ P(err)=1). `duplex` accepted a raw `u8` with no check. Added `Duplex::validate()` rejecting a zero pre/post-UMI error rate. (codec already guarded this; simplex correctly allows `>= 0`.)

## R2-UCC-01 (S4) — reject fragment reads

fgbio's `DuplexConsensusCaller` partitions unpaired/fragment reads out and rejects them as `NonPairedReads`; fgumi folded them into the strand groups where they were mis-accounted. Added a `NonPairedReads` rejection reason and partition/reject them in `consensus_reads`.

## R2-MET-05 (S4) — seed the duplex KV rejection rows

fgbio seeds and always emits per-caller rejection rows (`initializeRejectCounts`). The duplex caller emits `raw_reads_rejected_for_{non_paired_reads,single_strand_only,potential_umi_collision}` even at zero; fgumi emitted only the four vanilla rows. Replaced the fixed core/optional split with per-caller seeding driven by a new `ConsensusCallerKind`, re-keyed the collision reason to fgbio's `potential_umi_collision`, and aligned the three newly seeded rows' descriptions. (Row-set half only; #504 owns the remaining description-text parity.)

## Parity evidence (fgbio 4.1.0 ↔ fgumi, before → after)

- **CONS-01** — coordinate-sorted input: fgbio exit 1 (reject); fgumi BEFORE exit 0 (silently accepted); fgumi AFTER exit 1 (rejects); template-coordinate input AFTER exit 0.
- **DUP-01** — `--error-rate-pre/post-umi 0`: fgbio exit 1; fgumi BEFORE exit 0; fgumi AFTER exit 1; defaults exit 0.
- **R2-MET-05** — duplex KV rejection rows: fgbio 7; fgumi BEFORE 4; fgumi AFTER 7 (keys match fgbio exactly).
- **R2-UCC-01** — one fragment read: fgbio `non_paired_reads=1`; fgumi BEFORE no such row; fgumi AFTER `non_paired_reads=1`.

Reproducers: `reports/fgbio-parity-fixtures/cons-01-dup-01-consensus-guards.sh` and `reports/fgbio-parity-fixtures/r2-met-05-ucc-01-duplex-rejection-rows.sh`.

`cargo ci-fmt`, `cargo ci-lint`, and `cargo ci-test` (2221 tests) all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consensus input sort-order validation (template-coordinate accepted; query-grouped unsorted warns; others error with guidance).
  * Added template-coordinate header stamping plus a SAM builder option to apply it.
  * Added caller-aware consensus rejection metrics and KV “seeded” rows for vanilla/duplex/codec workflows.

* **Bug Fixes**
  * Fragment/unpaired reads now map consistently to centralized “non-paired reads” metrics and are counted correctly.
  * Duplex rejects invalid zero pre-/post-UMI error-rate settings.
  * Fragment rejects no longer affect strand/MI accounting.

* **Tests**
  * Updated and expanded unit/integration tests for sorting validation, fragment rejection/stats behavior, and caller-specific KV output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->