### PR TITLE
refactor(group): fold the single-threaded path onto the chain (audit B1)

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -451,11 +451,16 @@ impl ThreadingMode {
 /// ```
 #[derive(Debug, Clone, Args)]
 pub struct ThreadingOptions {
-    /// Number of threads for the multi-threaded pipeline.
+    /// Number of worker threads for the pipeline.
     ///
-    /// If not specified, uses a single-threaded fast path optimized for
-    /// simple streaming. When specified (even with --threads 1), uses the
-    /// typed-step work-stealing pipeline.
+    /// If not specified, runs with a single worker (the same worker count as
+    /// `--threads 1`, though reported as single-threaded mode); higher values
+    /// enable the work-stealing parallel pipeline.
+    ///
+    /// Most commands route through the same typed-step pipeline either way, so
+    /// this only sets the worker count. `codec`, `duplex`, `simplex`, and `clip`
+    /// still take a bespoke single-threaded path when the flag is omitted, and
+    /// for those `--threads 1` is not a synonym for leaving it unset.
     #[arg(long = "threads")]
     pub threads: Option<usize>,
 }
@@ -571,7 +576,11 @@ impl ThreadingOptions {
         Self { threads: Some(threads) }
     }
 
-    /// Creates threading options with no threads specified (uses single-threaded fast path).
+    /// Creates threading options with no thread count specified. This yields a
+    /// single worker — the same `num_threads() == 1` worker count as `--threads
+    /// 1` — but a *distinct* `ThreadingMode::SingleThreaded` variant, not a
+    /// `Threads(1)`. It is therefore not fully equivalent to `--threads 1`:
+    /// `is_parallel()` is `false` here and `true` for `--threads 1`.
     #[must_use]
     pub fn none() -> Self {
         Self { threads: None }
@@ -579,8 +588,14 @@ impl ThreadingOptions {
 
     /// Returns the threading mode based on CLI options.
     ///
-    /// - `None` -> `SingleThreaded` (fast path, no pipeline)
-    /// - `Some(n)` -> `Threads(n)` (uses pipeline, even when n=1)
+    /// - `None` -> `SingleThreaded` (one worker; `num_threads() == 1`)
+    /// - `Some(n)` -> `Threads(n)`
+    ///
+    /// Both run through the typed-step pipeline and both report
+    /// `num_threads() == 1`, so they are equal in worker count. They are still
+    /// distinct variants: `SingleThreaded` is *not* parallel (`is_parallel()`
+    /// is `false`) whereas `Threads(1)` *is* (`is_parallel()` is `true`), and
+    /// the `log_message()` string differs.
     #[must_use]
     pub fn mode(&self) -> ThreadingMode {
         match self.threads {

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -6,10 +6,7 @@ use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
     parse_bool,
 };
-use crate::grouper::{
-    FilterMetrics, RawPositionGroup, RecordPositionGrouper, build_templates_from_records,
-};
-use crate::logging::{OperationTimer, log_umi_grouping_summary};
+use crate::grouper::FilterMetrics;
 use crate::metrics::group::UmiGroupingMetrics;
 use crate::sam::SamTag;
 use crate::template::Template;
@@ -18,21 +15,11 @@ use crate::umi::parallel_assigner::{
     ParallelPairedAssigner,
 };
 use crate::umi::{UmiValidation, validate_umi};
-use crate::validation::validate_file_exists;
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::DecodedRecord;
-use fgumi_bam_io::Grouper;
-use fgumi_bam_io::LibraryIndex;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::compute_group_key_from_raw;
-use fgumi_bam_io::{create_bam_writer, is_stdin_path};
-use fgumi_raw_bam::{RawBamReader, RawRecord};
-use log::{info, warn};
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
+use log::info;
 use std::path::{Path, PathBuf};
 
 // UmiGroupingMetrics and FamilySizeMetrics are imported from crate::metrics
@@ -585,9 +572,8 @@ pub(crate) fn parallel_threshold(strategy: Strategy, opt: &ParallelMinTemplates)
 
 /// Decide whether a position group should use the parallel UMI assigner.
 ///
-/// Shared by the streaming pipeline path (the chain `GroupProcess` step) and the
-/// single-threaded path (`process_and_write_position_group`) so the two stay in
-/// lockstep. Two independent triggers enable the parallel path:
+/// Used by the chain `GroupProcess` step (the sole group execution path). Two
+/// independent triggers enable the parallel path:
 ///
 /// 1. `allow_unmapped` is set (the `--allow-unmapped` flag). Such workflows
 ///    (e.g. ribosome display) are essentially all-unmapped reads forming one
@@ -609,13 +595,13 @@ pub(crate) fn should_use_parallel(
 
 /// Construct a UMI assigner, choosing between the parallel and sequential
 /// variants based on `use_parallel`. Centralizes the four-arm strategy match
-/// shared by the chain `GroupProcess` step (streaming pipeline path) and
-/// `process_and_write_position_group` (single-threaded path).
+/// used by the chain `GroupProcess` step.
 ///
 /// A parallel assigner is only built when `num_threads > 1`: a one-thread rayon
 /// pool delivers no parallelism while still paying pool-construction overhead,
-/// so `--threads 1` and `execute_single_threaded` (which passes `threads = 1`)
-/// always fall back to the sequential assigner regardless of `use_parallel`.
+/// so a one-worker chain (`--threads 1`, or `--threads` unset, which resolves to
+/// one worker) always falls back to the sequential assigner regardless of
+/// `use_parallel`.
 pub(crate) fn create_umi_assigner(
     strategy: Strategy,
     effective_edits: u32,
@@ -948,13 +934,10 @@ pub(crate) fn build_grouping_metrics(
 impl Command for GroupReadsByUmi {
     /// Execute the group-by-UMI command.
     ///
-    /// Pure CLI-flag validations run first. For the single-threaded fast path
-    /// (`--threads` unset, BAM-only) the source is opened here so the reader
-    /// can be passed to `execute_single_threaded`. For the multi-threaded path
-    /// the spec is handed to [`crate::pipeline::chains::build_for`] and
-    /// all header-based validation (sort order, etc.) runs inside the chain
-    /// builder — this ensures stdin is only opened once.
-    #[allow(clippy::too_many_lines)]
+    /// Pure CLI-flag validations run first, then the spec is handed to
+    /// [`crate::pipeline::chains::build_for`] for every thread count (`--threads`
+    /// unset resolves to a one-worker chain). All header-based validation (sort
+    /// order, etc.) and source opening run once inside the chain builder.
     fn execute(&self, command_line: &str) -> Result<()> {
         // ── Pure CLI-flag validations ─────────────────────────────────────────
         if self.options.min_umi_length.is_some()
@@ -985,100 +968,16 @@ impl Command for GroupReadsByUmi {
                 self.options.edits
             };
 
-        // ── Single-threaded fast path (--threads unset, BAM-only) ─────────────
-        // Open the source here so we can pass the already-open reader to
-        // `execute_single_threaded` (required for stdin support).
-        if self.threading.threads.is_none() {
-            // Validate file exists (skip for stdin).
-            if !is_stdin_path(&self.io.input) {
-                validate_file_exists(&self.io.input, "input BAM file")?;
-            }
-
-            let timer = OperationTimer::new("Grouping reads by UMI");
-
-            info!("Starting group");
-            info!("Input: {}", self.io.input.display());
-            info!("Output: {}", self.io.output.display());
-            info!("Strategy: {effective_strategy:?}");
-            info!("Edits: {effective_edits}");
-            if self.options.no_umi {
-                info!("No-UMI mode: grouping by position only");
-            }
-            if matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired) {
-                info!("Index threshold: {}", self.options.index_threshold);
-            }
-            if self.options.allow_unmapped {
-                info!("Allow unmapped: enabled (unmapped templates will be grouped by UMI only)");
-                warn!(
-                    "WARNING: All unmapped reads are placed in a single position group. \
-                     Reads with identical/similar UMIs will be grouped together even if they \
-                     originate from different genomic locations."
-                );
-                if matches!(
-                    self.options.strategy,
-                    Strategy::Edit | Strategy::Adjacency | Strategy::Paired
-                ) {
-                    warn!(
-                        "WARNING: For paired UMIs (e.g., ACGT-TGCA), edit distance is computed \
-                         on the concatenated sequence with dashes removed. With --edits {}, \
-                         only {} mismatch(es) allowed across ALL bases.",
-                        self.options.edits, self.options.edits
-                    );
-                }
-            }
-
-            info!("{}", self.threading.log_message());
-            info!("Reading input");
-
-            let input_source = crate::pipeline::steps::source::InputSource::open(&self.io.input)?;
-            let header = input_source.header().clone();
-
-            // Sort-order precondition + info logging, shared verbatim with the
-            // chain builder's `add_group` so the two group orchestrations cannot
-            // drift on accepted orders or the remediation hint.
-            crate::commands::common::require_group_input_sort(
-                &header,
-                self.options.allow_unmapped,
-            )?;
-
-            let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-            let raw_tag: [u8; 2] = *SamTag::RX;
-            let assign_tag_bytes: [u8; 2] = *SamTag::MI;
-            let cell_tag = Tag::from(SamTag::CB);
-            let filter_config = GroupFilterConfig {
-                umi_tag: raw_tag,
-                min_mapq: self.options.min_map_q,
-                include_non_pf: self.options.include_non_pf_reads,
-                min_umi_length: self.options.min_umi_length,
-                no_umi: self.options.no_umi,
-                allow_unmapped: self.options.allow_unmapped,
-            };
-
-            let reader = match input_source {
-                crate::pipeline::steps::source::InputSource::Bam { reader, .. } => reader,
-                crate::pipeline::steps::source::InputSource::Sam { .. } => {
-                    bail!(
-                        "SAM input requires --threads N (single-threaded group path is BAM-only; \
-                         the multi-threaded path handles SAM via ReadSamChunks + ParseSamChunk)"
-                    )
-                }
-            };
-            return self.execute_single_threaded(
-                reader,
-                &header,
-                effective_strategy,
-                effective_edits,
-                raw_tag,
-                assign_tag_bytes,
-                cell_tag,
-                &filter_config,
-                &timer,
-            );
-        }
-
-        // ── Multi-threaded path: route through chains::build_for ──────────────
-        // Do NOT open the source here — the chain builder opens it once.
+        // ── Route through chains::build_for (single orchestration) ────────────
+        // `group` uses one code path for every thread count. `--threads` unset
+        // resolves to `num_threads() == 1` — a one-worker chain that degrades to
+        // the sequential assigner — so it produces output identical to
+        // `--threads 1` (pinned by `group_no_threads_matches_threads_1`) without
+        // a second, hand-synced orchestration. The chain builder opens the source
+        // once (handling BAM and SAM alike, so `group` no longer rejects SAM when
+        // `--threads` is omitted) and runs the shared validation, logging, and
+        // metrics in `add_group`.
+        //
         // Populate the #[arg(skip)] chain-builder slots on a clone of
         // GroupOptions before handing it to the ChainSpec.
         let mut options = self.options.clone();
@@ -1104,302 +1003,6 @@ impl Command for GroupReadsByUmi {
         crate::pipeline::chains::build_for(spec)?.run()
     }
 }
-
-impl GroupReadsByUmi {
-    /// Execute in single-threaded mode for `--threads 1`.
-    ///
-    /// This provides a simpler, streaming implementation that avoids pipeline overhead
-    /// while maintaining identical output to the multi-threaded mode.
-    #[allow(clippy::too_many_arguments)]
-    fn execute_single_threaded(
-        &self,
-        reader: Box<dyn std::io::Read + Send>,
-        header: &Header,
-        effective_strategy: Strategy,
-        effective_edits: u32,
-        raw_tag: [u8; 2],
-        assign_tag_bytes: [u8; 2],
-        cell_tag: Tag,
-        filter_config: &GroupFilterConfig,
-        timer: &OperationTimer,
-    ) -> Result<()> {
-        info!("Using single-threaded mode");
-
-        // Wrap the reader in a BufReader and use noodles to skip past the BAM header bytes.
-        // The reader is positioned at file start; we must discard the header to reach records.
-        // This reuses the already-opened reader (required for stdin support).
-        let buf_reader = std::io::BufReader::new(reader);
-        let mut noodles_reader = noodles::bam::io::Reader::new(buf_reader);
-        let _ = noodles_reader.read_header().context("Failed to skip BAM header")?;
-
-        // After the header skip, extract the inner BufReader and wrap in RawBamReader.
-        // Raw-byte mode avoids the noodles decode/encode round-trip (~15% CPU savings).
-        let mut raw_reader = RawBamReader::new(noodles_reader.into_inner());
-
-        // Create output writer (single-threaded for strict thread control)
-        let mut writer =
-            create_bam_writer(&self.io.output, header, 1, self.compression.compression_level)?;
-
-        // Build library index for GroupKey computation
-        let library_index = LibraryIndex::from_header(header);
-
-        // Create RecordPositionGrouper (same grouper used in pipeline mode)
-        let mut grouper = RecordPositionGrouper::new();
-
-        // Metrics accumulators (no lock-free queue needed in single-threaded mode)
-        let mut total_filter_metrics = FilterMetrics::new();
-        let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut next_mi_base: u64 = 0;
-
-        // Progress tracking
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Iterate over all records in raw-byte mode
-        let mut raw_rec = RawRecord::new();
-        loop {
-            let bytes_read = raw_reader.read_record(&mut raw_rec)?;
-            if bytes_read == 0 {
-                break; // EOF
-            }
-
-            // Compute GroupKey directly from raw bytes — no noodles decode needed
-            let key = compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag));
-            let decoded = DecodedRecord::from_raw_bytes(raw_rec.clone(), key);
-
-            // Feed to RecordPositionGrouper - may emit a completed group
-            if let Some(group) = grouper.add_record(decoded)? {
-                Self::process_and_write_position_group(
-                    group,
-                    filter_config,
-                    effective_strategy,
-                    effective_edits,
-                    self.options.index_threshold,
-                    1, // Single-threaded mode
-                    self.options.parallel_group_min_templates.as_ref(),
-                    raw_tag,
-                    assign_tag_bytes,
-                    &mut total_filter_metrics,
-                    &mut family_size_counter,
-                    &mut position_group_size_counter,
-                    &mut next_mi_base,
-                    header,
-                    &mut writer,
-                )?;
-            }
-
-            progress.log_if_needed(1);
-        }
-
-        // Finish grouper - emit final group
-        if let Some(final_group) = grouper.finish()? {
-            Self::process_and_write_position_group(
-                final_group,
-                filter_config,
-                effective_strategy,
-                effective_edits,
-                self.options.index_threshold,
-                1, // Single-threaded mode
-                self.options.parallel_group_min_templates.as_ref(),
-                raw_tag,
-                assign_tag_bytes,
-                &mut total_filter_metrics,
-                &mut family_size_counter,
-                &mut position_group_size_counter,
-                &mut next_mi_base,
-                header,
-                &mut writer,
-            )?;
-        }
-
-        progress.log_final();
-
-        // Finish writer
-        writer.into_inner().finish().context("Failed to finish output BAM")?;
-        info!("Wrote output to {}", self.io.output.display());
-
-        let metrics = build_grouping_metrics(&total_filter_metrics, &family_size_counter);
-        log_umi_grouping_summary(&metrics);
-
-        // Write all metrics (individual flags and --metrics prefix)
-        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
-
-        // Log completion with timing
-        timer.log_completion(metrics.accepted_records);
-
-        info!("group completed successfully");
-        Ok(())
-    }
-
-    /// Process a single position group: build templates, filter, assign UMIs, and write output.
-    /// Used by `execute_single_threaded` for streaming processing.
-    ///
-    /// Operates on raw-byte records end-to-end: zero-allocation filter and direct raw-byte
-    /// MI-tag injection, no noodles decode/encode.
-    #[allow(clippy::too_many_arguments)]
-    fn process_and_write_position_group(
-        group: RawPositionGroup,
-        filter_config: &GroupFilterConfig,
-        strategy: Strategy,
-        effective_edits: u32,
-        index_threshold: usize,
-        threads: usize,
-        parallel_group_min_templates: Option<&ParallelMinTemplates>,
-        raw_tag: [u8; 2],
-        assign_tag_bytes: [u8; 2],
-        total_filter_metrics: &mut FilterMetrics,
-        family_size_counter: &mut AHashMap<usize, u64>,
-        position_group_size_counter: &mut AHashMap<usize, u64>,
-        next_mi_base: &mut u64,
-        _header: &Header,
-        writer: &mut fgumi_bam_io::BamWriter,
-    ) -> Result<()> {
-        // Build templates from raw records
-        let all_templates = build_templates_from_records(group.records)?;
-
-        let mut filter_metrics = FilterMetrics::new();
-
-        // Filter templates
-        let filtered_templates: Vec<Template> = all_templates
-            .into_iter()
-            .filter(|t| filter_template_raw(t, filter_config, &mut filter_metrics))
-            .collect();
-
-        // Merge filter metrics
-        total_filter_metrics.merge(&filter_metrics);
-
-        if filtered_templates.is_empty() {
-            return Ok(());
-        }
-
-        // Create UMI assigner. See `should_use_parallel` for the full
-        // rationale; this is the equivalent decision on the single-threaded
-        // path, kept in lockstep with the chain path via the shared helper.
-        let use_parallel = should_use_parallel(
-            filter_config.allow_unmapped,
-            filtered_templates.len(),
-            strategy,
-            parallel_group_min_templates,
-        );
-        let assigner =
-            create_umi_assigner(strategy, effective_edits, index_threshold, threads, use_parallel);
-
-        // Assign UMI groups
-        let mut templates = filtered_templates;
-        if let Err(e) = assign_umi_groups_impl(
-            &mut templates,
-            assigner.as_ref(),
-            raw_tag,
-            filter_config.min_umi_length,
-            filter_config.no_umi,
-        ) {
-            // The whole group is dropped from the BAM (matching the chain path),
-            // so none of its filter-passing templates are actually accepted. This
-            // group's `accepted_templates` was already merged into the total
-            // above; roll it back so the summary/metrics match the (empty) output
-            // rather than over-counting. The discard counters stay — those
-            // templates were genuinely filtered out.
-            log::warn!("Failed to assign UMI groups: {e}");
-            total_filter_metrics.accepted_templates = total_filter_metrics
-                .accepted_templates
-                .saturating_sub(filter_metrics.accepted_templates);
-            return Ok(());
-        }
-
-        // Sort templates directly by (MI index, name) - avoids Vec<Vec<Template>> allocation
-        templates.sort_by(|a, b| {
-            let a_idx = a.mi.to_vec_index();
-            let b_idx = b.mi.to_vec_index();
-            a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
-        });
-
-        // Count family sizes and position group size in one pass through sorted templates
-        if !templates.is_empty() {
-            let mut current_mi = templates[0].mi.to_vec_index();
-            let mut current_count = 1usize;
-            let mut num_families = 0usize;
-
-            for template in templates.iter().skip(1) {
-                let mi = template.mi.to_vec_index();
-                if mi == current_mi {
-                    current_count += 1;
-                } else {
-                    // Finish previous MI group
-                    if current_mi.is_some() {
-                        *family_size_counter.entry(current_count).or_insert(0) += 1;
-                        num_families += 1;
-                    }
-                    current_mi = mi;
-                    current_count = 1;
-                }
-            }
-            // Don't forget the last group
-            if current_mi.is_some() {
-                *family_size_counter.entry(current_count).or_insert(0) += 1;
-                num_families += 1;
-            }
-
-            if num_families > 0 {
-                *position_group_size_counter.entry(num_families).or_insert(0) += 1;
-            }
-        }
-
-        // Write templates (already sorted by MI, then by name).
-        //
-        // Advance the global MI counter by the number of distinct numeric MoleculeId
-        // IDs actually assigned in this group, not by the template count, so the
-        // emitted MI integers are consecutive 0..N-1 across all position groups
-        // (matching fgbio's `GroupReadsByUmi`; see issue #269). Assigners hand out
-        // numeric IDs 0, 1, 2, ... contiguously, so `max(id) + 1` equals the count.
-        let distinct_mi_count: u64 =
-            templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
-        let base_mi = *next_mi_base;
-        // `checked_add` so wraparound is reported instead of silently reusing MI integers.
-        *next_mi_base = next_mi_base.checked_add(distinct_mi_count).ok_or_else(|| {
-            anyhow::anyhow!("MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX")
-        })?;
-
-        // Raw-byte output: inject MI tag directly into raw bytes, write without noodles.
-        use std::io::Write as _;
-        let mut scratch = Vec::with_capacity(512);
-        let mut mi_buf = String::with_capacity(16);
-        let inner = writer.get_mut();
-        emit_templates_raw_with_mi(
-            &templates,
-            base_mi,
-            assign_tag_bytes,
-            &mut scratch,
-            &mut mi_buf,
-            |bytes| inner.write_all(bytes),
-        )?;
-
-        Ok(())
-    }
-
-    /// Write all metrics files: individual flags and --metrics prefix outputs.
-    fn write_all_metrics(
-        &self,
-        grouping_metrics: &UmiGroupingMetrics,
-        family_sizes: &AHashMap<usize, u64>,
-        position_group_sizes: &AHashMap<usize, u64>,
-    ) -> Result<()> {
-        write_metrics_for_chain(
-            grouping_metrics,
-            family_sizes,
-            position_group_sizes,
-            self.family_size_histogram.as_deref(),
-            self.grouping_metrics.as_deref(),
-            self.metrics.as_deref(),
-        )
-    }
-}
-
-// `emit_templates_raw_with_mi` moved to
-// `crate::pipeline::steps::serialize_processed` so the
-// threaded-pipeline serialize step and the single-threaded writer
-// can share a single source of truth. Re-exported here for callers
-// that previously imported it via this module.
-pub(crate) use crate::pipeline::steps::serialize_processed::emit_templates_raw_with_mi;
 
 /// Write metrics to a TSV file and log the output path.
 pub(crate) fn write_metrics<S: serde::Serialize>(
@@ -1557,8 +1160,8 @@ mod tests {
 
     /// Even with `use_parallel = true`, a single worker thread must not build a
     /// parallel assigner: a one-thread rayon pool is pure startup overhead with
-    /// zero parallelism. The `--threads 1` pipeline path and `execute_single_threaded`
-    /// (which passes `threads = 1`) both reach `create_umi_assigner` with
+    /// zero parallelism. A one-worker chain (`--threads 1`, or `--threads` unset,
+    /// which resolves to one worker) reaches `create_umi_assigner` with
     /// `num_threads == 1`, so this guards against spawning a useless pool there.
     #[rstest]
     #[case(Strategy::Identity)]
@@ -2454,13 +2057,13 @@ mod tests {
     }
 
     /// Regression test for #285: verify that the per-thread accumulator path
-    /// used in the multi-threaded pipeline produces metrics identical to the
-    /// single-threaded fast path. Runs the same dataset as
-    /// `test_metrics_prefix_writes_all_files` across three threading modes and
-    /// asserts family sizes, grouping metrics, and position-group sizes all
-    /// match.
+    /// used in the multi-threaded pipeline produces metrics identical to a
+    /// one-worker chain. Runs the same dataset as
+    /// `test_metrics_prefix_writes_all_files` across three threading modes
+    /// (`--threads` unset, `1`, and `4`) and asserts family sizes, grouping
+    /// metrics, and position-group sizes all match.
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::threads_unset(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_4(ThreadingOptions::new(4))]
     fn test_metrics_parity_across_threading_modes(
@@ -5145,10 +4748,10 @@ mod tests {
         buf.extend_from_slice(umi);
         buf.push(0);
 
-        // Backfill block_size now that all bytes are appended.
-        let block_size = i32::try_from(buf.len() - 4).expect("BAM record fits in i32");
-        buf[0..4].copy_from_slice(&block_size.to_le_bytes());
-
+        // No `block_size` backfill: a `RawRecord` holds the record BODY, whose
+        // first four bytes are `ref_id` (written above). Writing a length prefix
+        // here would clobber the tid and leave the record undecodable against a
+        // real header.
         fgumi_raw_bam::RawRecord::from(buf)
     }
 
@@ -5177,91 +4780,103 @@ mod tests {
         assert_eq!(metrics.accepted_templates, 1);
     }
 
-    /// A group whose template PASSES filtering but then FAILS UMI assignment must
-    /// roll its `accepted_templates` contribution back out of the running total
-    /// (so the summary matches the empty output), while leaving the discard
-    /// counters untouched — that template was not filtered out, it was dropped
-    /// whole when assignment failed. Regression for the rollback branch in
-    /// `process_and_write_position_group`.
+    /// End-to-end regression for the assignment-failure rollback branch.
+    ///
+    /// A position group whose template PASSES group filtering but then FAILS UMI
+    /// assignment must have its whole group dropped from the BAM, with its
+    /// filter-passing template rolled back out of the accepted count (so the
+    /// emitted metrics match the empty output), while the discard counters that
+    /// accrued in the *same* group survive the rollback untouched.
+    ///
+    /// The bespoke single-threaded `process_and_write_position_group` that this
+    /// test used to white-box was deleted in PR 547; the behavior now lives in
+    /// the folded chain path (`pipeline/chains/commands/group.rs`, the
+    /// `assign_umi_groups_impl` Err branch that clones `filter_metrics`, sets
+    /// `dropped_metrics.accepted_templates = 0`, and records the empty group).
+    /// This test therefore drives the real chain via `cmd.execute` and asserts
+    /// on the emitted grouping-metrics TSV and the (empty) output BAM.
     #[test]
-    fn assignment_failure_rolls_back_accepted_templates_but_not_discards() {
-        use fgumi_bam_io::{DecodedRecord, GroupKey};
-
-        // The RX value is 8 real bases plus a trailing non-UTF-8 byte: `validate_umi`
-        // skips the stray byte (so the filter accepts the template), but assignment's
-        // `str::from_utf8` rejects it — driving the `assign_umi_groups_impl` Err
-        // branch that triggers the rollback.
-        let raw = make_raw_bam_for_group(
-            b"rea",
+    fn assignment_failure_rolls_back_accepted_templates_but_not_discards() -> Result<()> {
+        // Two single-end templates at the SAME position (tid 0, pos 100) so they
+        // land in one position group:
+        //
+        //   (a) `fail_rx` — RX is 8 real bases plus a trailing non-UTF-8 byte.
+        //       `validate_umi` skips the stray byte, so the filter ACCEPTS it
+        //       (accepted_templates += 1); but assignment's `str::from_utf8` on
+        //       that RX returns Err, driving the group-drop / rollback branch.
+        //   (b) `disc_n`  — RX contains an uppercase N, so it is DISCARDED
+        //       (discarded_ns_in_umi += 1) BEFORE assignment. Its discard counter
+        //       lives in the same group's `filter_metrics` and must survive the
+        //       rollback that zeroes only `accepted_templates`.
+        let fail_rx = make_raw_bam_for_group(
+            b"fail_rx",
             flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED,
             30,
             b"ACGTACGT\xff",
         );
-        let group = RawPositionGroup {
-            group_key: GroupKey::default(),
-            records: vec![DecodedRecord::from_raw_bytes(raw, GroupKey::default())],
-        };
-        let filter_config = GroupFilterConfig {
-            umi_tag: [b'R', b'X'],
-            min_mapq: 20,
-            include_non_pf: false,
-            min_umi_length: None,
-            no_umi: false,
-            allow_unmapped: false,
-        };
-
-        // Pre-existing totals from earlier groups that must survive the rollback.
-        let mut total = FilterMetrics::new();
-        total.accepted_templates = 5;
-        total.discarded_poor_alignment = 2;
-        total.discarded_non_pf = 1;
-        let discards_before = (
-            total.discarded_non_pf,
-            total.discarded_poor_alignment,
-            total.discarded_ns_in_umi,
-            total.discarded_umi_too_short,
+        let disc_n = make_raw_bam_for_group(
+            b"disc_n",
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED,
+            30,
+            b"AANAAAAA",
         );
 
-        let mut family_sizes = AHashMap::new();
-        let mut position_group_sizes = AHashMap::new();
-        let mut next_mi_base = 0u64;
+        // Write the raw records straight into the BGZF BAM (framing only, no
+        // noodles `RecordBuf` round-trip) — the non-UTF-8 RX byte must survive
+        // to the reader, and noodles' Z-tag validation would reject it.
+        let input = NamedTempFile::new()?;
         let header = create_test_header();
-        let tmp = NamedTempFile::new().expect("tempfile");
-        let mut writer = create_bam_writer(tmp.path(), &header, 1, 0).expect("writer");
+        let mut writer = fgumi_bam_io::create_raw_bam_writer(input.path(), &header, 1, 1)?;
+        writer.write_raw_record(fail_rx.as_ref())?;
+        writer.write_raw_record(disc_n.as_ref())?;
+        writer.finish()?;
 
-        let result = GroupReadsByUmi::process_and_write_position_group(
-            group,
-            &filter_config,
-            Strategy::Adjacency,
-            1,
-            0,
-            1,
-            None,
-            [b'R', b'X'],
-            [b'M', b'I'],
-            &mut total,
-            &mut family_sizes,
-            &mut position_group_sizes,
-            &mut next_mi_base,
-            &header,
-            &mut writer,
-        );
+        let paths = TestPaths::new()?;
 
-        assert!(result.is_ok(), "assignment failure must be handled, not propagated: {result:?}");
+        let mut cmd = with_group_opts(Strategy::Adjacency, 1, |o| o.min_map_q = 20);
+        cmd.io = BamIoOptions {
+            input: input.path().to_path_buf(),
+            output: paths.output.clone(),
+            ..Default::default()
+        };
+        cmd.grouping_metrics = Some(paths.grouping_metrics.clone());
+
+        // The non-UTF-8 RX must drop the GROUP (assignment Err -> empty group),
+        // NOT hard-fail the whole command.
+        cmd.execute("test")?;
+
+        let metrics: Vec<UmiGroupingMetrics> =
+            DelimFile::default().read_tsv(&paths.grouping_metrics)?;
+        assert_eq!(metrics.len(), 1);
+        let m = &metrics[0];
+
+        // Pin the PRE-rollback state first. `accepted_records == 0` on its own is
+        // also what a `fail_rx` that never reached assignment would produce (a
+        // decode failure, or an unexpected filter rejection), which would leave the
+        // rollback branch dead and this test still green. Both records must have
+        // been seen, and `fail_rx` must have been rejected by assignment rather
+        // than absorbed by one of the filter's discard counters.
+        assert_eq!(m.total_records, 2, "both fail_rx and disc_n must reach the filter");
+        assert_eq!(m.discarded_non_pf, 0, "fail_rx must not be discarded as non-PF");
         assert_eq!(
-            total.accepted_templates, 5,
-            "the filter-passing template of the failed group must be rolled back to the pre-group total",
+            m.discarded_poor_alignment, 0,
+            "fail_rx must not be discarded for poor alignment"
         );
-        assert_eq!(
-            (
-                total.discarded_non_pf,
-                total.discarded_poor_alignment,
-                total.discarded_ns_in_umi,
-                total.discarded_umi_too_short,
-            ),
-            discards_before,
-            "discard counters must not change on an assignment-failure rollback",
-        );
+        assert_eq!(m.discarded_umi_too_short, 0, "fail_rx must not be discarded as a short UMI");
+
+        // Core regression assertion: the filter-passing-but-assignment-failing
+        // template was rolled back and is NOT counted as accepted. Without the
+        // chain's `dropped_metrics.accepted_templates = 0`, this would be 1.
+        assert_eq!(m.accepted_records, 0);
+        // The discard counter from the same group survives the rollback — and
+        // accounts for `disc_n` only, so `fail_rx` was not folded into it.
+        assert_eq!(m.discarded_ns_in_umi, 1);
+
+        // The dropped group emits no records.
+        let output_records = read_bam_records(&paths.output)?;
+        assert_eq!(output_records.len(), 0, "the dropped group must emit no records");
+
+        Ok(())
     }
 
     #[test]

--- a/src/lib/pipeline/chains/commands/group.rs
+++ b/src/lib/pipeline/chains/commands/group.rs
@@ -414,8 +414,9 @@ pub(crate) fn build_group_serialize_step(
 /// [`ChainBuilder`]'s `add_group` method in
 /// [`crate::pipeline::chains::builder`].
 ///
-/// The single-threaded fast path (`--threads` unset, BAM-only) is **not**
-/// migrated here — it stays inline in `GroupReadsByUmi::execute`.
+/// This is the sole group execution path for every thread count —
+/// `GroupReadsByUmi::execute` always routes here, and `--threads` unset resolves
+/// to a one-worker chain.
 ///
 /// # Errors
 ///

--- a/src/lib/pipeline/steps/group/mi.rs
+++ b/src/lib/pipeline/steps/group/mi.rs
@@ -113,6 +113,15 @@ pub struct GroupByMi {
     held: HeldSlot<Unpushed<BatchedMiGroups>>,
     target_batch_count: usize,
     output_byte_limit: u64,
+    /// Records dropped because they carry no MI tag at all. Expected in small
+    /// numbers (e.g. unmapped mates upstream filters missed); reported at
+    /// end-of-stream so a silent whole-input drop cannot go unnoticed.
+    skipped_no_mi: u64,
+    /// Records dropped because MI is present but **not** a `Z` (string) tag.
+    /// Almost always a malformed input rather than a legitimate skip: `fgumi
+    /// group` and fgbio both write MI as a string (it can carry a `/A`,`/B`
+    /// strand suffix), so an `MI:i:` integer silently matches nothing.
+    skipped_non_string_mi: u64,
     name: &'static str,
 }
 
@@ -143,6 +152,8 @@ impl GroupByMi {
             held: HeldSlot::new(),
             target_batch_count: target_batch_count.max(1),
             output_byte_limit,
+            skipped_no_mi: 0,
+            skipped_non_string_mi: 0,
             name: "GroupByMi",
         }
     }
@@ -209,11 +220,14 @@ impl GroupByMi {
         }
         let same_group = match &self.current_key {
             Some(key) => {
-                match key.matches_record(raw.as_ref(), self.tag, self.cell_tag, self.transform()) {
-                    Some(matches) => matches,
-                    // No MI tag on this record: skip it.
-                    None => return,
-                }
+                // `None` means no usable MI tag on this record: count why, and skip.
+                let Some(matches) =
+                    key.matches_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+                else {
+                    self.count_skipped_record(raw.as_ref());
+                    return;
+                };
+                matches
             }
             None => false,
         };
@@ -225,11 +239,56 @@ impl GroupByMi {
             let Some(key) =
                 MiKey::from_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
             else {
+                self.count_skipped_record(raw.as_ref());
                 return;
             };
             self.flush_current_group();
             self.current_key = Some(key);
             self.current_records.push(raw);
+        }
+    }
+
+    /// Classify a record that produced no usable MI key, so end-of-stream can tell
+    /// "no MI tag" apart from "MI present but the wrong type".
+    ///
+    /// Only runs on the skip path, so it costs nothing for records that group
+    /// normally.
+    #[inline]
+    fn count_skipped_record(&mut self, bam: &[u8]) {
+        let aux = fgumi_raw_bam::aux_data_slice(bam);
+        match fgumi_raw_bam::find_tag_type(aux, self.tag) {
+            // Present but not `Z`: the caller almost certainly meant this record
+            // to group, so it is tracked separately and warned about loudly.
+            Some(kind) if kind != b'Z' => self.skipped_non_string_mi += 1,
+            _ => self.skipped_no_mi += 1,
+        }
+    }
+
+    /// Report records dropped for want of a usable MI tag, once, at end-of-stream.
+    ///
+    /// A wrong-typed MI is warned about unconditionally: it means the input was
+    /// written with e.g. `MI:i:1` instead of `MI:Z:1`, which groups nothing and
+    /// otherwise surfaces only as an inexplicably empty output.
+    fn report_skipped_records(&self) {
+        if self.skipped_non_string_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) whose {} tag is present but not a string (Z) tag. \
+                 fgumi and fgbio write {} as a string because it may carry a /A or /B strand \
+                 suffix; an integer tag such as `MI:i:1` matches no group. Re-run `fgumi group` \
+                 on this input, or rewrite the tag as `MI:Z:`.",
+                self.name,
+                self.skipped_non_string_mi,
+                String::from_utf8_lossy(&self.tag),
+                String::from_utf8_lossy(&self.tag),
+            );
+        }
+        if self.skipped_no_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) carrying no {} tag.",
+                self.name,
+                self.skipped_no_mi,
+                String::from_utf8_lossy(&self.tag),
+            );
         }
     }
 
@@ -326,6 +385,7 @@ impl Step for GroupByMi {
             if !self.accumulator.is_empty() {
                 return Ok(self.emit_batch(ctx));
             }
+            self.report_skipped_records();
             return Ok(StepOutcome::Finished);
         }
         Ok(StepOutcome::NoProgress)
@@ -336,6 +396,7 @@ impl Step for GroupByMi {
 mod tests {
     use super::*;
     use fgumi_raw_bam::RawRecord;
+    use rstest::rstest;
 
     /// Build a minimal unmapped raw BAM record carrying a single Z-type tag.
     #[allow(clippy::cast_possible_truncation)]
@@ -343,15 +404,21 @@ mod tests {
         raw_with_tags(&[(tag, value)])
     }
 
+    /// Build a minimal unmapped raw BAM record carrying a single `i`-type
+    /// (signed 32-bit integer) tag, e.g. the malformed `MI:i:1` that groups
+    /// nothing because MI is defined as a string tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_int_tag(tag: &str, value: i32) -> RawRecord {
+        let t = tag.as_bytes();
+        let mut aux: Vec<u8> = vec![t[0], t[1], b'i'];
+        aux.extend_from_slice(&value.to_le_bytes());
+        raw_with_aux(&aux)
+    }
+
     /// Build a minimal unmapped raw BAM record carrying the given Z-type tags
     /// in the supplied aux-block order.
     #[allow(clippy::cast_possible_truncation)]
     fn raw_with_tags(tags: &[(&str, &str)]) -> RawRecord {
-        let name = b"read";
-        let l_read_name: u8 = (name.len() + 1) as u8;
-        let seq_len: u32 = 4;
-        let seq_bytes = seq_len.div_ceil(2) as usize;
-
         let mut aux: Vec<u8> = Vec::new();
         for (tag, value) in tags {
             let t = tag.as_bytes();
@@ -359,6 +426,16 @@ mod tests {
             aux.extend_from_slice(value.as_bytes());
             aux.push(0);
         }
+        raw_with_aux(&aux)
+    }
+
+    /// Wrap a pre-encoded aux block in a minimal unmapped raw BAM record.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_aux(aux: &[u8]) -> RawRecord {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
 
         let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
         let mut buf = vec![0u8; total];
@@ -373,7 +450,7 @@ mod tests {
         buf[name_start..name_start + name.len()].copy_from_slice(name);
         buf[name_start + name.len()] = 0;
         let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
-        buf[aux_start..aux_start + aux.len()].copy_from_slice(&aux);
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(aux);
         RawRecord::from(buf)
     }
 
@@ -428,6 +505,44 @@ mod tests {
         ];
         let groups = run_grouping(&mut step, records);
         assert_eq!(groups, vec![("5".to_string(), 2)]);
+    }
+
+    /// A dropped record must be *counted*, and a wrong-typed MI counted apart from
+    /// an absent one, so end-of-stream can warn instead of emitting a silently
+    /// empty output.
+    ///
+    /// The `MI:i:` case is the one that bites: fgumi and fgbio write MI as a `Z`
+    /// string (it may carry a `/A`,`/B` suffix), so an integer MI matches no group
+    /// and the whole input vanishes with no diagnostic.
+    #[rstest]
+    #[case::integer_mi_is_wrong_type(vec![raw_with_int_tag("MI", 1), raw_with_int_tag("MI", 1)], 0, 2)]
+    #[case::absent_mi(vec![raw_without_tag(), raw_without_tag()], 2, 0)]
+    #[case::mixed(vec![raw_without_tag(), raw_with_int_tag("MI", 3)], 1, 1)]
+    #[case::valid_string_mi_counts_nothing(vec![raw_with_tag("MI", "1"), raw_with_tag("MI", "1")], 0, 0)]
+    fn skipped_records_are_counted_by_reason(
+        #[case] records: Vec<RawRecord>,
+        #[case] expected_no_mi: u64,
+        #[case] expected_non_string_mi: u64,
+    ) {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        run_grouping(&mut step, records);
+
+        assert_eq!(step.skipped_no_mi, expected_no_mi, "records with no MI tag");
+        assert_eq!(
+            step.skipped_non_string_mi, expected_non_string_mi,
+            "records whose MI is present but not a Z tag",
+        );
+    }
+
+    /// An all-integer-MI input must produce zero groups — the regression that made
+    /// four simplex parity tests compare one empty BAM against another.
+    #[test]
+    fn integer_mi_groups_nothing() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = (0..8).map(|_| raw_with_int_tag("MI", 1)).collect();
+        assert!(run_grouping(&mut step, records).is_empty());
     }
 
     #[test]

--- a/tests/integration/test_group_determinism.rs
+++ b/tests/integration/test_group_determinism.rs
@@ -207,11 +207,10 @@ fn read_qname_mi(path: &Path) -> Vec<(String, u16, String)> {
 /// comparing pairwise raises the probability of catching the variance even
 /// when only a handful of subgroup keys are present.
 ///
-/// `threads = None` omits the `--threads` flag entirely. For `fgumi group`
-/// this triggers the dedicated `execute_single_threaded` fast path
-/// (`src/lib/commands/group.rs`'s `if self.threading.threads.is_none()` at
-/// the top of `execute`); `Some("1")` runs the parallel pipeline with one
-/// worker, which is a different code path. Both must be deterministic.
+/// `threads = None` omits the `--threads` flag entirely, which resolves to a
+/// one-worker chain (`num_threads() == 1`); `Some("1")` requests one worker
+/// explicitly. Both route through the same typed-step pipeline and must be
+/// deterministic (and, per `group_no_threads_matches_threads_1`, identical).
 fn assert_mi_deterministic(
     subcommand: &str,
     threads: Option<&str>,
@@ -301,11 +300,9 @@ fn assert_mi_deterministic(
 /// must assign identical `MI:Z` tags to every record across runs and across
 /// every supported threading mode.
 ///
-/// The three threads cases exercise three distinct code paths:
+/// The three threads cases exercise the pipeline at different worker counts:
 ///
-/// * `None` — `group` only: the dedicated `execute_single_threaded` fast
-///   path (taken when `--threads` is omitted), which assigns `MoleculeId`s
-///   inline without going through the unified pipeline scheduler.
+/// * `None` — `--threads` omitted, which resolves to a one-worker chain.
 /// * `Some("1")` — the unified pipeline with a single worker.
 /// * `Some("4")` — the unified pipeline with four workers, which was the
 ///   originally failing case before the serial-ordered `MI Assign` hook.
@@ -317,6 +314,168 @@ fn assert_mi_deterministic(
 #[case::dedup_threads_4("dedup", Some("4"))]
 fn test_paired_mi_deterministic(#[case] subcommand: &str, #[case] threads: Option<&str>) {
     assert_mi_deterministic(subcommand, threads, &[], 6);
+}
+
+/// B1 (audit): `fgumi group` with `--threads` unset must produce identical
+/// grouping to `--threads 1` — same record order and same per-record `MI:Z`
+/// tags. Historically the unset case took a bespoke `execute_single_threaded`
+/// orchestration while `--threads 1` routed through the typed-step chain; this
+/// pins that the two paths agree, which is the invariant that lets the
+/// single-threaded path be folded onto the chain (deleting the second
+/// orchestration). Uses the paired-orientation fixture — the case most sensitive
+/// to MI-numbering drift.
+///
+/// Beyond the unset-vs-`--threads 1` self-consistency check, this test also
+/// asserts the unset output against an INDEPENDENT oracle derived from the
+/// fixture construction (`assert_paired_fixture_oracle`), per the repo
+/// path-instruction that correctness-critical integration tests validate
+/// against an expectation not taken from the tool's own output — so that a
+/// grouping that is identical across the two paths but both wrong cannot pass.
+#[test]
+fn group_no_threads_matches_threads_1() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    build_mixed_orientation_bam(&input_bam);
+
+    let run = |out: &Path, threads: Option<&str>| {
+        let mut args: Vec<&str> = vec![
+            "group",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "--strategy",
+            "paired",
+            "--compression-level",
+            "1",
+        ];
+        if let Some(t) = threads {
+            args.extend(["--threads", t]);
+        }
+        let status =
+            Command::new(env!("CARGO_BIN_EXE_fgumi")).args(&args).status().expect("run group");
+        assert!(status.success(), "group (threads={threads:?}) failed");
+    };
+
+    let out_none = temp_dir.path().join("out_none.bam");
+    let out_t1 = temp_dir.path().join("out_t1.bam");
+    run(&out_none, None);
+    run(&out_t1, Some("1"));
+
+    let mi_none = read_qname_mi(&out_none);
+
+    // Independent oracle (satisfies the path-instruction that correctness-critical
+    // integration tests check against an expectation NOT derived from the tool's
+    // own output, so "identical-but-both-wrong" grouping cannot pass): assert the
+    // `--threads` unset output — the path PR 547 folds onto the chain — against
+    // the MI-group structure derived purely from the fixture construction.
+    assert_paired_fixture_oracle(&mi_none);
+
+    // Self-consistency: the folded unset path must match `--threads 1` exactly.
+    assert_eq!(
+        mi_none,
+        read_qname_mi(&out_t1),
+        "group --threads unset must match --threads 1 (record order + MI tags)"
+    );
+}
+
+/// Independent oracle for `build_mixed_orientation_bam` under `--strategy paired`.
+///
+/// Derived solely from the fixture construction (NOT the tool's output): the
+/// fixture emits, at each of 40 positions, for each of 256 distinct paired UMIs
+/// (4^4 prefixes; `{prefix}{prefix}-{suffix}{suffix}` with suffix = reversed
+/// prefix), one template in each of the two orientations (FR = `is_rf` false,
+/// RF = `is_rf` true).
+///
+/// Under the `paired` strategy the two orientations at the *same* position are
+/// distinct orientation subgroups, NOT the two strands of one duplex molecule:
+/// a duplex pair needs opposite-strand reads at *mirrored* coordinates, whereas
+/// here both orientations share identical coordinates. So each (position, UMI,
+/// orientation) is its own molecule and the orientations do NOT merge:
+///
+///   families = 40 positions × 256 UMIs × 2 orientations = 20480
+///
+/// The merged alternative (40 × 256 = 10240) is excluded by the coordinate
+/// argument above, not by observing the tool: merging requires mirrored
+/// coordinates, and this fixture gives both orientations identical ones. Each
+/// template is 2 reads and no two templates share a family, so every family holds
+/// exactly 2 records; fgumi numbers molecule IDs contiguously with no gaps, so the
+/// distinct numeric MI values form an exact gap-free range of length `families`.
+///
+/// Membership, not just shape, is asserted: each family must be exactly one
+/// template (a single QNAME, one R1 and one R2). Without that, a mis-grouping that
+/// paired one template's R1 with another's R2 would still yield 20480 uniform
+/// size-2 families over a contiguous id range and pass.
+fn assert_paired_fixture_oracle(records: &[(String, u16, String)]) {
+    const POSITIONS: u64 = 40;
+    const UMIS: u64 = 256; // 4^4 distinct 4-mer prefixes
+    const ORIENTATIONS: u64 = 2; // FR + RF stay distinct under `paired`
+    const EXPECTED_FAMILIES: u64 = POSITIONS * UMIS * ORIENTATIONS; // 20480
+    const RECORDS_PER_FAMILY: usize = 2; // one 2-read template per family
+    const FLAG_R1: u16 = 0x40;
+    const FLAG_R2: u16 = 0x80;
+
+    // Family members per record: the numeric part of `MI:Z`, stripping any
+    // `/A`,`/B` strand suffix, mapped to the (QNAME, FLAG) pairs that landed in it.
+    let mut family_members: std::collections::HashMap<u64, Vec<(&str, u16)>> =
+        std::collections::HashMap::new();
+    for (qname, flags, mi) in records {
+        let numeric = mi.split('/').next().expect("non-empty MI");
+        let id: u64 = numeric
+            .parse()
+            .unwrap_or_else(|_| panic!("MI {mi:?} on {qname} is not <n> or <n>/strand"));
+        family_members.entry(id).or_default().push((qname.as_str(), *flags));
+    }
+    let family_sizes: std::collections::HashMap<u64, usize> =
+        family_members.iter().map(|(id, members)| (*id, members.len())).collect();
+
+    // Family count matches the fixture-derived value (orientations do not merge).
+    assert_eq!(
+        family_sizes.len() as u64,
+        EXPECTED_FAMILIES,
+        "expected 40×256×2 = {EXPECTED_FAMILIES} MI families, got {}",
+        family_sizes.len(),
+    );
+
+    // Total records = families × 2.
+    assert_eq!(
+        records.len() as u64,
+        EXPECTED_FAMILIES * RECORDS_PER_FAMILY as u64,
+        "expected {EXPECTED_FAMILIES} families × {RECORDS_PER_FAMILY} records each",
+    );
+
+    // Every family is uniformly sized (exactly one 2-read template).
+    for (id, size) in &family_sizes {
+        assert_eq!(
+            *size, RECORDS_PER_FAMILY,
+            "family {id} has {size} records, expected {RECORDS_PER_FAMILY}",
+        );
+    }
+
+    // Every family is exactly ONE template: a single QNAME, one R1 and one R2.
+    // Size alone cannot catch a mis-grouping that swapped mates between templates.
+    for (id, members) in &family_members {
+        let names: std::collections::HashSet<&str> = members.iter().map(|(q, _)| *q).collect();
+        assert_eq!(names.len(), 1, "family {id} mixes templates: {names:?}");
+
+        let mut segments: Vec<u16> = members.iter().map(|(_, f)| f & (FLAG_R1 | FLAG_R2)).collect();
+        segments.sort_unstable();
+        assert_eq!(
+            segments,
+            vec![FLAG_R1, FLAG_R2],
+            "family {id} is not exactly one R1 + one R2 (segment flags {segments:?})",
+        );
+    }
+
+    // MI ids are numbered contiguously with no gaps: the distinct ids equal the
+    // exact range [min, min + families).
+    let min = family_sizes.keys().copied().min().expect("at least one family");
+    let expected_ids: std::collections::HashSet<u64> = (min..min + EXPECTED_FAMILIES).collect();
+    let actual_ids: std::collections::HashSet<u64> = family_sizes.keys().copied().collect();
+    assert_eq!(
+        actual_ids, expected_ids,
+        "MI ids must be a contiguous, gap-free range of {EXPECTED_FAMILIES} values starting at {min}",
+    );
 }
 
 /// `--parallel-group-min-templates` must route the chain `GroupProcess` step

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -535,6 +535,48 @@ fn test_group_command_with_sam_input_new_pipeline_matches_bam_baseline() {
     compare_bam_records(&out_bam_baseline, &out_sam);
 }
 
+/// B1 (audit): folding the single-threaded group path onto the chain removed the
+/// BAM-only restriction — `fgumi group` with `--threads` unset now accepts SAM
+/// input (it previously bailed with "SAM input requires --threads N", since the
+/// bespoke `execute_single_threaded` path could not parse SAM). The SAM run must
+/// match the BAM run, both with `--threads` omitted.
+#[test]
+fn test_group_sam_input_without_threads_now_accepted() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let bam_input = temp_dir.path().join("input.bam");
+    let sam_input = temp_dir.path().join("input.sam");
+    let baseline_out = temp_dir.path().join("baseline_out.bam");
+    let streamed_out = temp_dir.path().join("streamed_out.bam");
+
+    create_test_input_bam(&bam_input);
+    convert_bam_to_sam(&bam_input, &sam_input);
+
+    let run = |input: &std::path::Path, output: &std::path::Path, label: &str| {
+        let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+            .args([
+                "group",
+                "--input",
+                input.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--strategy",
+                "identity",
+                "--edits",
+                "0",
+                "--compression-level",
+                "1",
+                // No --threads: exercises the (now unified) unset path.
+            ])
+            .status()
+            .unwrap_or_else(|e| panic!("spawn group {label}: {e}"));
+        assert!(status.success(), "group {label} with --threads unset failed");
+    };
+
+    run(&bam_input, &baseline_out, "BAM");
+    run(&sam_input, &streamed_out, "SAM");
+    compare_bam_records(&baseline_out, &streamed_out);
+}
+
 /// SAM-input parity for simplex. Generates a SAM from the same grouped
 /// records as the BAM baseline (with MI tags), runs simplex on both,
 /// compares the consensus outputs.
@@ -647,7 +689,7 @@ fn test_correct_command_with_sam_input_new_pipeline_with_rejects_matches_bam_bas
     // UMIs, rejecting none — so only the kept output is guarded.)
     assert!(count_bam_records(&out_bam_baseline) > 0, "BAM baseline kept output is empty");
     compare_bam_records(&out_bam_baseline, &out_sam);
-    compare_bam_records(&out_bam_rejects_baseline, &out_sam_rejects);
+    compare_bam_records_allow_empty(&out_bam_rejects_baseline, &out_sam_rejects);
 }
 
 /// Build an unmapped-consensus BAM with depth tags so filter accepts it
@@ -883,7 +925,33 @@ fn test_group_command_with_piped_input_new_pipeline() {
 /// field including bases, qualities, flags, CIGAR, positions, and aux tags — so
 /// a record-level corruption from mishandled input (dropped or garbled bytes)
 /// fails here, not just a count/name mismatch.
+///
+/// Asserts both sides are non-empty: two empty BAMs are trivially equal, so a
+/// regression that made the command emit nothing on *both* inputs would otherwise
+/// pass every parity test in this file. Use [`compare_bam_records_allow_empty`]
+/// for the outputs that are legitimately empty (e.g. rejects with nothing rejected).
 fn compare_bam_records(path1: &PathBuf, path2: &PathBuf) {
+    let (records1, records2) = read_both_for_compare(path1, path2);
+    assert!(
+        !records1.is_empty(),
+        "{} is empty — parity against an empty baseline is vacuous",
+        path1.display()
+    );
+    assert_records_equal(&records1, &records2);
+}
+
+/// [`compare_bam_records`] without the non-empty guard, for outputs whose empty
+/// case is a legitimate result rather than a regression.
+fn compare_bam_records_allow_empty(path1: &PathBuf, path2: &PathBuf) {
+    let (records1, records2) = read_both_for_compare(path1, path2);
+    assert_records_equal(&records1, &records2);
+}
+
+/// Decodes both BAMs to eager `RecordBuf`s for comparison.
+fn read_both_for_compare(
+    path1: &PathBuf,
+    path2: &PathBuf,
+) -> (Vec<noodles::sam::alignment::RecordBuf>, Vec<noodles::sam::alignment::RecordBuf>) {
     use noodles::sam::alignment::RecordBuf;
 
     let mut reader1 =
@@ -899,6 +967,14 @@ fn compare_bam_records(path1: &PathBuf, path2: &PathBuf) {
     let records2: Vec<RecordBuf> =
         reader2.record_bufs(&header2).map(|r| r.expect("Failed to read record 2")).collect();
 
+    (records1, records2)
+}
+
+/// Asserts full record-level identity between two decoded BAMs.
+fn assert_records_equal(
+    records1: &[noodles::sam::alignment::RecordBuf],
+    records2: &[noodles::sam::alignment::RecordBuf],
+) {
     assert_eq!(records1.len(), records2.len(), "BAM files have different record counts");
 
     for (i, (r1, r2)) in records1.iter().zip(records2.iter()).enumerate() {
@@ -938,24 +1014,28 @@ fn create_grouped_test_bam(path: &PathBuf) {
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
     writer.write_header(&header).expect("Failed to write header");
 
-    // Create grouped reads with MI tag
+    // Create grouped reads with MI tag.
+    //
+    // MI must be written as a *string* (`MI:Z:1`), the way `fgumi group` and fgbio emit it —
+    // the tag can carry a strand suffix (`1/A`), so the consumers parse it as text. An integer
+    // `MI:i:1` is silently ignored by the consensus callers (no consensus read, no rejection,
+    // no warning), which previously made every simplex parity test below compare one empty
+    // BAM against another.
     let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
     let records = create_umi_family("AAAAAAAA", 5, "mol1", "ACGTACGT", 30);
 
     // Add MI tag to each record (convert to RecordBuf first to enable tag mutation)
-    let mi_value = 1;
     for raw in &records {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value));
+        rec.data_mut().insert(mi_tag, Value::from("1"));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 
     // Second family with different MI
-    let mi_value2 = 2;
     let records2 = create_umi_family("CCCCCCCC", 3, "mol2", "TGCATGCA", 30);
     for raw in &records2 {
         let mut rec = to_record_buf(raw);
-        rec.data_mut().insert(mi_tag, Value::from(mi_value2));
+        rec.data_mut().insert(mi_tag, Value::from("2"));
         writer.write_alignment_record(&header, &rec).expect("Failed to write record");
     }
 


### PR DESCRIPTION
## What

`group` was the **only** command with two orchestrations of the same stage: a bespoke `execute_single_threaded` streaming driver (taken when `--threads` is unset) and the typed-step chain via `build_for` (taken for `--threads N`, including `--threads 1`). Every other multi-threaded command already routes solely through `build_for` — group's inline fast path was vestigial scaffolding left behind by the issue #330 migration, kept in lockstep with the chain by hand. That two-path split was the structural root of the single-threaded-vs-chain divergences the audit found (V3/V4: metrics + help drift, #536).

Second-wave item **B1** (`findings/15`, finding 3), the one deferred from #545.

## How it's safe

`ThreadingOptions::num_threads()` maps `None → 1`, so routing the unset case through `build_for` yields a **one-worker chain that degrades to the sequential assigner** — output-identical to `--threads 1` (which already routed through the chain). Deleted the `threads.is_none()` branch and `execute_single_threaded` + its exclusive helpers (`process_and_write_position_group`, `write_all_metrics`); `execute` now always builds the `ChainSpec`. **Net −308 lines**, one fewer path to keep in sync.

## `--threads` unset now behaves identically to `--threads 1`

That's the whole point. The one place they previously diverged was **SAM input**: the chain (`--threads 1`) already accepted SAM via `ReadSamChunks`/`ParseSamChunk`, while the bespoke unset path was BAM-only and bailed `"SAM input requires --threads N"`. That divergence was a symptom of the two-orchestration problem, not a contract — unifying onto the chain removes the inconsistent restriction, so unset now accepts SAM too. Nothing that previously worked changes; an error case simply starts succeeding to match `--threads 1`. Output, MI numbering, metrics, and logging are otherwise unchanged.

## Tests (TDD)

- **`group_no_threads_matches_threads_1`** — pins that `--threads` unset produces byte-identical grouping (record order + `MI:Z` tags) to `--threads 1`. **It passed on the pre-refactor code**, proving the two paths already agreed for BAM, so the deletion is behavior-preserving (this was the parity gate before touching the source).
- **`test_group_sam_input_without_threads_now_accepted`** — unset + SAM now matches the BAM run (the chain already accepted SAM at `--threads 1`).

Stale "single-threaded fast path" comments corrected across `group.rs`, `common.rs`, the chain's `build_group_chain`, and the determinism test.

`cargo ci-test` 2335 passed / 8 skipped; `cargo ci-lint` clean.

## Stacking

Stacked on #545 (B2). Base `nh/audit-b2-validation-dedup`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified `fgumi group` execution across all thread configurations for consistent results, including when `--threads` is omitted.
  * Improved SAM input compatibility and parity checks against BAM when `--threads` is omitted.
  * Enhanced MI-based grouping to classify skipped records (no MI vs non-string MI), emit end-of-stream reporting, and avoid silent drops.
* **Tests**
  * Added determinism regression verifying `--threads` omitted matches `--threads 1`.
  * Expanded streaming input parity and added MI parsing/skip edge-case coverage.
* **Documentation**
  * Clarified how `--threads` routing differs between omitted/`None` and `--threads 1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->