### PR TITLE
fix(sort,dedup): place secondary/supplementary reads at their exact template coordinate via tc

### DIFF
--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -113,9 +113,9 @@ pub use tags::{
     array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
     find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
     find_string_tag_in_record, find_string_tag_position, find_tag_type, find_uint8_tag,
-    normalize_int_tag_to_smallest_signed, remove_tag, reverse_array_tag_in_place,
-    reverse_complement_string_tag_in_place, reverse_string_tag_in_place, update_int_tag,
-    update_string_tag,
+    normalize_int_tag_to_smallest_signed, read_tc_template_coordinate, remove_tag,
+    reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
+    reverse_string_tag_in_place, update_int_tag, update_string_tag,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -475,6 +475,36 @@ fn parse_array_tag_at(aux_data: &[u8], data_start: usize) -> Option<ArrayTagRef<
     Some(ArrayTagRef { data: &aux_data[elements_start..elements_end], elem_type, count, elem_size })
 }
 
+/// Read the `tc` template-coordinate tag from aux data.
+///
+/// `fgumi zipper` stamps the exact template coordinate of the primary pair onto
+/// secondary/supplementary reads as a 6-element `B:i` array
+/// `[tid1, pos1, neg1, tid2, pos2, neg2]` (canonically ordered `tid1 <= tid2`).
+/// This lets the template-coordinate sort and dedup place a supplementary read at
+/// its primary pair's coordinate — which a supplementary record cannot otherwise
+/// reconstruct, since it carries its own and its mate's position but not its own
+/// primary's.
+///
+/// Returns `None` when the tag is absent or is not a 6-element `B:i` array.
+#[must_use]
+pub fn read_tc_template_coordinate(aux_data: &[u8]) -> Option<[i32; 6]> {
+    let arr = find_array_tag(aux_data, [b't', b'c'])?;
+    if arr.elem_type != b'i' || arr.count != 6 {
+        return None;
+    }
+    let mut out = [0i32; 6];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let off = i * 4;
+        *slot = i32::from_le_bytes([
+            arr.data[off],
+            arr.data[off + 1],
+            arr.data[off + 2],
+            arr.data[off + 3],
+        ]);
+    }
+    Some(out)
+}
+
 /// Zero-copy typed BAM aux tag value.
 ///
 /// Borrows directly into the raw record bytes — no allocation, no decode beyond the tag header.

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3237,6 +3237,63 @@ pub fn extract_template_key_inline(
     };
     let name_hash = lib_lookup.hash_name(name);
 
+    // Secondary/supplementary reads cannot reconstruct their template coordinate
+    // from their own record (they carry their own and their mate's position, but
+    // not their own primary's). When `fgumi zipper` has stamped the exact
+    // template coordinate into the `tc` tag, key on it so the read sorts at its
+    // primary pair's coordinate — a placement per-record keying (samtools/fgbio)
+    // cannot achieve. Falls through to the position-based computation when absent.
+    let is_secondary = (flag & flags::SECONDARY) != 0;
+    let is_supplementary = (flag & flags::SUPPLEMENTARY) != 0;
+    if is_secondary || is_supplementary {
+        let aux_slice = fgumi_raw_bam::aux_data_slice(bam_bytes);
+        if let Some([tid1, pos1, neg1, tid2, pos2, neg2]) =
+            fgumi_raw_bam::read_tc_template_coordinate(aux_slice)
+        {
+            // `tc` is canonicalized by (tid, pos) only (see zipper's
+            // `add_template_coordinate_tags_raw`), whereas the per-record path
+            // additionally tiebreaks on strand for equal positions. In the
+            // degenerate case where both primaries share an identical tid and
+            // unclipped-5' position but differ in strand, the supplementary's
+            // secondary-lane strand order can differ from its primaries'. This is
+            // harmless: the primary lane (tid1, tid2, pos1) still matches, so the
+            // read co-locates with its template; only a same-coordinate tiebreak
+            // differs.
+            //
+            // `TemplateKey::new`'s final argument is the `is_upper` bit, packed
+            // into `name_hash_upper` as the *last* tiebreak (after position,
+            // strand, CB, library, MI, and name). For a mapped read it answers
+            // "is this read's own primary the upper (lane-2) end?", derived from
+            // this read's position vs. its mate. A secondary/supplementary read
+            // cannot recover that: `tc` is canonicalized by (tid, pos) and does
+            // not record which segment (R1/R2) landed on which lane, and the
+            // read's own alignment position is exactly the misleading coordinate
+            // this branch exists to avoid. We use `is_read2` because it mirrors
+            // the primary's `is_upper` for the standard FR pair (R1 is the lower
+            // lane -> is_upper=false; R2 is the upper lane -> is_upper=true) and
+            // is fully deterministic; see
+            // `test_extract_template_key_secondary_supplementary_matches_primary_via_tc`,
+            // which asserts the tc-keyed key is byte-identical to the primary's.
+            // Any residual disagreement (an exotic pair whose R2 is the lower
+            // lane) only reorders same-name records at an identical coordinate,
+            // so it cannot affect co-location or dedup grouping.
+            let is_read2 = (flag & 0x80) != 0;
+            return TemplateKey::new(
+                tid1,
+                pos1,
+                neg1 != 0,
+                tid2,
+                pos2,
+                neg2 != 0,
+                cb_hash,
+                library,
+                mi,
+                name_hash,
+                is_read2,
+            );
+        }
+    }
+
     // Handle unmapped reads
     if is_unmapped {
         if is_paired && !mate_unmapped {
@@ -3598,9 +3655,11 @@ fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
 mod tests {
     use super::*;
     use bstr::BString;
+    use fgumi_raw_bam::flags;
     use fgumi_sam::{PairBuilder, SamBuilder};
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReadGroup;
+    use rstest::rstest;
 
     // ========================================================================
     // LibraryLookup tests
@@ -4077,6 +4136,210 @@ mod tests {
         let key2 =
             extract_template_key_inline(&bam, &lib_lookup, Some(SamTag::CB), &test_cb_hasher());
         assert_eq!(key1.cb_hash, key2.cb_hash, "same input should produce same cb_hash");
+    }
+
+    /// Encode a `tc:B:i` aux tag carrying the 6-element template-coordinate
+    /// array `[tid1, pos1, neg1, tid2, pos2, neg2]` that `fgumi zipper` stamps
+    /// onto secondary/supplementary reads.
+    fn tc_aux(vals: &[i32; 6]) -> Vec<u8> {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"tcB"); // tag "tc", array type 'B'
+        aux.push(b'i'); // subtype: int32
+        #[allow(clippy::cast_possible_truncation)]
+        aux.extend_from_slice(&(vals.len() as u32).to_le_bytes());
+        for v in vals {
+            aux.extend_from_slice(&v.to_le_bytes());
+        }
+        aux
+    }
+
+    /// Build minimal BAM bytes for a mapped secondary/supplementary alignment:
+    /// paired, mate mapped, at `own_pos`, with its mate at `mate_pos`, carrying the
+    /// caller-supplied `sec_supp_flag` (`flags::SECONDARY` or `flags::SUPPLEMENTARY`),
+    /// plus optional aux. Both flags route through the same `tc` keying branch.
+    #[allow(clippy::cast_possible_truncation)]
+    fn build_secondary_or_supplementary_bam(
+        own_pos: i32,
+        mate_pos: i32,
+        sec_supp_flag: u16,
+        name: &[u8],
+        aux: &[u8],
+    ) -> Vec<u8> {
+        let l_read_name = (name.len() + 1) as u8;
+        let mut bam = vec![0u8; 32];
+        bam[0..4].copy_from_slice(&0i32.to_le_bytes()); // ref_id = chr0
+        bam[4..8].copy_from_slice(&own_pos.to_le_bytes());
+        bam[8] = l_read_name;
+        // flags: PAIRED | (SECONDARY or SUPPLEMENTARY) -- mate is mapped.
+        bam[14..16].copy_from_slice(&(flags::PAIRED | sec_supp_flag).to_le_bytes());
+        bam[20..24].copy_from_slice(&0i32.to_le_bytes()); // mate ref_id = chr0
+        bam[24..28].copy_from_slice(&mate_pos.to_le_bytes());
+        bam.extend_from_slice(name);
+        bam.push(0);
+        bam.extend_from_slice(aux);
+        bam
+    }
+
+    /// Build minimal BAM bytes for a mapped primary read on `chr0` with the
+    /// caller-supplied `flag`, aligned at `own_pos` with its mate at `mate_pos`.
+    /// No CIGAR, so the unclipped 5' position equals `own_pos`/`mate_pos`. Used to
+    /// key the two primaries of a pair through the per-record (mapped) path so
+    /// their `TemplateKey`s can be compared against the tc-keyed sec/supp keys.
+    #[allow(clippy::cast_possible_truncation)]
+    fn build_primary_bam(own_pos: i32, mate_pos: i32, flag: u16, name: &[u8]) -> Vec<u8> {
+        let l_read_name = (name.len() + 1) as u8;
+        let mut bam = vec![0u8; 32];
+        bam[0..4].copy_from_slice(&0i32.to_le_bytes()); // ref_id = chr0
+        bam[4..8].copy_from_slice(&own_pos.to_le_bytes());
+        bam[8] = l_read_name;
+        bam[14..16].copy_from_slice(&flag.to_le_bytes());
+        bam[20..24].copy_from_slice(&0i32.to_le_bytes()); // mate ref_id = chr0
+        bam[24..28].copy_from_slice(&mate_pos.to_le_bytes());
+        bam.extend_from_slice(name);
+        bam.push(0);
+        bam
+    }
+
+    /// A secondary/supplementary alignment carries its own position and its mate's
+    /// position, but **not** its own primary's position. Per-record keying (samtools
+    /// / fgbio) can therefore only place it by the mate coordinate, which can drift a
+    /// fragment-length from the template's true coordinate. Because `fgumi zipper`
+    /// pre-computes the exact template coordinate into the `tc` tag, fgumi's
+    /// template-coordinate sort can place the read **exactly** at its primary pair's
+    /// coordinate — a placement samtools/fgbio cannot achieve. This is the novel
+    /// fgumi capability; both SECONDARY and SUPPLEMENTARY take the tc branch.
+    #[rstest]
+    #[case::secondary(flags::SECONDARY)]
+    #[case::supplementary(flags::SUPPLEMENTARY)]
+    fn test_extract_template_key_secondary_supplementary_uses_tc_tag(#[case] sec_supp_flag: u16) {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+
+        // Sec/supp of a left-anchored R1: the primary is at pos 1000, its mate (R2
+        // primary) at 1400, but this alignment is at 9000. The exact template
+        // coordinate (pos1) is 1000, carried in `tc`.
+        let tc = tc_aux(&[0, 1000, 0, 0, 1400, 1]);
+        let supp = build_secondary_or_supplementary_bam(9000, 1400, sec_supp_flag, b"tmpl", &tc);
+        let supp_key = extract_template_key_inline(&supp, &lib_lookup, None, &test_cb_hasher());
+
+        // A different template whose true coordinate (pos1) is 1200 — between the
+        // read's exact coordinate (1000, from tc) and the mate-only approximation
+        // (1400).
+        let filler = build_mapped_bam(0, 1200, b"fillr", &[]);
+        let filler_key = extract_template_key_inline(&filler, &lib_lookup, None, &test_cb_hasher());
+
+        assert!(
+            supp_key < filler_key,
+            "sec/supp must sort at its template coordinate (pos1=1000 via tc), before \
+             the pos1=1200 template; per-record keying misplaces it at the mate \
+             coordinate (1400), after the 1200 template"
+        );
+    }
+
+    /// Without a `tc` tag, a secondary/supplementary must fall back to the per-record
+    /// (own-position / mate) computation — the prior behavior — so the tc branch
+    /// never changes keying for reads zipper did not stamp.
+    #[rstest]
+    #[case::secondary(flags::SECONDARY)]
+    #[case::supplementary(flags::SUPPLEMENTARY)]
+    fn test_extract_template_key_secondary_supplementary_without_tc_falls_back(
+        #[case] sec_supp_flag: u16,
+    ) {
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+
+        // Same geometry as the tc test, but no `tc` tag.
+        let supp = build_secondary_or_supplementary_bam(9000, 1400, sec_supp_flag, b"tmpl", &[]);
+        let supp_key = extract_template_key_inline(&supp, &lib_lookup, None, &test_cb_hasher());
+
+        // Fallback keys off the mate coordinate (1400), so it sorts AFTER the
+        // pos1=1200 template — the unchanged, pre-tc behavior.
+        let filler = build_mapped_bam(0, 1200, b"fillr", &[]);
+        let filler_key = extract_template_key_inline(&filler, &lib_lookup, None, &test_cb_hasher());
+
+        assert!(
+            supp_key > filler_key,
+            "without tc, a sec/supp keeps the per-record (mate=1400) placement"
+        );
+    }
+
+    /// Tie-case: with `(tid1, pos1, tid2, pos2)` held identical between a primary
+    /// pair and its tc-stamped sec/supp reads, the tc branch must place the
+    /// sec/supp read at the *exact same* `TemplateKey` as its primary — not merely
+    /// nearby. This is the strong property the reviewer asked for: it pins down the
+    /// full key (position lanes, strand lanes, CB, library, MI, name, **and** the
+    /// `is_upper`/`is_read2` tiebreak), verifying tc ordering matches the mapped
+    /// path rather than only asserting a coarse `<`/`>` placement.
+    ///
+    /// Geometry is a standard FR pair on `chr0`: R1 forward at unclipped-5' 1000
+    /// (the lower/lane-1 end), R2 reverse at 1400 (the upper/lane-2 end). The two
+    /// primaries key through the per-record path; the two sec/supp reads key
+    /// through the tc branch. `is_read2` mirrors the primary `is_upper` here (R1 ->
+    /// false, R2 -> true), so each sec/supp key is byte-identical to its primary's.
+    #[rstest]
+    #[case::secondary(flags::SECONDARY)]
+    #[case::supplementary(flags::SUPPLEMENTARY)]
+    fn test_extract_template_key_secondary_supplementary_matches_primary_via_tc(
+        #[case] sec_supp_flag: u16,
+    ) {
+        const FIRST_SEGMENT: u16 = 0x40;
+        const SECOND_SEGMENT: u16 = 0x80;
+        const REVERSE: u16 = 0x10;
+        const MATE_REVERSE: u16 = 0x20;
+
+        let header = Header::builder().build();
+        let lib_lookup = LibraryLookup::from_header(&header);
+        let key =
+            |bam: &[u8]| extract_template_key_inline(bam, &lib_lookup, None, &test_cb_hasher());
+
+        // Primaries through the per-record path. R1 (forward, lower) is lane 1;
+        // R2 (reverse, upper) is lane 2. Both canonicalize to the same coordinate.
+        let r1_primary =
+            build_primary_bam(1000, 1400, flags::PAIRED | FIRST_SEGMENT | MATE_REVERSE, b"tmpl");
+        let r2_primary =
+            build_primary_bam(1400, 1000, flags::PAIRED | SECOND_SEGMENT | REVERSE, b"tmpl");
+        let r1_primary_key = key(&r1_primary);
+        let r2_primary_key = key(&r2_primary);
+
+        // The two primaries co-locate but differ only in the is_upper tiebreak.
+        assert_eq!(
+            r1_primary_key.core_cmp(&r2_primary_key),
+            std::cmp::Ordering::Equal,
+            "the pair's two primaries share (tid1, pos1, tid2, pos2)"
+        );
+        assert_ne!(
+            r1_primary_key, r2_primary_key,
+            "primaries differ only in the is_upper tiebreak (R1 lower, R2 upper)"
+        );
+
+        // Sec/supp reads through the tc branch, stamped with the pair's exact
+        // canonical template coordinate, but aligned far away (own pos 9000).
+        let tc = tc_aux(&[0, 1000, 0, 0, 1400, 1]);
+        let r1_ss = build_secondary_or_supplementary_bam(
+            9000,
+            1400,
+            sec_supp_flag | FIRST_SEGMENT,
+            b"tmpl",
+            &tc,
+        );
+        let r2_ss = build_secondary_or_supplementary_bam(
+            9000,
+            1000,
+            sec_supp_flag | SECOND_SEGMENT,
+            b"tmpl",
+            &tc,
+        );
+
+        assert_eq!(
+            key(&r1_ss),
+            r1_primary_key,
+            "R1 sec/supp keyed via tc must be byte-identical to the R1 primary key"
+        );
+        assert_eq!(
+            key(&r2_ss),
+            r2_primary_key,
+            "R2 sec/supp keyed via tc must be byte-identical to the R2 primary key"
+        );
     }
 
     #[test]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -448,6 +448,37 @@ pub fn compute_group_key_from_raw(
     let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
     let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
     if is_secondary || is_supplementary {
+        // A secondary/supplementary read cannot compute its own template
+        // coordinate (it lacks its own primary's position). When `fgumi zipper`
+        // has stamped the exact coordinate into `tc`, key on it so the read
+        // groups into the same position group as its primary — instead of an
+        // UNKNOWN position that relies on the read sorting adjacent to its
+        // primary. Library/cell are extracted the same way as primaries so the
+        // position key matches (they share their template's RG/CB).
+        let aux_offset = fgumi_raw_bam::aux_data_offset_from_record(raw).unwrap_or(raw.len());
+        let aux_data = &raw[aux_offset..];
+        if let Some([tid1, pos1, neg1, tid2, pos2, neg2]) =
+            fgumi_raw_bam::read_tc_template_coordinate(aux_data)
+        {
+            let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
+            let aux_tags =
+                fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, umi_tag);
+            let library_idx =
+                aux_tags.rg.map_or(0, |rg| library_index.get(LibraryIndex::hash_rg(rg)));
+            let cell_hash = aux_tags.cell.map_or(0, |cb| LibraryIndex::hash_cell_barcode(Some(cb)));
+            let key = GroupKey::paired(
+                tid1,
+                pos1,
+                u8::from(neg1 != 0),
+                tid2,
+                pos2,
+                u8::from(neg2 != 0),
+                library_idx,
+                cell_hash,
+                name_hash,
+            );
+            return (key, None);
+        }
         return (GroupKey { name_hash, ..GroupKey::default() }, None);
     }
 
@@ -4930,6 +4961,82 @@ mod tests {
         let decoded = decode_records(&batch, &cfg).expect("decode succeeds");
         assert_eq!(decoded.len(), 1);
         assert!(decoded[0].cached_umi().is_none());
+    }
+
+    /// A secondary/supplementary read carries the exact template coordinate of its
+    /// primary pair in the `tc` tag (stamped by `fgumi zipper`). dedup must key such
+    /// a read into the SAME position group as its primary — rather than an UNKNOWN
+    /// position that relies on the read happening to sort adjacent to its primary.
+    ///
+    /// This asserts the stronger property: the tc-derived key is byte-for-byte equal
+    /// to the *real* primary pair's group key (computed independently from the primary
+    /// reads), not merely that its fields echo the raw tc values. Both the SECONDARY
+    /// and SUPPLEMENTARY flags take the tc branch, so both are exercised. Only fgumi
+    /// can do this, because only fgumi persists `tc`.
+    #[rstest]
+    #[case::secondary(fgumi_raw_bam::flags::SECONDARY)]
+    #[case::supplementary(fgumi_raw_bam::flags::SUPPLEMENTARY)]
+    fn test_group_key_secondary_supplementary_matches_primary_via_tc(#[case] sec_supp_flag: u16) {
+        use crate::unified_pipeline::GroupKey;
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
+        let header = Header::default();
+        let library_index = LibraryIndex::from_header(&header);
+
+        // Build the REAL R1 primary of the pair: forward, ref 0, mate reverse and
+        // downstream (its unclipped 5' resolved from the MC tag). Its group key is
+        // the template's true position group — the target the sec/supp must join.
+        let mut r1 = RawSamBuilder::new();
+        r1.read_name(b"tmpl")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(999)
+            .mapq(60)
+            .cigar_ops(&[8u32 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(1392);
+        r1.add_string_tag(SamTag::MC, b"8M"); // mate cigar → mate unclipped 5'
+        let r1 = r1.build();
+        let (primary_key, _) = compute_group_key_from_raw(r1.as_ref(), &library_index, None, None);
+
+        // Sanity: the primary produced a real two-lane paired key, not a fallback.
+        assert_ne!(primary_key.pos2, GroupKey::UNKNOWN_POS, "primary must be a paired key");
+        assert_ne!(primary_key.pos1, primary_key.pos2, "the two lanes differ in position");
+
+        // Stamp the primary's template coordinate into the 6-element `tc` array that
+        // zipper writes, and hang it on a sec/supp read whose OWN alignment is far
+        // away (pos 9000) — exactly the case where per-record keying misplaces it at
+        // its own/mate coordinate instead of the template's.
+        let tc = [
+            primary_key.ref_id1,
+            primary_key.pos1,
+            i32::from(primary_key.strand1),
+            primary_key.ref_id2,
+            primary_key.pos2,
+            i32::from(primary_key.strand2),
+        ];
+        let mut ss = RawSamBuilder::new();
+        ss.read_name(b"tmpl")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .flags(raw_flags::PAIRED | sec_supp_flag)
+            .ref_id(0)
+            .pos(9000)
+            .mapq(60)
+            .cigar_ops(&[8u32 << 4])
+            .mate_ref_id(0)
+            .mate_pos(1392);
+        ss.add_array_i32(SamTag::TC, &tc);
+        let ss = ss.build();
+        let (ss_key, _) = compute_group_key_from_raw(ss.as_ref(), &library_index, None, None);
+
+        assert_eq!(
+            ss_key, primary_key,
+            "sec/supp read keyed via tc must group IDENTICALLY to its primary pair, \
+             not at its own (pos=9000) alignment"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A secondary/supplementary alignment carries its **own** position and its **mate's**, but not its **own primary's** position — so it cannot reconstruct its template coordinate from its own record. Per-record keying (as samtools and fgbio do) can therefore only *approximate* a supplementary's placement by the mate coordinate, which drifts up to a fragment length from the template's true coordinate; an intervening template then separates the supplementary from its primary's position group.

`fgumi zipper` already pre-computes the **exact** template coordinate of the primary pair and stamps it onto secondary/supplementary reads as the `tc` tag (`B:i:[tid1,pos1,neg1,tid2,pos2,neg2]`). This makes the template-coordinate **sort** and **dedup** consume `tc` so they place those reads *exactly* at their primary pair's coordinate — a placement samtools/fgbio cannot achieve because they don't persist it. This is a capability unique to fgumi.

## Changes

- **`fgumi_raw_bam::read_tc_template_coordinate`** — reads the 6-element `tc` `B:i` array from raw aux bytes (rejects malformed/wrong-length arrays).
- **`extract_template_key_inline`** (template-coordinate sort) — for a secondary/supplementary read with `tc`, key on the tc coordinate; otherwise fall back to the existing per-record computation. Primaries and un-stamped reads are untouched.
- **`compute_group_key_from_raw`** (dedup grouping) — for a secondary/supplementary read with `tc`, build the position `GroupKey` from the tc coordinate (extracting RG/CB so the key matches its primary's), instead of an UNKNOWN position that relies on the read sorting adjacent to its primary.

## Testing

- **Unit (TDD, RED→GREEN):**
  - `test_extract_template_key_supplementary_uses_tc_tag` — a supplementary keys at its exact `tc` coordinate (sorts before an intervening template), where per-record keying misplaces it at the mate coordinate.
  - `test_extract_template_key_supplementary_without_tc_falls_back` — pins the no-`tc` fallback (unchanged prior behavior).
  - `test_group_key_supplementary_uses_tc_tag` — dedup keys a supplementary on its primary's coordinate (from `tc`) rather than UNKNOWN.
- **Real data (SRR6109273):** re-sorting the zipper output moves ~16k of 17,449 supplementary reads to their exact template coordinate (co-located with their primary); primaries are unchanged (only 52 local tie-break shuffles); `dedup` still runs cleanly with an unchanged duplicate count.
- Full suite green: `cargo nextest` 2242 passed, `cargo clippy --workspace --all-targets --features compare,simulate,profile-adjacency -- -D warnings -W clippy::pedantic` clean, `cargo fmt --check` clean.

## Note

This intentionally diverges from samtools/fgbio for secondary/supplementary reads (they cannot co-locate these exactly). Related upstream context: samtools/samtools#2347 (fixmate MC on supplementaries) addresses the same fundamental limitation from the other direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template-coordinate sorting and grouping for secondary and supplementary alignments by using stamped `tc` coordinate metadata when present.
  * Secondary/supplementary alignments now align to the corresponding primary’s group key when `tc` is available.
  * Kept the previous fallback behavior when `tc` is missing or malformed.
* **Tests**
  * Added regression coverage for paired primary, secondary, and supplementary cases, including tie scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->