### PR TITLE
fix(codec,consensus): soft-only overlap-clip boundary, MC-independent codec clip, fgbio-faithful quality masking (CODEC3-03/04/05/06)

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -663,9 +663,14 @@ impl CodecConsensusCaller {
                 }
             };
 
-            // Compute clip amounts from raw bytes
-            let clip_r1 = bam_fields::num_bases_extending_past_mate_raw(&records[i1]);
-            let clip_r2 = bam_fields::num_bases_extending_past_mate_raw(&records[i2]);
+            // Compute overlap-clip amounts from the mate record in hand (not the MC tag), so
+            // clipping still occurs when MC is absent — mirroring fgbio `updateMateCigars`, which
+            // backfills the mate CIGAR from the in-group mate before clipping (CODEC3-04). The
+            // mate boundary is soft-only, matching fgbio `mateUnSoftClippedStart/End` (CODEC3-03).
+            let clip_r1 =
+                bam_fields::num_bases_extending_past_mate_vs_mate_raw(&records[i1], &records[i2]);
+            let clip_r2 =
+                bam_fields::num_bases_extending_past_mate_vs_mate_raw(&records[i2], &records[i1]);
 
             // Build ClippedRecordInfo for R1
             let r1_info = Self::build_clipped_info(&records[i1], i1, clip_r1);
@@ -1286,36 +1291,48 @@ impl CodecConsensusCaller {
         })
     }
 
-    /// Masks consensus qualities for query-based consensus.
-    /// Identifies single-strand regions by checking if either padded consensus has 'N'.
-    /// This matches fgbio's maskCodecConsensusQuals behavior.
+    /// Masks consensus qualities for query-based consensus, matching fgbio's
+    /// `CodecConsensusCaller.maskCodecConsensusQuals`.
+    ///
+    /// Two masks are applied in fgbio's order:
+    /// 1. **Outer bases** (`--outer-bases-qual`): the first/last `outer_bases_length` qualities are
+    ///    **assigned** the outer quality (not `min`-ed) so the mask can raise as well as lower.
+    /// 2. **Single-strand regions** (`--single-strand-qual`): positions where either padded strand
+    ///    lacks coverage are assigned the single-strand quality. "Lacks coverage" is represented by
+    ///    lowercase `n` padding (`NO_CALL_BASE_LOWER`) OR an uppercase `N` no-call, matching fgbio's
+    ///    `a(i)∈{n,N} || b(i)∈{n,N}` check.
+    ///
+    /// Outer masking runs first so single-strand masking wins where the two regions overlap.
     fn mask_consensus_quals_query_based(
         &self,
         mut consensus: SingleStrandConsensus,
         padded_r1: &SingleStrandConsensus,
         padded_r2: &SingleStrandConsensus,
     ) -> SingleStrandConsensus {
-        let len = consensus.bases.len();
+        let len = consensus.quals.len();
 
-        for idx in 0..len {
-            // Mask single-strand regions first
-            // Single-strand positions are where one padded consensus has 'N'
-            // This matches fgbio's check: if (a(i) == 'N' || b(i) == 'N')
-            let a_is_n = padded_r1.bases.get(idx).copied().unwrap_or(NO_CALL_BASE) == NO_CALL_BASE;
-            let b_is_n = padded_r2.bases.get(idx).copied().unwrap_or(NO_CALL_BASE) == NO_CALL_BASE;
-
-            if (a_is_n || b_is_n) && consensus.bases[idx] != NO_CALL_BASE {
-                // This is a single-strand position with a base
-                if let Some(ss_qual) = self.options.single_strand_qual {
-                    consensus.quals[idx] = ss_qual;
+        // 1. Outer bases: assign the outer quality to the first/last `outer_bases_length` bases.
+        if self.options.outer_bases_length > 0 {
+            if let Some(outer_qual) = self.options.outer_bases_qual {
+                let last_idx = len.saturating_sub(1);
+                for i in 0..min(self.options.outer_bases_length, len) {
+                    consensus.quals[i] = outer_qual;
+                    consensus.quals[last_idx - i] = outer_qual;
                 }
             }
+        }
 
-            // Mask outer bases
-            if let Some(outer_qual) = self.options.outer_bases_qual {
-                let outer_len = self.options.outer_bases_length;
-                if idx < outer_len || idx >= len.saturating_sub(outer_len) {
-                    consensus.quals[idx] = min(consensus.quals[idx], outer_qual);
+        // 2. Single-strand regions: assign the single-strand quality where either strand lacks
+        //    coverage. Lowercase `n` padding must count here — otherwise the single-strand tails
+        //    (the exact target of `--single-strand-qual`) are never masked (CODEC3-05).
+        if let Some(ss_qual) = self.options.single_strand_qual {
+            for idx in 0..len {
+                let a = padded_r1.bases.get(idx).copied().unwrap_or(NO_CALL_BASE);
+                let b = padded_r2.bases.get(idx).copied().unwrap_or(NO_CALL_BASE);
+                let a_is_n = a == NO_CALL_BASE || a == NO_CALL_BASE_LOWER;
+                let b_is_n = b == NO_CALL_BASE || b == NO_CALL_BASE_LOWER;
+                if a_is_n || b_is_n {
+                    consensus.quals[idx] = ss_qual;
                 }
             }
         }
@@ -1455,7 +1472,15 @@ impl CodecConsensusCaller {
             self.bam_builder.append_phred33_string_tag(SamTag::BQ, &ss_b.quals);
         }
 
-        // Cell barcode tag - extract from first source read if configured
+        // Cell barcode tag - extract from the first source read carrying it.
+        //
+        // Unlike fgbio `CodecConsensusCaller` (which groups by MI only, then `require`s a single
+        // distinct CB across the molecule and errors on conflict), fgumi groups reads by the
+        // composite key `MI\tCB` (see `MiGroupIterator::with_cell_tag`, wired in `codec.rs`). Every
+        // record reaching a single consensus group therefore already shares one cell barcode, so
+        // fgbio's cross-barcode conflict guard is inapplicable here — an intentional single-cell
+        // divergence, not a missing check (CODEC3-07). Because the group is CB-homogeneous, taking
+        // the first present value is unambiguous.
         if let Some(cell_tag) = &self.options.cell_tag {
             let cell_tag_bytes: [u8; 2] = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
             for raw in source_raws {
@@ -3338,6 +3363,70 @@ mod tests {
             has_low_qual || quals.is_empty(),
             "Should have some low-quality single-strand regions (or be filtered)"
         );
+    }
+
+    /// Builds a `SingleStrandConsensus` for masking tests: `bases` + `quals`, everything else zeroed.
+    fn ss_for_mask(bases: &[u8], quals: Vec<PhredScore>) -> SingleStrandConsensus {
+        let len = bases.len();
+        SingleStrandConsensus {
+            bases: bases.to_vec(),
+            quals,
+            depths: vec![2; len],
+            errors: vec![0; len],
+            raw_read_count: 2,
+            ref_start: 0,
+            ref_end: len.saturating_sub(1),
+            is_negative_strand: false,
+        }
+    }
+
+    /// CODEC3-05: single-strand tails are padded with lowercase `n`; `--single-strand-qual`
+    /// masking must fire on them (the previous code only matched uppercase `N`).
+    #[test]
+    fn test_mask_consensus_quals_masks_lowercase_n_single_strand_tails() {
+        let options = CodecConsensusOptions {
+            single_strand_qual: Some(20),
+            outer_bases_qual: None,
+            outer_bases_length: 0,
+            ..CodecConsensusOptions::default()
+        };
+        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        let consensus = ss_for_mask(b"ACGTA", vec![40, 40, 40, 40, 40]);
+        // padded_r1 lacks coverage at 0,1 (lowercase 'n'); padded_r2 lacks coverage at 4.
+        let padded_r1 = ss_for_mask(b"nnGTA", vec![0, 0, 40, 40, 40]);
+        let padded_r2 = ss_for_mask(b"ACGTn", vec![40, 40, 40, 40, 0]);
+
+        let masked = caller.mask_consensus_quals_query_based(consensus, &padded_r1, &padded_r2);
+        // Single-strand positions {0,1,4} -> Q20; duplex positions {2,3} unchanged.
+        assert_eq!(masked.quals, vec![20, 20, 40, 40, 20]);
+    }
+
+    /// CODEC3-06: outer masking is applied FIRST and ASSIGNS (not `min`), and single-strand
+    /// masking (applied second) wins where the two regions overlap.
+    #[test]
+    fn test_mask_consensus_quals_outer_first_then_single_strand_wins() {
+        let options = CodecConsensusOptions {
+            single_strand_qual: Some(20),
+            outer_bases_qual: Some(10),
+            outer_bases_length: 2,
+            ..CodecConsensusOptions::default()
+        };
+        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // Position 1 starts at Q5 (below the Q10 outer quality) so this case distinguishes
+        // assignment from `min`: outer masking assigning Q10 raises it to Q10, whereas
+        // `min(Q5, Q10)` would leave it at Q5.
+        let consensus = ss_for_mask(b"ACGTAC", vec![40, 5, 40, 40, 40, 40]);
+        // Position 0 is single-strand (a='n'); the rest are duplex.
+        let padded_r1 = ss_for_mask(b"nCGTAC", vec![0, 40, 40, 40, 40, 40]);
+        let padded_r2 = ss_for_mask(b"ACGTAC", vec![40, 40, 40, 40, 40, 40]);
+
+        let masked = caller.mask_consensus_quals_query_based(consensus, &padded_r1, &padded_r2);
+        // Outer (len 2) assigns Q10 to {0,1,4,5} (position 1's Q5 is raised to Q10, proving
+        // assignment rather than min); then single-strand assigns Q20 to {0}, winning over the
+        // outer Q10 there. (The old min+single-strand-first order left position 0 at Q10.)
+        assert_eq!(masked.quals, vec![20, 10, 40, 40, 10, 10]);
     }
 
     /// Test that uppercase 'N' (`NoCall`) from one strand masks the result to N,

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -87,7 +87,10 @@ pub use cigar::{
 };
 
 // -- overlap --
-pub use overlap::{is_fr_pair_raw, is_primary_fr_pair_raw, num_bases_extending_past_mate_raw};
+pub use overlap::{
+    is_fr_pair_raw, is_primary_fr_pair_raw, num_bases_extending_past_mate_raw,
+    num_bases_extending_past_mate_vs_mate_raw,
+};
 
 // -- raw_bam_record --
 pub use raw_bam_record::{

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -1,7 +1,6 @@
 use crate::SamTag;
 use crate::cigar::{
     consumes_query, get_cigar_ops, reference_length_from_cigar, reference_length_from_raw_bam,
-    unclipped_other_end, unclipped_other_start,
 };
 use crate::fields::{RawRecordView, aux_data_slice, flags, mate_pos, mate_ref_id, template_length};
 use crate::tags::RawTagsView;
@@ -101,16 +100,25 @@ pub fn is_primary_fr_pair_raw(a: &[u8], b: &[u8]) -> bool {
     is_fr_pair_raw(reverse_record)
 }
 
+/// Number of bases a read extends past its mate for FR pairs, deriving the mate's boundary
+/// from the read's own **MC tag** (the mate CIGAR). Returns `0` for non-FR pairs or when the
+/// MC tag is absent/invalid.
+///
+/// The mate boundary uses **soft-only** unclipped coordinates (fgbio `mateUnSoftClippedStart`/
+/// `mateUnSoftClippedEnd`) — hard clips do NOT extend it. This deliberately differs from the
+/// samtools-style soft+hard unclipped 5' position used for template-coordinate sorting/grouping
+/// (see [`crate::cigar::mate_unclipped_5prime`]): overlap clipping counts only bases physically
+/// present in the mate's sequence, whereas the sort/group key follows samtools' soft+hard
+/// convention. Used by the simplex (vanilla) and duplex consensus callers, mirroring fgbio's
+/// base `UmiConsensusCaller.numBasesExtendingPastMate`. The codec caller instead uses
+/// [`num_bases_extending_past_mate_vs_mate_raw`], which reads the mate boundary from the mate
+/// record in hand rather than its MC tag (see CODEC3-04).
 #[must_use]
 pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
     // Only applies to FR pairs (matching the RecordBuf-based `num_bases_extending_past_mate`)
     if !is_fr_pair_raw(bam) {
         return 0;
     }
-
-    let v = RawRecordView::new(bam);
-    let flg = v.flags();
-    let is_reverse = flg & flags::REVERSE != 0;
 
     // Need MC tag for mate CIGAR information
     let aux = aux_data_slice(bam);
@@ -121,13 +129,55 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
         return 0;
     };
 
-    let this_pos_0based = v.pos();
-    let m_pos_0based = mate_pos(bam);
-    // Convert to 1-based for coordinate calculations
-    let this_pos = this_pos_0based + 1;
-    let m_pos = m_pos_0based + 1;
+    // A malformed MC CIGAR fails closed to 0 (no clip), honoring the doc contract above
+    // ("Returns 0 ... when the MC tag is absent/invalid").
+    let Some((mate_unclipped_start, mate_unclipped_end)) =
+        mate_soft_unclipped_from_mc(mate_pos(bam) + 1, mc_cigar)
+    else {
+        return 0;
+    };
+    bases_extending_past_mate(bam, mate_unclipped_start, mate_unclipped_end)
+}
 
-    // Calculate read length from CIGAR (query-consuming ops)
+/// Number of bases a read extends past its mate for FR pairs, deriving the mate's boundary
+/// from the **mate record in hand** rather than the read's MC tag.
+///
+/// Codec (and any caller holding both primary reads) uses this so overlap clipping does not
+/// silently no-op when the MC tag is missing — mirroring fgbio's `updateMateCigars`, which
+/// backfills the mate CIGAR from the in-group mate before clipping. Uses the same soft-only
+/// mate boundary as [`num_bases_extending_past_mate_raw`].
+///
+/// Because both records are in hand, FR classification uses the symmetric per-pair
+/// [`is_primary_fr_pair_raw`] rather than the per-record [`is_fr_pair_raw`]. The per-record test is
+/// asymmetric for dovetail pairs (htsjdk/samtools#1771): a valid dovetail-forward pair can be
+/// mis-classified as non-FR from the forward read's perspective, which would zero its clip even
+/// though the caller (e.g. the codec caller's `is_primary_fr_pair_raw` gate) accepted the pair.
+#[must_use]
+pub fn num_bases_extending_past_mate_vs_mate_raw(rec: &[u8], mate: &[u8]) -> usize {
+    if !is_primary_fr_pair_raw(rec, mate) {
+        return 0;
+    }
+    let mate_pos_1based = RawRecordView::new(mate).pos() + 1;
+    let mate_ops = get_cigar_ops(mate);
+    let (mate_unclipped_start, mate_unclipped_end) =
+        mate_soft_unclipped_from_ops(mate_pos_1based, &mate_ops);
+    bases_extending_past_mate(rec, mate_unclipped_start, mate_unclipped_end)
+}
+
+/// Core of the overlap-clip computation shared by the MC-based and mate-record-based entry
+/// points: given the mate's soft-only unclipped start/end (1-based), returns how many bases at
+/// the read's 3' (sequencing) end extend past the mate. Mirrors fgbio
+/// `SamRecordClipper.numBasesExtendingPastMate`.
+#[must_use]
+fn bases_extending_past_mate(
+    bam: &[u8],
+    mate_unclipped_start: i32,
+    mate_unclipped_end: i32,
+) -> usize {
+    let v = RawRecordView::new(bam);
+    let is_reverse = v.flags() & flags::REVERSE != 0;
+    let this_pos = v.pos() + 1; // 1-based
+
     let cigar_ops = get_cigar_ops(bam);
     let read_length: usize = cigar_ops
         .iter()
@@ -140,34 +190,150 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
 
     if is_reverse {
         // Negative strand: check if read extends before mate's unclipped start
-        let mate_us = unclipped_other_start(m_pos, mc_cigar);
-
-        if this_pos <= mate_us {
-            compute_bases_before_ref_pos(&cigar_ops, this_pos, mate_us)
+        if this_pos <= mate_unclipped_start {
+            compute_bases_before_ref_pos(&cigar_ops, this_pos, mate_unclipped_start)
         } else {
-            // Only clip excess soft-clipped bases at the start
+            // Only clip excess soft-clipped bases at the start.
+            // saturating: an adversarial MC-tag/mate CIGAR can push mate_unclipped_start far
+            // negative (leading_soft saturates to i32::MAX upstream), so a plain subtraction
+            // would overflow i32 here — panic in debug, wrap to garbage in release.
             let leading_sc = leading_soft_clip_from_ops(&cigar_ops);
-            let gap = (this_pos - mate_us).cast_unsigned() as usize;
+            let gap = this_pos.saturating_sub(mate_unclipped_start).cast_unsigned() as usize;
             leading_sc.saturating_sub(gap)
         }
     } else {
-        // Positive strand: check if read extends past mate's unclipped end
+        // Positive strand: check if read extends past mate's unclipped end.
+        // saturating: an oversized decoded CIGAR can drive `ref_len` up to `i32::MAX`, so a plain
+        // `this_pos + ref_len - 1` would overflow i32 before clipping can fail closed — panic in
+        // debug, wrap to garbage in release.
         let ref_len = reference_length_from_cigar(&cigar_ops);
-        let alignment_end = this_pos + ref_len - 1;
-        let mate_ue = unclipped_other_end(m_pos, mc_cigar);
+        let alignment_end = this_pos.saturating_add(ref_len).saturating_sub(1);
 
-        if alignment_end >= mate_ue {
+        if alignment_end >= mate_unclipped_end {
             // Compute read position at mate's unclipped end
-            // Simplified: use reference position mapping
-            let bases_past = compute_bases_past_ref_pos(&cigar_ops, this_pos, mate_ue);
+            let bases_past = compute_bases_past_ref_pos(&cigar_ops, this_pos, mate_unclipped_end);
             read_length.saturating_sub(bases_past)
         } else {
-            // Only clip excess soft-clipped bases
+            // Only clip excess soft-clipped bases.
+            // saturating for symmetry with the reverse-strand branch: mate_unclipped_end only
+            // saturates upward (bounded by i32::MAX) so this is not currently reachable-overflow,
+            // but saturating the subtraction closes the analogous gap defensively and cheaply.
             let trailing_sc = trailing_soft_clip_from_ops(&cigar_ops);
-            let gap = (mate_ue - alignment_end).cast_unsigned() as usize;
+            let gap = mate_unclipped_end.saturating_sub(alignment_end).cast_unsigned() as usize;
             trailing_sc.saturating_sub(gap)
         }
     }
+}
+
+/// Mate's soft-only unclipped start/end (1-based) from an MC-tag CIGAR **string** and the
+/// mate's 1-based leftmost position. Only soft clips count — hard clips are excluded — matching
+/// fgbio `mateUnSoftClippedStart`/`mateUnSoftClippedEnd`.
+fn mate_soft_unclipped_from_mc(mate_pos_1based: i32, mc_cigar: &str) -> Option<(i32, i32)> {
+    let (leading_soft, ref_len, trailing_soft) = parse_soft_clips_and_ref_len(mc_cigar)?;
+    // saturating: a saturated ref_len/soft-clip (from an adversarial MC CIGAR) must
+    // clamp the boundary, not overflow-panic (debug) / wrap to a negative (release).
+    Some((
+        mate_pos_1based.saturating_sub(leading_soft),
+        mate_pos_1based.saturating_add(ref_len).saturating_add(trailing_soft) - 1,
+    ))
+}
+
+/// Mate's soft-only unclipped start/end (1-based) from the mate record's own CIGAR **ops**.
+fn mate_soft_unclipped_from_ops(mate_pos_1based: i32, mate_ops: &[u32]) -> (i32, i32) {
+    // Both soft-clip totals clamp to i32::MAX (not 0) when they overflow i32: an oversized
+    // trailing clip that collapsed to 0 would shrink mate_unclipped_end, making the read look
+    // like it extends further past the mate and over-clipping the consensus. Fail closed by
+    // clamping the boundary outward, matching leading_soft.
+    let leading_soft = i32::try_from(leading_soft_clip_from_ops(mate_ops)).unwrap_or(i32::MAX);
+    let trailing_soft = i32::try_from(trailing_soft_clip_from_ops(mate_ops)).unwrap_or(i32::MAX);
+    let ref_len = reference_length_from_cigar(mate_ops);
+    (
+        mate_pos_1based.saturating_sub(leading_soft),
+        mate_pos_1based.saturating_add(ref_len).saturating_add(trailing_soft) - 1,
+    )
+}
+
+/// Parses `(leading_soft_clips, reference_length, trailing_soft_clips)` from a CIGAR string,
+/// counting only soft (`S`) clips — hard clips (`H`) are ignored, giving the soft-only unclipped
+/// extent fgbio uses for overlap clipping.
+///
+/// Returns `None` for any CIGAR that is not a structurally valid SAM CIGAR for a mapped record,
+/// so malformed MC-tag input fails closed rather than yielding a partial boundary. Rejected:
+/// - an unknown operator byte (e.g. the `f`/`o` in `10Mfoo5S`, or a non-ASCII byte);
+/// - an operator with no preceding run-length (a bare `MS`) or a zero run-length (`0M`, `10M0S`);
+/// - a trailing run-length with no operator (`10M5`), or an empty CIGAR;
+/// - a soft (`S`) or hard (`H`) clip that is not at the end of the CIGAR — `S` may only sit at the
+///   ends (inside any `H`), and `H` only as the first/last operation (e.g. `10M5S10M` is invalid);
+/// - a CIGAR with no reference-consuming operation (`10S`), which a mapped mate cannot have.
+fn parse_soft_clips_and_ref_len(cigar: &str) -> Option<(i32, i32, i32)> {
+    // Phase 1: tokenize into (run_length, operator) pairs. Accumulate the run-length from digit
+    // bytes directly rather than slicing the string by byte offset — slicing on a non-ASCII byte
+    // (a malformed CIGAR) would panic on a char boundary. Reject lexical errors here.
+    let mut tokens: Vec<(i32, u8)> = Vec::new();
+    let mut num = 0i32;
+    let mut have_digits = false;
+    for &c in cigar.as_bytes() {
+        if c.is_ascii_digit() {
+            // saturating: an adversarial MC CIGAR can sum a run-length past i32::MAX; clamp
+            // rather than overflow-panic (debug) / wrap (release).
+            num = num.saturating_mul(10).saturating_add(i32::from(c - b'0'));
+            have_digits = true;
+            continue;
+        }
+        // Every operator needs a positive run-length, and must be a known CIGAR operator.
+        if !have_digits || num == 0 {
+            return None;
+        }
+        if !matches!(c, b'M' | b'I' | b'D' | b'N' | b'S' | b'H' | b'P' | b'=' | b'X') {
+            return None;
+        }
+        tokens.push((num, c));
+        num = 0;
+        have_digits = false;
+    }
+    // A dangling run-length with no operator (`10M5`), or an empty CIGAR, is malformed.
+    if have_digits || tokens.is_empty() {
+        return None;
+    }
+
+    // Phase 2: validate structure and accumulate the soft-only boundary in one pass. Soft clips
+    // must sit at the ends (inside any hard clip); hard clips only as the first/last operation.
+    let last = tokens.len() - 1;
+    let mut leading_soft = 0i32;
+    let mut trailing_soft = 0i32;
+    let mut ref_len = 0i32;
+    let mut saw_ref_op = false;
+    for (i, &(len, op)) in tokens.iter().enumerate() {
+        match op {
+            b'M' | b'D' | b'N' | b'=' | b'X' => {
+                ref_len = ref_len.saturating_add(len);
+                saw_ref_op = true;
+            }
+            b'I' | b'P' => {} // interior op: no boundary contribution, no placement constraint
+            b'S' => {
+                let leading = tokens[..i].iter().all(|&(_, o)| o == b'H');
+                let trailing = tokens[i + 1..].iter().all(|&(_, o)| o == b'H');
+                if !leading && !trailing {
+                    return None; // internal soft clip: invalid placement
+                }
+                if saw_ref_op {
+                    trailing_soft = trailing_soft.saturating_add(len);
+                } else {
+                    leading_soft = leading_soft.saturating_add(len);
+                }
+            }
+            b'H' if i == 0 || i == last => {} // hard clip only permitted at the ends
+            // An internal hard clip is invalid placement; the tokenizer already rejected unknown
+            // operators, so every other operator byte here also fails closed.
+            _ => return None,
+        }
+    }
+    // A mapped mate's CIGAR must consume reference; a fully-clipped CIGAR (`10S`) cannot.
+    if !saw_ref_op {
+        return None;
+    }
+
+    Some((leading_soft, ref_len, trailing_soft))
 }
 
 /// Whether to return the read position at or past the target reference position,
@@ -291,6 +457,97 @@ fn leading_soft_clip_from_ops(cigar_ops: &[u32]) -> usize {
 mod tests {
     use super::*;
     use crate::testutil::*;
+    use rstest::rstest;
+
+    // ========================================================================
+    // parse_soft_clips_and_ref_len tests
+    // ========================================================================
+
+    /// `(leading_soft, ref_len, trailing_soft)`, counting only soft clips (H excluded).
+    /// Any CIGAR that is not a structurally valid SAM CIGAR for a mapped record fails closed
+    /// to `None` rather than yielding a partial boundary.
+    #[rstest]
+    // --- valid CIGARs ---
+    #[case::simple_match("40M", Some((0, 40, 0)))]
+    #[case::leading_soft("5S10M", Some((5, 10, 0)))]
+    #[case::trailing_soft("10M3S", Some((0, 10, 3)))]
+    #[case::both_soft("5S10M3S", Some((5, 10, 3)))]
+    #[case::hard_excluded("5H10M2H", Some((0, 10, 0)))]
+    #[case::soft_and_hard("2H5S10M3S2H", Some((5, 10, 3)))]
+    #[case::ref_ops_summed("5M2D3N4M", Some((0, 14, 0)))]
+    #[case::insertion_ignored("5M2I3M", Some((0, 8, 0)))]
+    // A malformed/adversarial MC CIGAR whose ref ops sum past i32::MAX must
+    // saturate rather than overflow the `ref_len += num` accumulation.
+    #[case::oversized_ref_ops_saturate("2000000000M2000000000M", Some((0, i32::MAX, 0)))]
+    // --- lexically malformed: unknown byte, missing/zero run-length, dangling length, empty ---
+    #[case::non_ascii_rejected("10M\u{20ac}5S", None)]
+    #[case::embedded_garbage_rejected("10Mfoo5S", None)]
+    #[case::bare_operator_rejected("MS", None)]
+    #[case::dangling_length_rejected("10M5", None)]
+    #[case::empty_rejected("", None)]
+    #[case::zero_length_ref_rejected("0M", None)]
+    #[case::zero_length_soft_rejected("10M0S", None)]
+    // --- structurally malformed: misplaced clips, or no reference-consuming operation ---
+    #[case::internal_soft_rejected("10M5S10M", None)]
+    #[case::internal_hard_rejected("10M5H10M", None)]
+    #[case::leading_hard_after_soft_rejected("5S2H10M", None)]
+    #[case::no_ref_op_soft_only_rejected("36S", None)]
+    #[case::no_ref_op_insertion_only_rejected("5S5I", None)]
+    fn test_parse_soft_clips_and_ref_len(
+        #[case] cigar: &str,
+        #[case] expected: Option<(i32, i32, i32)>,
+    ) {
+        assert_eq!(parse_soft_clips_and_ref_len(cigar), expected);
+    }
+
+    /// A crafted (valid-UTF-8) MC-tag CIGAR with an op length that saturates
+    /// `ref_len` must not overflow the boundary arithmetic
+    /// (`mate_pos_1based + ref_len + trailing_soft - 1`). Pre-fix this panicked in
+    /// debug/test and wrapped to a bogus negative boundary in release, corrupting
+    /// the overlap-clip amount. A well-formed BAM cannot reach this (real ref
+    /// lengths are chromosome-bounded), but the MC Z-string is never length-checked.
+    #[rstest]
+    #[case::from_mc(mate_soft_unclipped_from_mc(100, "9999999999M"))]
+    fn mate_soft_unclipped_saturates_on_oversized_cigar(#[case] bounds: Option<(i32, i32)>) {
+        let (start, end) = bounds.expect("well-formed (if oversized) CIGAR parses");
+        assert_eq!(start, 100, "no leading soft clip -> start stays at mate_pos");
+        assert!(end >= start, "end boundary must stay >= start, not wrap negative");
+        assert_eq!(end, i32::MAX - 1, "saturated ref_len clamps the end boundary");
+    }
+
+    /// A malformed MC CIGAR fails closed through the whole MC-tag boundary path:
+    /// `mate_soft_unclipped_from_mc` returns `None` rather than a partial boundary.
+    #[rstest]
+    #[case::embedded_garbage("10Mfoo5S")]
+    #[case::bare_operator("MS")]
+    #[case::non_ascii("10M\u{20ac}5S")]
+    #[case::internal_soft("10M5S10M")]
+    #[case::no_ref_op("36S")]
+    #[case::empty("")]
+    fn mate_soft_unclipped_from_mc_rejects_malformed(#[case] cigar: &str) {
+        assert_eq!(mate_soft_unclipped_from_mc(100, cigar), None);
+    }
+
+    /// A mate record whose trailing soft clips sum past `i32::MAX` must clamp the mate
+    /// boundary outward (to `i32::MAX`), not collapse to `0`. Collapsing to `0` shrank
+    /// `mate_unclipped_end`, making the read look like it extends further past the mate
+    /// and over-clipping the consensus.
+    #[test]
+    fn mate_soft_unclipped_from_ops_clamps_oversized_trailing_soft() {
+        // A CIGAR op length is stored in 28 bits, so a single op maxes at 2^28 - 1; nine of
+        // them sum past i32::MAX. The leading 10M anchors the ref op so the S ops count as
+        // *trailing* soft clips.
+        let max_op_len = (1usize << 28) - 1;
+        let mut ops = vec![encode_op(0, 10)]; // 10M
+        ops.extend(vec![encode_op(4, max_op_len); 9]); // 9 oversized trailing S
+        let (start, end) = mate_soft_unclipped_from_ops(100, &ops);
+        assert_eq!(start, 100, "no leading soft clip -> start stays at mate_pos");
+        assert_eq!(
+            end,
+            i32::MAX - 1,
+            "oversized trailing soft clip clamps the boundary outward, not to a shrunken 109"
+        );
+    }
 
     // ========================================================================
     // is_fr_pair_raw tests
@@ -810,7 +1067,7 @@ mod tests {
         // Positive strand read extending past reverse mate's unclipped end
         // Read: forward at pos 100, 20M (alignment_end = 101 + 20 - 1 = 120, 1-based)
         // Mate: reverse at pos 105, MC=10M (mate unclipped_end = 106 + 10 - 1 = 115, 1-based)
-        // alignment_end (120) >= mate_ue (115), so need to compute bases past ref 115
+        // alignment_end (120) >= mate_unclipped_end (115), so need to compute bases past ref 115
         // At ref 115 (1-based), starting from alignment_start=101:
         // offset in 20M = 115 - 101 + 1 = 15 -> read_pos 15
         // read_length = 20
@@ -837,7 +1094,7 @@ mod tests {
         // Positive strand read NOT extending past reverse mate's unclipped end
         // Read: forward at pos 100, 10M (alignment_end = 101 + 10 - 1 = 110)
         // Mate: reverse at pos 200, MC=10M (mate unclipped_end = 201 + 10 - 1 = 210)
-        // alignment_end (110) < mate_ue (210), check trailing soft clips
+        // alignment_end (110) < mate_unclipped_end (210), check trailing soft clips
         // No trailing soft clips => trailing_sc.saturating_sub(gap) = 0
         let mut aux = Vec::new();
         aux.extend_from_slice(b"MCZ10M\x00");
@@ -856,12 +1113,42 @@ mod tests {
         assert_eq!(num_bases_extending_past_mate_raw(&rec), 0);
     }
 
+    /// An oversized reference-consuming read CIGAR must not overflow the positive-strand
+    /// `alignment_end = this_pos + ref_len - 1` computation. Eight max-length `M` ops sum to
+    /// `8 * (2^28 - 1) = 2_147_483_640` (just under `i32::MAX`, so `reference_length_from_cigar`
+    /// itself does not overflow), and `this_pos (101) + ref_len` then exceeds `i32::MAX` — a plain
+    /// subtraction would panic in debug / wrap in release. The saturating computation instead
+    /// clamps `alignment_end` to `i32::MAX - 1`, which still exceeds the mate's unclipped end (210),
+    /// so the read is measured to extend past the mate by `read_length - 110` bases.
+    #[test]
+    fn test_num_bases_extending_past_mate_raw_oversized_ref_cigar_saturates() {
+        let max_op_len = (1usize << 28) - 1; // CIGAR op length is 28 bits
+        let cigar: Vec<u32> = vec![encode_op(0, max_op_len); 8]; // 8 oversized M ops
+        let read_length = 8 * max_op_len;
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MCZ10M\x00");
+        let rec = make_bam_bytes_with_tlen(
+            0,
+            100, // 0-based pos -> this_pos = 101
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"rea",
+            &cigar,
+            10, // l_seq is unused by the overlap math; keep the record small
+            0,
+            200, // mate reverse at 200 -> mate unclipped_end = 210
+            100, // TLEN > 0 so the forward read classifies as a valid FR pair
+            &aux,
+        );
+        // read_pos at ref 210 (alignment_start 101) = 110 -> read_length - 110.
+        assert_eq!(num_bases_extending_past_mate_raw(&rec), read_length - 110);
+    }
+
     #[test]
     fn test_num_bases_extending_past_mate_raw_negative_strand_overlap() {
         // Negative strand read extending before forward mate's unclipped start
         // Read: reverse at pos 100, 20M
         // Mate: forward at pos 105, MC=10M (mate unclipped_start = 106)
-        // this_pos (101) <= mate_us (106), so compute bases before ref pos 106
+        // this_pos (101) <= mate_unclipped_start (106), so compute bases before ref pos 106
         // 20M from pos 101: at ref 106, read_pos = 6, returns 6-1 = 5
         let mut aux = Vec::new();
         aux.extend_from_slice(b"MCZ10M\x00");
@@ -884,7 +1171,7 @@ mod tests {
         // Negative strand read NOT extending before forward mate
         // Read: reverse at pos 200, 10M
         // Mate: forward at pos 100, MC=10M (mate unclipped_start = 101)
-        // this_pos (201) > mate_us (101), check leading soft clips
+        // this_pos (201) > mate_unclipped_start (101), check leading soft clips
         // No leading soft clips, gap = 201 - 101 = 100, 0.saturating_sub(100) = 0
         let mut aux = Vec::new();
         aux.extend_from_slice(b"MCZ10M\x00");
@@ -904,11 +1191,11 @@ mod tests {
 
     #[test]
     fn test_num_bases_extending_past_mate_raw_negative_strand_gap_with_soft_clip() {
-        // Negative strand read with soft clip, this_pos > mate_us
+        // Negative strand read with soft clip, this_pos > mate_unclipped_start
         // Read: reverse at pos 110 (0-based), 3S10M (query_len=13)
         // Mate: forward at pos 105 (0-based), MC=10M (mate unclipped_start = 106)
-        // this_pos = 111, mate_us = 106
-        // this_pos > mate_us, so gap = 111 - 106 = 5
+        // this_pos = 111, mate_unclipped_start = 106
+        // this_pos > mate_unclipped_start, so gap = 111 - 106 = 5
         // leading_soft_clip = 3, 3.saturating_sub(5) = 0
         let mut aux = Vec::new();
         aux.extend_from_slice(b"MCZ10M\x00");
@@ -927,11 +1214,42 @@ mod tests {
     }
 
     #[test]
+    fn test_num_bases_extending_past_mate_raw_reverse_oversized_mc_leading_soft_no_overflow() {
+        // Regression (CodeRabbit): an adversarial MC-tag CIGAR with an oversized leading
+        // soft clip saturates `leading_soft` to i32::MAX, pushing the mate's soft-only
+        // unclipped start far negative. In the reverse-strand `this_pos > mate_unclipped_start`
+        // branch, the gap subtraction `this_pos - mate_unclipped_start` then exceeds i32::MAX.
+        // Pre-fix this panicked in debug/test (overflow) and wrapped to garbage in release;
+        // it must saturate instead and clip nothing.
+        //
+        // Read: reverse at pos 100 (0-based) => this_pos = 101, 20M (no leading soft clip)
+        // Mate: forward at pos 0 (0-based) => mate_pos_1based = 1
+        //   MC = "9999999999S10M" => leading_soft saturates to i32::MAX
+        //   => mate_unclipped_start = 1 - i32::MAX (well below this_pos)
+        // gap = 101 - (1 - i32::MAX) overflows i32; saturating_sub clamps it, and with no
+        // leading soft clip the result is leading_sc(0).saturating_sub(gap) = 0.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MCZ9999999999S10M\x00");
+        let rec = make_bam_bytes(
+            0,
+            100,
+            flags::PAIRED | flags::REVERSE,
+            b"rea",
+            &[encode_op(0, 20)],
+            20,
+            0,
+            0,
+            &aux,
+        );
+        assert_eq!(num_bases_extending_past_mate_raw(&rec), 0);
+    }
+
+    #[test]
     fn test_num_bases_extending_past_mate_raw_positive_strand_gap_with_soft_clip() {
-        // Positive strand read with trailing soft clip, alignment_end < mate_ue
+        // Positive strand read with trailing soft clip, alignment_end < mate_unclipped_end
         // Read: forward at pos 100 (0-based), 10M3S (query_len=13)
         // Mate: reverse at pos 200 (0-based), MC=10M (mate unclipped_end = 201+10-1=210)
-        // alignment_end = 101+10-1 = 110, mate_ue = 210
+        // alignment_end = 101+10-1 = 110, mate_unclipped_end = 210
         // 110 < 210, gap = 210 - 110 = 100
         // trailing_soft_clip = 3, 3.saturating_sub(100) = 0
         let mut aux = Vec::new();
@@ -1021,6 +1339,136 @@ mod tests {
         );
         // Not FR pair, so should return 0 (no clipping)
         assert_eq!(num_bases_extending_past_mate_raw(&rec), 0);
+    }
+
+    #[test]
+    fn test_num_bases_extending_past_mate_raw_soft_only_mate_end() {
+        // CODEC3-03: the mate boundary must count SOFT clips only (fgbio mateUnSoftClippedEnd),
+        // not hard clips. Positive read 40M @100 (alignment end ref 140). Reverse mate MC=30M5H
+        // at ref 101:
+        //   soft-only unclipped end = 101 + 30 - 1 = 130  -> clip 40 - readPos(ref130)=30 = 10
+        //   (old soft+hard end 135 would have clipped only 5).
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MCZ30M5H\x00");
+        let rec = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"rea",
+            &[encode_op(0, 40)], // 40M
+            40,
+            0,
+            100,
+            40, // positive TLEN -> FR
+            &aux,
+        );
+        assert_eq!(num_bases_extending_past_mate_raw(&rec), 10);
+    }
+
+    #[test]
+    fn test_num_bases_extending_past_mate_vs_mate_raw_no_mc_uses_mate() {
+        // CODEC3-04: with the MC tag absent, the MC-based path under-clips (returns 0), but the
+        // mate-record path derives the (soft-only) boundary from the mate in hand and still clips.
+        let rec = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"rea",
+            &[encode_op(0, 40)], // 40M
+            40,
+            0,
+            100,
+            40,
+            &[], // no MC tag
+        );
+        let mate = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::REVERSE,
+            b"rea",
+            &[encode_op(0, 30), encode_op(5, 5)], // 30M5H
+            30,
+            0,
+            100,
+            -40,
+            &[],
+        );
+        // MC-based path: no MC tag -> silent no-clip.
+        assert_eq!(num_bases_extending_past_mate_raw(&rec), 0);
+        // mate-record path: clips 10 using the mate's real soft-only boundary (ref end 130).
+        assert_eq!(num_bases_extending_past_mate_vs_mate_raw(&rec, &mate), 10);
+    }
+
+    #[test]
+    fn test_num_bases_extending_past_mate_vs_mate_raw_symmetric_on_dovetail() {
+        // A dovetail-forward pair whose forward read has a negative TLEN, so the per-record
+        // is_fr_pair_raw(fwd) wrongly reports NOT FR (htsjdk/samtools#1771). The pair IS a primary
+        // FR pair, and the forward read extends 50 bases past the mate's (soft-only) end. Using the
+        // symmetric per-pair guard, the clip is computed (50); the old per-record guard returned 0.
+        let fwd = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE | 0x40,
+            b"dtl",
+            &[encode_op(0, 60)], // 60M -> ref 101..160
+            60,
+            0,
+            60,
+            -50, // negative TLEN -> is_fr_pair_raw(fwd) == false
+            &[],
+        );
+        let mate = make_bam_bytes_with_tlen(
+            0,
+            60,
+            flags::PAIRED | flags::REVERSE | 0x80,
+            b"dtl",
+            &[encode_op(0, 50)], // 50M -> ref 61..110 (soft-only end 110)
+            50,
+            0,
+            100,
+            50,
+            &[],
+        );
+        // The per-record check is asymmetric and mis-reports the forward read as non-FR ...
+        assert!(!is_fr_pair_raw(&fwd));
+        // ... but the pair is a valid primary FR pair, so the clip is still computed.
+        assert!(is_primary_fr_pair_raw(&fwd, &mate));
+        assert_eq!(num_bases_extending_past_mate_vs_mate_raw(&fwd, &mate), 50);
+    }
+
+    #[test]
+    fn test_num_bases_extending_past_mate_vs_mate_matches_mc_without_hard_clips() {
+        // Sanity: when the mate has no hard clips, the mate-record path and the MC-tag path agree.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MCZ30M\x00");
+        let rec = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::MATE_REVERSE,
+            b"rea",
+            &[encode_op(0, 40)],
+            40,
+            0,
+            100,
+            40,
+            &aux,
+        );
+        let mate = make_bam_bytes_with_tlen(
+            0,
+            100,
+            flags::PAIRED | flags::REVERSE,
+            b"rea",
+            &[encode_op(0, 30)],
+            30,
+            0,
+            100,
+            -40,
+            &[],
+        );
+        let via_mc = num_bases_extending_past_mate_raw(&rec);
+        let via_mate = num_bases_extending_past_mate_vs_mate_raw(&rec, &mate);
+        assert_eq!(via_mc, via_mate);
+        assert_eq!(via_mc, 10); // 40M end ref 140, mate soft end ref 130 -> clip 40 - readPos(130)=30 = 10
     }
 
     #[test]

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -155,6 +155,109 @@ fn test_codec_command_basic_consensus() {
     assert!(consensus_count > 0, "Should have produced at least one consensus read");
 }
 
+/// CODEC3-05 (end-to-end): `--single-strand-qual` must mask the single-strand tails, which are
+/// padded with lowercase `n`. The offset molecule spans ref[0..40) with 10 single-strand
+/// positions on each end. Asserts the *complete* emitted output — record count, all consensus
+/// bases, and the full per-base quality vector — for both option states against fixed
+/// expectations (pinned to fgumi's output, externally verified byte-identical to fgbio 4.1.0),
+/// so wrong bases, drifted interior qualities, or an extra/dropped record all fail the test.
+/// Before the fix the option had no effect on the tails (the mask check missed lowercase `n`).
+#[test]
+fn test_codec_command_masks_single_strand_tails() {
+    // The two same-UMI molecules collapse to a single 40bp consensus. The overlap window
+    // (ref[10..30]) disagrees between the two synthetic strands, so its bases are called `N`; the
+    // single-strand tails (ref[0..10] from R1, ref[30..40] from R2) carry each read's base. Only
+    // the per-base qualities change under masking. All values are pinned to what fgumi emits
+    // (externally verified byte-identical to fgbio 4.1.0), so the test fails on any drift in
+    // bases, interior qualities, or record count.
+    const EXPECTED_BASES: &[u8; 40] = b"AAAAAAAAAANNNNNNNNNNNNNNNNNNNNGGGGGGGGGG";
+    // ref[10..30] is the 20bp overlap (single-strand-disagreement `N` calls); tails (ref[0..10],
+    // ref[30..40]) are the lowercase-'n'-padded single-strand positions the option masks.
+    const OVERLAP_QUALS: [u8; 20] = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2];
+    // Without --single-strand-qual the single-strand tails keep their unmasked Q45.
+    let expected_baseline_quals: Vec<u8> = {
+        let mut q = vec![45u8; 40];
+        q[10..30].copy_from_slice(&OVERLAP_QUALS);
+        q
+    };
+    // With --single-strand-qual 2 the single-strand tails are masked to Q2; the overlap
+    // (already Q2 from the disagreement calls) is untouched.
+    let expected_masked_quals: Vec<u8> = {
+        let mut q = vec![2u8; 40];
+        q[10..30].copy_from_slice(&OVERLAP_QUALS);
+        q
+    };
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_codec_test_bam(
+        &input_bam,
+        vec![create_offset_codec_pair("m1", "UMI1"), create_offset_codec_pair("m2", "UMI1")],
+    );
+
+    // Run the codec command with the given single-strand-qual (None = option omitted) and return
+    // every emitted consensus record's (bases, qualities). Reading *all* records (not just the
+    // first) guards against extra/dropped records; returning full base+quality vectors guards
+    // against wrong bases or interior qualities that a tail-only threshold check would miss.
+    let run_codec = |ssq: Option<&str>| -> Vec<(Vec<u8>, Vec<u8>)> {
+        let output_bam = temp_dir.path().join(format!("out_{}.bam", ssq.unwrap_or("none")));
+        let mut args = vec![
+            "codec",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--min-duplex-length",
+            "1",
+            "--max-duplex-disagreements",
+            "1000",
+            "--max-duplex-disagreement-rate",
+            "1.0",
+            "--compression-level",
+            "1",
+        ];
+        if let Some(q) = ssq {
+            args.push("--single-strand-qual");
+            args.push(q);
+        }
+        Codec::try_parse_from(args)
+            .expect("failed to parse codec args")
+            .execute("fgumi codec")
+            .expect("Failed to run codec command");
+        let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+        let _header = reader.read_header().unwrap();
+        reader
+            .records()
+            .map(|r| {
+                let record = r.expect("read record");
+                let bases = record.sequence().iter().collect::<Vec<u8>>();
+                let quals = record.quality_scores().as_ref().to_vec();
+                (bases, quals)
+            })
+            .collect()
+    };
+
+    let baseline = run_codec(None);
+    let masked = run_codec(Some("2"));
+
+    assert_eq!(baseline.len(), 1, "exactly one consensus record without masking");
+    assert_eq!(masked.len(), 1, "exactly one consensus record with masking");
+
+    let (baseline_bases, baseline_quals) = &baseline[0];
+    let (masked_bases, masked_quals) = &masked[0];
+
+    // Masking must not perturb the called bases.
+    assert_eq!(baseline_bases, EXPECTED_BASES, "unmasked consensus bases");
+    assert_eq!(masked_bases, EXPECTED_BASES, "masked consensus bases");
+
+    // Full quality-vector identity for both states — before the fix the tails stayed at Q45 even
+    // with --single-strand-qual set (the mask check missed the lowercase-'n' padding).
+    assert_eq!(baseline_quals, &expected_baseline_quals, "unmasked consensus qualities");
+    assert_eq!(masked_quals, &expected_masked_quals, "masked consensus qualities");
+}
+
 /// Test CODEC command with statistics output.
 #[test]
 fn test_codec_command_with_stats() {


### PR DESCRIPTION
## Summary

W6 of the final-audit burn-down: the codec masking/clip cluster. Drives CODEC3-03/04/05/06 to fgbio parity and documents CODEC3-07 as an intentional divergence. Stacked on #505 (`nh/fix-codec-fr-pair-rejection`) — the only open PR touching `overlap.rs`/`codec_caller.rs` — and retargets to `main` on merge.

Every finding was re-verified against fgbio 4.x source (both sides read), reproduced against the real `fgbio CallCodecConsensusReads` before and after, and covered by RED-first unit tests.

## Findings

### CODEC3-03 (S2) — overlap-clip mate boundary counted hard clips
`num_bases_extending_past_mate_raw` (shared by the simplex, duplex, and codec callers, mirroring fgbio `UmiConsensusCaller.numBasesExtendingPastMate`) derived the mate boundary from the MC tag counting **soft + hard** clips. fgbio uses `mateUnSoftClippedStart/End` — **soft only** — so a hard-clipped mate shifted the clip amount. Fixed to compute the boundary soft-only.

This is intentionally scoped to overlap clipping. The samtools-style **soft + hard** unclipped 5' position used for template-coordinate sorting and grouping (`mate_unclipped_5prime`, consumed by `fgumi-sort` and the grouping pipeline) is deliberately left unchanged — that key must follow samtools' convention, not fgbio's.

### CODEC3-04 (S3) — overlap clip silently skipped when MC absent
The MC-tag path returns `0` (no clip) when the MC tag is missing, silently under-clipping. Codec always holds both primary FR reads, so it now derives the boundary from the **mate record in hand** (`num_bases_extending_past_mate_vs_mate_raw`), mirroring fgbio `updateMateCigars` (which backfills the mate CIGAR from the in-group mate before clipping). The MC-based entry point is retained for the simplex/duplex callers.

### CODEC3-05 (S2 → S1 with `--single-strand-qual`) — single-strand tails never masked
`pad_consensus` fills single-strand tails with lowercase `n` (`NO_CALL_BASE_LOWER`), but the mask check tested only `== NO_CALL_BASE` (uppercase `N`), so the tails — the exact target of `--single-strand-qual` — were never masked. Now matches fgbio's `a(i) ∈ {n,N} || b(i) ∈ {n,N}`.

### CODEC3-06 (S2, conditional) — outer-base masking order and semantics
fgbio applies outer masking **first** and **assigns** the quality; fgumi applied single-strand first, then outer as `min`. Rewrote `mask_consensus_quals_query_based` to match fgbio `maskCodecConsensusQuals`: outer first (assign), single-strand second (assign) — so single-strand masking wins where the two regions overlap.

### CODEC3-07 (S3) — cell-barcode conflict guard: intentional divergence (documented, not fixed)
fgbio groups by MI only, then `require`s a single distinct CB across the molecule and errors on conflict. fgumi groups by the composite key `MI\tCB` (`MiGroupIterator::with_cell_tag`, wired in `codec.rs`), so every record reaching a single consensus group already shares one cell barcode — fgbio's cross-barcode conflict guard is structurally inapplicable. This is an intentional single-cell divergence (consistent with fgumi's opinionated hardcoded-CB design); documented in code, no behavior change.

## Real-tool parity evidence (fgbio 4.x `CallCodecConsensusReads`)

Fixtures: a single-strand-tail molecule (`--single-strand-qual 20 --outer-bases-qual 10`), a hard-clipped-mate molecule, and an MC-absent molecule.

- **Before:** fgumi left the single-strand tails at Q45 (fgbio Q20) and applied outer masking as `min` at the ends; it **rejected** the hard-clip and MC-absent molecules that fgbio consensus-called.
- **After:** BAM content (seq + cigar + qual) is **byte-identical** between fgumi and fgbio across every molecule.

## Tests

- `overlap.rs`: soft-only mate boundary (`..._soft_only_mate_end`), MC-independent mate-record path (`..._vs_mate_raw_no_mc_uses_mate`), and MC/mate-record agreement without hard clips. RED-verified (soft+hard gives 5, soft-only gives 10).
- `codec_caller.rs`: `mask_consensus_quals_query_based` lowercase-`n` masking (CODEC3-05) and outer-first-then-single-strand-wins (CODEC3-06). Both RED-verified against the old logic.
- `test_codec_command.rs`: end-to-end `--single-strand-qual` masking of the single-strand tails (baseline vs masked), addressing the BS5 "option-gated behavior never exercised" gap.

`cargo ci-fmt && cargo ci-lint && cargo ci-test` all clean (2216 tests).

## Not in this PR

- **CODEC3-08** (S4/doc — reject-reason label residual) is scoped as a follow-up on top of #516, which owns `rejection.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved paired-read consensus clipping using soft-only mate boundaries, improving behavior when mate details (including MC tag) are absent or malformed.
  - Updated single-strand quality masking to correctly mask lowercase `n` tails and to apply outer masking first, with single-strand masking overriding on overlaps.
- **New Features**
  - Added an order-independent mate-versus-mate overlap clipping helper to improve consistent overlap calculations.
- **Tests**
  - Added an end-to-end regression test covering `--single-strand-qual` (baseline vs masked tail qualities) and expanded overlap/masking regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->