### PR TITLE
refactor(sort): rename SpillCompress → SpillBlockCompress to disambiguate from CompressSpill

### DIFF
--- a/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
+++ b/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
@@ -40,11 +40,11 @@ use fgumi_pipeline_core::{
 /// residual chunks, emitting [`SortPhase1Event`]s to `SortSpillDecompress`.
 ///
 /// Not to be confused with the similarly-named
-/// [`SpillCompress`](super::SpillCompress): this `CompressSpill` is the
+/// [`SpillBlockCompress`](super::SpillBlockCompress): this `CompressSpill` is the
 /// **composite compress-and-write-to-disk** step of the coarser
 /// `SortBuffer → CompressSpill → SortSpillDecompress → SortMerge` chain, whereas
-/// `SpillCompress` is the **pure block-compression** middle step of the finer
-/// `SpillGather → SpillCompress → SpillWrite` split (where the disk write is a
+/// `SpillBlockCompress` is the **pure block-compression** middle step of the finer
+/// `SpillGather → SpillBlockCompress → SpillWrite` split (where the disk write is a
 /// separate `SpillWrite` step).
 pub struct CompressSpill {
     /// Shared temp-directory allocator (free-space-aware round-robin). Behind a

--- a/crates/fgumi-pipeline-io/src/sort/mod.rs
+++ b/crates/fgumi-pipeline-io/src/sort/mod.rs
@@ -20,7 +20,7 @@ pub mod compress_spill;
 pub mod merge;
 pub mod protocol;
 pub mod sort_buffer;
-pub mod spill_compress;
+pub mod spill_block_compress;
 pub mod spill_decompress;
 pub mod spill_gather;
 pub mod spill_write;
@@ -32,7 +32,7 @@ pub use arena_ingest::{
 pub use compress_spill::CompressSpill;
 pub use merge::{BlockOutput, MergeBatchBuilder, MergeOutput, RecordBatchOutput, SortMerge};
 pub use sort_buffer::SortBuffer;
-pub use spill_compress::SpillCompress;
+pub use spill_block_compress::SpillBlockCompress;
 pub use spill_decompress::{SortDecompressTuning, SortSpillDecompress};
 pub use spill_gather::SpillGather;
 pub use spill_write::SpillWrite;

--- a/crates/fgumi-pipeline-io/src/sort/protocol.rs
+++ b/crates/fgumi-pipeline-io/src/sort/protocol.rs
@@ -146,13 +146,13 @@ impl SortChunkEvent {
     }
 }
 
-/// Events from `SpillGather` → `SpillCompress` → `SpillWrite` (the
+/// Events from `SpillGather` → `SpillBlockCompress` → `SpillWrite` (the
 /// block-parallel spill-write split that replaces the monolithic single-worker
 /// `CompressSpill`).
 ///
 /// `SpillGather` (Serial) fans each `SortChunkEvent::Spill` chunk into
 /// record-aligned raw [`Block`](Self::Block)s and forwards `Residual` /
-/// `AllAnnounced`. `SpillCompress` (Parallel) compresses each `Block`'s `bytes`
+/// `AllAnnounced`. `SpillBlockCompress` (Parallel) compresses each `Block`'s `bytes`
 /// in place. `SpillWrite` (Serial) demultiplexes blocks back to per-`file_id`
 /// spill files and emits the existing [`SortPhase1Event`].
 ///
@@ -165,7 +165,7 @@ impl SortChunkEvent {
 /// **contiguous** in the ordinal stream — so `SpillWrite` only ever has one
 /// spill file open at a time.
 pub enum SpillBlockEvent {
-    /// One raw (pre-compression) or compressed (post-`SpillCompress`) block of a
+    /// One raw (pre-compression) or compressed (post-`SpillBlockCompress`) block of a
     /// spill file. `file_id` is the spill `seq` (the eventual slot `file_id`),
     /// `is_last_in_file` marks the final block so `SpillWrite` can finalize the
     /// file and emit `SpillReady`. `SpillWrite` (Serial) owns the path allocation,

--- a/crates/fgumi-pipeline-io/src/sort/spill_block_compress.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_block_compress.rs
@@ -1,7 +1,7 @@
-//! `SpillCompress` — middle step of the block-parallel spill-write split
-//! (`SpillGather` → `SpillCompress` → `SpillWrite`).
+//! `SpillBlockCompress` — middle step of the block-parallel spill-write split
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`).
 //!
-//! `SpillCompress` (`Parallel + ByItemOrdinal`) compresses each raw
+//! `SpillBlockCompress` (`Parallel + ByItemOrdinal`) compresses each raw
 //! [`SpillBlockEvent::Block`] from `SpillGather` into a self-contained
 //! compressed unit (framed BGZF block(s) for bgzf, or a `[u32 len][zstd frame]`
 //! for zstd) via the shared [`SpillBlockCompressor`] kernel, replacing the
@@ -32,13 +32,13 @@ use fgumi_pipeline_core::{
 /// `Parallel + ByItemOrdinal` block compressor for the spill-write split.
 ///
 /// Not to be confused with the similarly-named
-/// [`CompressSpill`](super::CompressSpill): this `SpillCompress` is the
+/// [`CompressSpill`](super::CompressSpill): this `SpillBlockCompress` is the
 /// **pure block-compression** middle step of the finer
-/// `SpillGather → SpillCompress → SpillWrite` split (the disk write is the
+/// `SpillGather → SpillBlockCompress → SpillWrite` split (the disk write is the
 /// separate `SpillWrite` step), whereas `CompressSpill` is the **composite
 /// compress-and-write-to-disk** step of the coarser
 /// `SortBuffer → CompressSpill → SortSpillDecompress → SortMerge` chain.
-pub struct SpillCompress {
+pub struct SpillBlockCompress {
     codec: SpillCodec,
     compression: u32,
     /// Per-worker compressor, built lazily on the first block. `None` until then
@@ -48,8 +48,8 @@ pub struct SpillCompress {
     output_byte_limit: u64,
 }
 
-impl SpillCompress {
-    /// Build a `SpillCompress` for `codec` at `compression`. `output_byte_limit`
+impl SpillBlockCompress {
+    /// Build a `SpillBlockCompress` for `codec` at `compression`. `output_byte_limit`
     /// byte-bounds the compressed-block output queue.
     #[must_use]
     pub fn new(codec: SpillCodec, compression: u32, output_byte_limit: u64) -> Self {
@@ -97,7 +97,7 @@ impl SpillCompress {
     }
 }
 
-impl Clone for SpillCompress {
+impl Clone for SpillBlockCompress {
     fn clone(&self) -> Self {
         // Fresh per-worker compressor + held slot; shared config copied.
         Self {
@@ -110,13 +110,13 @@ impl Clone for SpillCompress {
     }
 }
 
-impl Step for SpillCompress {
+impl Step for SpillBlockCompress {
     type Input = SpillBlockEvent;
     type Outputs = OrderedBytesSingle<SpillBlockEvent>;
 
     fn profile(&self) -> StepProfile {
         StepProfile {
-            name: "SpillCompress",
+            name: "SpillBlockCompress",
             kind: StepKind::Parallel,
             sticky: false,
             output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],

--- a/crates/fgumi-pipeline-io/src/sort/spill_block_compress/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_block_compress/tests.rs
@@ -1,16 +1,22 @@
-//! Unit tests for `SpillCompress::compress_event` (the `StepCtx`-free core).
+//! Unit tests for `SpillBlockCompress::compress_event` (the `StepCtx`-free core).
 
 use super::*;
 use crate::sort::protocol::MemoryChunkErased;
 use fgumi_sort::{InMemoryChunk, RawCoordinateKey, SpillBlockDecompressor};
 use rstest::rstest;
 
-fn raw_block(ordinal: u64, file_id: u32, is_last: bool, bytes: Vec<u8>) -> SpillBlockEvent {
+fn raw_block(
+    ordinal: u64,
+    file_id: u32,
+    is_last: bool,
+    records_ingested_so_far: u64,
+    bytes: Vec<u8>,
+) -> SpillBlockEvent {
     SpillBlockEvent::Block {
         ordinal,
         file_id,
         is_last_in_file: is_last,
-        records_ingested_so_far: 0,
+        records_ingested_so_far,
         bytes,
     }
 }
@@ -19,15 +25,26 @@ fn raw_block(ordinal: u64, file_id: u32, is_last: bool, bytes: Vec<u8>) -> Spill
 #[case(SpillCodec::Zstd)]
 #[case(SpillCodec::Bgzf)]
 fn block_payload_is_compressed_and_routing_preserved(#[case] codec: SpillCodec) {
-    let mut step = SpillCompress::new(codec, 1, 1 << 20);
+    let mut step = SpillBlockCompress::new(codec, 1, 1 << 20);
     let raw = vec![0xABu8; 4096];
-    let out = step.compress_event(raw_block(7, 2, true, raw.clone())).unwrap();
-    let SpillBlockEvent::Block { ordinal, file_id, is_last_in_file, bytes, .. } = out else {
+    let out = step.compress_event(raw_block(7, 2, true, 123, raw.clone())).unwrap();
+    let SpillBlockEvent::Block {
+        ordinal,
+        file_id,
+        is_last_in_file,
+        records_ingested_so_far,
+        bytes,
+    } = out
+    else {
         panic!("expected Block");
     };
     assert_eq!(ordinal, 7, "ordinal must be preserved ({codec:?})");
     assert_eq!(file_id, 2, "file_id must be preserved ({codec:?})");
     assert!(is_last_in_file, "is_last must be preserved ({codec:?})");
+    assert_eq!(
+        records_ingested_so_far, 123,
+        "records_ingested_so_far must pass through compression unchanged ({codec:?})"
+    );
     assert_ne!(bytes, raw, "payload must change (be compressed) ({codec:?})");
     assert!(!bytes.is_empty(), "compressed payload non-empty ({codec:?})");
 
@@ -48,7 +65,7 @@ fn block_payload_is_compressed_and_routing_preserved(#[case] codec: SpillCodec) 
 
 #[test]
 fn residual_and_announced_pass_through_unchanged() {
-    let mut step = SpillCompress::new(SpillCodec::Zstd, 1, 1 << 20);
+    let mut step = SpillBlockCompress::new(SpillCodec::Zstd, 1, 1 << 20);
 
     let chunk = MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(vec![(
         RawCoordinateKey { sort_key: 1 },
@@ -56,7 +73,14 @@ fn residual_and_announced_pass_through_unchanged() {
     )]));
     let residual = SpillBlockEvent::Residual { ordinal: 5, chunk, records_ingested_so_far: 1 };
     let out = step.compress_event(residual).unwrap();
-    assert!(matches!(out, SpillBlockEvent::Residual { ordinal: 5, .. }));
+    let SpillBlockEvent::Residual { ordinal, records_ingested_so_far, .. } = out else {
+        panic!("expected Residual");
+    };
+    assert_eq!(ordinal, 5, "residual ordinal must pass through unchanged");
+    assert_eq!(
+        records_ingested_so_far, 1,
+        "residual records_ingested_so_far must pass through unchanged (not reset)"
+    );
 
     let announced = SpillBlockEvent::AllAnnounced {
         ordinal: 6,
@@ -78,9 +102,9 @@ fn residual_and_announced_pass_through_unchanged() {
 
 #[test]
 fn clone_starts_with_fresh_lazy_compressor() {
-    let mut step = SpillCompress::new(SpillCodec::Zstd, 1, 1 << 20);
+    let mut step = SpillBlockCompress::new(SpillCodec::Zstd, 1, 1 << 20);
     // Force the original to build its compressor.
-    let _ = step.compress_event(raw_block(0, 0, true, vec![1u8; 16])).unwrap();
+    let _ = step.compress_event(raw_block(0, 0, true, 0, vec![1u8; 16])).unwrap();
     assert!(step.compressor.is_some(), "original built its compressor");
     let fresh = step.clone();
     assert!(fresh.compressor.is_none(), "clone must start with no compressor");

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
@@ -1,11 +1,11 @@
 //! `SpillGather` — first step of the block-parallel spill-write split
-//! (`SpillGather` → `SpillCompress` → `SpillWrite`), replacing the monolithic
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`), replacing the monolithic
 //! single-worker `CompressSpill`.
 //!
 //! `SpillGather` (`Serial`) consumes the [`SortChunkEvent`]s `SortBuffer`
 //! emits and fans each `Spill` chunk into record-aligned **raw** (uncompressed)
 //! [`SpillBlockEvent::Block`]s of ≤`BGZF_MAX_BLOCK_SIZE`, so the downstream
-//! `Parallel` `SpillCompress` can compress them across the framework pool. The
+//! `Parallel` `SpillBlockCompress` can compress them across the framework pool. The
 //! in-memory `Residual` and the terminal `AllAnnounced` pass straight through.
 //!
 //! # Ordinal minting
@@ -29,7 +29,7 @@
 //! `MAX_EVENTS_PER_LOCK` blocks into `pending`, drains them, and only frees the
 //! source chunk once its last record is framed. `pending` therefore holds ≤ a
 //! handful of 64 KiB blocks (~½ MiB) regardless of chunk size, and the chunk
-//! drains as fast as `SpillCompress` consumes blocks.
+//! drains as fast as `SpillBlockCompress` consumes blocks.
 
 use std::collections::VecDeque;
 use std::io;
@@ -137,7 +137,7 @@ struct ActiveSpill {
     records_ingested_so_far: u64,
 }
 
-/// `Serial` step that fans sorted spill chunks into raw blocks for `SpillCompress`.
+/// `Serial` step that fans sorted spill chunks into raw blocks for `SpillBlockCompress`.
 pub struct SpillGather {
     /// The spill chunk currently being framed incrementally (`None` between
     /// chunks). Holding it here — rather than materializing all its blocks into

--- a/crates/fgumi-pipeline-io/src/sort/spill_write.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_write.rs
@@ -1,5 +1,5 @@
 //! `SpillWrite` — final step of the block-parallel spill-write split
-//! (`SpillGather` → `SpillCompress` → `SpillWrite`).
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`).
 //!
 //! `SpillWrite` (`Serial + Affinity::Writer`) receives the compressed
 //! [`SpillBlockEvent`]s in dense `ordinal` order (the framework's `ByItemOrdinal`
@@ -103,7 +103,7 @@ impl SpillWrite {
     /// instead of as a pool-scheduled `Serial + Affinity::Writer` step. Used
     /// ONLY on the standalone-sort spill path (the Phase-1 analogue of Lever 2's
     /// detached terminal writer): it frees a pool worker for the
-    /// compression-bound `SpillCompress` work, matching feat-runall's dedicated
+    /// compression-bound `SpillBlockCompress` work, matching feat-runall's dedicated
     /// spill-I/O thread — but as a single persistent thread for the whole run,
     /// not one per spill chunk.
     ///

--- a/crates/fgumi-pipeline-io/src/sort/spill_write/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_write/tests.rs
@@ -19,7 +19,7 @@ fn make_writer(codec: SpillCodec) -> (SpillWrite, TempDir) {
     (writer, dir)
 }
 
-/// Kernel-compress one raw block for `codec`, mirroring `SpillCompress`.
+/// Kernel-compress one raw block for `codec`, mirroring `SpillBlockCompress`.
 fn compress(codec: SpillCodec, raw: &[u8]) -> Vec<u8> {
     SpillBlockCompressor::new(codec, 1).unwrap().compress_block(raw).unwrap()
 }

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -62,7 +62,7 @@ pub mod ref_sort;
 pub mod segmented_buf;
 pub mod template_arena;
 // Block-granular spill compression kernel for the block-parallel spill steps
-// (`SpillGather`/`SpillCompress`/`SpillWrite`). Surfaced via the re-exports
+// (`SpillGather`/`SpillBlockCompress`/`SpillWrite`). Surfaced via the re-exports
 // below.
 pub(crate) mod spill_block;
 pub(crate) mod spill_block_reader;

--- a/crates/fgumi-sort/src/spill_block.rs
+++ b/crates/fgumi-sort/src/spill_block.rs
@@ -1,5 +1,5 @@
 //! Block-granular spill compression kernel shared by the Phase-1 spill steps
-//! (`SpillGather` → `SpillCompress` → `SpillWrite`).
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`).
 //!
 //! The legacy [`SyncSpillWriter`](crate::sync_spill_writer) streams a whole
 //! sorted chunk through one stateful compressor on a single worker. To compress

--- a/src/lib/pipeline/chains/build.rs
+++ b/src/lib/pipeline/chains/build.rs
@@ -16,7 +16,7 @@
 //! work-stealing pool. There is no longer a Sort-terminal special case: the
 //! former self-contained file→file `SortBamFile` step was removed, and
 //! standalone sort now streams (`ParseBamRecords` → arena sort ingest →
-//! `SpillGather` → `SpillCompress` → `SpillWrite` → `SortSpillDecompress` →
+//! `SpillGather` → `SpillBlockCompress` → `SpillWrite` → `SortSpillDecompress` →
 //! `SortMerge` → sink) like every other command.
 
 use anyhow::{Result, bail};

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2262,7 +2262,7 @@ impl<'a> ChainBuilder<'a> {
     ///     ↓ arena sort ingest:
     ///        SAM → SortBuffer (Serial)
     ///        BAM → ReadBlocks → InflateToArena → FindBoundariesAndSort
-    ///     ↓ SpillGather (Serial) → SpillCompress (Parallel) → SpillWrite (Serial)
+    ///     ↓ SpillGather (Serial) → SpillBlockCompress (Parallel) → SpillWrite (Serial)
     /// SortPhase1Event
     ///     ↓ SortSpillDecompress (Parallel)
     /// SortPhase2Event
@@ -2302,7 +2302,7 @@ impl<'a> ChainBuilder<'a> {
             //
             // Every sort — including a sole-`[Stage::Sort]` standalone sort —
             // runs through the streaming source → arena sort ingest →
-            // SpillGather → SpillCompress → SpillWrite → SortSpillDecompress →
+            // SpillGather → SpillBlockCompress → SpillWrite → SortSpillDecompress →
             // SortMerge → sink pipeline. `add_source` always runs first (even
             // for `[Sort]`), so `current_tail` is always `Some` here.
             //
@@ -2314,7 +2314,7 @@ impl<'a> ChainBuilder<'a> {
             //       ↓ arena sort ingest (SortBuffer, or ReadBlocks →
             //         InflateToArena → FindBoundariesAndSort for BAM)
             //       ↓
-            //   SpillGather (Serial) → SpillCompress (Parallel) → SpillWrite
+            //   SpillGather (Serial) → SpillBlockCompress (Parallel) → SpillWrite
             //       (Serial) → SortPhase1Event
             //       ↓
             //   SortSpillDecompress (Parallel)
@@ -2339,7 +2339,7 @@ impl<'a> ChainBuilder<'a> {
             use crate::pipeline::steps::parse::decode::DecodeFromRecords;
             use crate::pipeline::steps::sort::{
                 BlockOutput, RecordBatchOutput, SortBuffer, SortDecompressTuning, SortMerge,
-                SortSpillDecompress, SpillCompress, SpillGather, SpillWrite,
+                SortSpillDecompress, SpillBlockCompress, SpillGather, SpillWrite,
             };
             use fgumi_sort::{RawExternalSorter, SortOrder};
 
@@ -2487,7 +2487,7 @@ impl<'a> ChainBuilder<'a> {
             // Phase-1 head — the block-parallel spill-write split for ALL sort
             // orders: `SortBuffer` (Serial: ingest + par-sort + emit sorted
             // chunks) → `SpillGather` (Serial: fan each chunk into raw blocks,
-            // mint a dense ordinal) → `SpillCompress` (Parallel + ByItemOrdinal:
+            // mint a dense ordinal) → `SpillBlockCompress` (Parallel + ByItemOrdinal:
             // compress blocks across the work-stealing pool) → `SpillWrite`
             // (Serial + Writer: demux blocks to per-file spill files, emit
             // `SortPhase1Event`). This mirrors the output BAM tail
@@ -2612,13 +2612,13 @@ impl<'a> ChainBuilder<'a> {
                 // head, so it never contends a pool worker — the driver frames the
                 // just-sorted chunk into blocks while the pool inflates/compresses.
                 let serialize = SpillGather::new(byte_limit);
-                let compress = SpillCompress::new(temp_codec, temp_compression, byte_limit);
+                let compress = SpillBlockCompress::new(temp_codec, temp_compression, byte_limit);
                 let write = SpillWrite::new(alloc, temp_codec, byte_limit, temp_dirs);
                 // Lever 2, Phase-1 analogue: on the standalone-sort terminal,
                 // detach the spill writer onto its own dedicated thread as well,
                 // so the single serial spill-write stream stops occupying a pool
                 // worker that could be running the compression-bound
-                // `SpillCompress`. One persistent writer thread for the whole run
+                // `SpillBlockCompress`. One persistent writer thread for the whole run
                 // (not one per spill chunk). Same gate as the terminal output
                 // writer set above; every other chain keeps the pool-scheduled
                 // `Serial + Affinity::Writer` spill writer.

--- a/src/lib/pipeline/chains/commands/sort.rs
+++ b/src/lib/pipeline/chains/commands/sort.rs
@@ -10,7 +10,7 @@
 //! ## Sort pipeline topology
 //!
 //! A sole-`[Stage::Sort]` chain runs through the same streaming source → arena
-//! sort ingest → `SpillGather` → `SpillCompress` → `SpillWrite` →
+//! sort ingest → `SpillGather` → `SpillBlockCompress` → `SpillWrite` →
 //! `SortSpillDecompress` → `SortMerge` → sink pipeline as a
 //! fused sort stage, via the normal `add_source` / `add_sink` flow that
 //! [`crate::pipeline::chains::build::build_for`] drives for every stage; there

--- a/src/lib/pipeline/steps/sort/mod.rs
+++ b/src/lib/pipeline/steps/sort/mod.rs
@@ -3,7 +3,7 @@
 pub use fgumi_pipeline_io::sort::{
     BlockOutput, CompressSpill, MergeBatchBuilder, MergeOutput, RecordBatchOutput,
     SORT_COORD_GROUP, SORT_IO_GROUP, SortBuffer, SortDecompressTuning, SortMerge,
-    SortSpillDecompress, SpillCompress, SpillGather, SpillWrite, protocol,
+    SortSpillDecompress, SpillBlockCompress, SpillGather, SpillWrite, protocol,
 };
 
 pub mod compress_spill {
@@ -21,8 +21,8 @@ pub mod spill_decompress {
 pub mod spill_gather {
     pub use fgumi_pipeline_io::sort::spill_gather::*;
 }
-pub mod spill_compress {
-    pub use fgumi_pipeline_io::sort::spill_compress::*;
+pub mod spill_block_compress {
+    pub use fgumi_pipeline_io::sort::spill_block_compress::*;
 }
 pub mod spill_write {
     pub use fgumi_pipeline_io::sort::spill_write::*;


### PR DESCRIPTION
## What

Two distinct spill-compression steps had confusable, word-swapped names:

- **`CompressSpill`** (chunk-granularity) — compresses a whole sorted chunk *and* writes the spill file, in the P6 Phase-1 split (`SortBuffer → CompressSpill → SortSpillDecompress → SortMerge`).
- **`SpillCompress`** (block-granularity) — compresses one raw `SpillBlockEvent::Block` in place (no file write; `SpillWrite` writes), in the block-parallel split (`SpillGather → SpillCompress → SpillWrite`).

They do different things, but the near-mirrored names invited mix-ups. Rename the block-parallel step to **`SpillBlockCompress`** (and its module/file to `spill_block_compress`), which reads naturally against the `SpillBlockCompressor` kernel it drives and the `SpillBlockEvent::Block` it consumes.

## Notes

- Pure rename, no behavior change. `fgumi-pipeline-io`/`fgumi-sort` are feat-runall-only, so no `main`-reconcile conflict. Targets `nh/audit-3-parity`.

## Verification

`cargo ci-test` 2332 passed; `cargo ci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the sorting pipeline to use block-level spill compression, enabling clearer separation between compression and disk writing.
  * Renamed the spill compression stage to better reflect its block-oriented behavior.

* **Documentation**
  * Updated pipeline descriptions and inline documentation to reflect the revised processing stages.

* **Tests**
  * Expanded coverage to verify compressed block metadata, residual event passthrough, and clone behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->