### PR TITLE
fix(metrics): finish fgbio float format + reads-threshold guards (DXM3-04, DXM3-06, SIMM3-02)

### DIFF
--- a/crates/fgumi-metrics/src/float.rs
+++ b/crates/fgumi-metrics/src/float.rs
@@ -19,8 +19,15 @@ use serde::{Deserialize, Deserializer, Serializer};
 /// Non-finite values become `Infinity`/`-Infinity`/`NaN` (readable by fgbio's
 /// `Double.parseDouble`); finite whole numbers drop the fractional part; all other
 /// finite values keep full precision.
-#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde requires &T signature")]
-pub(crate) fn serialize<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
+///
+/// Intended for use as `#[serde(with = "fgumi_metrics::float")]` on `f64` metric
+/// fields so every crate's metric TSVs format floats consistently.
+///
+/// # Errors
+///
+/// Propagates any error from the underlying `serializer`.
+#[allow(clippy::trivially_copy_pass_by_ref, reason = "serde requires &T signature")]
+pub fn serialize<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -49,7 +56,12 @@ where
 
 /// Deserializes an `f64` written by [`serialize`], accepting the non-finite
 /// tokens `NaN`, `Infinity`, and `-Infinity` in addition to ordinary numbers.
-pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<f64, D::Error>
+///
+/// # Errors
+///
+/// Returns an error if the underlying `deserializer` fails or the value is
+/// neither a recognized non-finite token nor a parseable number.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -13,7 +13,7 @@ pub mod clip;
 pub mod consensus;
 pub mod correct;
 pub mod duplex;
-pub(crate) mod float;
+pub mod float;
 pub mod group;
 pub mod rejection;
 pub mod shared;

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -122,6 +122,9 @@ struct DedupMetricsOutput {
     total_templates: u64,
     unique_templates: u64,
     duplicate_templates: u64,
+    // DXM3-04: format the one fraction column like fgbio's DecimalFormat, matching
+    // the float serialization #504 wired onto the fgumi-metrics-crate structs.
+    #[serde(with = "fgumi_metrics::float")]
     duplicate_rate: f64,
     total_reads: u64,
     unique_reads: u64,
@@ -2373,6 +2376,34 @@ mod tests {
         assert_eq!(output.secondary_reads, 10);
         assert_eq!(output.supplementary_reads, 5);
         assert_eq!(output.missing_tc_tag, 2);
+    }
+
+    /// DXM3-04: `duplicate_rate` serializes through the fgbio-style float
+    /// formatter (#504's now-public `fgumi_metrics::float`), so a whole-number
+    /// rate is written as `1`, not serde's raw `1.0` — consistent with the other
+    /// fgumi metric files.
+    #[test]
+    fn test_dedup_metrics_duplicate_rate_uses_float_formatter() -> Result<()> {
+        let metrics = DedupMetrics {
+            total_templates: 2,
+            duplicate_templates: 2,
+            unique_templates: 0,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("dedup.metrics.txt");
+        write_dedup_metrics(&metrics, &path)?;
+
+        let text = std::fs::read_to_string(&path)?;
+        let data_row = text.lines().nth(1).expect("metrics data row");
+        let columns: Vec<&str> = data_row.split('\t').collect();
+        // Field order: total, unique, duplicate templates, then duplicate_rate.
+        assert_eq!(
+            columns.get(3).copied(),
+            Some("1"),
+            "duplicate_rate must format as `1`, not `1.0`; row: {data_row:?}"
+        );
+        Ok(())
     }
 
     // ========================================================================

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -126,7 +126,12 @@ impl Command for DuplexMetrics {
         // Validate inputs
         validate_file_exists(&self.input, "input BAM file")?;
 
-        // Validate parameters
+        // Validate parameters (fgbio CollectDuplexSeqMetrics requires minAb >= 1,
+        // minBa >= 0, minBa <= minAb; DXM3-06). min_ab == 0 would label every
+        // family a duplex, so reject it like fgbio rather than proceeding.
+        if self.min_ab_reads == 0 {
+            anyhow::bail!("--min-ab-reads must be >= 1 (got {})", self.min_ab_reads);
+        }
         if self.min_ab_reads < self.min_ba_reads {
             anyhow::bail!(
                 "--min-ab-reads ({}) must be >= --min-ba-reads ({})",
@@ -776,6 +781,27 @@ mod tests {
     }
 
     // ==================== Test Cases ====================
+
+    /// DXM3-06: `--min-ab-reads 0` is rejected (fgbio validates `minAbReads >= 1`);
+    /// otherwise every tag family would be labeled a duplex.
+    #[test]
+    fn test_duplex_metrics_rejects_min_ab_reads_zero() -> Result<()> {
+        let (r1, r2) = build_test_pair("q1", 0, 100, 200, "AAA-GGG", "1/A", true, false);
+        let input = create_test_bam(vec![r1, r2])?;
+        let output_dir = TempDir::new()?;
+        let cmd = DuplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output_dir.path().join("output"),
+            min_ab_reads: 0,
+            min_ba_reads: 0,
+            duplex_umi_counts: false,
+            intervals: None,
+            description: None,
+        };
+        let err = cmd.execute("test").expect_err("must reject --min-ab-reads 0");
+        assert!(err.to_string().contains("min-ab-reads must be >= 1"), "unexpected: {err}");
+        Ok(())
+    }
 
     #[test]
     fn test_count_umis_once_per_read_pair() -> Result<()> {

--- a/src/lib/commands/simplex_metrics.rs
+++ b/src/lib/commands/simplex_metrics.rs
@@ -98,6 +98,12 @@ impl Command for SimplexMetrics {
         // Validate inputs
         validate_file_exists(&self.input, "input BAM file")?;
 
+        // fgbio's analog validates minReads >= 1; --min-reads 0 would label every
+        // family (size >= 0) a consensus family, so reject it (SIMM3-02).
+        if self.min_reads == 0 {
+            anyhow::bail!("--min-reads must be >= 1 (got {})", self.min_reads);
+        }
+
         // Check that input is not a consensus BAM
         validate_not_consensus_bam(&self.input)?;
 
@@ -440,6 +446,25 @@ mod tests {
         }
         drop(writer);
         Ok(temp_file)
+    }
+
+    /// SIMM3-02: `--min-reads 0` is rejected (fgbio validates `minReads >= 1`);
+    /// otherwise every family of size >= 0 is silently labeled a consensus family.
+    #[test]
+    fn test_simplex_metrics_rejects_min_reads_zero() -> Result<()> {
+        let (r1, r2) = build_test_pair("q1", 0, 100, 200, "AAA", "1/A");
+        let input = create_test_bam(vec![r1, r2])?;
+        let output_dir = TempDir::new()?;
+        let cmd = SimplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output_dir.path().join("output"),
+            min_reads: 0,
+            intervals: None,
+            description: None,
+        };
+        let err = cmd.execute("test").expect_err("must reject --min-reads 0");
+        assert!(err.to_string().contains("min-reads must be >= 1"), "unexpected: {err}");
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Completes the fgbio metrics-parity work #504 started. Three findings:

**DXM3-04** — #504 wired the fgbio-style float formatter (`#[serde(with="crate::float")]`) onto the `fgumi-metrics`-crate structs but left `DedupMetricsOutput.duplicate_rate` (in `fgumi_lib`) on raw serde `f64`. Make `fgumi_metrics::float` public and wire it there, so dedup's one fraction column formats like every other fgumi metric file (a whole-number rate writes `1`, not `1.0`).

> §0 re-scoping note: the audit named "dedup + clip" structs, but `ClippingMetrics` is all `usize` (no f64) and `UmiGroupingMetrics.avg_reads_per_molecule` is `#[serde(skip)]` — so `dedup.duplicate_rate` is the only serialized f64 gap. (Separately noted: #504's formatter special-cases integral/NaN/Inf but does not truncate to fgbio's 6-decimal `DecimalFormat`, so non-integral fractions still serialize at full precision — a deeper DXM3-04 item out of scope here.)

**DXM3-06** — `fgumi duplex-metrics` accepted `--min-ab-reads 0`, silently labeling every tag family a duplex. fgbio `CollectDuplexSeqMetrics` validates `minAbReads >= 1` (`CollectDuplexSeqMetrics.scala:288`). Add the guard; the message matches fgbio's wording.

**SIMM3-02** — `fgumi simplex-metrics` accepted `--min-reads 0` (every family of size ≥ 0 labeled a consensus family). Add the `min_reads >= 1` guard.

## Evidence

fgbio source confirms `validate(minAbReads >= 1, "min-ab-reads must be >= 1")`; fgumi now errors identically on `0`. Tests added: dedup float-format serialization (`1.0` → `1`), and duplex/simplex zero-threshold rejects.

Stacked on **#504** (`nh/fix-metrics-fgbio-parity`). Tracker: `reports/2026-07-09-fgumi-final-audit-burndown-tracker.md` (W3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made floating-point TSV formatting utilities available for broader integration and reuse.
  - Improved documentation for configuring custom metric serialization.

- **Bug Fixes**
  - Whole-number duplicate rates now appear without an unnecessary trailing “.0” in TSV output.
  - Added validation to reject `--min-reads 0` and `--min-ab-reads 0` with clear error messages.

- **Tests**
  - Added coverage for duplicate-rate formatting and invalid minimum-read settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->