### PR TITLE
docs: clear fgbio-parity doc tail across commands (W11)

### DIFF
--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -48,7 +48,8 @@ between the reads. This ensures that downstream processes, particularly variant 
 evidence from the same template when both reads span a variant site in the same template.
 
 Clipping overlapping reads is only performed on FR read pairs, and is implemented by clipping approximately half
-the overlapping bases from each read. By default soft clipping is performed.
+the overlapping bases from each read. By default hard clipping is performed; the mode may be changed with
+--clipping-mode.
 
 Secondary alignments and supplemental alignments are not clipped, but are passed through into the output.
 
@@ -127,7 +128,8 @@ pub struct Clip {
     #[arg(short = 'a', long = "auto-clip-attributes", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub auto_clip_attributes: bool,
 
-    /// Output file for clipping metrics
+    /// Output file for clipping metrics (only produced by the single-threaded path; cannot be
+    /// combined with --threads)
     #[arg(short = 'm', long = "metrics")]
     pub metrics: Option<PathBuf>,
 

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -198,11 +198,11 @@ pub struct Codec {
     pub compression: CompressionOptions,
 
     // --- CODEC-specific options below ---
-    /// Minimum read pairs per strand to form consensus (same as --min-reads)
+    /// Minimum read pairs per strand to form consensus (fgbio's `--min-read-pairs`)
     #[arg(short = 'M', long = "min-reads", default_value = "1")]
     pub min_reads: usize,
 
-    /// Maximum read pairs per strand (downsample if exceeded)
+    /// Maximum read pairs per strand, downsample if exceeded (fgbio's `--max-read-pairs`)
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -392,7 +392,9 @@ pub struct ConsensusCallingOptions {
     #[arg(short = 'm', long = "min-input-base-quality", default_value = "10")]
     pub min_input_base_quality: u8,
 
-    /// Produce per-base tags (cd, ce) in addition to per-read tags
+    /// Produce per-base tags (cd, ce) in addition to per-read tags. The default (true) matches
+    /// fgbio, which always writes per-base tags; setting this to false drops per-base tags that
+    /// fgbio emits unconditionally.
     #[arg(short = 'B', long = "output-per-base-tags", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub output_per_base_tags: bool,
 
@@ -400,7 +402,10 @@ pub struct ConsensusCallingOptions {
     #[arg(long = "trim", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub trim: bool,
 
-    /// Minimum consensus base quality (output consensus bases below this are masked to N)
+    /// Minimum consensus base quality (output consensus bases below this are masked to N). The
+    /// default (2) matches fgbio, which hardcodes the consensus base-quality minimum to `MIN_PHRED`
+    /// (2) and defers further masking to `fgumi filter` / fgbio `FilterConsensusReads`; exposing
+    /// this as a flag is an fgumi superset.
     #[arg(long = "min-consensus-base-quality", default_value = "2")]
     pub min_consensus_base_quality: u8,
 }

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -49,6 +49,20 @@ The tool processes families in streaming fashion by grouping consecutive reads w
 MI tag value. For each family, a random decision is made based on the fraction parameter to
 either keep or reject all reads in that family.
 
+NOTE: this command is NOT a port of Picard `DownsampleSam`. It is a UMI-family sampler by
+design, and differs from `DownsampleSam` in several deliberate ways:
+  - Sampling unit: whole UMI families (MI tag), not individual read templates. Every record
+    must carry an MI tag and the input must be group-produced, template-coordinate-sorted BAM.
+    `DownsampleSam` downsamples any BAM in any order by read name.
+  - Decision function: one sequential random draw per family (order-dependent), rather than
+    `DownsampleSam`'s stateless, name+seed hash (order-independent, cross-tool reproducible).
+  - Determinism: without --seed, a run is non-deterministic (seeded from entropy), whereas
+    `DownsampleSam` defaults to a fixed seed of 1. Pass --seed for reproducible output.
+  - --fraction must be in (0.0, 1.0]; 0.0 is rejected (unlike `DownsampleSam`, which allows
+    PROBABILITY=0 for an empty pass). NaN and infinities are also rejected.
+Because the sampling unit, decision function, and RNG all differ, output is intentionally not
+bit-identical to `DownsampleSam`; only a statistically-equivalent fraction of families is kept.
+
 Example usage:
   fgumi downsample -i grouped.bam -o downsampled.bam -f 0.1 --seed 42
   fgumi downsample -i grouped.bam -o kept.bam -f 0.5 --rejects rejected.bam

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -144,7 +144,8 @@ And those that have a value per base (duplex values are not generated, but can b
 The per base depths and errors are both capped at 32,767. In all cases no-calls (Ns) and bases below the
 min-input-base-quality are not counted in tag value calculations.
 
-The --min-reads option can take 1-3 values similar to `filter`. For example:
+The --min-reads option can take 1-3 values similar to `filter`. Values are comma-delimited in
+fgumi (whereas fgbio's `CallDuplexConsensusReads` takes them space-separated). For example:
 
   fgumi duplex ... --min-reads 10,5,3
 

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -46,6 +46,9 @@ The input to this tool must be a BAM file that is either:
 2. A BAM file that has MI tags present on all reads (usually set by `group` and has been
    sorted into template-coordinate order
 
+Paired templates are expected to carry both mate records; templates for which the physical R2
+record is absent are skipped (a non-issue for properly grouped, template-coordinate-sorted BAMs).
+
 Calculation of metrics may be restricted to a set of regions using the `--intervals` parameter.
 This can significantly affect results as off-target reads in duplex sequencing experiments often
 have very different properties than on-target reads due to the lack of enrichment.
@@ -107,7 +110,9 @@ pub struct DuplexMetrics {
     #[arg(short = 'l', long = "intervals")]
     pub intervals: Option<PathBuf>,
 
-    /// Optional sample name or description for PDF plot titles
+    /// Optional sample name or description for PDF plot titles. When omitted, fgumi uses the
+    /// literal "Sample" (fgbio instead derives the sample/library name from the BAM `@RG` header,
+    /// so plot titles differ unless this is set).
     #[arg(long = "description")]
     pub description: Option<String>,
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -137,7 +137,8 @@ pub struct Filter {
     #[arg(short = 'e', long = "max-base-error-rate", value_delimiter = ',', default_value = "0.1")]
     pub max_base_error_rate: Vec<f64>,
 
-    /// Minimum base quality score (after masking)
+    /// Minimum base quality score (after masking). Optional in fgumi (unlike fgbio, which requires
+    /// it): when omitted, no per-base quality masking is performed.
     #[arg(short = 'N', long = "min-base-quality")]
     pub min_base_quality: Option<u8>,
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -659,8 +659,8 @@ len bases will be compared, where len is the length of the shortest UMI. The UMI
 of [ACGT] bases in the UMI (i.e. does not count dashes and other non-ACGT characters). This option is
 not implemented for reads with UMI pairs (i.e. using the paired assigner).
 
-Note: the --min-map-q parameter defaults to 0 in duplicate marking mode and 1 otherwise, and is
-directly settable on the command line.
+Note: the --min-map-q parameter defaults to 1 and is directly settable on the command line.
+(Duplicate marking is not performed by this command in fgumi; it is handled by `fgumi dedup`.)
 
 # Cell Barcodes
 
@@ -671,7 +671,9 @@ The cell barcode is read from the standard `CB` tag. No correction or
 error-handling is performed on cell barcodes; they must be corrected upstream.
 
 Multi-threaded operation is supported via --threads N, which spawns N pipeline threads
-allocated based on the command's workload profile to optimize performance.
+allocated based on the command's workload profile to optimize performance. Note this differs
+from fgbio, where --threads sizes only the pool of UMI-comparison worker threads; in fgumi
+--threads sizes the whole read/assign/write pipeline.
 
 Example: --threads 8 spawns 8 pipeline threads (2 reader, 4 workers, 2 writer)
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -207,7 +207,10 @@ pub struct Simplex {
     #[arg(short = 'M', long = "min-reads")]
     pub min_reads: usize,
 
-    /// Maximum reads to use per tag family (downsample if exceeded)
+    /// Maximum reads to use per tag family (downsample if exceeded). Note: over-sized families are
+    /// downsampled with a different pseudo-random generator than fgbio's Scala `Random`, so which
+    /// reads survive (and therefore the consensus of a downsampled family) is not bit-identical to
+    /// fgbio, though it is deterministic within fgumi for a given input.
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
 

--- a/src/lib/commands/simplex_metrics.rs
+++ b/src/lib/commands/simplex_metrics.rs
@@ -77,11 +77,14 @@ pub struct SimplexMetrics {
     #[arg(long = "min-reads", default_value = "1")]
     pub min_reads: usize,
 
-    /// Optional intervals file to restrict analysis (BED or Picard interval list format).
+    /// Optional intervals file to restrict analysis. Both BED and Picard interval-list formats are
+    /// auto-detected (an fgumi superset; fgbio's duplex analog accepts only the Picard interval list).
     #[arg(short = 'l', long = "intervals")]
     pub intervals: Option<PathBuf>,
 
-    /// Optional sample name or description for PDF plot titles.
+    /// Optional sample name or description for PDF plot titles. When omitted, fgumi uses the
+    /// literal "Sample" (fgbio instead derives the sample/library name from the BAM `@RG` header,
+    /// so plot titles differ unless this is set).
     #[arg(long = "description")]
     pub description: Option<String>,
 }

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -103,6 +103,11 @@ Named tag sets like "Consensus" are automatically expanded to their constituent 
 - --tags-to-revcomp Consensus:  ac bc  (per-base consensus base arrays; reverse-complemented)
 Per-read scalar tags (aD bD cD, aM bM cM, aE bE cE) are never reversed or reverse-complemented.
 
+Tag lists are comma-delimited in fgumi (e.g. `--tags-to-reverse cd,ce,ad`), whereas fgbio's
+`ZipperBams` takes space-separated values. Tags that are not present, or whose type does not
+support the requested transform (e.g. a scalar tag listed under --tags-to-reverse), are silently
+skipped rather than raising an error.
+
 ## Default Behavior
 
 By default, input is read from stdin and output is written to stdout, allowing for streaming


### PR DESCRIPTION
## Summary

W11 of the final-audit burn-down: the docs / wontfix sweep. This is a **documentation-only** PR that clears the low-value fgbio/Picard-parity doc tail — help text, `long_about`, and shared-option doc comments — with no runtime, metric, or test changes. Each correction was verified against the actual code and the per-command audit files under `reports/final-audit/`.

## Doc changes (finding → file → what changed)

| Finding | File | Change |
|---|---|---|
| CLIP3-06 | `commands/clip.rs` | `long_about` said "By default soft clipping is performed"; the actual default clipping mode is `hard`. Corrected. |
| CLIP3-07 | `commands/clip.rs` | Documented that `--metrics` is produced only by the single-threaded path and cannot be combined with `--threads`. |
| FILT3-07 | `commands/filter.rs` | Documented that `--min-base-quality` is optional in fgumi (required in fgbio) and that omitting it performs no per-base quality masking. |
| GRP3-02 | `commands/group.rs` | Removed the stale "defaults to 0 in duplicate marking mode" note on `--min-map-q` (fgumi has no duplicate-marking mode in `group`; `dedup` handles it); state the default is 1. |
| GRP3-07 | `commands/group.rs` | Documented that `--threads` sizes the whole read/assign/write pipeline in fgumi, unlike fgbio where it sizes only the UMI-comparison worker pool. |
| ZIP3-07 | `commands/zipper.rs` | Documented that tag-list flags are comma-delimited in fgumi vs space-separated in fgbio's `ZipperBams`. |
| ZIP3-12 | `commands/zipper.rs` | Documented that absent tags, or tags whose type does not support the requested transform, are silently skipped rather than raising an error. |
| DOWN3-01/02/03 | `commands/downsample.rs` | Documented that fgumi `downsample` is a UMI-family sampler **by design**, not a Picard `DownsampleSam` port: different sampling unit (MI family vs read template), order-dependent per-family draw vs stateless name-hash, non-deterministic without `--seed` (vs Picard's fixed seed 1), and `--fraction` restricted to `(0.0, 1.0]`. |
| SIMPLEX3-02 | `commands/simplex.rs` | Documented that `--max-reads` downsampling uses a different PRNG than fgbio's Scala `Random`, so surviving reads (and the consensus of a downsampled family) are not bit-identical to fgbio (deterministic within fgumi). |
| SIMPLEX3-05 | `commands/common.rs` | Documented `--min-consensus-base-quality` as an fgumi superset: default 2 matches fgbio, which hardcodes the minimum to `MIN_PHRED` (2) and defers masking to `filter`. |
| DUPLEX3-08 | `commands/common.rs` | Documented that `--output-per-base-tags` default (true) matches fgbio and that setting it false drops per-base tags fgbio writes unconditionally. |
| DUPLEX3-09 | `commands/duplex.rs` | Documented that `--min-reads` is comma-delimited in fgumi vs space-separated in fgbio. |
| CODEC3-09 | `commands/codec.rs` | Mapped fgumi's `--min-reads`/`--max-reads` to fgbio's `--min-read-pairs`/`--max-read-pairs` in the flag help. |
| DXM3-08 | `commands/duplex_metrics.rs` | Documented that paired templates missing the physical R2 record are skipped (non-issue for properly grouped/sorted BAMs). |
| DXM3-09 | `commands/duplex_metrics.rs` | Documented the literal `"Sample"` default for `--description` (fgbio derives sample/library from the `@RG` header, so plot titles differ unless set). |
| SIMM3-04 | `commands/simplex_metrics.rs` | Documented the literal `"Sample"` default for `--description` (as DXM3-09). |
| SIMM3-05 | `commands/simplex_metrics.rs` | Documented that both BED and Picard interval-list formats are auto-detected (an fgumi superset; fgbio's analog accepts only the Picard interval list). |

## Excluded / skipped (not doc-only, or wrong base)

These findings from the same audit files were **not** touched here because they are behavior changes, wrong-base, or already resolved:

- **RUN3-04** — lives in `src/lib/commands/runall.rs` on the `feat-runall` branch, not `main`. Different base; excluded.
- **SORT3-10** (`lexicographic` → `lexicographical`) — changes an emitted `@HD SS` header value and a test that pins it (a behavior/round-trip change, marked "discuss"). Excluded; needs a disposition.
- **FILT3-09** (drop the `cc > ab` error-rate rejection) — the described over-restriction is **not present** in current `main`: `validate_parameters` only enforces `ab <= ba`, which already matches fgbio. No change needed.
- **ZIP3-09** (RG/PG declaration order) — the resulting header set is identical; nothing user-facing to correct. Wontfix.
- **ZIP3-13** (`am`/`bm` methylation MM-strings unclassified) — disposition is "verify EM-seq duplex need"; adding these tags to a transform set would be a behavior change. Excluded pending verification.
- **SIMPLEX3-03/06/07/08** — deep numeric edge cases (unanimous fast-path over-report, unclamped `cD`/`cM`, base-case sensitivity flip, single-input quality clamp), all unreachable under defaults, with no natural user-facing help surface. Noted, not changed.
- **SIMPLEX3-04, DUPLEX3-07, SIMM3-03** — hardcoded standard tags / no `--cell-tag`; disposition "likely wontfix (opinionated standard-tag design)." Not a help-text correction.
- **DUPLEX3-05** (dead `--min-consensus-base-quality` for duplex) — disposition "remove or wire" (behavior). Excluded.
- **DUPLEX3-06, CODEC3-10** — `--sort-order` output re-sort (behavior/discuss) and MT chain string-vs-typed error match (code fix). Excluded.
- **DUPLEX3-10** — zero-depth error-rate guard; fgumi safer, unreachable. Wontfix (see below).

## Wontfix / not-a-gap set (recorded so it stops re-surfacing)

fgumi is correct or intentionally divergent in each of these; no change is warranted:

- **EXT-02** — read-name UMI field-count ≥8 leniency; intentional (over-count sibling of the strict-throw path). fgumi accepts lenient input by design.
- **EXT3-08** — extract CLI-surface divergence (missing `--umi-tag`/`--cell-tag`/`--sort`, repurposed short flags); intentional opinionated standard-tags-only design; defaults keep output correct.
- **EXT3-09** — 8-field name with empty trailing field: fgumi returns `None` where fgbio emits an empty-string `RX`; fgumi is arguably more correct.
- **FASTQ3-05** — `/1`,`/2` appended by default (unless `-n`): diverges from Picard but matches samtools; sensible for the pipe-to-aligner use.
- **FASTQ3-06** — non-PF and duplicates kept by default: matches samtools (Picard excludes non-PF); documented default.
- **FASTQ3-07** — intentional single-stream design (no R1/R2/singleton split, per-RG, index-read, or interleave toggles); documented "pipe to aligner."
- **ZIP3-01** — TC/template-coordinate tags added to secondary/supplementary by default: part of fgumi's template-coordinate-sort pipeline design (gated off by `--skip-tc-tags`); not an fgbio bug.
- **FILT3-05** — fgumi's even-length per-base tag reversal is **correct**; fgbio has an off-by-one bug (interior pairs never swapped for even n). Do **not** "fix toward" fgbio.
- **FILT3-10** — empty-read no-call edge: fgumi guards `seq_len > 0` and keeps; fgbio drops on `NaN`. Unreachable for real consensus reads; fgumi safer.
- **DEDUP-01** — fgumi adds no mapq to the duplicate score, matching Picard `SUM_OF_BASE_QUALITIES` (fgbio adds mapq); fgumi is a Picard drop-in.
- **DEDUP-03** — fgumi keeps + marks secondary/supplementary of a duplicate template (Picard also flags them); fgbio discards them. fgumi is closer to Picard.
- **CLIP3-04** — `N`/skip excluded from ref-consumption in the clip loop; deliberate to keep the raw and typed clippers byte-identical. Affects only spliced/RNA reads (rare in UMI workflows).
- **SORT-01** — template-coordinate name tie-break uses a 63-bit hash, not lexical; deterministic with negligible collision probability, no grouping impact; only breaks byte-identity with `samtools sort --template-coordinate`.
- **DXM3-10-class** — the family of NaN/±inf/overflow/divide-by-zero guards that fgbio lacks (e.g. DUPLEX3-10, FILT3-10): fgumi is safer on unreachable edges. Wontfix.

## Testing

- `cargo ci-fmt` — clean
- `cargo ci-lint` — clean (features `compare,simulate,profile-adjacency`)
- `cargo ci-test` — 2267 passed, 22 skipped, 0 failed
- `cargo test --doc` — 34 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified clipping defaults, metrics limitations, and read-pair downsampling options.
  * Expanded consensus-calling guidance for per-base tags and quality masking.
  * Documented downsampling differences, validation rules, determinism, and compatibility expectations.
  * Clarified input formatting for duplex options and tag-reversal settings.
  * Improved guidance for paired templates, plot descriptions, interval formats, mapping quality defaults, threading, and duplicate marking.
  * Documented simplex downsampling behavior and handling of missing or unsupported tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->