### PR TITLE
refactor(group): share the group sort-order precondition across both paths (audit B2)

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -121,6 +121,54 @@ pub fn add_pg_to_builder(
     fgumi_bam_io::header::add_pg_to_builder(builder, crate::version::VERSION.as_str(), command_line)
 }
 
+/// Validate that `header` advertises a sort order the group stage accepts, and
+/// emit the accompanying info logging.
+///
+/// Accepts template-coordinate order always, and queryname order when
+/// `allow_unmapped` is set. On rejection, bails with the order-specific
+/// remediation hint. Shared by `Group::execute`'s single-threaded path and the
+/// chain builder's `add_group` so the two orchestrations of the same stage
+/// cannot drift on the accepted orders, the error text, or the info logging —
+/// the standalone-vs-runall divergence class. The predicates themselves are the
+/// shared `crate::sam::{is_template_coordinate_sorted, is_sorted}`.
+pub(crate) fn require_group_input_sort(
+    header: &Header,
+    allow_unmapped: bool,
+) -> anyhow::Result<()> {
+    use crate::sam::{is_sorted, is_template_coordinate_sorted};
+    use anyhow::bail;
+    use log::info;
+    use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
+
+    let is_tc_sorted = is_template_coordinate_sorted(header);
+    let is_qname_sorted = is_sorted(header, QUERY_NAME);
+
+    if !(is_tc_sorted || allow_unmapped && is_qname_sorted) {
+        if allow_unmapped {
+            bail!(
+                "Input BAM must be template-coordinate sorted or queryname sorted \
+                when --allow-unmapped is enabled.\n\n\
+                To queryname sort your BAM file, run:\n  \
+                samtools sort -n input.bam -o sorted.bam"
+            );
+        }
+        bail!(
+            "Input BAM must be template-coordinate sorted (header must advertise \
+            SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+            To sort your BAM file, run:\n  \
+            fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
+        );
+    }
+
+    if is_tc_sorted {
+        info!("Input is template-coordinate sorted");
+    } else {
+        info!("Input is queryname sorted (accepted with --allow-unmapped)");
+        info!("All unmapped reads will form a single position group per library/cell");
+    }
+    Ok(())
+}
+
 /// EM-Seq methylation-aware consensus calling options.
 #[derive(Debug, Clone, Default, Args)]
 pub struct EmSeqOptions {
@@ -924,6 +972,44 @@ fn parse_instrumentation_level(raw: &str) -> crate::pipeline::core::builder::Ins
 mod tests {
     use super::*;
     use crate::pipeline::core::builder::InstrumentationLevel;
+
+    /// Build a SAM header with the given `@HD` line plus one `@SQ`, for the
+    /// `require_group_input_sort` matrix below.
+    fn header(hd: &str) -> Header {
+        format!("{hd}\n@SQ\tSN:chr1\tLN:1000\n").parse().expect("parse SAM header")
+    }
+
+    /// B2 (audit): `require_group_input_sort` is the single source of the group
+    /// stage's sort-order precondition, shared by the single-threaded command path
+    /// and the chain builder's `add_group`. Pin its ACCEPT matrix — template-coordinate
+    /// is accepted regardless of `--allow-unmapped`; queryname only with it — so the two
+    /// callers cannot drift.
+    #[rstest]
+    #[case::tc_no_allow("@HD\tVN:1.6\tSO:unsorted\tGO:query\tSS:template-coordinate", false)]
+    #[case::tc_allow("@HD\tVN:1.6\tSO:unsorted\tGO:query\tSS:template-coordinate", true)]
+    #[case::queryname_allow("@HD\tVN:1.6\tSO:queryname", true)]
+    fn require_group_input_sort_accepts(#[case] hd: &str, #[case] allow_unmapped: bool) {
+        assert!(require_group_input_sort(&header(hd), allow_unmapped).is_ok());
+    }
+
+    /// B2 (audit): the REJECT side of the same precondition — the diagnostic differs by
+    /// `--allow-unmapped` (queryname without the flag points at template-coordinate;
+    /// coordinate with the flag mentions the queryname escape hatch).
+    #[rstest]
+    #[case::queryname_no_allow(
+        "@HD\tVN:1.6\tSO:queryname",
+        false,
+        "must be template-coordinate sorted"
+    )]
+    #[case::coordinate_allow("@HD\tVN:1.6\tSO:coordinate", true, "queryname sorted")]
+    fn require_group_input_sort_rejects(
+        #[case] hd: &str,
+        #[case] allow_unmapped: bool,
+        #[case] expected_substr: &str,
+    ) {
+        let err = require_group_input_sort(&header(hd), allow_unmapped).unwrap_err().to_string();
+        assert!(err.contains(expected_substr), "got: {err}");
+    }
 
     // Pure mapping — independent of the ambient `FGUMI_PIPELINE_TRACE`, so every
     // case always runs (no skip-on-set that could silently no-op if another test

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -12,7 +12,6 @@ use crate::grouper::{
 use crate::logging::{OperationTimer, log_umi_grouping_summary};
 use crate::metrics::group::UmiGroupingMetrics;
 use crate::sam::SamTag;
-use crate::sam::{is_sorted, is_template_coordinate_sorted};
 use crate::template::Template;
 use crate::umi::parallel_assigner::{
     ParallelAdjacencyAssigner, ParallelEditAssigner, ParallelIdentityAssigner,
@@ -34,7 +33,6 @@ use fgumi_raw_bam::{RawBamReader, RawRecord};
 use log::{info, warn};
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
 use std::path::{Path, PathBuf};
 
 // UmiGroupingMetrics and FamilySizeMetrics are imported from crate::metrics
@@ -1035,32 +1033,13 @@ impl Command for GroupReadsByUmi {
             let input_source = crate::pipeline::steps::source::InputSource::open(&self.io.input)?;
             let header = input_source.header().clone();
 
-            // Sort order check for single-threaded path.
-            let is_tc_sorted = is_template_coordinate_sorted(&header);
-            let is_qname_sorted = is_sorted(&header, QUERY_NAME);
-            if !(is_tc_sorted || self.options.allow_unmapped && is_qname_sorted) {
-                if self.options.allow_unmapped {
-                    bail!(
-                        "Input BAM must be template-coordinate sorted or queryname sorted \
-                        when --allow-unmapped is enabled.\n\n\
-                        To queryname sort your BAM file, run:\n  \
-                        samtools sort -n input.bam -o sorted.bam"
-                    );
-                } else {
-                    bail!(
-                        "Input BAM must be template-coordinate sorted (header must advertise \
-                        SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
-                        To sort your BAM file, run:\n  \
-                        fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
-                    );
-                }
-            }
-            if is_tc_sorted {
-                info!("Input is template-coordinate sorted");
-            } else {
-                info!("Input is queryname sorted (accepted with --allow-unmapped)");
-                info!("All unmapped reads will form a single position group per library/cell");
-            }
+            // Sort-order precondition + info logging, shared verbatim with the
+            // chain builder's `add_group` so the two group orchestrations cannot
+            // drift on accepted orders or the remediation hint.
+            crate::commands::common::require_group_input_sort(
+                &header,
+                self.options.allow_unmapped,
+            )?;
 
             let header = crate::commands::common::add_pg_record(header, command_line)?;
 

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2769,9 +2769,8 @@ impl<'a> ChainBuilder<'a> {
             build_group_serialize_step,
         };
         use crate::pipeline::steps::group::position::GroupByPosition;
-        use crate::sam::{SamTag, is_sorted, is_template_coordinate_sorted};
+        use crate::sam::SamTag;
         use log::{info, warn};
-        use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
 
         let group = self
             .spec
@@ -2844,32 +2843,9 @@ impl<'a> ChainBuilder<'a> {
         info!("Using pipeline with {num_threads} threads");
 
         // Check sort order — identical validation to GroupReadsByUmi::execute.
-        let is_tc_sorted = is_template_coordinate_sorted(&self.header);
-        let is_qname_sorted = is_sorted(&self.header, QUERY_NAME);
-
-        if !(is_tc_sorted || group.allow_unmapped && is_qname_sorted) {
-            if group.allow_unmapped {
-                bail!(
-                    "Input BAM must be template-coordinate sorted or queryname sorted \
-                    when --allow-unmapped is enabled.\n\n\
-                    To queryname sort your BAM file, run:\n  \
-                    samtools sort -n input.bam -o sorted.bam"
-                );
-            }
-            bail!(
-                "Input BAM must be template-coordinate sorted (header must advertise \
-                SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
-                To sort your BAM file, run:\n  \
-                fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
-            );
-        }
-
-        if is_tc_sorted {
-            info!("Input is template-coordinate sorted");
-        } else {
-            info!("Input is queryname sorted (accepted with --allow-unmapped)");
-            info!("All unmapped reads will form a single position group per library/cell");
-        }
+        // Sort-order precondition + info logging, shared verbatim with
+        // `Group::execute`'s single-threaded path (see `require_group_input_sort`).
+        crate::commands::common::require_group_input_sort(&self.header, group.allow_unmapped)?;
 
         // Tag constants per SAM specification.
         let raw_tag: [u8; 2] = *SamTag::RX;


### PR DESCRIPTION
## What

`group` is the only command with **two** orchestrations of the same stage — the single-threaded `Group::execute` path and the chain builder's `add_group` — and each carried a **byte-for-byte** copy of the sort-order precondition: the same `is_template_coordinate_sorted` / `is_sorted(QUERY_NAME)` predicate, the same two bail messages (with/without `--allow-unmapped`), and the same info logging. A change to the accepted orders or the remediation hint had to be made in both, or the two paths would silently accept/reject different inputs for the same command — the standalone-vs-runall divergence class the per-module audit repeatedly hit.

Second-wave item **B2** (`findings/15`, finding 2).

## Fix

Extract the policy into `commands::common::require_group_input_sort(header, allow_unmapped)` (error strings + logging preserved verbatim) and call it from both paths. The predicates were already shared (`crate::sam`); this consolidates the *policy* that wraps them. Added a unit test pinning the accept/reject matrix.

## Scope

- This is finding-2's genuine within-command duplication (group's two paths). The `add_dedup` and `downsample` template-coordinate checks are each **single-site** with intentionally different remediation text (dedup: "merged.bam"; downsample: "output from group / fgbio GroupReadsByUmi"), so they aren't duplicated within a command and are left as-is (consolidating would homogenize distinct messages).
- **B1 (finding 3) is deferred**: unifying the single-threaded group path onto the chain (deleting `execute_single_threaded`) is not a mechanical refactor — it **changes user-visible behavior** (the single-threaded path hard-rejects SAM while the chain accepts it) and touches the allocation-free single-thread fast path. It needs a dedicated output+metrics parity harness and a decision on the SAM-acceptance change before landing. The V3/V4 symptoms it would root-cause are already fixed as targeted bugs (#536).

## Target rationale

`add_group`/`build_for` and `commands/common.rs` are feat-runall infrastructure (absent on `origin/main`), so this targets the audit stack (`nh/audit-3-parity`).

## Tests

`require_group_input_sort_accept_reject_matrix` (new); `cargo ci-test` 2332 passed / 8 skipped; `cargo ci-lint` clean.

> Note: this commit is currently unsigned — the local 1Password signing agent was wedged this session. It will be re-signed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized validation of input sort order for read-grouping workflows.
  * Template-coordinate-sorted input is accepted consistently.
  * Queryname-sorted input is accepted when unmapped reads are enabled; otherwise, users receive a clear remediation message.
  * Added informative logging describing the detected input sort order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->