### PR TITLE
fix(fastq): narrow read-name sync suffix strip to fgbio parity

### DIFF
--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -266,11 +266,20 @@ fn find_newline(data: &[u8]) -> Option<usize> {
     data.iter().position(|&b| b == b'\n')
 }
 
-/// Strip mate-indicator suffix and CASAVA comment from a read name for comparison.
+/// Strip a mate-indicator suffix and CASAVA comment from a read name for comparison.
 ///
 /// First truncates at the first ASCII space (removing CASAVA-style comments like
-/// `read1 1:N:0:ATCACG`), then strips common pair suffixes: `/1`, `/2`, `.1`,
-/// `.2`, `_1`, `_2`, `:1`, `:2`.
+/// `read1 1:N:0:ATCACG`), then strips a trailing `/` followed by a single ASCII
+/// digit (`0`-`9`), e.g. `read/1` -> `read`.
+///
+/// This mirrors fgbio's `FastqSource` read-name canonicalization (see
+/// `com/fulcrumgenomics/fastq/FastqSource.scala`), which strips only a trailing
+/// `/` + single digit. It deliberately does **not** strip `.`/`_`/`:` separators
+/// or multi-digit runs (`read/12` is left intact): those separators are not a
+/// reliable mate indicator, and treating them as one makes genuinely mismatched
+/// pairs such as `read_1` (R1) vs `read_2` (R2) collapse to the same base name
+/// and be silently accepted as "in sync". Used to validate that reads at the same
+/// position across paired/interleaved FASTQ streams have matching names.
 #[must_use]
 pub fn strip_read_suffix(name: &[u8]) -> &[u8] {
     // Truncate at the first space (CASAVA comment separator).
@@ -279,14 +288,11 @@ pub fn strip_read_suffix(name: &[u8]) -> &[u8] {
         None => name,
     };
 
-    // Strip common pair suffixes: separator + digit where separator is
-    // one of '/', '.', '_', ':' and digit is '1' or '2'.
+    // Strip a trailing '/' + single ASCII digit (fgbio FastqSource parity).
     if name.len() >= 2 {
         let last = name[name.len() - 1];
         let sep = name[name.len() - 2];
-        if (last == b'1' || last == b'2')
-            && (sep == b'/' || sep == b'.' || sep == b'_' || sep == b':')
-        {
+        if sep == b'/' && last.is_ascii_digit() {
             return &name[..name.len() - 2];
         }
     }
@@ -295,6 +301,8 @@ pub fn strip_read_suffix(name: &[u8]) -> &[u8] {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -360,25 +368,50 @@ mod tests {
         assert_eq!(leftover, b"@read2\nTG");
     }
 
+    #[rstest]
+    // A trailing '/' + single digit is stripped (any digit, fgbio parity).
+    #[case::slash_one(b"read/1", b"read")]
+    #[case::slash_two(b"read/2", b"read")]
+    #[case::slash_three(b"read/3", b"read")]
+    #[case::slash_zero(b"read/0", b"read")]
+    // Non-'/' separators are preserved: they are not a reliable mate indicator,
+    // and stripping them collapses genuinely different reads (see the collision
+    // test below). This narrows the previous over-lenient behavior to match
+    // fgbio's FastqSource.
+    #[case::dot_one(b"read.1", b"read.1")]
+    #[case::dot_two(b"read.2", b"read.2")]
+    #[case::underscore_one(b"read_1", b"read_1")]
+    #[case::underscore_two(b"read_2", b"read_2")]
+    #[case::colon_one(b"read:1", b"read:1")]
+    #[case::colon_two(b"read:2", b"read:2")]
+    // Multi-digit runs are preserved (only a single trailing digit is stripped).
+    #[case::slash_multidigit(b"read/12", b"read/12")]
+    // Non-digit after '/' is preserved.
+    #[case::slash_nondigit(b"read/x", b"read/x")]
+    // A trailing space comment is stripped first, then the '/'+digit suffix.
+    #[case::comment_and_slash(b"read/1 1:N:0:ATCACG", b"read")]
+    // A comment is stripped even when there is no mate suffix.
+    #[case::comment_only(b"read 1:N:0:ATCACG", b"read")]
+    // No suffix at all.
+    #[case::no_suffix(b"read", b"read")]
+    #[case::single_char(b"a", b"a")]
+    #[case::empty(b"", b"")]
+    fn test_strip_read_suffix(#[case] input: &[u8], #[case] expected: &[u8]) {
+        assert_eq!(strip_read_suffix(input), expected);
+    }
+
     #[test]
-    fn test_strip_read_suffix() {
-        // Slash separators (original behavior).
-        assert_eq!(strip_read_suffix(b"read1/1"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1/2"), b"read1");
-        // Dot, underscore, colon separators.
-        assert_eq!(strip_read_suffix(b"read1.1"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1.2"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1_1"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1_2"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1:1"), b"read1");
-        assert_eq!(strip_read_suffix(b"read1:2"), b"read1");
-        // CASAVA-style headers with space-separated comments.
-        assert_eq!(strip_read_suffix(b"read1/1 1:N:0:ATCACG"), b"read1");
-        // No pair suffix, but CASAVA comment is still stripped.
-        assert_eq!(strip_read_suffix(b"read1 1:N:0:ATCACG"), b"read1");
-        // No suffix.
-        assert_eq!(strip_read_suffix(b"read1"), b"read1");
-        assert_eq!(strip_read_suffix(b"a"), b"a");
-        assert_eq!(strip_read_suffix(b""), b"" as &[u8]);
+    fn test_strip_read_suffix_rejects_mismatched_underscore_pair() {
+        // Behavior tradeoff / regression guard: `read_1` (R1) and `read_2` (R2)
+        // are genuinely different reads. The previous over-lenient rule stripped
+        // the `_1`/`_2` suffix, collapsing both to `read` so a mismatched pair of
+        // streams was silently accepted as "in sync". The fgbio-parity rule now
+        // preserves them, so the two no longer collide and sync-validation
+        // correctly rejects the pair. This also means non-standard paired FASTQs
+        // that legitimately use `_1`/`_2` (or `.1`/`.2`/`:1`/`:2`) suffixes are
+        // now rejected — matching fgbio, which rejects them too.
+        assert_eq!(strip_read_suffix(b"read_1"), b"read_1");
+        assert_eq!(strip_read_suffix(b"read_2"), b"read_2");
+        assert_ne!(strip_read_suffix(b"read_1"), strip_read_suffix(b"read_2"));
     }
 }

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -1025,6 +1025,30 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("out of sync"));
     }
 
+    #[test]
+    fn test_fastq_grouper_rejects_mismatched_underscore_pair() {
+        // Behavior tradeoff: read-name sync-validation strips only a trailing
+        // '/' + single digit (fgbio FastqSource parity), NOT '_1'/'_2'. So a
+        // genuinely mismatched pair — `read_1` on stream 0 and `read_2` on
+        // stream 1 — no longer collapses to a shared base name and is correctly
+        // rejected as out of sync. Under the previous over-lenient rule the
+        // '_1'/'_2' suffixes were stripped, both became `read`, and the mismatch
+        // was silently accepted. The cost of this correctness fix is that
+        // non-standard paired FASTQs legitimately using '_1'/'_2' suffixes are
+        // now rejected too — this matches fgbio, which also rejects them.
+        let mut grouper = FastqGrouper::new(2);
+        grouper
+            .add_bytes_for_stream(0, b"@read_1\nACGT\n+\nIIII\n")
+            .expect("add_bytes_for_stream failed");
+        grouper
+            .add_bytes_for_stream(1, b"@read_2\nTGCA\n+\nJJJJ\n")
+            .expect("add_bytes_for_stream failed");
+
+        let result = grouper.drain_complete_templates();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("out of sync"));
+    }
+
     // ========================================================================
     // RecordPositionGrouper tests
     // ========================================================================


### PR DESCRIPTION
## Problem

`fastq_parse::strip_read_suffix` canonicalizes read names before validating that paired/interleaved FASTQ streams are in sync — i.e. that the reads at the same position across streams share a name. Its rule was too lenient: after stripping a trailing space-separated comment, it also stripped a trailing `separator + digit` where the separator was one of `/`, `.`, `_`, `:` and the digit was `1` or `2`. That collapses a genuinely mismatched pair such as `read_1` (stream 0) and `read_2` (stream 1) to the same base name `read`, so two different reads are silently accepted as "in sync" instead of being rejected.

## Fix

Narrow the rule to match fgbio's `FastqSource` read-name canonicalization in `com/fulcrumgenomics/fastq/FastqSource.scala`, which strips only a trailing `/` followed by a single ASCII digit (0-9):

```scala
val suffix = fullName.takeRight(2)
val (name, readNumber) = suffix.length == 2 && suffix(0) == '/' && suffix(1).isDigit match {
  case true  => (fullName.dropRight(2), Some(fullName.last.asDigit))
  case false => (fullName, None)
}
```

The trailing space-comment strip (a separate, correct concern) is unchanged. After it, `strip_read_suffix` now strips a suffix only when it is `/` + a single ASCII digit. It no longer strips `.`/`_`/`:` separators, and it no longer strips multi-digit runs (`read/12` is left intact). This is the same rule PR #489 established for the extract path (`strip_read_number_suffix`), now applied to the shared FASTQ-sync helper.

New one-line spec: strip a trailing space comment, then strip a trailing `/` + single ASCII digit; leave everything else (`.`/`_`/`:` separators, multi-digit runs, non-digit suffixes) intact.

## Affected callers

All three production callers are paired-FASTQ name-sync validation and benefit uniformly with no call-site changes:

- `FastqGrouper::drain_complete_templates` (`src/lib/grouper.rs`)
- `zip_fastq` source step
- `parse_zip_fastq` source step

(On this branch's base only `grouper.rs` actually calls the shared helper; the `zip_fastq`/`parse_zip_fastq` source steps are not present on `main` yet, but they use the same helper and get the fix for free when they land.)

## Behavior tradeoff (please note)

Narrowing correctly **rejects** mismatched `read_1` / `read_2` streams that the old rule silently accepted. But it also now **rejects** non-standard paired FASTQs that legitimately use `.1`/`.2`/`_1`/`_2`/`:1`/`:2` read-number suffixes to distinguish R1/R2. This matches fgbio, which also rejects such names as out of sync, so it is correct fgbio parity — but it is a real, user-visible behavior change reviewers should be aware of. FASTQs using the standard `/1`/`/2` (or no suffix) are unaffected.

## Tests

- Rewrote `test_strip_read_suffix` (`fastq_parse.rs`) as an `rstest` table: `/1`, `/2`, `/3`, `/0` strip to `read`; `.1`/`.2`/`_1`/`_2`/`:1`/`:2` are preserved; `read/12` (multi-digit) and `read/x` (non-digit) are preserved; a trailing space comment is still stripped first (with and without a following `/`+digit).
- Added `test_strip_read_suffix_rejects_mismatched_underscore_pair` (`fastq_parse.rs`) asserting `read_1` and `read_2` no longer collide, with a comment documenting the tradeoff.
- Added `test_fastq_grouper_rejects_mismatched_underscore_pair` (`grouper.rs`) driving `FastqGrouper` end-to-end to prove the sync-validation now rejects a mismatched `read_1` / `read_2` pair as "out of sync".
- No other tests codified the old broad behavior; the existing grouper/fastq tests all use `/1`/`/2` suffixes, which remain valid.

## Follow-up (out of scope here)

`src/lib/commands/extract.rs` still carries its own broad `strip_read_suffix_extract`. Consolidating both onto the narrow shared helper is a natural follow-up, intentionally left out to keep this fix focused on `strip_read_suffix`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paired-end read-name handling to prevent distinct reads such as `_1` and `_2` from being incorrectly treated as identical.
  * Preserved multi-digit, nonstandard, and underscore-based suffixes during read-name processing.
  * Added validation for mismatched paired-end names, with a clear “out of sync” error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->