### PR TITLE
feat(compare): clip preset + review-.txt comparison lane (W8a: CMP3-01/02/03)

### DIFF
--- a/docs/compare-cli.md
+++ b/docs/compare-cli.md
@@ -68,7 +68,7 @@ which routes to the dedicated sort-verify engine and *rejects* both options
 (passing either alongside it is an error).
 
 Presets: `extract`, `zipper`, `sort`, `correct`, `dedup`, `group`, `simplex`, `duplex`,
-`codec`, `filter`. See [Recommended Settings by Command](#recommended-settings-by-command)
+`codec`, `filter`, `clip`. See [Recommended Settings by Command](#recommended-settings-by-command)
 below for what each resolves to.
 
 ```bash
@@ -102,8 +102,8 @@ default `content` mode, so no flags are needed.
 | `simplex` | ✅ `--command simplex` | content | false | Exact content comparison (compares the `cD`/`cM`/`cE` depth tags exactly; fgumi clamps them to fgbio's `Short` ceiling at the source, so no saturation carve-out is needed) |
 | `duplex` | ✅ `--command duplex` | content | false | Exact content comparison (compares `cD`/`cM`/`cE` plus duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE` exactly) |
 | `codec` | ✅ `--command codec` | content | false | Exact content comparison, same as `simplex`/`duplex` |
-| `filter` | ✅ `--command filter` | content | false | Passes through MI/depth tags unchanged; uses the same exact content comparison as consensus output |
-| `clip` | ❌ no preset (default `content` mode) | content | false | Does not modify MI tags |
+| `filter` | ✅ `--command filter` | content | false | Drops failing reads and masks failing bases (rewriting SEQ/QUAL on the reads it keeps), but passes the MI/depth tags through unchanged; uses the same exact content comparison as consensus output, so a masking divergence is caught as a SEQ/QUAL difference |
+| `clip` | ✅ `--command clip` | content | false | Post-consensus reads with overlapping/read-end clipping applied. Clipping rewrites CIGAR/SEQ/QUAL in the clipped span and, as a consequence, regenerates the alignment tags (`NM`/`UQ`/`MD`) and repairs mate-pair metadata; only the MI/depth tags pass through unchanged. Uses the same exact content comparison as `filter`/consensus output, which checks the regenerated alignment tags and repaired mate fields as well as SEQ/QUAL/CIGAR — sound because fgumi and fgbio clip regenerate them identically, so clipping-correctness diffs are caught |
 | `downsample` | ❌ no preset (default `content` mode) | content | false | Deterministic with seed |
 | `review` | ❌ no preset (default `content` mode) | content | false | Preserves MI tags |
 
@@ -235,6 +235,12 @@ fgumi compare metrics file1.txt file2.txt --rel-tol 1e-6 --abs-tol 1e-9
 
 # Multi-column key, e.g. duplex_family_sizes keyed on (ab_size, ba_size)
 fgumi compare metrics file1.txt file2.txt --key-columns ab_size,ba_size
+
+# Compare a `review` command's <output>.txt (a headered TSV, one
+# variant-site x consensus-read row per line): join on the site+read key so
+# row-order differences are tolerated and a per-read consensus base/quality
+# divergence is localized to the offending variant/read
+fgumi compare metrics review1.txt review2.txt --key-columns chrom,pos,consensus_read
 
 # Quiet mode for CI
 fgumi compare metrics fgumi_metrics.txt fgbio_metrics.txt --quiet

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -106,13 +106,25 @@ pub enum CommandPreset {
     /// CODEC consensus output: positional, exact content comparison
     /// (see [`ContentPredicate::Exact`]).
     Codec,
-    /// Filter output: consensus reads with reads dropped, but the same depth tags
-    /// (`cD`/`cM`/`cE`, and duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) as the consensus command
-    /// that produced them, passed through unchanged. Compares via the same predicate as
-    /// consensus output
+    /// Filter output: consensus reads with failing reads dropped and failing bases masked —
+    /// masking rewrites `SEQ` (base → `N`) and `QUAL` (→ the minimum Phred) in place, and
+    /// per-base tags may be reoriented under `--reverse-per-base-tags` (see
+    /// `commands::filter`) — but the depth tags (`cD`/`cM`/`cE`, and duplex
+    /// `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) written by the consensus command are never recomputed.
+    /// Compares via the same predicate as consensus output
     /// ([`ContentPredicate::Exact`]);
     /// see `CommandPreset::resolve` for the full rationale.
     Filter,
+    /// Clip output: post-consensus reads with overlapping/read-end clipping applied. Clipping
+    /// rewrites CIGAR/SEQ/QUAL in the clipped span and, as a consequence, regenerates the
+    /// alignment tags (`NM`/`UQ`/`MD`) and repairs mate-pair metadata (see `commands::clip`);
+    /// the depth tags (`cD`/`cM`/`cE`, and duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) written by the
+    /// consensus command, and the `MI` tag, are passed through unchanged. Compares via the same
+    /// exact predicate as consensus and `filter` output
+    /// ([`ContentPredicate::Exact`]), which checks the regenerated alignment tags and repaired
+    /// mate fields as well as the passed-through `MI`/depth tags;
+    /// see `CommandPreset::resolve` for the full rationale.
+    Clip,
 }
 
 impl CommandPreset {
@@ -131,15 +143,24 @@ impl CommandPreset {
     ///   [`super::engines::sort_verify::sort_verify_compare`] instead, which has no notion of
     ///   `CompareMode`/`ContentPredicate` at all. This arm exists only so the match stays
     ///   exhaustive without a wildcard.)
-    /// - `Filter | Simplex | Duplex | Codec` → `(Content, false, Exact)`: all four
+    /// - `Filter | Clip | Simplex | Duplex | Codec` → `(Content, false, Exact)`: all five
     ///   deal in consensus reads carrying the depth tags (`cD`/`cM`/`cE`, and duplex
     ///   `aD`/`aM`/`bD`/`bM`/`aE`/`bE`). `Simplex`/`Duplex`/`Codec` are the commands that
-    ///   write those tags; `filter` only drops reads afterward, it never rewrites them. All
-    ///   four compare positionally under
+    ///   write those tags; `filter` both drops failing reads and rewrites the reads it keeps
+    ///   (base-level masking sets failing bases to `N` and their qualities to the minimum
+    ///   Phred, and per-base tags may be reoriented under `--reverse-per-base-tags`), and
+    ///   `clip` rewrites CIGAR/SEQ/QUAL in the clipped span and, as a consequence, regenerates
+    ///   the alignment tags (`NM`/`UQ`/`MD`) and repairs mate-pair metadata — but neither ever
+    ///   recomputes the depth-tag values. All five compare positionally under
     ///   [`ContentPredicate::Exact`](super::engines::content::ContentPredicate::Exact):
     ///   because fgumi clamps the depth tags to fgbio's `Short` ceiling at the source, the
     ///   tags are bit-identical and an exact comparison is both sound and complete — no
-    ///   consensus-specific predicate is needed.
+    ///   consensus-specific predicate is needed. Since `Exact` holds every core SAM field
+    ///   (SEQ/QUAL/CIGAR) plus the regenerated alignment tags and repaired mate fields exact,
+    ///   `clip`'s clipping-correctness cluster (CLIP3-01/02/03) is still caught — sound because
+    ///   fgumi and fgbio clip regenerate `NM`/`UQ`/`MD` and mate info identically — and so is
+    ///   any `filter` masking divergence, since a masked base/quality is itself a SEQ/QUAL
+    ///   difference.
     /// - `Group` → `(Grouping, true, ExactMinusMi)`: MI values and molecule order may
     ///   legitimately differ between tools or runs, so `Group` is the only preset that
     ///   verifies grouping equivalence instead of routing to `execute_content`. It compares
@@ -159,7 +180,7 @@ impl CommandPreset {
             Self::Extract | Self::Zipper | Self::Sort | Self::Correct | Self::Dedup => {
                 (CompareMode::Content, false, ContentPredicate::Exact)
             }
-            Self::Filter | Self::Simplex | Self::Duplex | Self::Codec => {
+            Self::Filter | Self::Clip | Self::Simplex | Self::Duplex | Self::Codec => {
                 (CompareMode::Content, false, ContentPredicate::Exact)
             }
             Self::Group => (CompareMode::Grouping, true, ContentPredicate::ExactMinusMi),
@@ -240,6 +261,7 @@ COMMAND PRESETS (--command):
   sort            (dedicated sort-verify engine; --mode/--ignore-order rejected)
   correct         content     false            Modifies RX tag only, not MI
   dedup           content     false            Deterministic
+  clip            content     false            Post-consensus; passes MI/depth tags through unchanged; exact (like filter)
   filter          content     false            Passes through MI/depth tags unchanged; exact (like consensus)
   group           grouping    true             Molecule-join: EXACT-MI content + membership/strand (cross-tool)
   simplex         content     false            Exact (cD/cM/cE compared exactly; clamped at source)
@@ -290,7 +312,7 @@ pub struct CompareBams {
     pub command: Option<CommandPreset>,
 
     /// Comparison mode: 'content' (all fields and tags, order-sound positional
-    /// pairing — for extract/zipper/correct/dedup/simplex/duplex/codec/filter
+    /// pairing — for extract/zipper/correct/dedup/clip/simplex/duplex/codec/filter
     /// output), or 'grouping' (MI equivalence via the streaming molecule-join
     /// engine — for group output; requires grouped, same-MI-consecutive input).
     /// Overrides `--command` preset if both given. Defaults to 'content' when
@@ -996,6 +1018,7 @@ mod tests {
     #[case(CommandPreset::Correct)]
     #[case(CommandPreset::Dedup)]
     #[case(CommandPreset::Filter)]
+    #[case(CommandPreset::Clip)]
     fn preset_defaults_content_stages_map_to_content_no_ignore_order(#[case] stage: CommandPreset) {
         let (mode, ignore) = stage.defaults();
         assert!(matches!(mode, CompareMode::Content), "{stage:?} → {mode:?}");
@@ -1034,12 +1057,28 @@ mod tests {
 
     /// `filter` output is consensus reads that still carry the depth tags (`cD`/`cM`/`cE`,
     /// and duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) as the consensus command that produced them
-    /// -- `filter` only drops reads, it never rewrites these tags. So `Filter` routes through
+    /// -- `filter` drops failing reads and masks failing bases (rewriting SEQ/QUAL on the reads
+    /// it keeps), but it never recomputes these tags. So `Filter` routes through
     /// the same `Exact` predicate as `Simplex`/`Duplex`/`Codec`, keeping the four consensus
     /// commands on one predicate.
     #[test]
     fn filter_preset_content_predicate_is_exact() {
         assert_eq!(CommandPreset::Filter.content_predicate(), ContentPredicate::Exact);
+    }
+
+    /// `clip` output is post-consensus reads that still carry the same depth tags
+    /// (`cD`/`cM`/`cE`, and duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) as the consensus command
+    /// that produced them -- clip rewrites CIGAR/SEQ/QUAL in the clipped span and, as a
+    /// consequence, regenerates the alignment tags (`NM`/`UQ`/`MD`) and repairs mate-pair
+    /// metadata, but never these depth tags. So `Clip`'s content predicate routes through the
+    /// same `Exact` predicate as `Filter`/`Simplex`/`Duplex`/`Codec`: because fgumi clamps the
+    /// depth tags to fgbio's `Short` ceiling at the source, they are bit-identical and an exact
+    /// comparison is both sound and complete. `Exact` holds SEQ/QUAL/CIGAR plus the regenerated
+    /// alignment tags and repaired mate fields exact, so the CLIP3-01/02/03
+    /// clipping-correctness cluster is caught.
+    #[test]
+    fn clip_preset_content_predicate_is_exact() {
+        assert_eq!(CommandPreset::Clip.content_predicate(), ContentPredicate::Exact);
     }
 
     #[test]

--- a/src/lib/commands/compare/metrics.rs
+++ b/src/lib/commands/compare/metrics.rs
@@ -80,11 +80,18 @@ By default the join key is the first column (works for metrics files keyed by
 `umi`, `family_size`, `fraction`, or `key`). Pass `--key-columns` for a
 multi-column key, e.g. `duplex_family_sizes`'s `ab_size,ba_size`.
 
+This is also the comparator for the `review` command's `<output>.txt` file: it
+is a headered TSV with one `<variant-site> x <consensus-read>` row per line, so
+join it on `chrom,pos,consensus_read` to tolerate row-order differences between
+two `review` runs while still catching a per-read consensus base/quality
+divergence, localized to the offending variant/read.
+
 Example usage:
   fgumi compare metrics file1.txt file2.txt
   fgumi compare metrics file1.txt file2.txt --precision 6
   fgumi compare metrics file1.txt file2.txt --rel-tol 1e-6 --abs-tol 1e-9
   fgumi compare metrics file1.txt file2.txt --key-columns ab_size,ba_size
+  fgumi compare metrics review1.txt review2.txt --key-columns chrom,pos,consensus_read
   fgumi compare metrics file1.txt file2.txt --quiet
 "#
 )]
@@ -171,6 +178,16 @@ fn parse_value(value: &str, precision: Option<u32>) -> ParsedValue {
     ParsedValue::String(value.to_string())
 }
 
+/// Whether `diff` falls inside the combined relative/absolute tolerance window for two values
+/// whose larger magnitude is `max_val`.
+///
+/// The single definition of the tolerance rule, shared by every numeric arm of
+/// [`values_equal`] (float/float, in-range int/float, out-of-`i64`-range int/float, and the
+/// float-space fallback) so the rule can only ever be changed in one place.
+fn within_tolerance(diff: f64, max_val: f64, rel_tol: f64, abs_tol: f64) -> bool {
+    diff <= (rel_tol * max_val).max(abs_tol)
+}
+
 /// Compare two values, using tolerance for floats.
 fn values_equal(val1: &ParsedValue, val2: &ParsedValue, rel_tol: f64, abs_tol: f64) -> bool {
     match (val1, val2) {
@@ -190,7 +207,7 @@ fn values_equal(val1: &ParsedValue, val2: &ParsedValue, rel_tol: f64, abs_tol: f
             }
             let diff = (f1 - f2).abs();
             let max_val = f1.abs().max(f2.abs());
-            diff <= (rel_tol * max_val).max(abs_tol)
+            within_tolerance(diff, max_val, rel_tol, abs_tol)
         }
         // Try to compare as floats if one is int and one is float
         (ParsedValue::Int(i), ParsedValue::Float(f))
@@ -216,25 +233,30 @@ fn values_equal(val1: &ParsedValue, val2: &ParsedValue, rel_tol: f64, abs_tol: f
                     let f2_int = f2 as i64;
                     let diff = i.abs_diff(f2_int) as f64;
                     let max_val = i.unsigned_abs().max(f2_int.unsigned_abs()) as f64;
-                    return diff <= (rel_tol * max_val).max(abs_tol);
+                    return within_tolerance(diff, max_val, rel_tol, abs_tol);
                 }
                 // `f2` is integral but `|f2| >= 2^63`, so no `i64` can equal it — the exact
                 // difference is at least 1. `i64::MAX as f64` rounds *up* to `2^63`, which is
-                // exactly the boundary float `9223372036854775808.0`; the float-space fallback
-                // below would then read `diff == 0` and manufacture a false MATCH in exact mode
-                // (`rel_tol == abs_tol == 0`). Short-circuit that here. Tolerance mode still falls
-                // through: at magnitude 2^63 the window dwarfs the 1-unit gap, so the fallback's
-                // answer is correct there.
-                if rel_tol == 0.0 && abs_tol == 0.0 {
-                    return false;
+                // exactly the boundary float `9223372036854775808.0`, so the float-space fallback
+                // `*i as f64 - f2` reads `diff == 0` and manufactures a false MATCH — not only in
+                // exact mode but under any `abs_tol`/`rel_tol` window narrower than the real gap
+                // (e.g. `abs_tol == 0.5 < 1`). Compute the distance exactly against the boundary in
+                // `i128` (an integral `f64` with `|f2| < 2^127` converts losslessly) and hold it to
+                // the same tolerance window, so every mode sees the true gap. Only `|f2| >= 2^127`
+                // still falls through to float space, where the diff is astronomically large and a
+                // ULP of `*i as f64` loss cannot flip any realistic tolerance decision.
+                if f2.abs() < (i128::MAX as f64) {
+                    let diff = (i128::from(*i) - f2 as i128).unsigned_abs() as f64;
+                    let max_val = (*i as f64).abs().max(f2.abs());
+                    return within_tolerance(diff, max_val, rel_tol, abs_tol);
                 }
             }
-            // Non-integral (or out-of-i64-range) float: compare in float space. Any 1-ULP loss
+            // Non-integral (or `|f2| >= 2^127`) float: compare in float space. Any 1-ULP loss
             // from `*i as f64` at magnitude >2^53 is swamped by the tolerance window there.
             let f1 = *i as f64;
             let diff = (f1 - f2).abs();
             let max_val = f1.abs().max(f2.abs());
-            diff <= (rel_tol * max_val).max(abs_tol)
+            within_tolerance(diff, max_val, rel_tol, abs_tol)
         }
         (ParsedValue::String(s1), ParsedValue::String(s2)) => s1 == s2,
         _ => false,
@@ -924,6 +946,12 @@ mod tests {
     // one apart — even though the naive `*i as f64` cast collapses them onto the same float.
     #[case::i64_max_boundary_exact(i64::MAX, "9223372036854775808.0", 0.0, 0.0, false)]
     #[case::i64_max_boundary_tolerated(i64::MAX, "9223372036854775808.0", 1e-9, 0.0, true)]
+    // A nonzero `abs_tol` smaller than the true 1-unit gap must still DIFFER: the distance is
+    // computed against the i64 boundary (exact `1`), not in the collapsed float space where
+    // `*i as f64 == 9223372036854775808.0` reads `0` and would falsely fall inside `abs_tol`.
+    #[case::i64_max_boundary_abs_tol_below_gap(i64::MAX, "9223372036854775808.0", 0.0, 0.5, false)]
+    // A nonzero `abs_tol` at or above the true 1-unit gap tolerates it, same as any other pair.
+    #[case::i64_max_boundary_abs_tol_covers_gap(i64::MAX, "9223372036854775808.0", 0.0, 1.0, true)]
     #[case::small_int_exact_match(5, "5.0", 0.0, 0.0, true)]
     #[case::small_int_exact_differ(5, "6.0", 0.0, 0.0, false)]
     fn mixed_int_float_preserves_large_integer_identity(

--- a/src/lib/variant_review.rs
+++ b/src/lib/variant_review.rs
@@ -66,6 +66,94 @@ pub struct ConsensusVariantReviewInfo {
     pub n: usize,
 }
 
+impl ConsensusVariantReviewInfo {
+    /// The tab-delimited column header for the review `.txt` output.
+    ///
+    /// Derived by csv-serializing an instance of this struct — the exact
+    /// mechanism the `review` command uses when it writes rows (see
+    /// `commands::review`), so the header always reflects this struct's serde
+    /// field order and `#[serde(rename = ...)]` attributes. This is the single
+    /// source of truth for the header; consumers (e.g. test fixtures that need a
+    /// faithful review header) should call it rather than hardcode the columns,
+    /// so they cannot silently drift when a field is added, removed, or renamed.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: serializing this fixed, fully-owned struct through an
+    /// in-memory `csv` writer cannot fail, and the resulting header bytes are
+    /// always valid UTF-8. The `expect`s guard those internal invariants only.
+    #[must_use]
+    pub fn tsv_header() -> String {
+        // Field values are irrelevant to the header row; use zero/empty values.
+        let sample = Self {
+            chrom: String::new(),
+            pos: 0,
+            ref_allele: String::new(),
+            genotype: String::new(),
+            filters: String::new(),
+            consensus_a: 0,
+            consensus_c: 0,
+            consensus_g: 0,
+            consensus_t: 0,
+            consensus_n: 0,
+            consensus_read: String::new(),
+            consensus_insert: String::new(),
+            consensus_call: '.',
+            consensus_qual: 0,
+            a: 0,
+            c: 0,
+            g: 0,
+            t: 0,
+            n: 0,
+        };
+        let mut writer = csv::WriterBuilder::new().delimiter(b'\t').from_writer(Vec::new());
+        writer.serialize(&sample).expect("serialize review header row");
+        let bytes = writer.into_inner().expect("flush review header writer");
+        let text = String::from_utf8(bytes).expect("review header is valid UTF-8");
+        // The default writer has `has_headers = true`, so `serialize` emits the
+        // header row *followed by* the sample's data row; take only the first line.
+        // (Header column names are constant identifiers and never embed a newline,
+        // so first-line truncation is safe here — unlike `to_tsv_row`, whose data
+        // fields can, which is why that companion strips only the trailing
+        // terminator.)
+        text.lines().next().expect("csv writer emits a header line").to_string()
+    }
+
+    /// This instance serialized as a single tab-delimited review-`.txt` data row
+    /// (no header, no trailing newline).
+    ///
+    /// The row companion to [`tsv_header`](Self::tsv_header): both drive the same
+    /// serde/`csv` serialization the `review` command uses (see
+    /// `commands::review`), so a header produced by `tsv_header()` and a row
+    /// produced here always agree on column order and `#[serde(rename = ...)]`
+    /// mapping — they cannot drift when a field is added, removed, renamed, or
+    /// reordered. Consumers (e.g. test fixtures that need faithful review rows)
+    /// should build a typed instance and call this rather than hand-assemble a
+    /// positional tab-joined string, so field values stay bound to named struct
+    /// fields and a reorder shifts the row in lockstep with the header instead of
+    /// silently misassigning columns.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: serializing this fully-owned struct through an
+    /// in-memory `csv` writer cannot fail, and the resulting bytes are always
+    /// valid UTF-8. The `expect`s guard those internal invariants only.
+    #[must_use]
+    pub fn to_tsv_row(&self) -> String {
+        let mut writer =
+            csv::WriterBuilder::new().delimiter(b'\t').has_headers(false).from_writer(Vec::new());
+        writer.serialize(self).expect("serialize review row");
+        let bytes = writer.into_inner().expect("flush review row writer");
+        let text = String::from_utf8(bytes).expect("review row is valid UTF-8");
+        // Strip only the trailing record terminator (`csv` writes a single `\n`),
+        // not everything after the first embedded newline. `lines().next()` would
+        // truncate a field whose serialized value contains a `\n` (the `csv` writer
+        // quotes such a field, keeping the row well-formed), silently dropping the
+        // remaining columns; stripping the suffix preserves the embedded newline.
+        text.strip_suffix('\n').expect("csv writer emits a row terminator").to_string()
+    }
+}
+
 /// Represents a variant position
 #[derive(Debug, Clone)]
 pub struct Variant {
@@ -241,6 +329,85 @@ mod tests {
     #[case::first_of_pair_or_unpaired(false, "/1")]
     fn test_read_number_suffix(#[case] is_second_of_pair: bool, #[case] expected: &str) {
         assert_eq!(read_number_suffix(is_second_of_pair), expected);
+    }
+
+    /// A representative review record for the header/row serialization tests.
+    fn sample_review_info() -> ConsensusVariantReviewInfo {
+        ConsensusVariantReviewInfo {
+            chrom: "chr1".to_string(),
+            pos: 100,
+            ref_allele: "A".to_string(),
+            genotype: "0/1".to_string(),
+            filters: "PASS".to_string(),
+            consensus_a: 3,
+            consensus_c: 0,
+            consensus_g: 1,
+            consensus_t: 0,
+            consensus_n: 0,
+            consensus_read: "readX".to_string(),
+            consensus_insert: "chr1:100-200 | F1R2".to_string(),
+            consensus_call: 'A',
+            consensus_qual: 40,
+            a: 5,
+            c: 0,
+            g: 2,
+            t: 0,
+            n: 0,
+        }
+    }
+
+    #[test]
+    fn test_tsv_header_reflects_serde_field_order_and_renames() {
+        // `#[serde(rename = ...)]` maps the count fields to bare base letters; the
+        // rest use their field names verbatim, in declaration order.
+        assert_eq!(
+            ConsensusVariantReviewInfo::tsv_header(),
+            "chrom\tpos\tref\tgenotype\tfilters\tA\tC\tG\tT\tN\t\
+             consensus_read\tconsensus_insert\tconsensus_call\tconsensus_qual\ta\tc\tg\tt\tn",
+        );
+    }
+
+    #[test]
+    fn test_to_tsv_row_serializes_values_in_header_order() {
+        assert_eq!(
+            sample_review_info().to_tsv_row(),
+            "chr1\t100\tA\t0/1\tPASS\t3\t0\t1\t0\t0\t\
+             readX\tchr1:100-200 | F1R2\tA\t40\t5\t0\t2\t0\t0",
+        );
+    }
+
+    #[test]
+    fn test_to_tsv_row_preserves_embedded_newline_in_field() {
+        // A field whose serialized value contains a newline is quoted by the `csv`
+        // writer, keeping the row well-formed. `to_tsv_row` must strip only the
+        // trailing record terminator, preserving the embedded newline — the old
+        // `lines().next()` truncated the row at the first internal `\n`, dropping
+        // every column after it.
+        let mut info = sample_review_info();
+        info.consensus_read = "read\nY".to_string();
+
+        let row = info.to_tsv_row();
+
+        // The embedded newline survives inside the quoted field, every trailing
+        // column is still present (not truncated at the `\n`), and the trailing
+        // record terminator is excluded.
+        assert_eq!(
+            row,
+            "chr1\t100\tA\t0/1\tPASS\t3\t0\t1\t0\t0\t\
+             \"read\nY\"\tchr1:100-200 | F1R2\tA\t40\t5\t0\t2\t0\t0",
+        );
+        assert!(row.contains("\"read\nY\""), "embedded newline dropped: {row:?}");
+        assert!(!row.ends_with('\n'), "trailing terminator not stripped: {row:?}");
+    }
+
+    #[test]
+    fn test_header_and_row_have_matching_column_counts() {
+        // The header/row pair is the review-`.txt` contract; a field added to one
+        // but not reflected by the other would desynchronize the output. Both are
+        // struct-derived, so their column counts must always agree.
+        let header_cols = ConsensusVariantReviewInfo::tsv_header().split('\t').count();
+        let row_cols = sample_review_info().to_tsv_row().split('\t').count();
+        assert_eq!(header_cols, row_cols);
     }
 
     #[test]

--- a/tests/integration/test_compare_metrics_command.rs
+++ b/tests/integration/test_compare_metrics_command.rs
@@ -9,6 +9,8 @@
 use clap::Parser;
 use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_lib::commands::compare::{CompareMetrics, CompareMismatch};
+use fgumi_lib::variant_review::ConsensusVariantReviewInfo;
+use proptest::prelude::*;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -173,4 +175,208 @@ fn localized_differ_names_the_offending_key() {
     let (code, stdout, _stderr) = run_compare_subprocess(&f1, &f2, &[]);
     assert_eq!(code, Some(1), "a clean DIFFER must exit exactly 1: {stdout}");
     assert!(stdout.contains("3 only in file1"), "stdout was: {stdout}");
+}
+
+// ---------------------------------------------------------------------------
+// CMP3-02 (BS2): `compare metrics` is the review-`.txt` comparator.
+//
+// The `review` command writes its `<output>.txt` as a headered TSV (serde/csv
+// serialize of `ConsensusVariantReviewInfo`), so the generic row key-join
+// comparator handles it directly — one `<variant-site> × <consensus-read>` row
+// per line, joined on `chrom,pos,consensus_read`. These two tests pin that the
+// review file's own failure modes are visible to the oracle: row order between
+// two `review` runs must be tolerated, and a per-read consensus base/quality
+// divergence (the class the whole `review` command's parity findings live in)
+// must DIFFER and be localized to the offending variant/read key.
+// ---------------------------------------------------------------------------
+
+/// A minimal `review`-`.txt` fixture: the real column header emitted by
+/// `ConsensusVariantReviewInfo` (derived from the struct itself via
+/// `tsv_header()`, so it can't drift if a field is added/renamed), followed by
+/// the given data rows (each a full tab-joined line without its trailing
+/// newline).
+fn review_txt(rows: &[&str]) -> String {
+    let mut out = ConsensusVariantReviewInfo::tsv_header();
+    for row in rows {
+        out.push('\n');
+        out.push_str(row);
+    }
+    out.push('\n');
+    out
+}
+
+/// A baseline `ConsensusVariantReviewInfo` for the review-`.txt` fixtures.
+///
+/// Each fixture starts from this and mutates only the fields it cares about via
+/// [`review_row`], so every value stays bound to a *named* struct field. A
+/// reorder of two same-typed fields (e.g. two `String`s) is then a compiler- and
+/// header-visible change — the row moves in lockstep with the struct-derived
+/// header — rather than a silent positional misassignment in a hand-typed
+/// tab-joined literal.
+fn baseline_review_info() -> ConsensusVariantReviewInfo {
+    ConsensusVariantReviewInfo {
+        chrom: "chr1".to_string(),
+        pos: 100,
+        ref_allele: "A".to_string(),
+        genotype: "0/1".to_string(),
+        filters: "PASS".to_string(),
+        consensus_a: 3,
+        consensus_c: 0,
+        consensus_g: 1,
+        consensus_t: 0,
+        consensus_n: 0,
+        consensus_read: "read".to_string(),
+        consensus_insert: "chr1:100-200 | F1R2".to_string(),
+        consensus_call: 'A',
+        consensus_qual: 40,
+        a: 5,
+        c: 0,
+        g: 2,
+        t: 0,
+        n: 0,
+    }
+}
+
+/// Build one review-`.txt` row from the baseline, applying `overrides`, and
+/// serialize it through `ConsensusVariantReviewInfo::to_tsv_row()` — the same
+/// serde/csv mechanism as the struct-derived header — so the row can never drift
+/// from the header's column order.
+fn review_row(overrides: impl FnOnce(&mut ConsensusVariantReviewInfo)) -> String {
+    let mut info = baseline_review_info();
+    overrides(&mut info);
+    info.to_tsv_row()
+}
+
+/// Build `n` review rows with pairwise-distinct join keys
+/// (`chrom,pos,consensus_read`), so any reordering of the set is unambiguously a
+/// pure permutation of identical content.
+fn distinct_review_rows(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            review_row(|info| {
+                info.chrom = format!("chr{i}");
+                info.pos = 100 + i32::try_from(i).expect("row index fits i32");
+                info.consensus_read = format!("read{i}");
+                info.consensus_insert = format!("chr{i}:100-200 | F1R2");
+            })
+        })
+        .collect()
+}
+
+/// `readX` — the baseline row, distinguished only by its read name.
+fn review_row_x() -> String {
+    review_row(|info| info.consensus_read = "readX".to_string())
+}
+
+/// The `readY`-specific fields shared by both the reference and the diverged
+/// `readY` row *except* its consensus base call and quality. Both rows derive
+/// from this, so the `consensus_call`/`consensus_qual` transition is guaranteed
+/// to be their *only* difference — a later edit to readY's key/insert/raw counts
+/// can't silently turn the divergence test into a multi-column diff.
+fn apply_read_y_context(info: &mut ConsensusVariantReviewInfo) {
+    info.consensus_read = "readY".to_string();
+    info.consensus_insert = "chr1:100-200 | F2R1".to_string();
+    info.a = 0;
+    info.g = 0;
+    info.t = 4;
+}
+
+/// `readY` — same variant site as `readX`, a distinct read on the F2R1 insert
+/// calling `G@38`.
+fn review_row_y() -> String {
+    review_row(|info| {
+        apply_read_y_context(info);
+        info.consensus_call = 'G';
+        info.consensus_qual = 38;
+    })
+}
+
+/// `readZ` — a different variant site (`chr2:250`, ref `C`).
+fn review_row_z() -> String {
+    review_row(|info| {
+        info.chrom = "chr2".to_string();
+        info.pos = 250;
+        info.ref_allele = "C".to_string();
+        info.genotype = "1/1".to_string();
+        info.consensus_a = 0;
+        info.consensus_c = 2;
+        info.consensus_g = 0;
+        info.consensus_t = 1;
+        info.consensus_read = "readZ".to_string();
+        info.consensus_insert = "chr2:250-350 | F1R2".to_string();
+        info.consensus_call = 'C';
+        info.consensus_qual = 42;
+        info.a = 0;
+        info.c = 3;
+        info.g = 0;
+        info.t = 1;
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Row order between two `review` runs is tolerated for ANY permutation, not
+    /// just one hand-picked shuffle: two runs may legitimately emit identical
+    /// rows in different order, and `compare metrics`' key-join on
+    /// `chrom,pos,consensus_read` exists to tolerate exactly that. Generalizes
+    /// the former single fixed shuffle to a property over a generated N-row set
+    /// and an arbitrary permutation. (Coding guidelines: use proptest for
+    /// property-based testing.)
+    #[test]
+    fn review_txt_row_order_is_tolerated(
+        perm in (1usize..8).prop_flat_map(|n| Just((0..n).collect::<Vec<usize>>()).prop_shuffle())
+    ) {
+        let rows = distinct_review_rows(perm.len());
+        let canonical: Vec<&str> = rows.iter().map(String::as_str).collect();
+        let shuffled: Vec<&str> = perm.iter().map(|&i| rows[i].as_str()).collect();
+
+        let dir = TempDir::new().expect("tempdir");
+        let f1 = write_tsv(dir.path(), "a.txt", &review_txt(&canonical));
+        let f2 = write_tsv(dir.path(), "b.txt", &review_txt(&shuffled));
+        prop_assert!(
+            run_compare_in_process(&f1, &f2, &["--key-columns", "chrom,pos,consensus_read"]),
+            "reordered review rows with identical content must MATCH (perm={perm:?})"
+        );
+    }
+}
+
+#[test]
+fn review_txt_consensus_call_and_qual_divergence_differs_and_is_localized() {
+    let dir = TempDir::new().expect("tempdir");
+    let (row_x, row_y, row_z) = (review_row_x(), review_row_y(), review_row_z());
+    let f1 = write_tsv(
+        dir.path(),
+        "a.txt",
+        &review_txt(&[row_x.as_str(), row_y.as_str(), row_z.as_str()]),
+    );
+    // readY's consensus base G→T and quality 38→20 — the per-read consensus
+    // divergence class the `review` command's parity findings live in. Shares
+    // `apply_read_y_context` with `review_row_y` so call+qual are the ONLY diff.
+    let row_y_diff = review_row(|info| {
+        apply_read_y_context(info);
+        info.consensus_call = 'T';
+        info.consensus_qual = 20;
+    });
+    let f2 = write_tsv(
+        dir.path(),
+        "b.txt",
+        &review_txt(&[row_x.as_str(), row_y_diff.as_str(), row_z.as_str()]),
+    );
+    let (code, stdout, _stderr) =
+        run_compare_subprocess(&f1, &f2, &["--key-columns", "chrom,pos,consensus_read"]);
+    assert_eq!(code, Some(1), "a consensus base/qual divergence must exit non-zero (DIFFER)");
+    assert!(stdout.contains("RESULT: metrics files DIFFER"), "stdout was: {stdout}");
+    // Localized to the offending variant-site × read key (chr1:100, readY)...
+    assert!(stdout.contains("chr1"), "diff must name the offending contig: {stdout}");
+    assert!(stdout.contains("100"), "diff must name the offending position: {stdout}");
+    assert!(stdout.contains("readY"), "diff must name the offending read: {stdout}");
+    // ...naming both changed columns and their exact value transitions.
+    assert!(stdout.contains("consensus_call"), "diff must name the call column: {stdout}");
+    assert!(stdout.contains(r#""G" != "T""#), "diff must show the base transition: {stdout}");
+    assert!(stdout.contains("consensus_qual"), "diff must name the qual column: {stdout}");
+    assert!(stdout.contains(r#""38" != "20""#), "diff must show the qual transition: {stdout}");
+    // The unchanged readX/readZ rows must NOT be reported (no cascade).
+    assert!(!stdout.contains("readX"), "unchanged rows must not appear: {stdout}");
+    assert!(!stdout.contains("readZ"), "unchanged rows must not appear: {stdout}");
 }


### PR DESCRIPTION
## What / why

W8a of the final-audit burn-down — the **compare** half of the compare/runall test-infrastructure workstream (BS1–BS3). Stacked on #530 (`nh/compare-hardening`), which auto-retargets to `main` when #530 merges.

The three CMP3 findings were written against the **pre-#530** compare snapshot. Re-verifying each against the branch #530 actually delivers (§0 step 1):

- **CMP3-01 (BS1 — consensus content lane): already closed by #530, no code here.** The audit's complaint was that `simplex`/`duplex`/`codec` routed to `Grouping` mode (name+flag+MI only, consensus base/qual invisible). #530 reroutes them (and `filter`) to positional `Content` comparison under the saturation-aware `ExactConsensus` predicate; the mutation harness (`test_compare_mutation.rs` §2) already proves that lane catches SEQ/QUAL and a non-saturated depth diff while tolerating the accepted depth saturation. Documented as done in the burn-down tracker.

- **CMP3-03 (BS3 — no clip preset): the one genuine code gap.** Adds a `Clip` `CommandPreset` resolving to `(Content, false, ExactConsensus)`, grouped with `Filter`. Clip is post-consensus and passes the saturated depth tags (`cD`/`cM`/`cE`, duplex `aD`/`aM`/`bD`/`bM`/`aE`/`bE`) through unchanged — same carve-out as `filter`/consensus — while `ExactConsensus` still holds every core SAM field (SEQ/QUAL/CIGAR) exact, so the CLIP3-01/02/03 clipping-correctness cluster is caught. (`dedup↔group cross-tool` / dedup-has-no-fgbio-baseline is a benchmarks-repo handoff, not fgumi — see the compare-hardening tracker.)

- **CMP3-02 (BS2 — review-`.txt` comparator): serviceable via #530's generic `compare metrics`.** The `review` command writes `<output>.txt` as a headered TSV (serde/csv serialize of `ConsensusVariantReviewInfo`), so #530's generic row key-join comparator handles it directly with `--key-columns chrom,pos,consensus_read` — tolerating row-order differences between two `review` runs while localizing a per-read consensus base/quality divergence. Locked with two integration tests (order tolerated; call+qual divergence differs and is localized to `chr1:100,readY` with exact `"G" != "T"`/`"38" != "20"` transitions, no cascade onto unchanged rows) and documented in `compare metrics --help` + `docs/compare-cli.md`.

## Verification

- Real-tool repro (§0 step 2/4): `fgumi compare metrics --key-columns chrom,pos,consensus_read` on hand-built review-`.txt` fixtures — reordered-same-content → MATCH (exit 0); readY call/qual flipped → DIFFER (exit 1), localized to `row (chr1, 100, readY)` naming both columns.
- RED-first TDD for the `Clip` preset: variant routed to the wrong (`Exact`) arm first → `clip_preset_content_predicate_is_exact_consensus` fails `Exact` vs `ExactConsensus` → moved to the correct arm → green.
- `cargo ci-fmt && cargo ci-lint && cargo ci-test` (`--features compare,simulate,profile-adjacency`) all green (2453 tests).

## Reviewers

Both ran. In-diff fixes folded by amend: the stale `--mode grouping` help line (a #530 residual on the doc block this PR edits — both reviewers flagged it; corrected so `simplex/duplex/codec` sit under `content` and `grouping` is described as cross-tool group output) and strengthened the divergence test to pin the exact value transitions. One CodeRabbit-CLI finding skipped with reason: adding an independent parse-and-compare oracle to the two review-`.txt` tests — the tests already form a MATCH/DIFFER pair, the key-join engine is unit-tested in `metrics.rs`, and re-implementing key-join in the test would mirror the implementation (inconsistent with the sibling `compare metrics` integration tests, which likewise assert on the production verdict).

## Not in this PR

RUN3-01/02 (the runall half of W8) live in `runall.rs` / `test_runall_parity.rs`, which exist only on `feat-runall` — a different base — so they ship separately as **W8b** on `feat-runall` (§0.0 split, recorded in the burn-down tracker).

Merge order: after #530.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `clip` preset for BAM comparisons, including post-consensus clipping behavior and exact-content comparison.
  * Enhanced `compare metrics` to support `review <output>.txt` headered TSVs via `--key-columns chrom,pos,consensus_read`, tolerating row reordering while isolating per-key consensus base/quality differences.
* **Bug Fixes**
  * Improved tolerance handling for i64-vs-float boundary comparisons to prevent incorrect matches.
* **Documentation**
  * Updated CLI docs/help with `clip` preset details and `review` comparison usage/behavior.
* **Tests**
  * Added unit/integration coverage for `clip`, TSV formatting contracts, and order-independent, localized `review` diffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->