### PR TITLE
fix(umi): fold case in the sequential paired assigner to match the parallel path

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -1884,12 +1884,27 @@ impl UmiAssigner for PairedUmiAssigner {
             assert!((umi.split('-').count() == 2), "UMI {umi} is not a paired UMI");
         }
 
+        // Work on uppercased UMIs so counting, matching, tie-break, and strand assignment are
+        // all case-insensitive. Unlike the single-UMI adjacency tie-break (deliberately RAW /
+        // case-sensitive per S7-002 / FU-004), the parallel paired assigner
+        // (`ParallelPairedAssigner::canonicalize`) already uppercases, so its node identity is
+        // case-insensitive; the sequential paired path MUST fold case too, or `group`/`dedup
+        // --threads 1` (sequential) and `--threads N` (parallel) group mixed-case paired UMIs —
+        // which the CLI does NOT pre-uppercase — differently. Folding here converges the two
+        // paired paths on the case dimension. NOTE: this is an intentional DIVERGENCE from
+        // fgbio, whose paired *grouping* comparator (`AdjacencyUmiAssigner.matches`,
+        // `GroupReadsByUmi.scala:248-256`) is case-SENSITIVE — only `countMismatches` (strand
+        // assignment / the edit strategy) folds case. fgumi opts for case-insensitive paired
+        // grouping for robustness and sequential/parallel consistency; it is a no-op for the
+        // uppercase UMIs the CLI emits, and only differs from fgbio on mixed-case paired input.
+        // (The reverse-orientation adjacency-matching divergence between the two paired paths is a
+        // separate, still-open follow-up — see the NOTE in `parallel_assigner.rs`.)
+        let upper_umis: Vec<Umi> = raw_umis.iter().map(|umi| umi.to_uppercase()).collect();
+
         // Count with A-B and B-A combined
-        let mut umi_counts = Self::count_paired(raw_umis);
-        // Tie-break equal-count canonical UMIs by the case-SENSITIVE canonical string
-        // (`canonicalize_paired` normalizes orientation only, not case), matching fgbio's
-        // raw ordering — consistent with the single-UMI raw tie-break in
-        // `AdjacencyUmiAssigner::assign` (S7-002/FU-004).
+        let mut umi_counts = Self::count_paired(&upper_umis);
+        // Tie-break equal-count canonical UMIs by the (now uppercase) canonical string so the
+        // ordering is case-insensitive, agreeing with the parallel paired assigner.
         umi_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
         if umi_counts.len() == 1 {
@@ -1897,7 +1912,7 @@ impl UmiAssigner for PairedUmiAssigner {
             let ab = MoleculeId::PairedA(id);
             let ba = MoleculeId::PairedB(id);
 
-            return raw_umis
+            return upper_umis
                 .iter()
                 .map(|umi| {
                     let reversed = Self::reverse(umi)
@@ -1950,16 +1965,24 @@ impl UmiAssigner for PairedUmiAssigner {
             }
         }
 
-        // Build result Vec indexed by input position
-        raw_umis.iter().map(|umi| umi_to_id.get(umi).copied().unwrap_or(MoleculeId::None)).collect()
+        // Build result Vec indexed by input position (keyed on the uppercased UMIs the graph
+        // was built from).
+        upper_umis
+            .iter()
+            .map(|umi| umi_to_id.get(umi).copied().unwrap_or(MoleculeId::None))
+            .collect()
     }
 
     fn is_same_umi(&self, a: &str, b: &str) -> bool {
+        // Fold case so this helper matches `assign()` (which works on uppercased UMIs) and the
+        // parallel paired canonicalizer; mixed-case callers must not disagree.
+        let a = a.to_uppercase();
+        let b = b.to_uppercase();
         if a == b {
             return true;
         }
         // Check if A-B equals B-A
-        if let (Ok((a1, a2)), Ok((b1, b2))) = (Self::split(a), Self::split(b)) {
+        if let (Ok((a1, a2)), Ok((b1, b2))) = (Self::split(&a), Self::split(&b)) {
             a1 == b2 && a2 == b1
         } else {
             false
@@ -1967,7 +1990,10 @@ impl UmiAssigner for PairedUmiAssigner {
     }
 
     fn canonicalize(&self, umi: &str) -> String {
-        Self::canonicalize_paired(umi).unwrap_or_else(|_| umi.to_string())
+        // Fold case before canonicalizing so mixed-case spellings collapse to the same
+        // uppercase canonical form, matching `assign()` and the parallel paired assigner.
+        let upper = umi.to_uppercase();
+        Self::canonicalize_paired(&upper).unwrap_or(upper)
     }
 
     fn split_templates_by_pair_orientation(&self) -> bool {
@@ -2286,9 +2312,10 @@ mod tests {
     #[test]
     fn test_simple_error_assigner_is_case_insensitive() {
         // Audit P2: the sequential edit assigner must fold case so it agrees with the
-        // parallel edit assigner (which uppercases before encoding) and with fgbio (which
-        // uppercases every UMI before assignment). Different spellings of the same UMI must
-        // collapse into a single molecule even at zero edits.
+        // parallel edit assigner (which uppercases before encoding) and with fgbio's edit
+        // assigner (which compares case-insensitively via `Sequences.countMismatches`).
+        // Different spellings of the same UMI must collapse into a single molecule even at
+        // zero edits.
         let assigner = SimpleErrorUmiAssigner::new(0);
         let umis = vec!["ACGTAC".to_string(), "acgtac".to_string(), "AcGtAc".to_string()];
         let assignments = assigner.assign(&umis);
@@ -2652,6 +2679,31 @@ mod tests {
 
         // Different UMI
         assert!(!assigner.is_same_umi("ACGT-TGCA", "AAAA-TTTT"));
+    }
+
+    #[test]
+    fn test_paired_helpers_are_case_insensitive() {
+        // `assign()` folds case (see `upper_umis`); the trait helpers that make up the rest of
+        // the paired assigner's public, case-insensitive contract must agree, so that mixed-case
+        // callers reaching these helpers directly cannot disagree with `assign()` or the parallel
+        // paired canonicalizer (which uppercases). This is the paired analogue of the edit
+        // assigner's case fold (P2). NOTE: unlike the edit assigner — whose case-insensitivity
+        // matches fgbio's `countMismatches` — fgbio's paired *grouping* (`AdjacencyUmiAssigner.matches`)
+        // is case-SENSITIVE, so fgumi's case-insensitive paired grouping is an intentional divergence
+        // (robustness + sequential/parallel consistency), a no-op for conventional uppercase UMIs.
+        let assigner = PairedUmiAssigner::new(1);
+
+        // is_same_umi: lower vs upper spelling of the same orientation.
+        assert!(assigner.is_same_umi("acgt-tgca", "ACGT-TGCA"));
+        // is_same_umi: lower vs upper spelling of the reversed orientation.
+        assert!(assigner.is_same_umi("acgt-tgca", "TGCA-ACGT"));
+        // is_same_umi: still distinguishes genuinely different UMIs regardless of case.
+        assert!(!assigner.is_same_umi("acgt-tgca", "aaaa-tttt"));
+
+        // canonicalize: case spelling does not change the canonical form, and reversed spellings
+        // canonicalize to the same uppercase string.
+        assert_eq!(assigner.canonicalize("acgt-tgca"), "ACGT-TGCA");
+        assert_eq!(assigner.canonicalize("tgca-ACGT"), assigner.canonicalize("ACGT-TGCA"));
     }
 
     #[test]

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -778,9 +778,10 @@ impl UmiAssigner for ParallelPairedAssigner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::umi::{AdjacencyUmiAssigner, SimpleErrorUmiAssigner};
+    use crate::umi::{AdjacencyUmiAssigner, PairedUmiAssigner, SimpleErrorUmiAssigner};
     use fgumi_umi::assigner::DEFAULT_INDEX_THRESHOLD;
     use proptest::prelude::*;
+    use rstest::rstest;
 
     // ==================== UnionFind Tests ====================
 
@@ -1382,9 +1383,9 @@ mod tests {
         // before encoding. Mixed-case UMIs therefore grouped differently depending on
         // `--threads` (sequential vs parallel path). Both must fold case.
         //
-        // fgbio baseline: `GroupReadsByUmi` uppercases every UMI before assignment
-        // (`canonicalize(rawTag.toUpperCase)`), so case-insensitive grouping is the
-        // fgbio-faithful behavior — this converges with fgbio's user-facing output.
+        // fgbio baseline: the edit assigner compares UMIs case-insensitively in its mismatch
+        // counter (`Sequences.countMismatches`), so case-insensitive grouping is fgbio-faithful
+        // for the edit strategy — this converges with fgbio.
         let umis: Vec<String> =
             vec!["ACGT", "acgt", "AcGt", "TTTT", "tttt"].into_iter().map(String::from).collect();
 
@@ -1730,15 +1731,131 @@ mod tests {
         }
     }
 
-    // NOTE on the paired strategy (S7-002 / FU-004 scope): the sequential `PairedUmiAssigner`
-    // tie-break is the case-SENSITIVE canonical string (`canonicalize_paired` normalizes
-    // orientation only, not case) — raw/fgbio-compatible, matching the single-UMI raw tie-break.
-    // The parallel `ParallelPairedAssigner` is NOT converged onto raw here, and a *full* paired
-    // parity proptest is intentionally NOT added: the two paired paths diverge on inputs
-    // unrelated to the tie-break key — `ParallelPairedAssigner::canonicalize` uppercases (so its
-    // node identity itself is case-insensitive, unlike the sequential), and the two paths
-    // implement reverse-orientation adjacency matching differently (e.g. `GAAA-CCCC` vs
-    // `AAAA-CCCC`, 1 edit apart, group in the parallel path but not the sequential one).
-    // Converging the paired paths means reconciling those deeper divergences, which is a
-    // pre-existing, out-of-scope follow-up distinct from the FU-004 tie-break-key fix.
+    // NOTE on the paired strategy (S7-002 / FU-004 scope): the paired paths have TWO independent
+    // divergences, and they are converged separately.
+    //
+    //  1. CASE (converged): `ParallelPairedAssigner::canonicalize` uppercases, so its node
+    //     identity is case-insensitive. The sequential `PairedUmiAssigner` used to count/match/
+    //     tie-break on the RAW string (unlike the parallel path), so on mixed-case paired UMIs —
+    //     which the CLI does NOT pre-uppercase — `--threads 1` and `--threads N` could group and
+    //     strand-assign differently. The sequential path now folds case (`assign` works on
+    //     uppercased UMIs; `is_same_umi`/`canonicalize` uppercase first), matching the parallel
+    //     path and fgbio's user-facing output. `paired_sequential_and_parallel_agree_on_mixed_case`
+    //     below pins this. This is INTENTIONALLY different from the single-UMI adjacency tie-break,
+    //     which stays RAW/case-sensitive (both paths) — there the parallel path was converged onto
+    //     raw, so no case fold is needed; here the parallel path is already uppercase, so the
+    //     sequential path is folded onto it instead.
+    //
+    //  2. REVERSE-ORIENTATION MATCHING (still divergent): the two paths implement reverse-
+    //     orientation adjacency matching differently (e.g. `GAAA-CCCC` vs `AAAA-CCCC`, 1 edit
+    //     apart, group in the parallel path but not the sequential one). Converging this is a
+    //     separate, pre-existing follow-up tracked by the reverse-orientation-edges fix on `main`
+    //     (GRP3-01); it arrives via the eventual `feat-runall` <- `main` reconcile and is NOT
+    //     ported here to avoid duplicating in-review work. Because of it, only a case-dimension
+    //     parity test (inputs 0 edits apart) is added, not a full paired parity proptest.
+
+    /// Case-dimension parity for the paired strategy (divergence #1 in the NOTE above). All three
+    /// inputs spell the SAME molecule and are 0 edits apart in canonical form — `"ACGT-TGCA"`
+    /// (forward), `"acgt-tgca"` (forward, lowercase), `"TGCA-ACGT"` (reverse strand) — so the
+    /// reverse-orientation-matching divergence (#2, still open) is NOT exercised and this test is
+    /// a clean guard for the case fold alone. The parallel paired assigner canonicalizes to
+    /// uppercase, so it already groups all three with consistent strand (A/B) assignment; the
+    /// sequential paired assigner must now agree. Without the case fold it counts/matches on the
+    /// raw string, splitting `"acgt-tgca"` from `"ACGT-TGCA"`.
+    ///
+    /// Expectation is fgumi-internal (sequential must match parallel), NOT fgbio parity: both
+    /// fgumi paired paths uppercase, so the two forward spellings (0, 1) collapse to the canonical
+    /// `"ACGT-TGCA"` (strand A) while the reverse spelling (2) lands on strand B. This DIVERGES
+    /// from fgbio, whose paired grouping comparator (`AdjacencyUmiAssigner.matches`) is
+    /// case-SENSITIVE and would keep the spellings separate — a no-op only for uppercase input.
+    /// Pin the concrete PairedA/PairedB variants so a global A/B inversion (which
+    /// `assert_same_partition_by_molecule` alone would accept) still fails.
+    #[test]
+    fn paired_sequential_and_parallel_agree_on_mixed_case() {
+        let umis: Vec<Umi> =
+            vec!["ACGT-TGCA", "acgt-tgca", "TGCA-ACGT"].into_iter().map(String::from).collect();
+
+        let sequential = PairedUmiAssigner::new(1).assign(&umis);
+        let parallel = ParallelPairedAssigner::new(1, 2).assign(&umis);
+
+        assert_same_partition_by_molecule(&sequential, &parallel);
+
+        for (label, mol) in [("sequential", &sequential), ("parallel", &parallel)] {
+            assert!(
+                matches!(mol[0], MoleculeId::PairedA(_))
+                    && matches!(mol[1], MoleculeId::PairedA(_))
+                    && matches!(mol[2], MoleculeId::PairedB(_)),
+                "{label}: expected fwd,fwd,rev => A,A,B; got {mol:?}",
+            );
+            assert_eq!(mol[0], mol[1], "{label}: forward spellings share a strand");
+            assert_eq!(
+                mol[0].base_id_string(),
+                mol[2].base_id_string(),
+                "{label}: reverse spelling shares the base molecule",
+            );
+            assert_ne!(mol[0], mol[2], "{label}: reverse spelling is the opposite strand");
+        }
+    }
+
+    /// Case parity on the **graph** path, where the fast path above cannot reach.
+    ///
+    /// `paired_sequential_and_parallel_agree_on_mixed_case` feeds three spellings of one
+    /// molecule, so `umi_counts.len() == 1` and `assign` early-returns before building any
+    /// adjacency graph — the count aggregation, the uppercase tie-break sort, and the
+    /// root/child strand assignment are all skipped. These cases supply two distinct canonical
+    /// UMIs so the graph path actually runs.
+    ///
+    /// Every input pair here matches in FORWARD orientation (a direct 1-edit neighbour), so the
+    /// still-open reverse-orientation-matching divergence (#2 in the NOTE above) is not
+    /// exercised and a failure here means the case dimension regressed.
+    ///
+    /// * `equal_count_roots` — `"TCGT-TGCA"` and `"acgt-tgca"` are 1 edit apart with equal
+    ///   counts, and their sort order *inverts* under the case fold: raw, `'T'` (0x54) sorts
+    ///   before `'a'` (0x61), so `TCGT-TGCA` would be the root; uppercased, `ACGT-TGCA` sorts
+    ///   first and becomes the root instead. Root choice drives the A/B strand assignment, so
+    ///   this pins the tie-break the fix changed.
+    /// * `count_aggregation_at_threshold` — the two uppercase and one lowercase spellings of
+    ///   `ACGT-TGCA` must aggregate to a single count of 3, which sets
+    ///   `max_child_count = 3 / 2 + 1 = 2` and lets the 1-edit `TCGT-TGCA` (count 2) be absorbed
+    ///   at exactly the threshold. Counting the lowercase spelling separately would leave the
+    ///   root at count 2 and change the graph.
+    #[rstest]
+    #[case::equal_count_roots(vec!["TCGT-TGCA", "acgt-tgca"])]
+    #[case::count_aggregation_at_threshold(
+        vec!["ACGT-TGCA", "ACGT-TGCA", "acgt-tgca", "TCGT-TGCA", "TCGT-TGCA"]
+    )]
+    fn paired_sequential_and_parallel_agree_on_mixed_case_graph_path(#[case] spellings: Vec<&str>) {
+        let umis: Vec<Umi> = spellings.iter().map(|s| String::from(*s)).collect();
+
+        let sequential = PairedUmiAssigner::new(1).assign(&umis);
+        let parallel = ParallelPairedAssigner::new(1, 2).assign(&umis);
+
+        // The graph path must actually have run — more than one canonical UMI.
+        let canonical: std::collections::HashSet<String> =
+            umis.iter().map(|u| u.to_uppercase()).collect();
+        assert!(
+            canonical.len() > 1,
+            "fixture must have >1 canonical UMI to reach the graph path, got {canonical:?}",
+        );
+
+        assert_same_partition_by_molecule(&sequential, &parallel);
+
+        // Spellings that differ only by case must land on the same molecule AND strand in both
+        // paths; that is the whole point of folding case in the sequential assigner.
+        for (i, a) in umis.iter().enumerate() {
+            for (j, b) in umis.iter().enumerate().skip(i + 1) {
+                if a.to_uppercase() != b.to_uppercase() {
+                    continue;
+                }
+                assert_eq!(
+                    sequential[i], sequential[j],
+                    "sequential: {a:?} and {b:?} differ only by case, so must share a strand",
+                );
+                assert_eq!(
+                    parallel[i], parallel[j],
+                    "parallel: {a:?} and {b:?} differ only by case, so must share a strand",
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Converges the **case** dimension of the sequential-vs-parallel divergence in the paired UMI assigner. Stacked on #537 (P2, the sequential *edit* assigner case fold); this is the paired sibling.

The paired strategy has two independent sequential-vs-parallel divergences (documented in the S7-002/FU-004 NOTE in `parallel_assigner.rs`):

1. **Case** — fixed here.
2. **Reverse-orientation adjacency matching** (e.g. `GAAA-CCCC` vs `AAAA-CCCC`, 1 edit apart) — a separate, still-open follow-up tracked by the reverse-orientation-edges fix on `main` (GRP3-01); it arrives via the eventual `feat-runall` ← `main` reconcile and is deliberately **not** ported here to avoid duplicating in-review work.

## Why

`ParallelPairedAssigner::canonicalize` uppercases, so the parallel path's node identity is case-insensitive. The sequential `PairedUmiAssigner` counted, matched, tie-broke, and strand-assigned on the RAW string. On mixed-case paired UMIs — which the CLI does **not** pre-uppercase — `group`/`dedup --threads 1` (sequential) and `--threads N` (parallel) could group and strand-assign the same molecule differently. That is a real, CLI-reachable `--threads`-dependent grouping bug.

Folding case in the sequential path makes the two agree, and also matches fgbio's user-facing output (its `GroupReadsByUmi` uppercases every UMI before assignment via `canonicalize(rawTag.toUpperCase)`). It is a no-op for the uppercase UMIs the CLI emits.

This is intentionally **different** from the single-UMI adjacency tie-break, which stays RAW/case-sensitive on *both* paths (S7-002/FU-004): there the parallel path was converged onto raw, so no case fold is needed; here the parallel path is already uppercase, so the sequential path is folded onto it instead. The adjacency DIRECTION test (`adjacency_tie_break_is_case_sensitive_raw_not_uppercased`) is untouched and still passes.

## Changes

- `PairedUmiAssigner::assign` works on uppercased UMIs; `is_same_umi`/`canonicalize` uppercase before comparing/canonicalizing.
- New `paired_sequential_and_parallel_agree_on_mixed_case` parity test (inputs 0 edits apart, so the still-open reverse-orientation divergence is not exercised) — verified to fail before the fix ("Partitions diverge between assigners").
- New `test_paired_helpers_are_case_insensitive` unit test.
- Updated the S7-002/FU-004 NOTE to document both divergences and which is now converged.

## Verification

`cargo ci-test` (2334 passed) and `cargo ci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paired UMI assignment is now case-insensitive, returning consistent results across mixed-case and reverse-strand representations.
  * Sequential and parallel paired assignment now agree on molecule grouping and strand/canonical UMI outcomes, including tie-breaking.
* **Tests**
  * Added new assertions for case-insensitive paired UMI comparison and canonicalization.
  * Extended sequential-versus-parallel verification for mixed-case inputs, including coverage of alternate graph-path behavior and boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->