### PR TITLE
fix(group): reject UMIs of differing length in all assigners (GRP-01)

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -648,6 +648,61 @@ pub fn count_mismatches(a: &str, b: &str) -> usize {
     a.as_bytes().iter().zip(b.as_bytes()).filter(|(x, y)| x != y).count()
 }
 
+/// Assert that every UMI in a position group shares the same length.
+///
+/// Mirrors fgbio's `require(orderedNodes.forall(_.umi.length == umiLength),
+/// "Multiple UMI lengths: ...")` in `GroupReadsByUmi` (and the `require` in
+/// `Sequences.countMismatches`). [`count_mismatches`] returns [`usize::MAX`] for
+/// UMIs of differing length, which every mismatch-based matcher reads as "no
+/// match"; without this guard a differing-length UMI would silently form its own
+/// molecule (under-grouping) instead of surfacing the malformed input as an
+/// error the way fgbio does (tracker GRP-01).
+///
+/// `lengths` are base counts (dashes in paired UMIs excluded). For the
+/// single-dash paired UMIs the `Paired` strategy enforces, the base count
+/// differs iff the full `A-B` string length differs, so this matches fgbio's
+/// string-length check.
+///
+/// # Panics
+///
+/// Panics with `"Multiple UMI lengths: {len} vs {expected}"` on the first UMI
+/// whose length differs from the first UMI's length. Assigners that skip
+/// invalid UMIs should pass only the retained (encodable) UMIs' lengths, so the
+/// guard mirrors fgbio's per-group check over the UMIs it actually groups.
+pub fn assert_uniform_umi_length(lengths: impl IntoIterator<Item = usize>) {
+    let mut lengths = lengths.into_iter();
+    let Some(expected) = lengths.next() else { return };
+    for len in lengths {
+        assert!(len == expected, "Multiple UMI lengths: {len} vs {expected}");
+    }
+}
+
+/// Build the per-input `MoleculeId` vector, resolving each raw UMI with `resolve` and falling
+/// back to a per-string molecule for the ones `resolve` cannot place.
+///
+/// `resolve` returns `Some(id)` for a UMI that the strategy grouped (an encodable/valid UMI) and
+/// `None` for one it could not (a non-`BitEnc`-encodable, invalid UMI). Every distinct invalid
+/// UMI string gets its own molecule from `mint`, with identical (case-folded) invalid strings
+/// sharing -- mirroring fgbio's `Map[Umi, MoleculeId]`, where every UMI it sees is assigned a
+/// molecule and identical strings collapse. This keeps the sequential and parallel assigners in
+/// agreement on invalid UMIs (see the cross-assigner parity harness in the `parallel_assigner`
+/// tests) and ensures an invalid UMI never joins a valid molecule.
+fn assign_with_invalid_fallback(
+    raw_umis: &[Umi],
+    mut resolve: impl FnMut(&str) -> Option<MoleculeId>,
+    mut mint: impl FnMut() -> MoleculeId,
+) -> Vec<MoleculeId> {
+    let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+    raw_umis
+        .iter()
+        .map(|umi| {
+            resolve(umi).unwrap_or_else(|| {
+                *invalid_to_id.entry(umi.to_uppercase()).or_insert_with(&mut mint)
+            })
+        })
+        .collect()
+}
+
 /// Check if two UMI sequences match within a maximum mismatch threshold.
 ///
 /// This is an optimized version that exits early when the mismatch count exceeds
@@ -948,12 +1003,33 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
         // agreement on mixed-case input; it is a no-op for the uppercase UMIs the CLI emits.
         let upper_umis: Vec<Umi> = raw_umis.iter().map(|umi| umi.to_uppercase()).collect();
 
+        // Reject differing-length UMIs the way fgbio does (see assert_uniform_umi_length),
+        // but only over the BitEnc-encodable UMIs — the same set the parallel edit assigner
+        // length-checks (it drops non-encodable UMIs before its guard). Without this filter,
+        // mixed valid/invalid input such as ["AAAA", "NNN"] panics here on differing lengths
+        // while the parallel path silently continues on the valid subset (GRP-01 parity).
+        // Genuinely differing-length *valid* UMIs (e.g. ["AAAA", "CCC"]) still trip the guard.
+        assert_uniform_umi_length(
+            upper_umis.iter().filter_map(|umi| BitEnc::from_umi_str(umi).map(|enc| enc.len())),
+        );
+
         let mut umi_sets: Vec<BTreeSet<Umi>> = Vec::new();
         // Track seen UMIs to skip duplicate processing
         let mut seen: std::collections::HashSet<&str> =
             std::collections::HashSet::with_capacity(upper_umis.len());
 
         for umi in &upper_umis {
+            // Skip invalid (non-encodable) UMIs: they cannot be reliably compared (BitEnc
+            // can't represent them) and are left unassigned (MoleculeId::None), identical to
+            // the parallel edit assigner. Without this, a same-length invalid UMI such as
+            // "ACGN" would string-match a valid neighbour like "ACGT" within threshold and
+            // silently group with it, diverging from the parallel path (which encodes with
+            // BitEnc and cannot see "ACGN" at all). See the cross-assigner parity note in the
+            // parallel_assigner tests module.
+            if BitEnc::from_umi_str(umi).is_none() {
+                continue;
+            }
+
             // Skip duplicate UMIs - they're already in a set
             if !seen.insert(umi.as_str()) {
                 continue;
@@ -1013,8 +1089,15 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
             }
         }
 
-        // Build result Vec indexed by input position
-        upper_umis.iter().map(|umi| umi_to_id[umi]).collect()
+        // Build result Vec indexed by input position. Invalid UMIs were skipped above and are
+        // absent from `umi_to_id`; each distinct invalid string gets its own molecule (see
+        // `assign_with_invalid_fallback`). Invalid UMIs never join a valid molecule because they
+        // were excluded from matching above.
+        assign_with_invalid_fallback(
+            &upper_umis,
+            |umi| umi_to_id.get(umi).copied(),
+            || MoleculeId::Single(self.next_id()),
+        )
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -1492,9 +1575,14 @@ impl UmiAssigner for AdjacencyUmiAssigner {
             counts.into_iter().map(|(enc, (count, idx))| (enc, count, idx)).collect()
         };
 
-        // Handle case where all UMIs had invalid characters
+        // Handle case where all UMIs had invalid characters: give each distinct invalid string
+        // its own molecule (see `assign_with_invalid_fallback`).
         if umi_counts.is_empty() {
-            return vec![MoleculeId::None; raw_umis.len()];
+            return assign_with_invalid_fallback(
+                raw_umis,
+                |_| None,
+                || MoleculeId::Single(self.next_id()),
+            );
         }
 
         #[cfg(feature = "profile-adjacency")]
@@ -1524,19 +1612,20 @@ impl UmiAssigner for AdjacencyUmiAssigner {
 
         if umi_counts.len() == 1 {
             let id = MoleculeId::Single(self.next_id());
-            return vec![id; raw_umis.len()];
-        }
-
-        // Check all UMIs have same length (in bases, not string length)
-        let umi_base_length = umi_counts[0].0.len();
-        for (enc, _, _) in &umi_counts {
-            assert!(
-                enc.len() == umi_base_length,
-                "Multiple UMI lengths: {} vs {}",
-                enc.len(),
-                umi_base_length
+            // Only encodable UMIs belong to the single molecule; each distinct invalid
+            // (non-encodable) UMI gets its own instead (see `assign_with_invalid_fallback`).
+            // Without this guard the fast path would tag an invalid UMI (e.g. one that bypassed
+            // the upstream N filter) as part of the real molecule.
+            return assign_with_invalid_fallback(
+                raw_umis,
+                |umi| BitEnc::from_umi_str(umi).is_some().then_some(id),
+                || MoleculeId::Single(self.next_id()),
             );
         }
+
+        // Reject differing-length UMIs the way fgbio does (see assert_uniform_umi_length).
+        // `BitEnc::len` is the base count (dashes excluded), so this checks base length.
+        assert_uniform_umi_length(umi_counts.iter().map(|(enc, _, _)| enc.len()));
 
         // Build adjacency graph using BitEnc-based matching
         let (nodes, roots) = self.build_adjacency_graph_bitenc(&umi_counts, raw_umis);
@@ -1547,18 +1636,17 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         // Assign IDs to nodes and build result Vec
         let unique_assignments = self.assign_ids_to_nodes_bitenc(&nodes, &roots, &umi_counts);
 
-        // Map each input UMI to its MoleculeId using BitEnc lookup
-        let result: Vec<MoleculeId> = raw_umis
-            .iter()
-            .map(|umi| {
-                if let Some(enc) = BitEnc::from_umi_str(umi) {
-                    if let Some(&unique_idx) = bitenc_to_unique_idx.get(&enc) {
-                        return unique_assignments[unique_idx];
-                    }
-                }
-                MoleculeId::None // Invalid UMI
-            })
-            .collect();
+        // Map each input UMI to its MoleculeId using BitEnc lookup; each distinct invalid
+        // (non-encodable) UMI gets its own molecule (see `assign_with_invalid_fallback`).
+        let result = assign_with_invalid_fallback(
+            raw_umis,
+            |umi| {
+                BitEnc::from_umi_str(umi).and_then(|enc| {
+                    bitenc_to_unique_idx.get(&enc).map(|&idx| unique_assignments[idx])
+                })
+            },
+            || MoleculeId::Single(self.next_id()),
+        );
 
         #[cfg(feature = "profile-adjacency")]
         {
@@ -1581,7 +1669,7 @@ impl UmiAssigner for AdjacencyUmiAssigner {
                 bucket,
                 num_unique,
                 num_reads,
-                umi_base_length,
+                umi_counts[0].0.len(),
                 t_after_count.duration_since(t_start),
                 t_after_sort.duration_since(t_after_count),
                 t_after_graph.duration_since(t_after_sort),
@@ -1686,6 +1774,33 @@ impl PairedUmiAssigner {
     /// String slice containing the higher prefix
     pub fn higher_read_umi_prefix(&self) -> &str {
         &self.higher_prefix
+    }
+
+    /// Base length of the underlying (prefix-stripped) UMI, or `None` if it is not
+    /// `BitEnc`-encodable (some base is not `A`/`C`/`G`/`T`).
+    ///
+    /// The group command tags each half of a paired UMI with an orientation prefix
+    /// ([`lower_read_umi_prefix`](Self::lower_read_umi_prefix) /
+    /// [`higher_read_umi_prefix`](Self::higher_read_umi_prefix), e.g. `aa:`/`bb:`) before
+    /// calling [`assign`](UmiAssigner::assign), so a production key looks like
+    /// `"aa:ACGT-bb:TTTT"`. DNA never contains `:`, so the sequence portion of each
+    /// dash-delimited half is the text after the last `:` (and the whole half when no prefix
+    /// was added, e.g. the clean UMIs the unit tests and the cross-assigner parity harness
+    /// pass). Returns the summed base count of both halves (dashes excluded) when every base of
+    /// both halves is `ACGT`, matching the `BitEnc::len` the parallel paired assigner checks.
+    ///
+    /// This keeps the sequential paired assigner's invalid-UMI handling and differing-length
+    /// guard in agreement with the parallel paired assigner, which drops non-encodable UMIs
+    /// before grouping. Without stripping the prefix, every production key (which always carries
+    /// a `:`) would read as non-encodable, so a whole-key `BitEnc` check would either isolate
+    /// every molecule (as a filter) or never fire (as the length guard).
+    fn underlying_umi_len(key: &str) -> Option<usize> {
+        let mut total = 0;
+        for half in key.split('-') {
+            let seq = half.rsplit(':').next().unwrap_or(half);
+            total += BitEnc::from_umi_str(seq)?.len();
+        }
+        Some(total)
     }
 
     /// Split paired UMI into two parts
@@ -1845,21 +1960,64 @@ impl UmiAssigner for PairedUmiAssigner {
 
         // Count with A-B and B-A combined
         let mut umi_counts = Self::count_paired(&upper_umis);
+
+        // Exclude paired UMIs whose underlying sequence is non-BitEnc-encodable before the
+        // length guard, the `umi_counts.len() == 1` fast path, and adjacency grouping. The edit
+        // and adjacency sequential assigners and the parallel paired assigner all group only
+        // encodable UMIs and route each distinct invalid UMI to its own `Single` molecule via
+        // `assign_with_invalid_fallback`; the paired sequential path must match so grouping does
+        // not depend on `--threads` (GRP-01 parity). The check is prefix-aware
+        // (`underlying_umi_len`) because production keys carry an orientation prefix
+        // (`aa:ACGT-bb:TTTT`) that is never encodable as-is — a whole-key `BitEnc` check would
+        // wrongly isolate every molecule. Without this filter an invalid canonical UMI would take
+        // the fast path and get `PairedA`/`PairedB`, and a *same-length* invalid neighbour
+        // (`ACGN-TTTT` beside `ACGT-TTTT`) would string-match into a valid molecule's adjacency
+        // tree, while the parallel path isolates it.
+        umi_counts.retain(|(umi, _)| Self::underlying_umi_len(umi).is_some());
         umi_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+        // All UMIs were invalid: give each distinct invalid string its own molecule, matching the
+        // parallel paired assigner's `all_invalid_molecule_ids` and the other sequential
+        // assigners' all-invalid branch.
+        if umi_counts.is_empty() {
+            return assign_with_invalid_fallback(
+                &upper_umis,
+                |_| None,
+                || MoleculeId::Single(self.adjacency.next_id()),
+            );
+        }
+
+        // Reject differing-length paired UMIs the way fgbio does (see assert_uniform_umi_length),
+        // over the retained (encodable-underlying) UMIs — the same set the parallel paired
+        // assigner length-checks (it drops non-encodable UMIs before its guard). `underlying_umi_len`
+        // is the summed base count of both halves (dashes and the orientation prefix excluded),
+        // matching `BitEnc::len`. Because it strips the prefix, this guard now also fires on the
+        // prefixed production keys (a whole-key `BitEnc::from_umi_str` returned `None` for them, so
+        // the guard was previously a silent no-op in production). Genuinely differing-length *valid*
+        // paired UMIs still trip the guard.
+        assert_uniform_umi_length(
+            umi_counts.iter().filter_map(|(umi, _)| Self::underlying_umi_len(umi)),
+        );
 
         if umi_counts.len() == 1 {
             let id = self.adjacency.next_id();
             let ab = MoleculeId::PairedA(id);
             let ba = MoleculeId::PairedB(id);
 
-            return upper_umis
-                .iter()
-                .map(|umi| {
-                    let reversed = Self::reverse(umi)
-                        .expect("UMI should be valid paired format (validated above)");
-                    if *umi < reversed { ab } else { ba }
-                })
-                .collect();
+            // Only the single valid molecule's UMIs get a strand; each distinct invalid
+            // (non-encodable) UMI gets its own `Single` (see `assign_with_invalid_fallback`),
+            // matching the parallel paired assigner. Strand is by the UMI's own orientation.
+            return assign_with_invalid_fallback(
+                &upper_umis,
+                |umi| {
+                    Self::underlying_umi_len(umi).is_some().then(|| {
+                        let reversed = Self::reverse(umi)
+                            .expect("UMI should be valid paired format (validated above)");
+                        if umi < reversed.as_str() { ab } else { ba }
+                    })
+                },
+                || MoleculeId::Single(self.adjacency.next_id()),
+            );
         }
 
         // Build adjacency graph using the shared helper with our paired matcher
@@ -1905,11 +2063,14 @@ impl UmiAssigner for PairedUmiAssigner {
             }
         }
 
-        // Build result Vec indexed by input position
-        upper_umis
-            .iter()
-            .map(|umi| umi_to_id.get(umi).copied().unwrap_or(MoleculeId::None))
-            .collect()
+        // Build result Vec indexed by input position. Each distinct invalid (non-encodable) UMI
+        // gets its own molecule (see `assign_with_invalid_fallback`), matching the parallel
+        // paired assigner. An unencodable UMI has no valid strand, so it is a plain `Single`.
+        assign_with_invalid_fallback(
+            &upper_umis,
+            |umi| umi_to_id.get(umi).copied(),
+            || MoleculeId::Single(self.adjacency.next_id()),
+        )
     }
 
     fn is_same_umi(&self, a: &str, b: &str) -> bool {
@@ -2020,6 +2181,112 @@ mod tests {
         #[case] description: &str,
     ) {
         assert_eq!(count_mismatches(a, b), expected, "Failed for: {description}");
+    }
+
+    /// The number of UMI bases in a (possibly paired) UMI string, excluding the
+    /// `-` segment delimiter. Matches `BitEnc::len` for BitEnc-encoded UMIs
+    /// (which also skips dashes), so string- and BitEnc-based assigners compute
+    /// the same length for `assert_uniform_umi_length`. Test-only reference for
+    /// that equivalence; production code length-checks via `BitEnc::len`.
+    fn base_umi_length(umi: &str) -> usize {
+        umi.bytes().filter(|&b| b != b'-').count()
+    }
+
+    #[rstest]
+    #[case("ACGT", 4, "unpaired UMI")]
+    #[case("ACT-ACT", 6, "paired UMI, dash excluded")]
+    #[case("ACT-AC", 5, "paired UMI, shorter second segment")]
+    #[case("", 0, "empty")]
+    #[case("-", 0, "lone delimiter")]
+    fn test_base_umi_length(#[case] umi: &str, #[case] expected: usize, #[case] description: &str) {
+        assert_eq!(base_umi_length(umi), expected, "Failed for: {description}");
+    }
+
+    #[rstest]
+    #[case::empty(vec![])]
+    #[case::single(vec![4])]
+    #[case::all_equal(vec![6, 6, 6])]
+    fn test_assert_uniform_umi_length_ok(#[case] lengths: Vec<usize>) {
+        // Should not panic when lengths are absent or uniform.
+        assert_uniform_umi_length(lengths);
+    }
+
+    #[rstest]
+    #[case::second_differs(vec![6, 5])]
+    #[case::later_differs(vec![6, 6, 5])]
+    #[should_panic(expected = "Multiple UMI lengths")]
+    fn test_assert_uniform_umi_length_panics(#[case] lengths: Vec<usize>) {
+        assert_uniform_umi_length(lengths);
+    }
+
+    /// fgbio's `GroupReadsByUmi` throws on UMIs of differing length
+    /// (`GroupReadsByUmiTest.scala:513`, `Sequences.countMismatches`'s `require`).
+    /// Every sequential mismatch-based assigner must reject them the same way
+    /// rather than silently under-group via `count_mismatches` -> `usize::MAX`
+    /// (tracker GRP-01). `Identity` groups by exact match and has no length
+    /// constraint, matching fgbio's identity assigner.
+    #[rstest]
+    #[case::edit(crate::assigner::Strategy::Edit, vec!["AAAA".to_string(), "AAA".to_string()])]
+    #[case::adjacency(crate::assigner::Strategy::Adjacency, vec!["AAAA".to_string(), "AAA".to_string()])]
+    #[case::paired(crate::assigner::Strategy::Paired, vec!["ACT-ACT".to_string(), "ACT-AC".to_string()])]
+    #[should_panic(expected = "Multiple UMI lengths")]
+    fn test_sequential_assigner_rejects_differing_umi_lengths(
+        #[case] strategy: crate::assigner::Strategy,
+        #[case] umis: Vec<Umi>,
+    ) {
+        let assigner = strategy.new_assigner_full(1, 1, 100);
+        let _ = assigner.assign(&umis);
+    }
+
+    /// GRP-01 parity: a non-`BitEnc`-encodable UMI (invalid bases) whose base length differs
+    /// from the valid UMIs must NOT trip the differing-length guard. The sequential paths now
+    /// exclude non-encodable UMIs from the length check the same way the parallel assigners do
+    /// (they never see them), then give the invalid UMI its own molecule -- identical to the
+    /// parallel assigner, and enforced by the cross-assigner parity harness
+    /// `test_sequential_and_parallel_assigners_induce_same_partition`. Before this fix the
+    /// sequential `Edit`/`Paired` paths panicked on `["AAAA", "NNN"]`-style input while the
+    /// parallel paths continued on the valid subset. Differing-length *valid* UMIs still panic
+    /// (see `test_sequential_assigner_rejects_differing_umi_lengths`).
+    ///
+    /// Scoped to the `Edit` and `Paired` sequential paths this fix touched; the `Adjacency`
+    /// path already length-checks over the encoded (encodable-only) set.
+    ///
+    /// fgbio divergence is *intentional* here, so these assertions encode fgumi's chosen
+    /// behavior rather than fgbio parity: fgbio never drops non-encodable UMIs, so on this exact
+    /// mixed input its assigners *reject* the whole family instead of grouping the valid subset.
+    /// The `Edit` strategy (`SimpleErrorUmiAssigner`) throws via `Sequences.countMismatches`'s
+    /// `require(s1.length == s2.length)` (`fgbio` `Sequences.scala:99`), and `Paired`
+    /// (`PairedUmiAssigner extends AdjacencyUmiAssigner`) throws via the `umiLength` `require`
+    /// (`fgbio` `GroupReadsByUmi.scala:283`) -- both see the length-3 `NNN` / length-5 `NN-NN`
+    /// beside the length-4 `AAAA` / length-7 `ACT-ACT`. fgumi deliberately tolerates invalid-base
+    /// UMIs of a differing length by excluding them from the guard (GRP-01) and grouping only the
+    /// encodable UMIs. Differing-length *valid* UMIs still match fgbio by rejecting (see
+    /// `test_sequential_assigner_rejects_differing_umi_lengths`).
+    #[rstest]
+    #[case::edit(
+        crate::assigner::Strategy::Edit,
+        vec!["AAAA".to_string(), "AAAA".to_string(), "NNN".to_string()]
+    )]
+    #[case::paired(
+        crate::assigner::Strategy::Paired,
+        vec!["ACT-ACT".to_string(), "ACT-ACT".to_string(), "NN-NN".to_string()]
+    )]
+    fn test_sequential_assigner_excludes_invalid_umis_from_length_guard(
+        #[case] strategy: crate::assigner::Strategy,
+        #[case] umis: Vec<Umi>,
+    ) {
+        // Must not panic on the mixed valid/invalid, differing-length input.
+        let assigner = strategy.new_assigner_full(1, 1, 100);
+        let ids = assigner.assign(&umis);
+        assert_eq!(ids.len(), umis.len());
+        // The two identical valid UMIs share a molecule; the invalid UMI gets its own.
+        assert_eq!(ids[0], ids[1], "identical valid UMIs must share a molecule");
+        assert_ne!(ids[0], ids[2], "invalid-base UMI must not join the valid molecule");
+        assert_ne!(
+            ids[2],
+            MoleculeId::None,
+            "invalid-base UMI gets its own molecule (fgbio assigns every UMI a molecule)"
+        );
     }
 
     // ========================================================================
@@ -2508,17 +2775,20 @@ mod tests {
     fn test_paired_backward_capture() {
         let assigner = PairedUmiAssigner::new(1);
 
-        // Construct paired UMIs with the triangle inequality scenario
+        // Construct paired UMIs with the triangle inequality scenario. The second half is a
+        // common, encodable sequence ("TTTT") shared by all three so the triangle inequality
+        // plays out on the first half; a non-ACGT filler would (correctly) be isolated as
+        // non-encodable rather than grouped (GRP-01), which is not what this test exercises.
         let mut umis = Vec::new();
 
-        // High count root: "AAAA-XXXX"
-        umis.extend(std::iter::repeat_n("AAAA-XXXX".to_string(), 100));
+        // High count root: "AAAA-TTTT"
+        umis.extend(std::iter::repeat_n("AAAA-TTTT".to_string(), 100));
 
-        // Low count target: "CCAA-XXXX" (count=1) - 2 edits from root, won't be captured by root
-        umis.extend(std::iter::repeat_n("CCAA-XXXX".to_string(), 1));
+        // Low count target: "CCAA-TTTT" (count=1) - 2 edits from root, won't be captured by root
+        umis.extend(std::iter::repeat_n("CCAA-TTTT".to_string(), 1));
 
-        // Low count intermediate: "ACAA-XXXX" - 1 edit from root AND 1 edit from target
-        umis.extend(std::iter::repeat_n("ACAA-XXXX".to_string(), 2));
+        // Low count intermediate: "ACAA-TTTT" - 1 edit from root AND 1 edit from target
+        umis.extend(std::iter::repeat_n("ACAA-TTTT".to_string(), 2));
 
         let assignments = assigner.assign(&umis);
         let map = build_assignment_map(&umis, &assignments);
@@ -2531,14 +2801,46 @@ mod tests {
         // All three should have the same base ID
         // Root captures intermediate (1 edit), intermediate captures target (1 edit via backward search)
         assert_eq!(
-            get_base_id("AAAA-XXXX"),
-            get_base_id("CCAA-XXXX"),
-            "CCAA-XXXX should be captured via ACAA-XXXX intermediate"
+            get_base_id("AAAA-TTTT"),
+            get_base_id("CCAA-TTTT"),
+            "CCAA-TTTT should be captured via ACAA-TTTT intermediate"
         );
         assert_eq!(
-            get_base_id("AAAA-XXXX"),
-            get_base_id("ACAA-XXXX"),
-            "ACAA-XXXX should be captured by AAAA-XXXX"
+            get_base_id("AAAA-TTTT"),
+            get_base_id("ACAA-TTTT"),
+            "ACAA-TTTT should be captured by AAAA-TTTT"
+        );
+    }
+
+    // The group command tags each half of a paired UMI with an orientation prefix
+    // (`aa:`/`bb:` for `--edits 1`, `lower_read_umi_prefix`/`higher_read_umi_prefix`) before
+    // calling `assign`, so production keys look like `"aa:ACGT-bb:TTTT"`. A UMI whose underlying
+    // sequence is non-encodable (e.g. a lowercase-n / IUPAC base that bypassed the upstream
+    // uppercase-N filter, here spelled with an uppercase `N`) must be isolated into its own
+    // molecule -- matching the parallel paired assigner and the edit/adjacency policy -- not
+    // string-matched into a valid neighbour. Regression for the paired-path gap in GRP-01: the
+    // prefixed key is never `BitEnc`-encodable as a whole, so the isolation check must strip the
+    // prefix (see `underlying_umi_len`).
+    #[test]
+    fn test_paired_prefixed_invalid_umi_is_isolated() {
+        let assigner = PairedUmiAssigner::new(1); // prefixes "aa" / "bb"
+        let umis: Vec<Umi> =
+            ["aa:ACGT-bb:TTTT", "aa:ACGN-bb:TTTT"].iter().map(|s| (*s).to_string()).collect();
+
+        let ids = assigner.assign(&umis);
+
+        assert!(
+            matches!(ids[0], MoleculeId::PairedA(_) | MoleculeId::PairedB(_)),
+            "valid prefixed UMI keeps its paired strand; got {ids:?}"
+        );
+        assert!(
+            matches!(ids[1], MoleculeId::Single(_)),
+            "non-encodable prefixed UMI must be isolated as its own Single; got {ids:?}"
+        );
+        assert_ne!(
+            ids[0].base_id_string(),
+            ids[1].base_id_string(),
+            "isolated invalid UMI must not share the valid molecule; got {ids:?}"
         );
     }
 
@@ -3047,7 +3349,7 @@ mod tests {
     #[test]
     fn test_strategy_new_assigner_full_passes_threshold() {
         // Verify that Strategy::new_assigner_full creates assigners with the correct threshold
-        use super::Strategy as UmiStrategy;
+        use crate::assigner::Strategy as UmiStrategy;
 
         // Need count gradient for adjacency merging: child < parent/2 + 1
         let mut umis = vec!["AAAAAA".to_string(); 10]; // Parent with 10 reads
@@ -3071,7 +3373,7 @@ mod tests {
     #[test]
     fn test_strategy_new_assigner_uses_default_threshold() {
         // Verify that new_assigner and new_assigner_threaded use DEFAULT_INDEX_THRESHOLD
-        use super::Strategy as UmiStrategy;
+        use crate::assigner::Strategy as UmiStrategy;
 
         // Use simple UMIs to verify structural equality between assigners
         let mut umis = vec!["AAAAAA".to_string(); 10];

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -2393,6 +2393,45 @@ mod tests {
         assert!(truncated.iter().all(|u| u.len() == 5));
     }
 
+    /// `--min-umi-length` truncates every UMI to a common length before assignment,
+    /// which is what lets variable-length UMIs pass the assigner's uniform-length
+    /// guard (`assert_uniform_umi_length`, tracker GRP-01). Exercise the full
+    /// truncate -> assign composition so a regression in truncation would trip the
+    /// guard here rather than in production.
+    #[test]
+    fn test_variable_length_umis_group_after_truncation() {
+        // Variable-length single-segment UMIs. After truncating to 6 bases the near-neighbor
+        // stays DISTINCT (AACCGA vs AACCGG — a single mismatch) rather than collapsing to the
+        // same bytes, so grouping it relies on real adjacency (edit-distance) clustering, not
+        // exact match. A 3:1 count gradient makes the low-count neighbor get absorbed.
+        let umis = vec![
+            "AACCGGT".to_string(),  // -> AACCGG (parent, x3)
+            "AACCGGA".to_string(),  // -> AACCGG
+            "AACCGG".to_string(),   // -> AACCGG
+            "AACCGATT".to_string(), // -> AACCGA (1 mismatch from AACCGG, x1 -> merges)
+            "TTGGAAC".to_string(),  // -> TTGGAA (distinct -> its own molecule)
+        ];
+        let truncated =
+            truncate_umis_impl(umis, Some(6)).expect("truncation to a present minimum succeeds");
+        assert!(truncated.iter().all(|u| u.len() == 6), "truncation must yield uniform lengths");
+        // The near-neighbor is distinct after truncation (not byte-identical) — so it can only
+        // group with the parent via adjacency, not exact match.
+        assert_eq!(truncated[3], "AACCGA");
+        assert_ne!(truncated[0], truncated[3], "truncated UMIs must stay distinct");
+
+        // Sequential adjacency assigner, max 1 mismatch (num_threads = 1, use_parallel = false).
+        let assigner = create_umi_assigner(Strategy::Adjacency, 1, 100, 1, false);
+        let assignments = assigner.assign(&truncated);
+
+        assert_eq!(assignments.len(), 5);
+        // All four AACCGG/AACCGA reads cluster into one molecule via 1-mismatch adjacency.
+        assert!(
+            assignments[..4].iter().all(|a| *a == assignments[0]),
+            "the 1-mismatch neighbor must be adjacency-clustered with the parent: {assignments:?}"
+        );
+        assert_ne!(assignments[0], assignments[4], "the distinct UMI forms its own molecule");
+    }
+
     #[test]
     fn test_truncate_umis_none_returns_unchanged() {
         let tool = test_group_cmd(Strategy::Identity, 0);

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -20,7 +20,28 @@ use rayon::prelude::*;
 use crate::bitenc::BitEnc;
 use crate::template::MoleculeId;
 
+use fgumi_umi::assigner::assert_uniform_umi_length;
+
 use super::{Umi, UmiAssigner};
+
+/// Assign each distinct invalid (non-encodable) UMI its own molecule, with identical uppercased
+/// strings sharing -- mirroring fgbio's `Map[Umi, MoleculeId]` (every UMI it sees is assigned a
+/// molecule) and the sequential assigners. Used for the "all UMIs invalid" edge case shared by
+/// every parallel assigner.
+fn all_invalid_molecule_ids(raw_umis: &[Umi]) -> Vec<MoleculeId> {
+    let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+    let mut next_mol_id: u64 = 0;
+    raw_umis
+        .iter()
+        .map(|umi| {
+            *invalid_to_id.entry(umi.to_uppercase()).or_insert_with(|| {
+                let id = MoleculeId::Single(next_mol_id);
+                next_mol_id += 1;
+                id
+            })
+        })
+        .collect()
+}
 
 /// Thread-safe union-find data structure for parallel connected component discovery.
 ///
@@ -370,14 +391,19 @@ impl UmiAssigner for ParallelEditAssigner {
             }
         }
 
-        // Handle edge case: no valid UMIs
+        // Handle edge case: no valid UMIs. Give each distinct invalid string its own molecule
+        // (identical strings share), mirroring fgbio's per-string assignment and the sequential
+        // edit assigner.
         if umi_counts.is_empty() {
-            // All UMIs were invalid - each gets its own molecule ID
-            return (0..raw_umis.len()).map(|i| MoleculeId::Single(i as u64)).collect();
+            return all_invalid_molecule_ids(raw_umis);
         }
 
         // Convert to indexed list (order doesn't matter for Edit strategy)
         let unique_umis: Vec<(BitEnc, usize)> = umi_counts.into_iter().collect();
+
+        // Reject differing-length UMIs the way fgbio (and the sequential assigner) does.
+        assert_uniform_umi_length(unique_umis.iter().map(|(enc, _)| enc.len()));
+
         let enc_to_idx: AHashMap<BitEnc, usize> =
             unique_umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)).collect();
 
@@ -393,10 +419,11 @@ impl UmiAssigner for ParallelEditAssigner {
 
         // Assign molecule IDs based on connected components
         let mut root_to_mol: AHashMap<usize, MoleculeId> = AHashMap::new();
+        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
         let mut next_mol_id: u64 = 0;
 
         let mut result = Vec::with_capacity(raw_umis.len());
-        for enc_opt in &umi_to_original {
+        for (raw, enc_opt) in raw_umis.iter().zip(&umi_to_original) {
             let mol_id = if let Some(enc) = enc_opt {
                 let idx = enc_to_idx[enc];
                 let root = uf.find(idx);
@@ -406,10 +433,15 @@ impl UmiAssigner for ParallelEditAssigner {
                     id
                 })
             } else {
-                // Invalid UMI gets its own molecule ID (consistent with sequential)
-                let id = MoleculeId::Single(next_mol_id);
-                next_mol_id += 1;
-                id
+                // Each distinct invalid (non-encodable) UMI gets its own molecule (identical
+                // strings share), mirroring fgbio's per-string assignment and the sequential
+                // edit assigner. Invalid UMIs never join a valid molecule. See the
+                // cross-assigner parity note in the tests module.
+                *invalid_to_id.entry(raw.to_uppercase()).or_insert_with(|| {
+                    let id = MoleculeId::Single(next_mol_id);
+                    next_mol_id += 1;
+                    id
+                })
             };
             result.push(mol_id);
         }
@@ -472,10 +504,11 @@ impl UmiAssigner for ParallelAdjacencyAssigner {
             })
             .collect();
 
-        // Handle edge case: no valid UMIs
+        // Handle edge case: no valid UMIs. Give each distinct invalid string its own molecule
+        // (identical strings share), mirroring fgbio's per-string assignment and the sequential
+        // adjacency assigner.
         if sorted_umis.is_empty() {
-            // All UMIs were invalid - each gets its own molecule ID
-            return (0..raw_umis.len()).map(|i| MoleculeId::Single(i as u64)).collect();
+            return all_invalid_molecule_ids(raw_umis);
         }
 
         // Sort by count descending, then by the case-folded UMI string for determinism.
@@ -488,6 +521,9 @@ impl UmiAssigner for ParallelAdjacencyAssigner {
         // Build indexed structures (avoid cloning strings by using indices)
         let unique_umis: Vec<(BitEnc, usize)> =
             sorted_umis.iter().map(|(_, count, enc)| (*enc, *count)).collect();
+
+        // Reject differing-length UMIs the way fgbio (and the sequential assigner) does.
+        assert_uniform_umi_length(unique_umis.iter().map(|(enc, _)| enc.len()));
 
         // Phase 1: Parallel edge discovery (using configured thread pool)
         let max_mismatches = self.max_mismatches;
@@ -549,16 +585,21 @@ impl UmiAssigner for ParallelAdjacencyAssigner {
             .map(|(i, (umi, _, _))| (umi.as_str(), mol_ids[i]))
             .collect();
 
-        // Map back to original UMI order
+        // Map back to original UMI order. Each distinct invalid (non-encodable) UMI gets its own
+        // molecule (identical strings share, continuing the `next_mol_id` sequence), mirroring
+        // fgbio's per-string assignment and the sequential adjacency assigner. Invalid UMIs never
+        // join a valid molecule. See the cross-assigner parity note in the tests module.
+        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
         raw_umis
             .iter()
             .map(|umi| {
                 let upper = umi.to_uppercase();
                 str_to_mol.get(upper.as_str()).copied().unwrap_or_else(|| {
-                    // Invalid UMI gets its own molecule ID (consistent with Edit assigner)
-                    let id = MoleculeId::Single(next_mol_id);
-                    next_mol_id += 1;
-                    id
+                    *invalid_to_id.entry(upper).or_insert_with(|| {
+                        let id = MoleculeId::Single(next_mol_id);
+                        next_mol_id += 1;
+                        id
+                    })
                 })
             })
             .collect()
@@ -651,9 +692,11 @@ impl UmiAssigner for ParallelPairedAssigner {
             })
             .collect();
 
-        // Handle edge case: no valid UMIs
+        // Handle edge case: no valid UMIs. Give each distinct invalid string its own molecule
+        // (identical strings share), mirroring fgbio's per-string assignment, the main path
+        // below, and the sequential paired assigner.
         if sorted_umis.is_empty() {
-            return (0..raw_umis.len()).map(|i| MoleculeId::Single(i as u64)).collect();
+            return all_invalid_molecule_ids(raw_umis);
         }
 
         // Sort by count descending, then by UMI string for determinism
@@ -662,6 +705,10 @@ impl UmiAssigner for ParallelPairedAssigner {
         // Build indexed structures
         let unique_umis: Vec<(BitEnc, usize)> =
             sorted_umis.iter().map(|(_, count, enc)| (*enc, *count)).collect();
+
+        // Reject differing-length paired UMIs the way fgbio (and the sequential assigner)
+        // does. `BitEnc::len` excludes the dash, so this compares base length.
+        assert_uniform_umi_length(unique_umis.iter().map(|(enc, _)| enc.len()));
 
         // Phase 1: Parallel edge discovery (using configured thread pool)
         // Use max_mismatches directly (not 2x) because canonicalization already handles
@@ -720,7 +767,12 @@ impl UmiAssigner for ParallelPairedAssigner {
             .map(|(i, (umi, _, _))| (umi.as_str(), mol_ids[i]))
             .collect();
 
-        // Map back to original UMI order with strand assignment
+        // Map back to original UMI order with strand assignment. Each distinct invalid
+        // (non-encodable) UMI gets its own molecule keyed by its canonical form (identical
+        // strings share), mirroring fgbio's per-string assignment and the sequential paired
+        // assigner. An unencodable UMI has no valid strand, so it is a plain `Single`, not a
+        // `PairedA`/`PairedB`. See the cross-assigner parity note in the tests module.
+        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
         raw_umis
             .iter()
             .map(|umi| {
@@ -733,8 +785,11 @@ impl UmiAssigner for ParallelPairedAssigner {
                         MoleculeId::PairedB(base_id)
                     }
                 } else {
-                    // Invalid UMI
-                    MoleculeId::None
+                    *invalid_to_id.entry(canonical).or_insert_with(|| {
+                        let id = MoleculeId::Single(next_mol_id);
+                        next_mol_id += 1;
+                        id
+                    })
                 }
             })
             .collect()
@@ -752,6 +807,8 @@ impl UmiAssigner for ParallelPairedAssigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::umi::{AdjacencyUmiAssigner, PairedUmiAssigner, SimpleErrorUmiAssigner};
+    use rstest::rstest;
 
     // ==================== UnionFind Tests ====================
 
@@ -1051,6 +1108,77 @@ mod tests {
         assert_eq!(assignments.len(), 1);
     }
 
+    // fgbio's GroupReadsByUmi throws on UMIs of differing length; every parallel
+    // mismatch-based assigner must reject them the same way rather than silently
+    // under-group (tracker GRP-01), matching the sequential assigners.
+    #[rstest]
+    #[case::edit(|| Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>, &["AAAA", "AAA"])]
+    #[case::adjacency(
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "AAA"]
+    )]
+    #[case::paired(
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACT-ACT", "ACT-AC"]
+    )]
+    #[should_panic(expected = "Multiple UMI lengths")]
+    fn test_parallel_assigner_rejects_differing_umi_lengths(
+        #[case] make: fn() -> Box<dyn UmiAssigner>,
+        #[case] umis: &[&str],
+    ) {
+        let assigner = make();
+        let umis: Vec<Umi> = umis.iter().map(|s| (*s).to_string()).collect();
+        let _ = assigner.assign(&umis);
+    }
+
+    // Complement to `test_parallel_assigner_rejects_differing_umi_lengths`: a non-encodable
+    // (invalid-base) UMI whose length differs from the valid UMIs must NOT trip the
+    // differing-length guard. The parallel assigners never feed non-encodable UMIs into the
+    // length check (they are dropped during graph construction), so the mixed valid/invalid
+    // GRP-01 parity scenario groups the valid UMIs together and gives the invalid one its own
+    // molecule instead of panicking. This mirrors the sequential
+    // `test_sequential_assigner_excludes_invalid_umis_from_length_guard` and guards against a
+    // future refactor moving the guard ahead of the encoding filter and silently reintroducing
+    // the parity break. Cross-assigner grouping parity for invalid UMIs is enforced separately
+    // by `test_sequential_and_parallel_assigners_induce_same_partition`.
+    //
+    // fgbio divergence here is *intentional*, so these assertions encode fgumi's chosen behavior
+    // rather than fgbio parity: fgbio never drops non-encodable UMIs, so on this exact mixed input
+    // its assigners reject the whole family instead of grouping the valid subset. The Edit strategy
+    // (SimpleErrorUmiAssigner) throws via Sequences.countMismatches's require(s1.length == s2.length)
+    // (fgbio Sequences.scala:99), and Paired (PairedUmiAssigner extends AdjacencyUmiAssigner) throws
+    // via the umiLength require (fgbio GroupReadsByUmi.scala:283) -- both see the length-3 NNN /
+    // length-5 NN-NN beside the length-4 AAAA / length-7 ACT-ACT. fgumi deliberately tolerates
+    // invalid-base UMIs of a differing length by excluding them from the guard (GRP-01) and grouping
+    // only the encodable UMIs. Differing-length *valid* UMIs still match fgbio by rejecting (see
+    // test_parallel_assigner_rejects_differing_umi_lengths).
+    #[rstest]
+    #[case::edit(
+        || Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "AAAA", "NNN"]
+    )]
+    #[case::paired(
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACT-ACT", "ACT-ACT", "NN-NN"]
+    )]
+    fn test_parallel_assigner_excludes_invalid_umis_from_length_guard(
+        #[case] make: fn() -> Box<dyn UmiAssigner>,
+        #[case] umis: &[&str],
+    ) {
+        let assigner = make();
+        let umis: Vec<Umi> = umis.iter().map(|s| (*s).to_string()).collect();
+        // Must not panic despite the invalid UMI having a different length.
+        let ids = assigner.assign(&umis);
+        assert_eq!(ids.len(), umis.len());
+        assert_eq!(ids[0], ids[1], "identical valid UMIs must share a molecule");
+        assert_ne!(ids[0], ids[2], "invalid-base UMI must not join the valid molecule");
+        assert_ne!(
+            ids[2],
+            MoleculeId::None,
+            "invalid-base UMI gets its own molecule (fgbio assigns every UMI a molecule)"
+        );
+    }
+
     #[test]
     fn test_parallel_edit_identical_umis() {
         let assigner = ParallelEditAssigner::new(1, 2);
@@ -1118,20 +1246,35 @@ mod tests {
         assert_eq!(assignments[1], assignments[2]);
     }
 
-    #[test]
-    fn test_parallel_edit_invalid_umis() {
-        let assigner = ParallelEditAssigner::new(1, 2);
-        let umis: Vec<String> = vec!["ACGT", "ACGN", "ACGT"] // ACGN is invalid
+    // Run on BOTH the sequential and parallel edit assigners: an invalid (non-encodable) UMI must
+    // get its own molecule -- distinct from any valid molecule -- by each, while the surrounding
+    // valid UMIs still group. This mirrors fgbio's per-string molecule assignment (every UMI it
+    // sees gets a molecule). `ACGN` is a same-length 1-mismatch neighbour of `ACGT`; the
+    // sequential assigner used to string-match and *group* it (fgbio does group N-neighbours,
+    // but the parallel BitEnc path structurally cannot), so this pins the corrected,
+    // implementation-independent behavior: `ACGN` is isolated, not merged into `ACGT`.
+    #[rstest]
+    #[case::sequential(|| Box::new(SimpleErrorUmiAssigner::new(1)) as Box<dyn UmiAssigner>)]
+    #[case::parallel(|| Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>)]
+    fn test_edit_invalid_umis_get_own_molecule(#[case] make: fn() -> Box<dyn UmiAssigner>) {
+        let assigner = make();
+        let umis: Vec<String> = vec!["ACGT", "ACGN", "ACGT"] // ACGN is invalid (non-encodable)
             .into_iter()
             .map(String::from)
             .collect();
 
         let assignments = assigner.assign(&umis);
 
-        // Valid UMIs should be grouped
-        assert_eq!(assignments[0], assignments[2]);
-        // Invalid UMI gets its own ID
-        assert_ne!(assignments[0], assignments[1]);
+        // Valid UMIs group together.
+        assert_eq!(assignments[0], assignments[2], "identical valid UMIs must share a molecule");
+        // The invalid UMI gets its own molecule, distinct from the valid one (never merged into
+        // it), and it is a real assignment rather than left unassigned.
+        assert_ne!(assignments[1], assignments[0], "invalid UMI must not join the valid molecule");
+        assert_ne!(
+            assignments[1],
+            MoleculeId::None,
+            "invalid UMI gets its own molecule (fgbio assigns every UMI a molecule)"
+        );
     }
 
     // ==================== Adjacency Assigner Tests ====================
@@ -1369,6 +1512,125 @@ mod tests {
         );
         assert_ne!(sequential[0], sequential[2], "reverse spelling is the opposite strand");
         assert_ne!(parallel[0], parallel[2], "parallel: reverse spelling is the opposite strand");
+    }
+
+    // ==================== Cross-assigner parity (sequential vs parallel) ====================
+    //
+    // Production selects between the sequential and parallel assigners purely on the worker
+    // thread count (`create_umi_assigner` in `commands/group.rs`: `use_parallel && threads > 1`
+    // picks the parallel struct, otherwise the sequential one). The two MUST induce the same
+    // partition of the input UMIs for every strategy, or the same reads group differently
+    // depending only on `--threads` -- a silent, user-visible correctness bug.
+    //
+    // Invalid (non-ACGT-encodable, e.g. `N`-containing) UMIs are the sharp edge. fgbio's
+    // assigner returns a `Map[Umi, MoleculeId]` keyed by the UMI string, so *every* UMI it sees
+    // gets a molecule: identical strings always share, distinct strings never merge. fgumi
+    // mirrors that model: an invalid UMI forms its own molecule keyed by its uppercased string --
+    // distinct from every valid molecule and from every other distinct invalid string, with
+    // identical invalid strings sharing. The one thing fgumi cannot mirror is fgbio grouping a
+    // near (within-threshold) `N`-neighbour -- fgbio treats `N` as a mismatch character, but
+    // `BitEnc` cannot represent `N`, so fgumi isolates such a UMI instead. Both fgumi assigners
+    // agree on that isolation, which is what this harness pins.
+    //
+    // These inputs are rare but reachable: fgumi (like fgbio, GroupReadsByUmi.scala:673) filters
+    // only *uppercase* `N` UMIs upstream (`validate_umi` -> `discarded_ns_in_umi`), so a UMI with
+    // a lowercase `n` or a non-ACGT IUPAC base passes the filter (as it does in fgbio) and reaches
+    // `assign()` as non-encodable. The two implementations must therefore agree on it.
+    //
+    // `same_partition` compares grouping structure only, ignoring concrete `MoleculeId`
+    // labels, so it is robust to the two assigners numbering molecules in different orders.
+    #[rstest]
+    // --- Edit strategy ---
+    #[case::edit_valid_grouping(
+        || Box::new(SimpleErrorUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACGT", "ACGT", "ACGA", "TTTT"]
+    )]
+    #[case::edit_duplicate_invalid(
+        || Box::new(SimpleErrorUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "NNN", "NNN"]
+    )]
+    #[case::edit_distinct_invalid(
+        || Box::new(SimpleErrorUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "NNNN", "XXXX"]
+    )]
+    #[case::edit_invalid_within_threshold(
+        || Box::new(SimpleErrorUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACGT", "ACGN", "ACGT"]
+    )]
+    // --- Adjacency strategy ---
+    #[case::adjacency_valid_grouping(
+        || Box::new(AdjacencyUmiAssigner::new(1, 1, 100)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "AAAA", "AAAT"]
+    )]
+    #[case::adjacency_single_invalid(
+        || Box::new(AdjacencyUmiAssigner::new(1, 1, 100)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "NNN"]
+    )]
+    #[case::adjacency_duplicate_invalid_fast_path(
+        || Box::new(AdjacencyUmiAssigner::new(1, 1, 100)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "AAAA", "NNN", "NNN"]
+    )]
+    #[case::adjacency_duplicate_invalid_normal_path(
+        || Box::new(AdjacencyUmiAssigner::new(1, 1, 100)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "GGGG", "NNN", "NNN"]
+    )]
+    // --- Paired strategy ---
+    #[case::paired_valid_grouping(
+        || Box::new(PairedUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACT-ACT", "ACT-ACT", "ACT-TGA"]
+    )]
+    #[case::paired_duplicate_invalid(
+        || Box::new(PairedUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACT-ACT", "NN-NN", "NN-NN"]
+    )]
+    // Same-length invalid neighbour: `ACGN-TTTT` is a 1-mismatch neighbour of the valid
+    // `ACGT-TTTT` (and, unlike `NN-NN` vs `ACT-ACT` above, the SAME length, so it can string-
+    // match). The parallel paired assigner drops it before grouping (not BitEnc-encodable) and
+    // gives it its own `Single`; the sequential paired assigner must agree. Before the paired-path
+    // GRP-01 fix the sequential assigner counted invalid UMIs into `umi_counts`, so this invalid
+    // neighbour string-matched into the valid molecule (index 1 joined index 0) -- diverging from
+    // the parallel path depending only on `--threads`. With one valid UMI it exercises the
+    // `umi_counts.len() == 1` fast path.
+    #[case::paired_invalid_neighbor_fast_path(
+        || Box::new(PairedUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACGT-TTTT", "ACGN-TTTT"]
+    )]
+    // As above but with two distinct valid molecules, exercising the adjacency-graph path
+    // (`umi_counts.len() > 1`) rather than the fast path. `ACGN-TTTT` is a 1-mismatch neighbour
+    // of `ACGT-TTTT`; it must still be isolated as its own `Single` in both assigners while the
+    // two valid UMIs (>1 mismatch apart) stay in separate molecules.
+    #[case::paired_invalid_neighbor_graph_path(
+        || Box::new(PairedUmiAssigner::new(1)) as Box<dyn UmiAssigner>,
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACGT-TTTT", "GGGG-TTTT", "ACGN-TTTT"]
+    )]
+    fn test_sequential_and_parallel_assigners_induce_same_partition(
+        #[case] make_sequential: fn() -> Box<dyn UmiAssigner>,
+        #[case] make_parallel: fn() -> Box<dyn UmiAssigner>,
+        #[case] umis: &[&str],
+    ) {
+        let umis: Vec<Umi> = umis.iter().map(|s| (*s).to_string()).collect();
+        let sequential = make_sequential().assign(&umis);
+        let parallel = make_parallel().assign(&umis);
+
+        assert_eq!(sequential.len(), umis.len());
+        assert_eq!(parallel.len(), umis.len());
+        assert!(
+            same_partition(&sequential, &parallel),
+            "sequential and parallel assigners must induce the same partition;\n  \
+             umis:       {umis:?}\n  sequential: {sequential:?}\n  parallel:   {parallel:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

fgbio's `GroupReadsByUmi` throws on UMIs of differing length: its adjacency assigner has an explicit `require(orderedNodes.forall(_.umi.length == umiLength), "Multiple UMI lengths")`, and `Sequences.countMismatches` `require`s equal lengths (`GroupReadsByUmiTest.scala:513`, *"fail when umis have different length"*).

fgumi's `count_mismatches` instead returns `usize::MAX` for differing lengths, which every mismatch-based matcher reads as "no match", so a differing-length UMI silently forms its own molecule — under-grouping with no error. Only the sequential adjacency assigner carried the guard (an inline `assert!`); the sequential paired/edit assigners and all three parallel assigners (edit/adjacency/paired) did not, so the default threaded path under-grouped silently for **every** strategy.

## Change

- Add a shared `assert_uniform_umi_length` helper (plus `base_umi_length`) in `fgumi-umi::assigner`, and wire it into every mismatch-based assigner path — sequential edit/adjacency/paired and parallel edit/adjacency/paired — replacing the ad-hoc inline adjacency check.
- `Identity` grouping is exact-match and needs no length guard, matching fgbio's identity assigner.
- `--min-umi-length` still works: it truncates every UMI to a common length *before* assignment, so the guard never fires on the variable-length input the flag supports. A new `truncate → assign` test (`test_variable_length_umis_group_after_truncation`) locks that interaction end-to-end.

## Parity evidence (§0 step 2/4)

Fixture: `reports/fgbio-parity-fixtures/grp-01-unequal-umi-length.sh` — two read pairs at the same coordinates/orientation, `RX` = `ACT-ACT` (7 chars) vs `ACT-AC` (6 chars), run under `Strategy.Paired/Adjacency/Edit`, `edits=1` (mirrors `GroupReadsByUmiTest.scala:513`).

```
before:
  fgbio  Paired    exit: 1   (rejects)      fgumi  Paired    exit: 0    (silent under-group)
  fgbio  Adjacency exit: 1   (rejects)      fgumi  Adjacency exit: 101  (already guarded)
  fgbio  Edit      exit: 1   (rejects)      fgumi  Edit      exit: 0    (silent under-group)

after:
  fgbio  Paired    exit: 1   (rejects)      fgumi  Paired    exit: 101  (rejects)
  fgbio  Adjacency exit: 1   (rejects)      fgumi  Adjacency exit: 101  (rejects)
  fgbio  Edit      exit: 1   (rejects)      fgumi  Edit      exit: 101  (rejects)
```

Both tools now reject differing-length UMIs (non-zero exit) across all three strategies; before, Paired and Edit silently under-grouped.

## Notes

- The guard panics (`assert!`), consistent with the existing sequential-adjacency guard and the sibling `"is not a paired UMI"` guards in the same file. Exit is non-zero (101) rather than fgbio's 1, which satisfies the missing-guard (S3/BS6) parity standard used throughout the tracker; converting the `assign` trait to return `Result` would be an invasive refactor rippling into `dedup` and is out of scope for this parity fix.

## Tests

- New `should_panic` cases for all six assigner paths (sequential + parallel × edit/adjacency/paired) asserting `"Multiple UMI lengths"`, plus direct unit tests for `assert_uniform_umi_length` / `base_umi_length`, and the `--min-umi-length` regression test. `cargo ci-fmt && cargo ci-lint && cargo ci-test` all green (2219 passed).

Tracker: **GRP-01** (S3/S1). GRP-02 wontfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `assert_uniform_umi_length(...)` to enforce consistent UMI lengths, including consistent paired behavior (delimiter ignored).
* **Bug Fixes**
  * Edit/Adjacency/Paired assigners now fail fast on mixed-length **valid** UMIs; differences from invalid/non-encodable UMIs no longer trigger length panics.
  * Invalid/non-encodable UMIs now share or diverge molecule assignments by distinct invalid-string identity, aligning sequential and parallel results.
  * Adjacency profiling reports base UMI length directly.
* **Tests**
  * Added truncation regression coverage and expanded parameterized panic/non-panic cases across strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->