### PR TITLE
fix(simplex): enforce --min-reads/--max-reads range on the runall path (audit V5/C1)

### DIFF
--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -172,6 +172,24 @@ impl SimplexOptions {
             consensus_call_overlapping_bases: self.consensus_call_overlapping_bases,
         }
     }
+
+    /// Validate the `--min-reads` / `--max-reads` range.
+    ///
+    /// `min_reads` must be `>= 1` (a value of 0 admits empty groups) and, when
+    /// `max_reads` is set, it must be `>= min_reads`. Shared by the standalone
+    /// `Simplex::execute` and the chain builder's `add_simplex` so `runall`
+    /// rejects the same degenerate configurations the standalone command does.
+    pub(crate) fn validate_read_bounds(&self) -> Result<()> {
+        if self.min_reads == 0 {
+            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
+        }
+        if let Some(max) = self.max_reads {
+            if max < self.min_reads {
+                bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Calls simplex consensus sequences from reads with the same unique molecular tag.
@@ -300,14 +318,7 @@ impl Command for Simplex {
         // Validate inputs
         self.io.validate()?;
 
-        if self.options.min_reads == 0 {
-            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
-        }
-        if let Some(max) = self.options.max_reads {
-            if max < self.options.min_reads {
-                bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.options.min_reads);
-            }
-        }
+        self.options.validate_read_bounds()?;
 
         info!("Starting Simplex");
         info!("Input: {}", self.io.input.display());
@@ -1050,6 +1061,31 @@ mod tests {
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("--max-reads"));
         assert!(error_msg.contains("--min-reads"));
+    }
+
+    #[rstest]
+    #[case::valid_min_only(1, None, None)]
+    #[case::valid_min_and_max(3, Some(10), None)]
+    #[case::valid_min_equals_max(5, Some(5), None)]
+    #[case::min_reads_zero(0, None, Some("--min-reads must be >= 1"))]
+    #[case::max_below_min(5, Some(2), Some("--max-reads (2) must be >= --min-reads (5)"))]
+    fn test_validate_read_bounds(
+        #[case] min_reads: usize,
+        #[case] max_reads: Option<usize>,
+        #[case] expected_err: Option<&str>,
+    ) {
+        let options = SimplexOptions { min_reads, max_reads, ..SimplexOptions::default() };
+        match (options.validate_read_bounds(), expected_err) {
+            (Ok(()), None) => {}
+            (Err(err), Some(needle)) => {
+                assert!(
+                    err.to_string().contains(needle),
+                    "expected error containing {needle:?}, got: {err}"
+                );
+            }
+            (Ok(()), Some(needle)) => panic!("expected error containing {needle:?}, got Ok"),
+            (Err(err), None) => panic!("expected Ok, got error: {err}"),
+        }
     }
 
     #[test]

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3059,6 +3059,13 @@ impl<'a> ChainBuilder<'a> {
             bail!("--ref requires --methylation-mode to be set");
         }
 
+        // V5 fix: runall never calls Simplex::execute, so mirror its
+        // --min-reads / --max-reads range check here. Without this, runall
+        // silently accepts degenerate configs (`--simplex::min-reads 0`,
+        // `--simplex::max-reads < --simplex::min-reads`) the standalone command
+        // rejects, breaking the "same as standalone" contract.
+        simplex.validate_read_bounds()?;
+
         let tail = self.current_tail.expect("add_simplex called before add_source");
 
         // Resolve source path for log messages only.

--- a/tests/integration/test_chain_build.rs
+++ b/tests/integration/test_chain_build.rs
@@ -224,6 +224,71 @@ fn chain_build_group_to_simplex() {
     build_for(spec).expect("build_for([Group, Simplex]) should succeed");
 }
 
+/// V5 (audit): `runall` builds the chain via `build_for` and never calls
+/// `Simplex::execute`, so the `--min-reads` / `--max-reads` range check the
+/// standalone command enforces must be re-applied in `add_simplex`. This pins
+/// the parity contract: `build_for` must *accept* exactly the read-bound
+/// configurations the standalone `fgumi simplex` command accepts and *reject*
+/// exactly the degenerate ones it rejects.
+///
+/// The `expected` column is an explicit expected-validity oracle, authored
+/// independently of the validator rather than derived from it: `None` means the
+/// configuration is valid and the chain must build; `Some(msg)` means it is
+/// degenerate and `build_for` must reject it with an error containing `msg`.
+/// Exercising both the accept and reject decisions — not just echoing the
+/// validator's own error text — means a shared regression cannot make the test
+/// pass: a validator gutted to accept everything breaks the `Some(..)` cases,
+/// and one that rejects everything breaks the `None` cases.
+#[cfg(feature = "consensus")]
+#[rstest::rstest]
+#[case::default_bounds(1, None, None)]
+#[case::min_one_max_one(1, Some(1), None)]
+#[case::min_two_max_five(2, Some(5), None)]
+#[case::min_reads_zero(0, None, Some("--min-reads must be >= 1"))]
+#[case::max_below_min(5, Some(2), Some("--max-reads (2) must be >= --min-reads (5)"))]
+fn chain_build_simplex_enforces_read_bounds(
+    #[case] min_reads: usize,
+    #[case] max_reads: Option<usize>,
+    #[case] expected: Option<&str>,
+) {
+    use fgumi_lib::assigner::Strategy;
+    use fgumi_lib::commands::simplex::SimplexOptions;
+
+    let tmp = TempDir::new().unwrap();
+    let input = write_input_bam(tmp.path());
+
+    let build = || {
+        let simplex = SimplexOptions { min_reads, max_reads, ..SimplexOptions::default() };
+        let bag = StageOptionsBag {
+            group: Some(group_opts(Strategy::Adjacency)),
+            simplex: Some(simplex),
+            ..Default::default()
+        };
+        build_for(spec_for(vec![Stage::Group, Stage::Simplex], &input, bag))
+    };
+
+    match expected {
+        None => {
+            build().unwrap_or_else(|err| {
+                panic!(
+                    "build_for([Group, Simplex]) with min_reads={min_reads} max_reads={max_reads:?} must be accepted, got: {err}"
+                )
+            });
+        }
+        Some(msg) => {
+            let Err(err) = build() else {
+                panic!(
+                    "build_for([Group, Simplex]) with min_reads={min_reads} max_reads={max_reads:?} must be rejected"
+                );
+            };
+            assert!(
+                err.to_string().contains(msg),
+                "expected simplex read-bounds error containing {msg:?}, got: {err}"
+            );
+        }
+    }
+}
+
 /// `[Group, Duplex]` — duplex requires the `Paired` grouping strategy (MIs
 /// carry `/A`/`/B` suffixes), enforced by the cross-stage validator. Pins
 /// the Group→Duplex hand-off under that constraint.


### PR DESCRIPTION
## What

The standalone `Simplex::execute` rejects `--min-reads 0` ("a value of 0 admits empty groups") and `--max-reads < --min-reads` before dispatching, but `runall` never calls `Simplex::execute` — it builds the chain directly via `build_for`. Neither the `Stage::Simplex` arm nor `add_simplex` re-checked the range, so `fgumi runall … --consensus simplex --simplex::min-reads 0` (or a max below the min) was silently accepted, producing output the standalone command refuses and breaking runall's "same as standalone" contract.

Second-wave item **C1 / V5** from the feat-runall audit (`findings/02-unified_pipeline.md`, finding 2).

## Fix

Hoist the two checks into a shared `SimplexOptions::validate_read_bounds` and call it from both `Simplex::execute` and the chain builder's `add_simplex`. This mirrors the pattern already used for the duplex path (V1, `DuplexConsensusCaller::validate_min_reads` called in `add_duplex`) and the codec path (`.validate()`).

## Target rationale (main vs feat-runall)

`runall` and the chain builder (`src/lib/pipeline/chains/builder.rs`) do not exist on `origin/main` — they are the feat-runall typed-step surface (issue #330). This is a feat-runall-only gap, so the PR targets the feat-runall audit stack (`nh/audit-3-parity`).

## Tests

- `test_validate_read_bounds` — rstest table over valid and degenerate (`min_reads==0`, `max<min`) inputs.
- `chain_build_simplex_rejects_degenerate_read_bounds` — build-level regression: `build_for([Group, Simplex])` now errors for both degenerate configs (it built successfully before this fix).

`cargo ci-test` 2340 passed / 8 skipped; `cargo ci-lint` clean.

> Note: this commit is currently unsigned — the local 1Password signing agent was wedged at commit time (three signed attempts failed). It will be re-signed before the audit stack is finalized/merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent validation for simplex read limits.
  * Invalid configurations, including zero minimum reads or maximum reads below the minimum, are now rejected earlier with clear errors.
  * Pipeline construction now applies the same validation as the standalone simplex command.

* **Tests**
  * Added coverage for valid and invalid read-limit configurations.
  * Added integration tests confirming invalid pipeline configurations fail during build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->