### PR TITLE
fix(consensus)!: clamp codec/duplex scalar depth+error tags to fgbio's Short ceiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "anyhow",
  "approx",
  "bstr 1.12.1",
+ "fgumi-bam-io",
  "fgumi-dna",
  "fgumi-metrics",
  "fgumi-raw-bam",
@@ -745,6 +746,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rstest",
+ "tempfile",
  "thiserror 2.0.18",
  "wide 1.5.0",
 ]

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -24,6 +24,10 @@ fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
+# Read fgbio-oracle fixture BAMs back into RawRecords in the saturation-oracle
+# tests. fgumi-bam-io does NOT depend on fgumi-consensus, so this is cycle-free.
+fgumi-bam-io = { workspace = true }
+tempfile = "3.3.0"
 rstest = "0.26"
 proptest = "1.10"
 

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -342,6 +342,23 @@ pub fn calculate_error_rate(depths: &[u16], errors: &[u16]) -> f32 {
     total_errors as f32 / total_depth as f32
 }
 
+/// fgbio's `Short` per-base depth ceiling (`i16::MAX` = 32767).
+///
+/// fgumi stores per-base depths in `u16` (max 65535), but fgbio stores them in a
+/// `Short` `Array` capped at `Short.MaxValue`, and derives every scalar depth tag
+/// (`cD`/`aD`/`bD` and the `cM`/`aM`/`bM` minima) from those already-capped arrays.
+pub const FGBIO_SHORT_DEPTH_MAX: u16 = i16::MAX.unsigned_abs(); // 32_767
+
+/// Clamp one raw per-base depth to fgbio's `Short` ceiling before it contributes to a
+/// scalar consensus depth tag, so `min`/`max`/sum over per-base depths reproduce fgbio
+/// exactly (fgbio caps each per-base depth in its `Array[Short]`, then takes
+/// `.max`/`.min`; for the duplex combined depth it caps each strand's per-base value
+/// *before* summing). Returns `i32` so a summed duplex value cannot overflow.
+#[must_use]
+pub fn clamp_per_base_to_fgbio_short(depth: u16) -> i32 {
+    i32::from(depth.min(FGBIO_SHORT_DEPTH_MAX))
+}
+
 /// Reasons why reads might be rejected and not used in consensus calling
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RejectionReason {
@@ -514,6 +531,21 @@ pub fn make_prefix_from_header(header: &Header) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    /// The scalar depth-tag clamp mirrors fgbio's `Short` per-base ceiling: values at or
+    /// below 32767 pass through; anything above (up to `u16::MAX`) saturates at 32767,
+    /// never truncating to a negative or wrapped value.
+    #[rstest]
+    #[case::zero(0, 0)]
+    #[case::small(5, 5)]
+    #[case::at_ceiling(32_767, 32_767)]
+    #[case::just_above(32_768, 32_767)]
+    #[case::deep(40_000, 32_767)]
+    #[case::u16_max(65_535, 32_767)]
+    fn test_clamp_per_base_to_fgbio_short(#[case] input: u16, #[case] expected: i32) {
+        assert_eq!(clamp_per_base_to_fgbio_short(input), expected);
+    }
 
     #[test]
     fn test_consensus_output_estimate_heap_size_empty() {

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -74,7 +74,7 @@
 
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput,
-    RejectionReason as CallerRejectionReason,
+    RejectionReason as CallerRejectionReason, clamp_per_base_to_fgbio_short,
 };
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
 use crate::simple_umi::consensus_umis;
@@ -280,6 +280,14 @@ struct SingleStrandConsensus {
     ref_end: usize,
     /// Whether the original reads were on the negative strand
     is_negative_strand: bool,
+}
+
+/// Convert a per-base depth/error array to the `i16` `Array[Short]` form fgbio
+/// emits, saturating any value above the `Short` ceiling at `i16::MAX` (32767)
+/// rather than letting a raw `as i16` cast wrap it to a negative value. Matches
+/// the duplex caller's per-base tag encoding.
+fn capped_short_array(values: &[u16]) -> Vec<i16> {
+    values.iter().map(|&v| i16::try_from(v).unwrap_or(i16::MAX)).collect()
 }
 
 /// Precomputed clip metadata for a single record in the raw-byte codec pipeline.
@@ -1168,7 +1176,16 @@ impl CodecConsensusCaller {
                         eb + da.saturating_sub(ea)
                     };
 
-                    (final_base, final_qual, da + db, duplex_error)
+                    // Per-base duplex depth = sum of each strand's per-base depth,
+                    // each CAPPED at fgbio's `Short` ceiling first (fgbio's
+                    // `min(da,32767) + min(db,32767)`). Capping before the sum both
+                    // matches fgbio and keeps the total within u16 for very deep
+                    // families (a raw `da + db` u16 sum can overflow past 65535).
+                    let duplex_depth = u16::try_from(
+                        clamp_per_base_to_fgbio_short(da) + clamp_per_base_to_fgbio_short(db),
+                    )
+                    .expect("two Short-capped depths sum to at most 65534, which fits u16");
+                    (final_base, final_qual, duplex_depth, duplex_error)
                 }
                 (true, false) => {
                     // Only A has data - single-strand from A
@@ -1327,16 +1344,25 @@ impl CodecConsensusCaller {
         // Duplex consensus tags (cD, cM, cE)
         // fgbio calculates these from totalDepths = ab.depths + ba.depths (sum of SS depths),
         // NOT from the duplex consensus depths
+        // fgbio caps each strand's per-base depth at the `Short` ceiling *before* summing
+        // (`totalDepths(i) = min(abD_i,32767) + min(baD_i,32767)`), then derives cD/cM
+        // (max/min) and the cE denominator (sum) from those capped values.
         let total_depths: Vec<i32> = ss_a
             .depths
             .iter()
             .zip(ss_b.depths.iter())
-            .map(|(&a, &b)| i32::from(a) + i32::from(b))
+            .map(|(&a, &b)| clamp_per_base_to_fgbio_short(a) + clamp_per_base_to_fgbio_short(b))
             .collect();
         let total_depth = total_depths.iter().copied().max().unwrap_or(0);
         let min_depth = total_depths.iter().copied().min().unwrap_or(0);
-        let total_errors: usize = consensus.errors.iter().map(|&e| e as usize).sum();
-        let total_bases: i32 = total_depths.iter().sum();
+        // Cap each per-base duplex error at the `Short` ceiling before summing, matching fgbio's
+        // capped `duplexConsensus.errors` `Array[Short]` (cE = errors.sum / totalDepths.sum).
+        let total_errors: usize =
+            consensus.errors.iter().map(|&e| clamp_per_base_to_fgbio_short(e) as usize).sum();
+        // Accumulate in `usize` (not `i32`), matching the aD/bD strand totals below and the
+        // vanilla (`u64`) / duplex (`i64`) callers: each per-base value is Short-capped (<=65534),
+        // so a very long consensus could otherwise overflow a 32-bit sum.
+        let total_bases: usize = total_depths.iter().map(|&d| d as usize).sum();
         let error_rate =
             if total_bases > 0 { total_errors as f32 / total_bases as f32 } else { 0.0 };
 
@@ -1344,11 +1370,16 @@ impl CodecConsensusCaller {
         self.bam_builder.append_int_tag(SamTag::CM, min_depth);
         self.bam_builder.append_float_tag(SamTag::CE, error_rate);
 
-        // AB strand tags (aD, aM, aE)
-        let a_max_depth = ss_a.depths.iter().map(|&d| i32::from(d)).max().unwrap_or(0);
-        let a_min_depth = ss_a.depths.iter().map(|&d| i32::from(d)).min().unwrap_or(0);
-        let a_total_errors: usize = ss_a.errors.iter().map(|&e| e as usize).sum();
-        let a_total_bases: usize = ss_a.depths.iter().map(|&d| d as usize).sum();
+        // AB strand tags (aD, aM, aE) -- per-base depth capped at the `Short` ceiling
+        // before max/min/sum, matching fgbio's `abConsensus.depths` (`Array[Short]`).
+        let a_depths_capped: Vec<i32> =
+            ss_a.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).collect();
+        let a_max_depth = a_depths_capped.iter().copied().max().unwrap_or(0);
+        let a_min_depth = a_depths_capped.iter().copied().min().unwrap_or(0);
+        // Per-base error also capped at the `Short` ceiling, matching fgbio's `abConsensus.errors`.
+        let a_total_errors: usize =
+            ss_a.errors.iter().map(|&e| clamp_per_base_to_fgbio_short(e) as usize).sum();
+        let a_total_bases: usize = a_depths_capped.iter().map(|&d| d as usize).sum();
         let a_error_rate =
             if a_total_bases > 0 { a_total_errors as f32 / a_total_bases as f32 } else { 0.0 };
 
@@ -1356,11 +1387,15 @@ impl CodecConsensusCaller {
         self.bam_builder.append_int_tag(SamTag::AM, a_min_depth);
         self.bam_builder.append_float_tag(SamTag::AE, a_error_rate);
 
-        // BA strand tags (bD, bM, bE)
-        let b_max_depth = ss_b.depths.iter().map(|&d| i32::from(d)).max().unwrap_or(0);
-        let b_min_depth = ss_b.depths.iter().map(|&d| i32::from(d)).min().unwrap_or(0);
-        let b_total_errors: usize = ss_b.errors.iter().map(|&e| e as usize).sum();
-        let b_total_bases: usize = ss_b.depths.iter().map(|&d| d as usize).sum();
+        // BA strand tags (bD, bM, bE) -- same per-base `Short`-ceiling cap as AB.
+        let b_depths_capped: Vec<i32> =
+            ss_b.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).collect();
+        let b_max_depth = b_depths_capped.iter().copied().max().unwrap_or(0);
+        let b_min_depth = b_depths_capped.iter().copied().min().unwrap_or(0);
+        // Same `Short`-ceiling cap on the bE numerator as the AB strand above.
+        let b_total_errors: usize =
+            ss_b.errors.iter().map(|&e| clamp_per_base_to_fgbio_short(e) as usize).sum();
+        let b_total_bases: usize = b_depths_capped.iter().map(|&d| d as usize).sum();
         let b_error_rate =
             if b_total_bases > 0 { b_total_errors as f32 / b_total_bases as f32 } else { 0.0 };
 
@@ -1370,15 +1405,17 @@ impl CodecConsensusCaller {
 
         // Per-base tags if enabled
         if self.options.produce_per_base_tags {
-            // Per-base depth arrays - convert to signed integers to match fgbio/simplex/duplex
-            let ad_array: Vec<i16> = ss_a.depths.iter().map(|&d| d as i16).collect();
-            let bd_array: Vec<i16> = ss_b.depths.iter().map(|&d| d as i16).collect();
+            // Per-base depth/error arrays - each value capped at fgbio's `Short`
+            // ceiling (`Array[Short]`, i16::MAX = 32767) so a value above 32767
+            // saturates rather than wrapping to a NEGATIVE i16 (see `capped_short_array`).
+            // Mirrors the duplex caller and the scalar cD/aD/bD tags.
+            let ad_array = capped_short_array(&ss_a.depths);
+            let bd_array = capped_short_array(&ss_b.depths);
             self.bam_builder.append_i16_array_tag(SamTag::AD_BASES, &ad_array);
             self.bam_builder.append_i16_array_tag(SamTag::BD_BASES, &bd_array);
 
-            // Per-base error arrays - convert to signed integers to match fgbio/simplex/duplex
-            let ae_array: Vec<i16> = ss_a.errors.iter().map(|&e| e as i16).collect();
-            let be_array: Vec<i16> = ss_b.errors.iter().map(|&e| e as i16).collect();
+            let ae_array = capped_short_array(&ss_a.errors);
+            let be_array = capped_short_array(&ss_b.errors);
             self.bam_builder.append_i16_array_tag(SamTag::AE_BASES, &ae_array);
             self.bam_builder.append_i16_array_tag(SamTag::BE_BASES, &be_array);
 
@@ -3187,6 +3224,157 @@ mod tests {
         );
     }
 
+    /// Regression (CLI CRITICAL): the per-base duplex depth must be the sum of each
+    /// strand's per-base depth CAPPED at fgbio's `Short` ceiling first
+    /// (`min(da,32767) + min(db,32767)`), not the raw `da + db`. A raw u16 sum both
+    /// diverges from fgbio and OVERFLOWS u16 for very deep families — here
+    /// `40000 + 40000 = 80000 > u16::MAX`, which panicked in debug before the fix.
+    #[test]
+    fn test_duplex_per_base_depth_caps_each_strand_before_summing() {
+        let options = CodecConsensusOptions::default();
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // Both strands agree on both bases (drives the `da + db` agreement branch),
+        // with per-base depths at/above the `Short` ceiling.
+        let deep = SingleStrandConsensus {
+            bases: b"AC".to_vec(),
+            quals: vec![40, 40],
+            depths: vec![40_000, u16::MAX], // 40000 > 32767; u16::MAX = 65535
+            errors: vec![0, 0],
+            raw_read_count: 40_000,
+            ref_start: 0,
+            ref_end: 1,
+            is_negative_strand: false,
+        };
+        let ss_a = deep.clone();
+        let ss_b = SingleStrandConsensus { is_negative_strand: true, ..deep };
+
+        let duplex = caller
+            .build_duplex_consensus_from_padded(&ss_a, &ss_b)
+            .expect("Should build duplex consensus without overflowing");
+
+        // min(40000,32767)+min(40000,32767) = 32767+32767 = 65534, and
+        // min(65535,32767)+min(65535,32767) = 65534 too — both fit u16 (no overflow).
+        assert_eq!(
+            duplex.depths,
+            vec![65_534, 65_534],
+            "per-base duplex depth must be the sum of Short-capped strand depths, not the raw \
+             (overflowing) da + db"
+        );
+    }
+
+    /// The emitted error-rate NUMERATORS (aE/bE/cE) must sum per-base errors capped at fgbio's
+    /// `Short` ceiling, matching fgbio's capped `errors` `Array[Short]` — not just the depth
+    /// denominators that #552 already capped. A per-base error above 32767 left uncapped inflates
+    /// the rate past fgbio's value. Companion to the per-base depth-cap test above.
+    #[test]
+    fn test_codec_error_rate_numerator_caps_at_fgbio_short_ceiling() {
+        let options = CodecConsensusOptions::default();
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // AB strand: first base's error count exceeds the Short ceiling; depths saturate too.
+        let ss_a = SingleStrandConsensus {
+            bases: b"ACGT".to_vec(),
+            quals: vec![30, 30, 30, 30],
+            depths: vec![40_000, 40_000, 40_000, 40_000], // capped denominator: 32767 each
+            errors: vec![40_000, 0, 0, 0],                // first base's errors exceed the ceiling
+            raw_read_count: 40_000,
+            ref_start: 0,
+            ref_end: 3,
+            is_negative_strand: false,
+        };
+        // BA strand: below the ceiling, no errors.
+        let ss_b = SingleStrandConsensus {
+            bases: b"ACGT".to_vec(),
+            quals: vec![30, 30, 30, 30],
+            depths: vec![30_000, 30_000, 30_000, 30_000],
+            errors: vec![0, 0, 0, 0],
+            raw_read_count: 30_000,
+            ref_start: 0,
+            ref_end: 3,
+            is_negative_strand: true,
+        };
+        // Duplex consensus: per-base error above the ceiling drives the cE numerator.
+        let consensus = SingleStrandConsensus {
+            bases: b"ACGT".to_vec(),
+            quals: vec![30, 30, 30, 30],
+            depths: vec![65_534, 65_534, 65_534, 65_534],
+            errors: vec![40_000, 0, 0, 0],
+            raw_read_count: 40_000,
+            ref_start: 0,
+            ref_end: 3,
+            is_negative_strand: false,
+        };
+
+        let mut output = ConsensusOutput::default();
+        caller
+            .build_output_record_into(&mut output, &consensus, &ss_a, &ss_b, None, &[], &[])
+            .expect("build_output_record_into should succeed");
+
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let rec = &records[0];
+
+        // aE = min(40000,32767) / (32767 * 4) = 32767 / 131068 = 0.25 (uncapped would be 0.3052).
+        let ae = rec.get_float_tag(SamTag::AE).expect("aE present");
+        let expected_ae = 32_767.0f32 / (32_767.0f32 * 4.0);
+        assert!(
+            (ae - expected_ae).abs() < 1e-6,
+            "aE numerator must cap at the Short ceiling: expected {expected_ae}, got {ae}"
+        );
+        // bE strand has no errors → 0.
+        assert_eq!(rec.get_float_tag(SamTag::BE), Some(0.0), "bE has no errors");
+        // cE = min(40000,32767) / totalDepths.sum, totalDepths = (32767 + 30000) * 4.
+        let ce = rec.get_float_tag(SamTag::CE).expect("cE present");
+        let expected_ce = 32_767.0f32 / ((32_767.0f32 + 30_000.0f32) * 4.0);
+        assert!(
+            (ce - expected_ce).abs() < 1e-6,
+            "cE numerator must cap at the Short ceiling: expected {expected_ce}, got {ce}"
+        );
+    }
+
+    /// Regression: the combined-depth denominator for `cE` must accumulate in a type wider than
+    /// `i32`. Each per-base `totalDepths` entry is Short-capped (`min(da,32767)+min(db,32767)` <=
+    /// 65534), so a long consensus overflows a 32-bit sum (here `40_000 * 65_534 > i32::MAX`),
+    /// which panicked in debug before the fix. Mirrors the vanilla (`u64`) / duplex (`i64`) callers.
+    #[test]
+    fn test_codec_ce_denominator_does_not_overflow_for_long_deep_consensus() {
+        let options = CodecConsensusOptions::default();
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // A consensus long enough that summing the Short-capped per-base depths exceeds i32::MAX:
+        // 40_000 bases * 65_534 = 2_621_360_000 > 2_147_483_647.
+        let len = 40_000usize;
+        let deep = |is_negative_strand: bool| SingleStrandConsensus {
+            bases: vec![b'A'; len],
+            quals: vec![40; len],
+            depths: vec![u16::MAX; len], // clamps to 32_767 per strand
+            errors: vec![0; len],
+            raw_read_count: u16::MAX as usize,
+            ref_start: 0,
+            ref_end: len - 1,
+            is_negative_strand,
+        };
+        let ss_a = deep(false);
+        let ss_b = deep(true);
+        let consensus = deep(false);
+
+        let mut output = ConsensusOutput::default();
+        caller
+            .build_output_record_into(&mut output, &consensus, &ss_a, &ss_b, None, &[], &[])
+            .expect(
+                "build_output_record_into should succeed without overflowing the cE denominator",
+            );
+
+        let records = ParsedBamRecord::parse_all(&output.data);
+        // No errors -> cE is exactly 0.0; the point is that the denominator was computed without
+        // overflowing (an i32 sum would panic in debug before reaching this assertion).
+        assert_eq!(
+            records[0].get_float_tag(SamTag::CE),
+            Some(0.0),
+            "cE should be 0.0 for an error-free consensus"
+        );
+    }
+
     #[test]
     fn test_to_source_read_for_codec_positive_strand() {
         use noodles::sam::alignment::record::cigar::op::Kind;
@@ -4253,5 +4441,163 @@ mod tests {
             "TLEN must match between M and =/X CIGARs with identical reference consumption"
         );
         assert_eq!(match_r1_tlen, 100, "Expected TLEN=100 for start1=1, start2=71, ref_len=30");
+    }
+}
+
+// ============================================================================
+// fgbio-oracle saturation tests (offline-pinned)
+//
+// These tests drive fgumi's own CODEC caller on a DEEP fixture and assert the
+// emitted depth/error tags equal values CAPTURED FROM A REAL fgbio RUN on the
+// exact same input BAM, rather than re-derived from the implementation's own
+// formula. This closes the CodeRabbit finding that the hand-authored saturation
+// tests above "repeat the implementation's expected formulas, so a shared
+// misunderstanding of fgbio's cap-before-sum behavior would still pass".
+//
+// Equivalence: one `fgumi_sam::builder::SamBuilder` produces the fixture and
+// writes ONE BAM. That exact file is (1) what the offline fgbio run consumes and
+// (2) what the fgumi test reads back into `RawRecord`s. See the `#[ignore]`d
+// `regen_*` tests to re-emit the fixture BAM for a fresh fgbio capture.
+// ============================================================================
+#[cfg(test)]
+mod fgbio_oracle_saturation_tests {
+    use super::*;
+    use crate::oracle_test_support::{ExpectedOracleTags, records_from_builder, regen_write};
+    use fgumi_raw_bam::ParsedBamRecord;
+    use fgumi_sam::builder::{SamBuilder, Strand};
+    use rstest::rstest;
+
+    /// CODEC fixture: `n_pairs` FR read pairs on one molecule (single MI), each
+    /// carrying the RX (raw UMI) tag fgbio requires. R1 is on the plus strand and
+    /// R2 on the minus strand, both fully overlapping at position 100 with `bases`
+    /// (`ACGT` is its own reverse-complement, so both strands store the same
+    /// bytes). `r1_variant_bases`/`count` inject a disagreeing R1 sequence in the
+    /// first `count` pairs to exercise the per-strand error numerator.
+    fn build_codec_fixture(
+        n_pairs: usize,
+        bases: &str,
+        r1_variant_bases: Option<&str>,
+        variant_count: usize,
+    ) -> SamBuilder {
+        let mut b = SamBuilder::new();
+        b.set_template_coordinate_sort_order();
+        let quals = vec![40u8; bases.len()];
+        for i in 0..n_pairs {
+            let name = format!("p{i:07}");
+            let r1_bases = match r1_variant_bases {
+                Some(v) if i < variant_count => v,
+                _ => bases,
+            };
+            let _ = b
+                .add_pair()
+                .name(&name)
+                .bases1(r1_bases)
+                .bases2(bases)
+                .quals1(&quals)
+                .quals2(&quals)
+                .contig(0)
+                .start1(100)
+                .start2(100)
+                .strand1(Strand::Plus)
+                .strand2(Strand::Minus)
+                .attr("MI", "mol1")
+                .attr("RX", "ACC")
+                .build();
+        }
+        b
+    }
+
+    /// A CODEC caller configured to match fgbio's `CallCodecConsensusReads` CLI,
+    /// which always emits the per-base arrays (ad/bd/ae/be); the library default
+    /// leaves them off, so the oracle assertions on those arrays would otherwise
+    /// see absent tags.
+    fn codec_caller() -> CodecConsensusCaller {
+        let options = CodecConsensusOptions {
+            produce_per_base_tags: true,
+            ..CodecConsensusOptions::default()
+        };
+        CodecConsensusCaller::new("codec".to_string(), "A".to_string(), options)
+    }
+
+    // Note on the CODEC single-strand depths: every surviving primary FR pair
+    // contributes exactly one R1 and one R2 with the same (mutually clip-normalized)
+    // alignment, so aD (R1 depth) and bD (R2 depth) are structurally EQUAL. Hence the
+    // CODEC saturation shape is aD == bD == 32767 → cD = 65534 (the cap-before-sum
+    // boundary; an uncapped sum would overflow/wrap). The OPEN-interval mixed-strand
+    // case (aD != bD) is exercised by the duplex caller, whose /A and /B strand read
+    // sets are independent (see duplex_caller.rs fgbio_oracle_saturation_tests).
+
+    /// fgumi's CODEC caller, driven on a DEEP fixture, must emit depth/error tags
+    /// equal to values CAPTURED FROM A REAL fgbio RUN on the exact same input BAM.
+    ///
+    /// Oracle provenance — fgbio `4.0.1-de8e5d4-SNAPSHOT`, captured with (CLI
+    /// defaults: `--error-rate-pre-umi 45 --error-rate-post-umi 40
+    /// --min-input-base-quality 10 --min-read-pairs 1`, no `--max-read-pairs` so the
+    /// deep families are NOT downsampled):
+    ///
+    /// ```text
+    /// java -jar fgbio-4.0.1-de8e5d4-SNAPSHOT.jar CallCodecConsensusReads \
+    ///   -i <fixture>.bam -o out.bam
+    /// samtools view out.bam   # read aD/aM/aE/bD/bM/bE/cD/cM/cE and ad/bd/ae/be
+    /// ```
+    ///
+    /// Re-emit `<fixture>.bam` with the matching `#[ignore]`d `regen_codec_*` test
+    /// (`FGUMI_ORACLE_BAM_OUT=/path/to.bam cargo test ... -- --ignored`).
+    #[rstest]
+    // Depth saturation, equal strands: 33_000 identical FR pairs. Each strand's
+    // per-base depth (33_000) caps to 32_767, so cD = 32_767 + 32_767 = 65_534.
+    #[case::depth_saturation_equal_strands(
+        33_000, "ACGT", None, 0,
+        ExpectedOracleTags {
+            cd: 65_534, cm: 65_534, ce: 0.0,
+            ad: 32_767, am: 32_767, ae: 0.0,
+            bd: 32_767, bm: 32_767, be: 0.0,
+            ad_bases: vec![32_767; 4], bd_bases: vec![32_767; 4],
+            ae_bases: vec![0; 4], be_bases: vec![0; 4],
+        },
+    )]
+    // Error-numerator saturation: 73_000 R1 pairs, 33_000 disagreeing at base 0
+    // (C) vs 40_000 majority (A). The per-base error count at base 0 is
+    // 73_000 - 40_000 = 33_000, which caps to 32_767 (NOT wrapping to a negative
+    // i16). aE = 32_767 / (32_767 * 8) = 0.125.
+    #[case::error_numerator_saturation(
+        73_000, "ACGTACGT", Some("CCGTACGT"), 33_000,
+        ExpectedOracleTags {
+            cd: 65_534, cm: 65_534, ce: 0.062_5,
+            ad: 32_767, am: 32_767, ae: 0.125,
+            bd: 32_767, bm: 32_767, be: 0.0,
+            ad_bases: vec![32_767; 8], bd_bases: vec![32_767; 8],
+            ae_bases: vec![32_767, 0, 0, 0, 0, 0, 0, 0], be_bases: vec![0; 8],
+        },
+    )]
+    fn codec_saturation_matches_fgbio_oracle(
+        #[case] n_pairs: usize,
+        #[case] bases: &str,
+        #[case] variant: Option<&str>,
+        #[case] variant_count: usize,
+        #[case] expected: ExpectedOracleTags,
+    ) {
+        let builder = build_codec_fixture(n_pairs, bases, variant, variant_count);
+        let records = records_from_builder(&builder);
+        let mut caller = codec_caller();
+        let output =
+            caller.consensus_reads_from_sam_records(records).expect("codec consensus succeeds");
+        let parsed = ParsedBamRecord::parse_all(&output.data);
+        assert_eq!(parsed.len(), 1, "one CODEC consensus fragment expected");
+        expected.assert_matches(&parsed[0]);
+    }
+
+    /// Re-emit the CODEC depth-saturation fixture BAM for a fresh fgbio capture.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_codec_depth_saturation_fixture() {
+        regen_write(&build_codec_fixture(33_000, "ACGT", None, 0));
+    }
+
+    /// Re-emit the CODEC error-saturation fixture BAM for a fresh fgbio capture.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_codec_error_saturation_fixture() {
+        regen_write(&build_codec_fixture(73_000, "ACGTACGT", Some("CCGTACGT"), 33_000));
     }
 }

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -202,7 +202,9 @@ use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::RecordBuf;
 
 use crate::caller::ConsensusOutput;
-use crate::caller::{ConsensusCaller, ConsensusCallingStats, RejectionReason};
+use crate::caller::{
+    ConsensusCaller, ConsensusCallingStats, RejectionReason, clamp_per_base_to_fgbio_short,
+};
 use crate::phred::MAX_PHRED;
 use crate::phred::{MIN_PHRED, PhredScore};
 use crate::simple_umi::consensus_umis;
@@ -1100,10 +1102,18 @@ impl DuplexConsensusCaller {
         let ab = &consensus.ab_consensus;
         let ba_opt = consensus.ba_consensus.as_ref();
 
-        let ab_depth_max = i32::from(ab.depths.iter().copied().max().unwrap_or(0));
-        let ab_depth_min = i32::from(ab.depths.iter().copied().min().unwrap_or(0));
-        let ab_total_depth: i64 = ab.depths.iter().map(|&d| i64::from(d)).sum();
-        let ab_total_errors: i64 = ab.errors.iter().map(|&e| i64::from(e)).sum();
+        // Clamp each per-base depth to fgbio's `Short` ceiling before max/min, so the
+        // scalar aD/aM match fgbio (which derives them from its capped `Array[Short]`).
+        let ab_depth_max =
+            ab.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).max().unwrap_or(0);
+        let ab_depth_min =
+            ab.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).min().unwrap_or(0);
+        let ab_total_depth: i64 =
+            ab.depths.iter().map(|&d| i64::from(clamp_per_base_to_fgbio_short(d))).sum();
+        // Clamp each per-base error count to the same `Short` ceiling before summing, so the
+        // aE numerator matches fgbio (which stores `abConsensus.errors` as a capped `Array[Short]`).
+        let ab_total_errors: i64 =
+            ab.errors.iter().map(|&e| i64::from(clamp_per_base_to_fgbio_short(e))).sum();
         let ab_error_rate =
             if ab_total_depth > 0 { ab_total_errors as f32 / ab_total_depth as f32 } else { 0.0 };
 
@@ -1129,10 +1139,15 @@ impl DuplexConsensusCaller {
 
         // Calculate BA strand metrics
         let (ba_depth_max, ba_depth_min, ba_error_rate) = if let Some(ba) = ba_opt {
-            let ba_depth_max = i32::from(ba.depths.iter().copied().max().unwrap_or(0));
-            let ba_depth_min = i32::from(ba.depths.iter().copied().min().unwrap_or(0));
-            let ba_total_depth: i64 = ba.depths.iter().map(|&d| i64::from(d)).sum();
-            let ba_total_errors: i64 = ba.errors.iter().map(|&e| i64::from(e)).sum();
+            let ba_depth_max =
+                ba.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).max().unwrap_or(0);
+            let ba_depth_min =
+                ba.depths.iter().map(|&d| clamp_per_base_to_fgbio_short(d)).min().unwrap_or(0);
+            let ba_total_depth: i64 =
+                ba.depths.iter().map(|&d| i64::from(clamp_per_base_to_fgbio_short(d))).sum();
+            // Same `Short`-ceiling cap on the bE numerator as the aE strand above.
+            let ba_total_errors: i64 =
+                ba.errors.iter().map(|&e| i64::from(clamp_per_base_to_fgbio_short(e))).sum();
             let ba_error_rate = if ba_total_depth > 0 {
                 ba_total_errors as f32 / ba_total_depth as f32
             } else {
@@ -1166,10 +1181,15 @@ impl DuplexConsensusCaller {
         }
 
         // 8. Duplex consensus tags (cD, cM, cE)
+        // fgbio's combined depth caps EACH strand's per-base value at the `Short`
+        // ceiling *before* summing (`totalDepths(i) = min(abD_i,32767) + min(baD_i,32767)`),
+        // so clamp per strand per base, then max/min for cD/cM.
         let combined_depths: Vec<i32> = (0..consensus.len())
             .map(|i| {
-                let ab_d = i32::from(ab.depths.get(i).copied().unwrap_or(0));
-                let ba_d = i32::from(ba_opt.and_then(|b| b.depths.get(i).copied()).unwrap_or(0));
+                let ab_d = clamp_per_base_to_fgbio_short(ab.depths.get(i).copied().unwrap_or(0));
+                let ba_d = clamp_per_base_to_fgbio_short(
+                    ba_opt.and_then(|b| b.depths.get(i).copied()).unwrap_or(0),
+                );
                 ab_d + ba_d
             })
             .collect();
@@ -1178,7 +1198,10 @@ impl DuplexConsensusCaller {
         let duplex_depth_min = combined_depths.iter().copied().min().unwrap_or(0);
 
         let total_depth: i64 = combined_depths.iter().map(|&d| i64::from(d)).sum();
-        let total_errors: i64 = consensus.errors.iter().map(|&e| i64::from(e)).sum();
+        // Cap each per-base duplex error at the `Short` ceiling before summing, matching
+        // fgbio's capped `duplexConsensus.errors` `Array[Short]` (cE = errors.sum / totalDepths.sum).
+        let total_errors: i64 =
+            consensus.errors.iter().map(|&e| i64::from(clamp_per_base_to_fgbio_short(e))).sum();
         let duplex_error_rate =
             if total_depth > 0 { total_errors as f32 / total_depth as f32 } else { 0.0 };
 
@@ -5002,6 +5025,156 @@ mod tests {
         assert_eq!(rec.get_int_tag(SamTag::AM), Some(5)); // min depth from AB
     }
 
+    /// Deep families must report depth tags saturated at fgbio's `Short` ceiling, matching
+    /// fgbio (which stores per-base depth as `Array[Short]`). The per-strand `aD`/`bD` cap
+    /// at 32767; the combined `cD` caps EACH strand's per-base value *before* summing
+    /// (`cD = max_i(min(abD_i,32767) + min(baD_i,32767))`), so a mixed pair where only one
+    /// strand saturates lands in the open interval (32767, 65534) — the exact case an
+    /// "only at 32767/65534" tolerance would miss.
+    #[test]
+    fn test_duplex_depth_tags_saturate_at_fgbio_short_ceiling() {
+        let ab_consensus = VanillaConsensusRead {
+            id: "ab".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            depths: vec![40_000, 40_000, 40_000, 40_000], // > i16::MAX (32767)
+            errors: vec![0, 0, 0, 0],
+            source_reads: None,
+            methylation: None,
+        };
+        let ba_consensus = VanillaConsensusRead {
+            id: "ba".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            depths: vec![30_000, 30_000, 30_000, 30_000], // < i16::MAX, not saturated
+            errors: vec![0, 0, 0, 0],
+            source_reads: None,
+            methylation: None,
+        };
+        let duplex = DuplexConsensusRead {
+            id: "test".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            errors: vec![0, 0, 0, 0],
+            ab_consensus,
+            ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
+        };
+
+        let mut builder = UnmappedSamBuilder::new();
+        let mut output = ConsensusOutput::default();
+        DuplexConsensusCaller::duplex_read_into(
+            &mut builder,
+            &mut output,
+            &duplex,
+            ReadType::R1,
+            "UMI123",
+            &[],
+            &[],
+            false,
+            "consensus",
+            "RG1",
+            true,
+            crate::MethylationMode::Disabled,
+            None,
+            None,
+        )
+        .expect("duplex_read_into should succeed");
+
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let rec = &records[0];
+
+        // Per-strand tags saturate at the Short ceiling.
+        assert_eq!(rec.get_int_tag(SamTag::AD), Some(32_767), "aD caps at i16::MAX");
+        assert_eq!(rec.get_int_tag(SamTag::AM), Some(32_767), "aM caps at i16::MAX");
+        // BA strand is below the ceiling and is unchanged.
+        assert_eq!(rec.get_int_tag(SamTag::BD), Some(30_000), "bD unchanged below ceiling");
+        assert_eq!(rec.get_int_tag(SamTag::BM), Some(30_000), "bM unchanged below ceiling");
+        // Combined caps EACH strand per base before summing: 32767 + 30000 = 62767 — the
+        // intermediate value in (32767, 65534) that a boundary-only tolerance would miss.
+        assert_eq!(rec.get_int_tag(SamTag::CD), Some(62_767), "cD = min(ab,32767)+min(ba,32767)");
+        assert_eq!(rec.get_int_tag(SamTag::CM), Some(62_767), "cM = per-strand-capped sum");
+    }
+
+    /// The error-rate NUMERATORS (aE/bE/cE) must also be summed from per-base errors capped at
+    /// fgbio's `Short` ceiling, matching fgbio's capped `errors` `Array[Short]` — not just the
+    /// depth denominators. A per-base error above 32767 that is left uncapped inflates the rate
+    /// past fgbio's value (and can even exceed 1.0). Companion to the depth-saturation test above.
+    #[test]
+    fn test_duplex_error_rate_numerator_caps_at_fgbio_short_ceiling() {
+        let ab_consensus = VanillaConsensusRead {
+            id: "ab".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            depths: vec![40_000, 40_000, 40_000, 40_000], // capped denominator: 32767 each
+            errors: vec![40_000, 0, 0, 0], // first base's errors exceed the Short ceiling
+            source_reads: None,
+            methylation: None,
+        };
+        let ba_consensus = VanillaConsensusRead {
+            id: "ba".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            depths: vec![30_000, 30_000, 30_000, 30_000], // below the ceiling
+            errors: vec![0, 0, 0, 0],
+            source_reads: None,
+            methylation: None,
+        };
+        let duplex = DuplexConsensusRead {
+            id: "test".to_string(),
+            bases: vec![b'A', b'C', b'G', b'T'],
+            quals: vec![30, 30, 30, 30],
+            errors: vec![40_000, 0, 0, 0], // duplex per-base error above the ceiling
+            ab_consensus,
+            ba_consensus: Some(ba_consensus),
+            methylation: None,
+            is_ba_only: false,
+        };
+
+        let mut builder = UnmappedSamBuilder::new();
+        let mut output = ConsensusOutput::default();
+        DuplexConsensusCaller::duplex_read_into(
+            &mut builder,
+            &mut output,
+            &duplex,
+            ReadType::R1,
+            "UMI123",
+            &[],
+            &[],
+            false,
+            "consensus",
+            "RG1",
+            true,
+            crate::MethylationMode::Disabled,
+            None,
+            None,
+        )
+        .expect("duplex_read_into should succeed");
+
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let rec = &records[0];
+
+        // aE numerator caps at 32767: aE = min(40000,32767) / (32767 * 4) = 32767 / 131068 = 0.25.
+        // With an uncapped numerator it would be 40000 / 131068 = 0.3052, so assert it landed at
+        // the capped value (and did NOT exceed the uncapped inflation).
+        let ae = rec.get_float_tag(SamTag::AE).expect("aE present");
+        let expected_ae = 32_767.0f32 / (32_767.0f32 * 4.0);
+        assert!(
+            (ae - expected_ae).abs() < 1e-6,
+            "aE numerator must cap at the Short ceiling: expected {expected_ae}, got {ae}"
+        );
+        // bE strand has no errors → 0.
+        assert_eq!(rec.get_float_tag(SamTag::BE), Some(0.0), "bE has no errors");
+        // cE numerator caps at 32767 too: 32767 / totalDepths.sum, totalDepths = (32767+30000)*4.
+        let ce = rec.get_float_tag(SamTag::CE).expect("cE present");
+        let expected_ce = 32_767.0f32 / ((32_767.0f32 + 30_000.0f32) * 4.0);
+        assert!(
+            (ce - expected_ce).abs() < 1e-6,
+            "cE numerator must cap at the Short ceiling: expected {expected_ce}, got {ce}"
+        );
+    }
+
     #[test]
     fn test_are_all_same_strand_mixed() {
         // Test are_all_same_strand with mixed strands
@@ -6233,5 +6406,215 @@ mod tests {
         );
 
         Ok(())
+    }
+}
+
+// ============================================================================
+// fgbio-oracle saturation tests (offline-pinned)
+//
+// These tests drive fgumi's own duplex caller on a DEEP fixture and assert the
+// emitted depth/error tags equal values CAPTURED FROM A REAL fgbio RUN on the
+// exact same input BAM, rather than re-derived from the implementation's own
+// formula. This closes the CodeRabbit finding that the hand-authored saturation
+// tests "repeat the implementation's expected formulas, so a shared
+// misunderstanding of fgbio's cap-before-sum behavior would still pass".
+//
+// Equivalence: one `fgumi_sam::builder::SamBuilder` produces the fixture and
+// writes ONE BAM. That exact file is (1) what the offline fgbio run consumes and
+// (2) what the fgumi test reads back into `RawRecord`s. See the `#[ignore]`d
+// `regen_*` tests to re-emit the fixture BAM for a fresh fgbio capture.
+// ============================================================================
+#[cfg(test)]
+mod fgbio_oracle_saturation_tests {
+    use super::*;
+    use crate::oracle_test_support::{ExpectedOracleTags, records_from_builder, regen_write};
+    use fgumi_raw_bam::ParsedBamRecord;
+    use fgumi_sam::builder::{SamBuilder, Strand};
+    use rstest::rstest;
+
+    /// DUPLEX fixture: one source molecule sequenced on both strands. `n_ab` read
+    /// pairs carry `MI = mol/A`, `n_ba` pairs carry `MI = mol/B`. For the R1 duplex
+    /// consensus fgbio builds the AB single-strand consensus from the /A pairs' R1s
+    /// (so `aD = n_ab`) and the BA single-strand consensus from the /B pairs' R2s
+    /// (so `bD = n_ba`); because the two counts are independent, an unequal
+    /// `n_ab`/`n_ba` makes `cD = min(aD,32767) + min(bD,32767)` land in the OPEN
+    /// interval (32767, 65534) when one strand saturates.
+    ///
+    /// Strand layout (so fgbio's `areAllSameStrand` check holds):
+    ///   AB (mol/A): R1 = plus,  R2 = minus
+    ///   BA (mol/B): R1 = minus, R2 = plus
+    /// R1 starts at 100 and R2 at `start2`. `start2` is set NON-overlapping with R1
+    /// (e.g. 200) so that when a per-strand error variant is injected, fgbio's
+    /// FR-pair overlapping-base masking does NOT mask the disagreeing R1 base
+    /// against its own (agreeing) R2 mate — which would otherwise drop that base
+    /// from the AB single-strand depth and zero the error. `bases` uses `ACGT`-style
+    /// palindromic bytes so both strands store identical bytes. `variant_bases`/
+    /// `count` inject a disagreeing AB-R1 sequence in the first `count` /A pairs to
+    /// exercise the per-strand error numerator.
+    fn build_duplex_fixture(
+        n_ab: usize,
+        n_ba: usize,
+        bases: &str,
+        variant_bases: Option<&str>,
+        variant_count: usize,
+        start2: usize,
+    ) -> SamBuilder {
+        let mut b = SamBuilder::new();
+        b.set_template_coordinate_sort_order();
+        let quals = vec![40u8; bases.len()];
+        for i in 0..n_ab {
+            let name = format!("a{i:07}");
+            let r1_bases = match variant_bases {
+                Some(v) if i < variant_count => v,
+                _ => bases,
+            };
+            let _ = b
+                .add_pair()
+                .name(&name)
+                .bases1(r1_bases)
+                .bases2(bases)
+                .quals1(&quals)
+                .quals2(&quals)
+                .contig(0)
+                .start1(100)
+                .start2(start2)
+                .strand1(Strand::Plus)
+                .strand2(Strand::Minus)
+                .attr("MI", "mol/A")
+                .build();
+        }
+        for i in 0..n_ba {
+            let name = format!("b{i:07}");
+            let _ = b
+                .add_pair()
+                .name(&name)
+                .bases1(bases)
+                .bases2(bases)
+                .quals1(&quals)
+                .quals2(&quals)
+                .contig(0)
+                .start1(100)
+                .start2(start2)
+                .strand1(Strand::Minus)
+                .strand2(Strand::Plus)
+                .attr("MI", "mol/B")
+                .build();
+        }
+        b
+    }
+
+    fn duplex_caller() -> DuplexConsensusCaller {
+        DuplexConsensusCaller::new(
+            "duplex".to_string(),
+            "A".to_string(),
+            vec![1],
+            10,    // min_input_base_quality (fgbio default)
+            true,  // produce_per_base_tags (fgbio CLI always emits per-base arrays)
+            false, // trim
+            None,  // max_reads_per_strand
+            None,  // cell_tag
+            false, // track_rejects
+            45,    // error_rate_pre_umi
+            40,    // error_rate_post_umi
+        )
+        .expect("duplex caller")
+    }
+
+    /// Non-overlapping R2 start for the fixtures: keeps R1 (start 100, ≤8bp) and
+    /// R2 (start 200) apart so fgbio's FR overlapping-base masking never touches an
+    /// injected AB-R1 error base (see `build_duplex_fixture`).
+    const NON_OVERLAP_R2_START: usize = 200;
+
+    /// fgumi's duplex caller, driven on a DEEP fixture, must emit depth/error tags
+    /// equal to values CAPTURED FROM A REAL fgbio RUN on the exact same input BAM.
+    /// Assertions target the R1 duplex record (`FIRST_SEGMENT`), whose AB
+    /// single-strand consensus carries the injected error.
+    ///
+    /// Oracle provenance — fgbio `4.0.1-de8e5d4-SNAPSHOT`, captured with (CLI
+    /// defaults: `--error-rate-pre-umi 45 --error-rate-post-umi 40
+    /// --min-input-base-quality 10 --min-reads 1`, no `--max-reads-per-strand` so
+    /// the deep families are NOT downsampled):
+    ///
+    /// ```text
+    /// java -jar fgbio-4.0.1-de8e5d4-SNAPSHOT.jar CallDuplexConsensusReads \
+    ///   -i <fixture>.bam -o out.bam
+    /// samtools view out.bam   # first (R1) record: aD/aM/aE/bD/bM/bE/cD/cM/cE, ad/bd/ae/be
+    /// ```
+    ///
+    /// Re-emit `<fixture>.bam` with the matching `#[ignore]`d `regen_duplex_*` test
+    /// (`FGUMI_ORACLE_BAM_OUT=/path/to.bam cargo test ... -- --ignored`).
+    #[rstest]
+    // Open-interval depth saturation, mixed strands: 33_000 /A pairs (AB depth
+    // 33_000 → caps to 32_767) and 20_000 /B pairs (BA depth 20_000, below the
+    // cap). cD = min(33_000,32_767) + 20_000 = 52_767, landing strictly INSIDE the
+    // open interval (32_767, 65_534) — the case a "saturates only at 32_767/65_534"
+    // tolerance would miss.
+    #[case::open_interval_depth_saturation(
+        33_000, 20_000, "ACGT", None, 0,
+        ExpectedOracleTags {
+            cd: 52_767, cm: 52_767, ce: 0.0,
+            ad: 32_767, am: 32_767, ae: 0.0,
+            bd: 20_000, bm: 20_000, be: 0.0,
+            ad_bases: vec![32_767; 4], bd_bases: vec![20_000; 4],
+            ae_bases: vec![0; 4], be_bases: vec![0; 4],
+        },
+    )]
+    // Error-numerator saturation on the (saturated) AB strand: 73_000 /A pairs,
+    // 33_000 disagreeing at base 0, 40_000 majority. AB per-base error at base 0 is
+    // 73_000 - 40_000 = 33_000, which caps to 32_767 (NOT wrapping negative).
+    // aE = 32_767 / (32_767 * 8) = 0.125. The BA strand (20_000 /B pairs) is clean.
+    #[case::error_numerator_saturation(
+        73_000, 20_000, "ACGTACGT", Some("CCGTACGT"), 33_000,
+        ExpectedOracleTags {
+            cd: 52_767, cm: 52_767, ce: 0.077_621_91,
+            ad: 32_767, am: 32_767, ae: 0.125,
+            bd: 20_000, bm: 20_000, be: 0.0,
+            ad_bases: vec![32_767; 8], bd_bases: vec![20_000; 8],
+            ae_bases: vec![32_767, 0, 0, 0, 0, 0, 0, 0], be_bases: vec![0; 8],
+        },
+    )]
+    fn duplex_saturation_matches_fgbio_oracle(
+        #[case] n_ab: usize,
+        #[case] n_ba: usize,
+        #[case] bases: &str,
+        #[case] variant: Option<&str>,
+        #[case] variant_count: usize,
+        #[case] expected: ExpectedOracleTags,
+    ) {
+        let builder =
+            build_duplex_fixture(n_ab, n_ba, bases, variant, variant_count, NON_OVERLAP_R2_START);
+        let records = records_from_builder(&builder);
+        let mut caller = duplex_caller();
+        let output = caller.consensus_reads(records).expect("duplex consensus succeeds");
+        let parsed = ParsedBamRecord::parse_all(&output.data);
+        assert_eq!(parsed.len(), 2, "duplex emits R1 and R2 consensus records");
+        // The AB single-strand consensus (and any injected error) lands on the R1
+        // duplex record; assert against it.
+        let rec = parsed
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT != 0)
+            .expect("R1 (first-of-pair) consensus present");
+        expected.assert_matches(rec);
+    }
+
+    /// Re-emit the duplex open-interval depth-saturation fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_depth_saturation_fixture() {
+        regen_write(&build_duplex_fixture(33_000, 20_000, "ACGT", None, 0, NON_OVERLAP_R2_START));
+    }
+
+    /// Re-emit the duplex error-saturation fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_error_saturation_fixture() {
+        regen_write(&build_duplex_fixture(
+            73_000,
+            20_000,
+            "ACGTACGT",
+            Some("CCGTACGT"),
+            33_000,
+            NON_OVERLAP_R2_START,
+        ));
     }
 }

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -34,6 +34,14 @@ pub mod codec_caller;
 #[cfg(feature = "simplex")]
 pub mod methylation;
 
+/// Shared helpers for the offline-pinned fgbio-oracle saturation tests in the
+/// codec and duplex caller modules. Test-only: depends on the `fgumi-bam-io`
+/// and `tempfile` dev-dependencies, so it is gated behind `cfg(test)`. Gated on
+/// `codec`/`duplex` too so it is not compiled (and flagged unused) when neither
+/// caller that uses it is enabled.
+#[cfg(all(test, any(feature = "codec", feature = "duplex")))]
+mod oracle_test_support;
+
 /// Methylation chemistry mode for consensus calling.
 ///
 /// Controls how C→T conversions at reference cytosine positions are interpreted

--- a/crates/fgumi-consensus/src/oracle_test_support.rs
+++ b/crates/fgumi-consensus/src/oracle_test_support.rs
@@ -1,0 +1,122 @@
+//! Shared test-only helpers for the offline-pinned fgbio-oracle saturation
+//! tests in [`codec_caller`](crate::codec_caller) and
+//! [`duplex_caller`](crate::duplex_caller).
+//!
+//! Each oracle test drives fgumi's own caller on a DEEP fixture and asserts the
+//! emitted depth/error tags equal values CAPTURED FROM A REAL fgbio RUN on the
+//! exact same input BAM, rather than re-derived from the implementation's own
+//! formula. This closes the CodeRabbit finding that the hand-authored
+//! saturation tests "repeat the implementation's expected formulas, so a shared
+//! misunderstanding of fgbio's cap-before-sum behavior would still pass".
+//!
+//! Equivalence: one [`SamBuilder`] produces the fixture and writes ONE BAM. That
+//! exact file is both (1) what the offline fgbio run consumes and (2) what the
+//! fgumi test reads back into `RawRecord`s. See the `#[ignore]`d `regen_*` tests
+//! in each caller module to re-emit the fixture BAM for a fresh fgbio capture.
+
+use std::path::Path;
+
+use fgumi_raw_bam::{ParsedBamRecord, RawRecord, SamTag};
+use fgumi_sam::builder::SamBuilder;
+
+/// Read a BAM at `path` back into a `Vec<RawRecord>` in file order — the same
+/// records the offline fgbio run sees (byte-identical input equivalence).
+pub(crate) fn raw_records_from_bam(path: &Path) -> Vec<RawRecord> {
+    let (mut reader, _header) =
+        fgumi_bam_io::create_raw_bam_reader(path, 1).expect("open fixture BAM");
+    let mut records = Vec::new();
+    let mut rec = RawRecord::new();
+    loop {
+        let n = reader.read_record(&mut rec).expect("read raw record");
+        if n == 0 {
+            break;
+        }
+        records.push(rec.clone());
+    }
+    records
+}
+
+/// Write `builder` to a temp BAM and read the records straight back. The
+/// permanent oracle tests use this so the fgumi caller consumes exactly the
+/// bytes the offline fgbio run would (a temp file, never overwriting a
+/// maintainer's `FGUMI_ORACLE_BAM_OUT`).
+pub(crate) fn records_from_builder(builder: &SamBuilder) -> Vec<RawRecord> {
+    let tmp = tempfile::NamedTempFile::new().expect("temp fixture BAM");
+    builder.write_bam(tmp.path()).expect("write fixture BAM");
+    raw_records_from_bam(tmp.path())
+}
+
+/// Re-emit a fixture BAM for a fresh fgbio capture: writes to
+/// `FGUMI_ORACLE_BAM_OUT` if set, otherwise a temp file whose path is logged.
+/// Used only by the `#[ignore]`d `regen_*` tests.
+pub(crate) fn regen_write(builder: &SamBuilder) {
+    if let Some(out) = std::env::var_os("FGUMI_ORACLE_BAM_OUT") {
+        let path = Path::new(&out);
+        builder.write_bam(path).expect("write fixture BAM to FGUMI_ORACLE_BAM_OUT");
+        eprintln!("wrote fixture BAM to {}", path.display());
+    } else {
+        let tmp = tempfile::NamedTempFile::new().expect("temp fixture BAM");
+        let (_file, path) = tmp.keep().expect("persist temp fixture BAM");
+        builder.write_bam(&path).expect("write fixture BAM");
+        eprintln!("wrote fixture BAM to {}", path.display());
+    }
+}
+
+/// The full set of fgbio-captured (pinned) consensus tag values for one
+/// consensus record. Bundling them keeps each `#[rstest]` case table readable
+/// (expected values live in the table) and each case's arg count small.
+pub(crate) struct ExpectedOracleTags {
+    pub(crate) cd: i32,
+    pub(crate) cm: i32,
+    pub(crate) ce: f32,
+    pub(crate) ad: i32,
+    pub(crate) am: i32,
+    pub(crate) ae: f32,
+    pub(crate) bd: i32,
+    pub(crate) bm: i32,
+    pub(crate) be: f32,
+    pub(crate) ad_bases: Vec<i16>,
+    pub(crate) bd_bases: Vec<i16>,
+    pub(crate) ae_bases: Vec<i16>,
+    pub(crate) be_bases: Vec<i16>,
+}
+
+impl ExpectedOracleTags {
+    /// Assert every emitted depth/error tag on `rec` equals the pinned value.
+    pub(crate) fn assert_matches(&self, rec: &ParsedBamRecord) {
+        assert_eq!(rec.get_int_tag(SamTag::CD), Some(self.cd), "cD (fgbio-pinned)");
+        assert_eq!(rec.get_int_tag(SamTag::CM), Some(self.cm), "cM (fgbio-pinned)");
+        assert_eq!(rec.get_int_tag(SamTag::AD), Some(self.ad), "aD (fgbio-pinned)");
+        assert_eq!(rec.get_int_tag(SamTag::AM), Some(self.am), "aM (fgbio-pinned)");
+        assert_eq!(rec.get_int_tag(SamTag::BD), Some(self.bd), "bD (fgbio-pinned)");
+        assert_eq!(rec.get_int_tag(SamTag::BM), Some(self.bm), "bM (fgbio-pinned)");
+
+        let ce = rec.get_float_tag(SamTag::CE).expect("cE present");
+        assert!((ce - self.ce).abs() < 1e-6, "cE (fgbio-pinned): expected {}, got {ce}", self.ce);
+        let ae = rec.get_float_tag(SamTag::AE).expect("aE present");
+        assert!((ae - self.ae).abs() < 1e-6, "aE (fgbio-pinned): expected {}, got {ae}", self.ae);
+        let be = rec.get_float_tag(SamTag::BE).expect("bE present");
+        assert!((be - self.be).abs() < 1e-6, "bE (fgbio-pinned): expected {}, got {be}", self.be);
+
+        assert_eq!(
+            rec.get_i16_array_tag(SamTag::AD_BASES),
+            Some(self.ad_bases.clone()),
+            "ad (fgbio-pinned)"
+        );
+        assert_eq!(
+            rec.get_i16_array_tag(SamTag::BD_BASES),
+            Some(self.bd_bases.clone()),
+            "bd (fgbio-pinned)"
+        );
+        assert_eq!(
+            rec.get_i16_array_tag(SamTag::AE_BASES),
+            Some(self.ae_bases.clone()),
+            "ae (fgbio-pinned)"
+        );
+        assert_eq!(
+            rec.get_i16_array_tag(SamTag::BE_BASES),
+            Some(self.be_bases.clone()),
+            "be (fgbio-pinned)"
+        );
+    }
+}


### PR DESCRIPTION
## What

Clamp the scalar consensus depth tags (`aD`/`bD`/`cD` and the `aM`/`bM`/`cM` minima) **and** the error-rate tags (`aE`/`bE`/`cE` — both the depth denominators and the error numerators) to fgbio's `Short` ceiling (`i16::MAX` = 32767) in the **codec** and **duplex** callers, matching what the **vanilla** (simplex) caller already does and what fgbio emits. This makes all three consensus callers consistent with each other and bit-identical to fgbio.

## Why

fgbio stores per-base consensus depth *and* per-base error counts as `Array[Short]` capped at `Short.MaxValue` and derives every scalar depth/error-rate tag from those capped arrays. fgumi keeps per-base depth and errors in `u16`. The vanilla caller already matches fgbio by clamping both depths and errors at push (with a test), and `base_builder.rs` documents the intent to clamp "at tag emission" — but the codec and duplex callers emitted the scalar depth *and* error-rate tags **uncapped**, so they diverged from fgbio on families deeper than 32767 reads (e.g. measured `aD 59034 vs 32767`). The three callers were inconsistent with each other and with fgbio, and this had been re-litigated repeatedly (the per-base arrays were hardened before, but the scalars were left uncapped).

## How

- Add a shared `clamp_per_base_to_fgbio_short(u16) -> i32` helper.
- codec/duplex: clamp each per-base depth before `max`/`min`/sum. For the **combined** duplex/codec `cD`/`cM`, cap each strand's per-base value **before** summing, exactly as fgbio's `totalDepths(i) = min(abD_i, 32767) + min(baD_i, 32767)` — so a mixed pair where only one strand saturates yields the correct intermediate value (e.g. 62767), not an uncapped sum.
- Cap the error-rate **numerators** the same way: `aE`/`bE`/`cE` are now summed from per-base errors capped at the ceiling, matching fgbio's capped `errors` `Array[Short]`. Both the numerator and the denominator of every error rate now derive from Short-capped per-base values.
- Only the emitted tags are capped; the unclamped depth is still used for the `--min-reads` threshold, so no behavior is lost.

## Tests

- Helper case table (in-range / at-ceiling / above / `u16::MAX`).
- Duplex + codec depth-saturation tests covering the intermediate `cD` case (`aD`→32767, `bD`→30000, `cD`→62767), alongside the existing vanilla saturation test.
- Duplex + codec error-rate numerator-cap tests: a per-base error above the ceiling yields the capped rate (`aE` = 32767/(32767·4) = 0.25) rather than the uncapped value (0.3052); verified to fail before the numerator fix.

## Notes

- **Breaking** (`!`): changes the emitted depth- and error-rate-tag values for consensus families deeper than 32767 reads (now capped, matching fgbio).
- Pairs with the compare-tool change on `nh/compare-hardening` (#530), which drops the now-unnecessary depth-saturation tolerance and compares these tags exactly. With the error numerators now capped too, the tolerance can be dropped for `aE`/`bE`/`cE` as well, not just the depth tags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated consensus depth and error calculations to respect fgbio’s Short ceiling before computing SAM scalar and per-base tags.
  - Prevented overflow/wraparound in very deep coverage scenarios, including duplex and strand-level depth/error-rate outputs.
  - Ensured duplex totals and error-rate numerators/denominators are derived from capped per-strand/per-base inputs for consistent tag behavior.

- **Tests**
  - Added regression tests for saturation edge cases (including mixed-saturation) and for overflow-safe error-rate denominator computation.
  - Added offline “fgbio oracle” saturation comparisons against pinned BAM captures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->