### PR TITLE
docs(metrics): correct format_float doc-comment (R2-MET-01)

### DIFF
--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -21,13 +21,19 @@ pub mod writer;
 
 use serde::{Deserialize, Serialize};
 
-/// Number of decimal places used for float metrics (matches fgbio).
+/// Number of decimal places used for fixed-precision float metrics.
 pub const FLOAT_PRECISION: usize = 6;
 
-/// Formats a float value with the standard precision for metrics.
+/// Formats a float value with a fixed [`FLOAT_PRECISION`] decimal places.
 ///
-/// This ensures consistent float formatting across all metrics output,
-/// matching fgbio's 6 decimal place precision.
+/// This produces a stable, fixed-width representation for metrics output
+/// (`0.9` → `"0.900000"`). Note this is **not** byte-identical to fgbio, which
+/// formats floats with `DecimalFormat("0.######")` and therefore strips
+/// trailing zeros (`0.9` → `"0.9"`) and switches to scientific notation for
+/// very small magnitudes. The difference is intentional and harmless:
+/// `fgumi compare metrics` parses values numerically (with rounding tolerance),
+/// and `Double.parseDouble` reads either form, so no consumer depends on the
+/// exact string. See the round-2 parity notes (R2-MET-01).
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
## Summary

The `format_float` / `FLOAT_PRECISION` doc-comments claimed the output "matches fgbio", but it doesn't: fgumi emits fixed 6-decimal strings (`0.9` → `"0.900000"`) whereas fgbio's `DecimalFormat("0.######")` strips trailing zeros (`0.9` → `"0.9"`) and uses scientific notation for very small magnitudes.

This corrects the doc to describe the actual fixed-precision behavior and notes the divergence is intentional and harmless — `fgumi compare metrics` compares values numerically (with rounding tolerance) and `Double.parseDouble` reads either form, so no consumer depends on the exact string.

Round-2 audit finding **R2-MET-01** (dispositioned WONTFIX + doc fix: the real `Metric.read` breakers were the `inf` serialization and column-set issues, handled in #504).

## Scope

Doc-comment only — no behavior change (the doctest, which pins the actual output, is unchanged). `ci-fmt`/`ci-lint` clean; doctest passes.