### PR TITLE
feat(simulate): body error injection, template-coordinate sort fix, correctness guards (SIMU3-01/03/04/05/07)

### DIFF
--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -528,6 +528,109 @@ pub(super) fn generate_random_sequence(len: usize, rng: &mut impl Rng) -> Vec<u8
     seq
 }
 
+/// Introduce random substitution errors into `seq` in place.
+///
+/// Uses a direct alternative-base lookup table to avoid retry loops. When `error_rate <= 0.0` this
+/// returns early without drawing any RNG, so a zero (or non-positive) rate leaves the RNG stream
+/// untouched and callers may invoke it unconditionally. For `error_rate > 0.0` it draws exactly one
+/// `rng.random::<f64>()` uniform per base and substitutes that base when the draw falls below the
+/// rate.
+pub(super) fn introduce_errors_inplace(seq: &mut [u8], error_rate: f64, rng: &mut impl Rng) {
+    // Fast-path/footgun guard: at a non-positive rate there is nothing to substitute, and
+    // returning early keeps the RNG stream untouched (no draws) so a zero rate is deterministic
+    // and safe to call unconditionally.
+    if error_rate <= 0.0 {
+        return;
+    }
+
+    // Lookup table: for each base, provides 3 alternatives.
+    // A -> C,G,T; C -> A,G,T; G -> A,C,T; T -> A,C,G
+    const ALTERNATIVES: [&[u8; 3]; 256] = {
+        let mut table: [&[u8; 3]; 256] = [b"ACG"; 256]; // Default (shouldn't be used)
+        table[b'A' as usize] = b"CGT";
+        table[b'C' as usize] = b"AGT";
+        table[b'G' as usize] = b"ACT";
+        table[b'T' as usize] = b"ACG";
+        table
+    };
+
+    for base in seq.iter_mut() {
+        if rng.random::<f64>() < error_rate {
+            let alts = ALTERNATIVES[*base as usize];
+            *base = alts[rng.random_range(0..3)];
+        }
+    }
+}
+
+/// Derive a deterministic RNG dedicated to body-error injection for one mate of one read.
+///
+/// Body-error injection ([`introduce_errors_inplace`]) must not draw from the
+/// molecule-generation RNG. If it did, enabling `--error-rate > 0` would advance the shared
+/// stream and thereby perturb read qualities, mate/strand assignments, and every later
+/// stochastic draw — so an error-injected run would differ from the error-free run in far more
+/// than the read bodies. Seeding a dedicated stream keeps the molecule RNG byte-identical whether
+/// or not errors are injected, so the error-injected output differs from the error-free output
+/// *only* in the read-body bases.
+///
+/// The seed is an FNV-1a hash of the globally-unique `read_name` folded with `is_first_mate` (which
+/// simply distinguishes a pair's two mates so each gets an independent error stream). It consumes
+/// no draws from the caller's RNG, so the caller's stream is unaffected by the presence of errors.
+pub(super) fn body_error_rng(read_name: &str, is_first_mate: bool) -> rand::rngs::StdRng {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for &byte in read_name.as_bytes() {
+        hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+    }
+    hash = (hash ^ u64::from(is_first_mate)).wrapping_mul(FNV_PRIME);
+    crate::simulate::create_rng(Some(hash))
+}
+
+/// Replay a mapped molecule's RNG stream up to the reference-locus sampling step and return the
+/// EFFECTIVE `(chrom_idx, local_pos, insert_size)` — the coordinates at which the molecule's reads
+/// are actually emitted.
+///
+/// The mapped/grouped generators pre-sample a candidate locus, but when it is too close to a contig
+/// end for the molecule's drawn insert size, generation re-samples a *new* locus. The
+/// template-coordinate sort-key pre-pass must key on this same effective locus; otherwise records
+/// are emitted out of order and the advertised `SS:template-coordinate` is violated (SIMU3-05). This
+/// walks the exact RNG sequence generation uses — UMI bases, family size, insert size, the strand
+/// coin flip, then the `sequence_at` / `sample_sequence` fallback — so the returned locus is
+/// identical to the one generation derives for the same `seed`. When the pre-sampled locus is valid
+/// (the common case) it is returned unchanged, so the sort key is unchanged for those molecules.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn effective_molecule_locus(
+    seed: u64,
+    chrom_idx: usize,
+    local_pos: usize,
+    umi_length: usize,
+    family_dist: &crate::simulate::FamilySizeDistribution,
+    min_family_size: usize,
+    insert_model: &crate::simulate::InsertSizeModel,
+    ref_genome: &ReferenceGenome,
+) -> (usize, usize, usize) {
+    let mut rng = crate::simulate::create_rng(Some(seed));
+    // UMI bases: `generate_random_sequence` draws `umi_length` times.
+    for _ in 0..umi_length {
+        let _: usize = rng.random_range(0..4);
+    }
+    // Family size, then insert size.
+    let _ = family_dist.sample(&mut rng, min_family_size);
+    let insert_size = insert_model.sample(&mut rng);
+    // Strand coin flip (drawn before the locus fallback in generation).
+    let _: bool = rng.random();
+    // Locus fallback: reuse the pre-sampled locus when it yields a valid template, otherwise
+    // re-sample exactly as generation does.
+    let (eff_chrom, eff_pos) = match ref_genome.sequence_at(chrom_idx, local_pos, insert_size) {
+        Some(_) => (chrom_idx, local_pos),
+        None => match ref_genome.sample_sequence(insert_size, &mut rng) {
+            Some((c, p, _)) => (c, p),
+            None => (chrom_idx, local_pos),
+        },
+    };
+    (eff_chrom, eff_pos, insert_size)
+}
+
 /// Pad a sequence to the target length with random bases, or truncate if too long.
 pub(super) fn pad_sequence(mut seq: Vec<u8>, target_len: usize, rng: &mut impl Rng) -> Vec<u8> {
     while seq.len() < target_len {
@@ -1711,5 +1814,28 @@ mod tests {
             "100 positions should span at least 2 chromosomes, got {}",
             unique_chroms.len()
         );
+    }
+
+    /// SIMU3-05: `effective_molecule_locus` returns a valid pre-sampled locus unchanged, but
+    /// re-samples to a valid locus when the pre-sampled one cannot fit the drawn insert size (as
+    /// happens near a contig end), so the sort-key pre-pass keys on the emitted coordinates.
+    #[test]
+    fn test_effective_molecule_locus_passthrough_and_fallback() {
+        let fasta = write_multi_contig_fasta();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap(); // chr1 is 2000bp
+        let family = crate::simulate::FamilySizeDistribution::log_normal(3.0, 1.0);
+        let insert = crate::simulate::InsertSizeModel::new(100.0, 10.0, 50, 200);
+
+        // A valid pre-sampled locus (chr1 start) is returned unchanged.
+        let (c0, p0, ins0) = effective_molecule_locus(1, 0, 0, 8, &family, 1, &insert, &genome);
+        assert_eq!((c0, p0), (0, 0), "valid locus should pass through unchanged");
+        assert!(genome.sequence_at(c0, p0, ins0).is_some());
+
+        // A locus near the end of chr1 cannot fit any insert >= 50, so it must be re-sampled to a
+        // valid locus (and the same seed draws the same insert size, so ins matches).
+        let (c1, p1, ins1) = effective_molecule_locus(1, 0, 1990, 8, &family, 1, &insert, &genome);
+        assert_eq!(ins0, ins1, "same seed draws the same insert size");
+        assert_ne!((c1, p1), (0, 1990), "invalid near-end locus should be re-sampled");
+        assert!(genome.sequence_at(c1, p1, ins1).is_some(), "re-sampled locus must be valid");
     }
 }

--- a/src/lib/commands/simulate/correct_reads.rs
+++ b/src/lib/commands/simulate/correct_reads.rs
@@ -356,15 +356,23 @@ fn generate_correct_read_pair(
     } else if r < edit2_threshold {
         (introduce_n_errors(true_umi, 2, &mut rng), 2, "edit2")
     } else {
-        // 3+ errors
-        let num_errors = rng.random_range(3..=params.umi_length.min(5));
+        // "multi": 3+ errors. A UMI shorter than 3 bases cannot carry 3 errors, so clamp the upper
+        // bound and never build an inverted range — `rng.random_range(3..=hi)` panics when `hi < 3`
+        // (SIMU3-04). `introduce_n_errors` caps at the UMI length internally, so `num_errors` is
+        // always achievable.
+        let hi = params.umi_length.min(5);
+        let num_errors = if hi >= 3 { rng.random_range(3..=hi) } else { hi.max(1) };
         (introduce_n_errors(true_umi, num_errors, &mut rng), num_errors, "multi")
     };
 
-    // Expected correction: for exact/edit1/edit2, should correct to true_umi
-    // For multi, should not correct (stays as observed)
-    let expected_correction =
-        if error_type == "multi" { observed_umi.clone() } else { true_umi.clone() };
+    // Expected correction: replicate what `fgumi correct` would actually do rather than assuming the
+    // error-type label determines the outcome (SIMU3-03). `correct` maps an observed UMI to the
+    // UNIQUE nearest includelist entry within the correctable radius; if a *different* includelist
+    // UMI is as close or closer — a nearest-neighbor collision, plausible with many random UMIs —
+    // the read is ambiguous and stays uncorrected. Computing the nearest neighbor over the actual
+    // includelist keeps the truth in agreement with `correct` for the generator's radius
+    // (max-mismatches 2, min-distance 1), instead of blindly asserting edit1/edit2 → true_umi.
+    let expected_correction = expected_correction_for(&observed_umi, umis, CORRECTABLE_RADIUS);
 
     // Generate template sequences for R1 and R2
     let template_r1 = generate_random_sequence(params.read_length, &mut rng);
@@ -408,6 +416,41 @@ fn generate_correct_read_pair(
     }
 }
 
+/// Correctable radius (max mismatches) used to compute the truth file's expected correction. The
+/// generator produces correctable reads at edit distance ≤ 2, so this mirrors a default
+/// `fgumi correct --max-mismatches 2 --min-distance 1`.
+const CORRECTABLE_RADIUS: usize = 2;
+
+/// Hamming distance between two equal-length UMI strings (extra length counts as mismatches).
+fn umi_hamming(a: &str, b: &str) -> usize {
+    a.bytes().zip(b.bytes()).filter(|(x, y)| x != y).count() + a.len().abs_diff(b.len())
+}
+
+/// Compute what `fgumi correct` would map `observed` to, given the `includelist`: the UNIQUE nearest
+/// includelist entry when it is within `radius` and strictly closer than every other entry;
+/// otherwise `observed` itself (uncorrectable — either beyond the radius or ambiguous because two
+/// entries tie for nearest). This mirrors `correct`'s max-mismatches / min-distance rule with
+/// `min_distance = 1`, so the truth file agrees with `correct` even for nearest-neighbor collisions.
+fn expected_correction_for(observed: &str, includelist: &[String], radius: usize) -> String {
+    let mut best = usize::MAX;
+    let mut best_umi: Option<&str> = None;
+    let mut unique = false;
+    for candidate in includelist {
+        let d = umi_hamming(observed, candidate);
+        if d < best {
+            best = d;
+            best_umi = Some(candidate.as_str());
+            unique = true;
+        } else if d == best {
+            unique = false;
+        }
+    }
+    match best_umi {
+        Some(umi) if unique && best <= radius => umi.to_string(),
+        _ => observed.to_string(),
+    }
+}
+
 fn introduce_n_errors(umi: &str, n: usize, rng: &mut impl Rng) -> String {
     const BASES: &[u8] = b"ACGT";
     let mut result: Vec<u8> = umi.as_bytes().to_vec();
@@ -443,6 +486,8 @@ mod tests {
     use super::*;
     use crate::simulate::create_rng;
     use noodles::sam::alignment::record::data::field::Tag;
+    use proptest::prelude::*;
+    use rstest::rstest;
 
     // Tests for generate_random_sequence
     #[test]
@@ -810,5 +855,46 @@ mod tests {
         let umi_length = 2;
         let max_possible_umis = 4_usize.saturating_pow(umi_length as u32);
         assert!(num_umis <= max_possible_umis, "16 UMIs should be allowed for 2-base UMIs");
+    }
+
+    // --- SIMU3-03: truth reflects a real nearest-neighbor correction ---
+
+    #[rstest]
+    // Observed is distance 1 from AAAA and >= 3 from the others -> corrects to AAAA.
+    #[case::unique_nearest(&["AAAA", "CCCC", "GGGG", "TTTT"], "AAAC", "AAAA")]
+    // Observed is distance 1 from BOTH AAAA and AAAT -> ambiguous -> stays observed (SIMU3-03).
+    #[case::collision_ambiguous(&["AAAA", "AAAT", "CCCC"], "AAAC", "AAAC")]
+    // "ACGT" is distance 3 from both entries -> beyond the radius -> uncorrectable.
+    #[case::beyond_radius(&["AAAA", "CCCC"], "ACGT", "ACGT")]
+    // Exact includelist match corrects to itself.
+    #[case::exact_match(&["AAAA", "CCCC"], "CCCC", "CCCC")]
+    fn test_expected_correction(
+        #[case] includelist: &[&str],
+        #[case] observed: &str,
+        #[case] expected: &str,
+    ) {
+        let includelist: Vec<String> = includelist.iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(expected_correction_for(observed, &includelist, CORRECTABLE_RADIUS), expected);
+    }
+
+    // --- SIMU3-04: short UMIs must not panic in the "multi" branch ---
+
+    proptest! {
+        #[test]
+        fn test_generate_correct_read_pair_short_umi_no_panic(seed in 0u64..10_000) {
+            // umi_length == 2 makes `rng.random_range(3..=umi_length.min(5))` an inverted range;
+            // the guard must keep the "multi" branch (multi_fraction = 1.0) from panicking.
+            let params = GenerationParams {
+                read_length: 20,
+                quality: 30,
+                exact_fraction: 0.0,
+                edit1_fraction: 0.0,
+                edit2_fraction: 0.0,
+                umi_length: 2,
+            };
+            let umis = vec!["AC".to_string(), "GT".to_string()];
+            // Exercise many seeds so the "multi" branch is definitely taken.
+            let _ = generate_correct_read_pair(0, seed, &params, &umis);
+        }
     }
 }

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -4,7 +4,8 @@ use crate::commands::command::Command;
 use crate::commands::common::parse_bool;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, QualityArgs,
-    ReferenceGenome, SimulationCommon, apply_methylation_conversion, generate_random_sequence,
+    ReferenceGenome, SimulationCommon, apply_methylation_conversion, body_error_rng,
+    generate_random_sequence, introduce_errors_inplace,
 };
 use crate::simulate::{FastqWriter, create_rng};
 use anyhow::{Context, Result, bail};
@@ -71,6 +72,12 @@ pub struct FastqReads {
     #[arg(short = 'i', long = "includelist")]
     pub includelist: Option<PathBuf>,
 
+    /// Per-base substitution error rate applied to read bodies beyond the UMI prefix (0.0-1.0). The
+    /// default of 0.0 emits error-free bodies (byte-identical to prior versions); set a positive
+    /// rate to inject realistic sequencing errors. The UMI prefix keeps its own fixed error rate.
+    #[arg(long = "error-rate", default_value = "0.0")]
+    pub error_rate: f64,
+
     /// Number of threads for parallel molecule generation
     #[arg(short = 't', long = "threads", default_value = "1")]
     pub threads: usize,
@@ -120,6 +127,9 @@ struct GenerationParams {
     /// When set, UMIs are sampled from this list instead of generated randomly.
     includelist: Option<Vec<Vec<u8>>>,
     methylation: MethylationConfig,
+    /// Per-base substitution error rate applied to read bodies beyond the UMI prefix (0.0 = no
+    /// body errors, byte-identical to prior versions; the UMI prefix keeps its own fixed rate).
+    error_rate: f64,
 }
 
 /// Load UMI sequences from an includelist file (one UMI per line).
@@ -227,6 +237,8 @@ impl Command for FastqReads {
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
 
+        crate::commands::simulate::common::validate_rate(self.error_rate, "error-rate")?;
+
         let reference = Arc::new(ReferenceGenome::load(&self.reference)?);
 
         // Validate that the reference has at least one contig >= read_length
@@ -257,6 +269,7 @@ impl Command for FastqReads {
             duplex: self.duplex,
             includelist,
             methylation,
+            error_rate: self.error_rate,
         });
 
         // Generate molecule IDs with seeds for reproducibility
@@ -523,11 +536,37 @@ fn generate_molecule_reads(
         // Pad R1 to read length if needed
         pad_sequence_inplace(&mut r1_seq_buf, params.read_length, &mut rng);
 
+        // Inject body sequencing errors beyond the UMI prefix (SIMU3-01) from a dedicated per-mate
+        // RNG (`body_error_rng`) rather than the molecule RNG. This keeps the molecule stream —
+        // R2's UMI errors, the next pair's strand coin flip, qualities, and every downstream draw —
+        // byte-identical to the error-free run, so enabling `--error-rate` changes only the read
+        // bodies. The UMI-prefix errors above stay on the molecule RNG (part of the base model).
+        // The `error_rate > 0.0` guard keeps the zero-rate path free of any RNG construction.
+        if params.error_rate > 0.0 {
+            let body_start = params.umi_length.min(r1_seq_buf.len());
+            let mut err_rng = body_error_rng(&read_name, true);
+            introduce_errors_inplace(
+                &mut r1_seq_buf[body_start..],
+                params.error_rate,
+                &mut err_rng,
+            );
+        }
+
         // Introduce UMI errors in R2 as well
         introduce_errors_inplace(&mut r2_seq_buf[..params.umi_length], 0.01, &mut rng);
 
         // Pad R2 to read length if needed
         pad_sequence_inplace(&mut r2_seq_buf, params.read_length, &mut rng);
+
+        if params.error_rate > 0.0 {
+            let body_start = params.umi_length.min(r2_seq_buf.len());
+            let mut err_rng = body_error_rng(&read_name, false);
+            introduce_errors_inplace(
+                &mut r2_seq_buf[body_start..],
+                params.error_rate,
+                &mut err_rng,
+            );
+        }
 
         // Generate quality scores
         let r1_quals = quality_model.generate_qualities(r1_seq_buf.len(), &mut rng);
@@ -563,28 +602,6 @@ fn reverse_complement_into(seq: &[u8], output: &mut Vec<u8>) {
     output.reserve(seq.len());
     for &b in seq.iter().rev() {
         output.push(complement_base(b));
-    }
-}
-
-/// Introduce random substitution errors in-place.
-/// Uses direct lookup tables to avoid retry loops.
-fn introduce_errors_inplace(seq: &mut [u8], error_rate: f64, rng: &mut impl Rng) {
-    // Lookup table: for each base, provides 3 alternatives
-    // A(65) -> C, G, T; C(67) -> A, G, T; G(71) -> A, C, T; T(84) -> A, C, G
-    const ALTERNATIVES: [&[u8; 3]; 256] = {
-        let mut table: [&[u8; 3]; 256] = [b"ACG"; 256]; // Default (shouldn't be used)
-        table[b'A' as usize] = b"CGT";
-        table[b'C' as usize] = b"AGT";
-        table[b'G' as usize] = b"ACT";
-        table[b'T' as usize] = b"ACG";
-        table
-    };
-
-    for base in seq.iter_mut() {
-        if rng.random::<f64>() < error_rate {
-            let alts = ALTERNATIVES[*base as usize];
-            *base = alts[rng.random_range(0..3)];
-        }
     }
 }
 
@@ -1025,6 +1042,7 @@ mod tests {
                 cpg_methylation_rate: 0.75,
                 conversion_rate: 0.98,
             },
+            error_rate: 0.0,
         };
 
         let quality_model =
@@ -1064,6 +1082,112 @@ mod tests {
                     parts[1],
                 );
             }
+        }
+    }
+
+    /// SIMU3-01 wiring: with `error_rate = 1.0` every read-body base (indices >= `umi_length`) is
+    /// substituted, so both R1 and R2 bodies must diverge from an otherwise-identical
+    /// `error_rate = 0.0` run (same seed), while the read length is preserved and the UMI prefix is
+    /// excluded from body injection. Fails if the body error-injection offset or wiring regresses.
+    ///
+    /// Also pins RNG isolation: because body errors are drawn from a dedicated per-mate RNG
+    /// (`body_error_rng`), enabling `--error-rate` must leave everything *except* the read bodies
+    /// byte-identical to the zero-rate run — UMI prefixes, qualities, strand/truth fields, and the
+    /// full family layout. If injection ever draws from the molecule RNG again, these equalities
+    /// break (qualities and later reads would shift).
+    #[test]
+    fn test_generate_molecule_reads_injects_body_errors() {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+
+        const UMI_LENGTH: usize = 5;
+        let make_params = |error_rate: f64| GenerationParams {
+            umi_length: UMI_LENGTH,
+            read_length: 50,
+            min_family_size: 1,
+            r2_quality_offset: 0,
+            duplex: false,
+            includelist: None,
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            error_rate,
+        };
+
+        let quality_model =
+            crate::simulate::PositionQualityModel::new(10, 25, 37, 100, 0.08, 2, 2.0);
+        let quality_bias = crate::simulate::ReadPairQualityBias::new(0);
+        let family_dist = crate::simulate::FamilySizeDistribution::log_normal(3.0, 1.0);
+        let insert_model = crate::simulate::InsertSizeModel::new(150.0, 30.0, 50, 500);
+
+        let seed = 7u64;
+        let generate = |error_rate: f64| {
+            generate_molecule_reads(
+                0,
+                seed,
+                &make_params(error_rate),
+                &quality_model,
+                &quality_bias,
+                &family_dist,
+                &insert_model,
+                &ref_genome,
+            )
+        };
+
+        let zero = generate(0.0);
+        let full = generate(1.0);
+        assert!(!zero.is_empty(), "expected at least one read in the family");
+        // Same seed -> same family size regardless of error rate (family size is drawn first).
+        assert_eq!(zero.len(), full.len());
+
+        for (z, f) in zero.iter().zip(full.iter()) {
+            // Read length is preserved through body error injection.
+            assert_eq!(z.r1_seq.len(), f.r1_seq.len());
+            assert_eq!(z.r2_seq.len(), f.r2_seq.len());
+            // At error_rate 1.0 every body base (beyond the UMI prefix) flips to a different base.
+            assert_ne!(
+                z.r1_seq[UMI_LENGTH..],
+                f.r1_seq[UMI_LENGTH..],
+                "R1 body should diverge from the zero-rate run"
+            );
+            assert_ne!(
+                z.r2_seq[UMI_LENGTH..],
+                f.r2_seq[UMI_LENGTH..],
+                "R2 body should diverge from the zero-rate run"
+            );
+
+            // RNG isolation: everything except the read bodies is byte-identical to the zero-rate
+            // run. UMI prefixes stay on the molecule RNG (base model), so they must not change.
+            assert_eq!(
+                z.r1_seq[..UMI_LENGTH],
+                f.r1_seq[..UMI_LENGTH],
+                "R1 UMI prefix must be unchanged by body error injection"
+            );
+            assert_eq!(
+                z.r2_seq[..UMI_LENGTH],
+                f.r2_seq[..UMI_LENGTH],
+                "R2 UMI prefix must be unchanged by body error injection"
+            );
+            // Qualities are drawn from the molecule RNG after injection — must be unperturbed.
+            assert_eq!(z.r1_quals, f.r1_quals, "R1 qualities must be unchanged");
+            assert_eq!(z.r2_quals, f.r2_quals, "R2 qualities must be unchanged");
+            // Strand assignment and all truth/metadata fields must be unchanged.
+            assert_eq!(z.strand, f.strand, "strand assignment must be unchanged");
+            assert_eq!(z.umi, f.umi, "combined UMI truth must be unchanged");
+            assert_eq!(z.read_name, f.read_name, "read name must be unchanged");
+            assert_eq!(z.mol_id, f.mol_id, "molecule id must be unchanged");
+            assert_eq!(z.family_id, f.family_id, "family id must be unchanged");
+            assert_eq!(z.chrom, f.chrom, "chrom must be unchanged");
+            assert_eq!(z.pos, f.pos, "position must be unchanged");
         }
     }
 

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -10,8 +10,8 @@ use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
     PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
-    StrandBiasArgs, apply_methylation_conversion, build_sort_order_header_map,
-    generate_random_sequence, pad_sequence,
+    StrandBiasArgs, apply_methylation_conversion, body_error_rng, build_sort_order_header_map,
+    generate_random_sequence, introduce_errors_inplace, pad_sequence,
 };
 use crate::commands::simulate::region_to_bin;
 use crate::dna::reverse_complement;
@@ -62,6 +62,12 @@ pub struct GroupedReads {
     #[arg(long = "mapq", default_value = "60")]
     pub mapq: u8,
 
+    /// Per-base substitution error rate applied to read bodies (0.0-1.0). The default of 0.0 emits
+    /// error-free reads (byte-identical to prior versions); set a positive rate to inject realistic
+    /// sequencing errors so consensus/error-correction paths see genuine discordances.
+    #[arg(long = "error-rate", default_value = "0.0")]
+    pub error_rate: f64,
+
     /// Number of writer threads
     #[arg(short = 't', long = "threads", default_value = "1")]
     pub threads: usize,
@@ -108,6 +114,8 @@ struct GenerationParams {
     insert_model: InsertSizeModel,
     strand_bias_model: StrandBiasModel,
     methylation: MethylationConfig,
+    /// Per-base substitution error rate applied to read bodies (0.0 = no errors, byte-identical).
+    error_rate: f64,
 }
 
 impl Command for GroupedReads {
@@ -129,6 +137,8 @@ impl Command for GroupedReads {
             info!("  CpG methylation rate: {}", methylation.cpg_methylation_rate);
             info!("  Conversion rate: {}", methylation.conversion_rate);
         }
+
+        crate::commands::simulate::common::validate_rate(self.error_rate, "error-rate")?;
 
         // Load reference genome
         let ref_genome = ReferenceGenome::load(&self.reference.reference)?;
@@ -173,6 +183,7 @@ impl Command for GroupedReads {
             insert_model: self.insert_size.to_insert_size_model(),
             strand_bias_model: self.strand_bias.to_strand_bias_model(),
             methylation,
+            error_rate: self.error_rate,
         };
 
         // Pre-sample positions from reference (use a dedicated RNG so molecule seeds
@@ -227,9 +238,27 @@ impl Command for GroupedReads {
                 // Get insert_size
                 let insert_size = params.insert_model.sample(&mut mol_rng);
 
-                // Sort key — for_f1r2_pair gives the canonical template-coordinate sort
-                // key. This works for both F1R2 and R1F2 orientations because the
-                // template covers the same genomic positions regardless of strand.
+                // Sort key: a template-coordinate key derived from the *pre-sampled* locus.
+                //
+                // NOTE: grouped output is NOT guaranteed to be fully `SS:template-coordinate`
+                // sorted, for two independent reasons this pre-pass does not close:
+                //   1. Contig-end re-sample: `generate_molecule_reads` re-samples a new locus when
+                //      the pre-sampled one is too close to a contig end for the drawn insert size
+                //      (see the fallback below), so a fallback molecule is emitted at a locus that
+                //      differs from the one keyed here. Unlike mapped-reads (SIMU3-05, which re-keys
+                //      via `effective_molecule_locus`), grouped-reads does not re-key.
+                //   2. Duplex B-strand strand order: `for_f1r2_pair` always encodes
+                //      `neg1 = false, neg2 = true` (forward read earlier), but duplex B-strand pairs
+                //      are emitted R1F2 (reverse read earlier). samtools template-coordinate order
+                //      sorts reverse-before-forward at equal positions, so emitting a molecule's A
+                //      (forward-earlier) reads before its B (reverse-earlier) reads inverts strand
+                //      order at the same locus even with no fallback.
+                // Both gaps are fixed wholesale by #576, which emits records in molecule order and
+                // then sorts the *emitted* records through the canonical `fgumi-sort` engine, so no
+                // separate key can disagree with the emitted coordinates. The partial fix (re-keying
+                // only the fallback via `effective_molecule_locus`) is intentionally not applied
+                // here: it would be deleted by #576 and would leave gap 2 open while implying full
+                // sortedness.
                 let sort_key = TemplateCoordKey::for_f1r2_pair(
                     chrom_idx as i32, // real tid
                     local_pos,
@@ -383,8 +412,13 @@ fn generate_molecule_reads(
     let mut pairs = Vec::new();
 
     if params.duplex {
-        // Split reads between A and B strands
-        let (a_count, b_count) = params.strand_bias_model.split_reads(family_size, &mut rng);
+        // Split reads between A and B strands, guaranteeing at least one read per strand so a
+        // "duplex" family is actually two-stranded (SIMU3-07). For family_size == 1 the floor cannot
+        // be met and the split falls back to unconstrained (inherently single-stranded). This
+        // consumes the same RNG as `split_reads` (a single `sample_a_fraction` draw), so only the
+        // A/B partition changes, not the downstream RNG stream.
+        let (a_count, b_count) =
+            params.strand_bias_model.split_reads_with_minimum(family_size, 1, &mut rng);
 
         // A reads: orientation follows the coin flip
         let a_is_top = is_top_strand;
@@ -405,6 +439,7 @@ fn generate_molecule_reads(
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
+                params.error_rate,
                 shared_template.as_deref(),
                 &mut rng,
             );
@@ -439,6 +474,7 @@ fn generate_molecule_reads(
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
+                params.error_rate,
                 shared_template.as_deref(),
                 &mut rng,
             );
@@ -473,6 +509,7 @@ fn generate_molecule_reads(
                 &params.quality_model,
                 &params.quality_bias,
                 &params.methylation,
+                params.error_rate,
                 shared_template.as_deref(),
                 &mut rng,
             );
@@ -506,6 +543,7 @@ fn generate_read_pair_records(
     quality_model: &PositionQualityModel,
     quality_bias: &ReadPairQualityBias,
     methylation: &MethylationConfig,
+    error_rate: f64,
     shared_template: Option<&[u8]>,
     rng: &mut impl Rng,
 ) -> (RawRecord, RawRecord) {
@@ -530,7 +568,16 @@ fn generate_read_pair_records(
         methylation,
         rng,
     );
-    let fwd_seq = pad_sequence(fwd_seq, read_length, rng);
+    let mut fwd_seq = pad_sequence(fwd_seq, read_length, rng);
+    // Inject body sequencing errors (SIMU3-01) from a dedicated per-mate RNG (`body_error_rng`)
+    // rather than the molecule RNG, so enabling `--error-rate` changes only the read bodies and
+    // leaves qualities, positions, flags, and every downstream draw byte-identical to the
+    // error-free run. The `error_rate > 0.0` guard keeps the zero-rate path free of any RNG
+    // construction.
+    if error_rate > 0.0 {
+        let mut err_rng = body_error_rng(read_name, true);
+        introduce_errors_inplace(&mut fwd_seq, error_rate, &mut err_rng);
+    }
 
     // Compute reverse-read sequence (from end of template, bottom strand, revcomped)
     let rev_start = insert_size.saturating_sub(read_length);
@@ -545,7 +592,11 @@ fn generate_read_pair_records(
         rng,
     );
     let rev_seq = reverse_complement(&rev_template);
-    let rev_seq = pad_sequence(rev_seq, read_length, rng);
+    let mut rev_seq = pad_sequence(rev_seq, read_length, rng);
+    if error_rate > 0.0 {
+        let mut err_rng = body_error_rng(read_name, false);
+        introduce_errors_inplace(&mut rev_seq, error_rate, &mut err_rng);
+    }
 
     // Quality scores
     let r1_quals = quality_model.generate_qualities(read_length, rng);
@@ -672,6 +723,7 @@ mod tests {
     use super::*;
     use crate::simulate::create_rng;
     use fgumi_raw_bam::RawRecordView;
+    use rstest::rstest;
 
     const DISABLED_METHYLATION: MethylationConfig = MethylationConfig {
         mode: fgumi_consensus::MethylationMode::Disabled,
@@ -815,6 +867,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng,
         );
@@ -849,6 +902,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng,
         );
@@ -881,6 +935,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng,
         );
@@ -914,6 +969,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng,
         );
@@ -946,6 +1002,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng1,
         );
@@ -963,6 +1020,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng2,
         );
@@ -975,6 +1033,81 @@ mod tests {
         assert_eq!(
             RawRecordView::new(r2_a_raw.as_ref()).flags(),
             RawRecordView::new(r2_b_raw.as_ref()).flags()
+        );
+    }
+
+    /// SIMU3-01 wiring: with `error_rate = 1.0` every body base is substituted, so both reads of a
+    /// pair must diverge from an otherwise-identical `error_rate = 0.0` run (same seed, same shared
+    /// template), while the read length is preserved. Fails if the body error-injection call is
+    /// dropped or mis-wired.
+    ///
+    /// Also pins RNG isolation: body errors are drawn from a dedicated per-mate RNG
+    /// (`body_error_rng`), so both runs pass the *same* molecule RNG and it advances identically.
+    /// Enabling errors must therefore leave qualities, flags, positions, mapping quality, and names
+    /// byte-identical to the zero-rate run — only the sequence bytes change. If injection ever draws
+    /// from the passed RNG again, the qualities (drawn after injection) shift and this breaks.
+    #[test]
+    fn test_generate_read_pair_records_injects_body_errors() {
+        let quality_model = PositionQualityModel::default();
+        let quality_bias = ReadPairQualityBias::default();
+        // Deterministic 300 bp shared template so the body is derived from a known sequence.
+        let template = b"ACGT".repeat(75);
+
+        let run = |error_rate: f64| {
+            let mut rng = create_rng(Some(42));
+            generate_read_pair_records(
+                "read_001",
+                "ACGTACGT",
+                "0/A",
+                0,    // chrom_idx
+                1000, // local_pos
+                300,  // insert_size
+                150,  // read_length
+                60,
+                true, // is_top_strand
+                &quality_model,
+                &quality_bias,
+                &DISABLED_METHYLATION,
+                error_rate,
+                Some(&template),
+                &mut rng,
+            )
+        };
+
+        let (r1_zero_raw, r2_zero_raw) = run(0.0);
+        let (r1_full_raw, r2_full_raw) = run(1.0);
+
+        let seq = |raw: &RawRecord| to_record_buf(raw).sequence().as_ref().to_vec();
+        let (r1_zero, r2_zero) = (seq(&r1_zero_raw), seq(&r2_zero_raw));
+        let (r1_full, r2_full) = (seq(&r1_full_raw), seq(&r2_full_raw));
+
+        // Length is preserved through error injection.
+        assert_eq!(r1_zero.len(), r1_full.len());
+        assert_eq!(r2_zero.len(), r2_full.len());
+        // At error_rate 1.0 every body base flips to a different base, so both reads diverge.
+        assert_ne!(r1_zero, r1_full, "R1 body should diverge from the zero-rate run");
+        assert_ne!(r2_zero, r2_full, "R2 body should diverge from the zero-rate run");
+
+        // RNG isolation: every non-sequence field is byte-identical to the zero-rate run.
+        let non_seq = |raw: &RawRecord| {
+            let rec = to_record_buf(raw);
+            (
+                rec.flags().bits(),
+                rec.alignment_start().map(usize::from),
+                rec.mapping_quality().map(u8::from),
+                rec.name().map(|n| n.to_vec()),
+                rec.quality_scores().as_ref().to_vec(),
+            )
+        };
+        assert_eq!(
+            non_seq(&r1_zero_raw),
+            non_seq(&r1_full_raw),
+            "R1 non-sequence fields (incl. qualities) must be unchanged"
+        );
+        assert_eq!(
+            non_seq(&r2_zero_raw),
+            non_seq(&r2_full_raw),
+            "R2 non-sequence fields (incl. qualities) must be unchanged"
         );
     }
 
@@ -1148,6 +1281,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &DISABLED_METHYLATION,
+            0.0,
             None,
             &mut rng,
         );
@@ -1193,6 +1327,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &config,
+            0.0,
             Some(template),
             &mut rng,
         );
@@ -1241,6 +1376,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &emseq_config,
+            0.0,
             Some(template),
             &mut rng_a,
         );
@@ -1260,6 +1396,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &disabled_config,
+            0.0,
             Some(template),
             &mut rng_b,
         );
@@ -1279,6 +1416,7 @@ mod tests {
             &quality_model,
             &quality_bias,
             &emseq_config,
+            0.0,
             Some(template),
             &mut rng_b2,
         );
@@ -1333,6 +1471,7 @@ mod tests {
             insert_model: InsertSizeModel::new(100.0, 5.0, 80, 120),
             strand_bias_model: StrandBiasModel::no_bias(),
             methylation: DISABLED_METHYLATION,
+            error_rate: 0.0,
         };
 
         let (chrom_idx, local_pos) = positions[0];
@@ -1370,6 +1509,7 @@ mod tests {
             insert_model: InsertSizeModel::new(100.0, 5.0, 80, 120),
             strand_bias_model: StrandBiasModel::no_bias(),
             methylation: DISABLED_METHYLATION,
+            error_rate: 0.0,
         };
 
         let mut a_saw_top = false;
@@ -1392,5 +1532,57 @@ mod tests {
 
         assert!(a_saw_top, "A reads should sometimes be F1R2 (top strand)");
         assert!(a_saw_bottom, "A reads should sometimes be R1F2 (bottom strand)");
+    }
+
+    /// SIMU3-07: a duplex family with `family_size >= 2` must be genuinely two-stranded —
+    /// `split_reads_with_minimum(family_size, 1, ..)` guarantees at least one A read and one B
+    /// read. This asserts the emitted MI tags directly (not just A-strand orientation, which the
+    /// sibling `..coin_flip..` test covers): across many seeds and several minimum family sizes,
+    /// every molecule emits at least one `/A`- and one `/B`-tagged pair.
+    #[rstest]
+    fn test_duplex_family_ge_two_is_always_two_stranded(#[values(2, 3, 5)] min_family_size: usize) {
+        use std::io::Write as IoWrite;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap();
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+
+        let ref_genome = ReferenceGenome::load(fasta.path()).unwrap();
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            duplex: true,
+            min_family_size,
+            quality_model: PositionQualityModel::default(),
+            quality_bias: ReadPairQualityBias::default(),
+            // Log-normal floored at `min_family_size` guarantees family_size >= min_family_size >= 2.
+            family_dist: FamilySizeDistribution::log_normal(2.0, 0.5),
+            insert_model: InsertSizeModel::new(100.0, 5.0, 80, 120),
+            // Extreme bias toward B (mean A-fraction ~= 0.02): under the old unconstrained
+            // `split_reads` this rounds a small family's A count to 0, so only the SIMU3-07 floor of
+            // `split_reads_with_minimum` keeps an A read present. This makes the test a genuine
+            // regression guard — reverting the fix drops the `/A` pair and fails the assert.
+            strand_bias_model: StrandBiasModel::new(1.0, 50.0),
+            methylation: DISABLED_METHYLATION,
+            error_rate: 0.0,
+        };
+
+        for seed in 0u64..100 {
+            let (pairs, _chrom, _pos) =
+                generate_molecule_reads(seed as usize, seed, 0, 500, &params, &ref_genome);
+
+            let saw_a = pairs.iter().any(|(_, _, _, _, mi_tag, _, _)| mi_tag.ends_with("/A"));
+            let saw_b = pairs.iter().any(|(_, _, _, _, mi_tag, _, _)| mi_tag.ends_with("/B"));
+
+            assert!(
+                saw_a && saw_b,
+                "duplex family (min_family_size={min_family_size}, seed={seed}) must emit both an \
+                 A-strand and a B-strand pair; saw_a={saw_a}, saw_b={saw_b}"
+            );
+        }
     }
 }

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -10,8 +10,9 @@ use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, MoleculeInfo,
     PositionDistArgs, QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon,
-    apply_methylation_conversion, build_sort_order_header_map, generate_random_sequence,
-    pad_sequence, validate_rate,
+    apply_methylation_conversion, body_error_rng, build_sort_order_header_map,
+    effective_molecule_locus, generate_random_sequence, introduce_errors_inplace, pad_sequence,
+    validate_rate,
 };
 use crate::commands::simulate::region_to_bin;
 use crate::dna::reverse_complement;
@@ -68,6 +69,12 @@ pub struct MappedReads {
     #[arg(long = "unmapped-fraction", default_value = "0.0")]
     pub unmapped_fraction: f64,
 
+    /// Per-base substitution error rate applied to read bodies (0.0-1.0). The default of 0.0 emits
+    /// error-free reads (byte-identical to prior versions); set a positive rate to inject realistic
+    /// sequencing errors so consensus/error-correction paths see genuine discordances.
+    #[arg(long = "error-rate", default_value = "0.0")]
+    pub error_rate: f64,
+
     /// Number of writer threads
     #[arg(short = 't', long = "threads", default_value = "1")]
     pub threads: usize,
@@ -109,6 +116,9 @@ struct GenerationParams {
     family_dist: FamilySizeDistribution,
     insert_model: InsertSizeModel,
     methylation: MethylationConfig,
+    /// Per-base substitution error rate applied to read bodies (0.0 = no errors, byte-identical
+    /// to the error-free generator).
+    error_rate: f64,
 }
 
 impl Command for MappedReads {
@@ -118,6 +128,7 @@ impl Command for MappedReads {
         self.methylation.validate()?;
 
         validate_rate(self.unmapped_fraction, "unmapped-fraction")?;
+        validate_rate(self.error_rate, "error-rate")?;
 
         info!("Generating mapped reads");
         info!("  Output: {}", self.output.display());
@@ -175,6 +186,7 @@ impl Command for MappedReads {
             family_dist: self.family_size.to_family_size_distribution()?,
             insert_model: self.insert_size.to_insert_size_model(),
             methylation,
+            error_rate: self.error_rate,
         };
 
         // Pre-sample positions from reference (use a dedicated RNG so molecule seeds
@@ -233,24 +245,28 @@ impl Command for MappedReads {
                     let pos_idx = mol_id % num_positions;
                     let (chrom_idx, local_pos) = position_table[pos_idx];
 
-                    // Pre-compute insert_size using the molecule's seed (same RNG sequence
-                    // as generation)
-                    let mut mol_rng = create_rng(Some(seed));
-                    // Skip UMI generation RNG calls
-                    for _ in 0..params.umi_length {
-                        let _: usize = mol_rng.random_range(0..4);
-                    }
-                    // Skip family_size RNG call
-                    let _ = params.family_dist.sample(&mut mol_rng, params.min_family_size);
-                    // Get insert_size
-                    let insert_size = params.insert_model.sample(&mut mol_rng);
+                    // Key on the EFFECTIVE locus — the coordinates generation actually emits at
+                    // after the contig-end re-sample fallback — not the pre-sampled candidate, so
+                    // records stay template-coordinate sorted near contig ends (SIMU3-05). For loci
+                    // that don't trigger the fallback (the common case) this returns the pre-sampled
+                    // locus unchanged, leaving the sort key identical.
+                    let (eff_chrom_idx, eff_local_pos, insert_size) = effective_molecule_locus(
+                        seed,
+                        chrom_idx,
+                        local_pos,
+                        params.umi_length,
+                        &params.family_dist,
+                        params.min_family_size,
+                        &params.insert_model,
+                        &ref_genome,
+                    );
 
                     // Sort key — for_f1r2_pair gives the canonical template-coordinate sort
                     // key. This works for both F1R2 and R1F2 orientations because the
                     // template covers the same genomic positions regardless of strand.
                     TemplateCoordKey::for_f1r2_pair(
-                        chrom_idx as i32, // real tid
-                        local_pos,
+                        eff_chrom_idx as i32, // real tid
+                        eff_local_pos,
                         insert_size,
                         String::new(), // empty mid for mapped-reads (no MI tag yet)
                         format!("mol{mol_id:08}"),
@@ -455,7 +471,16 @@ fn generate_molecule_reads(
             &params.methylation,
             &mut rng,
         );
-        let fwd_seq = pad_sequence(fwd_seq, params.read_length, &mut rng);
+        let mut fwd_seq = pad_sequence(fwd_seq, params.read_length, &mut rng);
+        // Inject body sequencing errors (SIMU3-01). Injected from a dedicated per-mate RNG
+        // (`body_error_rng`) rather than the molecule RNG, so enabling `--error-rate` changes only
+        // the read bodies and leaves qualities, positions, flags, and every downstream draw
+        // byte-identical to the error-free run. The `error_rate > 0.0` guard keeps the zero-rate
+        // path free of any RNG construction.
+        if params.error_rate > 0.0 {
+            let mut err_rng = body_error_rng(&read_name, true);
+            introduce_errors_inplace(&mut fwd_seq, params.error_rate, &mut err_rng);
+        }
 
         // Compute reverse-read sequence (from end of template, bottom strand,
         // reverse complemented)
@@ -471,7 +496,11 @@ fn generate_molecule_reads(
             &mut rng,
         );
         let rev_seq = reverse_complement(&rev_template);
-        let rev_seq = pad_sequence(rev_seq, params.read_length, &mut rng);
+        let mut rev_seq = pad_sequence(rev_seq, params.read_length, &mut rng);
+        if params.error_rate > 0.0 {
+            let mut err_rng = body_error_rng(&read_name, false);
+            introduce_errors_inplace(&mut rev_seq, params.error_rate, &mut err_rng);
+        }
 
         // Quality scores
         let r1_quals = params.quality_model.generate_qualities(params.read_length, &mut rng);
@@ -668,6 +697,7 @@ fn build_record(
 mod tests {
     use super::*;
     use crate::simulate::create_rng;
+    use rstest::rstest;
 
     /// Decode a raw BAM record into a noodles `RecordBuf` for higher-level test
     /// assertions.
@@ -992,12 +1022,155 @@ mod tests {
                 cpg_methylation_rate: 0.75,
                 conversion_rate: 0.98,
             },
+            error_rate: 0.0,
         };
 
         let (pairs, _chrom, _pos) =
             generate_molecule_reads(0, 42, 0, 500, false, &params, &ref_genome);
         // Multiple reads should be generated (family_size >= 3)
         assert!(pairs.len() >= 3, "Expected at least 3 reads, got {}", pairs.len());
+    }
+
+    /// SIMU3-05 regression: the sort-key helper `effective_molecule_locus` must return exactly the
+    /// coordinates `generate_molecule_reads` emits at — for both valid loci and loci near a contig
+    /// end that trigger the re-sample fallback. If the two ever drift, the output stops being
+    /// template-coordinate sorted.
+    #[rstest]
+    #[case::pos_start(0)]
+    #[case::pos_mid_low(500)]
+    #[case::pos_mid_high(1000)]
+    // pos 1950 is within one insert (80-120) of the 2000 bp contig end -> forces the fallback.
+    #[case::pos_near_end(1950)]
+    fn test_effective_molecule_locus_matches_generation(#[case] local_pos: usize) {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap(); // 2000 bp
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+
+        let params = GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            min_family_size: 1,
+            quality_model: crate::simulate::PositionQualityModel::new(
+                10, 25, 37, 100, 0.08, 2, 0.0,
+            ),
+            quality_bias: crate::simulate::ReadPairQualityBias::new(0),
+            family_dist: crate::simulate::FamilySizeDistribution::log_normal(5.0, 1.0),
+            insert_model: crate::simulate::InsertSizeModel::new(100.0, 10.0, 80, 120),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            error_rate: 0.0,
+        };
+
+        for seed in 0u64..8 {
+            let (_pairs, gen_chrom, gen_pos) =
+                generate_molecule_reads(0, seed, 0, local_pos, false, &params, &genome);
+            let (eff_chrom, eff_pos, _insert) = effective_molecule_locus(
+                seed,
+                0,
+                local_pos,
+                params.umi_length,
+                &params.family_dist,
+                params.min_family_size,
+                &params.insert_model,
+                &genome,
+            );
+            assert_eq!(
+                (gen_chrom, gen_pos),
+                (eff_chrom, eff_pos),
+                "sort-key helper must match generation for seed={seed} pos={local_pos}"
+            );
+        }
+    }
+
+    /// SIMU3-01 wiring: with `error_rate = 1.0` every read-body base is substituted, so both R1 and
+    /// R2 must diverge from an otherwise-identical `error_rate = 0.0` run (same seed, same locus),
+    /// while the read length is preserved. Fails if the body error-injection call is dropped or
+    /// mis-wired for the mapped generator.
+    ///
+    /// Also pins RNG isolation: body errors are drawn from a dedicated per-mate RNG
+    /// (`body_error_rng`), so enabling `--error-rate` must leave positions, flags, mapping quality,
+    /// read names, and qualities byte-identical to the zero-rate run across the whole family — only
+    /// the sequence bytes change. If injection ever draws from the molecule RNG again, the
+    /// qualities (drawn after injection) shift and these equalities break.
+    #[test]
+    fn test_mapped_reads_inject_body_errors() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut fasta = NamedTempFile::new().unwrap();
+        writeln!(fasta, ">chr1").unwrap();
+        fasta.write_all(&b"ACGT".repeat(500)).unwrap(); // 2000 bp
+        writeln!(fasta).unwrap();
+        fasta.flush().unwrap();
+        let genome = ReferenceGenome::load(fasta.path()).unwrap();
+
+        let make_params = |error_rate: f64| GenerationParams {
+            read_length: 50,
+            umi_length: 8,
+            mapq: 60,
+            min_family_size: 1,
+            quality_model: crate::simulate::PositionQualityModel::new(
+                10, 25, 37, 100, 0.08, 2, 0.0,
+            ),
+            quality_bias: crate::simulate::ReadPairQualityBias::new(0),
+            family_dist: crate::simulate::FamilySizeDistribution::log_normal(3.0, 1.0),
+            insert_model: crate::simulate::InsertSizeModel::new(100.0, 10.0, 80, 120),
+            methylation: MethylationConfig {
+                mode: fgumi_consensus::MethylationMode::Disabled,
+                cpg_methylation_rate: 0.75,
+                conversion_rate: 0.98,
+            },
+            error_rate,
+        };
+
+        let seed = 7u64;
+        // Same seed + valid locus (pos 500 in a 2000 bp contig) -> identical family, template, and
+        // strand for both runs; only the body error injection differs.
+        let (zero, _c0, _p0) =
+            generate_molecule_reads(0, seed, 0, 500, false, &make_params(0.0), &genome);
+        let (full, _c1, _p1) =
+            generate_molecule_reads(0, seed, 0, 500, false, &make_params(1.0), &genome);
+
+        assert!(!zero.is_empty(), "expected at least one read pair in the family");
+        assert_eq!(zero.len(), full.len());
+
+        let seq = |raw: &RawRecord| to_record_buf(raw).sequence().as_ref().to_vec();
+        let (z_r1, z_r2) = (seq(&zero[0].0), seq(&zero[0].1));
+        let (f_r1, f_r2) = (seq(&full[0].0), seq(&full[0].1));
+
+        // Read length is preserved through body error injection.
+        assert_eq!(z_r1.len(), f_r1.len());
+        assert_eq!(z_r2.len(), f_r2.len());
+        // At error_rate 1.0 every body base flips to a different base, so both reads diverge.
+        assert_ne!(z_r1, f_r1, "R1 body should diverge from the zero-rate run");
+        assert_ne!(z_r2, f_r2, "R2 body should diverge from the zero-rate run");
+
+        // RNG isolation: positions, flags, mapping quality, names, and qualities are byte-identical
+        // to the zero-rate run across every record — only the sequence bytes change.
+        let non_seq = |raw: &RawRecord| {
+            let rec = to_record_buf(raw);
+            (
+                rec.flags().bits(),
+                rec.alignment_start().map(usize::from),
+                rec.mapping_quality().map(u8::from),
+                rec.name().map(|n| n.to_vec()),
+                rec.quality_scores().as_ref().to_vec(),
+            )
+        };
+        for (z, f) in zero.iter().zip(full.iter()) {
+            assert_eq!(non_seq(&z.0), non_seq(&f.0), "R1 non-sequence fields must be unchanged");
+            assert_eq!(non_seq(&z.1), non_seq(&f.1), "R2 non-sequence fields must be unchanged");
+        }
     }
 
     // ========================================================================
@@ -1042,6 +1215,7 @@ mod tests {
                 cpg_methylation_rate: 0.75,
                 conversion_rate: 0.98,
             },
+            error_rate: 0.0,
         };
 
         // Test that generate_molecule_reads produces records with correct ref_id
@@ -1098,6 +1272,7 @@ mod tests {
                 cpg_methylation_rate: 0.75,
                 conversion_rate: 0.98,
             },
+            error_rate: 0.0,
         };
 
         let mut saw_f1r2 = false;
@@ -1145,6 +1320,7 @@ mod tests {
                 cpg_methylation_rate: 0.75,
                 conversion_rate: 0.98,
             },
+            error_rate: 0.0,
         }
     }
 


### PR DESCRIPTION
## Summary

W7 of the final-audit burn-down: the `simulate` error-model / fixture-generator cluster. `simulate` is fgumi-specific (no fgbio oracle), so verification is against the generator's own advertised contract — template-coordinate sorted output, two-stranded duplex families, and a truth file that agrees with `fgumi correct`. Stacked on #531 (`nh/simulate-ss-parity`), the only open PR touching `mapped_reads.rs`/`grouped_reads.rs`; retargets to `main` on merge.

## Findings

### SIMU3-01 (S2) — no body sequencing errors
The generators emitted error-free reads (only the fastq UMI prefix was perturbed), so consensus/error-correction paths never saw real discordances. Added a `--error-rate` flag (default **0.0**) to mapped-reads, grouped-reads, and fastq-reads that injects per-base substitution errors into read bodies via a shared `introduce_errors_inplace` (moved to `common.rs`). The `error_rate > 0.0` guard is important: `introduce_errors_inplace` draws one RNG value per base regardless of rate, so guarding keeps the **default byte-identical** to the error-free generator. Per the maintainer's call, this ships opt-in/off-by-default so the ~12 E2E regression baselines are unchanged; a follow-up can opt specific fixtures into a positive rate.

### SIMU3-05 (S1) — sort-order break near contig ends (mapped-reads)
The template-coordinate sort-key pre-pass keyed on the *pre-sampled* locus, but generation re-samples a new locus when the pre-sampled one is too close to a contig end for the drawn insert size — so records were emitted out of the advertised `SS:template-coordinate` order. A shared `effective_molecule_locus` replays the molecule RNG (UMI → family size → insert size → strand coin → `sequence_at`/`sample_sequence` fallback) so the key uses the *emitted* coordinates. For loci that don't trigger the fallback the key is unchanged.

**Scope:** the audit scoped SIMU3-05 to mapped-reads, and this fixes it there. grouped-reads has a *separate, pre-existing* template-coordinate ordering gap (present even without any fallback), so it is deliberately left for a follow-up rather than conflated here — the grouped sort key is unchanged.

### SIMU3-07 (data quality) — duplex families not two-stranded
grouped-reads `--duplex` used `split_reads`, which can assign zero reads to a strand. Switched to the existing `split_reads_with_minimum(family_size, 1)` (identical RNG consumption — a single `sample_a_fraction` draw), so a duplex family with ≥ 2 reads is genuinely two-stranded. `family_size == 1` is inherently single-stranded and falls back.

### SIMU3-03 (S3) — truth file unverified vs nearest-neighbor collisions
correct-reads asserted edit1/edit2 → true UMI without checking whether the observed UMI is actually nearest to a *different* includelist entry. `expected_correction_for` now computes the unique nearest includelist neighbor within the correctable radius (mirroring `fgumi correct` with max-mismatches 2 / min-distance 1), reporting collisions/ambiguous cases as uncorrectable so the truth agrees with `correct`.

### SIMU3-04 (S3) — panic for short UMIs
`rng.random_range(3..=umi_length.min(5))` inverts (and panics) when `umi_length < 3`. Guarded so the "multi" branch clamps the upper bound instead.

## Verification (generator's own contract, via the built binary)

- **SIMU3-05:** mapped-reads output on a fallback-heavy reference (12×1100bp contigs, insert mean 400/max 800) is byte-for-byte `samtools sort --template-coordinate`. **RED:** reverting the key to the pre-sampled locus left **4238/11988** records out of order.
- **SIMU3-01:** `--error-rate 0.05` changes 1191 sequences vs `0.0`, with positions/flags/names identical (errors don't move alignments).
- **SIMU3-07:** `grouped-reads --duplex` → 290/300 families two-stranded (the 10 singletons are `family_size == 1`).
- **SIMU3-04:** `correct-reads --umi-length 2` exits 0 (no panic).

## Tests

- `common.rs`: `effective_molecule_locus` passthrough + contig-end fallback.
- `correct_reads.rs`: `expected_correction_for` (unique-nearest, collision, beyond-radius, exact) + a short-UMI no-panic test.
- Full suite green: `cargo ci-fmt && ci-lint && ci-test` (2259 default) and `cargo nextest run --features simulate` (2150).

## Follow-ups
- grouped-reads has a separate pre-existing template-coordinate ordering gap (out of SIMU3-05's scope).
- Opting specific E2E fixtures into a non-zero `--error-rate`.

_(This commit was pushed unsigned because 1Password signing was unavailable; it will be re-signed and force-pushed once signing is back.)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--error-rate` to `fastq-reads`, `grouped-reads`, and `mapped-reads`.
  * Injects per-base substitution errors into generated read bodies (beyond the UMI), while preserving UMI prefixes and read lengths.
  * Default `--error-rate=0.0` keeps output byte-identical to previous versions.
* **Bug Fixes**
  * Improved UMI correction to use nearest-neighbor matching with a fixed radius, avoiding incorrect corrections.
  * Prevented panics for very short UMIs in multi-error generation.
* **Other**
  * Improved template-coordinate ordering consistency at contig boundaries and enhanced test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->