### PR TITLE
fix(consensus): clamp summary cD/cM/cE at i16::MAX like fgbio (re-harden #448)

### DIFF
--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1316,6 +1316,10 @@ impl VanillaUmiConsensusCaller {
         }
 
         // Multi-read consensus calling
+        //
+        // fgbio stores per-base depths/errors as `Short`, clamping above i16::MAX (32_767); see
+        // the per-position push below.
+        let max_short: u16 = i16::MAX.unsigned_abs(); // 32_767
         for pos in 0..consensus_len {
             self.consensus_builder.reset();
 
@@ -1334,8 +1338,15 @@ impl VanillaUmiConsensusCaller {
             let (base, qual) = self.consensus_builder.call();
             let depth = self.consensus_builder.contributions(); // u16
 
-            // Record depth
-            depths.push(depth);
+            // fgbio's VanillaUmiConsensusCaller stores per-base depths and errors as `Short`,
+            // clamping anything above i16::MAX (32_767), and derives cD/cM/cE from those clamped
+            // arrays (DuplexConsensusCaller sums the two clamped strand depths without re-clamping).
+            // Clamp at push so the depths/errors vectors — and everything derived from them (the
+            // summary cD/cM/cE tags, the per-base cd/ce tags, and duplex's strand-sum) — match
+            // fgbio. The unclamped `depth` local is still used for the min-reads threshold below
+            // (as fgbio does at VanillaUmiConsensusCaller.scala:329). `contributions()` already
+            // saturates at u16::MAX, so a raw `.min` here cannot see a wrapped value.
+            depths.push(depth.min(max_short));
 
             // Errors = contributing bases that disagree with the consensus call. Derived by summing
             // the non-consensus base counters at full width (see `non_consensus_contributions`)
@@ -1343,7 +1354,7 @@ impl VanillaUmiConsensusCaller {
             // *saturated* `u16` operands and collapses to 0 in deep mixed pileups (e.g.
             // A = u16::MAX, C = 1). In the non-saturated case the two are identical, matching fgbio.
             let error_count = self.consensus_builder.non_consensus_contributions(base);
-            errors.push(error_count);
+            errors.push(error_count.min(max_short));
 
             // Apply minimum depth and quality thresholds
             let (final_base, final_qual) = if (depth as usize) < min_reads {
@@ -2474,6 +2485,170 @@ mod tests {
                 assert_eq!(e, 0, "Position {i} should have 0 errors");
             }
         }
+    }
+
+    /// Independent, programmatic fgbio oracle for the summary consensus tags.
+    ///
+    /// Reimplements fgbio's `VanillaUmiConsensusCaller` derivation from per-position
+    /// `(depth, errors)`: each is stored as a `Short` — clamped at `i16::MAX` — and the
+    /// summary tags come off those clamped arrays, `cD` as the max depth, `cM` as the min,
+    /// and `cE` as `sum(errors) / sum(depths)`. No fgbio dependency; the same
+    /// reimplement-the-algorithm shape as `fgbio_edit_baseline_partition` in `fgumi-umi`.
+    ///
+    /// Having the oracle be a function rather than a hand-computed constant is what makes
+    /// the saturation tests below independent: they assert against fgbio's rule applied to
+    /// the fixture's known pileup, not against a number read back out of fgumi.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "mirrors the production error-rate computation exactly, including its cast"
+    )]
+    fn fgbio_summary_tags_baseline(per_position: &[(u32, u32)]) -> (i32, i32, f32) {
+        const SHORT_MAX: u32 = i16::MAX as u32;
+        let depths: Vec<u32> = per_position.iter().map(|(d, _)| (*d).min(SHORT_MAX)).collect();
+        let errors: Vec<u32> = per_position.iter().map(|(_, e)| (*e).min(SHORT_MAX)).collect();
+
+        let max_depth = i32::try_from(*depths.iter().max().unwrap_or(&0)).expect("fits i32");
+        let min_depth = i32::try_from(*depths.iter().min().unwrap_or(&0)).expect("fits i32");
+        let total_errors: u64 = errors.iter().map(|&e| u64::from(e)).sum();
+        let total_depth: u64 = depths.iter().map(|&d| u64::from(d)).sum();
+        let error_rate =
+            if total_depth > 0 { total_errors as f32 / total_depth as f32 } else { 0.0 };
+        (max_depth, min_depth, error_rate)
+    }
+
+    #[test]
+    fn test_consensus_depth_saturates_at_i16_max_like_fgbio() {
+        // A UMI family deeper than i16::MAX (32_767) must report consensus depth saturated at
+        // 32_767 — matching fgbio's VanillaUmiConsensusCaller, which stores depths/errors as
+        // `Short` and derives cD/cM/cE from those clamped arrays — rather than the true depth
+        // (which would diverge from fgbio) or a wrapped value. The SUMMARY tags cD/cM/cE must use
+        // the clamped depth too, not just the per-base cd/ce arrays; before the clamp-at-push fix
+        // the summary tags were computed from the unclamped depths and diverged for families
+        // deeper than 32_767 at a position. cE must use the clamped depth as its denominator,
+        // exactly as fgbio derives it from the clamped arrays.
+        let options =
+            VanillaUmiConsensusOptions { produce_per_base_tags: true, ..Default::default() };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        let read_len = 4;
+        let depth = 40_000u32; // > i16::MAX, so depth must clamp
+        let quals = vec![30u8; read_len];
+        let mut reads = Vec::with_capacity(depth as usize);
+        for i in 0..depth {
+            let mut bases = vec![b'A'; read_len];
+            if i == 0 {
+                bases[0] = b'C'; // a single disagreeing observation at position 0
+            }
+            reads.push(create_consensus_test_read(&format!("r{i}"), &bases, &quals, "UMI1"));
+        }
+
+        let output = consensus_reads_from_raw(&mut caller, reads)
+            .expect("consensus_reads_from_raw should succeed");
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        assert_eq!(consensus.bases, vec![b'A'; read_len]);
+        assert_eq!(
+            consensus.get_int_tag(SamTag::CD).expect("cD present"),
+            32_767,
+            "cD (max depth) must saturate at i16::MAX like fgbio"
+        );
+        assert_eq!(
+            consensus.get_int_tag(SamTag::CM).expect("cM present"),
+            32_767,
+            "cM (min depth) must saturate at i16::MAX like fgbio"
+        );
+        let cd_bases = consensus.get_i16_array_tag(SamTag::CD_BASES).expect("cd present");
+        assert_eq!(
+            cd_bases,
+            vec![32_767i16; read_len],
+            "per-base cd must all saturate at i16::MAX"
+        );
+
+        // Independent oracle: position 0 carries the single disagreement, the rest none.
+        let (_, _, expected_ce) =
+            fgbio_summary_tags_baseline(&[(depth, 1), (depth, 0), (depth, 0), (depth, 0)]);
+        let ce = consensus.get_float_tag(SamTag::CE).expect("cE present");
+        assert!(
+            (ce - expected_ce).abs() < expected_ce * 0.01,
+            "cE must be computed from the clamped depth: expected ~{expected_ce}, got {ce}"
+        );
+    }
+
+    /// The *error* clamp, which the depth test above never reaches.
+    ///
+    /// `test_consensus_depth_saturates_at_i16_max_like_fgbio` has a single disagreeing
+    /// observation, so `errors.push(error_count.min(max_short))` is never exercised — only the
+    /// depth half of the clamp is. Saturating errors needs depth above `2 * i16::MAX`, because
+    /// the error count is `depth - observations_for(consensus_base)` and the consensus base is
+    /// the majority: a family of `70_000` reads split `36_000` `A` / `34_000` `C` at position 0
+    /// puts `34_000` errors there, past the `32_767` ceiling.
+    ///
+    /// The oracle is derived from fgbio's algorithm, not from fgumi's output. fgbio stores
+    /// depths and errors as `Short` and computes the summary `cE` from those clamped arrays, so
+    /// with all four positions at clamped depth `32_767` and only position 0 carrying (clamped)
+    /// errors, `cE` is `32_767 / (32_767 * 4)` — exactly `0.25`.
+    ///
+    /// That constant is what makes this test discriminating: the per-base `ce` array is clamped
+    /// a second time when the tag is written, so it reads `32_767` either way — only the summary
+    /// `cE` reveals whether the *stored* error was clamped. Without the error clamp the sum is
+    /// `34_000`, giving `34_000 / 131_068` = `0.2594`, which this assertion rejects.
+    #[test]
+    fn test_consensus_errors_saturate_at_i16_max_like_fgbio() {
+        let options =
+            VanillaUmiConsensusOptions { produce_per_base_tags: true, ..Default::default() };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        let read_len = 4;
+        let majority = 36_000u32; // consensus 'A' at position 0
+        let minority = 34_000u32; // disagreeing 'C' -> 34_000 errors, past i16::MAX
+        let quals = vec![30u8; read_len];
+
+        let mut reads = Vec::with_capacity((majority + minority) as usize);
+        for i in 0..(majority + minority) {
+            let mut bases = vec![b'A'; read_len];
+            if i >= majority {
+                bases[0] = b'C';
+            }
+            reads.push(create_consensus_test_read(&format!("r{i}"), &bases, &quals, "UMI1"));
+        }
+
+        let output = consensus_reads_from_raw(&mut caller, reads)
+            .expect("consensus_reads_from_raw should succeed");
+        assert_eq!(output.count, 1);
+        let records = ParsedBamRecord::parse_all(&output.data);
+        let consensus = &records[0];
+
+        assert_eq!(
+            consensus.bases,
+            vec![b'A'; read_len],
+            "the majority base wins at every position"
+        );
+
+        let ce_bases = consensus.get_i16_array_tag(SamTag::CE_BASES).expect("ce present");
+        assert_eq!(
+            ce_bases[0], 32_767,
+            "position 0 carries 34_000 errors and must saturate at i16::MAX"
+        );
+        assert_eq!(&ce_bases[1..], &[0i16; 3], "positions 1-3 have no disagreement");
+
+        // The discriminating assertion: cE is summed from the CLAMPED error array.
+        // Position 0 carries `minority` errors at full depth; the rest carry none.
+        let total = majority + minority;
+        let (oracle_max_depth, oracle_min_depth, expected_ce) =
+            fgbio_summary_tags_baseline(&[(total, minority), (total, 0), (total, 0), (total, 0)]);
+        assert_eq!(consensus.get_int_tag(SamTag::CD).expect("cD present"), oracle_max_depth);
+        assert_eq!(consensus.get_int_tag(SamTag::CM).expect("cM present"), oracle_min_depth);
+
+        let ce = consensus.get_float_tag(SamTag::CE).expect("cE present");
+        assert!(
+            (ce - expected_ce).abs() < 1e-4,
+            "cE must sum the clamped errors: expected {expected_ce} (clamped), \
+             got {ce} (0.2594 would mean the stored error was never clamped)"
+        );
     }
 
     /// Port of fgbio test: "calculate the # of errors relative to the most likely consensus call"

--- a/crates/fgumi-raw-bam/src/testutil.rs
+++ b/crates/fgumi-raw-bam/src/testutil.rs
@@ -123,6 +123,23 @@ fn find_u8_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<u8>> {
     (arr.elem_type == b'C').then(|| arr.data.to_vec())
 }
 
+/// Advance `i` by `n` bytes, or `None` if that would run past `len`.
+///
+/// Every payload step in [`find_i16_array_tag_in_aux`] goes through this so a
+/// truncated aux block returns `None` instead of panicking on an out-of-range
+/// index.
+fn advance_within(i: usize, n: usize, len: usize) -> Option<usize> {
+    let end = i.checked_add(n)?;
+    (end <= len).then_some(end)
+}
+
+/// Scan an aux block for a `B:s` (int16 array) tag.
+///
+/// Fails closed on malformed input: a truncated scalar, an unterminated `Z`/`H`
+/// string, a `B` header or payload that runs past the end of `aux`, an unknown
+/// `B` subtype (whose element width is unknowable, so the cursor cannot be
+/// advanced safely), or an unknown type code all yield `None` rather than
+/// indexing out of bounds.
 fn find_i16_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<i16>> {
     let mut i = 0;
     while i + 3 <= aux.len() {
@@ -131,42 +148,43 @@ fn find_i16_array_tag_in_aux(aux: &[u8], tag: [u8; 2]) -> Option<Vec<i16>> {
         i += 3;
         match typ {
             b'B' => {
+                // Subtype byte + 4-byte little-endian element count.
+                let header_end = advance_within(i, 5, aux.len())?;
                 let sub = aux[i];
-                i += 1;
                 let count =
-                    u32::from_le_bytes([aux[i], aux[i + 1], aux[i + 2], aux[i + 3]]) as usize;
-                i += 4;
-                if t == tag && sub == b's' {
-                    let mut vals = Vec::with_capacity(count);
-                    for _ in 0..count {
-                        vals.push(i16::from_le_bytes([aux[i], aux[i + 1]]));
-                        i += 2;
-                    }
-                    return Some(vals);
-                }
+                    u32::from_le_bytes([aux[i + 1], aux[i + 2], aux[i + 3], aux[i + 4]]) as usize;
+                i = header_end;
+
                 let elem_size = match sub {
+                    b'c' | b'C' => 1,
                     b's' | b'S' => 2,
                     b'i' | b'I' | b'f' => 4,
-                    _ => 1,
+                    // Not a BAM array subtype: the payload width is unknown, so
+                    // skipping it would resync the cursor onto garbage.
+                    _ => return None,
                 };
-                i += count * elem_size;
-            }
-            b'c' => {
-                i += 1;
-            }
-            b's' => {
-                i += 2;
-            }
-            b'i' | b'f' => {
-                i += 4;
-            }
-            b'Z' => {
-                while i < aux.len() && aux[i] != 0 {
-                    i += 1;
+                let payload_end = advance_within(i, count.checked_mul(elem_size)?, aux.len())?;
+
+                if t == tag && sub == b's' {
+                    return Some(
+                        aux[i..payload_end]
+                            .chunks_exact(2)
+                            .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                            .collect(),
+                    );
                 }
-                i += 1;
+                i = payload_end;
             }
-            _ => break,
+            b'A' | b'c' | b'C' => i = advance_within(i, 1, aux.len())?,
+            b's' | b'S' => i = advance_within(i, 2, aux.len())?,
+            b'i' | b'I' | b'f' => i = advance_within(i, 4, aux.len())?,
+            b'Z' | b'H' => {
+                // NUL-terminated; a missing terminator is malformed, not an
+                // implicit end-of-block.
+                let nul = aux.get(i..)?.iter().position(|&b| b == 0)?;
+                i = advance_within(i, nul + 1, aux.len())?;
+            }
+            _ => return None,
         }
     }
     None
@@ -372,4 +390,99 @@ pub fn make_b_uint32_array_tag(tag: [u8; 2], values: &[u32]) -> Vec<u8> {
         u32::try_from(values.len()).expect("array length must fit in u32"),
         &bytes,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rstest::rstest;
+
+    /// A well-formed `B:s` array is still found after the bounds hardening.
+    #[test]
+    fn finds_a_well_formed_i16_array() {
+        // MI:i:7 then CD:B:s,[1,2]
+        let mut aux = vec![b'M', b'I', b'i'];
+        aux.extend_from_slice(&7i32.to_le_bytes());
+        aux.extend_from_slice(b"CDBs");
+        aux.extend_from_slice(&2u32.to_le_bytes());
+        aux.extend_from_slice(&1i16.to_le_bytes());
+        aux.extend_from_slice(&2i16.to_le_bytes());
+
+        assert_eq!(find_i16_array_tag_in_aux(&aux, [b'C', b'D']), Some(vec![1, 2]));
+        assert_eq!(find_i16_array_tag_in_aux(&aux, [b'X', b'X']), None);
+    }
+
+    /// Malformed aux data must return `None`, never panic.
+    ///
+    /// The scanner walks caller-supplied bytes, so every payload step has to be
+    /// bounds-checked; before hardening each of these indexed past the end of the
+    /// slice and panicked.
+    #[rstest]
+    #[case::truncated_b_header(vec![b'C', b'D', b'B'])]
+    #[case::truncated_b_count(vec![b'C', b'D', b'B', b's', 0x02, 0x00])]
+    #[case::b_payload_shorter_than_count({
+        let mut v = vec![b'C', b'D', b'B', b's'];
+        v.extend_from_slice(&9u32.to_le_bytes()); // claims 9 elements
+        v.extend_from_slice(&1i16.to_le_bytes()); // supplies 1
+        v
+    })]
+    #[case::b_count_overflows_usize({
+        let mut v = vec![b'C', b'D', b'B', b'i'];
+        v.extend_from_slice(&u32::MAX.to_le_bytes());
+        v
+    })]
+    #[case::unknown_b_subtype({
+        let mut v = vec![b'C', b'D', b'B', b'?'];
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.push(0);
+        v
+    })]
+    #[case::truncated_scalar(vec![b'N', b'M', b'i', 0x01, 0x02])]
+    #[case::unterminated_z_string(vec![b'R', b'X', b'Z', b'A', b'C', b'G'])]
+    #[case::unknown_type_code(vec![b'Z', b'Z', b'?', 0x00])]
+    fn malformed_aux_returns_none_instead_of_panicking(#[case] aux: Vec<u8>) {
+        assert_eq!(find_i16_array_tag_in_aux(&aux, [b'C', b'D']), None);
+    }
+
+    proptest! {
+        /// The "fail closed, never read past the buffer" contract, over arbitrary bytes.
+        ///
+        /// The case table above pins the truncation shapes worth naming; this covers the
+        /// ones nobody thought of. The scanner walks caller-supplied bytes with a cursor
+        /// it advances by type-dependent widths, which is exactly the shape where a
+        /// hand-picked corpus misses a case — so the property is simply that no input
+        /// panics, and that a returned array is self-consistent.
+        #[test]
+        fn arbitrary_aux_bytes_never_panic(aux in proptest::collection::vec(any::<u8>(), 0..256)) {
+            // Must not panic for any tag, present or absent.
+            let found = find_i16_array_tag_in_aux(&aux, [b'C', b'D']);
+            let _ = find_i16_array_tag_in_aux(&aux, [b'M', b'I']);
+
+            // Any array we do return must fit inside the block it was parsed from:
+            // two bytes per element cannot exceed the input length.
+            if let Some(vals) = found {
+                prop_assert!(
+                    vals.len() * 2 <= aux.len(),
+                    "returned {} i16 values from a {}-byte aux block",
+                    vals.len(),
+                    aux.len(),
+                );
+            }
+        }
+
+        /// A well-formed `B:s` array is always recovered exactly, whatever the values.
+        ///
+        /// Guards the hardening against the opposite failure: bounds checks that are too
+        /// strict and start rejecting valid input.
+        #[test]
+        fn well_formed_i16_arrays_round_trip(vals in proptest::collection::vec(any::<i16>(), 0..64)) {
+            let mut aux: Vec<u8> = vec![b'C', b'D', b'B', b's'];
+            aux.extend_from_slice(&u32::try_from(vals.len()).unwrap().to_le_bytes());
+            for v in &vals {
+                aux.extend_from_slice(&v.to_le_bytes());
+            }
+            prop_assert_eq!(find_i16_array_tag_in_aux(&aux, [b'C', b'D']), Some(vals));
+        }
+    }
 }

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -183,6 +183,19 @@ impl SimplexOptions {
         if self.min_reads == 0 {
             bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
         }
+        // The per-position depth the threshold is compared against is a `u16` that
+        // saturates at `u16::MAX` (see `ConsensusBaseBuilder::contributions`), so a
+        // larger `--min-reads` can never be satisfied: every position in an
+        // arbitrarily deep family would be silently no-called as `NotEnoughReads`.
+        // Reject it up front rather than masking valid ultra-deep families.
+        if self.min_reads > usize::from(u16::MAX) {
+            bail!(
+                "--min-reads ({}) must be <= {} — consensus depth saturates at that value, so a \
+                 larger threshold can never be met",
+                self.min_reads,
+                u16::MAX,
+            );
+        }
         if let Some(max) = self.max_reads {
             if max < self.min_reads {
                 bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
@@ -1062,12 +1075,22 @@ mod tests {
         assert!(error_msg.contains("--min-reads"));
     }
 
+    /// `--min-reads` / `--max-reads` range validation.
+    ///
+    /// The ceiling cases guard a silent failure mode rather than a typo: the threshold is
+    /// compared against a `u16` per-position depth that saturates at `u16::MAX`, so a larger
+    /// value can never be met and would no-call every position of an arbitrarily deep family
+    /// as `NotEnoughReads` while looking like a legitimate filter. `u16::MAX` itself stays
+    /// accepted — it is exactly reachable.
     #[rstest]
     #[case::valid_min_only(1, None, None)]
     #[case::valid_min_and_max(3, Some(10), None)]
     #[case::valid_min_equals_max(5, Some(5), None)]
     #[case::min_reads_zero(0, None, Some("--min-reads must be >= 1"))]
     #[case::max_below_min(5, Some(2), Some("--max-reads (2) must be >= --min-reads (5)"))]
+    #[case::min_reads_at_depth_ceiling(65_535, None, None)]
+    #[case::min_reads_one_past_depth_ceiling(65_536, None, Some("must be <= 65535"))]
+    #[case::min_reads_far_past_depth_ceiling(1_000_000, None, Some("must be <= 65535"))]
     fn test_validate_read_bounds(
         #[case] min_reads: usize,
         #[case] max_reads: Option<usize>,


### PR DESCRIPTION
## What

Re-hardens the consensus depth clamp on `feat-runall` to close a summary-tag parity gap versus fgbio (the same class of bug fixed on `main` by #448, but feat-runall took a different — and only partial — route). Targets `nh/audit-3-parity`.

## Background

feat-runall already avoids the original u16 **wrap** by *saturating* the observation counter at `u16::MAX` (rather than #448's u32 widening), and it clamps the **per-base** `cd`/`ce` arrays to `i16::MAX`. But it computes the **summary** tags cD/cM (max/min depth) and cE (errors / depth) from the **unclamped** `depths`/`errors` vectors.

## The bug

fgbio's `VanillaUmiConsensusCaller` stores per-base depths/errors as `Short`, clamping anything above `i16::MAX` (32_767), and derives cD/cM/cE from those clamped arrays. On a UMI family deeper than 32_767 at a position (high-duplication cfDNA routinely exceeds this), feat-runall's summary cD/cM report up to ~65_535 and cE uses an unclamped denominator — both diverge from fgbio. Because cE = errors / depth, a divergent denominator can push a read's error rate past the filter threshold and silently flip a keep/drop decision.

## Fix

Clamp `depths`/`errors` **at push** in the vanilla caller, so the vectors — and everything derived from them (summary cD/cM/cE, per-base cd/ce, and duplex's per-strand tags + combined strand-sum) — match fgbio. The unclamped `depth` local is still used for the min-reads threshold (as fgbio does at `VanillaUmiConsensusCaller.scala:329`); min-reads actually keys off `source_reads.len()`, so it is unaffected either way.

**Duplex needs no separate change:** it derives per-strand aD/aM/bD/bM and cd/ce from the vanilla `ConsensusResult` depths (now clamped) and sums the two clamped strand depths into the combined cD/cM *without* re-clamping — exactly `DuplexConsensusCaller.scala:480`.

Also completes the test-only aux-tag scanner `find_i16_array_tag_in_aux` (testutil) to skip the unsigned `C`/`S`/`I` (and `A`/`H`) BAM aux **scalar** types — it previously handled only `c`/`s`/`i`/`f`, so a preceding unsigned-typed tag made the scanner stop before reaching the per-base array tag. Surfaced by the new test. (Ported from #448.)

## Verification

New `test_consensus_depth_saturates_at_i16_max_like_fgbio` (40_000-read family) asserts cD=cM=32_767 with cE from the clamped depth — verified to **fail before the fix** ("cD must saturate at i16::MAX"). `cargo ci-test` 2332 passed; `cargo ci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected consensus depth/error tagging for extremely deep UMI families to match expected 32,767 saturation behavior, improving downstream summaries and per-base metrics consistency.
  * Hardened auxiliary BAM `B`-array tag parsing to safely return no result on malformed/truncated inputs instead of risking failures.
  * Updated command validation to reject `--min-reads` values above the maximum representable consensus depth.
* **Tests**
  * Added saturation regression tests for both summary tags and per-base tags.
  * Added unit, parameterized, and property-based tests for robust aux `B`-tag parsing, plus validation test coverage for the new `--min-reads` ceiling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->