### PR TITLE
refactor: drop stale dead-code allows + fix inaccurate comments (audit F, hygiene subset)

### DIFF
--- a/crates/fgumi-pipeline-core/src/handles.rs
+++ b/crates/fgumi-pipeline-core/src/handles.rs
@@ -538,11 +538,21 @@ pub(crate) fn build_branch_ordered_bytes<T: Send + HeapSize + Ordered + 'static>
 /// for non-`ByItemOrdinal` orderings. `ByItemOrdinal` requires `T: Ordered`
 /// — use `build_branch_ordered_bytes` for the combined case.
 ///
-/// Currently exercised only by tests; production code uses
-/// `build_branch_ordered_bytes` (BAM steps need both `HeapSize` and
-/// `Ordered`). Kept for the rare case where a step needs byte-bounded
-/// outputs without ordering.
-#[allow(dead_code)]
+/// The build path `build_single_queues` uses for every `Single<T>` output
+/// (`T: HeapSize`, no `Ordered` bound): it honors `ByteBounded` for
+/// `BranchOrdering::None` and `ByOrdinal`, and delegates every other spec
+/// straight back to `build_branch::<T>`. Steps needing both `HeapSize` and
+/// `Ordered` go through `build_branch_ordered_bytes` instead.
+///
+/// # Panics
+///
+/// Panics on `ByteBounded` + `ByItemOrdinal`: reading an item-carried serial
+/// needs `T: Ordered`, which this signature does not bound — so the ordinal is
+/// unreachable here even when the item type happens to implement `Ordered`. A
+/// step needing both declares `OrderedBytesSingle<T>`, which routes to
+/// `build_branch_ordered_bytes`; reaching this arm means a step asked for
+/// `ByItemOrdinal` through `Single<T>`, whose build path cannot read one. The
+/// panic is that guard rather than a supported configuration.
 pub(crate) fn build_branch_byte_aware<T: Send + HeapSize + 'static>(
     spec: QueueSpec,
     ordering: BranchOrdering,
@@ -1310,10 +1320,12 @@ pub(crate) fn build_single_queues<T: Send + HeapSize + 'static>(
     assert_eq!(ordering.len(), 1, "Single<T>::build_queues requires 1 ordering");
 
     // `Single<T>` bounds `T: HeapSize`, so use the byte-aware build path: it
-    // honors `QueueSpec::ByteBounded` (documented as supported for `Single<T>`
-    // outputs without item-carried serials) and delegates every non-byte spec
-    // straight back to `build_branch::<T>`, so count/unbounded paths are
-    // unchanged.
+    // honors `QueueSpec::ByteBounded` for `BranchOrdering::None` and
+    // `ByOrdinal` — the two orderings a `Single<T>` output can declare, since it
+    // carries no item serial — and delegates every non-byte spec straight back
+    // to `build_branch::<T>`, so count/unbounded paths are unchanged. A step
+    // needing `ByItemOrdinal` declares `OrderedBytesSingle<T>` instead; asking
+    // for it here panics (see `build_branch_byte_aware`).
     let branch = build_branch_byte_aware::<T>(specs[0], ordering[0], level);
     let view = SingleOutputsView { primary: branch.output };
     let outputs_view = OutputsViewAny { inner: Box::new(view) };

--- a/crates/fgumi-pipeline-core/src/signal.rs
+++ b/crates/fgumi-pipeline-core/src/signal.rs
@@ -231,10 +231,10 @@ pub struct CancelHandle {
 }
 
 impl CancelHandle {
-    /// Construct a `CancelHandle` from a shared signal. Used internally by
-    /// `Pipeline::run` (Phase 2) to hand a handle to the caller before
-    /// kicking off worker threads.
-    #[allow(dead_code)] // wired up by Phase 2 Pipeline::run.
+    /// Construct a `CancelHandle` from a shared signal. Used by
+    /// `Pipeline::cancel_handle` (see `builder.rs`) to hand a handle to the
+    /// caller of a built pipeline, before `Pipeline::run` kicks off worker
+    /// threads.
     pub(crate) fn from_signal(signal: Arc<PipelineSignal>) -> Self {
         Self { signal }
     }

--- a/crates/fgumi-pipeline-core/src/step.rs
+++ b/crates/fgumi-pipeline-core/src/step.rs
@@ -221,9 +221,14 @@ pub struct OutputHandles<O: StepOutputs> {
 }
 
 impl<O: StepOutputs> OutputHandles<O> {
-    /// Wrap a type-erased outputs view. Constructed by `TypedStep<S>`
-    /// (Phase 1 Task 15) when assembling the step's `StepCtx`.
-    #[allow(dead_code)] // wired up by Phase 1 Task 15 (TypedStep::wrap_outputs_view).
+    /// Wrap a type-erased outputs view into a typed `OutputHandles<O>`.
+    ///
+    /// Called from the `ErasedStep::wrap_outputs_view` impls in `erased.rs` —
+    /// `TypedStep<S>` for one-input steps and `TypedStep2<S>` for the two-input
+    /// (zipper) shape — while `build_chain_contexts` assembles one context per
+    /// step. That happens on the thread calling `Pipeline::run`, *before* any
+    /// worker is spawned; workers never construct one, they borrow the box built
+    /// here (which is what `TypedStep::resolve_outputs`' cache relies on).
     pub(crate) fn new(inner: OutputsViewAny) -> Self {
         Self { inner, _phantom: std::marker::PhantomData }
     }

--- a/src/lib/aligner.rs
+++ b/src/lib/aligner.rs
@@ -676,18 +676,18 @@ impl Default for AlignerOptions {
 /// `pub(crate)` because only the runall AAM dispatch consumes it;
 /// promote to `pub` if a cross-crate caller materializes.
 ///
-/// Fields are flagged `#[allow(dead_code)]` because the AAM validation path
-/// currently only validates them (via `_resolved` in
-/// `validate_align_and_merge`); the wired chain sources its parameters
-/// independently.
-#[allow(dead_code)]
+/// Every field is read when the chain builder wires the AAM stage
+/// (`chains/builder.rs`): `command` seeds `AlignAndMergeStep`, `chunk_size`
+/// derives the step's `in_flight_unmapped_budget` (via
+/// `in_flight_budget_for_chunk_size`), and `mode`/`threads` are info-logged.
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedAligner {
     /// The shell command to spawn (already substituted and validated).
     /// Passed directly to [`AlignerProcess::spawn`].
     pub command: String,
-    /// Bases per batch. Step 1 of the AAM chain uses this to size
-    /// outgoing batches so the aligner sees full `-K` chunks.
+    /// The aligner's `-K` chunk size, in bases. The chain builder converts
+    /// it into `AlignAndMergeStep`'s `in_flight_unmapped_budget` so the
+    /// resident unmapped backlog stays proportional to one aligner chunk.
     pub chunk_size: u64,
     /// Resolved thread count (default-substituted for preset mode;
     /// `None` if command mode let the user hardcode their own).
@@ -697,9 +697,11 @@ pub(crate) struct ResolvedAligner {
     pub mode: ResolvedAlignerMode,
 }
 
-/// How a [`ResolvedAligner`] was produced. Same dead-code rationale
-/// as [`ResolvedAligner`].
-#[allow(dead_code)]
+/// How a [`ResolvedAligner`] was produced. The AAM chain builder logs the mode
+/// (`chains/builder.rs`), so the `Preset` payload is consumed only through the
+/// derived `Debug` — the `allow(dead_code)` suppresses the never-read lint,
+/// which fires for a field read solely via a derived trait.
+#[allow(dead_code)] // `Preset`'s payload is diagnostic-only (Debug-logged).
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ResolvedAlignerMode {
     /// `--aligner::preset <preset>`. Carries the chosen preset so the
@@ -764,11 +766,12 @@ impl AlignerOptions {
                 // `--aligner::threads` are preset-only knobs; rejecting
                 // them surfaces the misuse loud.
                 //
-                // `--aligner::chunk-size` is NOT preset-only — Step 1
-                // of the AAM chain uses it for BAM-record batching
-                // regardless of mode, and command-mode users may
-                // legitimately want to align it with their `-K` choice
-                // in the template.
+                // `--aligner::chunk-size` is NOT preset-only — the chain
+                // builder derives the AAM step's
+                // `in_flight_unmapped_budget` from it regardless of mode
+                // (see `in_flight_budget_for_chunk_size`), and
+                // command-mode users may legitimately want to align it
+                // with their `-K` choice in the template.
                 if aligner_bin.is_some() {
                     bail!(
                         "--aligner-bin is only valid with --aligner::preset; \


### PR DESCRIPTION
## What

The **F** (quality/dead-code) audit bucket's safe, high-value core: remove `#[allow(dead_code)]` attributes that silence nothing and fix "wired up by Phase 1/2" / "exercised only by tests" comments that misdescribe now-production code (leftover scaffolding from the `pipeline::core → fgumi-pipeline-core` extraction #440 and the AAM wiring).

Every removal is verified against `cargo clippy -D warnings` — they are only safe because the compiler agrees the items are live:

- `CancelHandle::from_signal` (`signal.rs`) — called by `PipelineBuilder`; allow dropped, doc points at the real caller.
- `build_branch_byte_aware` (`handles.rs`) — called by production `build_single_queues`; allow dropped, "tests only" doc corrected.
- `OutputHandles::new` (`step.rs`) — called by `TypedStep::wrap_outputs_view`; allow dropped, "Phase 1 Task 15" doc corrected.
- `ResolvedAligner` (`aligner.rs`) — every field read when the AAM stage is wired; struct-level allow + stale rationale dropped.

`ResolvedAlignerMode` **keeps** its allow, but with an accurate comment: its `Preset` payload is consumed only through the derived `Debug` (info-logged), which the never-read lint flags — so the allow is legitimate, not stale. (This is a subtlety the finding's "remove both allows" recommendation missed; verified via the compiler.)

## Deferred F items (with rationale)

The rest of the F bucket (`findings/{04,06,07,16}`) is intentionally **not** in this PR:
- `retry_held` / `Process*::try_run` dedup, `CompressSpill`↔`SpillCompress` rename, `SortPhase1Event`/`SortPhase2Event` structural merge, `SpillReady.path` removal — churny type/rename/dedup refactors that would conflict with the in-flight feat-runall→main reconcile for little gain. Better folded into the reconcile.
- `decompress_into_slice` ISIZE cross-check (`findings/07` Q1) — already covered by the exact-fill (`bytes_written == out.len()`) + CRC32 verification (`findings/16`), so no change needed.

## Target rationale (main vs feat-runall)

`fgumi-pipeline-core` doesn't exist on `origin/main`; `aligner.rs`'s `ResolvedAligner` is feat-runall AAM infrastructure. Feat-runall-only, so this targets the audit stack (`nh/audit-3-parity`).

## Tests

`cargo ci-lint` clean (the load-bearing check here); `cargo ci-test` 2332 passed / 8 skipped.

> Note: this commit is currently unsigned — the local 1Password signing agent was wedged this session. It will be re-signed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how byte-bounded branch construction is handled in real runtime scenarios for certain single-output queues, removing misleading “tests-only” guidance and related lint notes.
  * Updated cancellation handle documentation to confirm it’s provided to the caller before worker threads start.
  * Improved step/output handle docs to explain that typed output handles are created by wrapping an underlying type-erased outputs view during pipeline setup.
  * Refreshed aligner docs to reflect how configuration fields are consumed during chain wiring and how preset data is used for diagnostic logging.
  * Removed outdated “inactive code path” explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->