### PR TITLE
test(runall): de-vacuum codec fusion parity fixtures + fix byte-identical docs (RUN3-01/02)

### DIFF
--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -34,11 +34,19 @@
 //!
 //! Goals:
 //!
-//!   * **Parity**: byte-for-byte equal to running standalone
-//!     `fgumi sort` (when `--start-from sort`) then `fgumi group`
-//!     then `fgumi {simplex,duplex,codec}` on the same input.
-//!     Differences in MI numbering would break parity so MI
-//!     assignment uses the exact same cumulative counter as group.
+//!   * **Parity**: the record stream and the `@HD`/`@SQ`/`@RG`
+//!     header are identical to running standalone `fgumi sort`
+//!     (when `--start-from sort`) then `fgumi group` then
+//!     `fgumi {simplex,duplex,codec}` on the same input. The output
+//!     is NOT byte-for-byte identical: the fused chain writes a
+//!     single `@PG` record while the staged run writes one `@PG`
+//!     per command, so parity is defined over the records plus the
+//!     `@HD` (`SO`/`GO`/`SS`), `@SQ`, and `@RG` header records —
+//!     exactly what the parity oracle in
+//!     `tests/integration/helpers/parity.rs` checks (other non-`@PG`
+//!     records such as `@CO` are outside the contract). Differences in
+//!     MI numbering would break parity so MI assignment uses the
+//!     exact same cumulative counter as group.
 //!   * **No intermediate file**: data flows in memory between every
 //!     stage. The temp BAMs that a sequential run would produce are
 //!     elided.
@@ -134,8 +142,10 @@ pub enum RunAllStage {
     /// `--extract::inputs` and read structures via
     /// `--extract::read-structures`. `--start-from extract --stop-after
     /// extract` runs the extract-only chain and writes the unmapped BAM
-    /// (byte-identical to standalone `fgumi extract`). Otherwise Extract
-    /// feeds into Correct (when `--correct::umi-files` is set) or Align.
+    /// (record-identical to standalone `fgumi extract`, with matching `@HD`
+    /// `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG` provenance differs, and
+    /// `@HD` `VN` / `@CO` are not compared). Otherwise Extract feeds into
+    /// Correct (when `--correct::umi-files` is set) or Align.
     Extract,
     /// Correct UMIs in an unmapped BAM against a fixed whitelist of
     /// expected sequences. `--start-from correct` accepts an
@@ -177,14 +187,18 @@ pub enum RunAllStage {
     /// selected by `--consensus`, not by this stage. `--start-from
     /// consensus` accepts a grouped (MI-tagged) BAM; `--stop-after
     /// consensus` runs the chosen consensus caller and writes the
-    /// consensus BAM (byte-identical to `fgumi simplex` / `duplex` /
-    /// `codec`). `--stop-after filter` fuses consensus → filter into one
+    /// consensus BAM (record-identical to `fgumi simplex` / `duplex` / `codec`,
+    /// with matching `@HD` `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG`
+    /// provenance differs, and `@HD` `VN` / `@CO` are not compared).
+    /// `--stop-after filter` fuses consensus → filter into one
     /// in-memory pipeline (no intermediate consensus BAM).
     Consensus,
     /// Post-consensus filtering. `--start-from filter` accepts a
     /// consensus BAM (output of `fgumi simplex`/`duplex`/`codec`) via
     /// `--input`; `--stop-after filter` runs the filter stage and writes
-    /// the filtered BAM (byte-identical to standalone `fgumi filter`).
+    /// the filtered BAM (record-identical to standalone `fgumi filter`, with
+    /// matching `@HD` `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG`
+    /// provenance differs, and `@HD` `VN` / `@CO` are not compared).
     /// Tunable via `--filter::*`. Filter is the last stage in the linear
     /// order — no stage follows it. It runs either as the filter self-pair
     /// (`--start-from filter --stop-after filter`, input = a consensus
@@ -338,9 +352,12 @@ consensus calling (optionally followed by filter) into a single in-memory \
 pipeline. Select the slice to run with `--start-from` and `--stop-after` (both \
 required); the stages run in the fixed order extract < correct < align < zipper \
 < sort < group < consensus < filter. Records flow directly between stages in \
-memory, so every intermediate BAM a sequential run would write is elided, and \
-the output is byte-for-byte identical to running the equivalent standalone \
-commands in turn.
+memory, so every intermediate BAM a sequential run would write is elided. The \
+record stream matches running the equivalent standalone commands in turn, as do \
+the `@HD` `SO`/`GO`/`SS` fields, the `@SQ` dictionary, and the `@RG` records. The \
+output is NOT byte-for-byte identical: the fused chain writes a single `@PG` \
+record while the staged run writes one `@PG` per command, and `@HD` `VN` and \
+`@CO` are not compared.
 
 `--start-from` declares the state of the input and selects the upstream work:
 
@@ -1857,7 +1874,9 @@ mod tests {
     /// `--start-from extract --stop-after extract` is the supported
     /// extract-only self-pair: it runs the FASTQ→unmapped-BAM extract
     /// chain inside runall and writes the unmapped BAM to `--output`
-    /// (byte-identical to standalone `fgumi extract`).
+    /// (record-identical to standalone `fgumi extract`, with matching `@HD`
+    /// `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG` provenance differs, and
+    /// `@HD` `VN` / `@CO` are not compared).
     #[test]
     fn validate_stages_for_accepts_extract_self_pair() {
         validate_stages_for(RunAllStage::Extract, RunAllStage::Extract).unwrap();

--- a/tests/integration/helpers/bam_generator.rs
+++ b/tests/integration/helpers/bam_generator.rs
@@ -73,10 +73,95 @@ pub fn create_umi_family_at(
         .collect()
 }
 
+/// The per-builder knobs that distinguish the paired-family fixtures below.
+///
+/// The three public paired builders differ only in flag shape, mate placement,
+/// and TLEN magnitude — everything else (read naming, MAPQ, `{len}M` CIGARs,
+/// `RX`/`MC` tags, per-base qualities) is identical. Keeping that scaffolding in
+/// one place stops them drifting on tag or CIGAR construction.
+struct PairedFamilyLayout {
+    /// Flag word for the first segment.
+    r1_flags: u16,
+    /// Flag word for the last segment.
+    r2_flags: u16,
+    /// 0-based reference position of R1.
+    r1_pos: i32,
+    /// 0-based reference position of R2 (equal to `r1_pos` for an FR-overlap pair).
+    r2_pos: i32,
+    /// Template length magnitude; R1 carries `+tlen`, R2 carries `-tlen`.
+    tlen: i32,
+}
+
+/// Build `depth` read pairs sharing one UMI, laid out per `layout`.
+///
+/// Each mate carries its partner's CIGAR in `MC` — what `samtools fixmate` /
+/// `fgumi zipper` would produce, and what `GroupByPosition` needs to compute the
+/// template span on paired input without a second pass over the BAM.
+fn create_paired_family_with_layout(
+    umi: &str,
+    depth: usize,
+    base_name: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    layout: &PairedFamilyLayout,
+) -> Vec<RawRecord> {
+    let r1_seq = r1_sequence.as_bytes();
+    let r2_seq = r2_sequence.as_bytes();
+    let r1_cigar = u32::try_from(r1_seq.len()).expect("r1_seq.len() fits u32") << 4;
+    let r2_cigar = u32::try_from(r2_seq.len()).expect("r2_seq.len() fits u32") << 4;
+
+    // Each read carries its mate's CIGAR.
+    let r1_mc = format!("{}M", r2_seq.len());
+    let r2_mc = format!("{}M", r1_seq.len());
+
+    let mut records = Vec::with_capacity(depth * 2);
+    for i in 0..depth {
+        let read_name = format!("{base_name}_{i}");
+
+        let mut b1 = SamBuilder::new();
+        b1.read_name(read_name.as_bytes())
+            .ref_id(0)
+            .pos(layout.r1_pos)
+            .mapq(60)
+            .flags(layout.r1_flags)
+            .mate_ref_id(0)
+            .mate_pos(layout.r2_pos)
+            .template_length(layout.tlen)
+            .cigar_ops(&[r1_cigar])
+            .sequence(r1_seq)
+            .qualities(&vec![quality; r1_seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, r1_mc.as_bytes());
+        records.push(b1.build());
+
+        let mut b2 = SamBuilder::new();
+        b2.read_name(read_name.as_bytes())
+            .ref_id(0)
+            .pos(layout.r2_pos)
+            .mapq(60)
+            .flags(layout.r2_flags)
+            .mate_ref_id(0)
+            .mate_pos(layout.r1_pos)
+            .template_length(-layout.tlen)
+            .cigar_ops(&[r2_cigar])
+            .sequence(r2_seq)
+            .qualities(&vec![quality; r2_seq.len()])
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, r2_mc.as_bytes());
+        records.push(b2.build());
+    }
+
+    records
+}
+
 /// Creates a paired-end UMI family.
 ///
 /// All reads are mapped to reference sequence 0. R1 is mapped at position 100,
 /// R2 at position 200 (to simulate insert size).
+///
+/// Shares [`create_paired_family_with_layout`] with the other two paired
+/// builders; only flag shape, mate placement, and TLEN differ between them.
 ///
 /// # Arguments
 ///
@@ -98,64 +183,25 @@ pub fn create_paired_umi_family(
     r2_sequence: &str,
     quality: u8,
 ) -> Vec<RawRecord> {
-    let r1_seq = r1_sequence.as_bytes();
-    let r2_seq = r2_sequence.as_bytes();
-    let r1_cigar = u32::try_from(r1_seq.len()).expect("r1_seq.len() fits u32") << 4;
-    let r2_cigar = u32::try_from(r2_seq.len()).expect("r2_seq.len() fits u32") << 4;
-
-    // MC tag (mate-cigar) as SAM-style text. Each read carries its
-    // mate's CIGAR — what `samtools fixmate` / `fgumi zipper` would
-    // produce. `GroupByPosition` requires MC on paired-end inputs so
-    // template span can be computed without a second pass over the
-    // BAM.
-    let r1_mc = format!("{}M", r2_seq.len());
-    let r2_mc = format!("{}M", r1_seq.len());
-
-    // R1 at pos 99 (0-based); R2 at pos 199. Template spans from R1 start through end
-    // of R2 — 100bp gap + R2 length — and R2 carries the negated length.
-    let template_len = i32::try_from(100 + r2_seq.len()).expect("template length fits i32");
-
-    let mut records = Vec::new();
-
-    for i in 0..depth {
-        let read_name = format!("{base_name}_{i}");
-
-        // R1: paired + first segment
-        let mut b1 = SamBuilder::new();
-        b1.read_name(read_name.as_bytes())
-            .ref_id(0)
-            .pos(99)
-            .mapq(60)
-            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
-            .mate_ref_id(0)
-            .mate_pos(199)
-            .template_length(template_len)
-            .cigar_ops(&[r1_cigar])
-            .sequence(r1_seq)
-            .qualities(&vec![quality; r1_seq.len()])
-            .add_string_tag(SamTag::RX, umi.as_bytes())
-            .add_string_tag(SamTag::MC, r1_mc.as_bytes());
-        records.push(b1.build());
-
-        // R2: paired + last segment
-        let mut b2 = SamBuilder::new();
-        b2.read_name(read_name.as_bytes())
-            .ref_id(0)
-            .pos(199)
-            .mapq(60)
-            .flags(flags::PAIRED | flags::LAST_SEGMENT)
-            .mate_ref_id(0)
-            .mate_pos(99)
-            .template_length(-template_len)
-            .cigar_ops(&[r2_cigar])
-            .sequence(r2_seq)
-            .qualities(&vec![quality; r2_seq.len()])
-            .add_string_tag(SamTag::RX, umi.as_bytes())
-            .add_string_tag(SamTag::MC, r2_mc.as_bytes());
-        records.push(b2.build());
-    }
-
-    records
+    // R1 at pos 99 (0-based); R2 at pos 199. Template spans from R1 start through
+    // end of R2 — 100bp gap + R2 length — and R2 carries the negated length.
+    let template_len = i32::try_from(100 + r2_sequence.len()).expect("template length fits i32");
+    let layout = PairedFamilyLayout {
+        r1_flags: flags::PAIRED | flags::FIRST_SEGMENT,
+        r2_flags: flags::PAIRED | flags::LAST_SEGMENT,
+        r1_pos: 99,
+        r2_pos: 199,
+        tlen: template_len,
+    };
+    create_paired_family_with_layout(
+        umi,
+        depth,
+        base_name,
+        r1_sequence,
+        r2_sequence,
+        quality,
+        &layout,
+    )
 }
 
 /// Like [`create_paired_umi_family`] but maps the pair at an explicit
@@ -166,7 +212,6 @@ pub fn create_paired_umi_family(
 ///
 /// R1 is placed at `r1_pos` (0-based) and R2 at `r1_pos + 100`, mirroring the
 /// fixed-position helper's 100bp insert.
-#[allow(clippy::too_many_arguments)]
 pub fn create_paired_umi_family_at(
     umi: &str,
     depth: usize,
@@ -176,57 +221,100 @@ pub fn create_paired_umi_family_at(
     quality: u8,
     r1_pos: usize,
 ) -> Vec<RawRecord> {
-    let r1_seq = r1_sequence.as_bytes();
-    let r2_seq = r2_sequence.as_bytes();
-    let r1_cigar = u32::try_from(r1_seq.len()).expect("r1_seq.len() fits u32") << 4;
-    let r2_cigar = u32::try_from(r2_seq.len()).expect("r2_seq.len() fits u32") << 4;
+    let layout = PairedFamilyLayout {
+        r1_flags: flags::PAIRED | flags::FIRST_SEGMENT,
+        r2_flags: flags::PAIRED | flags::LAST_SEGMENT,
+        r1_pos: i32::try_from(r1_pos).expect("r1_pos fits i32"),
+        r2_pos: i32::try_from(r1_pos + 100).expect("r2_pos fits i32"),
+        tlen: i32::try_from(100 + r2_sequence.len()).expect("template length fits i32"),
+    };
+    create_paired_family_with_layout(
+        umi,
+        depth,
+        base_name,
+        r1_sequence,
+        r2_sequence,
+        quality,
+        &layout,
+    )
+}
 
-    let r1_mc = format!("{}M", r2_seq.len());
-    let r2_mc = format!("{}M", r1_seq.len());
+/// Like [`create_paired_umi_family_at`] but emits the **FR-overlap flag shape**
+/// that the CODEC consensus caller requires to form a duplex consensus.
+///
+/// CODEC recognises a duplex pair by its flag/orientation shape, NOT by
+/// paired-UMI grouping: R1 must be `PAIRED | FIRST_SEGMENT | MATE_REVERSE` and
+/// R2 must be `PAIRED | LAST_SEGMENT | REVERSE`, with **both mates mapped at the
+/// SAME reference position** (a fully-overlapping FR pair). This mirrors the
+/// `create_codec_read_pair` helper in `tests/integration/test_codec_command.rs`
+/// and the `zipper_codec_fixture` in `test_runall_parity.rs`, both of which are
+/// known to yield non-empty CODEC output.
+///
+/// This contrasts with [`create_paired_umi_family_at`] /
+/// [`create_paired_umi_family`], which map R1 and R2 100bp apart with plain
+/// `PAIRED | FIRST_SEGMENT` / `PAIRED | LAST_SEGMENT` flags (no strand-
+/// orientation flags, no overlap) — a shape CODEC rejects, so those families
+/// produce **0** consensus records. Use this helper for any fixture whose chain
+/// reaches a CODEC consensus and must retain records.
+///
+/// Both mates are placed at `pos` (0-based), carry `mate_pos = pos`, an `MC`
+/// mate-cigar tag (`{mate_len}M`), the single-strand UMI in `RX`, a `{len}M`
+/// cigar, and template length `+len` (R1) / `-len` (R2). Use `depth >= 3` per
+/// family for enough duplex depth to form a consensus at `--min-reads 1`.
+///
+/// # Arguments
+///
+/// * `umi` - single-strand UMI sequence written to `RX` on both mates
+/// * `depth` - number of read pairs in the family (≥3 recommended)
+/// * `base_name` - base read name (suffixed with the pair index)
+/// * `r1_sequence` - R1 sequence, in reference orientation
+/// * `r2_sequence` - R2 sequence, in reference orientation; same length as R1 for
+///   a clean overlap. BAM `SEQ` is stored reference-oriented (SAM spec §1.4), so
+///   a *duplex-agreeing* pair passes the SAME bases here as for `r1_sequence`
+///   even though R2 is REVERSE-flagged. Passing the reverse complement of
+///   `r1_sequence` models two mates that disagree at every base, which CODEC
+///   collapses to an all-`N` consensus — pass it only when that is the intent.
+/// * `quality` - base quality score for every base
+/// * `pos` - shared 0-based reference position for both mates
+pub fn create_codec_fr_overlap_family_at(
+    umi: &str,
+    depth: usize,
+    base_name: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    pos: i32,
+) -> Vec<RawRecord> {
+    // Template length: the fully-overlapping FR pair spans a single read length,
+    // so both mates must agree on |TLEN| (htslib/samtools convention). Require
+    // equal-length reads rather than deriving each mate's TLEN independently — an
+    // unequal-length pair would carry mismatched |TLEN| and is not a well-formed
+    // FR-overlap family.
+    assert_eq!(
+        r1_sequence.len(),
+        r2_sequence.len(),
+        "create_codec_fr_overlap_family_at requires equal-length r1/r2 for a well-formed FR-overlap pair"
+    );
 
-    let r1_pos_i = i32::try_from(r1_pos).expect("r1_pos fits i32");
-    let r2_pos = r1_pos + 100;
-    let r2_pos_i = i32::try_from(r2_pos).expect("r2_pos fits i32");
-    let template_len = i32::try_from(100 + r2_seq.len()).expect("template length fits i32");
-
-    let mut records = Vec::new();
-    for i in 0..depth {
-        let read_name = format!("{base_name}_{i}");
-
-        let mut b1 = SamBuilder::new();
-        b1.read_name(read_name.as_bytes())
-            .ref_id(0)
-            .pos(r1_pos_i)
-            .mapq(60)
-            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
-            .mate_ref_id(0)
-            .mate_pos(r2_pos_i)
-            .template_length(template_len)
-            .cigar_ops(&[r1_cigar])
-            .sequence(r1_seq)
-            .qualities(&vec![quality; r1_seq.len()])
-            .add_string_tag(SamTag::RX, umi.as_bytes())
-            .add_string_tag(SamTag::MC, r1_mc.as_bytes());
-        records.push(b1.build());
-
-        let mut b2 = SamBuilder::new();
-        b2.read_name(read_name.as_bytes())
-            .ref_id(0)
-            .pos(r2_pos_i)
-            .mapq(60)
-            .flags(flags::PAIRED | flags::LAST_SEGMENT)
-            .mate_ref_id(0)
-            .mate_pos(r1_pos_i)
-            .template_length(-template_len)
-            .cigar_ops(&[r2_cigar])
-            .sequence(r2_seq)
-            .qualities(&vec![quality; r2_seq.len()])
-            .add_string_tag(SamTag::RX, umi.as_bytes())
-            .add_string_tag(SamTag::MC, r2_mc.as_bytes());
-        records.push(b2.build());
-    }
-
-    records
+    // R1 gets MATE_REVERSE (its R2 partner is reverse-strand) and R2 gets REVERSE;
+    // both mates sit at the same position, which is the FR-overlap shape CODEC
+    // recognises.
+    let layout = PairedFamilyLayout {
+        r1_flags: flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE,
+        r2_flags: flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE,
+        r1_pos: pos,
+        r2_pos: pos,
+        tlen: i32::try_from(r1_sequence.len()).expect("r1 length fits i32"),
+    };
+    create_paired_family_with_layout(
+        umi,
+        depth,
+        base_name,
+        r1_sequence,
+        r2_sequence,
+        quality,
+        &layout,
+    )
 }
 
 /// Creates a both-unmapped paired-end read pair carrying a paired UMI in `RX`.
@@ -529,6 +617,82 @@ mod tests {
         assert_ne!(r1_flags & flags::FIRST_SEGMENT, 0, "R1 should have FIRST_SEGMENT flag");
         assert_eq!(r2_flags & flags::FIRST_SEGMENT, 0, "R2 should not have FIRST_SEGMENT flag");
         assert_ne!(r2_flags & flags::LAST_SEGMENT, 0, "R2 should have LAST_SEGMENT flag");
+    }
+
+    #[test]
+    fn create_codec_fr_overlap_family_at_emits_codec_shape() {
+        // Pin the FR-overlap flag/position shape CODEC consensus requires: R1
+        // `PAIRED|FIRST|MATE_REVERSE`, R2 `PAIRED|LAST|REVERSE`, BOTH mates at
+        // the SAME position (unlike `create_paired_umi_family_at`'s 100bp gap /
+        // no strand flags, which CODEC rejects). A regression that dropped a
+        // strand flag or split the positions would silently re-vacuum the codec
+        // parity tests (RUN3-02), so assert the shape directly.
+        use noodles::sam::alignment::record::cigar::{Op, op::Kind};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        const POS: i32 = 512;
+        const UMI: &str = "ACGTACGT";
+        const SEQ: &str = "ACGT";
+        // Exact flag masks the helper contracts for — comparing the whole mask
+        // (not just individual bits) catches a stray extra flag as well as a
+        // dropped one.
+        let r1_flags_expected = flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE;
+        let r2_flags_expected = flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE;
+        let tlen = i32::try_from(SEQ.len()).expect("SEQ length fits i32");
+
+        let family = create_codec_fr_overlap_family_at(UMI, 3, "codec", SEQ, SEQ, 30, POS);
+        assert_eq!(family.len(), 6, "3 pairs → 6 records");
+
+        let rx_of = |raw: &RawRecord| -> Vec<u8> {
+            let buf = to_record_buf(raw);
+            match buf.data().get(&Tag::from(SamTag::RX)).expect("record carries an RX tag") {
+                noodles::sam::alignment::record_buf::data::field::Value::String(s) => s.to_vec(),
+                other => panic!("RX should be a string tag, got {other:?}"),
+            }
+        };
+        let mc_of = |raw: &RawRecord| -> Vec<u8> {
+            let buf = to_record_buf(raw);
+            match buf.data().get(&Tag::from(SamTag::MC)).expect("record carries an MC tag") {
+                noodles::sam::alignment::record_buf::data::field::Value::String(s) => s.to_vec(),
+                other => panic!("MC should be a string tag, got {other:?}"),
+            }
+        };
+        // Each mate is a single full-length match (`<len>M`); assert the record's
+        // own CIGAR directly so a bad `cigar_ops(&[len << 4])` encoding can't slip
+        // past the MC-tag checks (MC carries the *mate's* cigar, not the record's).
+        let cigar_of =
+            |raw: &RawRecord| -> Vec<Op> { to_record_buf(raw).cigar().as_ref().to_vec() };
+        let expected_cigar = vec![Op::new(Kind::Match, SEQ.len())];
+
+        for pair in family.chunks_exact(2) {
+            let (r1, r2) = (&pair[0], &pair[1]);
+
+            // R1: exact `PAIRED|FIRST_SEGMENT|MATE_REVERSE` — the FR-overlap
+            // shape; R2: exact `PAIRED|LAST_SEGMENT|REVERSE`, same position.
+            assert_eq!(r1.flags(), r1_flags_expected, "R1 flag mask");
+            assert_eq!(r2.flags(), r2_flags_expected, "R2 flag mask");
+
+            // Both mates map to the SAME position (the overlap CODEC needs) and
+            // each points at the other via mate_pos.
+            assert_eq!(r1.pos(), POS, "R1 at shared pos");
+            assert_eq!(r2.pos(), POS, "R2 at shared pos");
+            assert_eq!(r1.mate_pos(), POS, "R1 mate_pos = shared pos");
+            assert_eq!(r2.mate_pos(), POS, "R2 mate_pos = shared pos");
+
+            // Template length ±len (fully-overlapping single-read span).
+            assert_eq!(r1.template_length(), tlen, "R1 TLEN = +len");
+            assert_eq!(r2.template_length(), -tlen, "R2 TLEN = -len");
+
+            // Single-strand UMI shared in RX; MC carries the mate's cigar.
+            assert_eq!(rx_of(r1), UMI.as_bytes(), "R1 RX");
+            assert_eq!(rx_of(r2), UMI.as_bytes(), "R2 RX");
+            assert_eq!(mc_of(r1), format!("{}M", SEQ.len()).as_bytes(), "R1 MC = mate cigar");
+            assert_eq!(mc_of(r2), format!("{}M", SEQ.len()).as_bytes(), "R2 MC = mate cigar");
+
+            // The record's own CIGAR is `<len>M` for both mates.
+            assert_eq!(cigar_of(r1), expected_cigar, "R1 CIGAR = <len>M");
+            assert_eq!(cigar_of(r2), expected_cigar, "R2 CIGAR = <len>M");
+        }
     }
 
     #[test]

--- a/tests/integration/helpers/parity.rs
+++ b/tests/integration/helpers/parity.rs
@@ -72,9 +72,8 @@ pub fn assert_bams_record_equivalent(a: &Path, b: &Path) {
 /// green even if the fused pipeline silently emitted a header-only BAM
 /// (S9a-001). Use this variant for every parity chain that must carry
 /// records; reserve the bare `assert_bams_record_equivalent` (paired with
-/// an explicit `assert_eq!(read_bam_records(..).len(), 0, ..)`) for chains
-/// that legitimately produce zero records by design (the codec fixtures
-/// lack the FR-overlap shape — see the codec parity tests).
+/// an explicit `assert_eq!(read_bam_records(..).len(), 0, ..)`) only for
+/// chains that legitimately produce zero records by design.
 ///
 /// # Panics
 ///

--- a/tests/integration/test_runall_parity.rs
+++ b/tests/integration/test_runall_parity.rs
@@ -44,8 +44,9 @@ use rstest::rstest;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{
-    create_both_unmapped_pair, create_minimal_header, create_paired_umi_family,
-    create_paired_umi_family_at, create_umi_family, create_umi_family_at, to_record_buf,
+    create_both_unmapped_pair, create_codec_fr_overlap_family_at, create_minimal_header,
+    create_paired_umi_family, create_paired_umi_family_at, create_umi_family, create_umi_family_at,
+    to_record_buf,
 };
 use crate::helpers::cli_runner::{
     ParityArgs, Stage, fgumi, fgumi_binary, run_runall, run_runall_consensus_to_filter,
@@ -236,24 +237,131 @@ fn sorted_duplex_with_unmapped_fixture(dir: &Path) -> PathBuf {
     sorted
 }
 
+/// The CODEC fixture's families: `(umi, base_name, template, pos)`.
+///
+/// Single source of truth for both the fixture writer and the output oracle
+/// below, so the two cannot drift. `template` is the reference-oriented sequence
+/// stored by **both** mates — BAM `SEQ` is in reference orientation (SAM spec
+/// §1.4), so a fully-overlapping FR pair carries identical bases on R1 and on the
+/// REVERSE-flagged R2. There is deliberately no separate R2 column: writing R2 as
+/// the reverse complement of R1 would present the caller with two mates that
+/// disagree at every base and collapse the family to all-`N`.
+///
+/// `fam_b`'s template is deliberately **not** its own reverse complement. The
+/// other three are RC-palindromes, and a table of only palindromes cannot
+/// distinguish a template from its reverse complement — a caller that emitted
+/// every consensus reverse-complemented would satisfy the oracle. `fam_b` breaks
+/// that symmetry.
+const CODEC_FAMILIES: [(&str, &str, &str, i32); 4] = [
+    ("ACGTACGT", "fam_a", "ACGTACGT", 99),
+    ("AAAACCCC", "fam_b", "AAAACCCC", 999),
+    ("CCAATTGG", "fam_c", "CCAATTGG", 1999),
+    ("GGTTAACC", "fam_d", "GGTTAACC", 2999),
+];
+
+/// Independent oracle for any CODEC output built from [`CODEC_FAMILIES`].
+///
+/// Fused-vs-staged equality plus a non-empty check cannot catch a CODEC
+/// regression that affects BOTH paths identically — dropping three of the four
+/// families, or emitting the same wrong base on each. This asserts what the
+/// output must be on its own terms, derived from the fixture definition rather
+/// than from what the tool produced: every family is three *identical* Q30
+/// read-pairs whose R1 and R2 fully overlap and store the same reference-oriented
+/// bases, so there is no disagreement for the caller to resolve and each family's
+/// consensus sequence must be exactly that family's template. All four families
+/// must therefore appear, no sequence outside the fixture may, and the record
+/// count must be exactly one per family — the count is what catches a family
+/// emitted twice, which set equality alone collapses away.
+///
+/// Sequences are compared verbatim. CODEC emits *unmapped* consensus records, so
+/// there is no strand to normalize — that contract is asserted rather than
+/// assumed, because silently reverse-complementing on a flag that can never be
+/// set would make this oracle blind to the day it starts being set.
+fn assert_codec_output_matches_oracle(bam: &Path, label: &str) {
+    use fgumi_dna::reverse_complement_str;
+    use std::collections::BTreeSet;
+
+    // With an all-palindrome table, `expected` cannot tell a template from its
+    // own reverse complement: a caller that reverse-complemented every consensus
+    // would still pass. At least one family must break that symmetry.
+    assert!(
+        CODEC_FAMILIES
+            .iter()
+            .any(|(_, _, template, _)| reverse_complement_str(template) != *template),
+        "CODEC_FAMILIES must contain at least one non-RC-palindromic template, otherwise this \
+         oracle cannot tell a correct consensus from a reverse-complemented one"
+    );
+
+    let records = read_bam_records(bam);
+    assert!(!records.is_empty(), "{label}: CODEC emitted no records at all");
+    // The set-equality check below collapses duplicates, so it is blind to a
+    // regression that emits one family's consensus twice: `[A, A, B, C, D]`
+    // still reduces to `{A, B, C, D}` and passes. Fused-vs-staged equality does
+    // not catch it either when both paths regress identically. CODEC collapses
+    // each FR-overlap family into exactly one consensus record, so pin the
+    // count as well as the sequence set.
+    assert_eq!(
+        records.len(),
+        CODEC_FAMILIES.len(),
+        "{label}: CODEC must emit exactly one consensus record per fixture family ({} expected), \
+         got {}",
+        CODEC_FAMILIES.len(),
+        records.len(),
+    );
+
+    for rec in &records {
+        assert!(
+            rec.flags().is_unmapped() && !rec.flags().is_reverse_complemented(),
+            "{label}: CODEC consensus records are expected to be unmapped and forward-oriented, \
+             so the sequences below can be compared verbatim; got flags {:#06x}. If CODEC now \
+             emits mapped/reverse-strand consensus records, this oracle must normalize strand \
+             before comparing.",
+            u16::from(rec.flags()),
+        );
+    }
+
+    let observed: BTreeSet<Vec<u8>> =
+        records.iter().map(|rec| rec.sequence().as_ref().to_vec()).collect();
+
+    let expected: BTreeSet<Vec<u8>> =
+        CODEC_FAMILIES.iter().map(|(_, _, template, _)| template.as_bytes().to_vec()).collect();
+
+    let render = |s: &BTreeSet<Vec<u8>>| -> Vec<String> {
+        s.iter().map(|v| String::from_utf8_lossy(v).into_owned()).collect()
+    };
+    assert_eq!(
+        observed,
+        expected,
+        "{label}: CODEC consensus sequences must be exactly the {} fixture templates \
+         (every family formable, none dropped, none miscalled); observed {:?}, expected {:?}",
+        CODEC_FAMILIES.len(),
+        render(&observed),
+        render(&expected),
+    );
+}
+
 fn unsorted_codec_fixture(dir: &Path) -> PathBuf {
     let path = dir.join("unsorted_codec.bam");
     let header = create_minimal_header("chr1", 10000);
     let mut writer = bam::io::Writer::new(fs::File::create(&path).expect("create fixture BAM"));
     writer.write_header(&header).expect("write fixture header");
-    // 4 paired-end families × 4 read-pairs. Each pair shares one
-    // single-strand UMI in the RX tag; CODEC pairs the two strands at
-    // consensus time, not at grouping time. `--strategy adjacency`
-    // (not `paired`) is the documented grouping for CODEC.
-    let families = [
-        ("ACGTACGT", "fam_a", "ACGTACGT", "TTTTAAAA"),
-        ("TGCATGCA", "fam_b", "TGCATGCA", "CCCCGGGG"),
-        ("CCAATTGG", "fam_c", "CCAATTGG", "GGTTAACC"),
-        ("GGTTAACC", "fam_d", "GGTTAACC", "CCAATTGG"),
-    ];
+    // 4 CODEC-formable FR-overlap families, one per distinct reference
+    // position (99, 999, 1999, 2999 — all inside the 10000bp `chr1`).
+    // Each family is 3 read-pairs sharing one single-strand UMI in RX,
+    // built with the FR-overlap flag shape (R1 `PAIRED|FIRST|MATE_REVERSE`,
+    // R2 `PAIRED|LAST|REVERSE`, both mates at the SAME position) that CODEC
+    // consensus requires. `--strategy adjacency` (not `paired`) is the
+    // documented grouping for CODEC. Contrast `create_paired_umi_family`
+    // (100bp gap, no strand flags), which CODEC rejects → 0 consensus.
+    //
+    // Both mates store `template` verbatim, which is what makes the overlap
+    // clean: BAM `SEQ` is in *reference* orientation (SAM spec §1.4), so a
+    // fully-overlapping FR pair stores the same bases on R1 and on the
+    // REVERSE-flagged R2 even when the template is not its own reverse
+    // complement.
     let mut all_records = Vec::new();
-    for (umi, name, r1_seq, r2_seq) in families {
-        for r in create_paired_umi_family(umi, 4, name, r1_seq, r2_seq, 30) {
+    for (umi, name, template, pos) in CODEC_FAMILIES {
+        for r in create_codec_fr_overlap_family_at(umi, 3, name, template, template, 30, pos) {
             all_records.push(r);
         }
     }
@@ -400,18 +508,17 @@ fn parity_a_duplex_to_duplex() {
 }
 
 /// `Codec → Codec` parity vs standalone `fgumi codec`. Runs through the
-/// consensus-only delegation fast path. Uses `grouped_codec_fixture`
-/// (paired-end, single-UMI, grouped with `--strategy adjacency`).
+/// consensus-only delegation fast path. Uses `grouped_codec_fixture`, whose
+/// families now carry the **FR-overlap flag shape** CODEC requires (R1
+/// `PAIRED|FIRST|MATE_REVERSE` / R2 `PAIRED|LAST|REVERSE`, both mates at the
+/// same position, depth 3, `--strategy adjacency`, `--min-reads 1`), so the
+/// CODEC caller forms one duplex consensus per family (RUN3-02).
 ///
-/// NOTE (S9a-001): this fixture lacks the FR-overlap flag shape CODEC
-/// consensus requires (R1 `PAIRED|FIRST|MATE_REVERSE` / R2 `PAIRED|LAST|REVERSE`
-/// at the same position), so every pair is rejected and BOTH the fused and
-/// standalone paths emit **0 consensus records**. The parity therefore holds
-/// only because both sides are empty. The explicit `== 0` assertion below makes
-/// that deliberate zero VISIBLE: if a future change gives the codec fixture
-/// FR-overlap flags (making it non-empty), this test fails loudly and forces an
-/// upgrade to a real non-empty parity check (the `zipper_*_codec` smoke tests
-/// already cover the non-empty FR-overlap shape via `zipper_codec_fixture`).
+/// This pins a real, ≥1-record fused-vs-standalone CODEC parity floor: the
+/// fused and standalone paths must emit the SAME non-empty consensus record
+/// stream (plus matching `@HD`/`@SQ`/`@RG`). It replaces the former vacuous
+/// `0 == 0` check, which passed only because the codec fixture lacked the
+/// FR-overlap shape and both sides were empty.
 #[cfg(feature = "consensus")]
 #[test]
 fn parity_a_codec_to_codec() {
@@ -427,15 +534,10 @@ fn parity_a_codec_to_codec() {
     let r = run_standalone(Stage::Codec, &fixture, &standalone_out, &args);
     assert!(r.status.success(), "standalone: {}", String::from_utf8_lossy(&r.stderr));
 
-    assert_bams_record_equivalent(&runall_out, &standalone_out);
-    // Header parity matters most in this empty-stream case: a wrong fused
-    // @HD/@SQ/@RG would otherwise stay green behind the zero-record assertion.
+    assert_bams_record_equivalent_nonempty(&runall_out, &standalone_out);
+    assert_codec_output_matches_oracle(&runall_out, "standalone CODEC (runall)");
+    assert_codec_output_matches_oracle(&standalone_out, "standalone CODEC (staged)");
     assert_bam_headers_equivalent_ignoring_pg(&runall_out, &standalone_out);
-    assert_eq!(
-        read_bam_records(&runall_out).len(),
-        0,
-        "codec fixture lacks the FR-overlap shape → 0 consensus by design (S9a-001)"
-    );
 }
 
 // ────────────────────────── Class B — multi-stage parity ──────────────────────────
@@ -535,9 +637,11 @@ fn parity_b_sort_to_duplex() {
 }
 
 /// `Sort → Codec` parity vs staged `fgumi sort | fgumi group | fgumi codec`.
-/// Uses the codec fixture family (paired-end, single-strand UMI,
-/// `--strategy adjacency`) so the consensus stage actually exercises
-/// CODEC's duplex logic.
+/// Uses the FR-overlap codec fixture family (paired-end, single-strand UMI,
+/// R1 `PAIRED|FIRST|MATE_REVERSE` / R2 `PAIRED|LAST|REVERSE` at the same
+/// position, `--strategy adjacency`, `--min-reads 1`) so the consensus stage
+/// actually exercises CODEC's duplex logic and yields ≥1 consensus per family.
+/// Pins a real, non-empty fused-vs-staged CODEC parity floor (RUN3-02).
 #[cfg(feature = "consensus")]
 #[test]
 fn parity_b_sort_to_codec() {
@@ -559,14 +663,13 @@ fn parity_b_sort_to_codec() {
     );
     assert!(r.status.success(), "staged: {}", String::from_utf8_lossy(&r.stderr));
 
-    assert_bams_record_equivalent(&runall_out, &staged_out);
-    // S9a-005: header parity holds even for the zero-record codec branch (both
-    // sides still emit @HD/@SQ/@RG) — assert it before the zero-count pin below.
+    // RUN3-02: the FR-overlap codec fixture forms ≥1 consensus, so the fused
+    // and staged paths must emit the SAME non-empty record stream.
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_codec_output_matches_oracle(&runall_out, "sort→group→CODEC (runall)");
+    assert_codec_output_matches_oracle(&staged_out, "sort→group→CODEC (staged)");
+    // S9a-005: also pin @HD/@SQ/@RG parity across the fused-vs-staged paths.
     assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
-    // S9a-001: the codec fixture lacks the FR-overlap shape → 0 consensus by
-    // design; pin the deliberate zero so a future non-empty fixture forces a
-    // real parity check.
-    assert_eq!(read_bam_records(&runall_out).len(), 0, "codec fixture → 0 consensus by design");
 }
 
 /// `Group → Simplex` parity vs staged `fgumi group | fgumi simplex`.
@@ -808,8 +911,9 @@ fn new_002_group_to_duplex_allow_unmapped_parity() {
 }
 
 /// `Group → Codec` parity vs staged `fgumi group | fgumi codec`.
-/// Uses the codec fixture family; see [`parity_b_sort_to_codec`] for
-/// the rationale.
+/// Uses the FR-overlap codec fixture family; see [`parity_b_sort_to_codec`]
+/// for the rationale. Pins a real, non-empty fused-vs-staged CODEC parity
+/// floor (RUN3-02).
 #[cfg(feature = "consensus")]
 #[test]
 fn parity_b_group_to_codec() {
@@ -826,11 +930,13 @@ fn parity_b_group_to_codec() {
         run_staged_chain(&[Stage::Group, Stage::Codec], &fixture, &staged_out, tmp.path(), &args);
     assert!(r.status.success(), "staged: {}", String::from_utf8_lossy(&r.stderr));
 
-    assert_bams_record_equivalent(&runall_out, &staged_out);
-    // S9a-005: header parity holds even for the zero-record codec branch.
+    // RUN3-02: the FR-overlap codec fixture forms ≥1 consensus, so the fused
+    // and staged paths must emit the SAME non-empty record stream.
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_codec_output_matches_oracle(&runall_out, "group→CODEC (runall)");
+    assert_codec_output_matches_oracle(&staged_out, "group→CODEC (staged)");
+    // S9a-005: also pin @HD/@SQ/@RG parity across the fused-vs-staged paths.
     assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
-    // S9a-001: codec fixture lacks FR-overlap → 0 consensus by design.
-    assert_eq!(read_bam_records(&runall_out).len(), 0, "codec fixture → 0 consensus by design");
 }
 
 // ──────────────── Fused consensus → filter parity (issue #330 option a) ────────────────
@@ -911,6 +1017,9 @@ fn parity_group_to_duplex_to_filter() {
 }
 
 /// `Group → Codec → Filter` (fused) vs staged consensus BAM + `fgumi filter`.
+/// Uses the FR-overlap codec fixture, so the fused consensus→filter stream is
+/// non-empty and pins a real, ≥1-record fused-vs-staged CODEC→filter parity
+/// floor (RUN3-02).
 #[cfg(feature = "consensus")]
 #[test]
 fn parity_group_to_codec_to_filter() {
@@ -929,11 +1038,18 @@ fn parity_group_to_codec_to_filter() {
     let r = run_standalone_filter(&consensus_bam, &staged_out, &args);
     assert!(r.status.success(), "staged filter: {}", String::from_utf8_lossy(&r.stderr));
 
-    assert_bams_record_equivalent(&fused_out, &staged_out);
-    // S9a-005: header parity holds even for the zero-record codec→filter branch.
+    // RUN3-02: the FR-overlap codec fixture forms ≥1 consensus that survives
+    // `filter --min-reads 1`, so the fused consensus→filter stream is non-empty
+    // and must equal the staged consensus + standalone-filter chain.
+    assert_bams_record_equivalent_nonempty(&fused_out, &staged_out);
+    // Independent oracle on both sides: fused-vs-staged equality alone would
+    // still pass if CODEC dropped families or miscalled bases on both paths.
+    // Every fixture family is a clean, fully-agreeing FR-overlap trio, so all
+    // four survive `filter --min-reads 1` unchanged.
+    assert_codec_output_matches_oracle(&fused_out, "group→CODEC→filter (fused)");
+    assert_codec_output_matches_oracle(&staged_out, "group→CODEC→filter (staged)");
+    // S9a-005: also pin @HD/@SQ/@RG parity across the fused-vs-staged paths.
     assert_bam_headers_equivalent_ignoring_pg(&fused_out, &staged_out);
-    // S9a-001: codec fixture → 0 consensus → 0 after filter, by design.
-    assert_eq!(read_bam_records(&fused_out).len(), 0, "codec fixture → 0 consensus by design");
 }
 
 // ───────────────────── Run-to-run / thread-count determinism ─────────────────────
@@ -1777,11 +1893,10 @@ fn zipper_duplex_fixture(dir: &StdPath) -> ZipperInputs {
 /// `PAIRED | FIRST_SEGMENT | MATE_REVERSE`, R2 `PAIRED |
 /// LAST_SEGMENT | REVERSE`, both at the SAME position), NOT by
 /// paired-UMI grouping. Without those flags, CODEC consensus
-/// rejects every pair and emits 0 records — which is what
-/// `parity_b_sort_to_codec`'s `unsorted_codec_fixture` actually
-/// does in practice (the existing test passes only because both
-/// fused and staged produce 0 records, so they're trivially
-/// equivalent).
+/// rejects every pair and emits 0 records. `parity_b_sort_to_codec`'s
+/// `unsorted_codec_fixture` now shares this same FR-overlap recipe (via
+/// `create_codec_fr_overlap_family_at`, RUN3-02), so both fixtures yield
+/// non-empty CODEC output.
 ///
 /// This fixture mirrors the `create_codec_read_pair` helper from
 /// `tests/integration/test_codec_command.rs`, which IS known to


### PR DESCRIPTION
## Summary

W8b of the final-audit burn-down: the `runall` half of the compare/runall test-infrastructure workstream. Two findings, doc-only + test-gap.

## RUN3-01 — the "byte-for-byte identical" claim is false (doc-drift)

The runall docs claimed fused output is "byte-for-byte identical" to running the equivalent standalone commands. That is false: the fused chain writes a single `@PG` record while a staged run writes one `@PG` per command, so only the record stream plus the `@HD`/`@SQ`/`@RG` header (ignoring `@PG`) match — exactly what the parity oracle in `tests/integration/helpers/parity.rs` checks. The consensus-start docstring already stated this correctly; this PR aligns the six drifted sites with it:

- module-doc `Parity` goal (~line 37)
- `long_about` (~line 342)
- Extract / Consensus / Filter stage docs (~lines 137 / 180 / 187)
- the extract-self-pair test docstring (~line 1860)

After the edits, `grep -n "byte-for-byte\|byte-identical" src/lib/commands/runall.rs` shows only NEGATED occurrences. Doc-only; the oracle already encodes the true contract, so no test change is needed for this finding.

## RUN3-02 — de-vacuum the codec fusion parity tests (test-gap)

Four codec-parity tests were vacuous — they passed on `0 == 0` because both the fused and staged paths emitted zero consensus records: `parity_a_codec_to_codec`, `parity_b_sort_to_codec`, `parity_b_group_to_codec`, `parity_group_to_codec_to_filter`.

Root cause: the codec fixtures built pairs with `create_paired_umi_family`, which maps R1/R2 100bp apart with plain `PAIRED|FIRST_SEGMENT` / `PAIRED|LAST_SEGMENT` flags — no strand orientation, no overlap — so CODEC rejected every pair. The old test at `parity_a_codec_to_codec` explicitly invited this fix.

Changes:

- Add `create_codec_fr_overlap_family_at` to `tests/integration/helpers/bam_generator.rs`, emitting the FR-overlap flag shape CODEC requires: R1 `PAIRED|FIRST_SEGMENT|MATE_REVERSE`, R2 `PAIRED|LAST_SEGMENT|REVERSE`, both mates mapped at the SAME position, with `MC` mate-cigar tags, a single-strand UMI in `RX`, `{len}M` cigar, and tlen `±len`. The doc-comment contrasts it with `create_paired_umi_family_at` (100bp gap / no strand flags → CODEC rejects). Reverse-engineered from the working `zipper_codec_fixture` and `test_codec_command.rs`'s `create_codec_read_pair`.
- Rebuild `unsorted_codec_fixture` to use the new helper: 4 families at distinct positions (99/999/1999/2999), distinct RX UMIs, depth 3. `sorted_codec_fixture` / `grouped_codec_fixture` chain off it unchanged.
- Flip all four tests from `assert_bams_record_equivalent(...)` + `assert_eq!(len, 0, ...)` to `assert_bams_record_equivalent_nonempty(...)` (keeping the `@HD`/`@SQ`/`@RG` header check), and update their doc comments to state the real ≥1-record parity floor.
- Add a helper unit test pinning the FR-overlap flag/position/RX/MC/TLEN shape so a regression re-vacuuming the fixture fails loudly.

### RED-first evidence

Before rebuilding the fixture, flipping `parity_a_codec_to_codec` to `assert_bams_record_equivalent_nonempty` reproduced the vacuity — the test failed with `expected a non-empty record stream but runall.bam has 0 records`. After the fixture change it passed.

### Empirical codec-forms-consensus confirmation

With the FR-overlap fixture, the `sort → group(adjacency) → codec` chain (`--min-reads 1`) forms **4 consensus records** — one duplex consensus per FR-overlap family. All four tests now pin the real fused-vs-staged non-empty parity floor. A stale sibling docstring on `zipper_codec_fixture` (which described the old vacuous `unsorted_codec_fixture`) was updated to match.

## Base / merge order

Base is `nh/audit-3-parity`, the compiling fan-out root of the unmerged audit chain, because `feat-runall`'s tip (PR #482) does not compile — it destructures now-private `DecodedRecordBatch` fields that the audit chain (#534) replaced with accessors. This PR should merge after the audit chain (`feat-runall` ← #534 ← #535 ← #536); the base auto-retargets down the chain to `feat-runall` as each merges.

## CI

`cargo ci-fmt`, `cargo ci-lint`, and `cargo ci-test` all green (2333 tests passed, 8 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated runall “parity” wording in CLI help and docs, clarifying the exact equivalence criteria (including treatment of header records and differences in `@PG` output between fused vs staged execution).
  - Refined guidance for MI numbering and consistency across extract, consensus, and filtering flows.

- **Tests**
  - Reworked CODEC parity fixtures to use fully overlapping FR-overlap inputs that produce non-empty consensus output.
  - Added stronger assertions for consensus record orientation/selections and exact expected consensus sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->