### PR TITLE
docs(dedup): document that dedup filters templates like fgbio GroupReadsByUmi (DEDUP3-01)

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -881,6 +881,31 @@ Note: Using `samtools sort` will NOT work correctly because it doesn't use the
 - Mark only (default): Set duplicate flag (0x400) on non-representative reads
 - Remove (--remove-duplicates): Exclude duplicate reads from output entirely
 
+# Filtering (differs from Picard MarkDuplicates)
+
+Unlike Picard `MarkDuplicates` in its default mark-only mode, which passes *every* input
+record through to the output (unmapped reads are written unchanged; QC-fail and
+low-mapping-quality reads are still emitted, only flagged), `fgumi dedup` also acts as a
+read filter: templates that do not pass the criteria below are dropped entirely and never
+reach the output. (Picard drops records only under `REMOVE_DUPLICATES=true`, and even then
+only the reads it marked as duplicates — never the input filters `fgumi dedup` applies
+below.) As a result the output record count can be lower than the input, and this tool is
+NOT a Picard record-count drop-in. A template is discarded (not marked) when:
+
+- Both mates are unmapped (a template with no mapped read).
+- Any read is flagged QC-fail (unless -n/--include-non-pf-reads is given).
+- A mapped read has mapping quality below -q/--min-map-q (default 0, i.e. no reads are
+  dropped for mapping quality unless a threshold is set).
+- The mate mapping quality (MQ tag) is below -q/--min-map-q, when the mate is mapped.
+- The UMI contains an N base (unless --no-umi is given).
+- The UMI is shorter than -l/--min-umi-length, when that option is set.
+- The RX UMI tag is missing (unless --no-umi is given).
+- A record is truncated/corrupt (shorter than the minimum BAM record length).
+
+The counts of templates dropped for each reason are reported in the metrics output
+(--metrics). Deduplication of the templates that remain (representative selection, the
+0x400 flag, and --remove-duplicates) is otherwise faithful to Picard.
+
 # Cell Barcodes
 
 If the input data contains cell barcodes (e.g. from single-cell sequencing), reads at the same

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -881,16 +881,16 @@ Note: Using `samtools sort` will NOT work correctly because it doesn't use the
 - Mark only (default): Set duplicate flag (0x400) on non-representative reads
 - Remove (--remove-duplicates): Exclude duplicate reads from output entirely
 
-# Filtering (differs from Picard MarkDuplicates)
+# Filtering (same as fgbio GroupReadsByUmi)
 
-Unlike Picard `MarkDuplicates` in its default mark-only mode, which passes *every* input
-record through to the output (unmapped reads are written unchanged; QC-fail and
-low-mapping-quality reads are still emitted, only flagged), `fgumi dedup` also acts as a
-read filter: templates that do not pass the criteria below are dropped entirely and never
-reach the output. (Picard drops records only under `REMOVE_DUPLICATES=true`, and even then
-only the reads it marked as duplicates — never the input filters `fgumi dedup` applies
-below.) As a result the output record count can be lower than the input, and this tool is
-NOT a Picard record-count drop-in. A template is discarded (not marked) when:
+`fgumi dedup` is a re-implementation of `fgbio GroupReadsByUmi --mark-duplicates`, and like
+that tool it acts as a read *filter* in addition to marking duplicates: templates that do
+not pass the criteria below are dropped entirely and never reach the output, so the output
+record count can be lower than the input. This matches fgbio, which applies exactly these
+filters before grouping regardless of whether `--mark-duplicates` is set. It does, however,
+differ from Picard `MarkDuplicates`, which passes every record through and only sets the
+duplicate flag — so `fgumi dedup` is NOT a Picard record-count drop-in. A template is
+discarded (not marked) when:
 
 - Both mates are unmapped (a template with no mapped read).
 - Any read is flagged QC-fail (unless -n/--include-non-pf-reads is given).
@@ -902,9 +902,15 @@ NOT a Picard record-count drop-in. A template is discarded (not marked) when:
 - The RX UMI tag is missing (unless --no-umi is given).
 - A record is truncated/corrupt (shorter than the minimum BAM record length).
 
+To retain as many templates as possible, leave -q/--min-map-q at its default of 0, do not
+set -l/--min-umi-length, pass -n/--include-non-pf-reads to keep QC-fail reads, and, when the
+input has no usable UMIs, use --no-umi to bypass the UMI checks entirely. Two drops cannot
+be disabled, matching fgbio: templates with no mapped read (both mates unmapped) and
+truncated/corrupt records are always discarded.
+
 The counts of templates dropped for each reason are reported in the metrics output
 (--metrics). Deduplication of the templates that remain (representative selection, the
-0x400 flag, and --remove-duplicates) is otherwise faithful to Picard.
+0x400 flag, and --remove-duplicates) follows Picard `MarkDuplicates` semantics.
 
 # Cell Barcodes
 


### PR DESCRIPTION
## Summary

`fgumi dedup` is a re-implementation of `fgbio GroupReadsByUmi --mark-duplicates`, and — like that tool — it acts as a read *filter* in addition to marking duplicates: it drops unmapped / QC-fail / low-mapping-quality / short-or-missing-UMI / corrupt templates so they never reach the output. This is faithful to fgbio, which applies exactly these filters before grouping whether or not `--mark-duplicates` is set. It does differ from Picard `MarkDuplicates`, which passes every record through and only *marks* duplicates — so a user expecting a Picard record-count drop-in gets fewer output records than input, with no error.

This filtering was already the intended, correct behavior; it was just undocumented. This PR adds a `Filtering (same as fgbio GroupReadsByUmi)` section to the `fgumi dedup` long help that:

- States that dedup mirrors `fgbio GroupReadsByUmi --mark-duplicates`, citing the real `filter_template` predicates:
  - Both mates unmapped (no mapped read in the template).
  - Any primary read flagged QC-fail (unless `-n/--include-non-pf-reads`).
  - A mapped read with mapping quality below `-q/--min-map-q` (default 0).
  - The mate mapping quality (`MQ` tag) below `-q/--min-map-q`, when the mate is mapped.
  - The UMI contains an `N` base (unless `--no-umi`).
  - The UMI shorter than `-l/--min-umi-length`, when set.
  - The `RX` UMI tag missing (unless `--no-umi`).
  - A truncated/corrupt record.
- Notes the Picard divergence as a caveat (not a Picard record-count drop-in).
- Adds guidance on retaining as many templates as possible, and is explicit that two drops cannot be disabled (both-mates-unmapped and truncated/corrupt records), matching fgbio.

Doc-only; no logic change. The disposition for DEDUP3-01 is to keep the current filtering behavior and document that it is faithful to fgbio GroupReadsByUmi.

## Testing

`cargo ci-fmt && cargo ci-lint` — green (doc-only change).
