### PR TITLE
fix(clip): strand-normalize overlap clipping, count existing fixed clipping, honor SoftWithMask upgrade (CLIP3-01/02/03)

### DIFF
--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -1126,9 +1126,27 @@ impl SamRecordClipper {
                 *record.sequence_mut() = Sequence::from(seq[..new_len].to_vec());
                 *record.quality_scores_mut() = QualityScores::from(quals[..new_len].to_vec());
             }
+        } else if self.mode == ClippingMode::SoftWithMask {
+            // SoftWithMask: leave the soft clipping in the CIGAR but mask the upgraded
+            // soft-clipped bases to N with minimum quality. Mirrors fgbio's
+            // hardMaskStartOfRead call in upgradeClipping (SamRecordClipper.scala:528-529).
+            // Bases are not removed, so the CIGAR and extended attributes are untouched
+            // (fgbio's clipExtendedAttributes is a no-op outside Hard mode).
+            let mut new_seq = record.sequence().as_ref().to_vec();
+            let mut new_qual = record.quality_scores().as_ref().to_vec();
+            let seq_len = new_seq.len();
+            let (mask_start, mask_end) = if from_start {
+                (0, length_to_upgrade)
+            } else {
+                (seq_len - length_to_upgrade, seq_len)
+            };
+            for i in mask_start..mask_end {
+                new_seq[i] = NO_CALL_BASE;
+                new_qual[i] = MIN_PHRED;
+            }
+            *record.sequence_mut() = Sequence::from(new_seq);
+            *record.quality_scores_mut() = QualityScores::from(new_qual);
         }
-        // Note: SoftWithMask mode would use hard_mask_start_of_read/hard_mask_end_of_read
-        // but we don't implement that yet
     }
 
     /// Ensures at least `clip_length` bases are clipped at the start of the read
@@ -1213,12 +1231,17 @@ impl SamRecordClipper {
 
     /// Upgrades all existing clipping in a read to the current clipping mode
     ///
-    /// E.g., converts soft clips to hard clips if mode is Hard,
-    /// or soft clips to soft-with-mask if mode is `SoftWithMask`
+    /// In `Hard` mode existing soft clips are converted to hard clips (and the
+    /// corresponding bases removed from the sequence); in `SoftWithMask` mode the
+    /// CIGAR is left intact and the soft-clipped bases are masked to N with minimum
+    /// quality. `Soft` mode is a no-op.
     ///
-    /// Returns `(leading_clipped, trailing_clipped)` - the number of soft-clipped
-    /// bases that were converted to hard clips at the 5' and 3' ends respectively.
-    /// Returns `(0, 0)` if no conversion occurred.
+    /// Returns `(leading, trailing)` - the number of soft-clipped bases upgraded at
+    /// the CIGAR-leading and CIGAR-trailing ends respectively (converted in `Hard`
+    /// mode, masked in `SoftWithMask` mode). The ordering is by CIGAR position, not
+    /// biological 5'/3' end, so it is independent of strand (on a reverse-strand read
+    /// the CIGAR-leading end is the biological 3' end). Returns `(0, 0)` if nothing
+    /// was upgraded.
     ///
     /// # Panics
     ///
@@ -1240,8 +1263,8 @@ impl SamRecordClipper {
         reason = "CIGAR rewriting with attribute clipping requires many branches"
     )]
     pub fn upgrade_all_clipping(&self, record: &mut RecordBuf) -> Result<(usize, usize)> {
-        // Only upgrade in Hard mode
-        if !matches!(self.mode, ClippingMode::Hard) {
+        // Only upgrade in Hard or SoftWithMask mode (Soft leaves clipping untouched).
+        if matches!(self.mode, ClippingMode::Soft) {
             return Ok((0, 0));
         }
 
@@ -1276,15 +1299,30 @@ impl SamRecordClipper {
         }
 
         // Count trailing soft clips (from the end)
+        let mut trailing_hard = 0;
         for op in ops.iter().rev() {
             match op.kind() {
-                Kind::HardClip => {}
+                Kind::HardClip => trailing_hard += op.len(),
                 Kind::SoftClip => {
                     trailing_soft += op.len();
                     break;
                 }
                 _ => break,
             }
+        }
+
+        // SoftWithMask: mask the existing soft-clipped bases at both ends to N/min-quality,
+        // leaving the CIGAR intact. Delegates to upgrade_clipping per end, mirroring fgbio
+        // upgradeAllClipping's clipStartOfRead/clipEndOfRead -> upgradeClipping path
+        // (SamRecordClipper.scala:274-290). Returns the soft counts that were masked.
+        if self.mode == ClippingMode::SoftWithMask {
+            if leading_soft > 0 {
+                self.upgrade_clipping(record, leading_hard + leading_soft, true);
+            }
+            if trailing_soft > 0 {
+                self.upgrade_clipping(record, trailing_hard + trailing_soft, false);
+            }
+            return Ok((leading_soft, trailing_soft));
         }
 
         // Build new CIGAR, converting soft clips to hard clips
@@ -2322,12 +2360,33 @@ impl RawRecordClipper {
                 record.set_sequence_and_qualities(&new_seq, &new_qual);
             }
             self.clip_extended_attributes_raw(record, length_to_upgrade, from_start);
+        } else if self.mode == ClippingMode::SoftWithMask {
+            // SoftWithMask: mask the upgraded soft-clipped bases to N/min-quality without
+            // altering the CIGAR (see the typed `upgrade_clipping` for rationale).
+            let mut new_seq = record.sequence_vec();
+            let mut new_qual = record.quality_scores().to_vec();
+            let seq_len = new_seq.len();
+            let (mask_start, mask_end) = if from_start {
+                (0, length_to_upgrade)
+            } else {
+                (seq_len - length_to_upgrade, seq_len)
+            };
+            for i in mask_start..mask_end {
+                new_seq[i] = fgumi_dna::NO_CALL_BASE;
+                new_qual[i] = fgumi_dna::MIN_PHRED;
+            }
+            record.set_sequence_and_qualities(&new_seq, &new_qual);
         }
     }
 
-    /// Upgrades all existing soft clips to hard clips in a raw record.
+    /// Upgrades all existing clipping in a raw record to the current clipping mode.
     ///
-    /// Returns `(leading_soft, trailing_soft)` — the counts converted.
+    /// In `Hard` mode soft clips are converted to hard clips (bases removed); in
+    /// `SoftWithMask` mode the CIGAR is left intact and the soft-clipped bases are
+    /// masked to N with minimum quality. `Soft` mode is a no-op.
+    ///
+    /// Returns `(leading_soft, trailing_soft)` — the soft-clip counts upgraded at
+    /// each end (converted in `Hard` mode, masked in `SoftWithMask` mode).
     ///
     /// # Errors
     ///
@@ -2345,7 +2404,7 @@ impl RawRecordClipper {
         &self,
         record: &mut fgumi_raw_bam::RawRecord,
     ) -> anyhow::Result<(usize, usize)> {
-        if !matches!(self.mode, ClippingMode::Hard) {
+        if matches!(self.mode, ClippingMode::Soft) {
             return Ok((0, 0));
         }
         if record.flags() & fgumi_raw_bam::flags::UNMAPPED != 0 {
@@ -2361,6 +2420,7 @@ impl RawRecordClipper {
         let mut leading_hard: usize = 0;
         let mut leading_soft: usize = 0;
         let mut trailing_soft: usize = 0;
+        let mut trailing_hard: usize = 0;
 
         for &op in &ops {
             match op & 0xF {
@@ -2375,13 +2435,25 @@ impl RawRecordClipper {
         }
         for &op in ops.iter().rev() {
             match op & 0xF {
-                5 => {}
+                5 => trailing_hard += (op >> 4) as usize,
                 4 => {
                     trailing_soft += (op >> 4) as usize;
                     break;
                 }
                 _ => break,
             }
+        }
+
+        // SoftWithMask: mask existing soft-clipped bases at both ends via upgrade_clipping_raw,
+        // leaving the CIGAR intact (see the typed upgrade_all_clipping for rationale).
+        if self.mode == ClippingMode::SoftWithMask {
+            if leading_soft > 0 {
+                self.upgrade_clipping_raw(record, leading_hard + leading_soft, true);
+            }
+            if trailing_soft > 0 {
+                self.upgrade_clipping_raw(record, trailing_hard + trailing_soft, false);
+            }
+            return Ok((leading_soft, trailing_soft));
         }
 
         let old_seq_len = record.l_seq() as usize;
@@ -5079,18 +5151,62 @@ mod tests {
     }
 
     #[test]
-    fn test_not_upgrade_soft_with_mask_to_soft_with_mask() {
-        // Same mode - should not upgrade
+    fn test_upgrade_all_clipping_soft_with_mask_masks_existing_soft_clips() {
+        // CLIP3-03: SoftWithMask must mask existing soft-clipped bases to N/min-quality
+        // (CIGAR unchanged), matching fgbio upgradeAllClipping. Previously a no-op.
         let clipper = SamRecordClipper::new(ClippingMode::SoftWithMask);
-        let seq = "12345678901234567890123456789012345678901234567890";
+        let seq = "ACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTG"; // 50 bases, no N
         let mut record = create_test_record("5S35M10S", seq, 10);
 
         let result =
             clipper.upgrade_all_clipping(&mut record).expect("upgrade_all_clipping should succeed");
-        assert_eq!(result, (0, 0));
+        assert_eq!(result, (5, 10), "returns the (leading, trailing) soft counts masked");
 
-        let cigar_str = format_cigar(&record.cigar());
-        assert_eq!(cigar_str, "5S35M10S");
+        // CIGAR is unchanged; only the bases/quals of the soft-clipped regions change.
+        assert_eq!(format_cigar(&record.cigar()), "5S35M10S");
+
+        let bases = record.sequence().as_ref().to_vec();
+        assert!(bases[..5].iter().all(|&b| b == NO_CALL_BASE), "leading soft bases masked to N");
+        assert!(bases[40..].iter().all(|&b| b == NO_CALL_BASE), "trailing soft bases masked to N");
+        assert!(bases[5..40].iter().all(|&b| b != NO_CALL_BASE), "aligned bases untouched");
+
+        let quals = record.quality_scores().as_ref().to_vec();
+        assert!(quals[..5].iter().all(|&q| q == MIN_PHRED), "leading soft quals masked");
+        assert!(quals[40..].iter().all(|&q| q == MIN_PHRED), "trailing soft quals masked");
+    }
+
+    #[test]
+    fn test_upgrade_all_clipping_raw_soft_with_mask_masks_existing_soft_clips() {
+        // CLIP3-03 (raw): same masking behavior for the raw-byte upgrade path.
+        use fgumi_raw_bam::encode_record_buf_to_raw;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+
+        let seq = "ACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTGACGTG"; // 50 bases, no N
+        let buf = create_test_record("5S35M10S", seq, 10);
+        let ref_seq =
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(100_000).expect("ref length nonzero"));
+        let header =
+            noodles::sam::Header::builder().add_reference_sequence(b"chr1", ref_seq).build();
+        let mut raw = encode_record_buf_to_raw(&buf, &header).expect("encode raw");
+
+        let clipper = RawRecordClipper::new(ClippingMode::SoftWithMask);
+        let result =
+            clipper.upgrade_all_clipping_raw(&mut raw).expect("upgrade_all_clipping_raw succeeds");
+        assert_eq!(result, (5, 10));
+
+        // CIGAR unchanged: 5S 35M 10S.
+        assert_eq!(raw.cigar_ops_vec(), vec![(5u32 << 4) | 4, 35u32 << 4, (10u32 << 4) | 4]);
+
+        let bases = raw.sequence_vec();
+        assert!(bases[..5].iter().all(|&b| b == fgumi_dna::NO_CALL_BASE), "leading masked to N");
+        assert!(bases[40..].iter().all(|&b| b == fgumi_dna::NO_CALL_BASE), "trailing masked to N");
+        assert!(bases[5..40].iter().all(|&b| b != fgumi_dna::NO_CALL_BASE), "aligned untouched");
+
+        let quals = raw.quality_scores().to_vec();
+        assert!(quals[..5].iter().all(|&q| q == fgumi_dna::MIN_PHRED), "leading quals masked");
+        assert!(quals[40..].iter().all(|&q| q == fgumi_dna::MIN_PHRED), "trailing quals masked");
     }
 
     #[test]
@@ -5951,8 +6067,13 @@ mod crosscheck_tests {
     // upgrade_all_clipping cross-checks
     // =========================================================================
 
-    #[test]
-    fn crosscheck_upgrade_all_clipping_hard() {
+    // Hard converts the soft clips to hard clips (removing bases); SoftWithMask masks the
+    // soft-clipped bases to N/min-quality while leaving the CIGAR intact. Both are checked for
+    // raw/typed parity here. Soft is a documented no-op for upgrade and is omitted.
+    #[rstest]
+    #[case::hard(ClippingMode::Hard)]
+    #[case::soft_with_mask(ClippingMode::SoftWithMask)]
+    fn crosscheck_upgrade_all_clipping(#[case] mode: ClippingMode) {
         // 10S30M10S: query length = 50
         let mut buf = RecordBuilder::mapped_read()
             .sequence(&"A".repeat(50))
@@ -5961,16 +6082,27 @@ mod crosscheck_tests {
             .build();
         let mut raw = to_raw(&buf);
 
-        let buf_result = SamRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping(&mut buf);
-        let raw_result =
-            RawRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping_raw(&mut raw);
+        let buf_result = SamRecordClipper::new(mode).upgrade_all_clipping(&mut buf);
+        let raw_result = RawRecordClipper::new(mode).upgrade_all_clipping_raw(&mut raw);
 
-        assert_eq!(buf_result.unwrap(), raw_result.unwrap(), "upgrade_all_clipping return value");
-        assert_raw_matches_buf(&raw, &buf, "upgrade_all_clipping Hard 10S30M10S");
+        assert_eq!(
+            buf_result.unwrap(),
+            raw_result.unwrap(),
+            "upgrade_all_clipping return value mode={mode:?}",
+        );
+        assert_raw_matches_buf(
+            &raw,
+            &buf,
+            &format!("upgrade_all_clipping mode={mode:?} 10S30M10S"),
+        );
     }
 
-    #[test]
-    fn crosscheck_upgrade_all_clipping_no_soft_clips() {
+    // With no soft clips both modes early-return (0, 0) and leave the record untouched; check
+    // raw/typed parity for each.
+    #[rstest]
+    #[case::hard(ClippingMode::Hard)]
+    #[case::soft_with_mask(ClippingMode::SoftWithMask)]
+    fn crosscheck_upgrade_all_clipping_no_soft_clips(#[case] mode: ClippingMode) {
         let mut buf = RecordBuilder::mapped_read()
             .sequence(&"A".repeat(50))
             .cigar("50M")
@@ -5978,19 +6110,29 @@ mod crosscheck_tests {
             .build();
         let mut raw = to_raw(&buf);
 
-        let buf_result = SamRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping(&mut buf);
-        let raw_result =
-            RawRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping_raw(&mut raw);
+        let buf_result = SamRecordClipper::new(mode).upgrade_all_clipping(&mut buf);
+        let raw_result = RawRecordClipper::new(mode).upgrade_all_clipping_raw(&mut raw);
 
-        assert_eq!(buf_result.unwrap(), raw_result.unwrap(), "no soft clips return value");
-        assert_raw_matches_buf(&raw, &buf, "upgrade_all_clipping Hard 50M (no-op)");
+        assert_eq!(
+            buf_result.unwrap(),
+            raw_result.unwrap(),
+            "no soft clips return value mode={mode:?}",
+        );
+        assert_raw_matches_buf(
+            &raw,
+            &buf,
+            &format!("upgrade_all_clipping mode={mode:?} 50M (no-op)"),
+        );
     }
 
     /// Ref-only CIGAR ops (D/N/P) must not advance `seq_pos` in the raw path,
     /// or trailing query bases get shifted vs. the typed path. Uses a varied
-    /// sequence and varied qualities so any mis-aligned copy is visible.
-    #[test]
-    fn crosscheck_upgrade_all_clipping_with_deletion() {
+    /// sequence and varied qualities so any mis-aligned copy (Hard) or mis-aligned
+    /// mask (`SoftWithMask`) is visible. Both modes are checked for raw/typed parity.
+    #[rstest]
+    #[case::hard(ClippingMode::Hard)]
+    #[case::soft_with_mask(ClippingMode::SoftWithMask)]
+    fn crosscheck_upgrade_all_clipping_with_deletion(#[case] mode: ClippingMode) {
         // 10S20M5D20M10S: query length = 60 (D does not consume query).
         let bases = b"ACGT";
         let seq: String = (0..60).map(|i| bases[i % bases.len()] as char).collect();
@@ -6003,16 +6145,19 @@ mod crosscheck_tests {
             .build();
         let mut raw = to_raw(&buf);
 
-        let buf_result = SamRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping(&mut buf);
-        let raw_result =
-            RawRecordClipper::new(ClippingMode::Hard).upgrade_all_clipping_raw(&mut raw);
+        let buf_result = SamRecordClipper::new(mode).upgrade_all_clipping(&mut buf);
+        let raw_result = RawRecordClipper::new(mode).upgrade_all_clipping_raw(&mut raw);
 
         assert_eq!(
             buf_result.unwrap(),
             raw_result.unwrap(),
-            "upgrade_all_clipping return value with deletion",
+            "upgrade_all_clipping return value with deletion mode={mode:?}",
         );
-        assert_raw_matches_buf(&raw, &buf, "upgrade_all_clipping Hard 10S20M5D20M10S");
+        assert_raw_matches_buf(
+            &raw,
+            &buf,
+            &format!("upgrade_all_clipping mode={mode:?} 10S20M5D20M10S"),
+        );
     }
 
     // =========================================================================

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -677,6 +677,15 @@ impl SamRecordClipper {
             return (0, 0);
         }
 
+        // Normalize by strand so the positive-strand read is treated as r1 and the
+        // negative-strand read as r2. The body below assumes r1 is the forward read
+        // (5' at its start) and r2 the reverse read (5' at its end); an FR pair whose
+        // first-of-pair read is the reverse strand would otherwise be clipped at the
+        // wrong (outer) ends. Mirrors fgbio `SamRecordClipper.clipOverlappingReads`
+        // (`if (rec.negativeStrand) clipOverlappingReads(rec=mate, mate=rec).swap`).
+        let swapped = r1.flags().is_reverse_complemented();
+        let (r1, r2) = if swapped { (r2, r1) } else { (r1, r2) };
+
         // Get alignment positions
         let r1_start = match r1.alignment_start() {
             Some(pos) => usize::from(pos),
@@ -751,7 +760,8 @@ impl SamRecordClipper {
             let _ = self.upgrade_all_clipping(r2);
         }
 
-        (clipped_r1, clipped_r2)
+        // Map clip counts back to the caller's original (r1, r2) argument order.
+        if swapped { (clipped_r2, clipped_r1) } else { (clipped_r1, clipped_r2) }
     }
 
     /// Calculates the number of bases in a read that extend past the mate's unclipped boundary
@@ -1962,6 +1972,12 @@ impl RawRecordClipper {
             return (0, 0);
         }
 
+        // Normalize by strand so the positive-strand read is treated as r1 and the
+        // negative-strand read as r2 (see the typed `clip_overlapping_reads` for the
+        // rationale; mirrors fgbio `SamRecordClipper.clipOverlappingReads:305`).
+        let swapped = r1.flags() & fgumi_raw_bam::flags::REVERSE != 0;
+        let (r1, r2) = if swapped { (r2, r1) } else { (r1, r2) };
+
         let Some(r1_start) = r1.alignment_start_1based() else {
             return (0, 0);
         };
@@ -2018,7 +2034,8 @@ impl RawRecordClipper {
             let _ = self.upgrade_all_clipping_raw(r2);
         }
 
-        (clipped_r1, clipped_r2)
+        // Map clip counts back to the caller's original (r1, r2) argument order.
+        if swapped { (clipped_r2, clipped_r1) } else { (clipped_r1, clipped_r2) }
     }
 
     /// Returns the number of bases extending past the mate's boundaries.
@@ -2636,6 +2653,7 @@ pub mod cigar_utils {
 mod tests {
     use super::*;
     use crate::builder::RecordBuilder;
+    use rstest::rstest;
 
     #[test]
     fn test_clipping_mode() {
@@ -4379,6 +4397,94 @@ mod tests {
         *r2.template_length_mut() = -tlen;
 
         (r1, r2)
+    }
+
+    /// CLIP3-01 (typed): `clip_overlapping_reads` must normalize by *strand*, not by
+    /// argument order. Passing the negative-strand read first must produce the same
+    /// per-record clipping as passing the positive-strand read first, with the
+    /// returned tuple swapped. Mirrors fgbio `SamRecordClipper.clipOverlappingReads`
+    /// (`if (rec.negativeStrand) clipOverlappingReads(rec=mate, mate=rec).swap`).
+    #[rstest]
+    #[case::one_base_overlap(1, 100)]
+    #[case::large_overlap(1, 50)]
+    #[case::most_overlap(1, 20)]
+    fn test_clip_overlapping_reads_normalizes_by_strand_typed(
+        #[case] fwd_start: usize,
+        #[case] rev_start: usize,
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        let clipper = SamRecordClipper::new(mode);
+        let seq = "A".repeat(100);
+
+        // Forward-first: positive-strand read passed first (canonical, already handled).
+        let mut fwd_a =
+            create_paired_record("100M", &seq, fwd_start, false, true, rev_start, "100M");
+        let mut rev_a =
+            create_paired_record("100M", &seq, rev_start, true, false, fwd_start, "100M");
+        let (clip_fwd_a, clip_rev_a) = clipper.clip_overlapping_reads(&mut fwd_a, &mut rev_a);
+
+        // Reverse-first: same biology, negative-strand read passed first.
+        let mut rev_b =
+            create_paired_record("100M", &seq, rev_start, true, false, fwd_start, "100M");
+        let mut fwd_b =
+            create_paired_record("100M", &seq, fwd_start, false, true, rev_start, "100M");
+        let (clip_rev_b, clip_fwd_b) = clipper.clip_overlapping_reads(&mut rev_b, &mut fwd_b);
+
+        // Same per-record clip counts regardless of argument order.
+        assert_eq!(clip_fwd_a, clip_fwd_b, "forward-read clip count differs by arg order");
+        assert_eq!(clip_rev_a, clip_rev_b, "reverse-read clip count differs by arg order");
+
+        // Same resulting record state (CIGAR + alignment start) for each read.
+        assert_eq!(format_cigar(&fwd_a.cigar()), format_cigar(&fwd_b.cigar()), "forward CIGAR");
+        assert_eq!(fwd_a.alignment_start(), fwd_b.alignment_start(), "forward start");
+        assert_eq!(format_cigar(&rev_a.cigar()), format_cigar(&rev_b.cigar()), "reverse CIGAR");
+        assert_eq!(rev_a.alignment_start(), rev_b.alignment_start(), "reverse start");
+    }
+
+    /// CLIP3-01 (raw): same strand-normalization requirement for the raw-byte
+    /// `clip_overlapping_reads` used by the `clip` command's hot path.
+    #[rstest]
+    #[case::one_base_overlap(1, 100)]
+    #[case::large_overlap(1, 50)]
+    #[case::most_overlap(1, 20)]
+    fn test_clip_overlapping_reads_normalizes_by_strand_raw(
+        #[case] fwd_start: usize,
+        #[case] rev_start: usize,
+        #[values(ClippingMode::Soft, ClippingMode::Hard)] mode: ClippingMode,
+    ) {
+        use fgumi_raw_bam::encode_record_buf_to_raw;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+
+        let seq = "A".repeat(100);
+        let ref_seq =
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(100_000).expect("ref length nonzero"));
+        let header =
+            noodles::sam::Header::builder().add_reference_sequence(b"chr1", ref_seq).build();
+        let clipper = RawRecordClipper::new(mode);
+        let enc = |buf: &RecordBuf| encode_record_buf_to_raw(buf, &header).expect("encode raw");
+
+        // Forward-first.
+        let mut fwd_a =
+            enc(&create_paired_record("100M", &seq, fwd_start, false, true, rev_start, "100M"));
+        let mut rev_a =
+            enc(&create_paired_record("100M", &seq, rev_start, true, false, fwd_start, "100M"));
+        let (clip_fwd_a, clip_rev_a) = clipper.clip_overlapping_reads(&mut fwd_a, &mut rev_a);
+
+        // Reverse-first.
+        let mut rev_b =
+            enc(&create_paired_record("100M", &seq, rev_start, true, false, fwd_start, "100M"));
+        let mut fwd_b =
+            enc(&create_paired_record("100M", &seq, fwd_start, false, true, rev_start, "100M"));
+        let (clip_rev_b, clip_fwd_b) = clipper.clip_overlapping_reads(&mut rev_b, &mut fwd_b);
+
+        assert_eq!(clip_fwd_a, clip_fwd_b, "forward-read clip count differs by arg order");
+        assert_eq!(clip_rev_a, clip_rev_b, "reverse-read clip count differs by arg order");
+        assert_eq!(fwd_a.cigar_ops_vec(), fwd_b.cigar_ops_vec(), "forward CIGAR");
+        assert_eq!(fwd_a.alignment_start_1based(), fwd_b.alignment_start_1based(), "forward start");
+        assert_eq!(rev_a.cigar_ops_vec(), rev_b.cigar_ops_vec(), "reverse CIGAR");
+        assert_eq!(rev_a.alignment_start_1based(), rev_b.alignment_start_1based(), "reverse start");
     }
 
     #[test]

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -346,63 +346,15 @@ fn rebuild_header_with_hd(
     builder.set_header(header_map).build()
 }
 
-/// Returns a copy of `header` with its sort-order metadata cleared.
+/// Returns a copy of `header` with its `@HD` sort-order tags stamped.
 ///
-/// The `SO` tag is set to `unsorted` and any `GO` (group order) or `SS`
-/// (sub-sort) tags are removed. Use this when writing records whose emission
-/// order does not match the input's advertised sort order, so downstream tools
-/// don't mistakenly assume the output is sorted.
-#[must_use]
-pub fn header_as_unsorted(header: &Header) -> Header {
-    use bstr::BString;
-    use noodles::sam::header::record::value::Map;
-    use noodles::sam::header::record::value::map::header::tag::SORT_ORDER;
-
-    let mut header_map = header
-        .header()
-        .cloned()
-        .unwrap_or_else(Map::<noodles::sam::header::record::value::map::Header>::default);
-
-    let other_fields = header_map.other_fields_mut();
-    other_fields.insert(SORT_ORDER, BString::from(UNSORTED));
-    other_fields.shift_remove(b"GO");
-    other_fields.shift_remove(b"SS");
-
-    rebuild_header_with_hd(header, header_map)
-}
-
-/// Returns a copy of `header` advertising queryname sort order (`SO:queryname`),
-/// with any `GO`/`SS` tags removed.
-///
-/// This is the weakest order that satisfies [`is_query_grouped`], so it is the
-/// natural input order for template-based commands (filter, clip). Used by the
-/// test [`crate::builder::SamBuilder`] to stamp query-grouped fixtures.
-#[must_use]
-pub fn header_as_queryname(header: &Header) -> Header {
-    use bstr::BString;
-    use noodles::sam::header::record::value::Map;
-    use noodles::sam::header::record::value::map::header::tag::SORT_ORDER;
-
-    let mut header_map = header
-        .header()
-        .cloned()
-        .unwrap_or_else(Map::<noodles::sam::header::record::value::map::Header>::default);
-
-    let other_fields = header_map.other_fields_mut();
-    other_fields.insert(SORT_ORDER, BString::from(QUERY_NAME));
-    other_fields.shift_remove(b"GO");
-    other_fields.shift_remove(b"SS");
-
-    rebuild_header_with_hd(header, header_map)
-}
-
-/// Returns a copy of `header` advertising template-coordinate sort order.
-///
-/// Sets `SO:unsorted`, `GO:query`, and `SS:template-coordinate` — the order
-/// `is_template_coordinate_sorted` accepts and that `fgumi group`/`sort` emit.
-/// Primarily useful for constructing consensus-calling inputs (real or test).
-#[must_use]
-pub fn header_as_template_coordinate(header: &Header) -> Header {
+/// `so` is written to the `SO` (sort order) tag. `go` and `ss` control the `GO`
+/// (group order) and `SS` (sub-sort) tags: `Some(value)` inserts the tag with
+/// that value, `None` removes any existing tag. All other `@HD` fields and the
+/// header's read groups, reference sequences, programs, and comments are
+/// preserved. Shared by the `header_as_*` sort-order stampers, which differ only
+/// in the `(SO, GO, SS)` values they pass.
+fn stamp_hd_sort_order(header: &Header, so: &[u8], go: Option<&[u8]>, ss: Option<&[u8]>) -> Header {
     use bstr::BString;
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::header::tag::{
@@ -415,11 +367,71 @@ pub fn header_as_template_coordinate(header: &Header) -> Header {
         .unwrap_or_else(Map::<noodles::sam::header::record::value::map::Header>::default);
 
     let other_fields = header_map.other_fields_mut();
-    other_fields.insert(SORT_ORDER, BString::from(UNSORTED));
-    other_fields.insert(GROUP_ORDER, BString::from("query"));
-    other_fields.insert(SUBSORT_ORDER, BString::from("template-coordinate"));
+    other_fields.insert(SORT_ORDER, BString::from(so));
+    match go {
+        Some(value) => {
+            other_fields.insert(GROUP_ORDER, BString::from(value));
+        }
+        None => {
+            other_fields.shift_remove(b"GO");
+        }
+    }
+    match ss {
+        Some(value) => {
+            other_fields.insert(SUBSORT_ORDER, BString::from(value));
+        }
+        None => {
+            other_fields.shift_remove(b"SS");
+        }
+    }
 
     rebuild_header_with_hd(header, header_map)
+}
+
+/// Returns a copy of `header` with its sort-order metadata cleared.
+///
+/// The `SO` tag is set to `unsorted` and any `GO` (group order) or `SS`
+/// (sub-sort) tags are removed. Use this when writing records whose emission
+/// order does not match the input's advertised sort order, so downstream tools
+/// don't mistakenly assume the output is sorted.
+#[must_use]
+pub fn header_as_unsorted(header: &Header) -> Header {
+    stamp_hd_sort_order(header, UNSORTED, None, None)
+}
+
+/// Returns a copy of `header` advertising queryname sort order (`SO:queryname`),
+/// with any `GO`/`SS` tags removed.
+///
+/// This is the weakest order that satisfies [`is_query_grouped`], so it is the
+/// natural input order for template-based commands (filter, clip). Used by the
+/// test [`crate::builder::SamBuilder`] to stamp query-grouped fixtures.
+#[must_use]
+pub fn header_as_queryname(header: &Header) -> Header {
+    stamp_hd_sort_order(header, QUERY_NAME, None, None)
+}
+
+/// Returns a copy of `header` advertising template-coordinate sort order.
+///
+/// Sets `SO:unsorted`, `GO:query`, and `SS:template-coordinate` — the order
+/// `is_template_coordinate_sorted` accepts and that `fgumi group`/`sort` emit.
+/// Primarily useful for constructing consensus-calling inputs (real or test).
+#[must_use]
+pub fn header_as_template_coordinate(header: &Header) -> Header {
+    stamp_hd_sort_order(header, UNSORTED, Some(b"query"), Some(b"template-coordinate"))
+}
+
+/// Returns a copy of `header` advertising query grouping (`SO:unsorted`, `GO:query`).
+///
+/// The `SO` tag is set to `unsorted`, the `GO` (group order) tag to `query`, and any `SS`
+/// (sub-sort) tag is removed. Use this when the records being written are grouped by query
+/// name (a template's reads are adjacent) but not otherwise sorted — the order that
+/// `fgumi extract` and other FASTQ-order writers emit, and the minimum the template-oriented
+/// commands (`clip --clip-overlapping-reads`, `filter`, ...) require. It is the inverse of
+/// [`header_as_unsorted`]. Note this is *not* template-coordinate sorted: that additionally
+/// requires `SS:template-coordinate` (see [`is_template_coordinate_sorted`]).
+#[must_use]
+pub fn header_as_query_grouped(header: &Header) -> Header {
+    stamp_hd_sort_order(header, UNSORTED, Some(b"query"), None)
 }
 
 /// Reverses a `BufValue` (array or string).
@@ -922,6 +934,59 @@ mod tests {
         assert!(unsorted.read_groups().contains_key(b"rg1".as_slice()));
         assert_eq!(unsorted.programs().as_ref().len(), 1);
         assert!(is_sorted(&unsorted, UNSORTED));
+    }
+
+    // =========================================================================
+    // Tests for header_as_query_grouped()
+    // =========================================================================
+
+    #[test]
+    fn test_header_as_query_grouped_sets_so_unsorted_and_go_query() {
+        let header = create_header_with_so("coordinate");
+        let grouped = header_as_query_grouped(&header);
+        assert!(is_sorted(&grouped, UNSORTED), "SO must be unsorted");
+        let other_fields = grouped.header().expect("header map present").other_fields();
+        assert_eq!(other_fields.get(b"GO").map(AsRef::as_ref), Some(&b"query"[..]));
+    }
+
+    #[test]
+    fn test_header_as_query_grouped_sets_fields_when_hd_missing() {
+        let header = create_header_without_so();
+        let grouped = header_as_query_grouped(&header);
+        assert!(is_sorted(&grouped, UNSORTED));
+        let other_fields = grouped.header().expect("header map present").other_fields();
+        assert_eq!(other_fields.get(b"GO").map(AsRef::as_ref), Some(&b"query"[..]));
+    }
+
+    #[test]
+    fn test_header_as_query_grouped_drops_ss_and_is_not_template_coordinate() {
+        // Template-coordinate header has SO:unsorted, GO:query, SS:template-coordinate.
+        // Downgrading to query-grouped must drop SS so it no longer reads as
+        // template-coordinate sorted (which requires the SS sub-sort tag).
+        let header =
+            create_template_coord_header("unsorted", Some("query"), Some("template-coordinate"));
+        assert!(is_template_coordinate_sorted(&header));
+        let grouped = header_as_query_grouped(&header);
+        assert!(!is_template_coordinate_sorted(&grouped));
+        let other_fields = grouped.header().expect("header map present").other_fields();
+        assert!(other_fields.get(b"SS").is_none(), "SS should be cleared");
+        assert_eq!(other_fields.get(b"GO").map(AsRef::as_ref), Some(&b"query"[..]));
+        assert!(is_sorted(&grouped, UNSORTED));
+    }
+
+    #[test]
+    fn test_header_as_query_grouped_preserves_read_groups_and_refs() {
+        let header_str = "@HD\tVN:1.6\tSO:coordinate\n\
+                          @SQ\tSN:chr1\tLN:1000\n\
+                          @RG\tID:rg1\tSM:sample1\n\
+                          @PG\tID:prog1\tPN:tool\n";
+        let header: Header = header_str.parse().expect("parse header");
+        let grouped = header_as_query_grouped(&header);
+        assert_eq!(grouped.reference_sequences().len(), 1);
+        assert!(grouped.reference_sequences().contains_key(b"chr1".as_slice()));
+        assert_eq!(grouped.read_groups().len(), 1);
+        assert!(grouped.read_groups().contains_key(b"rg1".as_slice()));
+        assert_eq!(grouped.programs().as_ref().len(), 1);
     }
 
     // =========================================================================

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -2239,6 +2239,66 @@ mod tests {
         Ok(())
     }
 
+    /// CLIP3-03: `--upgrade-clipping` in `soft-with-mask` mode must mask existing
+    /// soft-clipped bases to N with minimum quality while leaving the CIGAR intact,
+    /// matching fgbio `ClipBam --upgrade-clipping --clipping-mode SoftWithMask`.
+    #[test]
+    fn test_upgrade_clipping_soft_with_mask_masks_existing_soft_bases() -> Result<()> {
+        let dir = TempDir::new()?;
+        let ref_path = create_test_reference(&dir);
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+
+        // A fragment with 5 existing soft-clipped bases at the 5' end.
+        let mut builder = SamBuilder::with_single_ref("chr1", 200);
+        let _ = builder
+            .add_frag()
+            .name("maskme")
+            .contig(0)
+            .start(20)
+            .cigar("5S15M")
+            .bases("ACGTACGTACGTACGTACGT") // 20 bases
+            .strand(Strand::Plus)
+            .build();
+        mark_query_grouped(&mut builder);
+        builder.write(&input_path)?;
+
+        let clip = Clip {
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
+            reference: ref_path,
+            clipping_mode: ClippingMode::SoftWithMask,
+            clip_overlapping_reads: false,
+            clip_extending_past_mate: false,
+            read_one_five_prime: 0,
+            read_one_three_prime: 0,
+            read_two_five_prime: 0,
+            read_two_three_prime: 0,
+            upgrade_clipping: true,
+            auto_clip_attributes: false,
+            metrics: None,
+            threading: ThreadingOptions::none(),
+            compression: CompressionOptions { compression_level: 1 },
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+        };
+        clip.execute("test")?;
+
+        let records = read_bam_records(&output_path)?;
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(cigar_string(record), "5S15M", "CIGAR unchanged");
+        let bases = record.sequence().as_ref().to_vec();
+        assert_eq!(&bases[..5], b"NNNNN", "leading soft bases masked to N");
+        assert!(bases[5..].iter().all(|&b| b != b'N'), "aligned bases untouched");
+        let quals = record.quality_scores().as_ref().to_vec();
+        assert!(quals[..5].iter().all(|&q| q == 2), "leading soft quals masked to 2");
+        Ok(())
+    }
+
     #[test]
     fn test_clip_execute_basic_overlapping() -> Result<()> {
         let dir = TempDir::new()?;

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -427,13 +427,13 @@ impl Clip {
 
         // Apply fixed-position clipping
         let num_five_prime = if self.read_one_five_prime > 0 {
-            clipper.clip_5_prime_end_of_alignment(record, self.read_one_five_prime)
+            clipper.clip_5_prime_end_of_read_raw(record, self.read_one_five_prime)
         } else {
             0
         };
 
         let num_three_prime = if self.read_one_three_prime > 0 {
-            clipper.clip_3_prime_end_of_alignment(record, self.read_one_three_prime)
+            clipper.clip_3_prime_end_of_read_raw(record, self.read_one_three_prime)
         } else {
             0
         };
@@ -502,34 +502,34 @@ impl Clip {
 
         // Apply fixed-position clipping for R1
         let num_r1_five_prime = if is_r1_first && self.read_one_five_prime > 0 {
-            clipper.clip_5_prime_end_of_alignment(r1, self.read_one_five_prime)
+            clipper.clip_5_prime_end_of_read_raw(r1, self.read_one_five_prime)
         } else if !is_r1_first && self.read_two_five_prime > 0 {
-            clipper.clip_5_prime_end_of_alignment(r1, self.read_two_five_prime)
+            clipper.clip_5_prime_end_of_read_raw(r1, self.read_two_five_prime)
         } else {
             0
         };
 
         let num_r1_three_prime = if is_r1_first && self.read_one_three_prime > 0 {
-            clipper.clip_3_prime_end_of_alignment(r1, self.read_one_three_prime)
+            clipper.clip_3_prime_end_of_read_raw(r1, self.read_one_three_prime)
         } else if !is_r1_first && self.read_two_three_prime > 0 {
-            clipper.clip_3_prime_end_of_alignment(r1, self.read_two_three_prime)
+            clipper.clip_3_prime_end_of_read_raw(r1, self.read_two_three_prime)
         } else {
             0
         };
 
         // Apply fixed-position clipping for R2
         let num_r2_five_prime = if is_r2_last && self.read_two_five_prime > 0 {
-            clipper.clip_5_prime_end_of_alignment(r2, self.read_two_five_prime)
+            clipper.clip_5_prime_end_of_read_raw(r2, self.read_two_five_prime)
         } else if !is_r2_last && self.read_one_five_prime > 0 {
-            clipper.clip_5_prime_end_of_alignment(r2, self.read_one_five_prime)
+            clipper.clip_5_prime_end_of_read_raw(r2, self.read_one_five_prime)
         } else {
             0
         };
 
         let num_r2_three_prime = if is_r2_last && self.read_two_three_prime > 0 {
-            clipper.clip_3_prime_end_of_alignment(r2, self.read_two_three_prime)
+            clipper.clip_3_prime_end_of_read_raw(r2, self.read_two_three_prime)
         } else if !is_r2_last && self.read_one_three_prime > 0 {
-            clipper.clip_3_prime_end_of_alignment(r2, self.read_one_three_prime)
+            clipper.clip_3_prime_end_of_read_raw(r2, self.read_one_three_prime)
         } else {
             0
         };
@@ -671,24 +671,24 @@ impl Clip {
 
                         // Apply fixed-position clipping for R1
                         if is_r1_first && read_one_five_prime > 0 {
-                            clipper.clip_5_prime_end_of_alignment(r1, read_one_five_prime);
+                            clipper.clip_5_prime_end_of_read_raw(r1, read_one_five_prime);
                         } else if !is_r1_first && read_two_five_prime > 0 {
-                            clipper.clip_5_prime_end_of_alignment(r1, read_two_five_prime);
+                            clipper.clip_5_prime_end_of_read_raw(r1, read_two_five_prime);
                         }
                         if is_r1_first && read_one_three_prime > 0 {
-                            clipper.clip_3_prime_end_of_alignment(r1, read_one_three_prime);
+                            clipper.clip_3_prime_end_of_read_raw(r1, read_one_three_prime);
                         } else if !is_r1_first && read_two_three_prime > 0 {
-                            clipper.clip_3_prime_end_of_alignment(r1, read_two_three_prime);
+                            clipper.clip_3_prime_end_of_read_raw(r1, read_two_three_prime);
                         }
 
                         // Apply fixed-position clipping for R2. The primary R2 slot is always a
                         // last-segment read (find_primary_pair_indices only fills it from an
                         // is_last_segment read), so it always uses the read-two thresholds.
                         if read_two_five_prime > 0 {
-                            clipper.clip_5_prime_end_of_alignment(r2, read_two_five_prime);
+                            clipper.clip_5_prime_end_of_read_raw(r2, read_two_five_prime);
                         }
                         if read_two_three_prime > 0 {
-                            clipper.clip_3_prime_end_of_alignment(r2, read_two_three_prime);
+                            clipper.clip_3_prime_end_of_read_raw(r2, read_two_three_prime);
                         }
 
                         // Clip overlapping reads
@@ -720,10 +720,10 @@ impl Clip {
                             clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
                         }
                         if read_one_five_prime > 0 {
-                            clipper.clip_5_prime_end_of_alignment(record, read_one_five_prime);
+                            clipper.clip_5_prime_end_of_read_raw(record, read_one_five_prime);
                         }
                         if read_one_three_prime > 0 {
-                            clipper.clip_3_prime_end_of_alignment(record, read_one_three_prime);
+                            clipper.clip_3_prime_end_of_read_raw(record, read_one_three_prime);
                         }
                     }
                     _ => {}
@@ -1220,12 +1220,15 @@ mod tests {
         assert_eq!(supp.tags().find_int(SamTag::MQ), Some(40));
     }
 
-    // With an unmapped mate, set_supplemental_mate_info_raw flags the mate unmapped and drops MC.
+    // With an unmapped mate, set_supplemental_mate_info_raw flags the mate unmapped and drops MC,
+    // but still writes MQ from the mate's mapping quality (htsjdk 5.0.0 sets MQ unconditionally).
     #[test]
     fn test_set_supplemental_mate_info_raw_unmapped_mate() {
         use crate::sam::RecordBuilder;
         use fgumi_raw_bam::flags as rflags;
 
+        // Give the unmapped mate a distinct, non-zero MAPQ so the MQ assertion below proves the
+        // value was copied from the mate rather than defaulting to 0.
         let mate = encode_raw(
             &RecordBuilder::mapped_read()
                 .name("q")
@@ -1234,6 +1237,7 @@ mod tests {
                 .unmapped(true)
                 .reference_sequence_id(0)
                 .alignment_start(301)
+                .mapping_quality(37)
                 .cigar("50M")
                 .sequence(&"A".repeat(50))
                 .build(),
@@ -1247,6 +1251,8 @@ mod tests {
 
         assert_ne!(supp.flags() & rflags::MATE_UNMAPPED, 0, "mate is unmapped");
         assert!(!supp.tags().contains(SamTag::MC), "MC dropped when mate unmapped");
+        // MQ is set unconditionally to the mate's mapping quality, even for an unmapped mate.
+        assert_eq!(supp.tags().find_int(SamTag::MQ), Some(37), "MQ set from unmapped mate MAPQ");
     }
 
     // fix_supplemental_mate_info points R1 supplementals at the primary R2 and R2 supplementals
@@ -1992,7 +1998,7 @@ mod tests {
     }
 
     // Integration tests
-    use crate::sam::SamBuilder;
+    use crate::sam::{SamBuilder, Strand};
     use anyhow::Result;
     use tempfile::TempDir;
 
@@ -2013,6 +2019,224 @@ mod tests {
         let header = reader.read_header()?;
         let records: Vec<_> = reader.record_bufs(&header).collect::<std::io::Result<Vec<_>>>()?;
         Ok(records)
+    }
+
+    /// Renders a record's CIGAR as a string (e.g. `"5S15M"`) for assertions.
+    fn cigar_string(record: &noodles::sam::alignment::RecordBuf) -> String {
+        use noodles::sam::alignment::record::Cigar as _;
+        use noodles::sam::alignment::record::cigar::op::Kind;
+        use std::fmt::Write as _;
+        record.cigar().iter().filter_map(std::result::Result::ok).fold(
+            String::new(),
+            |mut acc, op| {
+                let kind = match op.kind() {
+                    Kind::Match => 'M',
+                    Kind::Insertion => 'I',
+                    Kind::Deletion => 'D',
+                    Kind::Skip => 'N',
+                    Kind::SoftClip => 'S',
+                    Kind::HardClip => 'H',
+                    Kind::Pad => 'P',
+                    Kind::SequenceMatch => '=',
+                    Kind::SequenceMismatch => 'X',
+                };
+                let _ = write!(acc, "{}{}", op.len(), kind);
+                acc
+            },
+        )
+    }
+
+    /// Rewrites `builder`'s `@HD` line to advertise `SO:unsorted GO:query` (query grouped).
+    /// `SamBuilder` writes a template's reads adjacently, so the emitted BAM is genuinely
+    /// query grouped; the overlap-clip / clip-past-mate pipeline rejects input whose header
+    /// does not advertise queryname sorting or query grouping (`clip` requires a template's
+    /// reads to be adjacent).
+    fn mark_query_grouped(builder: &mut SamBuilder) {
+        builder.header = crate::sam::header_as_query_grouped(&builder.header);
+    }
+
+    /// CLIP3-02: fixed-position clipping must ensure *at least* N bases are clipped at
+    /// the 5'/3' end *including any existing clipping*, matching fgbio `ClipBam`'s use of
+    /// `clip5PrimeEndOfRead`/`clip3PrimeEndOfRead`. A read that already carries >= N
+    /// bases of clipping at the requested end must not be clipped further.
+    #[rstest]
+    #[case::single_threaded(ThreadingOptions::none())]
+    #[case::multi_threaded(ThreadingOptions::new(2))]
+    fn test_fixed_position_clip_counts_existing_clipping(
+        #[case] threading: ThreadingOptions,
+    ) -> Result<()> {
+        let dir = TempDir::new()?;
+        let ref_path = create_test_reference(&dir);
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+
+        // R1 forward with 5 bases already soft-clipped at its 5' (start) end.
+        // R2 reverse with 4 bases already soft-clipped at its 5' (end) end.
+        let mut builder = SamBuilder::with_single_ref("chr1", 200);
+        let _ = builder
+            .add_pair()
+            .name("read1")
+            .contig(0)
+            .start1(10)
+            .cigar1("5S15M")
+            .bases1("ACGTACGTACGTACGTACGT") // 20 bases
+            .start2(120)
+            .cigar2("16M4S")
+            .bases2("ACGTACGTACGTACGTACGT") // 20 bases
+            .build();
+        mark_query_grouped(&mut builder);
+        builder.write(&input_path)?;
+
+        let clip = Clip {
+            io: BamIoOptions {
+                input: input_path,
+                output: output_path.clone(),
+                async_reader: false,
+            },
+            reference: ref_path,
+            clipping_mode: ClippingMode::Soft,
+            clip_overlapping_reads: false,
+            clip_extending_past_mate: false,
+            // Request fewer 5' bases than already exist on each read: fgbio clips 0 more there
+            // (the existing-clipping check). Also request 5 bases at R1's 3' end, which has no
+            // existing clipping, so clipping *is* applied there — this makes the command path
+            // exercise real clipping rather than a no-op.
+            read_one_five_prime: 3,
+            read_one_three_prime: 5,
+            read_two_five_prime: 2,
+            read_two_three_prime: 0,
+            upgrade_clipping: false,
+            auto_clip_attributes: false,
+            metrics: None,
+            threading,
+            compression: CompressionOptions { compression_level: 1 },
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+        };
+        clip.execute("test")?;
+
+        let records = read_bam_records(&output_path)?;
+        assert_eq!(records.len(), 2);
+        for record in &records {
+            let cigar = cigar_string(record);
+            if record.flags().is_first_segment() {
+                assert_eq!(
+                    cigar, "5S10M5S",
+                    "R1: existing 5' clip counted (5S retained, no extra 5' clip), and the \
+                     requested 5 bases newly clipped at the 3' end"
+                );
+            } else {
+                assert_eq!(
+                    cigar, "16M4S",
+                    "R2 already had >= 2 bases 5'-clipped; expected no change"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// CLIP3-01 (command level): overlap clipping must be strand-normalized end to end.
+    /// A pair whose first-of-pair read is the reverse strand must yield the same
+    /// per-strand output as the mirror pair whose first-of-pair read is the forward
+    /// strand — the `clip` command must not clip the wrong (outer) ends. Exercised in
+    /// both the single-threaded (`threads == 0`) and multi-threaded pipeline paths.
+    #[rstest]
+    #[case::single_threaded(0)]
+    #[case::multi_threaded(4)]
+    fn test_clip_overlap_negative_strand_first_matches_mirror(
+        #[case] threads: usize,
+    ) -> Result<()> {
+        let dir = TempDir::new()?;
+        let ref_path = create_test_reference(&dir);
+
+        // Runs `clip --clip-overlapping-reads` on an FR pair with the given strands and
+        // returns (forward-read CIGAR, reverse-read CIGAR) from the output.
+        let run = |tag: &str,
+                   r1_minus: bool,
+                   r1_start: usize,
+                   r2_start: usize|
+         -> Result<(String, String)> {
+            let input_path = dir.path().join(format!("in_{tag}.bam"));
+            let output_path = dir.path().join(format!("out_{tag}.bam"));
+            let mut builder = SamBuilder::with_single_ref("chr1", 200);
+            let _ = builder
+                .add_pair()
+                .name("read1")
+                .contig(0)
+                .start1(r1_start)
+                .start2(r2_start)
+                .strand1(if r1_minus { Strand::Minus } else { Strand::Plus })
+                .strand2(if r1_minus { Strand::Plus } else { Strand::Minus })
+                .build();
+            mark_query_grouped(&mut builder);
+            builder.write(&input_path)?;
+
+            let threading = if threads == 0 {
+                ThreadingOptions::none()
+            } else {
+                ThreadingOptions::new(threads)
+            };
+            let clip = Clip {
+                io: BamIoOptions {
+                    input: input_path,
+                    output: output_path.clone(),
+                    async_reader: false,
+                },
+                reference: ref_path.clone(),
+                clipping_mode: ClippingMode::Soft,
+                clip_overlapping_reads: true,
+                clip_extending_past_mate: false,
+                read_one_five_prime: 0,
+                read_one_three_prime: 0,
+                read_two_five_prime: 0,
+                read_two_three_prime: 0,
+                upgrade_clipping: false,
+                auto_clip_attributes: false,
+                metrics: None,
+                threading,
+                compression: CompressionOptions { compression_level: 1 },
+                scheduler_opts: SchedulerOptions::default(),
+                queue_memory: QueueMemoryOptions::default(),
+            };
+            clip.execute("test")?;
+
+            let records = read_bam_records(&output_path)?;
+            assert_eq!(records.len(), 2);
+            let forward = records
+                .iter()
+                .find(|r| !r.flags().is_reverse_complemented())
+                .map(cigar_string)
+                .expect("a forward-strand read");
+            let reverse = records
+                .iter()
+                .find(|r| r.flags().is_reverse_complemented())
+                .map(cigar_string)
+                .expect("a reverse-strand read");
+            Ok((forward, reverse))
+        };
+
+        // Forward-first mirror: R1 forward on the left, R2 reverse on the right.
+        let (fwd_forward, fwd_reverse) = run("fwdfirst", false, 10, 20)?;
+        // Negative-strand first: R1 reverse on the right, R2 forward on the left.
+        let (rev_forward, rev_reverse) = run("revfirst", true, 20, 10)?;
+
+        // Pin the canonical (forward-first) output so the test fails if the command path
+        // becomes a no-op: the 100bp reads overlap over [20, 110), so overlap clipping trims
+        // 45bp from each read's 3' end where they meet (forward keeps [10, 65) -> 55M45S;
+        // reverse keeps [65, 120) -> 45S55M). Both differ from the unclipped 100M input, so
+        // a pipeline that silently skipped clipping would not satisfy these assertions.
+        assert_eq!(fwd_forward, "55M45S", "forward-read must be 3'-clipped over the overlap");
+        assert_eq!(fwd_reverse, "45S55M", "reverse-read must be 3'-clipped over the overlap");
+
+        assert_eq!(
+            fwd_forward, rev_forward,
+            "forward-read CIGAR must not depend on R1/R2 strand order"
+        );
+        assert_eq!(
+            fwd_reverse, rev_reverse,
+            "reverse-read CIGAR must not depend on R1/R2 strand order"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/lib/sam/mod.rs
+++ b/src/lib/sam/mod.rs
@@ -20,7 +20,7 @@ pub use fgumi_sam::{TC_TAG, TemplateCoordinateInfo};
 // re-exported here — nothing in the `fgumi` binary uses it directly, and
 // `check_sort` calls it internally within fgumi-sam.
 pub use fgumi_sam::{
-    buf_value_to_smallest_signed_int, check_sort, header_as_unsorted,
+    buf_value_to_smallest_signed_int, check_sort, header_as_query_grouped, header_as_unsorted,
     is_template_coordinate_sorted, revcomp_buf_value, reverse_buf_value, to_smallest_signed_int,
 };
 


### PR DESCRIPTION
## Summary

Three fgbio-parity fixes in the `clip` command / clipper, all verified against fgbio 4.1.0 `ClipBam`.

### CLIP3-01 — strand-normalize overlap clipping (S1)

`clip_overlapping_reads` (typed `SamRecordClipper` and raw `RawRecordClipper`) assumed the *first* argument was the positive-strand read: it computed the midpoint as `midpoint(r1.start, r2.end)` and clipped r1's END + r2's START. For an FR pair whose **first-of-pair read is the reverse strand** this clipped the wrong — outer, non-overlapping — ends, silently corrupting the output.

Fix: normalize by strand so the positive-strand read is always treated as r1, mirroring fgbio `SamRecordClipper.clipOverlappingReads` (`if (rec.negativeStrand) clipOverlappingReads(rec=mate, mate=rec).swap`). Returned counts are swapped back to caller order — also correcting metric attribution in `clip_pair`.

### CLIP3-02 — count existing clipping in fixed-position clips (S2)

Fixed-position 5'/3' clips (`--read-one-five-prime`, etc.) called the `_of_alignment` variants (clip N *beyond* existing). fgbio uses `clip5PrimeEndOfRead`/`clip3PrimeEndOfRead` (ensure *at least* N *including* existing). Switched all 18 fixed-position call sites (`clip_fragment`, `clip_pair`, and the multi-threaded `execute_threads_mode` inline path) to the `_of_read_raw` variants.

### CLIP3-03 — honor SoftWithMask in upgrade paths (S2)

`upgrade_clipping`/`upgrade_all_clipping` (typed and raw) were Hard-only and no-op'd in SoftWithMask mode, so `--upgrade-clipping --clipping-mode soft-with-mask` left existing soft-clipped bases un-masked. fgbio's `upgradeClipping`/`upgradeAllClipping` mask those bases to N with minimum quality (`hardMaskStartOfRead`), CIGAR intact. Implemented the SoftWithMask branch and routed `upgrade_all_clipping` through it for both ends. Extended attributes untouched (fgbio's `clipExtendedAttributes` is a no-op outside Hard mode).

## fgbio parity verification

**CLIP3-01/02** — 2-template fixture (reverse-strand-first FR overlap + pre-soft-clipped pair), `--clip-overlapping-reads --read-one-five-prime 3 --read-two-five-prime 2`:

| | fgbio == fgumi (post-fix) | fgumi (pre-fix) |
|---|---|---|
| `preclip` R1 | `5S15M` | `8S12M` |
| `preclip` R2 | `15M5S` | `13M7S` |
| `revfirst` R1 (rev) | `5S12M3S` | `5M15S` |
| `revfirst` R2 (fwd) | `2S13M5S` | `15S5M` |

**CLIP3-03** — `5S15M` read, `--upgrade-clipping --clipping-mode SoftWithMask`: both fgbio and fgumi produce CIGAR `5S15M`, SEQ `NNNNN…`, QUAL `#####…` (first 5 masked to N/Q2). Byte-identical.

Pre-fix diverged on every read; post-fix output is byte-identical to fgbio in all cases.

## Tests (TDD, red-first)

- `clipper.rs`: `test_clip_overlapping_reads_normalizes_by_strand_{typed,raw}` (arg-order symmetry, Soft/Hard × 3 overlaps); `test_upgrade_all_clipping_{,,raw_}soft_with_mask_masks_existing_soft_clips`.
- `clip.rs`: `test_fixed_position_clip_counts_existing_clipping`; `test_clip_overlap_negative_strand_first_matches_mirror` (single + multi-threaded); `test_upgrade_clipping_soft_with_mask_masks_existing_soft_bases`.
- The pre-existing `test_not_upgrade_soft_with_mask_to_soft_with_mask` asserted the buggy no-op; rewritten to assert the correct masking behavior.

## Notes

- Stacked on #502 (`nh/fix-clip-round2-mate-supp-window`); review the three W5 commits.
- Commit order: `7b033712` (CLIP3-01/02), `d9a0a0f1` (CLIP3-03).
- The CodeRabbit CLI earlier flagged three suggestions on `tests/integration/test_clip_command.rs` (assert full-record oracle comparisons rather than broad properties). That file belongs to base PR #502 and is not touched here — leaving those for #502. The new tests here already do full-CIGAR / fgbio-oracle comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SAM header utility to advertise query grouping (sets `GO=query`, `SO=unsorted`) while preserving existing header content.
* **Bug Fixes**
  * Made overlapping-read clipping deterministic across strand orientation and read argument order.
  * Fixed fixed-position end clipping to respect already soft-clipped bases and avoid unintended extra clipping.
  * Ensured mate mapping-quality (`MQ`) is set consistently, even when the mate is unmapped.
  * Implemented `SoftWithMask` upgrade clipping to mask upgraded soft-clipped bases to `N` with minimum quality while leaving CIGAR unchanged.
* **Tests**
  * Added/updated integration and parity tests covering the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->