### PR TITLE
fix(audit): extract/zipper/group parity, validator guard, memory accounting (3/3)

### DIFF
--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -39,6 +39,26 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// Validate that the read structures produce a valid SAM template: 1 or 2
+/// template (`T`) reads total. 0 template reads yields records with no sequence;
+/// 3+ produce more segments than a SAM template (R1/R2) can hold — either way
+/// the output BAM would be malformed. Shared by the standalone `Extract` command
+/// and the chain/runall `ChainBuilder::add_extract` so both paths reject it
+/// (the chain path previously skipped this check — silent malformed output).
+///
+/// # Errors
+///
+/// Returns an error unless the total template-read count is 1 or 2.
+pub(crate) fn validate_template_count(read_structures: &[ReadStructure]) -> anyhow::Result<()> {
+    let template_count: usize =
+        read_structures.iter().map(|rs| rs.segments_by_type(SegmentType::Template).count()).sum();
+    anyhow::ensure!(
+        (1..=2).contains(&template_count),
+        "read structures must contain 1-2 template reads total."
+    );
+    Ok(())
+}
+
 /// Per-stage options for [`crate::pipeline::chains::Stage::Extract`].
 ///
 /// Carries all the knobs that [`crate::pipeline::chains::commands::extract`]
@@ -601,14 +621,7 @@ impl Extract {
             "input and read-structure must be supplied the same number of times."
         );
 
-        let template_count: usize = read_structures
-            .iter()
-            .map(|rs| rs.segments_by_type(SegmentType::Template).count())
-            .sum();
-        ensure!(
-            (1..=2).contains(&template_count),
-            "read structures must contain 1-2 template reads total."
-        );
+        validate_template_count(&read_structures)?;
 
         ensure!(
             !self.extract_umis_from_read_names || !self.store_umi_quals,
@@ -1115,6 +1128,19 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
+
+    #[rstest]
+    #[case::one_template(&["+T"], true)]
+    #[case::two_templates(&["8B+T", "+T"], true)]
+    #[case::zero_templates(&["+B"], false)]
+    #[case::three_templates(&["+T", "+T", "+T"], false)]
+    fn validate_template_count_requires_1_or_2(#[case] structures: &[&str], #[case] ok: bool) {
+        let read_structures: Vec<ReadStructure> = structures
+            .iter()
+            .map(|s| ReadStructure::from_str(s).expect("valid read structure"))
+            .collect();
+        assert_eq!(validate_template_count(&read_structures).is_ok(), ok);
+    }
 
     /// Create a FASTQ file for testing
     ///

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -777,7 +777,9 @@ are grouped by template, and then templates are sorted by the 5' mapping positio
 the reads from the template, used from earliest mapping position to latest. Reads that
 have the same end positions are then sub-grouped by UMI sequence.
 
-Accepts reads in any order (including unsorted) and outputs reads sorted by:
+Requires the input to be template-coordinate sorted (or queryname sorted when
+`--allow-unmapped` is given); unlike fgbio it does not re-sort internally, and
+rejects input that is not in one of those orders. Outputs reads sorted by:
 
    1. The lower genome coordinate of the two outer ends of the templates (strand-aware)
    2. The sequencing library
@@ -785,10 +787,9 @@ Accepts reads in any order (including unsorted) and outputs reads sorted by:
    4. The assigned UMI tag
    5. Read Name
 
-It is recommended to sort the reads into template-coordinate order prior to running
-this tool to avoid re-sorting the input. Use `fgumi sort --order template-coordinate`
-for the pre-sorting. The output will always be written
-in template-coordinate order.
+Pre-sort the reads into template-coordinate order before running this tool with
+`fgumi sort --order template-coordinate`. The output is always written in
+template-coordinate order.
 
 During grouping, reads and templates are filtered out as follows:
 
@@ -1313,8 +1314,16 @@ impl GroupReadsByUmi {
             filter_config.min_umi_length,
             filter_config.no_umi,
         ) {
-            // Log error but continue processing
+            // The whole group is dropped from the BAM (matching the chain path),
+            // so none of its filter-passing templates are actually accepted. This
+            // group's `accepted_templates` was already merged into the total
+            // above; roll it back so the summary/metrics match the (empty) output
+            // rather than over-counting. The discard counters stay — those
+            // templates were genuinely filtered out.
             log::warn!("Failed to assign UMI groups: {e}");
+            total_filter_metrics.accepted_templates = total_filter_metrics
+                .accepted_templates
+                .saturating_sub(filter_metrics.accepted_templates);
             return Ok(());
         }
 
@@ -5187,6 +5196,93 @@ mod tests {
         let mut metrics = FilterMetrics::new();
         assert!(filter_template_raw(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates, 1);
+    }
+
+    /// A group whose template PASSES filtering but then FAILS UMI assignment must
+    /// roll its `accepted_templates` contribution back out of the running total
+    /// (so the summary matches the empty output), while leaving the discard
+    /// counters untouched — that template was not filtered out, it was dropped
+    /// whole when assignment failed. Regression for the rollback branch in
+    /// `process_and_write_position_group`.
+    #[test]
+    fn assignment_failure_rolls_back_accepted_templates_but_not_discards() {
+        use fgumi_bam_io::{DecodedRecord, GroupKey};
+
+        // The RX value is 8 real bases plus a trailing non-UTF-8 byte: `validate_umi`
+        // skips the stray byte (so the filter accepts the template), but assignment's
+        // `str::from_utf8` rejects it — driving the `assign_umi_groups_impl` Err
+        // branch that triggers the rollback.
+        let raw = make_raw_bam_for_group(
+            b"rea",
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED,
+            30,
+            b"ACGTACGT\xff",
+        );
+        let group = RawPositionGroup {
+            group_key: GroupKey::default(),
+            records: vec![DecodedRecord::from_raw_bytes(raw, GroupKey::default())],
+        };
+        let filter_config = GroupFilterConfig {
+            umi_tag: [b'R', b'X'],
+            min_mapq: 20,
+            include_non_pf: false,
+            min_umi_length: None,
+            no_umi: false,
+            allow_unmapped: false,
+        };
+
+        // Pre-existing totals from earlier groups that must survive the rollback.
+        let mut total = FilterMetrics::new();
+        total.accepted_templates = 5;
+        total.discarded_poor_alignment = 2;
+        total.discarded_non_pf = 1;
+        let discards_before = (
+            total.discarded_non_pf,
+            total.discarded_poor_alignment,
+            total.discarded_ns_in_umi,
+            total.discarded_umi_too_short,
+        );
+
+        let mut family_sizes = AHashMap::new();
+        let mut position_group_sizes = AHashMap::new();
+        let mut next_mi_base = 0u64;
+        let header = create_test_header();
+        let tmp = NamedTempFile::new().expect("tempfile");
+        let mut writer = create_bam_writer(tmp.path(), &header, 1, 0).expect("writer");
+
+        let result = GroupReadsByUmi::process_and_write_position_group(
+            group,
+            &filter_config,
+            Strategy::Adjacency,
+            1,
+            0,
+            1,
+            None,
+            [b'R', b'X'],
+            [b'M', b'I'],
+            &mut total,
+            &mut family_sizes,
+            &mut position_group_sizes,
+            &mut next_mi_base,
+            &header,
+            &mut writer,
+        );
+
+        assert!(result.is_ok(), "assignment failure must be handled, not propagated: {result:?}");
+        assert_eq!(
+            total.accepted_templates, 5,
+            "the filter-passing template of the failed group must be rolled back to the pre-group total",
+        );
+        assert_eq!(
+            (
+                total.discarded_non_pf,
+                total.discarded_poor_alignment,
+                total.discarded_ns_in_umi,
+                total.discarded_umi_too_short,
+            ),
+            discards_before,
+            "discard counters must not change on an assignment-failure rollback",
+        );
     }
 
     #[test]

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -1282,34 +1282,23 @@ pub(crate) mod merge_step {
                         let mapped = self.pending_b.as_mut().unwrap().take_current().unwrap();
                         self.emit_merged(unmapped, mapped, ctx)?
                     }
-                    Some(ref n) => {
-                        // MISMATCH. Mapped is expected to be a subsequence of
-                        // unmapped in the same queryname order, so the mapped
-                        // head must never sort *before* the unmapped head: if
-                        // it does, a mapped read has no corresponding unmapped
-                        // read (or the inputs are out of order), which is
-                        // corruption — fail rather than silently emitting the
-                        // unmapped read as missing-mapped.
-                        if fgumi_raw_bam::sort::natural_compare(n, &pa_name)
-                            == std::cmp::Ordering::Less
-                        {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!(
-                                    "Error: mapped read '{}' sorts before unmapped read '{}'; the \
-                                     mapped input has a read with no corresponding unmapped read, or \
-                                     the inputs are not in the same queryname order. Please ensure the \
-                                     unmapped and mapped reads have the same set of read names in the \
-                                     same order, and reads with the same name are consecutive (grouped) \
-                                     in each input.",
-                                    String::from_utf8_lossy(n),
-                                    String::from_utf8_lossy(&pa_name),
-                                ),
-                            ));
-                        }
-                        // Mapped head sorts after the unmapped head: the current
-                        // unmapped read is missing from mapped. Consume the
-                        // unmapped only; leave pending_b cursor where it is.
+                    Some(_) => {
+                        // MISMATCH: the mapped head names a different template.
+                        // The mapped BAM is a subsequence of the unmapped BAM in
+                        // the same queryname order, so a name mismatch means the
+                        // current unmapped read is simply missing from the mapped
+                        // BAM — emit it as unmapped-only and advance the unmapped
+                        // cursor (leaving the mapped cursor put), exactly as fgbio
+                        // ZipperBams does (name-equality only).
+                        //
+                        // We deliberately do NOT compare sort order here. The
+                        // inputs may be query-GROUPED (records with the same name
+                        // consecutive) rather than queryname-sorted, in which case
+                        // successive groups can be in any order and a `natural`
+                        // comparison would spuriously reject valid input. A
+                        // genuinely orphaned mapped read (no unmapped counterpart)
+                        // is still caught by the end-of-stream "mapped reads
+                        // remaining" check once the unmapped branch drains.
                         let unmapped = self.pending_a.as_mut().unwrap().take_current().unwrap();
                         self.emit_unmapped_only(unmapped, ctx)?
                     }
@@ -2787,6 +2776,53 @@ mod tests {
             "Supplementary without primary should not have pa tag"
         );
 
+        Ok(())
+    }
+
+    /// Query-GROUPED (not natural-sorted) input where the mapped BAM is missing
+    /// a read must be accepted. Unmapped templates are "q10" then "q2" (grouped,
+    /// not natural order); the mapped BAM has only "q2". At the "q10" step the
+    /// mapped head "q2" natural-sorts BEFORE "q10" — the old guard spuriously
+    /// rejected this as corruption. It must now emit "q10" unmapped-only and
+    /// merge "q2" (matching fgbio `ZipperBams`, which compares by name equality
+    /// only and never by sort order).
+    #[test]
+    fn grouped_out_of_natural_order_missing_mapped_read_is_accepted() -> Result<()> {
+        let mut unmapped = FgSamBuilder::new_unmapped();
+        let mut mapped = FgSamBuilder::new_mapped();
+
+        let empty = HashMap::new();
+        unmapped.add_pair_with_attrs("q10", None, None, true, true, &empty);
+        unmapped.add_pair_with_attrs("q2", None, None, true, true, &empty);
+        // Mapped is missing "q10"; it only has "q2".
+        let _ = mapped.add_pair().name("q2").start1(100).start2(200).build();
+
+        let records = run_zipper(&unmapped, &mapped, vec![], vec![], vec![])?;
+
+        // 2 unmapped-only q10 records (missing from the mapped BAM) + 2 merged q2
+        // records. A name-only check would miss q10 being dropped, duplicated, or
+        // wrongly merged against an unrelated mapped read.
+        assert_eq!(records.len(), 4, "expected 2 unmapped-only (q10) + 2 merged (q2) records");
+
+        let names: Vec<String> = records
+            .iter()
+            .map(|r| {
+                String::from_utf8(r.name().expect("record should have a name").as_bytes().to_vec())
+                    .expect("utf8 name")
+            })
+            .collect();
+        assert!(names.iter().any(|n| n == "q10"), "q10 must be emitted unmapped-only: {names:?}");
+        assert!(names.iter().any(|n| n == "q2"), "q2 must be merged: {names:?}");
+        // q10 has no mapped counterpart, so both its records must stay unmapped —
+        // mirrors the `flags().is_unmapped()` guard in `test_unmapped_only_reads`.
+        let mut q10_unmapped = 0;
+        for r in &records {
+            if r.name().expect("record should have a name").as_bytes() == b"q10" {
+                assert!(r.flags().is_unmapped(), "q10 must remain unmapped");
+                q10_unmapped += 1;
+            }
+        }
+        assert_eq!(q10_unmapped, 2, "both q10 mates must be emitted unmapped-only");
         Ok(())
     }
 

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1618,6 +1618,11 @@ impl<'a> ChainBuilder<'a> {
             other => bail!("add_extract requires SourceSpec::Fastqs, got {other:?}"),
         };
 
+        // Enforce the same read-structure guard the standalone `Extract` command
+        // applies (1-2 template reads total): the chain/runall path previously
+        // skipped it and would silently emit malformed BAM templates.
+        crate::commands::extract::validate_template_count(&read_structures)?;
+
         let input_path = self.resolve_log_input_path();
         log::info!("Starting Extract");
         log::info!("Input: {}", input_path.display());

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3770,6 +3770,20 @@ impl<'a> ChainBuilder<'a> {
             );
         }
 
+        // Clip groups the record stream internally (GroupBam), so it consumes a
+        // DecodedRecordBatch tail. If an upstream stage left a different tail type
+        // (e.g. an intermediate Group emits BatchedProcessedPositionGroups), the
+        // type-erased pipeline would build but panic at dispatch — reject it here
+        // with a clear error.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Clip requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; clip cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
         let clip = self
             .spec
             .stage_opts
@@ -3920,6 +3934,21 @@ impl<'a> ChainBuilder<'a> {
             bail!(
                 "intermediate filter not implemented; filter is typically terminal \
                 (no Phase 3 runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // Filter consumes a record stream (either a GroupByQueryname step in
+        // filter-by-template mode or a single-record filter step), so it needs a
+        // DecodedRecordBatch tail — the same requirement as clip/dedup. If an upstream
+        // stage left a different tail type (e.g. an intermediate Group emits
+        // BatchedProcessedPositionGroups), the type-erased pipeline would build but
+        // panic at dispatch — reject it here.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Filter requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; filter cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
             );
         }
 
@@ -4128,6 +4157,19 @@ impl<'a> ChainBuilder<'a> {
             bail!(
                 "intermediate dedup not implemented; dedup is typically terminal \
                 (no Phase 3 runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // Dedup groups the record stream internally (GroupByPosition), so it
+        // consumes a DecodedRecordBatch tail. Reject an incompatible upstream
+        // tail (e.g. an intermediate Group's BatchedProcessedPositionGroups) here
+        // rather than dispatch-panicking in the type-erased pipeline.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Dedup requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; dedup cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
             );
         }
 

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -165,14 +165,21 @@ impl Template {
         Some(value)
     }
 
-    /// Approximate heap footprint in bytes — the sum of all member records'
-    /// byte lengths plus the queryname's byte length. Used by the new
-    /// pipeline framework's `BamTemplateBatch` for byte-bounded queue
-    /// budgeting.
+    /// True allocated heap footprint in bytes: summed record **capacities** plus
+    /// the `Vec<RawRecord>` container overhead plus the queryname allocation.
+    /// Used by the pipeline framework's `BamTemplateBatch` for byte-bounded queue
+    /// budgeting, so the budget tracks real RSS. Accounting by logical `len()`
+    /// under-counts over-allocated record buffers and ignores container overhead,
+    /// which lets the pipeline buffer past its `--max-memory` budget and risk an
+    /// OOM (this mirrors `DecodedRecordBatch`, which already sizes by capacity).
+    /// `MemoryEstimate::estimate_heap_size` delegates here so the two never
+    /// diverge.
     #[must_use]
     pub fn heap_size(&self) -> usize {
-        let records_bytes: usize = self.records.iter().map(RawRecord::len).sum();
-        records_bytes + self.name.len()
+        let name_size = self.name.capacity();
+        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
+            + self.records.capacity() * std::mem::size_of::<RawRecord>();
+        name_size + records_size
     }
 
     /// Returns the primary R1 record if present.
@@ -1004,14 +1011,10 @@ impl<R: std::io::Read> Iterator for TemplateIterator<R> {
 
 impl MemoryEstimate for Template {
     fn estimate_heap_size(&self) -> usize {
-        // name: Vec<u8>
-        let name_size = self.name.capacity();
-
-        // records: Vec<RawRecord>
-        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
-            + self.records.capacity() * std::mem::size_of::<RawRecord>();
-
-        name_size + records_size
+        // Single source of truth: the pipeline byte-budget (`Template::heap_size`)
+        // and `MemoryEstimate` must agree, so both use the capacity-based
+        // footprint computed in `heap_size`.
+        self.heap_size()
     }
 }
 
@@ -1023,6 +1026,63 @@ impl MemoryEstimate for Template {
 mod tests {
     use super::*;
     use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, flags as raw_flags};
+
+    #[test]
+    fn heap_size_counts_capacity_and_matches_memory_estimate() {
+        // A queryname allocation with spare capacity: the byte budget must count
+        // the allocated capacity (real RSS), not the 5-byte logical length —
+        // otherwise the pipeline under-counts and can buffer past --max-memory.
+        let mut name = Vec::with_capacity(64);
+        name.extend_from_slice(b"read1");
+        let mut template = Template::new(name);
+
+        // Hold real records in a Vec with deliberately reserved spare capacity so
+        // BOTH record terms of `heap_size` are exercised — the per-record byte
+        // buffers (`RawRecord::capacity`) and the `Vec<RawRecord>` backing store
+        // (`records.capacity() * size_of::<RawRecord>()`). The empty-records case
+        // left both at zero, so a dropped record term would have gone unnoticed.
+        let mut records: Vec<RawRecord> = Vec::with_capacity(8);
+        records.push(create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT));
+        records.push(create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT));
+        template.records = records;
+
+        // heap_size (pipeline byte-budget) and estimate_heap_size (MemoryEstimate)
+        // are a single source of truth — they must never diverge.
+        assert_eq!(
+            template.heap_size(),
+            template.estimate_heap_size(),
+            "heap_size and estimate_heap_size must agree",
+        );
+
+        // Independent lower bound re-derived from the components in the test (NOT
+        // via estimate_heap_size, which delegates to heap_size and is tautological).
+        // If heap_size ever drops the record-buffer or Vec-backing term, this trips.
+        let record_bytes = template.records.iter().map(RawRecord::capacity).sum::<usize>();
+        let vec_backing = template.records.capacity() * std::mem::size_of::<RawRecord>();
+        let expected_min = template.name.capacity() + record_bytes + vec_backing;
+        assert!(
+            template.heap_size() >= expected_min,
+            "heap_size {} must cover queryname ({}) + record buffers ({record_bytes}) + \
+             Vec<RawRecord> backing ({vec_backing})",
+            template.heap_size(),
+            template.name.capacity(),
+        );
+        // The record terms must be non-trivial: real byte buffers and the reserved
+        // spare Vec slots both contribute, not just the queryname.
+        assert!(record_bytes > 0, "records must carry real byte capacity");
+        assert!(vec_backing > 0, "Vec<RawRecord> backing store must be counted");
+        assert!(
+            template.records.capacity() >= 8,
+            "reserved spare Vec capacity must be retained ({} < 8)",
+            template.records.capacity(),
+        );
+        // And the footprint reflects the allocated queryname capacity (>= 64).
+        assert!(
+            template.heap_size() >= 64,
+            "heap_size must count allocated capacity, got {}",
+            template.heap_size(),
+        );
+    }
 
     // SAM flag constants
     const FLAG_PAIRED: u16 = 0x1;

--- a/tests/integration/test_chain_build.rs
+++ b/tests/integration/test_chain_build.rs
@@ -266,3 +266,67 @@ fn chain_build_group_to_codec() {
     let spec = spec_for(vec![Stage::Group, Stage::Codec], &input, bag);
     build_for(spec).expect("build_for([Group, Codec]) should succeed");
 }
+
+/// `[Group, Clip]` — an ordering-valid but type-incompatible chain: Group emits
+/// grouped templates (`BamTemplateBatch`) while Clip consumes a record stream
+/// (`DecodedRecordBatch`, which it groups internally). The stage-ordering
+/// validators pass, but the type-erased pipeline would panic at dispatch. The
+/// `chain_tail_kind` guard in `add_clip` must reject it cleanly at build time.
+#[test]
+fn chain_build_group_to_clip_rejected() {
+    use clap::Parser;
+    use fgumi_lib::assigner::Strategy;
+    use fgumi_lib::commands::clip::Clip;
+
+    let tmp = TempDir::new().unwrap();
+    let input = write_input_bam(tmp.path());
+
+    // Minimal parse only — the guard fires before Clip's own options are read.
+    let clip =
+        Clip::try_parse_from(["clip", "-i", "/dev/null", "-o", "/dev/null", "-r", "/dev/null"])
+            .expect("parse minimal clip");
+
+    let bag = StageOptionsBag {
+        group: Some(group_opts(Strategy::Adjacency)),
+        clip: Some(clip),
+        ..Default::default()
+    };
+
+    let spec = spec_for(vec![Stage::Group, Stage::Clip], &input, bag);
+    let Err(err) = build_for(spec) else {
+        panic!("Group -> Clip must be rejected at build time");
+    };
+    assert!(
+        err.to_string().contains("Stage::Clip requires a record-stream input (DecodedRecordBatch)"),
+        "expected the clip tail-kind guard to fire, got: {err}"
+    );
+}
+
+/// Filter is the same class of record-stream consumer as Clip/Dedup, so a `Group -> Filter`
+/// chain (grouped-template tail feeding a record-stream stage) must also be rejected at build
+/// time rather than building and panicking at dispatch.
+#[test]
+fn chain_build_group_to_filter_rejected() {
+    use fgumi_lib::assigner::Strategy;
+    use fgumi_lib::commands::filter::FilterOptions;
+
+    let tmp = TempDir::new().unwrap();
+    let input = write_input_bam(tmp.path());
+
+    // Default opts — the guard fires before Filter's own options are read.
+    let bag = StageOptionsBag {
+        group: Some(group_opts(Strategy::Adjacency)),
+        filter: Some(FilterOptions::default()),
+        ..Default::default()
+    };
+
+    let spec = spec_for(vec![Stage::Group, Stage::Filter], &input, bag);
+    let Err(err) = build_for(spec) else {
+        panic!("Group -> Filter must be rejected at build time");
+    };
+    assert!(
+        err.to_string()
+            .contains("Stage::Filter requires a record-stream input (DecodedRecordBatch)"),
+        "expected the filter tail-kind guard to fire, got: {err}"
+    );
+}


### PR DESCRIPTION
Part 3 of a 3-PR audit-fix stack. **Base is `nh/audit-2-sort-data`** (PR 2); merge PRs 1 and 2 first, then this.

**Fixes in this PR (command parity + validator guard + memory accounting)**
- **V6b (extract)**: the 1-2 template-read guard lived only in the standalone command; the chain/runall path skipped it and would silently emit malformed BAM templates. Share the check between both paths.
- **V6c (zipper)**: a `natural_compare` mismatch guard rejected valid query-*grouped* (non-sorted) input. fgbio's `ZipperBams` matches by name equality only; a genuinely orphaned mapped read is still caught by the existing end-of-stream check.
- **validator gap (chains)**: an ordering-valid but type-incompatible chain (e.g. `Group -> Clip`, where Clip consumes a record stream but Group emits templates) built a mis-typed pipeline that panicked at dispatch. Guard the tail kind in `add_clip`/`add_dedup`. Latent today.
- **M1 (memory)**: `Template::heap_size` (the pipeline byte budget) summed logical `len()`, while `MemoryEstimate` summed `capacity()` + container overhead — so `--max-memory` under-counted RSS and could OOM. Unify on the capacity-based footprint.
- **V3/V4 (group)**: the single-threaded path over-counted `accepted_records` on UMI-assignment failure (the chain path zeroes it), and the help claimed "any order (including unsorted)" while the code requires template-coordinate/queryname sorted input. Fix both.

Each fix has a regression test (V4 is a help/doc correction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced template-read count validation consistently across extraction and chain building (only 1–2 template reads allowed).
  * Fixed UMI grouping metrics to reflect that failed assignment produces no output.
  * Updated zipper merge behavior to accept missing mapped reads in grouped, out-of-order inputs while preserving unmapped-only output.
  * Prevented incompatible pipeline stage combinations from failing unexpectedly.
  * Improved memory/heap size estimates to account for allocated capacity.
* **Documentation**
  * Clarified required input sorting and output ordering for UMI grouping in CLI help.
* **Tests**
  * Added coverage for validation, metric rollback, and grouped zipper-merge acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->