### PR TITLE
fix(audit): sort data-integrity, aligner header, filter parity, FASTQ deadlock (2/3)

### DIFF
--- a/crates/fgumi-pipeline-io/src/sink/write_bgzf.rs
+++ b/crates/fgumi-pipeline-io/src/sink/write_bgzf.rs
@@ -37,9 +37,17 @@ struct WriterState {
     pending_header: Option<PendingHeader>,
 }
 
+/// Transform applied to the aligner's runtime-resolved header before it is
+/// written. Lets a post-`Align` stage (sort-order rewrite, consensus header,
+/// clip) re-apply its header change on top of the resolved header — which
+/// carries the aligner's runtime `@PG`/`@RG`/`@CO` — instead of discarding that
+/// provenance by writing a build-time header.
+pub type ResolvedHeaderTransform = Box<dyn Fn(Header) -> io::Result<Header> + Send + Sync>;
+
 struct PendingHeader {
     handle: HeaderHandle,
     compression_level: u32,
+    transform: Option<ResolvedHeaderTransform>,
 }
 
 impl WriteBgzfFile {
@@ -91,6 +99,10 @@ impl WriteBgzfFile {
     /// Open `path` and return the sink with the BAM header write
     /// deferred until an upstream step resolves `handle`.
     ///
+    /// `transform`, when `Some`, is applied to the resolved header before it is
+    /// written — see [`ResolvedHeaderTransform`] for why this exists; pass `None`
+    /// when the resolved header should be written unchanged.
+    ///
     /// # Errors
     ///
     /// Returns I/O errors from path open. Header-write errors are
@@ -99,13 +111,14 @@ impl WriteBgzfFile {
         path: P,
         handle: HeaderHandle,
         compression_level: u32,
+        transform: Option<ResolvedHeaderTransform>,
     ) -> io::Result<Self> {
         let file = File::create(path.as_ref())?;
         let out = BufWriter::with_capacity(256 * 1024, file);
         Ok(Self {
             state: Mutex::new(Some(WriterState {
                 out,
-                pending_header: Some(PendingHeader { handle, compression_level }),
+                pending_header: Some(PendingHeader { handle, compression_level, transform }),
             })),
             name: "WriteBgzfFile",
             detached_group: None,
@@ -122,6 +135,13 @@ impl WriteBgzfFile {
             Some(Ok(h)) => h.clone(),
         };
         let level = pending.compression_level;
+        // Re-apply the post-align header change (sort order / consensus / clip)
+        // on top of the aligner's runtime-resolved header so its @PG/@RG/@CO
+        // survive into the written header.
+        let header_clone = match &pending.transform {
+            Some(transform) => transform(header_clone)?,
+            None => header_clone,
+        };
 
         let mut header_bytes = Vec::new();
         fgumi_bam_io::write_bam_header(&mut header_bytes, &header_clone)
@@ -281,7 +301,7 @@ mod tests {
     fn new_with_handle_defers_header_until_resolved() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let handle = HeaderHandle::new();
-        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1).unwrap();
+        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, None).unwrap();
 
         let bytes_before = std::fs::read(&path).unwrap();
         assert_eq!(bytes_before.len(), 0, "no bytes written until header resolves");
@@ -312,10 +332,59 @@ mod tests {
     }
 
     #[test]
+    fn resolved_header_transform_runs_on_the_resolved_header() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let handle = HeaderHandle::new();
+
+        // Capture the header the transform is handed, to prove it is the
+        // runtime-resolved (aligner) header — not a build-time header.
+        let seen: Arc<StdMutex<Option<Header>>> = Arc::new(StdMutex::new(None));
+        let seen_for_closure = Arc::clone(&seen);
+        let transform: ResolvedHeaderTransform = Box::new(move |resolved: Header| {
+            *seen_for_closure.lock().unwrap() = Some(resolved.clone());
+            Ok(resolved)
+        });
+
+        let step =
+            WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, Some(transform)).unwrap();
+
+        // Nothing is written (and the transform must not run) until the handle
+        // resolves.
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            assert!(!WriteBgzfFile::try_write_pending_header(state).unwrap());
+        }
+        assert!(seen.lock().unwrap().is_none(), "transform must not run before resolution");
+
+        // Resolve with a distinctive header standing in for the aligner's
+        // runtime-resolved header.
+        let resolved = Header::builder().add_comment("ALIGNER-PROVENANCE").build();
+        handle.set(resolved.clone()).expect("set");
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            assert!(WriteBgzfFile::try_write_pending_header(state).unwrap(), "resolved -> written");
+            state.out.flush().unwrap();
+        }
+
+        // The transform ran, and it received the resolved header — so a
+        // post-align stage's transform is applied on top of the aligner header.
+        assert_eq!(
+            seen.lock().unwrap().as_ref(),
+            Some(&resolved),
+            "transform must receive the resolved header, preserving aligner provenance",
+        );
+        assert!(std::fs::read(&path).unwrap().len() >= 2, "header block was written");
+    }
+
+    #[test]
     fn new_with_handle_propagates_poison() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let handle = HeaderHandle::new();
-        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1).unwrap();
+        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, None).unwrap();
 
         handle.poison(io::Error::new(io::ErrorKind::BrokenPipe, "aligner died")).unwrap();
         let mut guard = step.state.lock();
@@ -351,7 +420,7 @@ mod tests {
         let path = tempfile::NamedTempFile::new().unwrap();
         let path_buf = path.path().to_path_buf();
         let handle = HeaderHandle::new();
-        let step = WriteBgzfFile::new_with_handle(&path_buf, handle, 1).unwrap();
+        let step = WriteBgzfFile::new_with_handle(&path_buf, handle, 1, None).unwrap();
         drop(step);
 
         let bytes = std::fs::read(&path_buf).unwrap();

--- a/crates/fgumi-sort/src/spill_block_reader.rs
+++ b/crates/fgumi-sort/src/spill_block_reader.rs
@@ -27,6 +27,49 @@ use crate::worker_pool::read_length_prefix;
 /// the mimalloc size-class reuse pattern matches.
 const SCRATCH_CAP: usize = 256 * 1024;
 
+/// Grow `buf` so it can hold the decompressed content of a zstd `frame`.
+///
+/// zstd frames written by the one-shot bulk `Compressor` embed the decompressed
+/// content size in their header; read it and size the reusable scratch to fit,
+/// clamped up to `SCRATCH_CAP` so the common (small-block) path keeps its
+/// mimalloc size-class reuse. Falls back to `SCRATCH_CAP` when the content size
+/// is not declared (no regression).
+///
+/// The declared content size is header-controlled and therefore untrusted: both
+/// spill producers frame at most
+/// [`STAGING_FRAME_MAX_UNCOMPRESSED_BYTES`](crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES)
+/// of uncompressed content per block (`pooled_chunk_writer` flushes at
+/// `BGZF_MAX_BLOCK_SIZE` and splits oversized records via `write_chunked`; the
+/// streaming `SpillGather` emits `≤ BGZF_MAX_BLOCK_SIZE` blocks), so a frame
+/// declaring more than that came from a truncated or corrupted spill file. Reject
+/// it up front rather than letting a bogus header drive `Vec::resize` into an
+/// unbounded allocation.
+///
+/// # Errors
+///
+/// Returns an error when the declared content size exceeds the producer's
+/// per-frame limit
+/// ([`STAGING_FRAME_MAX_UNCOMPRESSED_BYTES`](crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES)).
+fn ensure_zstd_capacity(buf: &mut Vec<u8>, frame: &[u8]) -> io::Result<()> {
+    let content_size = zstd::zstd_safe::get_frame_content_size(frame)
+        .ok()
+        .flatten()
+        .and_then(|n| usize::try_from(n).ok())
+        .unwrap_or(0);
+    if content_size > crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES {
+        return Err(io::Error::other(format!(
+            "zstd spill frame declares {content_size} uncompressed bytes, exceeding the \
+             {} byte producer limit (truncated or corrupted spill file?)",
+            crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES
+        )));
+    }
+    let needed = content_size.max(SCRATCH_CAP);
+    if buf.len() < needed {
+        buf.resize(needed, 0);
+    }
+    Ok(())
+}
+
 /// Per-worker codec-aware decompressor. Holds a libdeflate decompressor (BGZF)
 /// and a zstd decompressor plus reusable scratch buffers; one instance per
 /// `SortSpillDecompress` worker copy.
@@ -111,9 +154,6 @@ impl SpillBlockDecompressor {
         reader: &mut R,
         max: usize,
     ) -> io::Result<Vec<Vec<u8>>> {
-        if self.zstd_buf.len() < SCRATCH_CAP {
-            self.zstd_buf.resize(SCRATCH_CAP, 0);
-        }
         let mut out = Vec::with_capacity(max);
         for _ in 0..max {
             // `read_length_prefix` returns `Ok(None)` only at a clean frame
@@ -124,6 +164,7 @@ impl SpillBlockDecompressor {
             self.zstd_frame.clear();
             self.zstd_frame.resize(frame_len, 0);
             reader.read_exact(&mut self.zstd_frame)?;
+            ensure_zstd_capacity(&mut self.zstd_buf, &self.zstd_frame)?;
             let n = self
                 .zstd
                 .decompress_to_buffer(&self.zstd_frame, &mut self.zstd_buf)
@@ -204,9 +245,7 @@ impl SpillBlockDecompressor {
                 Ok(std::mem::replace(&mut self.bgzf_scratch, Vec::with_capacity(SCRATCH_CAP)))
             }
             SpillCodec::Zstd => {
-                if self.zstd_buf.len() < SCRATCH_CAP {
-                    self.zstd_buf.resize(SCRATCH_CAP, 0);
-                }
+                ensure_zstd_capacity(&mut self.zstd_buf, raw)?;
                 let n = self
                     .zstd
                     .decompress_to_buffer(raw, &mut self.zstd_buf)
@@ -228,6 +267,7 @@ mod tests {
     use super::*;
     use crate::pooled_chunk_writer::PooledChunkWriter;
     use crate::worker_pool::SortWorkerPool;
+    use rstest::rstest;
     use std::io::Cursor;
     use std::sync::Arc;
 
@@ -235,16 +275,14 @@ mod tests {
     /// `SpillBlockDecompressor`, must yield the exact `[len][record]` byte
     /// stream that was written — for BOTH codecs. This is the round-trip the
     /// streaming merge depends on.
-    fn roundtrip(codec: SpillCodec) {
-        use crate::keys::{RawCoordinateKey, RawSortKey};
-        // Build framed records whose total size (~440 KB) far exceeds the
-        // writer's ~64 KB block cap, so the chunk is written as MANY blocks /
-        // frames. That is what actually exercises the per-block decompress and
-        // the downstream record reassembly across block boundaries — the whole
-        // reason `read_blocks` returns per-block `Vec<u8>`s. Each record is
-        // stamped with its index at both ends so a misaligned reassembly is
-        // caught, not just a stream of zeros.
-        let records: Vec<Vec<u8>> = (0usize..80)
+    /// Build framed records whose total size (~440 KB) far exceeds the writer's
+    /// ~64 KB block cap, so the chunk is written as MANY blocks / frames. That is
+    /// what actually exercises the per-block decompress and the downstream record
+    /// reassembly across block boundaries. Each record is stamped with its index
+    /// at both ends so a misaligned reassembly is caught, not just a stream of
+    /// zeros.
+    fn default_roundtrip_records() -> Vec<Vec<u8>> {
+        (0usize..80)
             .map(|i| {
                 let size = 3000 + (i % 13) * 500; // 3000..9000 bytes
                 let mut r = vec![0u8; size];
@@ -254,7 +292,19 @@ mod tests {
                 r[last] = stamp;
                 r
             })
-            .collect();
+            .collect()
+    }
+
+    #[rstest]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    #[case::zstd(SpillCodec::Zstd)]
+    fn roundtrip(#[case] codec: SpillCodec) {
+        roundtrip_records(codec, &default_roundtrip_records());
+    }
+
+    fn roundtrip_records(codec: SpillCodec, records: &[Vec<u8>]) {
+        use crate::keys::{RawCoordinateKey, RawSortKey};
+        // (records borrowed; callers keep ownership)
 
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("chunk.spill");
@@ -262,7 +312,7 @@ mod tests {
         {
             let mut w = PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &path, codec)
                 .expect("writer");
-            for rec in &records {
+            for rec in records {
                 let key = RawCoordinateKey::extract_from_record(rec);
                 w.write_record(&key, rec).expect("write");
             }
@@ -309,23 +359,75 @@ mod tests {
             cursor.read_exact(&mut rec).expect("record body");
             read_back.push(rec);
         }
-        assert_eq!(read_back, records, "round-trip mismatch for {codec:?}");
+        assert_eq!(read_back.as_slice(), records, "round-trip mismatch for {codec:?}");
     }
 
+    /// A zstd frame whose header declares more uncompressed content than any
+    /// producer can emit (`> STAGING_FRAME_MAX_UNCOMPRESSED_BYTES`) is treated as
+    /// corruption: `ensure_zstd_capacity` must error instead of resizing the
+    /// scratch buffer to the attacker-/corruption-chosen size. Guards against a
+    /// truncated or malicious spill file driving an unbounded allocation.
     #[test]
-    fn roundtrip_bgzf() {
-        roundtrip(SpillCodec::Bgzf);
+    fn ensure_zstd_capacity_rejects_over_limit_declared_size() {
+        use crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES;
+        let oversized = vec![7u8; STAGING_FRAME_MAX_UNCOMPRESSED_BYTES + 1];
+        // One-shot bulk compression stamps the pledged content size into the
+        // frame header, so `get_frame_content_size` reads back the full size.
+        let frame = zstd::bulk::compress(&oversized, 3).expect("compress");
+        let mut buf = vec![0u8; SCRATCH_CAP];
+        let err = ensure_zstd_capacity(&mut buf, &frame)
+            .expect_err("over-limit declared content size must be rejected");
+        assert!(err.to_string().contains("exceeding the"), "unexpected error message: {err}");
+        // The scratch must not have been grown to the bogus declared size.
+        assert_eq!(buf.len(), SCRATCH_CAP, "scratch must not grow on a rejected frame");
     }
 
+    /// A frame at the producer's per-frame limit is accepted, and the scratch is
+    /// kept at (at least) the `SCRATCH_CAP` floor for mimalloc size-class reuse.
     #[test]
-    fn roundtrip_zstd() {
-        roundtrip(SpillCodec::Zstd);
+    fn ensure_zstd_capacity_accepts_frame_at_producer_limit() {
+        use crate::bgzf_io::STAGING_FRAME_MAX_UNCOMPRESSED_BYTES;
+        let at_limit = vec![3u8; STAGING_FRAME_MAX_UNCOMPRESSED_BYTES];
+        let frame = zstd::bulk::compress(&at_limit, 3).expect("compress");
+        let mut buf = Vec::new();
+        ensure_zstd_capacity(&mut buf, &frame).expect("frame at the limit must be accepted");
+        assert!(buf.len() >= SCRATCH_CAP, "scratch keeps the SCRATCH_CAP floor");
+    }
+
+    /// A single record larger than `SCRATCH_CAP` (256 KiB) is framed as its own
+    /// oversized spill block/frame. The decompressor must grow its scratch to the
+    /// frame's declared content size rather than failing `decompress_to_buffer` —
+    /// otherwise any BAM with a >256 KiB record (e.g. long reads) aborts the sort
+    /// on the default zstd codec. Regression test for both codecs.
+    #[rstest]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    #[case::zstd(SpillCodec::Zstd)]
+    fn roundtrip_with_oversized_record(#[case] codec: SpillCodec) {
+        let mut records = default_roundtrip_records();
+        let big = {
+            let mut r = vec![0u8; 300 * 1024]; // > SCRATCH_CAP
+            r[0] = 42;
+            let last = r.len() - 1;
+            r[last] = 42;
+            // Vary the body so it isn't trivially compressible to a tiny frame.
+            for (i, b) in r.iter_mut().enumerate() {
+                if i % 7 == 0 {
+                    *b = u8::try_from(i % 251).expect("fits u8");
+                }
+            }
+            r
+        };
+        records.insert(40, big);
+        roundtrip_records(codec, &records);
     }
 
     /// The split `read_raw` + `decompress_one` path (used by the block-parallel
     /// `SortSpillDecompress`) must yield the exact same per-block bytes as the
     /// inline `read_blocks` path. We read the same chunk twice and compare.
-    fn read_raw_matches_read_blocks(codec: SpillCodec) {
+    #[rstest]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    #[case::zstd(SpillCodec::Zstd)]
+    fn read_raw_matches_read_blocks(#[case] codec: SpillCodec) {
         use crate::keys::{RawCoordinateKey, RawSortKey};
 
         let records: Vec<Vec<u8>> = (0usize..80)
@@ -402,15 +504,5 @@ mod tests {
             blocks_a, blocks_b,
             "split read_raw path must match inline read_blocks ({codec:?})"
         );
-    }
-
-    #[test]
-    fn read_raw_matches_read_blocks_bgzf() {
-        read_raw_matches_read_blocks(SpillCodec::Bgzf);
-    }
-
-    #[test]
-    fn read_raw_matches_read_blocks_zstd() {
-        read_raw_matches_read_blocks(SpillCodec::Zstd);
     }
 }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1498,14 +1498,29 @@ impl SortWorkerPool {
             return StepResult::InputEmpty;
         }
 
-        // Drop the lock before pushing to queue
+        // Reserve this batch's serial range WHILE STILL HOLDING the input lock,
+        // before releasing it. Otherwise a worker preempted between `drop(guard)`
+        // and the per-block `fetch_add` leaves its already-read blocks uncounted
+        // in `input_read_serial` while another worker acquires the lock, reads the
+        // empty EOF batch, and sets `input_eof`. The done-check
+        // (`input_blocks_queued == input_read_serial && input_eof`) then fires
+        // early, the merge finalizes, and this worker's trailing blocks are pushed
+        // after termination — silently truncating output. Reserving under the lock
+        // guarantees `input_read_serial` accounts for every read block before
+        // `input_eof` can be set (mirrors the Phase-2 reserve-under-lock protocol).
+        let batch_len = blocks.len() as u64;
+        let base_serial = shared.input_read_serial.fetch_add(batch_len, Ordering::Relaxed);
+
+        // Drop the lock before pushing to queue.
         drop(guard);
 
-        // Assign serial numbers and push to raw_input_blocks ArrayQueue.
-        // Once the queue is full, hold this block and all remaining blocks.
+        // Push blocks under their pre-reserved serials. Once the queue is full,
+        // hold this block and all remaining blocks.
+        let mut next_serial = base_serial;
         let mut blocks_iter = blocks.into_iter();
         for block in blocks_iter.by_ref() {
-            let serial = shared.input_read_serial.fetch_add(1, Ordering::Relaxed);
+            let serial = next_serial;
+            next_serial += 1;
             match shared.raw_input_blocks.push((serial, block)) {
                 Ok(()) => {}
                 Err((serial, block)) => {
@@ -1516,7 +1531,8 @@ impl SortWorkerPool {
         }
         // Hold any remaining blocks we didn't attempt to push
         for block in blocks_iter {
-            let serial = shared.input_read_serial.fetch_add(1, Ordering::Relaxed);
+            let serial = next_serial;
+            next_serial += 1;
             worker.held_raw_input_blocks.push((serial, block));
         }
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -626,7 +626,10 @@ impl FilterOptions {
     /// supplies separate CC/AB/BA values (indexed as `[0]` = CC/duplex,
     /// `[1]` = AB, `[2]` = BA), the more-stringent value must come first.
     /// - For min-reads: ba <= ab <= cc (more reads required = more stringent)
-    /// - For error rates: cc <= ab <= ba (lower error allowed = more stringent)
+    /// - For error rates: ONLY ab <= ba is enforced; CC is left unconstrained.
+    ///   This matches fgbio (`FilterConsensusReads` validates only
+    ///   `ba >= ab`), so e.g. `--max-base-error-rate 0.1 0.05 0.2` is valid
+    ///   (up to 10% overall, but only if at least one single strand is < 5%).
     pub(crate) fn validate_parameters(&self) -> Result<()> {
         // Validate min-reads
         if self.min_reads.is_empty() || self.min_reads.len() > 3 {
@@ -696,19 +699,13 @@ impl FilterOptions {
             }
         }
 
-        // Validate error rate ordering: CC (duplex) <= AB <= BA, where the lower
-        // allowed error is the more-stringent floor and must come first. The
-        // two-value case ([0]=CC, [1]=AB) is checked here; the three-value case
-        // adds the AB <= BA edge below.
-        if self.max_read_error_rate.len() >= 2 {
-            let cc_error = self.max_read_error_rate[0];
-            let ab_error = self.max_read_error_rate[1];
-            if cc_error > ab_error {
-                bail!(
-                    "max-read-error-rate for duplex (CC) must be <= AB (more stringent), got CC={cc_error} > AB={ab_error}"
-                );
-            }
-        }
+        // Validate error-rate ordering. Unlike min-reads (which must be strictly
+        // high to low), fgbio enforces ONLY that AB is at least as stringent as
+        // BA (AB <= BA) for the error rates — CC may be *larger* than AB. This
+        // deliberately allows e.g. `--max-base-error-rate 0.1 0.05 0.2` (up to 10%
+        // overall, but only if at least one single strand is < 5%). See fgbio
+        // FilterConsensusReads: "For error rates only enforce that ab is more
+        // stringent than ba". So only the three-value AB <= BA edge is checked.
         if self.max_read_error_rate.len() >= 3 {
             let ab_error = self.max_read_error_rate[1];
             let ba_error = self.max_read_error_rate[2];
@@ -719,15 +716,6 @@ impl FilterOptions {
             }
         }
 
-        if self.max_base_error_rate.len() >= 2 {
-            let cc_error = self.max_base_error_rate[0];
-            let ab_error = self.max_base_error_rate[1];
-            if cc_error > ab_error {
-                bail!(
-                    "max-base-error-rate for duplex (CC) must be <= AB (more stringent), got CC={cc_error} > AB={ab_error}"
-                );
-            }
-        }
         if self.max_base_error_rate.len() >= 3 {
             let ab_error = self.max_base_error_rate[1];
             let ba_error = self.max_base_error_rate[2];
@@ -1064,29 +1052,37 @@ mod tests {
         assert!(cmd.options.validate_parameters().is_err());
     }
 
-    #[test]
-    fn test_validate_read_error_rate_cc_gt_ab_rejected() {
-        // [0]=CC, [1]=AB: CC must be the more-stringent (lower) floor, so
-        // CC > AB violates the documented duplex-to-AB ordering even with only
-        // two values supplied (the prior code only checked the 3-value AB/BA edge).
+    // fgbio does NOT constrain CC <= AB for error rates (only AB <= BA), so a
+    // CC larger than AB is valid for BOTH the read- and base-error-rate vectors,
+    // at either the 2-value (CC, AB) or the 3-value (CC, AB, BA) length. The
+    // 3-value cases keep AB <= BA so only the CC-unconstrained behavior is
+    // exercised. Both fields are covered at both lengths so a regression in
+    // either field's two- or three-value path is caught.
+    #[rstest]
+    // read-error-rate, CC > AB, 2-value: `--max-read-error-rate 0.20 0.10`
+    #[case::read_two_value(true, vec![0.20, 0.10])]
+    // read-error-rate, CC > AB, 3-value (AB <= BA): `0.20 0.10 0.15`
+    #[case::read_three_value(true, vec![0.20, 0.10, 0.15])]
+    // base-error-rate, CC > AB, 2-value: `--max-base-error-rate 0.20 0.10`
+    #[case::base_two_value(false, vec![0.20, 0.10])]
+    // base-error-rate, CC > AB, 3-value (the fgbio-documented example): allow up
+    // to 10% overall but only if at least one single strand is < 5%
+    #[case::base_three_value(false, vec![0.1, 0.05, 0.2])]
+    fn test_validate_error_rate_cc_gt_ab_accepted(#[case] is_read: bool, #[case] values: Vec<f64>) {
         let mut cmd = create_filter_with_paths(
             PathBuf::from("input.bam"),
             PathBuf::from("output.bam"),
             PathBuf::from("ref.fa"),
         );
-        cmd.options.max_read_error_rate = vec![0.20, 0.10]; // CC=0.20 > AB=0.10
-        assert!(cmd.options.validate_parameters().is_err());
-    }
-
-    #[test]
-    fn test_validate_base_error_rate_cc_gt_ab_rejected() {
-        let mut cmd = create_filter_with_paths(
-            PathBuf::from("input.bam"),
-            PathBuf::from("output.bam"),
-            PathBuf::from("ref.fa"),
+        if is_read {
+            cmd.options.max_read_error_rate = values;
+        } else {
+            cmd.options.max_base_error_rate = values;
+        }
+        assert!(
+            cmd.options.validate_parameters().is_ok(),
+            "CC > AB error-rate vector must be accepted (is_read={is_read})"
         );
-        cmd.options.max_base_error_rate = vec![0.20, 0.10]; // CC=0.20 > AB=0.10
-        assert!(cmd.options.validate_parameters().is_err());
     }
 
     #[test]

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -482,6 +482,13 @@ pub struct ChainBuilder<'a> {
     /// [`WriteBgzfFile`]: crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile
     pending_header_handle: Option<crate::pipeline::core::header::HeaderHandle>,
 
+    /// When an aligner `HeaderHandle` is pending, this accumulates the header
+    /// changes made by later stages that *modify* the header (sort-order rewrite,
+    /// clip) so they are re-applied to the aligner's runtime-resolved header at
+    /// sink time — preserving the aligner `@PG`/`@RG`/`@CO` — instead of being
+    /// discarded. Forwarded to `WriteBgzfFile::new_with_handle` by `add_sink`.
+    pending_header_transform: Option<fgumi_pipeline_io::sink::write_bgzf::ResolvedHeaderTransform>,
+
     /// Tracks the logical output type of the current chain tail. Updated by
     /// `add_source` and each `add_<stage>` method. See [`ChainTailKind`]
     /// for the full enumeration and rationale.
@@ -550,6 +557,7 @@ impl<'a> ChainBuilder<'a> {
             override_pipeline_threads: None,
             use_drain_first_scheduler: false,
             pending_header_handle: None,
+            pending_header_transform: None,
             // Initialise to the default; add_source will set the correct kind
             // based on whether sort is the first intermediate stage.
             chain_tail_kind: ChainTailKind::DecodedRecordBatch,
@@ -1343,8 +1351,13 @@ impl<'a> ChainBuilder<'a> {
         // `HeaderHandle` stashed by `add_align` must be forwarded here so the
         // writer blocks until the handle is resolved before emitting any bytes.
         let write_step = if let Some(handle) = self.pending_header_handle.take() {
-            WriteBgzfFile::new_with_handle(output_path, handle, self.tuning.compression_level)
-                .map_err(|e| anyhow!("WriteBgzfFile::new_with_handle: {e}"))?
+            WriteBgzfFile::new_with_handle(
+                output_path,
+                handle,
+                self.tuning.compression_level,
+                self.pending_header_transform.take(),
+            )
+            .map_err(|e| anyhow!("WriteBgzfFile::new_with_handle: {e}"))?
         } else {
             WriteBgzfFile::new(output_path, &self.header, self.tuning.compression_level)
                 .map_err(|e| anyhow!("WriteBgzfFile::new: {e}"))?
@@ -1420,7 +1433,48 @@ impl<'a> ChainBuilder<'a> {
     /// [`HeaderHandle`]: crate::pipeline::core::header::HeaderHandle
     fn replace_header(&mut self, header: noodles::sam::Header) {
         self.header = header;
+        // A from-scratch header carries no aligner provenance, so drop BOTH the pending
+        // handle and any transform composed for it. Clearing only the handle would leave a
+        // stale transform that a later `add_align` handle would wrongly re-apply at sink time.
         self.pending_header_handle = None;
+        self.pending_header_transform = None;
+    }
+
+    /// Apply a header transform for a post-`Align` stage that *modifies* the
+    /// header (e.g. a sort-order rewrite or clip's `@HD` annotation).
+    ///
+    /// Updates the build-time `self.header` immediately (so downstream stage
+    /// construction and static checks see the change), and — when an aligner
+    /// `HeaderHandle` is still pending — composes the transform into
+    /// `self.pending_header_transform` so the same change is re-applied to the
+    /// aligner's runtime-resolved header at sink time, preserving its
+    /// `@PG`/`@RG`/`@CO`. When no handle is pending, `self.header` is
+    /// authoritative and no transform is retained.
+    ///
+    /// Prefer this over [`Self::replace_header`] for post-`Align` header
+    /// *modifications*. Stages that intentionally build a *fresh* header (e.g.
+    /// consensus, which emits an unmapped header with a single collapsed read
+    /// group and its own `@PG`) still use `replace_header`: there is no aligner
+    /// provenance to carry into a from-scratch header.
+    fn apply_output_header_transform<F>(&mut self, transform: F) -> Result<()>
+    where
+        F: Fn(noodles::sam::Header) -> std::io::Result<noodles::sam::Header>
+            + Send
+            + Sync
+            + 'static,
+    {
+        // Build-time: reflect the change now for downstream stages / static checks.
+        self.header = transform(self.header.clone())?;
+        // Runtime: compose onto the pending aligner-header transform chain so it
+        // re-runs on the resolved header at sink time.
+        if self.pending_header_handle.is_some() {
+            let prev = self.pending_header_transform.take();
+            self.pending_header_transform = Some(Box::new(move |header| match &prev {
+                Some(prev) => transform(prev(header)?),
+                None => transform(header),
+            }));
+        }
+        Ok(())
     }
 
     /// Build the final [`BuiltPipeline`] from the accumulated state.
@@ -2023,7 +2077,10 @@ impl<'a> ChainBuilder<'a> {
             self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
         }
 
-        // Stash the HeaderHandle for add_sink to pick up.
+        // Stash the HeaderHandle for add_sink to pick up. This is a fresh aligner, so any
+        // transform composed for a *previous* align's handle is stale — drop it so it cannot
+        // be re-applied to this aligner's runtime-resolved header at sink time.
+        self.pending_header_transform = None;
         self.pending_header_handle = Some(header_handle);
 
         // AAM spawns two daemon threads + aligner subprocess; 4 workers
@@ -2648,12 +2705,15 @@ impl<'a> ChainBuilder<'a> {
                 self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
             }
 
-            // Update self.header to reflect template-coordinate sort order so
-            // downstream add_group's sort-order header check passes. This is
-            // the same header update that the external sorter writes into the
-            // temp BAM — here we apply it directly so the static check at
-            // chain-construction time sees the correct sort order.
-            self.replace_header(fgumi_sort::create_output_header(sort_order, &self.header));
+            // Update self.header to reflect the sort order so downstream
+            // add_group's sort-order header check passes. This is the same header
+            // update the external sorter writes into the temp BAM. Applied as a
+            // header *transform* so that, when Align is upstream, the sort-order
+            // rewrite is re-applied to the aligner's runtime-resolved header at
+            // sink time (preserving its @PG/@RG/@CO) instead of dropping it.
+            self.apply_output_header_transform(move |header| {
+                Ok(fgumi_sort::create_output_header(sort_order, &header))
+            })?;
 
             // Streaming sort does NOT register a SortFinalizeHook
             // (no output-path stats to log; the overall chain timing hook
@@ -3761,8 +3821,16 @@ impl<'a> ChainBuilder<'a> {
         // Apply clip's sort-order annotation to the output header. This must
         // happen before add_sink() consumes self.header for WriteBgzfFile.
         // Order relative to the @PG record (already in self.header from new())
-        // does not matter — @HD and @PG are independent header sections.
-        self.replace_header(clip.update_header_sort_order(self.header.clone())?);
+        // does not matter — @HD and @PG are independent header sections. Applied
+        // as a header *transform* so that, when Align is upstream, the annotation
+        // re-applies to the aligner's runtime-resolved header at sink time,
+        // preserving its @PG/@RG/@CO.
+        let clip_for_header = clip.clone();
+        self.apply_output_header_transform(move |header| {
+            clip_for_header
+                .update_header_sort_order(header)
+                .map_err(|e| std::io::Error::other(format!("{e:#}")))
+        })?;
 
         // Load reference (always required for clip).
         let reference = Arc::new(crate::reference::ReferenceReader::new(&clip.reference)?);

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -321,13 +321,54 @@ impl Step2 for PairRawFastq {
             return Ok(StepOutcome::Progress);
         }
 
-        // Nothing pulled or emitted this call. If both input branches are
-        // drained, the pairing is complete — flush remaining pairs and finish.
+        // Nothing pulled or emitted this call. When over backpressure, pulling
+        // of the surplus (ahead) stream has stopped, so if the front pending pair
+        // is missing a record from a stream that is already drained, that stream
+        // can never complete the pair AND the ahead stream can never drain —
+        // `finalize_pairs` (both-drained) is unreachable, and `pending_total_bytes`
+        // plateaus below the 2x catastrophic-desync abort so that guard never
+        // fires either. This is the unequal-record-count case (e.g. a truncated
+        // R1): fail fast instead of spinning `NoProgress` forever (a silent hang).
+        // Under normal backpressure both streams still drain and the richer
+        // `finalize_pairs` desync report handles the mismatch.
+        if self.pending_total_bytes > self.pending_backpressure_bytes {
+            if let Some((&serial, (a_slot, b_slot))) = self.pending.iter().next() {
+                let a_short = a_slot.is_none() && ctx.a.is_drained();
+                let b_short = b_slot.is_none() && ctx.b.is_drained();
+                if a_short || b_short {
+                    // The stream whose front slot is missing is the one that ended
+                    // early. Report through the shared helper so this mid-stream
+                    // fail-fast names the short stream and orphaned serial exactly
+                    // like the both-drained `finalize_pairs` path.
+                    let short_stream = usize::from(!a_short);
+                    return Err(out_of_sync_error(short_stream, serial));
+                }
+            }
+        }
+
+        // If both input branches are drained, the pairing is complete — flush
+        // remaining pairs and finish.
         if ctx.a.is_drained() && ctx.b.is_drained() {
             return self.finalize_pairs(ctx);
         }
         Ok(StepOutcome::NoProgress)
     }
+}
+
+/// Build the canonical FASTQ out-of-sync error identifying the stream that ended
+/// early. `short_stream` is the 0-based index of the stream that ran out of
+/// records first (0 = R1/A, 1 = R2/B) and `chunk_serial` is the orphaned serial
+/// still holding only the other stream's chunk.
+///
+/// Shared by both fail paths — the both-drained [`PairRawFastq::finalize_pairs`]
+/// desync report and the over-backpressure mid-stream fail-fast — so the two
+/// surface byte-for-byte identical diagnostics regardless of which path detects
+/// the mismatch.
+fn out_of_sync_error(short_stream: usize, chunk_serial: u64) -> io::Error {
+    io::Error::other(format!(
+        "FASTQ sources out of sync: stream {short_stream} ended before chunk_serial \
+         {chunk_serial} while the other stream had more records"
+    ))
 }
 
 impl PairRawFastq {
@@ -344,10 +385,7 @@ impl PairRawFastq {
         let entry = self.pending.get(&lowest_serial).unwrap();
         if entry.0.is_none() || entry.1.is_none() {
             let short = usize::from(entry.0.is_some());
-            return Err(io::Error::other(format!(
-                "FASTQ sources out of sync: stream {short} ended before chunk_serial \
-                 {lowest_serial} while the other stream had more records"
-            )));
+            return Err(out_of_sync_error(short, lowest_serial));
         }
         let pair = self.try_emit_complete().expect("entry is complete");
         if let Err(unpushed) = ctx.outputs.push(pair) {
@@ -808,6 +846,14 @@ mod tests {
     /// both desync tests so the stream-0-short and stream-1-short cases exercise
     /// byte-for-byte the same wiring (only the lengths swap).
     fn run_desync_harness(serials0: u64, serials1: u64) -> Result<(), String> {
+        run_desync_harness_with_backpressure(serials0, serials1, None)
+    }
+
+    fn run_desync_harness_with_backpressure(
+        serials0: u64,
+        serials1: u64,
+        backpressure_bytes: Option<usize>,
+    ) -> Result<(), String> {
         use std::time::{Duration, Instant};
 
         // Both sources are leaders with no lag gate; the shared counter is
@@ -830,9 +876,14 @@ mod tests {
                     X3_SOURCE_QUEUE_BYTES,
                     progress_for_thread,
                 );
-                // Generous backpressure so the catastrophic-desync 2x abort never
-                // trips before the end-of-stream `finalize_pairs` desync path.
-                let pair = PairRawFastq::new(64 * 1024);
+                // Default (generous) backpressure lets the streams reach the
+                // end-of-stream `finalize_pairs` desync path; a small cap instead
+                // exercises the mid-stream fail-fast (surplus over 1x stops
+                // pulling before both branches drain).
+                let pair = match backpressure_bytes {
+                    Some(bytes) => PairRawFastq::new(64 * 1024).with_backpressure_bytes(bytes),
+                    None => PairRawFastq::new(64 * 1024),
+                };
                 let sink = PairSink {
                     seen_serials: Arc::new(Mutex::new(Vec::new())),
                     count: Arc::new(AtomicUsize::new(0)),
@@ -896,6 +947,42 @@ mod tests {
             err.contains("stream 0 ended before chunk_serial 2"),
             "desync error must name the short stream (index 0) and the orphaned \
              serial (2), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_over_backpressure_fails_fast_instead_of_hanging() {
+        // Stream 0 (a) has 3 chunks (X3_CHUNK_BYTES each), stream 1 (b) has 1.
+        // With a small backpressure cap, after the first pair the surplus from
+        // stream 0 crosses 1x the cap, so per-stream backpressure STOPS pulling
+        // stream 0 — leaving its remaining chunks unpulled (so it never drains),
+        // and pending plateaus BELOW the 2x catastrophic-desync abort, which
+        // therefore never fires. The front pair is missing stream 1, which is
+        // drained. Pre-fix this spun `NoProgress` forever (the harness's 30s
+        // deadline would trip); the fix detects the unpairable record and fails
+        // fast. This also proves the run terminates (no hang).
+        let result = run_desync_harness_with_backpressure(3, 1, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 1 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 1) and the orphaned serial (1), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_zero_over_backpressure_fails_fast_instead_of_hanging() {
+        // Mirror of the above with the lengths swapped: stream 0 (a) has 1 chunk,
+        // stream 1 (b) has 3. Now the surplus is stream 1, and the front pair is
+        // missing stream 0, which is drained — so this drives the symmetric
+        // `a_slot.is_none() && ctx.a.is_drained()` branch that the stream-1-short
+        // test leaves unexercised. The abort must name the short stream (index 0).
+        let result = run_desync_harness_with_backpressure(1, 3, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 0 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 0) and the orphaned serial (1), got: {err}"
         );
     }
 }


### PR DESCRIPTION
Part 2 of a 3-PR audit-fix stack. **Base is `nh/audit-1-hangs`** (PR 1); merge PR 1 first, then this.

**Fixes in this PR (sort data-integrity + aligner header + filter parity + FASTQ deadlock)**
- **D2**: the zstd spill decompressor used a fixed 256 KiB scratch buffer; a spill block holding a single record larger than that (e.g. a long read) failed `decompress_to_buffer` and aborted the whole sort on the default codec. Size the buffer to the frame's content size.
- **D1**: Phase-1 input serials were assigned *after* the input-file lock was dropped, so a worker preempted in that window let the done-check fire early and trailing blocks pushed after the merge finished — silent truncation. Reserve the batch's serial range under the lock.
- **D3**: post-`Align` header-modifying stages (sort, clip) called `replace_header`, which nulled the pending aligner `HeaderHandle`; the writer then fell back to the build-time header, dropping the aligner's runtime `@PG`/`@RG`/`@CO`. Re-apply the change to the resolved header via a transform.
- **V2**: filter rejected valid `CC>AB` error-rate vectors; fgbio's `FilterConsensusReads` only constrains `AB<=BA` and explicitly allows e.g. `--max-base-error-rate 0.1 0.05 0.2`. Drop the extra `CC<=AB` check.
- **H1**: length-mismatched paired FASTQ (e.g. truncated R1) could deadlock — per-stream backpressure stopped pulling the long stream, so the 2x desync abort never fired. Fail fast on an unpairable record when over backpressure.

Each fix has a regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sorting and clipping header updates now persist in BGZF output, including headers resolved at runtime.

- **Bug Fixes**
  - Improved spill-block decompression by sizing buffers per zstd frame to handle oversized records reliably.
  - Prevented premature end-of-file signaling during parallel input block reading.
  - Truncated or mismatched paired FASTQ inputs now fail promptly (with out-of-sync diagnostics) instead of hanging.
  - Updated duplex error-rate validation to match fgbio-compatible CC/AB combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->