### PR TITLE
chore: remove stale #[allow(dead_code)] attributes now that the code is used

### DIFF
--- a/crates/fgumi-bam-io/src/prefetch_reader.rs
+++ b/crates/fgumi-bam-io/src/prefetch_reader.rs
@@ -205,7 +205,6 @@ impl PrefetchReader {
 
     /// Total bytes served to callers of [`Read::read`] so far.
     #[must_use]
-    #[allow(dead_code)]
     pub fn bytes_consumed(&self) -> u64 {
         self.bytes_consumed
     }
@@ -214,7 +213,6 @@ impl PrefetchReader {
     /// to deliver the next chunk. Useful as a prototype-phase signal for
     /// whether [`DEFAULT_PREFETCH_DEPTH`] is large enough.
     #[must_use]
-    #[allow(dead_code)]
     pub fn consumer_stalls(&self) -> u64 {
         self.consumer_stalls
     }

--- a/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
+++ b/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
@@ -75,7 +75,6 @@ pub struct CompressSpill {
     /// unlink-after-emit lifetime (correct on the Unix targets). Empty in tests
     /// that hold their own `TempDir`. Held purely for RAII (`Arc`-cloned to each
     /// worker), never read for its value.
-    #[allow(dead_code)]
     temp_dirs: Arc<Vec<TempDir>>,
 }
 

--- a/crates/fgumi-sort/src/memory_probe.rs
+++ b/crates/fgumi-sort/src/memory_probe.rs
@@ -78,7 +78,6 @@ mod platform_ffi {
     /// `mi_stats_print_out(None, null_mut())` uses mimalloc's internal synchronization,
     /// making it safe to call concurrently with allocation/deallocation on other threads.
     #[cfg(feature = "memory-debug")]
-    #[allow(dead_code)] // consumed by main fgumi's pipeline via the crate-root re-export
     pub fn print_mi_stats() {
         // SAFETY: mimalloc synchronizes stats collection internally.
         unsafe {

--- a/crates/fgumi-sort/src/segmented_buf.rs
+++ b/crates/fgumi-sort/src/segmented_buf.rs
@@ -37,7 +37,6 @@ pub struct SegmentedBuf {
     cur: usize,
 }
 
-#[allow(dead_code)] // Some methods are only exercised from tests for now.
 impl SegmentedBuf {
     /// Create a new buffer with the given initial capacity hint and segment size.
     ///

--- a/crates/fgumi-sort/src/tmp_dir_alloc.rs
+++ b/crates/fgumi-sort/src/tmp_dir_alloc.rs
@@ -135,7 +135,6 @@ impl TmpDirAllocator {
 
     /// Override the periodic recheck interval (primarily for testing).
     #[must_use]
-    #[allow(dead_code)]
     pub fn with_recheck_interval(mut self, interval: usize) -> Self {
         self.recheck_interval = interval.max(1);
         self
@@ -175,7 +174,6 @@ impl TmpDirAllocator {
     /// Drop a directory from rotation (e.g. after `ENOSPC` during a spill write).
     ///
     /// Matches by path equality. A no-op if the path isn't currently active.
-    #[allow(dead_code)]
     pub fn mark_full(&mut self, dir: &Path) {
         if let Some(pos) = self.active.iter().position(|d| d == dir) {
             self.active.remove(pos);

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -691,7 +691,6 @@ mod tests {
 
     /// Helper struct for managing temporary test file paths.
     struct TestPaths {
-        #[allow(dead_code)]
         dir: TempDir,
         pub output: PathBuf,
     }

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -661,7 +661,6 @@ mod tests {
 
     /// Helper struct for managing temporary test file paths.
     struct TestPaths {
-        #[allow(dead_code)]
         dir: TempDir,
         pub input: PathBuf,
         pub output: PathBuf,


### PR DESCRIPTION
## What

Removes the `#[allow(dead_code)]` attributes whose guarded items are **no longer dead** — scaffolding that has since been wired up ("wired up by Phase 2 `Pipeline::run`", "wired up by Phase 1 Task 15"), a "for now" that became permanent, and an item "consumed by main fgumi via the crate-root re-export". 10 files.

## Method

Started by stripping *every* `#[allow(dead_code)]` in the tree and recompiling. ~40 items warned — those allows are **load-bearing** (guarding intentionally-retained-but-unused benchmark-only paths, feature-gated items, and in-progress scaffolding) and were restored. The ones that produced **no** warning are stale, and are the removals in this PR.

Each removal was verified warning-clean under:
- default features
- `--no-default-features` (the reduced consensus-off build)
- `compare,simulate,profile-adjacency`, both `--all-targets` and lib-only (so test-only usage isn't masked)

The pre-existing `replace_header`-dead-under-`--no-default-features` warning in `builder.rs` is unrelated (present in the base) and left untouched.

## Verification

`cargo ci-test` 2332 passed; `cargo ci-lint` clean (`-D warnings`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dead-code lint coverage across internal components and test helpers.
  * Restricted memory diagnostics to builds using the `memory-debug` feature.
  * No user-facing behavior or functional workflows changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->