### PR TITLE
fix(consensus)!: apply fgbio pre-group filter to simplex/codec, add --allow-unmapped

### DIFF
--- a/docs/src/guide/consensus-calling.md
+++ b/docs/src/guide/consensus-calling.md
@@ -86,3 +86,10 @@ Any consensus base with quality below the minimum threshold is masked to `N`.
 - Indel errors in the reads are not considered in the consensus model
 - `simplex` and `codec` do not accept a `--sort-order` flag; consensus reads are emitted as
   unmapped and should be sorted by the downstream pipeline (`fgumi zipper` + `fgumi sort`)
+- By default, reads that are unmapped and lack a mapped mate — along with all secondary and
+  supplementary alignments — are dropped before consensus calling, matching fgbio's
+  `ConsensusCallingIterator`. Pass `--allow-unmapped` to `simplex`, `duplex`, or `codec` to call
+  consensus on fully-unmapped input (e.g. ribosome/protein display, or cell-free DNA fragments
+  that fall outside the target region but still share UMIs with mapped molecules). This mirrors
+  `fgumi group --allow-unmapped`. `--allow-unmapped` relaxes **only** the unmapped-without-mapped-mate
+  rule; secondary and supplementary alignments are always dropped before grouping, regardless of the flag.

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -27,9 +27,9 @@ use fgumi_bam_io::{
 };
 
 use super::common::{
-    BamIoOptions, CompressionOptions, ConsensusCallingOptions, QueueMemoryOptions,
-    ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions, ThreadingOptions,
-    build_pipeline_config, serialize_raw_bam_records,
+    AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
+    QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
+    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
 };
 use crate::consensus::codec_caller::{
     CodecConsensusCaller, CodecConsensusError, CodecConsensusOptions, CodecConsensusStats,
@@ -43,7 +43,7 @@ use crate::unified_pipeline::{
     run_bam_pipeline_from_reader_with_secondary,
 };
 use fgumi_bam_io::ProgressTracker;
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
 use crate::sam::SamTag;
 use log::info;
@@ -231,6 +231,10 @@ pub struct Codec {
     #[arg(short = 'X', long = "max-duplex-disagreements")]
     pub max_duplex_disagreements: Option<usize>,
 
+    /// Whether to process unmapped reads (the shared `--allow-unmapped` flag).
+    #[command(flatten)]
+    pub allow_unmapped: AllowUnmappedOptions,
+
     /// Scheduler and pipeline statistics options.
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
@@ -397,13 +401,26 @@ impl Command for Codec {
         let mut record_count: usize = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Use the raw_reader opened above (single input open).
+        // Use the raw_reader opened above (single input open). Apply the fgbio
+        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
+        // relaxes only the unmapped-without-mapped-mate rule.
+        let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
-            let mut record = RawRecord::new();
-            match raw_reader.read_record(&mut record) {
-                Ok(0) => None, // EOF
-                Ok(_) => Some(Ok(record)),
-                Err(e) => Some(Err(e.into())),
+            loop {
+                let mut record = RawRecord::new();
+                match raw_reader.read_record(&mut record) {
+                    Ok(0) => return None, // EOF
+                    Ok(_) => {
+                        if crate::commands::common::consensus_pregroup_keep_flags(
+                            RawRecordView::new(&record).flags(),
+                            allow_unmapped,
+                        ) {
+                            return Some(Ok(record));
+                        }
+                        // Otherwise filtered out: keep reading.
+                    }
+                    Err(e) => return Some(Err(e.into())),
+                }
             }
         });
         let mi_group_iter =
@@ -585,9 +602,16 @@ impl Codec {
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // ========== grouper_fn ==========
+        // Apply the fgbio pre-group filter (always drop secondary/supplementary;
+        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule).
+        let allow_unmapped = self.allow_unmapped.enabled;
         let grouper_fn = move |_header: &Header| {
-            Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
-                as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+            let grouper = MiGrouper::new("MI", batch_size)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| {
+                    crate::commands::common::consensus_pregroup_keep_raw(raw, allow_unmapped)
+                });
+            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
         };
 
         // ========== process_fn: CODEC consensus calling ==========
@@ -779,6 +803,7 @@ mod tests {
             outer_bases_length: 5,
             max_duplex_disagreement_rate: 1.0,
             max_duplex_disagreements: None,
+            allow_unmapped: AllowUnmappedOptions { enabled: false },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
         }
@@ -786,6 +811,88 @@ mod tests {
 
     fn create_test_codec() -> Codec {
         create_codec_with_paths(PathBuf::from("input.bam"), PathBuf::from("output.bam"))
+    }
+
+    /// The `--allow-unmapped` CLI flag defaults to `false` (fgbio parity: the
+    /// pre-group filter is applied before consensus calling).
+    #[test]
+    fn test_codec_allow_unmapped_defaults_to_false() {
+        let default_cmd =
+            <Codec as clap::Parser>::try_parse_from(["codec", "-i", "in.bam", "-o", "out.bam"])
+                .expect("codec should parse with only the required args");
+        assert!(!default_cmd.allow_unmapped.enabled, "--allow-unmapped must default to false");
+
+        let enabled_cmd = <Codec as clap::Parser>::try_parse_from([
+            "codec",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--allow-unmapped",
+        ])
+        .expect("codec should parse with --allow-unmapped");
+        assert!(enabled_cmd.allow_unmapped.enabled, "bare --allow-unmapped must enable the flag");
+    }
+
+    /// The codec pre-group filter drops secondary/supplementary alignments before
+    /// grouping (fgbio parity), and `--allow-unmapped` must **not** relax that
+    /// exclusion — it only relaxes the unmapped-without-mapped-mate rule.
+    ///
+    /// This is the codec counterpart to simplex's
+    /// `test_allow_unmapped_gates_pregroup_filter` /
+    /// duplex's `test_duplex_allow_unmapped_gates_pregroup_filter`. Those tests
+    /// gate on unmapped, unpaired reads, but the codec caller itself rejects
+    /// unmapped pairs (`codec_caller.rs`: "Reads must be mapped and overlap on the
+    /// genome"), so an unmapped fixture yields zero consensus regardless of the
+    /// flag and cannot exercise the gate. Instead we add a supplementary
+    /// alignment to a valid mapped molecule and assert it never reaches the
+    /// consensus caller (observed via `total_input_reads`, which counts
+    /// post-filter reads) — with the flag both off and on. This pins the leak
+    /// where a bypassed filter would let non-primary alignments into grouping.
+    /// Runs the single-threaded fast path and the multi-threaded pipeline path,
+    /// which install the filter at independent sites.
+    #[rstest]
+    #[case::fast_path_default(ThreadingOptions::none(), false)]
+    #[case::fast_path_allow_unmapped(ThreadingOptions::none(), true)]
+    #[case::threaded_default(ThreadingOptions::new(2), false)]
+    #[case::threaded_allow_unmapped(ThreadingOptions::new(2), true)]
+    fn test_codec_allow_unmapped_gates_pregroup_filter(
+        #[case] threading: ThreadingOptions,
+        #[case] allow_unmapped: bool,
+    ) -> Result<()> {
+        let dir = TempDir::new()?;
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+        let stats_path = dir.path().join("stats.txt");
+
+        // A valid mapped, overlapping FR pair (one molecule) plus a supplementary
+        // alignment of R1, all sharing one MI. The pre-group filter must drop the
+        // supplementary before grouping, so only the two primaries reach the caller.
+        let (r1, r2) = create_codec_fr_pair_overlapping("UMI001", 100, 105, 20, &[30; 20]);
+        let supplementary = create_codec_supplementary_read("UMI001", 100, 20, &[30; 20]);
+        write_codec_bam(&input_path, vec![r1, r2, supplementary])?;
+
+        let mut cmd = create_codec_with_paths(input_path, output_path);
+        cmd.threading = threading;
+        cmd.allow_unmapped.enabled = allow_unmapped;
+        cmd.stats_opts.stats = Some(stats_path.clone());
+        cmd.read_group.read_name_prefix = Some("codec".to_string());
+        cmd.outer_bases_length = 0;
+        cmd.execute("test")?;
+
+        let metrics: Vec<ConsensusMetrics> = DelimFile::default().read_tsv(&stats_path)?;
+        let metrics = metrics.first().expect("stats file should contain one metrics row");
+        assert_eq!(
+            metrics.total_input_reads, 2,
+            "the supplementary alignment must be dropped before grouping (allow_unmapped={allow_unmapped}): \
+             only the two primary reads reach the codec caller"
+        );
+        assert_eq!(
+            metrics.consensus_reads, 1,
+            "the valid mapped FR pair is consensus-called (allow_unmapped={allow_unmapped})"
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -838,6 +945,7 @@ mod tests {
     }
 
     // Integration tests
+    use crate::metrics::consensus::ConsensusMetrics;
     use fgumi_raw_bam::{
         SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
     };
@@ -918,6 +1026,37 @@ mod tests {
         let r2 = to_record_buf(b2.build());
 
         (r1, r2)
+    }
+
+    /// A mapped supplementary alignment of R1 (`SUPPLEMENTARY` flag set) sharing
+    /// `mi_value`. Used to verify the consensus pre-group filter drops
+    /// non-primary alignments before grouping.
+    #[allow(clippy::cast_possible_truncation)]
+    fn create_codec_supplementary_read(
+        mi_value: &str,
+        start: usize,
+        read_len: usize,
+        quals: &[u8],
+    ) -> RecordBuf {
+        let seq_forward = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let seq = &seq_forward[..read_len];
+        let cigar = encode_op(0, read_len);
+        // PAIRED | FIRST_SEGMENT | SUPPLEMENTARY: a supplementary alignment of R1.
+        let sup_flags = flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY;
+        let mut b = RawSamBuilder::new();
+        b.read_name(format!("read_{mi_value}").as_bytes())
+            .flags(sup_flags)
+            .ref_id(0)
+            .pos(start as i32 - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar])
+            .sequence(seq)
+            .qualities(quals)
+            .mate_ref_id(0)
+            .mate_pos(start as i32 - 1);
+        b.add_string_tag(SamTag::MI, mi_value.as_bytes());
+        b.add_string_tag(SamTag::RG, b"A");
+        to_record_buf(b.build())
     }
 
     fn write_codec_bam(path: &std::path::Path, records: Vec<RecordBuf>) -> Result<()> {

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -231,6 +231,46 @@ fn header_sort_and_group_order(header: &Header) -> (String, String, Option<Strin
     )
 }
 
+/// The fgbio `ConsensusCallingIterator` pre-group filter
+/// (`ConsensusCallingIterator.scala:56-58`): drop secondary/supplementary
+/// alignments and any record that is unmapped **and** lacks a mapped mate.
+///
+/// fgbio applies this to *every* consensus caller (simplex, duplex, codec),
+/// for both the single- and multi-threaded execution paths, before grouping
+/// reads by molecular identifier. fgumi replicates it in the consensus
+/// commands.
+///
+/// `--allow-unmapped` relaxes **only** the unmapped-without-mapped-mate rule so
+/// fully-unmapped input can be consensus-called (mirroring
+/// `fgumi group --allow-unmapped`). Secondary/supplementary alignments are
+/// **always** dropped, matching fgbio — `--allow-unmapped` never lets
+/// non-primary alignments into grouping.
+///
+/// Returns `true` if the record should be kept.
+#[must_use]
+pub fn consensus_pregroup_keep_flags(flags: u16, allow_unmapped: bool) -> bool {
+    use fgumi_raw_bam::flags;
+    // Secondary/supplementary alignments are always excluded, regardless of
+    // --allow-unmapped: fgbio never groups non-primary alignments.
+    if flags & flags::SECONDARY != 0 || flags & flags::SUPPLEMENTARY != 0 {
+        return false;
+    }
+    // --allow-unmapped relaxes only the mapped-or-mate-mapped eligibility check.
+    if allow_unmapped {
+        return true;
+    }
+    let is_mapped = flags & flags::UNMAPPED == 0;
+    let has_mapped_mate = flags & flags::PAIRED != 0 && flags & flags::MATE_UNMAPPED == 0;
+    is_mapped || has_mapped_mate
+}
+
+/// Raw-BAM-bytes wrapper around [`consensus_pregroup_keep_flags`], suitable as
+/// a `MiGrouper` / raw-record-iterator record filter.
+#[must_use]
+pub fn consensus_pregroup_keep_raw(raw: &[u8], allow_unmapped: bool) -> bool {
+    consensus_pregroup_keep_flags(fgumi_raw_bam::RawRecordView::new(raw).flags(), allow_unmapped)
+}
+
 /// EM-Seq methylation-aware consensus calling options.
 #[derive(Debug, Clone, Default, Args)]
 pub struct EmSeqOptions {
@@ -535,6 +575,21 @@ pub struct CompressionOptions {
     /// Level 12 produces smallest files but is slowest.
     #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(0..=12))]
     pub compression_level: u32,
+}
+
+/// Option controlling whether unmapped reads are processed by a consensus caller.
+///
+/// Shared by the `simplex`, `duplex`, and `codec` commands so the `--allow-unmapped` flag
+/// (name, default, and boolean parsing) stays identical across all three.
+#[derive(Debug, Clone, Args)]
+pub struct AllowUnmappedOptions {
+    /// Process reads that are unmapped and lack a mapped mate. By default
+    /// (fgbio parity, `ConsensusCallingIterator.scala:56-58`) such reads — and
+    /// all secondary/supplementary alignments — are dropped before consensus
+    /// calling. Enable for consensus on unmapped input (e.g. ribosome/protein
+    /// display), mirroring `fgumi group --allow-unmapped`.
+    #[arg(long = "allow-unmapped", value_name = "ALLOW_UNMAPPED", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub enabled: bool,
 }
 
 /// Options for pipeline scheduler configuration.
@@ -1527,6 +1582,62 @@ mod tests {
     }
 
     use rstest::rstest;
+
+    /// The `ConsensusCallingIterator` pre-group filter (fgbio parity,
+    /// `ConsensusCallingIterator.scala:56-58`): secondary and supplementary alignments are
+    /// always dropped, and an unmapped read is kept only when it has a mapped mate.
+    ///
+    /// `--allow-unmapped` (the `allow_unmapped` column) relaxes **only** the
+    /// unmapped-without-mapped-mate rule: it makes otherwise-eligible primary alignments pass
+    /// regardless of mapping, but secondary/supplementary alignments are still dropped. The
+    /// `*_dropped_even_with_allow_unmapped` cases pin that the flag never lets a non-primary
+    /// alignment into grouping (the regression this exists to prevent).
+    #[rstest]
+    // allow_unmapped = false (fgbio parity default)
+    #[case::mapped_primary_kept(0, false, true)]
+    #[case::secondary_dropped(fgumi_raw_bam::flags::SECONDARY, false, false)]
+    #[case::supplementary_dropped(fgumi_raw_bam::flags::SUPPLEMENTARY, false, false)]
+    #[case::unmapped_unpaired_dropped(fgumi_raw_bam::flags::UNMAPPED, false, false)]
+    #[case::unmapped_paired_mate_unmapped_dropped(
+        fgumi_raw_bam::flags::UNMAPPED | fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::MATE_UNMAPPED,
+        false,
+        false
+    )]
+    #[case::unmapped_paired_mate_mapped_kept(
+        fgumi_raw_bam::flags::UNMAPPED | fgumi_raw_bam::flags::PAIRED,
+        false,
+        true
+    )]
+    // allow_unmapped = true relaxes only the unmapped rule
+    #[case::mapped_primary_kept_with_allow_unmapped(0, true, true)]
+    #[case::unmapped_unpaired_kept_with_allow_unmapped(fgumi_raw_bam::flags::UNMAPPED, true, true)]
+    #[case::unmapped_paired_mate_unmapped_kept_with_allow_unmapped(
+        fgumi_raw_bam::flags::UNMAPPED | fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::MATE_UNMAPPED,
+        true,
+        true
+    )]
+    #[case::secondary_dropped_even_with_allow_unmapped(
+        fgumi_raw_bam::flags::SECONDARY,
+        true,
+        false
+    )]
+    #[case::supplementary_dropped_even_with_allow_unmapped(
+        fgumi_raw_bam::flags::SUPPLEMENTARY,
+        true,
+        false
+    )]
+    #[case::unmapped_secondary_dropped_even_with_allow_unmapped(
+        fgumi_raw_bam::flags::UNMAPPED | fgumi_raw_bam::flags::SECONDARY,
+        true,
+        false
+    )]
+    fn test_consensus_pregroup_keep_flags(
+        #[case] flags_bits: u16,
+        #[case] allow_unmapped: bool,
+        #[case] keep: bool,
+    ) {
+        assert_eq!(consensus_pregroup_keep_flags(flags_bits, allow_unmapped), keep);
+    }
 
     #[rstest]
     // --output-per-base-tags (default true)

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -22,9 +22,10 @@ use fgumi_bam_io::{
 };
 
 use super::common::{
-    BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
-    QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
+    AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
+    OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
+    SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
+    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -195,6 +196,10 @@ pub struct Duplex {
     #[arg(long = "max-reads-per-strand")]
     pub max_reads_per_strand: Option<usize>,
 
+    /// Whether to process unmapped reads (the shared `--allow-unmapped` flag).
+    #[command(flatten)]
+    pub allow_unmapped: AllowUnmappedOptions,
+
     /// Scheduler and pipeline stats options
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
@@ -248,7 +253,7 @@ impl Command for Duplex {
     /// # use fgumi_lib::commands::duplex::Duplex;
     /// # use fgumi_lib::commands::command::Command;
     /// # use fgumi_lib::commands::common::{
-    /// #     BamIoOptions, CompressionOptions, ConsensusCallingOptions,
+    /// #     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     /// #     OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
     /// #     SchedulerOptions, StatsOptions, ThreadingOptions,
     /// # };
@@ -274,6 +279,7 @@ impl Command for Duplex {
     ///     compression: CompressionOptions::default(),
     ///     min_reads: vec![1],
     ///     max_reads_per_strand: None,
+    ///     allow_unmapped: AllowUnmappedOptions { enabled: false },
     ///     scheduler_opts: SchedulerOptions::default(),
     ///     queue_memory: QueueMemoryOptions::default(),
     ///     methylation_mode: None,
@@ -433,29 +439,23 @@ impl Command for Duplex {
         let mut consensus_count = 0usize;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Use the raw_reader opened above (single input open). Filter out
-        // secondary/supplementary and keep only mapped or mate-mapped reads.
+        // Use the raw_reader opened above (single input open). Apply the fgbio
+        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
+        // relaxes only the unmapped-without-mapped-mate rule.
+        let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
             loop {
                 let mut record = RawRecord::new();
                 match raw_reader.read_record(&mut record) {
                     Ok(0) => return None, // EOF
                     Ok(_) => {
-                        let flg = RawRecordView::new(&record).flags();
-                        // Skip secondary and supplementary reads
-                        if flg & fgumi_raw_bam::flags::SECONDARY != 0
-                            || flg & fgumi_raw_bam::flags::SUPPLEMENTARY != 0
-                        {
-                            continue;
-                        }
-                        // Only keep mapped reads or reads with mapped mates
-                        let is_mapped = flg & fgumi_raw_bam::flags::UNMAPPED == 0;
-                        let has_mapped_mate = flg & fgumi_raw_bam::flags::PAIRED != 0
-                            && flg & fgumi_raw_bam::flags::MATE_UNMAPPED == 0;
-                        if is_mapped || has_mapped_mate {
+                        if consensus_pregroup_keep_flags(
+                            RawRecordView::new(&record).flags(),
+                            allow_unmapped,
+                        ) {
                             return Some(Ok(record));
                         }
-                        // Skip unmapped reads without mapped mates
+                        // Otherwise filtered out: keep reading.
                     }
                     Err(e) => return Some(Err(e.into())),
                 }
@@ -629,21 +629,9 @@ impl Duplex {
         let cell_tag = Tag::from(SamTag::CB);
         let batch_size = 100; // MI groups per batch
 
-        // Record filter for duplex on raw bytes: skip secondary/supplementary, keep mapped or mate-mapped
-        let record_filter = |raw: &[u8]| -> bool {
-            let flg = RawRecordView::new(raw).flags();
-            // Skip secondary and supplementary reads
-            if flg & fgumi_raw_bam::flags::SECONDARY != 0
-                || flg & fgumi_raw_bam::flags::SUPPLEMENTARY != 0
-            {
-                return false;
-            }
-            // Only keep mapped reads or reads with mapped mates
-            let is_mapped = flg & fgumi_raw_bam::flags::UNMAPPED == 0;
-            let has_mapped_mate = flg & fgumi_raw_bam::flags::PAIRED != 0
-                && flg & fgumi_raw_bam::flags::MATE_UNMAPPED == 0;
-            is_mapped || has_mapped_mate
-        };
+        // Apply the fgbio pre-group filter: always drop secondary/supplementary;
+        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule.
+        let allow_unmapped = self.allow_unmapped.enabled;
 
         // MI transform for raw bytes: strip /A and /B suffixes for duplex grouping
         let mi_transform = |mi_bytes: &[u8]| -> String {
@@ -663,10 +651,11 @@ impl Duplex {
 
         // ========== grouper_fn ==========
         let grouper_fn = move |_header: &Header| {
-            Box::new(
-                MiGrouper::with_filter_and_transform("MI", batch_size, record_filter, mi_transform)
-                    .with_cell_tag(Some(*SamTag::CB)),
-            ) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+            let grouper = MiGrouper::new("MI", batch_size)
+                .with_mi_transform(mi_transform)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
+            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
         };
 
         // ========== process_fn: Duplex consensus calling ==========
@@ -970,6 +959,7 @@ mod tests {
             compression: CompressionOptions { compression_level: 1 },
             min_reads: vec![1],
             max_reads_per_strand: None,
+            allow_unmapped: AllowUnmappedOptions { enabled: false },
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
             methylation_mode: None,
@@ -1304,6 +1294,131 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// Builds an unmapped read (no reference, no position) carrying an MI tag,
+    /// for exercising the `--allow-unmapped` pre-group filter gate.
+    fn build_unmapped_read(
+        name: &str,
+        raw_flags: u16,
+        mi: &str,
+        bases: &[u8],
+        rx: &str,
+    ) -> sam::alignment::RecordBuf {
+        let qual = vec![40u8; bases.len()];
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .flags(raw_flags | flags::UNMAPPED | flags::MATE_UNMAPPED)
+            .ref_id(-1)
+            .pos(-1)
+            .mapq(0)
+            .cigar_ops(&[])
+            .sequence(bases)
+            .qualities(&qual);
+        b.add_string_tag(SamTag::MI, mi.as_bytes());
+        b.add_string_tag(SamTag::RX, rx.as_bytes());
+        to_record_buf(b.build())
+    }
+
+    /// The `--allow-unmapped` flag gates the fgbio pre-group filter for duplex.
+    /// The same AB/BA molecule as `test_duplex_consensus_basic_ab_ba_pairing`,
+    /// but with every read unmapped (and no mapped mate): dropped by default
+    /// (fgbio parity), consensus-called with `--allow-unmapped`. Covers both
+    /// the single-threaded fast path and the multi-threaded pipeline path.
+    #[rstest]
+    #[case::fast_path(ThreadingOptions::none())]
+    #[case::threaded(ThreadingOptions::new(2))]
+    fn test_duplex_allow_unmapped_gates_pregroup_filter(
+        #[case] threading: ThreadingOptions,
+    ) -> Result<()> {
+        let build_molecule = || {
+            vec![
+                // A strand (MI 1/A)
+                build_unmapped_read(
+                    "q1",
+                    flags::PAIRED | flags::FIRST_SEGMENT,
+                    "1/A",
+                    b"AAAAAAAAAA",
+                    "AAT-CCG",
+                ),
+                build_unmapped_read(
+                    "q1",
+                    flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE,
+                    "1/A",
+                    b"AAAAAAAAAA",
+                    "AAT-CCG",
+                ),
+                // B strand (MI 1/B) — reverse-complement strand
+                build_unmapped_read(
+                    "q2",
+                    flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE,
+                    "1/B",
+                    b"TTTTTTTTTT",
+                    "CCG-AAT",
+                ),
+                build_unmapped_read(
+                    "q2",
+                    flags::PAIRED | flags::LAST_SEGMENT,
+                    "1/B",
+                    b"AAAAAAAAAA",
+                    "CCG-AAT",
+                ),
+            ]
+        };
+
+        // Default: the pre-group filter drops the unmapped reads -> no consensus.
+        let default_input = create_test_bam(build_molecule())?;
+        let default_paths = TestPaths::new()?;
+        let mut default_cmd = create_duplex_with_paths(
+            default_input.path().to_path_buf(),
+            default_paths.output.clone(),
+        );
+        default_cmd.threading = threading.clone();
+        default_cmd.allow_unmapped.enabled = false;
+        default_cmd.execute("test")?;
+        let default_records = read_bam_records(&default_paths.output)?;
+        assert!(
+            default_records.is_empty(),
+            "default (fgbio parity) drops unmapped reads before duplex consensus"
+        );
+
+        // --allow-unmapped: the unmapped molecule is consensus-called (duplex
+        // emits R1 + R2 = 2 records).
+        let allow_input = create_test_bam(build_molecule())?;
+        let allow_paths = TestPaths::new()?;
+        let mut allow_cmd =
+            create_duplex_with_paths(allow_input.path().to_path_buf(), allow_paths.output.clone());
+        allow_cmd.threading = threading;
+        allow_cmd.allow_unmapped.enabled = true;
+        allow_cmd.execute("test")?;
+        let allow_records = read_bam_records(&allow_paths.output)?;
+        assert_eq!(
+            allow_records.len(),
+            2,
+            "--allow-unmapped consensus-calls the unmapped duplex molecule (R1 + R2)"
+        );
+
+        Ok(())
+    }
+
+    /// The `--allow-unmapped` CLI flag defaults to `false` (fgbio parity).
+    #[test]
+    fn test_duplex_allow_unmapped_defaults_to_false() {
+        let default_cmd =
+            <Duplex as clap::Parser>::try_parse_from(["duplex", "-i", "in.bam", "-o", "out.bam"])
+                .expect("duplex should parse with only the required args");
+        assert!(!default_cmd.allow_unmapped.enabled, "--allow-unmapped must default to false");
+
+        let enabled_cmd = <Duplex as clap::Parser>::try_parse_from([
+            "duplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--allow-unmapped",
+        ])
+        .expect("duplex should parse with --allow-unmapped");
+        assert!(enabled_cmd.allow_unmapped.enabled, "bare --allow-unmapped must enable the flag");
     }
 
     #[test]

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -34,7 +34,7 @@ use fgumi_bam_io::{
     create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
     create_raw_bam_reader_with_opts,
 };
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 // RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
@@ -49,9 +49,10 @@ use std::sync::Arc;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
-    BamIoOptions, CompressionOptions, ConsensusCallingOptions, OverlappingConsensusOptions,
-    QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
+    AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
+    OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
+    SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
+    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -209,6 +210,10 @@ pub struct Simplex {
     /// Maximum reads to use per tag family (downsample if exceeded)
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
+
+    /// Whether to process unmapped reads (the shared `--allow-unmapped` flag).
+    #[command(flatten)]
+    pub allow_unmapped: AllowUnmappedOptions,
 
     /// Scheduler and pipeline statistics options.
     #[command(flatten)]
@@ -388,13 +393,26 @@ impl Command for Simplex {
         let mut record_count: usize = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Use the raw_reader opened above (single input open).
+        // Use the raw_reader opened above (single input open). Apply the fgbio
+        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
+        // relaxes only the unmapped-without-mapped-mate rule.
+        let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
-            let mut record = RawRecord::new();
-            match raw_reader.read_record(&mut record) {
-                Ok(0) => None, // EOF
-                Ok(_) => Some(Ok(record)),
-                Err(e) => Some(Err(e.into())),
+            loop {
+                let mut record = RawRecord::new();
+                match raw_reader.read_record(&mut record) {
+                    Ok(0) => return None, // EOF
+                    Ok(_) => {
+                        if consensus_pregroup_keep_flags(
+                            RawRecordView::new(&record).flags(),
+                            allow_unmapped,
+                        ) {
+                            return Some(Ok(record));
+                        }
+                        // Otherwise filtered out: keep reading.
+                    }
+                    Err(e) => return Some(Err(e.into())),
+                }
             }
         });
         let mi_group_iter =
@@ -562,9 +580,14 @@ impl Simplex {
         pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
 
         // ========== grouper_fn ==========
+        // Apply the fgbio pre-group filter (always drop secondary/supplementary;
+        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule).
+        let allow_unmapped = self.allow_unmapped.enabled;
         let grouper_fn = move |_header: &Header| {
-            Box::new(MiGrouper::new("MI", batch_size).with_cell_tag(Some(*SamTag::CB)))
-                as Box<dyn Grouper<Group = MiGroupBatch> + Send>
+            let grouper = MiGrouper::new("MI", batch_size)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
+            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
         };
 
         // ========== process_fn: Consensus calling ==========
@@ -798,6 +821,12 @@ mod tests {
             queue_memory: QueueMemoryOptions::default(),
             min_reads: 1,
             max_reads: None,
+            // These fixtures use `SamBuilder::new_unmapped()` synthetic reads to
+            // exercise consensus behavior; opt back into consensus on unmapped
+            // input so they survive the default fgbio pre-group filter. The
+            // real CLI default (false) is pinned by
+            // `test_allow_unmapped_defaults_to_false`.
+            allow_unmapped: AllowUnmappedOptions { enabled: true },
             scheduler_opts: SchedulerOptions::default(),
             methylation_mode: None,
             reference: None,
@@ -1082,6 +1111,94 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// `--allow-unmapped` gates the fgbio `ConsensusCallingIterator` pre-group
+    /// filter. By default (fgbio parity) unmapped, unpaired reads are dropped
+    /// before consensus calling, so no consensus is produced; with
+    /// `--allow-unmapped` they are consensus-called. Runs both the
+    /// single-threaded fast path and the multi-threaded pipeline path, which
+    /// install the filter at independent sites.
+    #[rstest]
+    #[case::fast_path(ThreadingOptions::none())]
+    #[case::threaded(ThreadingOptions::new(2))]
+    fn test_allow_unmapped_gates_pregroup_filter(
+        #[case] threading: ThreadingOptions,
+    ) -> Result<()> {
+        let mut builder = SamBuilder::new_unmapped();
+        let mut attrs = HashMap::new();
+        attrs.insert("RX", BufValue::from("ACGT"));
+        attrs.insert("MI", BufValue::from("m1"));
+        attrs.insert("CB", BufValue::from("AB"));
+        // Two unmapped, unpaired fragments in one MI group.
+        builder.add_frag_with_attrs("r1", None, true, &attrs);
+        builder.add_frag_with_attrs("r2", None, true, &attrs);
+        // Advertise template-coordinate order so the input clears the consensus
+        // sort-order guard (`check_consensus_sort_order`); this test exercises the
+        // pre-group filter, not the sort guard.
+        builder.set_template_coordinate_sort_order();
+
+        // Default (allow_unmapped = false): the pre-group filter drops
+        // unmapped-unpaired reads -> no consensus records. (The shared test
+        // helper enables the flag for its unmapped fixtures, so set it back to
+        // the CLI default here explicitly.)
+        let default_paths = TestPaths::new()?;
+        builder.write(&default_paths.input)?;
+        let mut default_cmd =
+            create_simplex_with_paths(default_paths.input.clone(), default_paths.output.clone());
+        default_cmd.threading = threading.clone();
+        default_cmd.allow_unmapped.enabled = false;
+        default_cmd.execute("test")?;
+        let default_records = read_bam_records(&default_paths.output)?;
+        assert_eq!(
+            default_records.len(),
+            0,
+            "default (fgbio parity) drops unmapped, unpaired reads before consensus"
+        );
+
+        // --allow-unmapped: the unmapped reads are consensus-called (one
+        // consensus read for the single MI group).
+        let allow_paths = TestPaths::new()?;
+        builder.write(&allow_paths.input)?;
+        let mut allow_cmd =
+            create_simplex_with_paths(allow_paths.input.clone(), allow_paths.output.clone());
+        allow_cmd.threading = threading;
+        allow_cmd.allow_unmapped.enabled = true;
+        allow_cmd.execute("test")?;
+        let allow_records = read_bam_records(&allow_paths.output)?;
+        assert_eq!(
+            allow_records.len(),
+            1,
+            "--allow-unmapped consensus-calls unmapped reads (one consensus per MI group)"
+        );
+
+        Ok(())
+    }
+
+    /// The `--allow-unmapped` CLI flag defaults to `false` (fgbio parity: the
+    /// pre-group filter is on). Pinned separately from the behavioral tests
+    /// because the shared test helper enables the flag for its unmapped
+    /// fixtures.
+    #[test]
+    fn test_allow_unmapped_defaults_to_false() {
+        let default_cmd = <Simplex as clap::Parser>::try_parse_from([
+            "simplex", "-i", "in.bam", "-o", "out.bam", "-M", "1",
+        ])
+        .expect("simplex should parse with only the required args");
+        assert!(!default_cmd.allow_unmapped.enabled, "--allow-unmapped must default to false");
+
+        let enabled_cmd = <Simplex as clap::Parser>::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-M",
+            "1",
+            "--allow-unmapped",
+        ])
+        .expect("simplex should parse with --allow-unmapped");
+        assert!(enabled_cmd.allow_unmapped.enabled, "bare --allow-unmapped must enable the flag");
     }
 
     #[test]

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -198,6 +198,29 @@ impl MiGrouper {
         self
     }
 
+    /// Sets an optional per-record filter; records for which it returns `false`
+    /// are dropped before grouping. Enables applying the filter conditionally
+    /// (e.g. gating the consensus pre-group filter on `--allow-unmapped`).
+    #[must_use]
+    pub fn with_record_filter<F>(mut self, record_filter: F) -> Self
+    where
+        F: Fn(&[u8]) -> bool + Send + Sync + 'static,
+    {
+        self.record_filter = Some(Box::new(record_filter));
+        self
+    }
+
+    /// Sets an optional MI-tag transformation applied to each record's MI value
+    /// before grouping (e.g. stripping `/A` `/B` strand suffixes for duplex).
+    #[must_use]
+    pub fn with_mi_transform<T>(mut self, mi_transform: T) -> Self
+    where
+        T: Fn(&[u8]) -> String + Send + Sync + 'static,
+    {
+        self.mi_transform = Some(Box::new(mi_transform));
+        self
+    }
+
     /// Get MI tag from raw BAM bytes, optionally applying transformation.
     ///
     /// When `cell_tag` is set, returns a composite key of `"MI\tCELL"`.


### PR DESCRIPTION
## Summary

fgbio's `ConsensusCallingIterator` drops secondary/supplementary alignments and any read that is unmapped without a mapped mate before grouping reads for consensus calling (`ConsensusCallingIterator.scala:56-58`). This applies to every caller — `CallMolecularConsensusReads`, `CallDuplexConsensusReads`, `CallCodecConsensusReads` — and to both the single- and multi-threaded execution paths.

fgumi applied this filter only in `duplex` (both paths). `simplex` and `codec` installed no pre-group filter, so unmapped, unpaired reads flowed into consensus calling. This PR aligns `simplex` and `codec` with fgbio by applying the same filter by default, and adds a `--allow-unmapped` flag to opt back into calling consensus on fully-unmapped input.

## What changed

- **New `--allow-unmapped` flag** on `simplex`, `duplex`, and `codec` (default `false` = fgbio parity). It gates the entire pre-group filter, so consensus can still be called on fully-unmapped input (e.g. ribosome/protein display, or cell-free DNA fragments outside the target region), mirroring `fgumi group --allow-unmapped`.
- **Shared predicate** `commands::common::consensus_pregroup_keep_flags`/`_raw` backs both the single-threaded raw-record iterators and the multi-threaded `MiGrouper` record filter, so the filtered read set is identical regardless of thread count.
- **`MiGrouper` gains `with_record_filter` / `with_mi_transform` builders** so the filter can be installed conditionally.
- Docs: a note in `consensus-calling.md` documenting the default filtering and the flag.

`simplex`/`codec` now filter by default; `duplex`'s default behavior is unchanged (it was already filtered) and it now additionally honors `--allow-unmapped`.

## Corrections to the audit brief

While implementing, two claims from the parity audit were checked against the real code and corrected:

- The "single-threaded duplex lacks the filter / duplex parity depends on thread count" claim is **refuted** — single-threaded duplex already filters inline (in its `from_fn` raw-record closure), exactly like the multi-threaded path. The genuine gap was `simplex` + `codec`, unfiltered in both paths.
- The `filter` command correctly needs no flag (it operates on already-unmapped consensus reads, with no mapped pre-filter).

## Testing

- `simplex`: gating test across both the single-threaded and multi-threaded paths (unmapped input → dropped by default, consensus-called with `--allow-unmapped`); the 9 existing unmapped-fixture tests are migrated (the shared test helper enables the flag for its `SamBuilder::new_unmapped()` fixtures) and the real CLI default (`false`) is pinned by a dedicated parse test.
- `duplex`: behavioral test on an unmapped AB/BA molecule (default → 0 consensus, `--allow-unmapped` → 2) plus a CLI-default parse test.
- `codec`: CLI-default parse test.
- Full suite: 2222 tests pass; `ci-fmt` and `ci-lint` clean.

## Breaking change

`simplex` and `codec` now drop reads that are unmapped without a mapped mate (and all secondary/supplementary alignments) before consensus calling by default. Pass `--allow-unmapped` to restore the previous behavior of calling consensus on fully-unmapped input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `--allow-unmapped` option to `simplex`, `duplex`, and `codec`.
  - When enabled, consensus calling can proceed with fully-unmapped primary reads (including reads without a mapped mate), with consistent behavior in both standard and threaded modes.
  - Secondary and supplementary alignments are still excluded; default remains unchanged (`--allow-unmapped` is off).
- **Documentation**
  - Updated the consensus-calling guide to describe the default unmapped filtering and the exact effect of `--allow-unmapped`.
- **Tests**
  - Added/expanded tests to verify CLI defaulting, flag parsing, and pre-group filtering behavior in both execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->