### PR TITLE
refactor(fmt): extract shared format_count/format_duration into a fgumi-fmt leaf crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-channel",
+ "fgumi-fmt",
  "fgumi-raw-bam",
  "log",
  "nix",
@@ -755,6 +756,7 @@ dependencies = [
  "bytesize",
  "clap",
  "enum_dispatch",
+ "fgumi-fmt",
  "log",
  "num_cpus",
  "rstest",
@@ -801,11 +803,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fgumi-fmt"
+version = "0.3.0"
+dependencies = [
+ "rstest",
+]
+
+[[package]]
 name = "fgumi-metrics"
 version = "0.3.0"
 dependencies = [
  "anyhow",
  "fgoxide",
+ "fgumi-fmt",
  "fgumi-raw-bam",
  "fgumi-sam",
  "noodles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-simd-fastq", "crates/fgumi-tag", "crates/fgumi-umi", "crates/fgumi-consensus", "crates/fgumi-bam-io", "crates/fgumi-sort", "crates/fgumi-pipeline-core", "crates/fgumi-cli-macros", "crates/fgumi-cli-common", "crates/fgumi-pipeline-io", "crates/fgumi-sort-cli", "crates/xtask"]
+members = [".", "crates/fgumi-raw-bam", "crates/fgumi-dna", "crates/fgumi-bgzf", "crates/fgumi-fmt", "crates/fgumi-metrics", "crates/fgumi-sam", "crates/fgumi-simd-fastq", "crates/fgumi-tag", "crates/fgumi-umi", "crates/fgumi-consensus", "crates/fgumi-bam-io", "crates/fgumi-sort", "crates/fgumi-pipeline-core", "crates/fgumi-cli-macros", "crates/fgumi-cli-common", "crates/fgumi-pipeline-io", "crates/fgumi-sort-cli", "crates/xtask"]
 resolver = "2"
 
 [workspace.package]
@@ -15,6 +15,7 @@ fgumi-bgzf = { version = "0.3.0", path = "crates/fgumi-bgzf" }
 fgumi-cli-macros = { version = "0.3.0", path = "crates/fgumi-cli-macros" }
 fgumi-consensus = { version = "0.3.0", path = "crates/fgumi-consensus", default-features = false }
 fgumi-dna = { version = "0.3.0", path = "crates/fgumi-dna" }
+fgumi-fmt = { version = "0.3.0", path = "crates/fgumi-fmt" }
 fgumi-metrics = { version = "0.3.0", path = "crates/fgumi-metrics" }
 fgumi-raw-bam = { version = "0.3.0", path = "crates/fgumi-raw-bam" }
 fgumi-sam = { version = "0.3.0", path = "crates/fgumi-sam" }

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -15,6 +15,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [dependencies]
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
+fgumi-fmt = { workspace = true }
 noodles = { version = "0.111.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
 noodles-bgzf = { version = "0.47.0", features = ["libdeflate"] }
 noodles-csi = "0.56.0"

--- a/crates/fgumi-bam-io/src/progress.rs
+++ b/crates/fgumi-bam-io/src/progress.rs
@@ -5,6 +5,7 @@
 //! When a total is known, it also displays percentage complete and ETA using an exponential
 //! moving average (EMA) of the processing rate with bias correction (tqdm-style).
 
+use fgumi_fmt::format_duration;
 use log::info;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -66,22 +67,6 @@ impl EmaState {
         let beta = 1.0 - EMA_ALPHA;
         let correction = 1.0 - beta.powi(self.calls.cast_signed());
         if correction <= 0.0 { 0.0 } else { self.smoothed_rate / correction }
-    }
-}
-
-/// Formats a [`Duration`] as a human-readable string (e.g. `"2m 15s"`, `"1h 30m"`).
-fn format_duration(duration: Duration) -> String {
-    let secs = duration.as_secs();
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 3600 {
-        let mins = secs / 60;
-        let remaining_secs = secs % 60;
-        if remaining_secs == 0 { format!("{mins}m") } else { format!("{mins}m {remaining_secs}s") }
-    } else {
-        let hours = secs / 3600;
-        let mins = (secs % 3600) / 60;
-        if mins == 0 { format!("{hours}h") } else { format!("{hours}h {mins}m") }
     }
 }
 

--- a/crates/fgumi-cli-common/Cargo.toml
+++ b/crates/fgumi-cli-common/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.102"
 bytesize = "2.3"
 clap = { version = "4", features = ["derive", "string"] }
 enum_dispatch = "0.3.13"
+fgumi-fmt = { workspace = true }
 log = "0.4"
 num_cpus = "1.16"
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }

--- a/crates/fgumi-cli-common/src/lib.rs
+++ b/crates/fgumi-cli-common/src/lib.rs
@@ -128,52 +128,10 @@ pub fn detect_cpu_count() -> usize {
 // Formatting helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Format an integer with comma separators (e.g. 1234567 → "1,234,567").
-#[must_use]
-pub fn format_count(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::with_capacity(s.len() + s.len() / 3);
-    let offset = s.len() % 3;
-    for (i, c) in s.chars().enumerate() {
-        // Insert a comma before every group of three digits, but not before
-        // the first character. `offset` is the length of the leading partial
-        // group, so commas fall at indices `offset, offset+3, offset+6, …`
-        // (skipping index 0 when `offset == 0`).
-        if i >= offset && i > 0 && (i - offset).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(c);
-    }
-    result
-}
-
-/// Formats a duration in human-readable form.
-///
-/// # Examples
-///
-/// ```
-/// use fgumi_cli_common::format_duration;
-/// use std::time::Duration;
-///
-/// assert_eq!(format_duration(Duration::from_secs(45)), "45s");
-/// assert_eq!(format_duration(Duration::from_secs(135)), "2m 15s");
-/// assert_eq!(format_duration(Duration::from_secs(5400)), "1h 30m");
-/// ```
-#[must_use]
-pub fn format_duration(duration: std::time::Duration) -> String {
-    let secs = duration.as_secs();
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 3600 {
-        let mins = secs / 60;
-        let remaining_secs = secs % 60;
-        if remaining_secs == 0 { format!("{mins}m") } else { format!("{mins}m {remaining_secs}s") }
-    } else {
-        let hours = secs / 3600;
-        let mins = (secs % 3600) / 60;
-        if mins == 0 { format!("{hours}h") } else { format!("{hours}h {mins}m") }
-    }
-}
+// `format_count` and `format_duration` live in the dependency-free `fgumi-fmt` leaf crate
+// so `fgumi-cli-common`, `fgumi-metrics`, and `fgumi-bam-io` share one implementation.
+// Re-exported here so `fgumi_cli_common::{format_count, format_duration}` keep resolving.
+pub use fgumi_fmt::{format_count, format_duration};
 
 /// Formats a rate (items per second) with appropriate units.
 ///

--- a/crates/fgumi-fmt/Cargo.toml
+++ b/crates/fgumi-fmt/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fgumi-fmt"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Human-readable formatting helpers (counts, durations) shared across the fgumi workspace"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+rstest = "0.26"
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-fmt/src/lib.rs
+++ b/crates/fgumi-fmt/src/lib.rs
@@ -1,0 +1,102 @@
+#![deny(unsafe_code)]
+
+//! Small, dependency-free human-readable formatting helpers shared across the fgumi
+//! workspace.
+//!
+//! `format_count` and `format_duration` were each copied into more than one crate
+//! (`fgumi-cli-common`, `fgumi-metrics`, `fgumi-bam-io`). Those crates sit at different
+//! layers and do not depend on one another, so this dependency-free leaf crate is the
+//! shared home; each consumer re-exports or imports from here instead of carrying its own
+//! copy.
+
+use std::time::Duration;
+
+/// Format an integer with comma thousands-separators (e.g. `1234567` → `"1,234,567"`).
+///
+/// # Examples
+///
+/// ```
+/// use fgumi_fmt::format_count;
+///
+/// assert_eq!(format_count(1_234_567), "1,234,567");
+/// assert_eq!(format_count(123), "123");
+/// assert_eq!(format_count(0), "0");
+/// ```
+#[must_use]
+pub fn format_count(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let num_commas = if len > 3 { (len - 1) / 3 } else { 0 };
+    let mut result = String::with_capacity(len + num_commas);
+    for (i, &byte) in bytes.iter().enumerate() {
+        // A comma precedes every group of three trailing digits, but never leads the
+        // string: `len - i` is the number of digits remaining, so a comma falls before
+        // position `i` exactly when that count is a positive multiple of three.
+        if i > 0 && (len - i).is_multiple_of(3) {
+            result.push(',');
+        }
+        result.push(byte as char);
+    }
+    result
+}
+
+/// Formats a duration in human-readable form (e.g. `"45s"`, `"2m 15s"`, `"1h 30m"`).
+///
+/// Renders at most two units (whole seconds below a minute, minutes-and-seconds below an
+/// hour, hours-and-minutes above); the finer unit is dropped when it is zero.
+///
+/// # Examples
+///
+/// ```
+/// use fgumi_fmt::format_duration;
+/// use std::time::Duration;
+///
+/// assert_eq!(format_duration(Duration::from_secs(45)), "45s");
+/// assert_eq!(format_duration(Duration::from_secs(135)), "2m 15s");
+/// assert_eq!(format_duration(Duration::from_secs(5400)), "1h 30m");
+/// ```
+#[must_use]
+pub fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        let mins = secs / 60;
+        let remaining_secs = secs % 60;
+        if remaining_secs == 0 { format!("{mins}m") } else { format!("{mins}m {remaining_secs}s") }
+    } else {
+        let hours = secs / 3600;
+        let mins = (secs % 3600) / 60;
+        if mins == 0 { format!("{hours}h") } else { format!("{hours}h {mins}m") }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::zero(0, "0")]
+    #[case::single(1, "1")]
+    #[case::three_digits(123, "123")]
+    #[case::first_comma(1_234, "1,234")]
+    #[case::two_groups(1_234_567, "1,234,567")]
+    #[case::round_million(1_000_000, "1,000,000")]
+    #[case::max(u64::MAX, "18,446,744,073,709,551,615")]
+    fn format_count_inserts_commas(#[case] n: u64, #[case] expected: &str) {
+        assert_eq!(format_count(n), expected);
+    }
+
+    #[rstest]
+    #[case::zero(0, "0s")]
+    #[case::sub_minute(45, "45s")]
+    #[case::exact_minute(60, "1m")]
+    #[case::minutes_seconds(135, "2m 15s")]
+    #[case::exact_hour(3600, "1h")]
+    #[case::hours_minutes(5400, "1h 30m")]
+    fn format_duration_human_readable(#[case] secs: u64, #[case] expected: &str) {
+        assert_eq!(format_duration(Duration::from_secs(secs)), expected);
+    }
+}

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 fgoxide = "0.6.0"
+fgumi-fmt = { workspace = true }
 noodles = { version = "0.111.0", features = ["sam"], optional = true }
 fgumi-raw-bam = { workspace = true, optional = true }
 

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -133,31 +133,11 @@ impl fmt::Display for RejectionReason {
     }
 }
 
-/// Formats a count with thousands separators.
-///
-/// # Examples
-///
-/// ```
-/// use fgumi_metrics::rejection::format_count;
-///
-/// assert_eq!(format_count(1234567), "1,234,567");
-/// assert_eq!(format_count(123), "123");
-/// ```
-#[must_use]
-pub fn format_count(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let num_commas = if len > 3 { (len - 1) / 3 } else { 0 };
-    let mut result = String::with_capacity(len + num_commas);
-    for (i, &byte) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(byte as char);
-    }
-    result
-}
+// `format_count` lives in the dependency-free `fgumi-fmt` leaf crate so it is shared with
+// `fgumi-cli-common` and `fgumi-bam-io` instead of copied. Re-exported here (and via
+// `fgumi_metrics::format_count`) so existing `fgumi_metrics::rejection::format_count`
+// callers keep resolving.
+pub use fgumi_fmt::format_count;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## What

`format_count` was duplicated in `fgumi-cli-common` and `fgumi-metrics` (same output, two implementations), and `format_duration` was duplicated byte-for-byte in `fgumi-cli-common` and `fgumi-bam-io`. Those three crates sit at different layers and don't depend on one another, so there was no shared home — the reason this was previously ruled a layering-blocked NO-CHANGE.

Add a dependency-free **`fgumi-fmt`** leaf crate with one canonical `format_count` + `format_duration` (rstest tables + doctests), and have each consumer re-export or import from it:

- **fgumi-cli-common**: `pub use fgumi_fmt::{format_count, format_duration}` — keeps `fgumi_cli_common::format_count`/`format_duration` and `format_rate` working.
- **fgumi-metrics**: `pub use fgumi_fmt::format_count` in `rejection` — keeps `fgumi_metrics::rejection::format_count` and `fgumi_metrics::format_count`.
- **fgumi-bam-io**: `use fgumi_fmt::format_duration` in `progress` — drops the private copy.

No behavior change; every existing call path keeps resolving via the re-exports.

## Verification

`cargo ci-test` 2332 passed; `cargo ci-lint` clean; `fgumi-fmt` 13 unit + 2 doctests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent formatting for large counts with thousands separators.
  * Improved duration displays for elapsed time and estimated completion, including seconds, minutes, and hours.

* **Refactor**
  * Standardized count and duration formatting across progress reporting, command-line output, and metrics.
  * Preserved existing formatting access points for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->