### PR TITLE
fix(filter): count masked bases only for retained primary reads (FILT-05)

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -393,6 +393,53 @@ pub fn template_passes(raw_records: &[RawRecord], pass_map: &AHashMap<usize, boo
 
     has_primary && all_primary_pass
 }
+
+/// Sums the masked-base counts that fgbio's `maskedBases` statistic includes: only the
+/// **primary** reads of a **retained** template contribute; every read of a dropped
+/// template and every secondary/supplementary read contributes zero.
+///
+/// This mirrors `FilterConsensusReads.scala:207-219`, where fgbio accumulates
+/// `maskedBases += r1Result.maskedBases + r2Result.maskedBases` **only** inside
+/// `if (r1Result.keepRead && r2Result.keepRead)` and **only** over the primary R1/R2 —
+/// supplementary/secondary reads are filtered and written out, but their masked bases are
+/// never added to the tally ("Masked X of Y bases in retained primary consensus reads").
+///
+/// `masked_by_record[i]` is the number of bases masked in `raw_records[i]`; the slices are
+/// parallel and must be the same length. `template_pass` is the result of
+/// [`template_passes`] for this template (for the per-record streaming path, a single-read
+/// "template" whose pass value is the record's own filter result).
+///
+/// # Panics
+///
+/// Panics if `raw_records` and `masked_by_record` differ in length. A release-mode-silent
+/// truncation here would under/over-count the exact "Total bases masked" statistic this
+/// helper exists to compute, so the invariant is enforced unconditionally rather than only
+/// under `debug_assert`.
+#[must_use]
+pub fn retained_primary_masked_bases(
+    raw_records: &[RawRecord],
+    masked_by_record: &[u64],
+    template_pass: bool,
+) -> u64 {
+    assert_eq!(
+        raw_records.len(),
+        masked_by_record.len(),
+        "raw_records and masked_by_record must be parallel"
+    );
+    if !template_pass {
+        return 0;
+    }
+    raw_records
+        .iter()
+        .zip(masked_by_record)
+        .filter(|(record, _)| {
+            let flags = RawRecordView::new(record).flags();
+            (flags & bam_fields::flags::SECONDARY) == 0
+                && (flags & bam_fields::flags::SUPPLEMENTARY) == 0
+        })
+        .map(|(_, &masked)| masked)
+        .sum()
+}
 /// Pre-parsed methylation aux tags from a raw BAM record.
 ///
 /// Avoids repeated linear scans of the aux block when multiple filters
@@ -2236,5 +2283,74 @@ mod tests {
             expected,
             "aD={with_ad} bD={with_bd}: duplex iff both present"
         );
+    }
+
+    // -- FILT-05: the masked-bases statistic counts retained primary reads only --
+
+    /// Builds a minimal one-base raw record carrying only the given SAM flag bits.
+    fn record_with_flags(flag: u16) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.ref_id(0).pos(0).mapq(0).flags(flag).cigar_ops(&[1 << 4]).sequence(b"A").qualities(&[30]);
+        b.build()
+    }
+
+    /// fgbio accumulates `maskedBases` only for the **primary** reads of a **retained**
+    /// template (`FilterConsensusReads.scala:207-219`): the increment lives inside
+    /// `if (r1.keepRead && r2.keepRead)` and sums only R1/R2, never secondary/supplementary.
+    /// [`retained_primary_masked_bases`] must reproduce that: a dropped template contributes
+    /// 0, secondary/supplementary reads contribute 0 even when the template is kept, and a
+    /// kept template contributes exactly the sum over its primary reads.
+    #[rstest]
+    #[case::kept_primary(vec![(bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT, 7)], true, 7)]
+    #[case::dropped_template(vec![(bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT, 7)], false, 0)]
+    #[case::secondary_excluded(vec![(bam_fields::flags::SECONDARY, 7)], true, 0)]
+    #[case::supplementary_excluded(vec![(bam_fields::flags::SUPPLEMENTARY, 7)], true, 0)]
+    #[case::primary_pair_sums(vec![
+        (bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT, 3),
+        (bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT, 2),
+    ], true, 5)]
+    #[case::supplementary_excluded_from_kept_template(vec![
+        (bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT, 3),
+        (bam_fields::flags::SUPPLEMENTARY, 5),
+        (bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT, 2),
+    ], true, 5)]
+    #[case::mixed_template_dropped(vec![
+        (bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT, 3),
+        (bam_fields::flags::SUPPLEMENTARY, 5),
+        (bam_fields::flags::PAIRED | bam_fields::flags::LAST_SEGMENT, 2),
+    ], false, 0)]
+    // Boundary: an empty family contributes nothing even when "retained".
+    #[case::empty_family(vec![], true, 0)]
+    // An unpaired (fragment) primary read is not secondary/supplementary, so a
+    // retained single read still contributes its masked bases.
+    #[case::unpaired_single_primary(vec![(0, 4)], true, 4)]
+    fn test_retained_primary_masked_bases(
+        #[case] flags_and_masked: Vec<(u16, u64)>,
+        #[case] template_pass: bool,
+        #[case] expected: u64,
+    ) {
+        let records: Vec<RawRecord> =
+            flags_and_masked.iter().map(|&(flag, _)| record_with_flags(flag)).collect();
+        let masked_by_record: Vec<u64> =
+            flags_and_masked.iter().map(|&(_, masked)| masked).collect();
+
+        assert_eq!(
+            retained_primary_masked_bases(&records, &masked_by_record, template_pass),
+            expected,
+            "template_pass={template_pass}, records={flags_and_masked:?}"
+        );
+    }
+
+    /// The parallel-slice invariant is enforced with `assert_eq!` (not `debug_assert_eq!`)
+    /// so a length mismatch cannot silently truncate the masked-base tally in release
+    /// builds. `template_pass` is `true` here to prove the panic guards the counting path
+    /// itself, not merely the early `!template_pass` return.
+    #[rstest]
+    #[should_panic(expected = "raw_records and masked_by_record must be parallel")]
+    fn test_retained_primary_masked_bases_length_mismatch_panics() {
+        let records =
+            vec![record_with_flags(bam_fields::flags::PAIRED | bam_fields::flags::FIRST_SEGMENT)];
+        let masked_by_record: Vec<u64> = vec![3, 4];
+        let _ = retained_primary_masked_bases(&records, &masked_by_record, true);
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -17,7 +17,7 @@ use crate::consensus_filter::{
     filter_read, is_duplex_consensus, mask_bases, mask_duplex_bases,
     mask_methylation_depth_duplex_raw_with_tags, mask_methylation_depth_simplex_raw_with_tags,
     mask_strand_methylation_agreement_raw_with_ref_bases_and_tags, mean_base_quality_full_length,
-    template_passes,
+    retained_primary_masked_bases, template_passes,
 };
 use crate::grouper::{SingleRawRecordGrouper, TemplateGrouper};
 use crate::logging::OperationTimer;
@@ -554,7 +554,7 @@ impl Filter {
             let mut rejected_records: Vec<RawRecord> = Vec::new();
             let mut passed_count = 0u64;
 
-            let (bases_masked, pass) = Self::process_record_raw(
+            let (masked, pass) = Self::process_record_raw(
                 &mut record,
                 &ctx.config,
                 ctx.reference.as_deref(),
@@ -571,6 +571,13 @@ impl Filter {
                 &ctx.ref_names,
             )
             .map_err(io::Error::other)?;
+
+            // Match fgbio's `maskedBases`: count a record's masked bases only when it is a
+            // retained primary read (FilterConsensusReads.scala:207-219). In this per-record
+            // streaming mode the record is its own single-read "template", so `pass` is the
+            // template result; secondary/supplementary reads still contribute nothing.
+            let bases_masked =
+                retained_primary_masked_bases(std::slice::from_ref(&record), &[masked], pass);
 
             if pass {
                 passed_count = 1;
@@ -629,6 +636,7 @@ impl Filter {
             for template in batch {
                 let mut template_records: Vec<RawRecord> = template.into_records();
                 let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
+                let mut masked_by_record: Vec<u64> = Vec::with_capacity(template_records.len());
 
                 for (idx, record) in template_records.iter_mut().enumerate() {
                     total_records += 1;
@@ -650,11 +658,20 @@ impl Filter {
                         &ctx.ref_names,
                     )
                     .map_err(io::Error::other)?;
-                    bases_masked += masked;
+                    masked_by_record.push(masked);
                     pass_map.insert(idx, pass);
                 }
 
                 let template_pass = template_passes(&template_records, &pass_map);
+
+                // fgbio tallies masked bases only over the primary reads of retained
+                // templates (FilterConsensusReads.scala:207-219); a dropped template and
+                // any secondary/supplementary read contribute nothing.
+                bases_masked += retained_primary_masked_bases(
+                    &template_records,
+                    &masked_by_record,
+                    template_pass,
+                );
 
                 for (idx, record) in template_records.into_iter().enumerate() {
                     let flags = RawRecordView::new(&record).flags();


### PR DESCRIPTION
## What & why (FILT-05)

fgbio's `FilterConsensusReads` accumulates its `maskedBases` statistic **only** inside `if (r1Result.keepRead && r2Result.keepRead)` and **only** over the primary R1/R2 reads (`FilterConsensusReads.scala:207-219`). Secondary/supplementary reads are filtered and written out but never added to the tally, and reads in dropped templates contribute nothing — the log reads "Masked X of Y bases in **retained primary** consensus reads."

fgumi's `filter` instead added every processed record's masked-base count to the `Total bases masked` tally regardless of outcome:

- the template path (`execute_threads_mode_template`) summed masked bases for **every** record, ignoring `template_pass`, per-record pass, and read type;
- the single-read path (`execute_threads_mode_single_read`) emitted a record's masked count even when it was dropped.

So a read that was masked and then dropped (e.g. by the no-call threshold) inflated the statistic where fgbio reports zero. This was noted as a caveat while confirming the FILT-01/02/04 parity work (#493/#494).

## Fix

Add `retained_primary_masked_bases(raw_records, masked_by_record, template_pass)` next to `template_passes` in the consensus crate — it sums masked bases only for the **primary** reads of a **retained** template (returns 0 for a dropped template; skips secondary/supplementary). Both filter paths now route their tally through it; the single-read streaming path treats the record as its own single-read "template".

This is a **statistic-only** change. The mask/keep/drop decisions and the emitted BAM are unchanged (those already match fgbio via FILT-01/02/04) — only the log-only `Total bases masked` number moves to fgbio parity. It is not written to `--stats` and not compared by `compare bams`.

## Parity evidence

Input: one unmapped consensus read, `AAAAAAAAAA`, quals 5×Q40 + 5×Q10, per-read `cD:i:10`/`cE:f:0.01` and per-base `cd`/`ce` present, run with `--min-base-quality 30 --min-reads 1 --max-base-error-rate 0.1`. The 5 Q10 bases mask → 5 Ns.

| scenario | `--max-no-call-fraction` | outcome | before | after |
|---|---|---|---|---|
| masked then **dropped** | `0.2` (0.5 > 0.2) | read dropped | `Total bases masked: 5` | `Total bases masked: 0` |
| masked but **kept** | `0.6` (0.5 < 0.6) | read kept (`AAAAANNNNN`) | `Total bases masked: 5` | `Total bases masked: 5` |

Dropped-read output is identical (0 records) both ways; only the statistic changes. The kept case is unchanged, confirming the fix zeros only dropped reads.

## Tests / CI

- New `#[rstest]` case table `test_retained_primary_masked_bases` (kept primary; dropped template → 0; secondary/supplementary excluded even when kept; primary pair sums; supplementary excluded from an otherwise-kept template; mixed template dropped → 0).
- `cargo ci-fmt` / `ci-lint` / `ci-test` (2241 tests) all green.

Refs: FILT-05.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected “masked bases” counting to match fgbio retained-primary semantics.
  * Masked-base totals now include only retained **primary** reads.
  * Secondary and supplementary reads no longer contribute to masked-base totals.
  * Improved accuracy in both single-read and template modes, including paired/unpaired and empty/kept/dropped templates.
* **Tests**
  * Added coverage to verify correct retained-primary masking behavior and that length mismatches fail fast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->