### PR TITLE
fix(consensus): skip -inf lanes in ln_sum_exp_array to match fgbio's or() (SIMPLEX3-01)

### DIFF
--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -705,6 +705,40 @@ mod tests {
         assert!(qual <= 5, "Quality should be low due to conflicting evidence, got {qual}");
     }
 
+    /// SIMPLEX3-01: a Q0 observation of a *minority* base drives that base's
+    /// likelihood lane to `−∞`. The consensus base must stay the majority (`A`) and
+    /// the quality must NOT exceed the quality of the same pileup *without* the
+    /// contradicting read — a conflicting observation cannot increase confidence.
+    /// The pre-fix `ln_sum_exp_array` returned `−∞` for the normalizer whenever any
+    /// lane was `−∞`, driving the posterior to `+∞` and inflating the quality to the
+    /// pre-UMI cap (observed as fgumi Q45 vs fgbio Q44).
+    #[test]
+    fn test_neg_inf_lane_does_not_inflate_quality() {
+        let clean = {
+            let mut b = ConsensusBaseBuilder::new(45, 40);
+            b.add(b'A', 30);
+            b.add(b'A', 30);
+            b.call()
+        };
+        let with_q0_conflict = {
+            let mut b = ConsensusBaseBuilder::new(45, 40);
+            b.add(b'A', 30);
+            b.add(b'A', 30);
+            b.add(b'C', 0); // Q0 -> lane[C] = -inf
+            b.call()
+        };
+        assert_eq!(with_q0_conflict.0, b'A', "majority base must remain A");
+        // Pin the exact fgbio-compatible qualities: the clean 2×A pileup caps at Q44,
+        // and adding the Q0 (probability-0) `C` must leave it at Q44 — the pre-fix bug
+        // produced Q45 by driving the normalizer to +∞. Asserting the exact value (not
+        // just `conflict <= clean`) pins the fgbio baseline against future drift.
+        assert_eq!(clean.1, 44, "clean 2xA pileup must be fgbio's Q44");
+        assert_eq!(
+            with_q0_conflict.1, 44,
+            "a Q0 conflicting base must leave the quality at fgbio's Q44, not inflate it"
+        );
+    }
+
     // Port of fgbio test: "support calling multiple pileups from the same builder"
     #[test]
     fn test_reset_and_reuse_fgbio() {

--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -198,7 +198,7 @@ fn ln_one_minus_exp(x: f64) -> f64 {
 /// `test_ln_a_minus_b_near_equal_within_epsilon_*` and `test_ln_a_minus_b_panics_*` tests pin
 /// this boundary.
 ///
-/// Uses: a + log1mexp(a - b) for numerical stability.
+/// Uses: a + log1mexp(b - a) for numerical stability.
 #[inline]
 fn ln_a_minus_b(a: f64, b: f64) -> f64 {
     if b.is_infinite() && b < 0.0 {
@@ -208,7 +208,7 @@ fn ln_a_minus_b(a: f64, b: f64) -> f64 {
     } else if a < b {
         panic!("Subtraction will be less than zero.");
     } else {
-        // a + log(1 - exp(-(a-b))) = a + log1mexp(a-b)
+        // a + log(1 - exp(-(a-b))) = a + log1mexp(b-a)
         // In our convention, ln_one_minus_exp takes negative values, but here b < a
         a + ln_one_minus_exp(b - a)
     }

--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -322,7 +322,14 @@ pub fn ln_sum_exp(ln_a: LogProbability, ln_b: LogProbability) -> LogProbability 
 /// ```
 #[must_use]
 pub fn ln_sum_exp_array(values: &[LogProbability]) -> LogProbability {
-    if values.is_empty() {
+    // Mirror fgbio's `NumericTypes.or(values)`: the result is `−∞` only when the
+    // array is empty or *every* lane is `−∞`. A single `−∞` lane (e.g. a candidate
+    // base contradicted by a Q0/`error_rate_post_umi=0` observation) must NOT sink
+    // the whole sum — it contributes probability 0 and is skipped, just as fgbio's
+    // scalar `or` (and our `ln_sum_exp`) absorbs a `−∞` operand. Returning `−∞` here
+    // whenever the *minimum* lane is `−∞` drives the posterior to `+∞`, inflating the
+    // consensus quality to the pre-UMI cap instead of the correct, lower value.
+    if values.is_empty() || values.iter().all(|value| *value == f64::NEG_INFINITY) {
         return f64::NEG_INFINITY;
     }
 
@@ -333,9 +340,6 @@ pub fn ln_sum_exp_array(values: &[LogProbability]) -> LogProbability {
             min_index = i;
             min_value = *value;
         }
-    }
-    if min_value.is_infinite() {
-        return min_value;
     }
     let mut sum = min_value;
     for (i, value) in values.iter().enumerate() {
@@ -410,6 +414,32 @@ mod tests {
         let values = vec![0.1_f64.ln(), 0.2_f64.ln(), 0.3_f64.ln()];
         let result = ln_sum_exp_array(&values);
         assert!((result - 0.6_f64.ln()).abs() < 1e-10);
+    }
+
+    /// SIMPLEX3-01: a single `−∞` lane (probability 0) must be skipped, not sink the
+    /// whole sum. Mirrors fgbio's `NumericTypes.or`, which returns `−∞` only when every
+    /// lane is `−∞`. The `−∞` lane can be the minimum, first, last, or interior element.
+    #[rstest]
+    #[case::neg_inf_is_minimum(&[0.1_f64.ln(), f64::NEG_INFINITY, 0.3_f64.ln()], 0.4_f64.ln())]
+    #[case::neg_inf_first(&[f64::NEG_INFINITY, 0.2_f64.ln(), 0.3_f64.ln()], 0.5_f64.ln())]
+    #[case::neg_inf_last(&[0.1_f64.ln(), 0.2_f64.ln(), f64::NEG_INFINITY], 0.3_f64.ln())]
+    #[case::two_neg_inf(&[f64::NEG_INFINITY, 0.25_f64.ln(), f64::NEG_INFINITY], 0.25_f64.ln())]
+    fn test_ln_sum_exp_array_skips_neg_inf_lanes(#[case] values: &[f64], #[case] expected: f64) {
+        let result = ln_sum_exp_array(values);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "got {result}, expected {expected} for {values:?}"
+        );
+    }
+
+    /// An all-`−∞` array (and the empty array) yields `−∞`, matching fgbio's
+    /// `values.forall(_.isNegInfinity)` guard.
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::all_neg_inf(&[f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY])]
+    fn test_ln_sum_exp_array_all_neg_inf_is_neg_inf(#[case] values: &[f64]) {
+        let result = ln_sum_exp_array(values);
+        assert!(result.is_infinite() && result < 0.0, "expected −∞, got {result}");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #507 (base branch `nh/fix-consensus-glue-guards`) — both touch `crates/fgumi-consensus/src/phred.rs` (different functions; #507 fixes `ln_a_minus_b`, this fixes `ln_sum_exp_array`). Merge #507 first.

Fixes the audit's single most severe untouched simplex finding, **SIMPLEX3-01 (S1)**.

## The bug

`ln_sum_exp_array` returned `-inf` whenever the **minimum** likelihood lane was `-inf`, even when a different base had a unique finite maximum:

```rust
if min_value.is_infinite() { return min_value; }   // wrong: one -inf lane sinks the whole sum
```

A single `-inf` lane arises when a candidate base is contradicted by a Q0 observation (reachable via `--min-input-base-quality 0`) or by `--error-rate-post-umi 0`. That `-inf` normalizer drives the posterior to `+inf` and the consensus error to `-inf`, so the caller emits the **maximum** (pre-UMI-capped) quality instead of the correct, lower one.

fgbio's `NumericTypes.or(values)` returns `-inf` only when **every** lane is `-inf`; otherwise its scalar `or` (like our own `ln_sum_exp`) absorbs a `-inf` operand, so a contradicted lane contributes probability 0 and is skipped. This change matches that: return `-inf` only for an empty or all-`-inf` array, then let the min-based fold skip the `-inf` lanes.

## Parity evidence (real fgbio 4.1.0 CallMolecularConsensusReads)

A grouped family with a Q0 minority base, run with `--min-input-base-quality 0`, comparing the R1 consensus at the contradicted locus:

| case | fgbio | fgumi before | fgumi after |
|------|-------|--------------|-------------|
| clean family | `ACGT MMMM` | `ACGT MMMM` | `ACGT MMMM` |
| Q0 minority base | `ACGT MNNN` (Q44) | `ACGT NNNN` (Q45) | `ACGT MNNN` (Q44) |

Before: fgumi inflated the contradicted locus to Q45 (max); after: byte-identical to fgbio.

## No CLI guard added

The audit suggested also guarding `--min-input-base-quality >= 1` / `--error-rate-post-umi >= 1`. I deliberately did **not** add these: fgbio accepts `0` for both and produces correct output via `or()`, so guarding them in fgumi would over-restrict relative to fgbio (a FILT3-09-style divergence). The numeric fix alone restores parity.

## Tests

- `phred`: rstest tables for the `-inf`-lane cases (minimum / first / last / interior, all-`-inf`, empty).
- `base_builder`: regression asserting a Q0 conflicting base never inflates the called quality above the unconflicted pileup.

`cargo ci-fmt && ci-lint && ci-test` green (2215 tests).

## Reviewers

Local `/coderabbitai-review` clean (0 actionable). `coderabbit --agent` CLI was rate-limited at review time; relying on the PR-level CodeRabbit bot for the second pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consensus quality calculations when observations contain zero-quality or impossible likelihood values.
  * Prevented invalid quality inflation while preserving the correct majority consensus base.
  * Improved numerical handling for edge cases involving extremely small or equivalent probability values.
  * Added safeguards for invalid probability subtraction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->