### PR TITLE
fix(fastq): accept CRLF and unterminated final records (W9b: EXT3-06/07)

### DIFF
--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -184,6 +184,20 @@ impl<'a> Iterator for RecordIter<'a> {
     }
 }
 
+/// Strip a single trailing carriage return from a field so that CRLF
+/// (`\r\n`)-terminated FASTQ files parse identically to LF-terminated ones.
+///
+/// Record boundaries are found by scanning for `\n` only, so on a CRLF file the
+/// `\r` that precedes each `\n` is left as the last byte of the name, sequence,
+/// and quality fields. It is a line terminator, not data, and must be removed —
+/// fgbio's `Source.getLines` strips line terminators the same way. Only one
+/// trailing `\r` is dropped (a lone terminator); interior `\r` bytes, which are
+/// not valid in any of these fields anyway, are left untouched.
+#[inline]
+fn strip_trailing_cr(field: &[u8]) -> &[u8] {
+    if let [rest @ .., b'\r'] = field { rest } else { field }
+}
+
 /// Parse a single FASTQ record from a byte slice, validating its structure.
 ///
 /// Expects format: `@name\nsequence\n+\nquality\n`. Validates, in order, that
@@ -230,9 +244,9 @@ pub(crate) fn try_parse_single_record(record: &[u8]) -> Result<FastqRecord<'_>, 
     }
 
     // name: skip '@', up to first newline
-    let name = &record[1..name_end];
+    let name = strip_trailing_cr(&record[1..name_end]);
     // sequence: after first newline, up to second newline
-    let sequence = &record[name_end + 1..seq_end];
+    let sequence = strip_trailing_cr(&record[name_end + 1..seq_end]);
     // quality: after third newline, up to end (excluding trailing newline if present)
     let qual_start = plus_end + 1;
     let qual_end = if record.last() == Some(&b'\n') { record.len() - 1 } else { record.len() };
@@ -243,7 +257,7 @@ pub(crate) fn try_parse_single_record(record: &[u8]) -> Result<FastqRecord<'_>, 
     if qual_start > qual_end {
         return Err(FastqParseError::TooFewLines);
     }
-    let quality = &record[qual_start..qual_end];
+    let quality = strip_trailing_cr(&record[qual_start..qual_end]);
 
     if sequence.len() != quality.len() {
         return Err(FastqParseError::LengthMismatch {
@@ -331,6 +345,30 @@ mod tests {
         assert_eq!(records[0].name, b"read1");
         assert_eq!(records[0].sequence, b"ACGT");
         assert_eq!(records[0].quality, b"IIII");
+    }
+
+    /// EXT3-06: CRLF (`\r\n`)-terminated FASTQ must parse identically to LF —
+    /// the trailing `\r` is a line terminator, not data, and must not leak into
+    /// the name, sequence, or quality (fgbio's `Source.getLines` strips it). A
+    /// stray `\r` in the quality string is especially harmful: it is byte 13,
+    /// below the printable-ASCII floor, so it derails quality-encoding detection.
+    #[test]
+    fn parse_single_record_strips_crlf_terminators() {
+        let data = b"@read1\r\nACGT\r\n+\r\nIIII\r\n";
+        let records: Vec<_> = parse_records(data).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, b"read1", "name must not keep the \\r");
+        assert_eq!(records[0].sequence, b"ACGT", "sequence must not keep the \\r");
+        assert_eq!(records[0].quality, b"IIII", "quality must not keep the \\r");
+    }
+
+    /// EXT3-06 via the single-record entry point (used by the reader's EOF path).
+    #[test]
+    fn parse_single_record_strips_crlf_last_record_without_trailing_newline() {
+        let rec = parse_single_record(b"@r\r\nACGT\r\n+\r\nIIII");
+        assert_eq!(rec.name, b"r");
+        assert_eq!(rec.sequence, b"ACGT");
+        assert_eq!(rec.quality, b"IIII");
     }
 
     #[test]

--- a/crates/fgumi-simd-fastq/src/reader.rs
+++ b/crates/fgumi-simd-fastq/src/reader.rs
@@ -155,9 +155,49 @@ impl<R: BufRead> Iterator for SimdFastqReader<R> {
             }
 
             if self.at_eof {
-                // Check for leftover bytes that form an incomplete record
+                // Leftover bytes after the last complete-record boundary. A final
+                // record with no trailing newline is still *complete* — it has the
+                // three internal newlines after name/seq/`+`, only the fourth
+                // (terminating) newline is absent — so yield it rather than
+                // erroring (fgbio's `lines.take(4)` accepts an unterminated final
+                // record). Only a leftover with fewer than three newlines is
+                // genuinely truncated.
                 let leftover_start = self.offsets.last().copied().unwrap_or(0);
                 if leftover_start < self.valid {
+                    let leftover = &self.buffer[leftover_start..self.valid];
+                    // A complete-but-unterminated final record has exactly the three
+                    // internal newlines after name/seq/`+`; cap the scan at four so a
+                    // longer malformed run still fails the `== 3` check. It must also
+                    // NOT end in a newline: a genuine unterminated record ends with
+                    // its quality bytes, whereas a leftover like `@n\nseq\n+\n` has a
+                    // terminated `+` line and an *absent* quality line — three
+                    // newlines but no quality — which must error, not be parsed (its
+                    // empty quality span is not a valid record).
+                    let internal_newlines =
+                        leftover.iter().filter(|&&b| b == b'\n').take(4).count();
+                    if leftover.first() == Some(&b'@')
+                        && leftover.last() != Some(&b'\n')
+                        && internal_newlines == 3
+                    {
+                        // Route through the fallible parser like the main record path
+                        // above: the coarse guard admits the leftover, but a typed
+                        // `FastqParseError` (e.g. length mismatch) still surfaces as a
+                        // clean io::Error rather than a panic.
+                        let borrowed = match try_parse_single_record(leftover) {
+                            Ok(rec) => rec,
+                            Err(e) => {
+                                return Some(Err(io::Error::new(io::ErrorKind::InvalidData, e)));
+                            }
+                        };
+                        let record = OwnedFastqRecord {
+                            name: borrowed.name.to_vec(),
+                            sequence: borrowed.sequence.to_vec(),
+                            quality: borrowed.quality.to_vec(),
+                        };
+                        // Mark the leftover consumed so the next call terminates.
+                        self.valid = leftover_start;
+                        return Some(Ok(record));
+                    }
                     return Some(Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
@@ -218,6 +258,52 @@ mod tests {
         assert_eq!(rec2.name, b"r2");
 
         assert!(reader.next().is_none());
+    }
+
+    /// EXT3-07: a final record with no trailing newline is complete (it has the
+    /// three internal newlines after name/seq/`+`); the reader must yield it
+    /// rather than erroring "Truncated FASTQ record at EOF". fgbio's
+    /// `lines.take(4)` likewise accepts an unterminated final record.
+    #[test]
+    fn reader_accepts_final_record_without_trailing_newline() {
+        let data = b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJJJ"; // note: no trailing \n
+        let mut reader = SimdFastqReader::new(Cursor::new(&data[..]));
+
+        let rec1 = reader.next().expect("first record").expect("first record parses");
+        assert_eq!(rec1.name, b"r1");
+        let rec2 = reader
+            .next()
+            .expect("unterminated final record must still be yielded")
+            .expect("unterminated final record must parse, not error");
+        assert_eq!(rec2.name, b"r2");
+        assert_eq!(rec2.sequence, b"TTTT");
+        assert_eq!(rec2.quality, b"JJJJ");
+        assert!(reader.next().is_none(), "reader must terminate cleanly after the last record");
+    }
+
+    /// A malformed final record must surface an `InvalidData` error rather than
+    /// being silently dropped or mis-parsed, across every shape the coarse
+    /// end-of-stream gate can admit:
+    /// * `missing_quality_line` — genuinely truncated (fewer than the three
+    ///   internal newlines); the `+`/quality lines are absent entirely.
+    /// * `newline_terminated_plus_absent_quality` — the `+` line IS
+    ///   newline-terminated but the quality line is then entirely absent
+    ///   (`@n\nseq\n+\n`): exactly three internal newlines and a leading `@`, yet
+    ///   NOT a complete record (parsing it would compute `qual_start > qual_end`
+    ///   and panic). A genuine unterminated final record ends with its quality
+    ///   bytes, never a newline.
+    /// * `length_mismatch_via_eof` — passes the coarse gate (leading `@`, three
+    ///   internal newlines, no trailing `\n`) but the final record's quality is
+    ///   shorter than its sequence, so the coarse-gate→`try_parse_single_record`
+    ///   propagation path must reject it.
+    #[rstest]
+    #[case::missing_quality_line(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+")]
+    #[case::newline_terminated_plus_absent_quality(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\n")]
+    #[case::length_mismatch_via_eof(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nJJ")]
+    fn reader_errors_on_malformed_final_record(#[case] data: &[u8]) {
+        let mut reader = SimdFastqReader::new(Cursor::new(data));
+        let _ = reader.next().expect("first record").expect("first record parses");
+        assert_next_is_invalid_data(&mut reader);
     }
 
     #[test]

--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -34,8 +34,11 @@ pub struct FastqRecord {
 impl FastqRecord {
     /// Construct a `FastqRecord` from a raw FASTQ record slice.
     ///
-    /// The slice must contain exactly one complete FASTQ record in the form:
-    /// `@name\nseq\n+\nqual\n`
+    /// The slice must contain exactly one complete FASTQ record in the form
+    /// `@name\nseq\n+\nqual`, where the terminating newline after the quality line
+    /// is optional (a final record at EOF may omit it). CRLF (`\r\n`) line endings
+    /// are accepted: the `\r` before each `\n` is a line terminator and is stripped
+    /// from the name, sequence, and quality.
     ///
     /// # Errors
     ///
@@ -84,11 +87,25 @@ impl FastqRecord {
             ));
         }
 
-        // Validate sequence and quality lengths match.
-        let seq_len = seq_end - (name_end + 1);
+        // Validate sequence and quality lengths match. Compare the CRLF-stripped
+        // fields, not the raw spans: on a CRLF file every interior line keeps a
+        // trailing '\r', but an unterminated final quality line does not, so the
+        // raw spans would differ by one and spuriously reject a valid record.
+        let seq_len = strip_trailing_cr(&data[name_end + 1..seq_end]).len();
         // Quality ends at the trailing '\n' (excluded) or at data.len() if no trailing newline.
         let qual_end = if data.last() == Some(&b'\n') { data.len() - 1 } else { data.len() };
-        let qual_len = qual_end - qual_start;
+        // A quality-less record (`@name\nseq\n+\n`) leaves qual_start past qual_end;
+        // the slice below would panic. Reject it with a clean Err, matching the
+        // sibling parser (fgumi-simd-fastq try_parse_single_record). Reachable via
+        // stitch_cross_block_record / the middle-block path, which feed raw record
+        // windows straight to from_slice.
+        if qual_start > qual_end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "FASTQ record is missing its quality line",
+            ));
+        }
+        let qual_len = strip_trailing_cr(&data[qual_start..qual_end]).len();
 
         if seq_len != qual_len {
             return Err(io::Error::new(
@@ -114,14 +131,14 @@ impl FastqRecord {
     #[inline]
     #[must_use]
     pub fn name(&self) -> &[u8] {
-        &self.data[1..self.name_end as usize]
+        strip_trailing_cr(&self.data[1..self.name_end as usize])
     }
 
     /// Returns the sequence bytes.
     #[inline]
     #[must_use]
     pub fn sequence(&self) -> &[u8] {
-        &self.data[self.name_end as usize + 1..self.seq_end as usize]
+        strip_trailing_cr(&self.data[self.name_end as usize + 1..self.seq_end as usize])
     }
 
     /// Returns the quality bytes (Phred+33 encoded ASCII).
@@ -130,8 +147,22 @@ impl FastqRecord {
     pub fn quality(&self) -> &[u8] {
         let qual_end =
             if self.data.last() == Some(&b'\n') { self.data.len() - 1 } else { self.data.len() };
-        &self.data[self.qual_start as usize..qual_end]
+        strip_trailing_cr(&self.data[self.qual_start as usize..qual_end])
     }
+}
+
+/// Strip a single trailing carriage return so CRLF (`\r\n`)-terminated FASTQ
+/// files parse identically to LF-terminated ones. Record boundaries here are
+/// found by scanning for `\n` only, so on a CRLF file the `\r` preceding each
+/// `\n` is left as the last byte of the name, sequence, and quality fields; it
+/// is a line terminator, not data, and must be dropped (matching fgbio's
+/// `Source.getLines`). A stray `\r` in the quality string is byte 13, below the
+/// printable-ASCII floor, so leaving it in would derail quality-encoding
+/// detection. Only one trailing `\r` is removed.
+#[inline]
+#[must_use]
+fn strip_trailing_cr(field: &[u8]) -> &[u8] {
+    if let [rest @ .., b'\r'] = field { rest } else { field }
 }
 
 impl MemoryEstimate for FastqRecord {
@@ -161,10 +192,16 @@ enum FastqParseResult {
 ///
 /// Returns parsed records and leftover bytes for incomplete records.
 ///
+/// `at_eof` marks `data` as the complete, final input rather than one chunk of a
+/// stream. It is passed through to [`parse_single_fastq_record`]: only when
+/// `true` is a final record without a terminating newline accepted; when `false`
+/// such a tail is returned as leftover so an incremental caller (e.g.
+/// `FastqGrouper::add_bytes_for_stream`) can complete it with the next chunk.
+///
 /// # Errors
 ///
 /// Returns an error if a record has mismatched sequence and quality lengths.
-pub fn parse_fastq_records(data: &[u8]) -> io::Result<(Vec<FastqRecord>, Vec<u8>)> {
+pub fn parse_fastq_records(data: &[u8], at_eof: bool) -> io::Result<(Vec<FastqRecord>, Vec<u8>)> {
     let mut records = Vec::new();
     let mut pos = 0;
 
@@ -181,7 +218,7 @@ pub fn parse_fastq_records(data: &[u8]) -> io::Result<(Vec<FastqRecord>, Vec<u8>
         }
 
         // Try to parse a complete record
-        match parse_single_fastq_record(&data[pos..]) {
+        match parse_single_fastq_record(&data[pos..], at_eof) {
             Ok((record, consumed)) => {
                 records.push(record);
                 pos += consumed;
@@ -200,8 +237,19 @@ pub fn parse_fastq_records(data: &[u8]) -> io::Result<(Vec<FastqRecord>, Vec<u8>
 }
 
 /// Parse a single FASTQ record from the beginning of a buffer.
+///
+/// `at_eof` marks `data` as the complete, final input. When `true`, a record
+/// whose quality line lacks a terminating newline is accepted (a final record at
+/// EOF may omit it). When `false`, `data` is an incremental chunk that more bytes
+/// may follow, so an unterminated final quality line is reported as
+/// [`FastqParseResult::Incomplete`] and held for the next chunk rather than being
+/// mistaken for a complete (shorter) record.
+///
 /// Returns (record, `bytes_consumed`) or an error.
-fn parse_single_fastq_record(data: &[u8]) -> Result<(FastqRecord, usize), FastqParseResult> {
+fn parse_single_fastq_record(
+    data: &[u8],
+    at_eof: bool,
+) -> Result<(FastqRecord, usize), FastqParseResult> {
     let mut pos = 0;
 
     // Line 1: @name
@@ -220,7 +268,10 @@ fn parse_single_fastq_record(data: &[u8]) -> Result<(FastqRecord, usize), FastqP
         return Err(FastqParseResult::Incomplete);
     }
     let seq_end_rel = find_newline(&data[pos..]).ok_or(FastqParseResult::Incomplete)?;
-    let seq_len = seq_end_rel;
+    // Compare CRLF-stripped lengths below: on a CRLF file every interior line keeps
+    // a trailing '\r' that an unterminated final quality line would not, so raw
+    // spans would differ by one and spuriously reject a valid record.
+    let seq_len = strip_trailing_cr(&data[pos..pos + seq_end_rel]).len();
     pos += seq_end_rel + 1;
 
     // Line 3: + (separator)
@@ -240,13 +291,19 @@ fn parse_single_fastq_record(data: &[u8]) -> Result<(FastqRecord, usize), FastqP
     if pos >= data.len() {
         return Err(FastqParseResult::Incomplete);
     }
-    let (qual_len, advance) = if let Some(rel) = find_newline(&data[pos..]) {
+    let (qual_raw_len, advance) = if let Some(rel) = find_newline(&data[pos..]) {
         (rel, rel + 1)
-    } else {
-        // EOF without trailing newline — treat remaining bytes as the quality line.
+    } else if at_eof {
+        // Final input with no trailing newline — treat the remaining bytes as the
+        // quality line. Only valid when `data` is known to be the complete input:
+        // on an incremental chunk the tail may be a partial quality line that
+        // continues in the next chunk, so it must be held as leftover instead.
         let remaining = data.len() - pos;
         (remaining, remaining)
+    } else {
+        return Err(FastqParseResult::Incomplete);
     };
+    let qual_len = strip_trailing_cr(&data[pos..pos + qual_raw_len]).len();
     pos += advance;
 
     // Validate lengths match
@@ -309,7 +366,7 @@ mod tests {
     fn test_parse_single_fastq_record() {
         let data = b"@read1\nACGT\n+\nIIII\n";
         let (record, consumed) =
-            parse_single_fastq_record(data).expect("parse single FASTQ record");
+            parse_single_fastq_record(data, true).expect("parse single FASTQ record");
         assert_eq!(record.name(), b"read1");
         assert_eq!(record.sequence(), b"ACGT");
         assert_eq!(record.quality(), b"IIII");
@@ -319,26 +376,75 @@ mod tests {
     #[test]
     fn test_parse_fastq_records_multiple() {
         let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
-        let (records, leftover) = parse_fastq_records(data).expect("failed to parse FASTQ records");
+        let (records, leftover) =
+            parse_fastq_records(data, true).expect("failed to parse FASTQ records");
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].name(), b"read1");
         assert_eq!(records[1].name(), b"read2");
         assert!(leftover.is_empty());
     }
 
+    /// EXT3-06: CRLF (`\r\n`)-terminated records must expose the same
+    /// name/sequence/quality as LF records — the `\r` is a line terminator, not
+    /// data, and must not leak into any field (a `\r` in the quality would be
+    /// byte 13, below the printable-ASCII floor, and derail encoding detection).
+    #[test]
+    fn from_slice_strips_crlf_terminators() {
+        let rec = FastqRecord::from_slice(b"@r1\r\nACGT\r\n+\r\nIIII\r\n")
+            .expect("CRLF record should parse");
+        assert_eq!(rec.name(), b"r1");
+        assert_eq!(rec.sequence(), b"ACGT");
+        assert_eq!(rec.quality(), b"IIII");
+
+        // Also through the streaming entry point, including a CRLF final record
+        // with no trailing newline.
+        let (records, leftover) =
+            parse_fastq_records(b"@r1\r\nACGT\r\n+\r\nIIII\r\n@r2\r\nTGCA\r\n+\r\nJJJJ", true)
+                .expect("CRLF stream should parse");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].name(), b"r2");
+        assert_eq!(records[1].sequence(), b"TGCA");
+        assert_eq!(records[1].quality(), b"JJJJ");
+        assert!(leftover.is_empty(), "the unterminated CRLF final record must be consumed");
+    }
+
+    /// A quality-less record (`@name\nseq\n+\n`, no quality line) yields
+    /// `qual_start > qual_end`. `from_slice` must reject it with a clean `Err`
+    /// rather than panicking on the `data[qual_start..qual_end]` slice. This is
+    /// reachable in production: `stitch_cross_block_record` and the middle-block
+    /// path hand raw record windows straight to `from_slice`, so a quality-less
+    /// record straddling a BGZF block boundary reconstructs to exactly this
+    /// shape. The sibling parser (`fgumi-simd-fastq::try_parse_single_record`)
+    /// already guards the identical case; both parsers must agree (reject, not
+    /// panic).
+    #[rstest]
+    #[case::lf(b"@r\nA\n+\n")]
+    #[case::crlf(b"@r\r\nA\r\n+\r\n")]
+    #[case::longer_lf(b"@read1\nACGT\n+\n")]
+    #[case::plus_only_no_trailing_newline(b"@r\nA\n+")]
+    fn from_slice_rejects_quality_less_record_without_panicking(#[case] data: &[u8]) {
+        let result = FastqRecord::from_slice(data);
+        assert!(
+            result.is_err(),
+            "quality-less record {data:?} must return Err, not panic or succeed"
+        );
+    }
+
     #[test]
     fn test_parse_fastq_incomplete_record() {
         let data = b"@read1\nACGT\n+\n";
-        let (records, leftover) = parse_fastq_records(data).expect("failed to parse FASTQ records");
+        let (records, leftover) =
+            parse_fastq_records(data, true).expect("failed to parse FASTQ records");
         assert!(records.is_empty());
         assert_eq!(leftover, data);
     }
 
     #[test]
     fn test_parse_fastq_eof_without_trailing_newline() {
-        // Quality line has no trailing newline — should still parse.
+        // Quality line has no trailing newline — should still parse at EOF.
         let data = b"@read1\nACGT\n+\nIIII";
-        let (records, leftover) = parse_fastq_records(data).expect("failed to parse FASTQ records");
+        let (records, leftover) =
+            parse_fastq_records(data, true).expect("failed to parse FASTQ records");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name(), b"read1");
         assert_eq!(records[0].sequence(), b"ACGT");
@@ -346,11 +452,25 @@ mod tests {
         assert!(leftover.is_empty());
     }
 
+    /// Mirror of `test_parse_fastq_eof_without_trailing_newline` for the
+    /// incremental path: on a non-final chunk (`at_eof = false`) an unterminated
+    /// final record must NOT be consumed — its bytes are returned as leftover so
+    /// the caller can complete it with the next chunk. Otherwise a chunk boundary
+    /// landing mid-quality would be mistaken for a complete (shorter) record.
+    #[test]
+    fn test_parse_fastq_not_eof_holds_unterminated_record_as_leftover() {
+        let data = b"@read1\nACGT\n+\nIIII";
+        let (records, leftover) =
+            parse_fastq_records(data, false).expect("non-final chunk must not error");
+        assert!(records.is_empty(), "an unterminated final record must not be yielded mid-stream");
+        assert_eq!(leftover, data, "the whole record must be held as leftover for the next chunk");
+    }
+
     #[test]
     fn test_parse_fastq_eof_no_newline_seq_qual_mismatch() {
         // Quality shorter than sequence at EOF — should error.
         let data = b"@read1\nACGT\n+\nIII";
-        let result = parse_fastq_records(data);
+        let result = parse_fastq_records(data, true);
         assert!(
             result.is_err() || {
                 let (recs, leftover) = result.unwrap();
@@ -362,7 +482,8 @@ mod tests {
     #[test]
     fn test_parse_fastq_with_leftover() {
         let data = b"@read1\nACGT\n+\nIIII\n@read2\nTG";
-        let (records, leftover) = parse_fastq_records(data).expect("failed to parse FASTQ records");
+        let (records, leftover) =
+            parse_fastq_records(data, true).expect("failed to parse FASTQ records");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name(), b"read1");
         assert_eq!(leftover, b"@read2\nTG");

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -727,8 +727,11 @@ impl FastqGrouper {
             combined
         };
 
-        // Parse FASTQ records
-        let (records, leftover) = parse_fastq_records(&combined)?;
+        // Parse FASTQ records. This is an incremental chunk (more bytes may follow
+        // for this stream), so `at_eof = false`: an unterminated final record must
+        // be held as leftover and completed by the next chunk, not mistaken for a
+        // complete shorter record. `finish` re-parses the final leftover at EOF.
+        let (records, leftover) = parse_fastq_records(&combined, false)?;
         self.leftovers[stream_idx] = leftover;
 
         // Add to pending
@@ -859,6 +862,21 @@ impl FastqGrouper {
     ///
     /// Returns an error if there is incomplete or unmatched data at EOF.
     pub fn finish(&mut self) -> io::Result<Option<FastqTemplate>> {
+        // At EOF, re-parse each stream's leftover with `at_eof = true` so a
+        // complete final record whose quality line lacks a terminating newline is
+        // accepted (matching the sibling `SimdFastqReader` and fgbio). During
+        // streaming these bytes were held back (`add_bytes_for_stream` parses with
+        // `at_eof = false`); a genuinely truncated leftover stays as leftover and
+        // is rejected by the "Incomplete FASTQ record at EOF" check below.
+        for stream_idx in 0..self.num_inputs {
+            if !self.leftovers[stream_idx].is_empty() {
+                let leftover = std::mem::take(&mut self.leftovers[stream_idx]);
+                let (records, remaining) = parse_fastq_records(&leftover, true)?;
+                self.pending_records[stream_idx].extend(records);
+                self.leftovers[stream_idx] = remaining;
+            }
+        }
+
         // Check for any remaining complete templates
         let templates = self.drain_complete_templates()?;
         if templates.len() == 1 {
@@ -1006,6 +1024,54 @@ mod tests {
         let mut grouper = FastqGrouper::new(2);
         let result = grouper.finish().expect("finish should succeed");
         assert!(result.is_none());
+    }
+
+    /// `add_bytes_for_stream` feeds *incremental* chunks: a chunk boundary can
+    /// fall in the middle of a record, and the tail must be held as leftover until
+    /// the next chunk completes it. If the parser treated a chunk's unterminated
+    /// final quality bytes as a complete record, a boundary landing mid-quality
+    /// would compute a short quality span and reject the (valid) record with a
+    /// spurious `Sequence length != quality length` error — or, at an exact
+    /// boundary, silently truncate it. The chunk here splits the valid record
+    /// `@r/1\nACGT\n+\nIIII\n` after two of its four quality bytes; the grouper
+    /// must hold the partial record and reassemble the full `qual=IIII` record.
+    #[test]
+    fn add_bytes_for_stream_holds_unterminated_record_across_chunks() {
+        let mut grouper = FastqGrouper::new(1);
+        grouper
+            .add_bytes_for_stream(0, b"@r/1\nACGT\n+\nII")
+            .expect("a mid-quality chunk boundary must be held as leftover, not rejected");
+        grouper.add_bytes_for_stream(0, b"II\n").expect("second chunk should complete the record");
+
+        let template = grouper
+            .finish()
+            .expect("finish should succeed")
+            .expect("one reassembled template expected");
+        assert_eq!(template.records[0].sequence(), b"ACGT");
+        assert_eq!(
+            template.records[0].quality(),
+            b"IIII",
+            "the quality split across the chunk boundary must be reassembled, not truncated"
+        );
+    }
+
+    /// A complete final record whose quality line lacks a terminating newline is
+    /// still valid FASTQ (fgbio's `lines.take(4)` accepts it, as does the sibling
+    /// `SimdFastqReader`). Fed as a single final chunk, the grouper must accept it
+    /// at `finish()` rather than rejecting it as "Incomplete FASTQ record at EOF".
+    #[test]
+    fn finish_accepts_unterminated_final_record() {
+        let mut grouper = FastqGrouper::new(1);
+        grouper
+            .add_bytes_for_stream(0, b"@r/1\nACGT\n+\nIIII")
+            .expect("add_bytes_for_stream should succeed");
+
+        let template = grouper
+            .finish()
+            .expect("finish should accept an unterminated final record")
+            .expect("one final template expected");
+        assert_eq!(template.records[0].sequence(), b"ACGT");
+        assert_eq!(template.records[0].quality(), b"IIII");
     }
 
     #[test]


### PR DESCRIPTION
## What / why

Both FASTQ parsers split records on `\n` only, so two valid inputs that `fgbio FastqToBam` accepts were rejected by fgumi:

- **EXT3-06 (CRLF):** on a `\r\n`-terminated file the `\r` before each `\n` was left as the last byte of the name, sequence, and quality. A `\r` (byte 13) in the quality is below the printable-ASCII floor, so `fgumi extract` rejected the whole file: `Invalid quality scores detected: range [13, …]`.
- **EXT3-07 (no trailing newline):** `SimdFastqReader` errored `Truncated FASTQ record at EOF` on a final record lacking its terminating `\n`, even though the sibling `from_slice` parser already accepted it — the two paths disagreed (this is the exact inconsistency the audit flagged: `reader.rs` vs `fastq_parse.rs`).

The fix, applied to both the `fgumi-simd-fastq` crate (extract's path) and `src/lib/fastq_parse.rs` (the grouper / unified-pipeline path):
- Strip one trailing `\r` per field (`strip_trailing_cr`), matching fgbio's `Source.getLines`, and compare **CRLF-stripped** lengths in the seq/qual validation so an unterminated final CRLF record isn't spuriously rejected.
- In the reader's EOF branch, yield a complete-but-unterminated leftover (starts with `@`, does **not** end in `\n`, has exactly the three internal newlines) instead of erroring; a genuinely short/malformed leftover still errors. Matches fgbio's `lines.take(4)`.

## Verification (§0)

Real-tool repro — a CRLF FASTQ and a newline-less-final-record FASTQ:

| input | fgumi before | fgumi after | fgbio |
|---|---|---|---|
| CRLF | error (0 records) | **2 records** | 2 records |
| no trailing `\n` | error "Truncated…" (0) | **2 records** | 2 records |

fgumi-after name/sequence/quality are **byte-identical to `fgbio FastqToBam`** on the CRLF input. RED-first unit tests in both crates.

## Reviewers

Both ran. In-diff fixes folded by amend:
- **CodeRabbit-CLI (major, real bug it caught):** the first EOF-accept condition would have parsed a leftover like `@n\nseq\n+\n` — a newline-terminated `+` line with the quality line *absent* — which has three internal newlines but an empty quality span, panicking `parse_single_record` with `slice index starts at 11 but ends at 10`. Added `leftover.last() != Some(&b'\n')` (a genuine unterminated record ends with quality bytes, never `\n`) + a RED-first regression test that reproduces the panic.
- **CodeRabbit-CLI (minor):** corrected the `from_slice` doc — the trailing newline is optional and CRLF is accepted.

`cargo ci-fmt && ci-lint && ci-test` green (2234 tests).

## Scope

W9b of the extract/FASTQ residuals. Stacked on #512 (`nh/fix-fastqgrouper-readname-sync`, which also edits `fastq_parse.rs`) — auto-retargets to main on its merge. Remaining W9: FASTQ3-04 (suffix strip, main-based) and the FASTQ3-02/03 product decisions; EXT3-03 deferred on #496.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * FASTQ record parsing now accepts an `at_eof` flag to control how an unterminated final quality line is handled.
* **Bug Fixes**
  * Added CRLF compatibility so `\r` no longer appears in parsed name, sequence, or quality fields.
  * Final FASTQ records missing a trailing newline are now accepted when appropriate, both for streaming and chunked inputs.
  * Quality-less or malformed records now return a clean parsing error instead of failing unexpectedly.
  * Improved sequence/quality length validation across LF and CRLF inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->