### PR TITLE
fix(sort): write SS sub-sort tag as <sort-order>:<sub-sort> (R2-HDR-01)

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3873,7 +3873,7 @@ mod tests {
         assert_eq!(<_ as AsRef<[u8]>>::as_ref(go), b"query");
 
         let ss = fields.get(b"SS").expect("should have SS tag");
-        assert_eq!(<_ as AsRef<[u8]>>::as_ref(ss), b"template-coordinate");
+        assert_eq!(<_ as AsRef<[u8]>>::as_ref(ss), b"unsorted:template-coordinate");
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/keys.rs
+++ b/crates/fgumi-sort/src/keys.rs
@@ -196,14 +196,22 @@ impl SortOrder {
         }
     }
 
-    /// Get the SAM header sub-sort tag value.
+    /// Get the SAM header sub-sort (`SS`) tag value.
+    ///
+    /// The `SS` tag is written as `<sort-order>:<sub-sort>`, matching fgbio
+    /// (`SamOrder.applyTo`: `sortOrder.name() + ":" + ss`) and samtools. The
+    /// `<sort-order>` prefix is the value written to the `SO` tag for this
+    /// order (`queryname` for queryname sub-sorts; `unsorted` for
+    /// template-coordinate). Without the prefix, fgbio's `SamOrder.apply`
+    /// (which strips everything up to the first `:`) fails to re-recognize the
+    /// header.
     #[must_use]
     pub fn header_ss_tag(&self) -> Option<&'static str> {
         match self {
             Self::Coordinate => None,
-            Self::Queryname(QuerynameComparator::Lexicographic) => Some("lexicographic"),
-            Self::Queryname(QuerynameComparator::Natural) => Some("natural"),
-            Self::TemplateCoordinate => Some("template-coordinate"),
+            Self::Queryname(QuerynameComparator::Lexicographic) => Some("queryname:lexicographic"),
+            Self::Queryname(QuerynameComparator::Natural) => Some("queryname:natural"),
+            Self::TemplateCoordinate => Some("unsorted:template-coordinate"),
         }
     }
 }
@@ -1489,16 +1497,20 @@ mod tests {
 
     #[test]
     fn test_sort_order_header_ss_tag() {
+        // The SS tag carries the `<sort-order>:<sub-sort>` form (fgbio/samtools).
         assert_eq!(SortOrder::Coordinate.header_ss_tag(), None);
         assert_eq!(
             SortOrder::Queryname(QuerynameComparator::Lexicographic).header_ss_tag(),
-            Some("lexicographic")
+            Some("queryname:lexicographic")
         );
         assert_eq!(
             SortOrder::Queryname(QuerynameComparator::Natural).header_ss_tag(),
-            Some("natural")
+            Some("queryname:natural")
         );
-        assert_eq!(SortOrder::TemplateCoordinate.header_ss_tag(), Some("template-coordinate"));
+        assert_eq!(
+            SortOrder::TemplateCoordinate.header_ss_tag(),
+            Some("unsorted:template-coordinate")
+        );
     }
 
     #[test]

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -137,8 +137,9 @@ pub(crate) fn create_output_header(sort_order: keys::SortOrder, header: &Header)
         keys::SortOrder::TemplateCoordinate => {
             hd.other_fields_mut().insert(header_tag::SORT_ORDER, BString::from("unsorted"));
             hd.other_fields_mut().insert(header_tag::GROUP_ORDER, BString::from("query"));
-            hd.other_fields_mut()
-                .insert(header_tag::SUBSORT_ORDER, BString::from("template-coordinate"));
+            if let Some(ss) = sort_order.header_ss_tag() {
+                hd.other_fields_mut().insert(header_tag::SUBSORT_ORDER, BString::from(ss));
+            }
         }
     }
 
@@ -246,5 +247,37 @@ mod tests {
         let hd = output.header().expect("should have @HD");
         let so = hd.other_fields().get(b"SO").expect("should have SO");
         assert_eq!(<_ as AsRef<[u8]>>::as_ref(so), b"coordinate");
+    }
+
+    #[test]
+    fn test_create_output_header_ss_has_sort_order_prefix() {
+        // fgbio/samtools write SS as `<sort-order>:<sub-sort>`; pin that fgumi
+        // does too, so fgbio's `SamOrder.apply` re-recognizes the header.
+        let empty = Header::builder().build();
+        let ss_of = |hd: &Map<noodles::sam::header::record::value::map::Header>| {
+            <_ as AsRef<[u8]>>::as_ref(hd.other_fields().get(b"SS").expect("SS")).to_vec()
+        };
+
+        // queryname (natural) -> SO:queryname, SS:queryname:natural
+        let out = create_output_header(
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Natural),
+            &empty,
+        );
+        let hd = out.header().expect("@HD");
+        assert_eq!(
+            <_ as AsRef<[u8]>>::as_ref(hd.other_fields().get(b"SO").expect("SO")),
+            b"queryname"
+        );
+        assert_eq!(ss_of(hd), b"queryname:natural");
+
+        // template-coordinate -> SO:unsorted, GO:query, SS:unsorted:template-coordinate
+        let out = create_output_header(keys::SortOrder::TemplateCoordinate, &empty);
+        let hd = out.header().expect("@HD");
+        assert_eq!(
+            <_ as AsRef<[u8]>>::as_ref(hd.other_fields().get(b"SO").expect("SO")),
+            b"unsorted"
+        );
+        assert_eq!(<_ as AsRef<[u8]>>::as_ref(hd.other_fields().get(b"GO").expect("GO")), b"query");
+        assert_eq!(ss_of(hd), b"unsorted:template-coordinate");
     }
 }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -1004,14 +1004,14 @@ mod tests {
     fn test_queryname_lex_header_has_subsort() {
         let order = SortOrder::from(SortOrderArg::Queryname);
         assert_eq!(order.header_so_tag(), "queryname");
-        assert_eq!(order.header_ss_tag(), Some("lexicographic"));
+        assert_eq!(order.header_ss_tag(), Some("queryname:lexicographic"));
     }
 
     #[test]
     fn test_queryname_natural_header_has_subsort() {
         let order = SortOrder::from(SortOrderArg::QuerynameNatural);
         assert_eq!(order.header_so_tag(), "queryname");
-        assert_eq!(order.header_ss_tag(), Some("natural"));
+        assert_eq!(order.header_ss_tag(), Some("queryname:natural"));
     }
 
     #[test]
@@ -1025,7 +1025,7 @@ mod tests {
     fn test_template_coordinate_header_subsort() {
         let order = SortOrder::from(SortOrderArg::TemplateCoordinate);
         assert_eq!(order.header_so_tag(), "unsorted");
-        assert_eq!(order.header_ss_tag(), Some("template-coordinate"));
+        assert_eq!(order.header_ss_tag(), Some("unsorted:template-coordinate"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

fgbio (`SamOrder.applyTo`: `sortOrder.name() + ":" + ss`) and samtools write the `SS` header tag as `<sort-order>:<sub-sort>` — e.g. `queryname:natural`, `unsorted:template-coordinate`. fgumi wrote the bare sub-sort (`natural`, `template-coordinate`), diverging from **both** parity targets: fgbio's `SamOrder.apply` strips everything up to the first colon (`s.substring(s.indexOf(':') + 1)`), so a bare `SS:natural` header is not re-recognized as a queryname order. (Template-coordinate round-tripped only by luck.)

This is round-2 audit finding **R2-HDR-01**.

## What changed

- `SortOrder::header_ss_tag` now returns the `<sort-order>:<sub-sort>` form (`queryname:lexicographic`, `queryname:natural`, `unsorted:template-coordinate`).
- `create_output_header` uses it for both the queryname and template-coordinate branches (the template-coordinate branch previously hard-coded the bare value).

## No reader regression

`is_template_coordinate_sorted` already splits the `SS` value on the first colon and accepts both the prefixed and bare forms (mirroring fgbio's reader), so headers written by fgumi, fgbio, and samtools are all accepted by `group`/`merge`. There is no reader that inspects the queryname sub-sort value.

## Testing

- Updated `header_ss_tag` unit tests (fgumi-sort + sort command) and the external-sort output-header test to the prefixed values.
- New `create_output_header` test pinning the end-to-end `SO`/`GO`/`SS` triple for queryname and template-coordinate.
- Full suite: 2215 tests pass; `ci-fmt` and `ci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sorting output headers to use consistent `<sort-order>:<sub-sort>` values.
  * Corrected header metadata for lexicographic, natural, and template-coordinate sorting modes.
  * Ensured template-coordinate output includes the appropriate sort and group-order metadata.

* **Tests**
  * Updated and expanded coverage to verify the corrected sorting header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->