### PR TITLE
fix(audit): hang/deadlock family + build fix + duplex validation (1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,7 @@ dependencies = [
  "log",
  "noodles",
  "rand 0.10.1",
+ "rstest",
  "thiserror 2.0.18",
  "wide 1.5.0",
 ]

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -24,6 +24,7 @@ fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+rstest = "0.26"
 
 [features]
 default = ["simplex", "duplex", "codec"]

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -322,6 +322,57 @@ pub struct DuplexConsensusCaller {
     reason = "consensus calling uses numeric casts for quality/position math and has domain-specific variable names"
 )]
 impl DuplexConsensusCaller {
+    /// Validate a `min_reads` vector: 1–3 values specified high to low
+    /// (`total >= XY >= YX`), matching fgbio's `padTo(3, last)` semantics.
+    ///
+    /// Extracted from [`Self::new`] so callers that construct the caller inside
+    /// a worker-init closure (where a panic cannot propagate a `Result`) can
+    /// validate UP FRONT and surface a clean error, instead of the closure
+    /// `.expect()`-ing on `new` and panicking mid-pipeline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `min_reads` is empty, has more than 3 values, or the
+    /// values are not in decreasing order (`total >= XY >= YX`).
+    pub fn validate_min_reads(min_reads: &[usize]) -> Result<()> {
+        Self::pad_and_validate_min_reads(min_reads).map(|_| ())
+    }
+
+    /// Pad a `min_reads` vector to `[total, XY, YX]` (fgbio's `padTo(3, last)`) and
+    /// validate it, returning the three padded values on success.
+    ///
+    /// Single source of truth for the padding + ordering logic shared by
+    /// [`Self::validate_min_reads`] (up-front, panic-free validation) and
+    /// [`Self::new`] (which needs the padded values), so the two cannot drift.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `min_reads` is empty, has more than 3 values, or the
+    /// values are not in decreasing order (`total >= XY >= YX`).
+    fn pad_and_validate_min_reads(min_reads: &[usize]) -> Result<(usize, usize, usize)> {
+        if min_reads.is_empty() {
+            anyhow::bail!("min_reads parameter must have at least 1 value");
+        }
+        if min_reads.len() > 3 {
+            anyhow::bail!(
+                "min_reads parameter must have 1-3 values (total, [XY, [YX]]), got {} values",
+                min_reads.len()
+            );
+        }
+        // Non-empty guaranteed above; `unwrap_or` fallbacks keep this panic-free.
+        let min_total_reads = min_reads.first().copied().unwrap_or(0);
+        let last = min_reads.last().copied().unwrap_or(min_total_reads);
+        let min_xy_reads = min_reads.get(1).copied().unwrap_or(last);
+        let min_yx_reads = min_reads.get(2).copied().unwrap_or(last);
+        if min_xy_reads > min_total_reads {
+            anyhow::bail!("min-reads values must be specified high to low (total >= XY)");
+        }
+        if min_yx_reads > min_xy_reads {
+            anyhow::bail!("min-reads values must be specified high to low (XY >= YX)");
+        }
+        Ok((min_total_reads, min_xy_reads, min_yx_reads))
+    }
+
     /// Creates a new duplex consensus caller
     ///
     /// # Arguments
@@ -344,10 +395,6 @@ impl DuplexConsensusCaller {
     ///
     /// Returns an error if `min_reads` is empty, has more than 3 values, or the values
     /// are not in decreasing order (total >= XY >= YX).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `min_reads` is empty (though this is checked and returns an error first).
     #[expect(
         clippy::too_many_arguments,
         reason = "constructor needs all configuration parameters from CLI options"
@@ -371,29 +418,8 @@ impl DuplexConsensusCaller {
     ) -> Result<Self> {
         // Parse min_reads vector like fgbio: padTo(3, last)
         // [total, XY, YX] where XY >= YX (larger strand, smaller strand)
-        if min_reads.is_empty() {
-            anyhow::bail!("min_reads parameter must have at least 1 value");
-        }
-        if min_reads.len() > 3 {
-            anyhow::bail!(
-                "min_reads parameter must have 1-3 values (total, [XY, [YX]]), got {} values",
-                min_reads.len()
-            );
-        }
-
-        let last = *min_reads.last().expect("expected a last item");
-        let min_total_reads = min_reads[0];
-        let min_xy_reads = min_reads.get(1).copied().unwrap_or(last);
-        let min_yx_reads = min_reads.get(2).copied().unwrap_or(last);
-
-        // Validate min_reads ordering: yx <= xy <= total (matching fgbio)
-        // For depth thresholds it's required that yx <= xy <= total
-        if min_xy_reads > min_total_reads {
-            anyhow::bail!("min-reads values must be specified high to low (total >= XY)");
-        }
-        if min_yx_reads > min_xy_reads {
-            anyhow::bail!("min-reads values must be specified high to low (XY >= YX)");
-        }
+        let (min_total_reads, min_xy_reads, min_yx_reads) =
+            Self::pad_and_validate_min_reads(&min_reads)?;
 
         // Create single-strand consensus caller with min_reads=1 (matching fgbio)
         // Filtering happens at duplex level based on input read counts, not at SS level
@@ -2298,6 +2324,7 @@ mod tests {
     use super::*;
     use fgumi_raw_bam::{ParsedBamRecord, SamBuilder, testutil::encode_op};
     use noodles::sam::alignment::record_buf::data::field::Value;
+    use rstest::rstest;
 
     #[test]
     fn test_parse_mi_tag() {
@@ -2313,6 +2340,64 @@ mod tests {
             DuplexConsensusCaller::parse_mi_tag("ACGT-TGCA"),
             ("ACGT-TGCA".to_string(), None)
         );
+    }
+
+    /// fgbio-parity matrix for `validate_min_reads`. The vector is `padTo(3, last)`
+    /// (a single value fills all three; two values fill the third from the second)
+    /// and then required non-increasing (`total >= XY >= YX`), matching fgbio's
+    /// `CallDuplexConsensusReads` `--min-reads` contract. The accepted cases cover
+    /// the padding fallbacks plus the zero and tie (equal-value) boundaries; each
+    /// rejected case pins the exact guard that trips (empty, >3 values, `total < XY`,
+    /// or `XY < YX`).
+    ///
+    /// The `expected` column is the exact `(total, XY, YX)` triple fgbio's
+    /// `padTo(3, last)` derives for each accepted input — asserting `is_ok()` alone
+    /// would let a wrong padding fallback (e.g. filling YX from `total` instead of
+    /// `last`) slip through, so each accepted case pins the derived thresholds the
+    /// caller actually uses via `pad_and_validate_min_reads`. `None` marks a rejected
+    /// input.
+    #[rstest]
+    // --- accepted: expected fgbio `padTo(3, last)` (total, XY, YX) ---
+    #[case::single_pads_to_all(&[1], Some((1, 1, 1)))]
+    #[case::single_zero_boundary(&[0], Some((0, 0, 0)))]
+    #[case::single_large(&[7], Some((7, 7, 7)))]
+    #[case::two_equal_tie(&[5, 5], Some((5, 5, 5)))]
+    #[case::two_decreasing(&[5, 2], Some((5, 2, 2)))] // YX padded from `last`, not `total`
+    #[case::three_decreasing(&[3, 2, 1], Some((3, 2, 1)))]
+    #[case::three_all_equal_tie(&[3, 3, 3], Some((3, 3, 3)))]
+    #[case::three_tie_at_top(&[5, 5, 1], Some((5, 5, 1)))]
+    #[case::three_tie_at_bottom(&[5, 1, 1], Some((5, 1, 1)))]
+    #[case::all_zero_boundary(&[0, 0, 0], Some((0, 0, 0)))]
+    // --- rejected ---
+    #[case::empty(&[], None)]
+    #[case::four_values(&[4, 3, 2, 1], None)]
+    #[case::two_total_below_xy(&[1, 5], None)] // the reported `--min-reads 1 5` panic case
+    #[case::three_total_below_xy(&[2, 5, 1], None)]
+    #[case::three_xy_below_yx(&[5, 2, 3], None)]
+    fn validate_min_reads_matches_fgbio_padding_and_ordering(
+        #[case] min_reads: &[usize],
+        #[case] expected: Option<(usize, usize, usize)>,
+    ) {
+        // The public entry point agrees on accept vs. reject...
+        assert_eq!(
+            DuplexConsensusCaller::validate_min_reads(min_reads).is_ok(),
+            expected.is_some(),
+            "validate_min_reads({min_reads:?}): expected accepted={}",
+            expected.is_some()
+        );
+        // ...and for accepted inputs the padded `(total, XY, YX)` the caller will
+        // actually apply matches fgbio's `padTo(3, last)` derivation exactly.
+        match expected {
+            Some(padded) => assert_eq!(
+                DuplexConsensusCaller::pad_and_validate_min_reads(min_reads).unwrap(),
+                padded,
+                "pad_and_validate_min_reads({min_reads:?}): wrong padded (total, XY, YX)"
+            ),
+            None => assert!(
+                DuplexConsensusCaller::pad_and_validate_min_reads(min_reads).is_err(),
+                "pad_and_validate_min_reads({min_reads:?}): expected rejection"
+            ),
+        }
     }
 
     /// Build a minimal raw record with the given MI tag value.

--- a/crates/fgumi-pipeline-io/src/sort/spill_decompress.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_decompress.rs
@@ -287,8 +287,19 @@ impl SortSpillDecompress {
             return Ok(false);
         }
 
-        let Ok(mut reader_guard) = slot.reader.try_lock() else {
-            return Ok(false);
+        let mut reader_guard = match slot.reader.try_lock() {
+            Ok(guard) => guard,
+            // Contended (another worker owns the slot): a normal skip.
+            Err(std::sync::TryLockError::WouldBlock) => return Ok(false),
+            // Poisoned: a fill worker panicked mid-read. Fail the slot CLOSED so
+            // `SortMerge` surfaces the failure; swallowing it as a skip would
+            // leave `queue_eof` unset and spin `Contention` forever (deadlock).
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                Self::mark_slot_failed(slot);
+                return Err(io::Error::other(
+                    "spill reader mutex poisoned: a decompress fill worker panicked",
+                ));
+            }
         };
 
         let room = {
@@ -351,7 +362,20 @@ impl SortSpillDecompress {
         // Phase A: read a fresh batch if the reader is still live and the
         // FIFO / reorder window admit more.
         if !slot.reader_eof.load(Ordering::Acquire) {
-            if let Ok(mut reader_guard) = slot.reader.try_lock() {
+            let acquired = match slot.reader.try_lock() {
+                Ok(guard) => Some(guard),
+                // Contended: fall through to the drain-only phase below.
+                Err(std::sync::TryLockError::WouldBlock) => None,
+                // Poisoned: a fill worker panicked mid-read. Fail closed so
+                // `SortMerge` surfaces it instead of spinning forever.
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    Self::mark_slot_failed(slot);
+                    return Err(io::Error::other(
+                        "spill reader mutex poisoned: a decompress fill worker panicked",
+                    ));
+                }
+            };
+            if let Some(mut reader_guard) = acquired {
                 // Re-check under the lock: another worker may have hit EOF.
                 if !slot.reader_eof.load(Ordering::Acquire) {
                     let next_seq = reader_guard.next_seq;

--- a/crates/fgumi-pipeline-io/src/sort/spill_decompress/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_decompress/tests.rs
@@ -97,3 +97,46 @@ fn emptiest_first_order_sorts_by_fifo_len_ascending() {
     let slots = vec![mk(0, 5), mk(1, 1), mk(2, 3)];
     assert_eq!(SortSpillDecompress::emptiest_first_order(&slots), vec![1, 2, 0]);
 }
+
+/// A poisoned `reader` mutex (a fill worker panicked while holding the lock)
+/// must fail the slot CLOSED — `try_fill_*_slot` returns `Err` and sets
+/// `decomp_error`/`queue_eof` — rather than being swallowed as `WouldBlock` and
+/// skipped forever. If it were skipped, `queue_eof` would never be set and
+/// `SortMerge` would spin on `Contention` and deadlock instead of surfacing the
+/// panic. Regression test for the poisoned-vs-would-block conflation.
+#[test]
+fn poisoned_reader_lock_fails_closed_rather_than_hanging() {
+    let make_poisoned_slot = || {
+        let slot = Arc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            SpillCodec::Bgzf,
+        ));
+        let holder = Arc::clone(&slot);
+        // Panic while holding the reader lock; joining the panicked thread leaves
+        // the mutex poisoned (mirrors a fill worker dying mid-read).
+        let _ = std::thread::spawn(move || {
+            let _guard = holder.reader.lock().expect("acquire reader lock");
+            panic!("simulated fill-worker panic under the reader lock");
+        })
+        .join();
+        assert!(slot.reader.is_poisoned(), "precondition: reader mutex is poisoned");
+        slot
+    };
+
+    let mut dec = SortSpillDecompress::new(4 * 1024 * 1024, SortDecompressTuning::default());
+
+    // Inline path.
+    let inline_slot = make_poisoned_slot();
+    let inline = dec.try_fill_inline_slot(&inline_slot);
+    assert!(inline.is_err(), "inline path: poisoned reader must return Err, not Ok(false)");
+    assert!(inline_slot.decomp_error.load(Ordering::Acquire), "inline: decomp_error set");
+    assert!(inline_slot.queue_eof.load(Ordering::Acquire), "inline: queue_eof set");
+
+    // Block-parallel path.
+    let bp_slot = make_poisoned_slot();
+    let bp = dec.try_fill_block_parallel_slot(&bp_slot);
+    assert!(bp.is_err(), "block-parallel path: poisoned reader must return Err, not skip");
+    assert!(bp_slot.decomp_error.load(Ordering::Acquire), "bp: decomp_error set");
+    assert!(bp_slot.queue_eof.load(Ordering::Acquire), "bp: queue_eof set");
+}

--- a/src/lib/aligner.rs
+++ b/src/lib/aligner.rs
@@ -339,11 +339,31 @@ impl Drop for AlignerProcess {
 ///
 /// Returns the captured lines when the child closes its stderr fd.
 fn relay_stderr(stderr: impl std::io::Read, ring_size: usize) -> Vec<String> {
-    let reader = BufReader::new(stderr);
+    let mut reader = BufReader::new(stderr);
     let mut ring: VecDeque<String> = VecDeque::with_capacity(ring_size);
+    let mut buf: Vec<u8> = Vec::new();
 
-    for line in reader.lines() {
-        let Ok(line) = line else { break };
+    // Byte-oriented drain: `BufRead::lines()` yields `Err` on a non-UTF-8 line,
+    // and breaking on it would STOP draining the aligner's stderr — the aligner
+    // then blocks once its stderr pipe fills (~64 KiB) and the whole align
+    // pipeline deadlocks. Read raw lines and decode lossily so invalid UTF-8
+    // never halts the relay.
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            // EOF (child closed stderr) or an unrecoverable pipe read error:
+            // stop draining either way.
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        // Strip the line terminator to match `lines()` semantics.
+        if buf.last() == Some(&b'\n') {
+            buf.pop();
+            if buf.last() == Some(&b'\r') {
+                buf.pop();
+            }
+        }
+        let line = String::from_utf8_lossy(&buf).into_owned();
         eprintln!("{line}");
         if ring_size > 0 {
             if ring.len() == ring_size {
@@ -830,6 +850,34 @@ mod tests {
     use std::io::{Read, Write};
 
     use super::*;
+
+    /// A non-UTF-8 stderr line must NOT halt the relay: draining has to
+    /// continue to EOF, otherwise the aligner blocks once its stderr pipe fills
+    /// (~64 KiB) and the whole align pipeline deadlocks. Regression test for the
+    /// `lines()`-breaks-on-invalid-UTF-8 hang.
+    #[test]
+    fn relay_stderr_keeps_draining_past_non_utf8_line() {
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(b"first line\n");
+        data.extend_from_slice(&[0xff, 0xfe, b'\n']); // invalid UTF-8 line
+        data.extend_from_slice(b"third line\n");
+
+        let ring = relay_stderr(std::io::Cursor::new(data), 8);
+
+        // All three lines were read (the invalid one lossily decoded), proving
+        // the drain continued past the bad line to EOF.
+        assert_eq!(ring.len(), 3, "drain must not stop at the non-UTF-8 line");
+        assert_eq!(ring[0], "first line");
+        // Pin the "lossily decoded" claim itself: 0xff and 0xfe are each individually
+        // ill-formed in UTF-8 (never a valid lead or continuation byte), so
+        // `String::from_utf8_lossy` emits one U+FFFD per byte — the bad bytes are
+        // replaced, not dropped.
+        assert_eq!(
+            ring[1], "\u{FFFD}\u{FFFD}",
+            "invalid bytes must be lossily decoded, not dropped"
+        );
+        assert_eq!(ring[2], "third line");
+    }
 
     /// Spawn a simple `echo` command and verify that stdout can be read.
     #[test]

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3243,6 +3243,13 @@ impl<'a> ChainBuilder<'a> {
             bail!("--ref requires --methylation-mode to be set");
         }
 
+        // Validate min_reads UP FRONT (mirrors Duplex::execute's single-threaded
+        // path). The per-worker init closure builds DuplexConsensusCaller with
+        // `.expect()`, so an invalid ordering (e.g. `--duplex::min-reads 1 5`)
+        // would otherwise panic inside a worker thread — likely wedging the
+        // pipeline — instead of surfacing a clean error here before it is built.
+        fgumi_consensus::DuplexConsensusCaller::validate_min_reads(&duplex.min_reads)?;
+
         let tail = self.current_tail.expect("add_duplex called before add_source");
 
         // Resolve source path for log messages only.

--- a/src/lib/pipeline/chains/commands/fastq.rs
+++ b/src/lib/pipeline/chains/commands/fastq.rs
@@ -88,7 +88,8 @@ pub(crate) fn build_fastq_encode_step(
         move |state: &mut FastqEncodeState,
               batch: DecodedRecordBatch|
               -> io::Result<DecompressedBlock> {
-            let DecodedRecordBatch { batch_serial, records, .. } = batch;
+            let batch_serial = batch.batch_serial();
+            let records = batch.into_records();
             let mut out = Vec::with_capacity(records.len().saturating_mul(512));
             let mut written = 0u64;
             for record in &records {
@@ -135,7 +136,8 @@ fn encode_paired_batch(
     opts: &FastqOptions,
     records_written: &AtomicU64,
 ) -> io::Result<Process3Output<DecompressedBlock, DecompressedBlock, DecompressedBlock>> {
-    let DecodedRecordBatch { batch_serial, records, .. } = batch;
+    let batch_serial = batch.batch_serial();
+    let records = batch.into_records();
     let mut r1: Vec<u8> = Vec::new();
     let mut r2: Vec<u8> = Vec::new();
     let mut other: Vec<u8> = Vec::new();

--- a/src/lib/pipeline/steps/align_and_merge.rs
+++ b/src/lib/pipeline/steps/align_and_merge.rs
@@ -298,6 +298,19 @@ impl InFlightGate {
     }
 }
 
+/// RAII guard that latches consumer-gone on drop — on normal return, on an
+/// error return, AND on a panic unwinding out of `reader_loop`. Without the
+/// guard the panic path would skip `mark_consumer_gone`, leaving a writer
+/// parked in `gate.acquire` blocked forever and `Drop`'s `writer_thread.join()`
+/// hung with it.
+struct ConsumerGoneGuard<'a>(&'a InFlightGate);
+
+impl Drop for ConsumerGoneGuard<'_> {
+    fn drop(&mut self) {
+        self.0.mark_consumer_gone();
+    }
+}
+
 /// FASTQ-writer [`BufWriter`] capacity. 1 MiB matches the legacy
 /// orchestrator's choice (`align_and_merge.rs:259`): bigger than the
 /// OS pipe buffer (~64 KiB) so we amortize `write` syscalls, but not
@@ -572,12 +585,13 @@ impl AlignAndMergeStep {
             thread::Builder::new()
                 .name("aam-sam-reader".into())
                 .spawn(move || {
-                    let result = reader_loop(token_rx, out_tx, aligner_stdout, cfg, shared, &gate);
-                    // Latch consumer-gone on every reader exit (EOF or
-                    // error) so a writer blocked in `gate.acquire` wakes
-                    // and bails instead of hanging.
-                    gate.mark_consumer_gone();
-                    result
+                    // Latch consumer-gone on EVERY reader exit — normal return,
+                    // error, or a panic in `reader_loop` — via the RAII guard, so
+                    // a writer blocked in `gate.acquire` always wakes and bails
+                    // instead of hanging (and `Drop`'s `writer_thread.join()`
+                    // cannot deadlock on a panicked reader).
+                    let _consumer_gone = ConsumerGoneGuard(&gate);
+                    reader_loop(token_rx, out_tx, aligner_stdout, cfg, shared, &gate)
                 })
                 .map_err(|e| {
                     io::Error::other(format!(
@@ -1739,6 +1753,27 @@ mod tests {
         // Small / zero -K floors at IN_FLIGHT_MIN_BUDGET.
         assert_eq!(in_flight_budget_for_chunk_size(0), IN_FLIGHT_MIN_BUDGET);
         assert_eq!(in_flight_budget_for_chunk_size(1_000_000), IN_FLIGHT_MIN_BUDGET);
+    }
+
+    #[test]
+    fn consumer_gone_latched_even_when_reader_scope_panics() {
+        // A panic unwinding out of the reader scope must still latch
+        // consumer-gone via `ConsumerGoneGuard`, so a writer parked in
+        // `acquire` bails (returns false) instead of blocking forever. Without
+        // the guard the panic would skip `mark_consumer_gone`, deadlocking the
+        // writer and the `writer_thread.join()` in `Drop`.
+        let gate = InFlightGate::new(1024);
+        assert!(gate.acquire(10), "acquire succeeds before the consumer is gone");
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _consumer_gone = ConsumerGoneGuard(&gate);
+            panic!("simulated reader_loop panic");
+        }));
+        assert!(panicked.is_err(), "the panic must propagate out of the guarded scope");
+
+        // The guard's `Drop` latched consumer-gone during unwind, so a
+        // subsequent writer reservation bails instead of blocking.
+        assert!(!gate.acquire(10), "a writer must bail once the reader scope has panicked");
     }
 
     #[test]


### PR DESCRIPTION
Part 1 of a 3-PR stack landing correctness fixes found during a code-review audit of `feat-runall`. Each PR is a contiguous slice of the audit-fix branch; review/merge bottom-up (this one first).

**Stack**
1. **this PR** → `feat-runall`
2. `nh/audit-2-sort-data` → `nh/audit-1-hangs`
3. `nh/audit-3-parity` → `nh/audit-2-sort-data`

**Fixes in this PR (hang/deadlock family + build + duplex validation)**
- **build**: `fastq` encode/paired steps destructured now-private `DecodedRecordBatch` fields, breaking the workspace build; use the accessors.
- **H3**: spill-decompress treated a *poisoned* per-slot reader mutex like `WouldBlock` and skipped the slot forever — `queue_eof` never set, `SortMerge` deadlocked. Fail closed on poison.
- **H2**: the align-and-merge reader thread latched consumer-gone only on normal return, so a reader *panic* left a parked writer (and `Drop`'s `join`) hung forever. Latch via an RAII guard.
- **H4**: `relay_stderr` used `BufRead::lines()` and broke on the first non-UTF-8 line, stopping the drain — the aligner then blocked once its stderr pipe filled. Drain byte-oriented with lossy decode.
- **V1**: duplex `--min-reads` was validated only inside a worker-init closure that `.expect()`s, so an invalid ordering panicked in a worker (likely wedging the pipeline); validate up front in `add_duplex`.

Each fix has a regression test. Full `cargo ci-test` is green on the stack tip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid duplex `min-reads` values are now rejected immediately with a clear error.
  - Sort/merge no longer silently skips when internal reader locks are poisoned; failures now surface instead of risking stalled processing.
  - Alignment output relaying continues correctly even with invalid text encoding.
  - Pipeline reader shutdown is now reliably triggered even when unexpected panics occur.
- **Tests**
  - Added regression coverage for duplex validation, poisoned reader lock handling, stderr draining with invalid encoding, and panic-safe reader shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->