### PR TITLE
fix(consensus): emit @HD SO:unsorted to match fgbio

### DIFF
--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -14,6 +14,8 @@ use log::info;
 use noodles::sam::Header;
 use noodles::sam::header::record::value::Map;
 use noodles::sam::header::record::value::map::ReadGroup;
+use noodles::sam::header::record::value::map::header::group_order::QUERY;
+use noodles::sam::header::record::value::map::header::sort_order::UNSORTED;
 use noodles::sam::header::record::value::map::header::tag as header_tag;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use noodles::sam::header::record::value::map::tag::Other;
@@ -114,7 +116,8 @@ fn collapse_read_group_tag(input_header: &Header, tag: Other<rg_tag::Standard>) 
 /// - A single read group with the specified ID and attributes collapsed from all
 ///   input read groups (SM, LB, PL, PU, CN, DS tags are deduplicated and
 ///   comma-joined when multiple distinct values exist)
-/// - Sort order set to "unknown" and group order to "query"
+/// - Sort order set to "unsorted" and group order to "query" (matches fgbio's
+///   unmapped consensus output header exactly)
 /// - A comment indicating the number of input read groups
 /// - A @PG record with version and command line
 pub fn create_unmapped_consensus_header(
@@ -145,8 +148,8 @@ pub fn create_unmapped_consensus_header(
 
     // Set sort order
     let header_map = Map::<noodles::sam::header::record::value::map::Header>::builder()
-        .insert(header_tag::SORT_ORDER, BString::from("unknown"))
-        .insert(header_tag::GROUP_ORDER, BString::from("query"))
+        .insert(header_tag::SORT_ORDER, BString::from(UNSORTED))
+        .insert(header_tag::GROUP_ORDER, BString::from(QUERY))
         .build()?;
     output_header = output_header.set_header(header_map);
 
@@ -352,6 +355,29 @@ mod tests {
         assert!(rg.other_fields().get(&rg_tag::SAMPLE).is_none());
         assert!(rg.other_fields().get(&rg_tag::LIBRARY).is_none());
         assert!(rg.other_fields().get(&rg_tag::PLATFORM).is_none());
+    }
+
+    #[test]
+    fn test_create_unmapped_consensus_header_sort_order_matches_fgbio() {
+        // fgbio emits `@HD SO:unsorted GO:query` for unmapped consensus output
+        // (simplex/duplex/codec); fgumi must match exactly -- `SO:unknown` is a
+        // real header divergence `fgumi compare` now catches (compare-hardening
+        // §"Compare the header").
+        let input_header = Header::builder().build();
+        let output_header =
+            create_unmapped_consensus_header(&input_header, "A", "Read group", "fgumi simplex")
+                .expect("create_unmapped_consensus_header should succeed");
+
+        let hd = output_header.header().expect("@HD record must be present");
+        assert_eq!(
+            hd.other_fields().get(&header_tag::SORT_ORDER).map(|v| v.to_vec()),
+            Some(b"unsorted".to_vec()),
+            "SO must be 'unsorted' to match fgbio, not 'unknown'"
+        );
+        assert_eq!(
+            hd.other_fields().get(&header_tag::GROUP_ORDER).map(|v| v.to_vec()),
+            Some(b"query".to_vec())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Unmapped consensus output (`simplex`/`duplex`/`codec`) wrote `@HD ... SO:unknown` while fgbio's consensus tools emit `SO:unsorted` (both with `GO:query`). This changes `create_unmapped_consensus_header` to emit `SO:unsorted`, matching fgbio exactly.

## Evidence (real-data validation)

Across every consensus cross-compare on real data — `idt-cfdna`/`SRR6109255`/`SRR6109273`/`schmitt-abl1` simplex & duplex and `CODEC` codec — consensus record content was already byte-identical to fgbio (content diffs: 0); the **sole** divergence was this one header field, `@HD SO: "unknown" vs "unsorted"`.

Confirmed with the fixed binary on `idt-cfdna` duplex: regenerated output header is now `@HD VN:1.6 SO:unsorted GO:query`, byte-identical to the fgbio baseline, and the record comparison remains EQUIVALENT (322/322 records, 0 grouping mismatches).

## Testing

- New regression test `test_create_unmapped_consensus_header_sort_order_matches_fgbio` asserts `SO == unsorted` and `GO == query`.
- `cargo nextest` (consensus_runner module), `cargo clippy --workspace --all-targets --features compare,simulate,profile-adjacency -- -D warnings -W clippy::pedantic`, and `cargo fmt --check` all clean.

## Notes

Independent of #508 (`fix(consensus): sort-order + error-rate guards`), which validates consensus **input** sort order (`checkSortOrder`) and does not touch the output `@HD SO` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unmapped consensus SAM headers to use the standard `unsorted` sort order and `query` read-group order.
  * Improved compatibility with fgbio by matching its expected header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->